### PR TITLE
set env to path bash interpreter, because FreeBSD and other SO use difer...

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #----
 ## @Synopsis	Install Script for Centreon project
 ## @Copyright	Copyright 2008, Guillaume Watteeux

--- a/libinstall/CentCore.sh
+++ b/libinstall/CentCore.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #----
 ## @Synopsis	Install script for CentCore
 ## @Copyright	Copyright 2008, Guillaume Watteeux

--- a/libinstall/CentPlugins.sh
+++ b/libinstall/CentPlugins.sh
@@ -1,4 +1,4 @@
-#!/bin/bash	
+#!/usr/bin/env bash	
 #----
 ## @Synopsis	Install script for CentPlugins
 ## @Copyright	Copyright 2008, Guillaume Watteeux

--- a/libinstall/CentPluginsTraps.sh
+++ b/libinstall/CentPluginsTraps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #----
 ## @Synopsis	Install script for CentPluginsTraps
 ## @Copyright	Copyright 2008, Guillaume Watteeux

--- a/libinstall/CentStorage.sh
+++ b/libinstall/CentStorage.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #----
 ## @Synopsis	Install script for CentStorage
 ## @Copyright	Copyright 2008, Guillaume Watteeux

--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #----
 ## @Synopsis	Install script for Centreon Web Front (CentWeb)
 ## @Copyright	Copyright 2008, Guillaume Watteeux

--- a/libinstall/cinstall
+++ b/libinstall/cinstall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #----
 ## @Synopsis	Redefine install command for Centreon Install

--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1,4 +1,4 @@
-#!/bin/bash 
+#!/usr/bin/env bash 
 
 #----
 ## @Synopsis	This file contains functions to be used by Centreon install scripts

--- a/www/include/options/oreon/upGrade/functions.php
+++ b/www/include/options/oreon/upGrade/functions.php
@@ -225,7 +225,7 @@
 	 */
 	function writeShellHeaders($fd, $oreonInstallPath, $patchPath) {
 		global $lang;
-		fwrite($fd, "#!/bin/bash\n\n");
+		fwrite($fd, "#!/usr/bin/env bash\n\n");
 		fwrite($fd, "PATH_OREON=" . $oreonInstallPath . "\n");
 		fwrite($fd, "PATH_PATCH=" . $patchPath . "\n\n");
 		fwrite($fd, "PATH_OLD=`pwd`\n\n");


### PR DESCRIPTION
set ENV (/usr/bin/env) to path Bash interpreter, because FreeBSD and other SO use different path to bash -- more compatible with others SO