### PR TITLE
Replace simple quote by space in legend

### DIFF
--- a/www/class/centreonGraph.class.php
+++ b/www/class/centreonGraph.class.php
@@ -282,7 +282,7 @@ class CentreonGraph {
     */
     protected function cleanupDsNameForLegend($dsname, $reverse = false)
     {
-        $newDsName = str_replace(array("slash_", "bslash_", "pct_",  "#", "\\"), array("/", "\\", "%", "#", "\\\\"), $dsname);
+        $newDsName = str_replace(array("slash_", "bslash_", "pct_",  "'", "\\"), array("/", "\\", "%", " ", "\\\\"), $dsname);
         $newDsName = mb_convert_encoding($newDsName, "UTF-8");
         return $newDsName;
     }


### PR DESCRIPTION
Replace hash by hash isn't useful
I replace simple quote by space because graph wasn't displayed with this character