### PR TITLE
Fix recurrent downtimes with 00:00 or 24:00

### DIFF
--- a/www/class/centreonDowntime.class.php
+++ b/www/class/centreonDowntime.class.php
@@ -895,7 +895,7 @@ class CentreonDowntime
                     }
 
                     $timestamp_stop->setTime($sEndTime[0], $sEndTime[1], '00');
-                    if ($finish_tomorrow) {
+                    if ($start_tomorrow) {
                         $timestamp_stop->add(new DateInterval('P1D'));
                     }
 


### PR DESCRIPTION
Remove P1D in timestamp_stop if end_time==24:00 (added automatic by php)
Add P1D in timestamp_stop if start_time==00:00

Test Downtime cycle 1 :
 - Host : HOSTTEST
 - Period 1 : 19:00 to 24:00
 - Period 2 : 00:00 to 07:00


mer. févr. 17 16:54:27 CET 2016

date -s 18:54:45

[1455731702] [31305] EXTERNAL COMMAND: SCHEDULE_HOST_DOWNTIME;HOSTTEST;1455732000;1455750000;1;0;0;Downtime cycle;[Downtime cycle #1]
[1455731702] [31305] EXTERNAL COMMAND: SCHEDULE_HOST_SVC_DOWNTIME;HOSTTEST;1455732000;1455750000;1;0;0;Downtime cycle;[Downtime cycle #1]


date -s 18:59:45

[1455732000] [31305] HOST DOWNTIME ALERT: HOSTTEST;STARTED; Host has entered a period of scheduled downtime
[1455732000] [31305] SERVICE DOWNTIME ALERT: HOSTTEST;SERVICE1;STARTED; Service has entered a period of scheduled downtime
[1455732000] [31305] SERVICE DOWNTIME ALERT: HOSTTEST;SERVICE2;STARTED; Service has entered a period of scheduled downtime


date -s 23:54:45

[1455749712] [31305] EXTERNAL COMMAND: SCHEDULE_HOST_DOWNTIME;HOSTTEST;1455750000;1455775200;1;0;0;Downtime cycle;[Downtime cycle #1]
[1455749712] [31305] EXTERNAL COMMAND: SCHEDULE_HOST_SVC_DOWNTIME;HOSTTEST;1455750000;1455775200;1;0;0;Downtime cycle;[Downtime cycle #1]


date -s 23:59:45

[1455750000] [31305] HOST DOWNTIME ALERT: HOSTTEST;STOPPED; Host has exited from a period of scheduled downtime
[1455750000] [31305] SERVICE DOWNTIME ALERT: HOSTTEST;SERVICE1;STOPPED; Service has exited from a period of scheduled downtime
[1455750000] [31305] SERVICE DOWNTIME ALERT: HOSTTEST;SERVICE2;STOPPED; Service has exited from a period of scheduled downtime
[1455750000] [31305] HOST DOWNTIME ALERT: HOSTTEST;STARTED; Host has entered a period of scheduled downtime
[1455750000] [31305] SERVICE DOWNTIME ALERT: HOSTTEST;SERVICE1;STARTED; Service has entered a period of scheduled downtime
[1455750000] [31305] SERVICE DOWNTIME ALERT: HOSTTEST;SERVICE2;STARTED; Service has entered a period of scheduled downtime


date -s 06:59:45

[1455775200] [31305] HOST DOWNTIME ALERT: HOSTTEST;STOPPED; Host has exited from a period of scheduled downtime
[1455775200] [31305] SERVICE DOWNTIME ALERT: HOSTTEST;SERVICE1;STOPPED; Service has exited from a period of scheduled downtime
[1455775200] [31305] SERVICE DOWNTIME ALERT: HOSTTEST;SERVICE2;STOPPED; Service has exited from a period of scheduled downtime

jeu. févr. 18 07:07:35 CET 2016