### PR TITLE
Wrong SQL query

### DIFF
--- a/www/include/common/webServices/rest/centreon_performance_service.class.php
+++ b/www/include/common/webServices/rest/centreon_performance_service.class.php
@@ -87,7 +87,7 @@ class CentreonPerformanceService extends CentreonConfigurationObjects
         }        
         
         $query = "SELECT SQL_CALC_FOUND_ROWS DISTINCT i.service_description, i.service_id, i.host_name, i.host_id, m.index_id "
-            . "FROM index_data i, metrics m ".(!$isAdmin ? ', centreon_acl acl' : '')
+            . "FROM index_data i, metrics m ".(!$isAdmin ? ', centreon_acl acl ' : '')
             . 'WHERE i.id = m.index_id '
             . (!$isAdmin ? ' AND acl.host_id = i.host_id AND acl.service_id = i.service_id AND acl.group_id IN ('.$acl->getAccessGroupsString().') ' : '')
             . "AND (i.service_description LIKE '%$q%' OR i.host_name LIKE '%$q%') "


### PR DESCRIPTION
Hello,

The line below is written in /var/log/centreon/sql-error.log:

2016-04-28 13:46|0|0|DB Error: syntax error QUERY : SELECT SQL_CALC_FOUND_ROWS DISTINCT i.service_description, i.service_id, i.host_name, i.host_id, m.index_id FROM index_data i, metrics m , centreon_acl aclWHERE i.id = m.index_id  AND acl.host_id = i.host_id AND acl.service_id = i.service_id AND acl.group_id IN ('99','197','48') AND (i.service_description LIKE '%pmisanas1app%' OR i.host_name LIKE '%pmisanas1app%') ORDER BY i.host_name, i.service_description LIMIT 0,60

The reason of this issue: a blank is missing => "centreon_acl aclWHERE".

Thanks.