### PR TITLE
Issue when using poller name with POLLERRESTART

### DIFF
--- a/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -303,7 +303,7 @@ class CentreonConfigPoller {
         if (isset($host['localhost']) && $host['localhost'] == 1) {
             $msg_restart = exec(escapeshellcmd("sudo " . $nagios_init_script . " restart"), $lines, $return_code);
         } else {
-            exec("echo 'RESTART:".$variables."' >> ". $this->centcore_pipe, $stdout, $return_code);
+            exec("echo 'RESTART:".$host["id"]."' >> ". $this->centcore_pipe, $stdout, $return_code);
             $msg_restart = _("OK: A restart signal has been sent to '".$host["name"]."'");
         }
         print $msg_restart."\n";


### PR DESCRIPTION
Hello,

When you use command POLLERRESTART and you specify the name of the poller, no error is displayed.
However the command RESTART:<poller_name> is sent to centcore.
The error message in centcore.log is "Cannot restart Engine for poller".
Change code to be compliant with POLLERRELOAD command.

Regards.