### PR TITLE
Display the name of the centreon server in title 

### DIFF
--- a/www/htmlHeader.php
+++ b/www/htmlHeader.php
@@ -42,7 +42,7 @@ print "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
 ?><!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="<?php echo $centreon->user->lang; ?>">
 <head>
-<title>Centreon - IT & Network Monitoring</title>
+<title>Centreon - <?php echo $_SERVER['HTTP_HOST']?></title>
 <link rel="shortcut icon" href="./img/favicon.ico"/>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
 <meta name="Generator" content="Centreon - Copyright (C) 2005 - 2015 Open Source Matters. All rights reserved."/>


### PR DESCRIPTION
This is to distinguish browser tabs/windows when multiple centreon servers web consoles are opened