### PR TITLE
Fixing ACL when no parent template on category

### DIFF
--- a/cron/centAcl-Func.php
+++ b/cron/centAcl-Func.php
@@ -152,14 +152,18 @@ function getServiceTemplateCategoryList($service_id = NULL) {
      */
     $loopBreak = array();
     while (1) {
-        if (isset($svcTplCache[$service_id]) && !isset($loopBreak[$service_id])) {
+        if (!isset($loopBreak[$service_id])) {
             if (isset($svcCatCache[$service_id])) {
                 foreach ($svcCatCache[$service_id] as $ct_id => $flag) {
                     $tabCategory[$ct_id] = $ct_id;
                 }
             }
             $loopBreak[$service_id] = true;
-            $service_id = $svcTplCache[$service_id];
+	    $service_id = $svcTplCache[$service_id];
+	    if (!isset($svcTplCache[$service_id])){
+		$loopBreak[$service_id] = true;
+	    }
+
         } else {
             return $tabCategory;
         }


### PR DESCRIPTION
Steps to reproduce :
- create a service category : "Ping"
- create service templates : "Ping-WAN" and "Ping-LAN" (**without parent template**)
- link one or both services to a host
- create an account : "test" with GUI access but no admin rights
- create an access group in ACL : "organization"
- link "organization" access group with "test" user
- create a Menus Access rule : all the menus to "organization"
- In Resources Access, create a rule linking "organization" with all hosts, all services ... and filtering using the service category "Ping"
- Reload the ACLs
- Check "test" user visibility : the user can't see the Ping category associated with the host.
- Now change "Ping-WAN" and "PING-LAN" and add a parent  #template
- Reload ACLs
- Now "test" user can see "Ping" #
