### PR TITLE
Remove extra parameter that make centreon extract goes on error.

### DIFF
--- a/www/class/centreon-clapi/centreonHost.class.php
+++ b/www/class/centreon-clapi/centreonHost.class.php
@@ -1016,7 +1016,6 @@ class CentreonHost extends CentreonObject
             null,
             null,
             $filters_cgRel,
-            array("host_register" => $this->register),
             "AND"
         );
         foreach ($elements as $element) {


### PR DESCRIPTION
Running centreon -e fail with the following error : 
PHP Fatal error:  Uncaught exception 'PDOException' with message 'SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'Array host_register LIKE '0'' at line 4' in /usr/share/centreon/lib/Zend/Db/Statement/Pdo.php:228
Stack trace:
#0 /usr/share/centreon/lib/Zend/Db/Statement/Pdo.php(228): PDOStatement->execute(Array)
#1 /usr/share/centreon/lib/Zend/Db/Statement.php(300): Zend_Db_Statement_Pdo->_execute(Array)
#2 /usr/share/centreon/lib/Zend/Db/Adapter/Abstract.php(468): Zend_Db_Statement->execute(Array)
#3 /usr/share/centreon/lib/Zend/Db/Adapter/Pdo/Abstract.php(245): Zend_Db_Adapter_Abstract->query('SELECT contactg...', Array)
#4 /usr/share/centreon/lib/Centreon/Object/Relation/Relation.php(128): Zend_Db_Adapter_Pdo_Abstract->query('SELECT contactg...', Array)
#5 /usr/share/centreon/lib/Centreon/Object/Relation/Relation.php(197): Centreon_Object_Relation->getResult('SELECT contactg...', Ar in /usr/share/centreon/lib/Zend/Db/Statement/Pdo.php on line 234

The executed query was : 
SELECT contactgroup.cg_name,contactgroup.cg_id,host.host_name
        		FROM contactgroup,host,contactgroup_host_relation
        		WHERE contactgroup.cg_id = contactgroup_host_relation.contactgroup_cg_id
        		AND contactgroup_host_relation.host_host_id = host.host_id Array host_register LIKE ? 

An extra paramater make the query fail, remove the extra parameter fix it.
