### PR TITLE
An object line 978 was not instanced ($macroObj)

### DIFF
--- a/www/class/centreon-clapi/centreonServiceTemplate.class.php
+++ b/www/class/centreon-clapi/centreonServiceTemplate.class.php
@@ -975,6 +975,7 @@ class CentreonServiceTemplate extends CentreonObject
         }
 
         // macros
+        $macroObj = new \Centreon_Object_Service_Macro_Custom();
         $macros = $macroObj->getList(
             "*",
             -1,
@@ -990,7 +991,7 @@ class CentreonServiceTemplate extends CentreonObject
                 . $element['service_description'] . $this->delim
                 . $this->stripMacro($macro['svc_macro_name']) . $this->delim
                 . $macro['svc_macro_value'] . $this->delim
-                . "'" .$macro['description'] ."'". "\n";
+                . "'" . $macro['description'] . "'" . "\n";
         }
 
         // traps


### PR DESCRIPTION
#4781 Remove extra parameter that make centreon extract goes on error.

The variable $macroObj was a non-object.
Instantiate it and getList () works.