### PR TITLE
Bug : Edit menu view

### DIFF
--- a/www/include/home/customViews/index.ihtml
+++ b/www/include/home/customViews/index.ihtml
@@ -79,18 +79,18 @@
                                     <h3 style="color:#00bfb3;">{$formEditView.header.title}</h3>
                                 </td>
                             </tr>
-                            <tr class="create_field">
+                            <tr>
                                 <td class="FormRowField">{$formEditView.name.label}</td>
                                 <td class="FormRowValue">
                                     <div>{$formEditView.name.html}</div>
                                     <span class="error-msg" style="display: none;">{t}This view name is required{/t}</span>
                                 </td>
                             </tr>
-                            <tr class="create_field">
+                            <tr>
                                 <td class="FormRowField">{$formEditView.layout.label}</td>
                                 <td class="FormRowValue">{$formEditView.layout.html}</td>
                             </tr>
-                            <tr class="create_field">
+                            <tr>
                                 <td class="FormRowField">{$formEditView.public.label}</td>
                                 <td class="FormRowValue">{$formEditView.public.html}</td>
                             </tr>


### PR DESCRIPTION
Hi,

If "create view" is selected in "Add view", we see the whole "Edit view" part : 

![capture1](https://cloud.githubusercontent.com/assets/16583698/20972961/044cd5a2-bc97-11e6-874a-617898b2af03.PNG) 
![capture2](https://cloud.githubusercontent.com/assets/16583698/20972967/0a8a9eea-bc97-11e6-9532-28bd907b97cf.PNG)

If "load view" is selected in "Add view", some fields are hidden : 

![capture3](https://cloud.githubusercontent.com/assets/16583698/20972981/17a45576-bc97-11e6-9acc-ece552819e7d.PNG)
![capture4](https://cloud.githubusercontent.com/assets/16583698/20972984/199d5f6c-bc97-11e6-8ce4-4f521267d041.PNG)
