### PR TITLE
Add new url option to clear filters

### DIFF
--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -192,6 +192,11 @@ if (!isset($_GET['o'])) {
 /*
  * Values
  */
+if (isset($_GET['filters']) && $_GET['filters'] == 'clean') {
+    $centreon->historySearch[$url] = null;
+    $centreon->historySearchOutput[$url] = null;
+    $centreon->historySearchService[$url] = null;
+}
 if (isset($centreon->historySearch[$url])) {
     $tpl->assign("hostSearchValue", $centreon->historySearch[$url]);
 }


### PR DESCRIPTION
This URL option allows to clean previous stored filters to access to correct data using others filters (hg, sg, host_search, etc.).