### PR TITLE
Compatibility with old arguments

### DIFF
--- a/www/include/monitoring/objectDetails/common-func.php
+++ b/www/include/monitoring/objectDetails/common-func.php
@@ -76,6 +76,7 @@ function hidePasswordInCommand($command_name, $service_id) {
     }
 
     /* Get command line with macro */
+    $command_name = preg_replace( '!.*' , '' , $command_name );
     $query_command_line = "SELECT command_line FROM command WHERE command_name = '".$command_name."'";
     $res = $pearDB->query($query_command_line);
     $row = $res->fetchRow();


### PR DESCRIPTION
If we use old arguments ($ARG1$ $ARG2$ ... ) in the service configuration and one of these argument contains simple quote, so the detailed service page is blank.

In the table "services", the field "check_command" contains command_name and old arguments:
check_cluster_new!-S!'diskcluster'!20!30
The simple quote was a problem

I tested it on two platforms and it works