### PR TITLE
Better display in service detail with long output or long command

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -118,6 +118,15 @@ label {
     vertical-align: middle;
 }
 
+
+pre.wrap {
+  white-space: -moz-pre-wrap;
+  white-space: -pre-wrap;
+  white-space: -o-pre-wrap;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
 .margin_right {
     margin-right: 6px;
 }

--- a/www/include/monitoring/objectDetails/template/serviceDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/serviceDetails.ihtml
@@ -50,7 +50,7 @@
                             <tr class='list_one'>
                                 <td class="ListColLeft ColPopup" valign="top">{$m_mon_performance_data}</td>
                                 <td class="ListColNoWrap">
-                                    <pre>{$service_data.performance_data}</pre>
+                                    <pre class="wrap">{$service_data.performance_data}</pre>
                                 </td>
                             </tr>
                             <tr class='list_two'>
@@ -117,7 +117,7 @@
                             <tr class='list_one'>
                                 <td class="ListColLeft ColPopup" valign="top">{$m_mon_service_command_line}</td>
                                 <td class="ListColLeft ColPopup">
-                                    <pre>{$service_data.command_line}</pre>
+                                    <pre style="max-width: 900px; overflow-x: auto">{$service_data.command_line}</pre>
                                 </td>
                             </tr>
                             {/if}


### PR DESCRIPTION
* Use word wrap for long output in service detail
* Add a scroll when a command argument is very long in service detail page

Ref: #4974 #4975