### PR TITLE
Add backslashes to "Executed Check Command Line" before line breaks

### DIFF
--- a/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/www/include/monitoring/objectDetails/serviceDetails.php
@@ -301,7 +301,7 @@ if (!is_null($host_id)) {
          * Ajust data for beeing displayed in template
          */
         $centreon->CentreonGMT->getMyGMTFromSession(session_id(), $pearDB);
-        $service_status['command_line'] = str_replace(' -', "\n\t-", $service_status['command_line']);
+        $service_status['command_line'] = str_replace(' -', " \\\n\t-", $service_status['command_line']);
         $service_status['performance_data'] = str_replace(' \'', "\n'", $service_status['performance_data']);
         $service_status["status_color"] = $centreon->optGen["color_" . strtolower($service_status["current_state"])];
 


### PR DESCRIPTION
This makes it easier to copy-paste command lines to run them from a shell.