### PR TITLE
Delete Paragraph Shortcut and Tool in Real-Time View

### DIFF
--- a/doc/en/exploitation_guide/04realtime.rst
+++ b/doc/en/exploitation_guide/04realtime.rst
@@ -261,27 +261,6 @@ Options and controls available
 Options and controls allow you to perform a number of actions on the host.
 Options are described in the chapter :ref:`Exploitation guide<exploitationguide>`.
 
-.. _shorthostlinks:
-
-Host Shortcuts
---------------
-
-You have here direct action to the host :
-
-* Configure host xxxx : Allows to access to host's configuration page  
-* View logs for host xxxx : Allows to display host's event logs
-* View status of all services on host xxxx : Allows to display all the status of services linked to the host  
-* View report for host xxxx : Allows to display host's availability reporting
-* View graphs for host xxxx : Allows to display performance graphs of all services of the host
-
-Tools
-------
-
-The **Tools** box allows:
-
-* make a PING to the host
-* make a traceroute to the host
-
 Links
 ------
 

--- a/doc/fr/exploitation_guide/04realtime.rst
+++ b/doc/fr/exploitation_guide/04realtime.rst
@@ -257,35 +257,6 @@ Options et Commandes disponibles
 Les options ainsi que les commandes permettent d'effectuer un certain nombre d'actions sur l'hôte.
 Ces différentes options sont traitées au sein du :ref:`guide d'exploitation<exploitationguide>`.
 
-.. _shorthostlinks:
-
-Raccourcis d'hôtes
-------------------
-
-Le tableau ci-dessous résume la signification des icônes :
- 
-+------------------------+--------------------------------------------------------------------+
-|  Icône                 |  Description                                                       | 
-+========================+====================================================================+
-| |configure|            | Redirige vers la page de configuration de l'hôte                   |
-+------------------------+--------------------------------------------------------------------+
-| |showservicesstatuts|  | Affiche le statut de tous les services liés à l'hôte               |
-+------------------------+--------------------------------------------------------------------+
-| |showlogs|             | Affiche les journaux liés à l'hôte                                 |
-+------------------------+--------------------------------------------------------------------+
-| |showresult|           | Affiche le rapport de disponibilité lié à l'hôte                   |
-+------------------------+--------------------------------------------------------------------+
-| |showgraphperf|        | Affiche les graphiques de performances des services liés à l'hôte  |
-+------------------------+--------------------------------------------------------------------+
-
-Outils
-------
-
-Le conteneur **Outils** permet :
-
-* D'effectuer un PING vers l'hôte
-* D'effectuer un traceroute vers l'hôte
-
 Liens
 -----
 


### PR DESCRIPTION
In the real-time page, details of a host, the host shortcut icons and the Tools menu no longer exist in 2.7x and 2.8x versions.