### PR TITLE
#5010 - Do not insert twice service extended info

### DIFF
--- a/www/class/centreonHost.class.php
+++ b/www/class/centreonHost.class.php
@@ -1716,8 +1716,6 @@ class CentreonHost
                     );
 
                     $this->insertRelHostService($hostId, $svcId);
-
-                    $this->serviceObj->insertExtendInfo(array('service_service_id' => $svcId));
                 }
                 unset($res);
             }


### PR DESCRIPTION
Function $this->serviceObj->insert already insert extended information for service so remove call to $this->serviceObj->insertExtendInfo