### PR TITLE
fix excessively long id search in logs

### DIFF
--- a/www/class/centreon-clapi/centreonObject.class.php
+++ b/www/class/centreon-clapi/centreonObject.class.php
@@ -421,9 +421,7 @@ abstract class CentreonObject
             $userId
         ));
 
-        $query = 'SELECT MAX(action_log_id) as action_log_id
-            FROM log_action
-            WHERE action_log_date = ?';
+        $query = 'SELECT LAST_INSERT_ID() as action_log_id';
         $stmt = $dbstorage->query($query, array($time));
         $row = $stmt->fetch();
         if (false === $row) {

--- a/www/class/centreon-clapi/centreonObject.class.php
+++ b/www/class/centreon-clapi/centreonObject.class.php
@@ -422,7 +422,7 @@ abstract class CentreonObject
         ));
 
         $query = 'SELECT LAST_INSERT_ID() as action_log_id';
-        $stmt = $dbstorage->query($query, array($time));
+        $stmt = $dbstorage->query($query);
         $row = $stmt->fetch();
         if (false === $row) {
             throw new CentreonClapiException("Error while inserting log action");


### PR DESCRIPTION
This way, I go from 7 hours to 1 hour import time for a 100K lines file.