### PR TITLE
ref #5269 - check if wiki is configured and extend error message

### DIFF
--- a/cron/centKnowledgeSynchronizer.php
+++ b/cron/centKnowledgeSynchronizer.php
@@ -39,5 +39,5 @@ try {
     $wikiApi = new WikiApi();
     $wikiApi->synchronize();
 } catch (Exception $e) {
-    echo $e->getMessage(), "\n";
+    echo $e->getMessage() . "\n";
 }

--- a/cron/centKnowledgeSynchronizer.php
+++ b/cron/centKnowledgeSynchronizer.php
@@ -35,5 +35,9 @@
 
 require_once realpath(dirname(__FILE__) . "/../www/class/centreon-knowledge/wikiApi.class.php");
 
-$wikiApi = new WikiApi();
-$wikiApi->synchronize();
+try {
+    $wikiApi = new WikiApi();
+    $wikiApi->synchronize();
+} catch (Exception $e) {
+    echo $e->getMessage(), "\n";
+}

--- a/www/class/centreon-knowledge/wiki.class.php
+++ b/www/class/centreon-knowledge/wiki.class.php
@@ -64,8 +64,8 @@ class Wiki
         }
         $res->free();
 
-        if (!count($options)) {
-            throw new \Exception('Wiki is not configured.');
+        if ($options['kb_wiki_url'] == '') {
+            throw new \Exception('Wiki is not configured. You can disable cron in /etc/crond.d/centreon for wiki synchronization.');
         }
 
         if (!preg_match('#^http://|https://#',  $options['kb_wiki_url'])) {

--- a/www/class/centreon-knowledge/wiki.class.php
+++ b/www/class/centreon-knowledge/wiki.class.php
@@ -64,8 +64,10 @@ class Wiki
         }
         $res->free();
 
-        if ($options['kb_wiki_url'] == '') {
-            throw new \Exception('Wiki is not configured. You can disable cron in /etc/crond.d/centreon for wiki synchronization.');
+        if (!isset($options['kb_wiki_url']) || $options['kb_wiki_url'] == '') {
+            throw new \Exception(
+                'Wiki is not configured. ' .
+                'You can disable cron in /etc/crond.d/centreon for wiki synchronization.');
         }
 
         if (!preg_match('#^http://|https://#',  $options['kb_wiki_url'])) {


### PR DESCRIPTION
Bacause empty values are present in centreon database, the following check is always OK:

if (!count($options))