### PR TITLE
ref #5272 - Can't duplicate trap definition

### DIFF
--- a/www/include/configuration/configObject/traps/traps.php
+++ b/www/include/configuration/configObject/traps/traps.php
@@ -43,7 +43,10 @@ $inputArguments = array(
         'filter' => FILTER_SANITIZE_STRING,
         'flags' => FILTER_REQUIRE_ARRAY
     ),
-    'dupNbr' => FILTER_SANITIZE_STRING
+    'dupNbr' => array(
+        'filter' => FILTER_SANITIZE_STRING,
+        'flags' => FILTER_REQUIRE_ARRAY
+    ),
 );
 $inputGet = filter_input_array(
     INPUT_GET,


### PR DESCRIPTION
$dupNbr is an array and not a string