### PR TITLE
Do not export empty Centreon Broker parameters with API

### DIFF
--- a/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
+++ b/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
@@ -747,7 +747,7 @@ class CentreonCentbrokerCfg extends CentreonObject
                     }
                     $row['config_value'] = CentreonUtils::convertLineBreak($row['config_value']);
                     if ($row['config_value'] != '') {
-                        $setParamStr[$row['config_group'] . '_' . $row['config_group_id']] . =
+                        $setParamStr[$row['config_group'] . '_' . $row['config_group_id']] .=
                             $this->action.$this->delim."SET".strtoupper($row['config_group']) .
                             $this->delim.$element['config_name'] .
                             $this->delim.$row['config_group_id'] .

--- a/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
+++ b/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
@@ -747,12 +747,12 @@ class CentreonCentbrokerCfg extends CentreonObject
                     }
                     $row['config_value'] = CentreonUtils::convertLineBreak($row['config_value']);
                     if ($row['config_value'] != '') {
-                        $setParamStr[$row['config_group'].'_'.$row['config_group_id']] .=
-                            $this->action.$this->delim."SET".strtoupper($row['config_group']).
-                            $this->delim.$element['config_name'].
-                            $this->delim.$row['config_group_id'].
-                            $this->delim.$row['config_key'].
-                            $this->delim.$row['config_value']."\n";
+                        $setParamStr[$row['config_group'] . '_'.$row['config_group_id']] . =
+                            $this->action.$this->delim."SET".strtoupper($row['config_group']) .
+                            $this->delim.$element['config_name'] .
+                            $this->delim.$row['config_group_id'] .
+                            $this->delim.$row['config_key'] .
+                            $this->delim.$row['config_value'] . "\n";
                     }
                 } elseif ($row['config_key'] == 'name') {
                     $addParamStr[$row['config_group'].'_'.$row['config_group_id']] =

--- a/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
+++ b/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
@@ -747,7 +747,7 @@ class CentreonCentbrokerCfg extends CentreonObject
                     }
                     $row['config_value'] = CentreonUtils::convertLineBreak($row['config_value']);
                     if ($row['config_value'] != '') {
-                        $setParamStr[$row['config_group'] . '_'.$row['config_group_id']] . =
+                        $setParamStr[$row['config_group'] . '_' . $row['config_group_id']] . =
                             $this->action.$this->delim."SET".strtoupper($row['config_group']) .
                             $this->delim.$element['config_name'] .
                             $this->delim.$row['config_group_id'] .

--- a/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
+++ b/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
@@ -746,12 +746,14 @@ class CentreonCentbrokerCfg extends CentreonObject
                         $setParamStr[$row['config_group'].'_'.$row['config_group_id']] = "";
                     }
                     $row['config_value'] = CentreonUtils::convertLineBreak($row['config_value']);
-                    $setParamStr[$row['config_group'].'_'.$row['config_group_id']] .=
-                        $this->action.$this->delim."SET".strtoupper($row['config_group']).
-                        $this->delim.$element['config_name'].
-                        $this->delim.$row['config_group_id'].
-                        $this->delim.$row['config_key'].
-                        $this->delim.$row['config_value']."\n";
+                    if ($row['config_value'] != '') {
+                        $setParamStr[$row['config_group'].'_'.$row['config_group_id']] .=
+                            $this->action.$this->delim."SET".strtoupper($row['config_group']).
+                            $this->delim.$element['config_name'].
+                            $this->delim.$row['config_group_id'].
+                            $this->delim.$row['config_key'].
+                            $this->delim.$row['config_value']."\n";
+                    }
                 } elseif ($row['config_key'] == 'name') {
                     $addParamStr[$row['config_group'].'_'.$row['config_group_id']] =
                         $this->action.$this->delim."ADD".strtoupper($row['config_group']).


### PR DESCRIPTION
Remove for CLAPI epxort empty Centreon Broker configuration parameters. for example:

@@ -1363,20 +1363,11 @@
 CENTBROKERCFG;SETPARAM;Central Broker;daemon;1
 CENTBROKERCFG;ADDINPUT;Central Broker;CentralMaster;ipv4
 CENTBROKERCFG;SETINPUT;Central Broker;1;port;5669
-CENTBROKERCFG;SETINPUT;Central Broker;1;host;
-CENTBROKERCFG;SETINPUT;Central Broker;1;failover;
-CENTBROKERCFG;SETINPUT;Central Broker;1;retry_interval;
-CENTBROKERCFG;SETINPUT;Central Broker;1;buffering_timeout;
 CENTBROKERCFG;SETINPUT;Central Broker;1;protocol;bbdo
 CENTBROKERCFG;SETINPUT;Central Broker;1;tls;no
-CENTBROKERCFG;SETINPUT;Central Broker;1;private_key;
-CENTBROKERCFG;SETINPUT;Central Broker;1;public_cert;
-CENTBROKERCFG;SETINPUT;Central Broker;1;ca_certificate;
 CENTBROKERCFG;SETINPUT;Central Broker;1;negociation;yes
 CENTBROKERCFG;SETINPUT;Central Broker;1;one_peer_retention_mode;no
 CENTBROKERCFG;SETINPUT;Central Broker;1;compression;no
-CENTBROKERCFG;SETINPUT;Central Broker;1;compression_level;
-CENTBROKERCFG;SETINPUT;Central Broker;1;compression_buffer;
 CENTBROKERCFG;SETINPUT;Central Broker;1;type;ipv4
 CENTBROKERCFG;ADDLOGGER;Central Broker;/var/log/centreon-broker/central-broker.log;file
 CENTBROKERCFG;SETLOGGER;Central Broker;1;config;yes