### PR TITLE
remove sudo rule for centengine -v call

### DIFF
--- a/tmpl/install/sudoersCentreonEngine
+++ b/tmpl/install/sudoersCentreonEngine
@@ -22,7 +22,6 @@ CENTREON   ALL = NOPASSWD: /usr/sbin/service centengine start
 CENTREON   ALL = NOPASSWD: /usr/sbin/service centengine stop
 CENTREON   ALL = NOPASSWD: /usr/sbin/service centengine restart
 CENTREON   ALL = NOPASSWD: /usr/sbin/service centengine reload
-CENTREON   ALL = NOPASSWD: /usr/sbin/centengine -v *
 
 # Centreon Broker
 CENTREON   ALL = NOPASSWD: /sbin/service cbd start


### PR DESCRIPTION
Centreon engine is able to read his own files. So the rule is useless.