### PR TITLE
Do not list meta service to link to a SNMP trap - issue #5418

### DIFF
--- a/www/include/configuration/configObject/traps/formTraps.php
+++ b/www/include/configuration/configObject/traps/formTraps.php
@@ -114,7 +114,7 @@ $attrManufacturer= array(
 );
 $attrServices = array(
     'datasourceOrigin' => 'ajax',
-    'availableDatasetRoute' => './include/common/webServices/rest/internal.php?object=centreon_configuration_service&action=list',
+    'availableDatasetRoute' => './include/common/webServices/rest/internal.php?object=centreon_configuration_service&action=list&s=s',
     'multiple' => true,
     'linkedObject' => 'centreonService'
 );


### PR DESCRIPTION
Meta services are active only and it is not necessary to link a SNMP trap