### PR TITLE
Web post install

### DIFF
--- a/doc/en/installation/from_packages.rst
+++ b/doc/en/installation/from_packages.rst
@@ -62,9 +62,11 @@ Perform the command:
  ::
 
   $ yum install centreon-base-config-centreon-engine centreon
+  $ service centcore start
+  $ service httpd start
 
 
-:ref:`After this step you should connect to Centreon to finalise the installation process <installation_web_ces>`.
+:ref:`After this step you should look at the Post-package steps and connect to Centreon to finalise the installation process <installation_web_ces>`.
 
 Installing a poller
 -------------------


### PR DESCRIPTION
To connect, services have to be started and the firewall turned off or allowed; Reading the post package steps is thus a need.
You could also propose the rule for the default firewall of CentOS 7 :

```
$ firewall-cmd --zone=public --add-port=80/tcp --permanent
$ firewall-cmd --reload
```