### PR TITLE
Fix graph display with special characters #5554

### DIFF
--- a/www/class/centreonGraphService.class.php
+++ b/www/class/centreonGraphService.class.php
@@ -112,7 +112,6 @@ class CentreonGraphService extends CentreonGraph
                 $vname[$metric['metric']] = 'v' . $i;
                 $info = array(
                     "data" => array(),
-                    "legend" => $metric["metric_legend"],
                     "graph_type" => "line",
                     "unit" => $metric["unit"],
                     "color" => $metric["ds_color_line"],
@@ -121,6 +120,7 @@ class CentreonGraphService extends CentreonGraph
                     "crit" => null,
                     "warn" => null
                 );
+                $info['legend'] = str_replace('\\\\', '\\', $metric['metric_legend']);
 
                 /* Add legend getting data */
                 foreach ($legendDataInfo as $name => $key) {
@@ -135,7 +135,7 @@ class CentreonGraphService extends CentreonGraph
                             $displayformat = "%7.2lf";
                         }
                         $commandLegendLine .= ' VDEF:l' . $i . $key . '=v' . $i . ',' . $key;
-                        $commandLegendLine .= ' PRINT:l' . $i . $key . ':"' . $metric["metric_legend"] .
+                        $commandLegendLine .= ' PRINT:l' . $i . $key . ':"' . str_replace(':', '\:', $metric['metric_legend']) .
                             '|' . ucfirst($name) . '|' . $displayformat . '"';
                     }
                 }

--- a/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/www/include/monitoring/objectDetails/serviceDetails.php
@@ -433,7 +433,7 @@ if (!is_null($host_id)) {
 
         $optionsURL = "host_name=" . urlencode($host_name) . "&service_description=" . urlencode($svc_description);
 
-        $DBRES = $pearDBO->query("SELECT id FROM `index_data`, metrics WHERE metrics.index_id = index_data.id AND host_name LIKE '" . $pearDBO->escape($host_name) . "' AND service_description LIKE '" . $pearDBO->escape($svc_description) . "' LIMIT 1");
+        $DBRES = $pearDBO->query("SELECT id FROM `index_data` WHERE host_name = '" . $pearDBO->escape($host_name) . "' AND service_description = '" . $pearDBO->escape($svc_description) . "' LIMIT 1");
         $index_data = 0;
         if ($DBRES->numRows()) {
             $row = $DBRES->fetchRow();

--- a/www/include/views/graphs/graphs.html
+++ b/www/include/views/graphs/graphs.html
@@ -196,7 +196,7 @@
 <script src="./include/common/javascript/jquery/jquery.cookie.js"></script>
 <script src="./include/common/javascript/centreon/centreon-tour.js"></script>
 <script>
-var defaultCharts = JSON.parse('{$defaultCharts}');
+var defaultCharts = {$defaultCharts};
 var nbDisplayedCharts = {$nbDisplayedCharts};
 var tooManyChartMsg = "{t}You cannot add more charts. The maximum charts is {/t}" + nbDisplayedCharts;
 </script>


### PR DESCRIPTION
The problem is when we click on  the link of a service graph from monitoring page.

My patch also fixed:
* metrics with backslash and ':' in the name