### PR TITLE
5611 improve centreon documentation

### DIFF
--- a/doc/en/installation/from_packages.rst
+++ b/doc/en/installation/from_packages.rst
@@ -48,51 +48,18 @@ For CentOS 7.
 The repository is now installed.
 
 
-***************
-Package install
-***************
-
-Installing a central server
----------------------------
+************************
+Install a central server
+************************
 
 The chapter describes the installation of a Centreon central server.
 
 Perform the command:
 
- ::
+::
 
   $ yum install centreon-base-config-centreon-engine centreon
 
-
-:ref:`After this step you should connect to Centreon to finalise the installation process <installation_web_ces>`.
-
-Installing a poller
--------------------
-
-This chapter describes the installation of a collector.
-
-Perform the command:
-
- ::
-
- $ yum install centreon-poller-centreon-engine
-
-The communication between a central server and a poller server is by SSH.
-
-You should exchange the SSH keys between the servers.
-
-If you don’t have any private SSH keys on the central server for the Centreon user:
-
- ::
-
- $ su - centreon
- $ ssh-keygen -t rsa
-
-Copy this key on the collector:
-
- ::
-
- $ ssh-copy-id centreon@your_poller_ip
 
 Installing MySQL on the same server
 -----------------------------------
@@ -101,20 +68,16 @@ This chapter describes the installation of MySQL on a server including Centreon.
 
 Perform the command:
 
-  ::
+::
 
    $ yum install MariaDB-server
    $ service mysql restart
 
 
-******************
-Post-package steps
-******************
-
 PHP timezone
 ------------
 
-PHP timezone should be set; go to /etc/php.d directory and create a file named php-timezone.ini who contain the following line :
+PHP timezone should be set; go to /etc/php.d directory and create a file named php-timezone.ini which contains the following line :
 
 ::
 
@@ -153,3 +116,37 @@ Setting this option into /etc/my.cnf will NOT work.
    # echo -ne "[Service]\nLimitNOFILE=32000\n" | tee /etc/systemd/system/mariadb.service.d/limits.conf
    # systemctl daemon-reload
    # service mysql restart
+
+Conclude installation
+---------------------
+
+:ref:`click here to finalise the installation process <installation_web_ces>`.
+
+*******************
+Installing a poller
+*******************
+
+This chapter describes the installation of a collector.
+
+Perform the command:
+
+::
+
+  $ yum install centreon-poller-centreon-engine
+
+The communication between a central server and a poller server is by SSH.
+
+You should exchange the SSH keys between the servers.
+
+If you don’t have any private SSH keys on the central server for the Centreon user:
+
+::
+
+    $ su - centreon
+    $ ssh-keygen -t rsa
+
+Copy this key on the collector:
+
+::
+
+    $ ssh-copy-id centreon@your_poller_ip

--- a/doc/en/installation/from_packages.rst
+++ b/doc/en/installation/from_packages.rst
@@ -18,8 +18,8 @@ SELinux should be disabled; for this, you have to modify the file */etc/selinux/
 
     SELINUX=disabled
 
-After saving the file, please reboot your operating system to apply the changes.
-
+.. note::
+    After saving the file, please reboot your operating system to apply the changes.
 
 ******************
 Repository install

--- a/doc/fr/installation/from_packages.rst
+++ b/doc/fr/installation/from_packages.rst
@@ -50,51 +50,17 @@ Pour CentOS 7.
 Le dépôt est maintenant installé.
 
 
-************************
-Installation des paquets
-************************
-
-Installer un serveur central
-----------------------------
+*******************************
+Installation du serveur central
+*******************************
 
 Ce chapitre décrit l'installation d'un serveur central Centreon.
 
 Exécutez la commande :
 
- ::
+::
 
   $ yum install centreon-base-config-centreon-engine centreon
-
-
-:ref:`A la fin de cette étape, connectez-vous à Centreon pour finaliser le processus d'installation <installation_web_ces>`.
-
-Installer un collecteur
------------------------
-
-Ce chapitre décrit l'installation d'un collecteur.
-
-Exécutez la commande :
-
-  ::
-
-  $ yum install centreon-poller-centreon-engine
-
-La communication entre le serveur central et un collecteur se fait via SSH.
-
-Vous devez échanger les clés SSH entre les serveurs.
-
-Si vous n'avez pas de clé SSH privés sur le serveur central pour l'utilisateur 'centreon' :
-
-  ::
-
-  $ su - centreon
-  $ ssh-keygen -t rsa
-
-Vous devez copier cette clé sur le collecteur :
-
-  ::
-
-  $ ssh-copy-id centreon@your_poller_ip
 
 Installer MySQL sur le même serveur
 -----------------------------------
@@ -103,15 +69,10 @@ Ce chapitre décrit l'installation de MySQL sur un serveur comprenant Centreon.
 
 Exécutez la commande :
 
-  ::
+::
 
    $ yum install MariaDB-server
    $ service mysql restart
-
-
-*******************
-Étapes post-paquets
-*******************
 
 Fuseau horaire PHP
 ------------------
@@ -155,3 +116,36 @@ Changer cette option dans /etc/my.cnf NE fonctionnera PAS.
    # echo -ne "[Service]\nLimitNOFILE=32000\n" | tee /etc/systemd/system/mariadb.service.d/limits.conf
    # systemctl daemon-reload
    # service mysqld restart
+
+Terminer l'installation
+-----------------------
+
+:ref:`Clicquer ici pour finaliser le processus d'installation <installation_web_ces>`.
+
+Installer un collecteur
+-----------------------
+
+Ce chapitre décrit l'installation d'un collecteur.
+
+Exécutez la commande :
+
+::
+
+    $ yum install centreon-poller-centreon-engine
+
+La communication entre le serveur central et un collecteur se fait via SSH.
+
+Vous devez échanger les clés SSH entre les serveurs.
+
+Si vous n'avez pas de clé SSH privés sur le serveur central pour l'utilisateur 'centreon' :
+
+::
+
+   $ su - centreon
+   $ ssh-keygen -t rsa
+
+Vous devez copier cette clé sur le collecteur :
+
+::
+
+    $ ssh-copy-id centreon@your_poller_ip

--- a/doc/fr/installation/from_packages.rst
+++ b/doc/fr/installation/from_packages.rst
@@ -20,8 +20,8 @@ SELinux doit être désactivé. Pour cela vous devez modifier le fichier */etc/s
 
     SELINUX=disabled
 
-Après avoir sauvegardé le fichier, veuillez redémarrer votre système d'exploitation pour prendre en compte les changements.
-
+.. note::
+    Après avoir sauvegardé le fichier, veuillez redémarrer votre système d'exploitation pour prendre en compte les changements.
 
 ***********************
 Installation des dépôts

--- a/doc/fr/installation/from_packages.rst
+++ b/doc/fr/installation/from_packages.rst
@@ -107,7 +107,7 @@ Système de gestion de base de données
 
 La base de données MySQL doit être disponible pour pouvoir continuer l'installation (localement ou non). Pour information nous recommandons MariaDB.
 
-Pour les système CentOS / RHEL en verison 7, il est nécessaire de modifidier la limitation **LimitNOFILE**.
+Pour les systèmes CentOS / RHEL en version 7, il est nécessaire de modifier la limitation **LimitNOFILE**.
 Changer cette option dans /etc/my.cnf NE fonctionnera PAS.
 
 ::
@@ -137,7 +137,7 @@ La communication entre le serveur central et un collecteur se fait via SSH.
 
 Vous devez échanger les clés SSH entre les serveurs.
 
-Si vous n'avez pas de clé SSH privés sur le serveur central pour l'utilisateur 'centreon' :
+Si vous n'avez pas de clé SSH privées sur le serveur central pour l'utilisateur 'centreon' :
 
 ::
 


### PR DESCRIPTION
fix(doc): Improve Centreon documentation

For UK and FR installation chapter using package, I moved post-installation subchapter before finish Centreon web installation to do not have errors during process.

I added notice label to advice user that they have to restart server after disable SElinux.

I have corrected some spelling errors

refs: #5611