### PR TITLE
Clarify documentation of centreon clapi authentication

### DIFF
--- a/doc/en/api/clapi/overview.rst
+++ b/doc/en/api/clapi/overview.rst
@@ -23,7 +23,10 @@ All actions in Centreon CLAPI will require authentication, so your commands will
   # cd /usr/share/centreon/bin
   # ./centreon -u admin -p centreon [...]
 
-Obviously, the **-u** option is for the username and the **-p** option is for the password. If your passwords 
-are encoded with SHA1 in database, use the **-s** option::
+Obviously, the **-u** option is for the username and the **-p** option is for the password.
+The password can be in clear or the encrypted in the database.
+
+.. note::
+    If your passwords are encoded with SHA1 in database (MD5 by default), use the **-s** option::
 
   # ./centreon -u admin -p centreon -s [...]

--- a/doc/fr/api/clapi/overview.rst
+++ b/doc/fr/api/clapi/overview.rst
@@ -23,7 +23,10 @@ All actions in Centreon CLAPI will require authentication, so your commands will
   # cd /usr/share/centreon/bin
   # ./centreon -u admin -p centreon [...]
 
-Obviously, the **-u** option is for the username and the **-p** option is for the password. If your passwords 
-are encoded with SHA1 in database, use the **-s** option::
+Obviously, the **-u** option is for the username and the **-p** option is for the password.
+The password can be in clear or the encrypted in the database.
+
+.. note::
+    If your passwords are encoded with SHA1 in database (MD5 by default), use the **-s** option::
 
   # ./centreon -u admin -p centreon -s [...]


### PR DESCRIPTION
fix(doc): Clarify documentation of Centreon clapi authentication

Added in the documentation the possibility to use the encrypted password (in base) or the password in clear

refs: #5625 