### PR TITLE
fix(conf): Multiple 'update mode' fields in massive changes

### DIFF
--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -201,7 +201,7 @@
 		<tr class="list_lvl_1">
 		    <td class="ListColLvl1_name" colspan="2"><h4>{t}Notification options{/t}</h4></td>
 		</tr>
-	    {if $o == "mc"}
+	        {if $o == "mc"}
 		<tr class="list_two">
 			<td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_notifopts.label}</td>
 			<td class="FormRowValue">{$form.mc_mod_notifopts.html}</td>
@@ -211,13 +211,7 @@
 			<td class="FormRowField"><img class="helpTooltip" name="notification_options"> {$form.host_notifOpts.label}</td>
 			<td class="FormRowValue">{$form.host_notifOpts.html}</td>
 		</tr>
-	    {if $o == "mc"}
-	    <tr class="list_two">
-	    	<td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_hcg.label}</td>
-	    	<td class="FormRowValue">{$form.mc_mod_hcg.html}</td>
-	    </tr>
-		{/if}
-        {if $o == "mc"}
+	       {if $o == "mc"}
 		<tr class="list_one">
 			<td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_notifopt_notification_interval.label}</td>
 			<td class="FormRowValue">{$form.mc_mod_notifopt_notification_interval.html}</td>


### PR DESCRIPTION
fix(conf): Multiple 'update mode' fields in massive changes

Remove duplicate 'update mode' fields

refs: #5266 