### PR TITLE
fix(installBroker) Db conf changed to improve downtimes settings

### DIFF
--- a/www/install/installBroker.sql
+++ b/www/install/installBroker.sql
@@ -115,7 +115,7 @@ CREATE TABLE `downtimes` (
   `triggered_by` int(11) DEFAULT NULL,
   `type` smallint(6) DEFAULT NULL,
   PRIMARY KEY (`downtime_id`),
-  UNIQUE KEY `entry_time` (`entry_time`,`host_id`,`service_id`),
+  UNIQUE KEY `entry_time` (`entry_time`,`instance_id`,`internal_id`),
   KEY `host_id` (`host_id`),
   KEY `instance_id` (`instance_id`),
   KEY `entry_time_2` (`entry_time`),

--- a/www/install/sql/centstorage/Update-CSTG-2.8.13_to_2.8.14.sql
+++ b/www/install/sql/centstorage/Update-CSTG-2.8.13_to_2.8.14.sql
@@ -1,3 +1,8 @@
 ALTER TABLE `comments`
   DROP INDEX `entry_time`,
   ADD UNIQUE KEY `entry_time` (`entry_time`,`host_id`,`service_id`, `instance_id`, `internal_id`);
+
+ALTER TABLE `downtimes`
+  DROP INDEX `entry_time`,
+  ADD UNIQUE KEY `entry_time` (`entry_time`,`instance_id`,`internal_id`);
+


### PR DESCRIPTION
If we set two downtimes at the same date, the same host and the same
service. Broker considers them as the same.