### PR TITLE
fix(install): update /comments/ table UNIQUE constraint.

### DIFF
--- a/www/install/sql/centstorage/Update-CSTG-2.8.13_to_2.8.14.sql
+++ b/www/install/sql/centstorage/Update-CSTG-2.8.13_to_2.8.14.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `comments`
+  DROP INDEX `entry_time`,
+  ADD UNIQUE KEY `entry_time` (`entry_time`,`host_id`,`service_id`, `instance_id`, `internal_id`);


### PR DESCRIPTION
Comments are referenced through their entry_time, host_id, service_id,
instance_id and internal_id. While this was properly made in the
fresh install script, users migrating from earlier versions never had
a chance to get the UNIQUE constraint set right.