### PR TITLE
fix(test): do not use massive change option that was removed from the interface

### DIFF
--- a/features/bootstrap/MassiveChangeHostsContext.php
+++ b/features/bootstrap/MassiveChangeHostsContext.php
@@ -82,7 +82,6 @@ class MassiveChangeHostsContext extends CentreonContext
         'notify_on_downtime_scheduled' => 1,
         'notify_on_none' => 0,
         'notification_interval' => 17,
-        'update_mode_hcg' => 1,
         'update_mode_notif_interval' => 0,
         'update_mode_timeperiod' => 0,
         'notification_period' => 'none',


### PR DESCRIPTION
The massive change option was removed from the contact groups field of the
host configuration page. Tests should not use it.