### PR TITLE
Master fix downtime start stop tests

### DIFF
--- a/features/bootstrap/DowntimeStartAndStopContext.php
+++ b/features/bootstrap/DowntimeStartAndStopContext.php
@@ -66,12 +66,7 @@ class DowntimeStartAndStopContext extends CentreonContext
     {
 
         $page = new DowntimeConfigurationPage($this);
-
-        $downtimeEndTime = '+1 minutes';
-        $currentSeconds = date("s");
-        if ($currentSeconds >= 45) {
-            $downtimeEndTime = '+2 minutes';
-        }
+        $downtimeEndTime = '+2 minutes';
         $this->downtimeEndTime = date("H:i", strtotime($downtimeEndTime));
         $page->setProperties(array(
             'type' => DowntimeConfigurationPage::TYPE_SERVICE,
@@ -91,12 +86,7 @@ class DowntimeStartAndStopContext extends CentreonContext
         $this->submitServiceResult($this->host, $this->service, 0, __FUNCTION__);
 
         $page = new DowntimeConfigurationPage($this);
-
-        $downtimeEndTime = '+1 minutes';
-        $currentSeconds = date("s");
-        if ($currentSeconds >= 45) {
-            $downtimeEndTime = '+2 minutes';
-        }
+        $downtimeEndTime = '+2 minutes';
         $this->downtimeEndTime = date("H:i", strtotime($downtimeEndTime));
         $page->setProperties(array(
             'type' => DowntimeConfigurationPage::TYPE_SERVICE,


### PR DESCRIPTION
Increase downtime length to prevent early downtime termination (might need to be 3 minutes long if 2 minutes is not enough).