### PR TITLE
fix(api): Add backslash to load Centreon class in CentreonClapi namespace

### DIFF
--- a/www/class/centreon-clapi/centreonAPI.class.php
+++ b/www/class/centreon-clapi/centreonAPI.class.php
@@ -505,8 +505,8 @@ class CentreonAPI
                     \CentreonClapi\CentreonUtils::setUserId($row['contact_id']);
                     return 1;
                 } elseif ($row['contact_auth_type'] == 'ldap') {
-                    $CentreonLog = new CentreonUserLog(-1, $this->DB);
-                    $centreonAuth = new CentreonAuthLDAP(
+                    $CentreonLog = new \CentreonUserLog(-1, $this->DB);
+                    $centreonAuth = new \CentreonAuthLDAP(
                         $this->DB,
                         $CentreonLog,
                         $this->login,


### PR DESCRIPTION
Add "\" before CentreonUserLog and CentreonAuthLDAP to load this Centreon classes in CentreonClapi namespace

refs: #/5710