### PR TITLE
chore(build): run PPM 2.3 build at the end of Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,7 @@ try {
     }
     build job: 'centreon-license-manager/1.0', wait: false
     build job: 'centreon-poller-display/1.6.x', wait: false
-    build job: 'centreon-pp-manager/2.2', wait: false
+    build job: 'centreon-pp-manager/2.3', wait: false
     build job: 'centreon-bam/3.5.x', wait: false
     build job: 'des-mbi-bundle-centos6', wait: false
     build job: 'des-mbi-bundle-centos7', wait: false


### PR DESCRIPTION
PPM 2.2 should be superseeded by PPM 2.3 soon.