### PR TITLE
Apply PR #5616 on master for top counter

### DIFF
--- a/www/include/monitoring/status/TopCounter/xml/statusCounter.php
+++ b/www/include/monitoring/status/TopCounter/xml/statusCounter.php
@@ -110,77 +110,37 @@ $DBRESULT->closeCursor();
 /* *********************************************
  * Get Service stats
  */
+$query_svc_status = "SELECT " .
+    "SUM(CASE WHEN s.state = 0 THEN 1 ELSE 0 END) AS OK_TOTAL, " .
+    "SUM(CASE WHEN s.state = 1 THEN 1 ELSE 0 END) AS WARNING_TOTAL, " .
+    "SUM(CASE WHEN s.state = 1 AND (s.acknowledged = '1' OR s.scheduled_downtime_depth = '1') " .
+    "    THEN 1 ELSE 0 END) AS WARNING_ACK_DT, " .
+    "SUM(CASE WHEN s.state = 2 THEN 1 ELSE 0 END) AS CRITICAL_TOTAL, " .
+    "SUM(CASE WHEN s.state = 2 AND (s.acknowledged = '1' OR s.scheduled_downtime_depth = '1') " .
+    "    THEN 1 ELSE 0 END) AS CRITICAL_ACK_DT, " .
+    "SUM(CASE WHEN s.state = 3 THEN 1 ELSE 0 END) AS UNKNOWN_TOTAL, " .
+    "SUM(CASE WHEN s.state = 3 AND (s.acknowledged = '1' OR s.scheduled_downtime_depth = '1') " .
+    "    THEN 1 ELSE 0 END) AS UNKNOWN_ACK_DT, " .
+    "SUM(CASE WHEN s.state = 4 THEN 1 ELSE 0 END) AS PENDING_TOTAL " .
+    "FROM hosts h, services s, instances i " .
+    "WHERE i.deleted = 0 " .
+    "AND h.enabled = 1 " .
+    "AND s.enabled = 1 " .
+    "AND i.instance_id = h.instance_id " .
+    "AND h.host_id = s.host_id " .
+    "AND (h.name NOT LIKE '_Module_%' OR h.name LIKE '_Module_Meta%') ";
 if (!$obj->is_admin) {
-    $rq2 =  " SELECT COUNT(DISTINCT CONCAT(hosts.host_id,';', services.service_id)) as number, services.state" .
-            " FROM hosts, services, instances, centreon_acl " .
-            " WHERE instances.instance_id = hosts.instance_id ". 
-            " AND instances.deleted = 0 ".
-            " AND services.host_id = centreon_acl.host_id ".
-            " AND services.service_id = centreon_acl.service_id " .
-            " AND centreon_acl.group_id IN (".$obj->grouplistStr.") ".
-            " AND hosts.host_id = services.host_id".
-            " AND hosts.enabled = 1 " .
-            " AND services.enabled = 1 " .
-            " AND (hosts.name NOT LIKE '_Module_%' OR hosts.name LIKE '_Module_meta%')".
-            " GROUP BY services.state";
-} else {
-    $rq2 =  " SELECT count(services.state) AS number, services.state" .
-            " FROM hosts, services, instances" .
-            " WHERE instances.deleted = 0 ".
-            " AND hosts.enabled = 1 " .
-            " AND services.enabled = 1 " .
-            " AND instances.instance_id = hosts.instance_id ". 
-            " AND hosts.host_id = services.host_id".
-            " AND (hosts.name NOT LIKE '_Module_%' OR hosts.name LIKE '_Module_meta%') ".
-            " GROUP BY services.state";
+	$query_svc_status .=  "AND s.service_id IN ( " .
+	"SELECT DISTINCT service_id " .
+	"FROM centreon_acl " .
+	"WHERE centreon_acl.group_id IN (" . $obj->grouplistStr . ")) ";
 }
-$serviceCounter = 0;
-$svc_stat = array(0=>0, 1=>0, 2=>0, 3=>0, 4=>0, 6=>0, 7=>0, 8=>0);
-$DBRESULT = $obj->DBC->query($rq2);
-while ($data = $DBRESULT->fetchRow()) {
-    $svc_stat[$data["state"]] = $data["number"];
-    $serviceCounter += $svc_stat[$data["state"]];
-}
-$DBRESULT->closeCursor();
-
-/* ********************************************
- *  Get Real non-ok Status
- */
-if (!$obj->is_admin) {
-    $rq3 =  " SELECT COUNT(DISTINCT CONCAT(s.service_id,';', s.host_id)) as number, s.state_type, s.acknowledged, s.scheduled_downtime_depth, s.state " .
-            " FROM services s, hosts h, centreon_acl " .
-            " WHERE centreon_acl.host_id IS NOT NULL " .
-            "   AND s.host_id = centreon_acl.host_id ".
-            "   AND s.service_id = centreon_acl.service_id " .
-            " 	AND s.host_id = h.host_id " .
-            "   AND s.state <> '0' " .
-            "	AND s.scheduled_downtime_depth = '0' " .
-            "	AND s.acknowledged = '0' " .
-            "   AND h.state = '0' " .
-            "   AND s.enabled = 1 " .
-            "   AND h.enabled = 1 " .
-            "   AND (h.name NOT LIKE '_Module_%' OR h.name LIKE '_Module_meta%') ".
-            "   AND centreon_acl.group_id IN (".$obj->grouplistStr.") ".
-            " GROUP BY s.state, s.acknowledged, s.scheduled_downtime_depth";
-} else {
-    $rq3 =  " SELECT COUNT(DISTINCT CONCAT(s.service_id,';', s.host_id)) as number, s.state_type, s.acknowledged, s.scheduled_downtime_depth, s.state " .
-            " FROM services s, hosts h " .
-            " WHERE s.host_id = h.host_id " .
-            "   AND s.state <> '0' " .
-            "	AND s.scheduled_downtime_depth = '0' " .
-            "	AND s.acknowledged = '0' " .
-            "	AND h.state = '0' " .
-            "   AND s.enabled = 1 " .
-            "   AND h.enabled = 1 " .
-            "   AND (h.name NOT LIKE '_Module_%' OR h.name LIKE '_Module_meta%') ".
-            " GROUP BY s.state, s.acknowledged, s.scheduled_downtime_depth";
-}
-$DBRESULT = $obj->DBC->query($rq3);
-while ($data = $DBRESULT->fetchRow()) {
-    $svc_stat[$data["state"] + 5] = $data["number"];
-}
-$DBRESULT->closeCursor();
-unset($data);
+$DBRESULT = $obj->DBC->query($query_svc_status);
+$svc_stat = array_map("myDecode", $DBRESULT->fetchRow());
+$DBRESULT->free();
+$serviceCounter = $svc_stat["OK_TOTAL"] + $svc_stat["WARNING_TOTAL"] 
+    + $svc_stat["CRITICAL_TOTAL"] + $svc_stat["UNKNOWN_TOTAL"] 
+    + $svc_stat["PENDING_TOTAL"];
 
 /* ********************************************
  * Check Poller Status
@@ -303,14 +263,14 @@ $obj->XML->endElement();
 $obj->XML->startElement("s");
 $obj->XML->writeElement("th", $hostCounter);
 $obj->XML->writeElement("ts", $serviceCounter);
-$obj->XML->writeElement("o", $svc_stat["0"]);
-$obj->XML->writeElement("w", $svc_stat["1"]);
-$obj->XML->writeElement("wU", $svc_stat["6"]);
-$obj->XML->writeElement("c", $svc_stat["2"]);
-$obj->XML->writeElement("cU", $svc_stat["7"]);
-$obj->XML->writeElement("un1", $svc_stat["3"]);
-$obj->XML->writeElement("un1U", $svc_stat["8"]);
-$obj->XML->writeElement("p1", $svc_stat["4"]);
+$obj->XML->writeElement("o", $svc_stat["OK_TOTAL"]);
+$obj->XML->writeElement("w", $svc_stat["WARNING_TOTAL"]);
+$obj->XML->writeElement("wU", ($svc_stat["WARNING_TOTAL"] - $svc_stat["WARNING_ACK_DT"]));
+$obj->XML->writeElement("c", $svc_stat["CRITICAL_TOTAL"]);
+$obj->XML->writeElement("cU", ($svc_stat["CRITICAL_TOTAL"] - $svc_stat["CRITICAL_ACK_DT"]));
+$obj->XML->writeElement("un1", $svc_stat["UNKNOWN_TOTAL"]);
+$obj->XML->writeElement("un1U", ($svc_stat["UNKNOWN_TOTAL"] - $svc_stat["UNKNOWN_ACK_DT"]));
+$obj->XML->writeElement("p1", $svc_stat["PENDING_TOTAL"]);
 $obj->XML->writeElement("up", $host_stat["0"]);
 $obj->XML->writeElement("d", $host_stat["1"]);
 $obj->XML->writeElement("un2", $host_stat["2"]);


### PR DESCRIPTION
fix(monitoring) : Metaservices not counted properly in statuses filter

Merge SQL requests for statuses of services to:

combine ACL in one SQL request
combine selection of total services per status and total of ACK and DT services per status
This allow to correct issue with calculation of Meta-services

refs: #5458,  #5616