### PR TITLE
fix(test): use a freshly installed server when testing Clapi import/export

### DIFF
--- a/features/Clapi.feature
+++ b/features/Clapi.feature
@@ -4,7 +4,7 @@ Feature: Clapi
   To industrialize it
 
   Background:
-    Given a Centreon server
+    Given a freshly installed Centreon server
 
   @critical
   Scenario: import/export


### PR DESCRIPTION
This should fix the following error.

```
[centos7] Feature: Clapi
[centos7]   As a Centreon admin
[centos7]   I want to configure my centreon by command line
[centos7]   To industrialize it
[centos7] 
[centos7]   Background:               # features/Clapi.feature:6
[centos7]     Given a Centreon server # ClapiContext::aCentreonServer()
[centos7] 
[centos7]   @critical
[centos7]   Scenario: import/export                                   # features/Clapi.feature:10
[centos7]     Given a Clapi configuration file                        # ClapiContext::aClapiConfigurationFile()
[centos7]     And it was imported                                     # ClapiContext::itWasImported()
[centos7]       Cannot execute command on container web: Line 85 : Object already exists (Simple User) (command was centreon -u admin -p centreon -i /tmp/clapi-export.txt). (Exception)
[centos7]     │
[centos7]     ╳  Warning: file_put_contents(../acceptance-logs/2017-10-17-10-13-test_clapi-import/export.png): failed to open stream: No such file or directory in vendor/behat/mink-extension/src/Behat/MinkExtension/Context/RawMinkContext.php line 163
[centos7]     │
[centos7]     └─ @AfterStep # ClapiContext::takeScreenshotOnError()
[centos7]     When I export the configuration through Clapi           # ClapiContext::IExportTheConfigurationThroughClapi()
[centos7]     Then the exported file is similar to the imported filed # ClapiContext::theExportedFileIsSimilarToTheImportedFiled()
[centos7]   │
[centos7]   ╳  Warning: file_put_contents(../acceptance-logs/2017-10-17-10-13-test_clapi-import/export.txt): failed to open stream: No such file or directory in vendor/centreon/centreon-test-lib/src/behat/CentreonContext.php line 65
[centos7]   │
[centos7]   └─ @AfterScenario # ClapiContext::unsetContainer()
[centos7] 
[centos7] --- Failed scenarios:
[centos7] 
[centos7]     features/Clapi.feature:10
[centos7] 
[centos7] 1 scenario (1 failed)
[centos7] 5 steps (2 passed, 1 failed, 2 skipped)
[centos7] 0m20.16s (14.93Mb)
```