### PR TITLE
fix(monitoring): better rendering of notification config

### DIFF
--- a/www/include/monitoring/common-Func.php
+++ b/www/include/monitoring/common-Func.php
@@ -86,7 +86,7 @@ function get_notified_infos_for_host($hostId)
 {
     global $pearDB;
 
-    $loop = array();    
+    $loop = array();
     $stack = array($hostId);
     $hosts = array();
     $results = array('contacts' => array(), 'contactGroups' => array(), 'enableNotif' => 2);


### PR DESCRIPTION
+ fix asort function : SORT_NATURAL constant implemented since PHP 5.4, replaced by SORT_STRING for PHP 5.3 compatibility,
+ fix infinite loop : "continue" instead of "break",
+ handling of disabled notification on hosts and services (with templates inheritance),
+ handling of disabled contacts and contact groups,
+ handling of disabled notification on contacts,
+ fix case where service has no template and was ignored.