### PR TITLE
fix(chart): throw exception if no metrics

### DIFF
--- a/www/class/centreonGraphService.class.php
+++ b/www/class/centreonGraphService.class.php
@@ -95,6 +95,10 @@ class CentreonGraphService extends CentreonGraph
         $vname = array();
         $virtuals = array();
         $i = 0;
+        
+        if (empty($this->metrics)) {
+            throw new RuntimeException();
+        }
 
         /* Parse metrics */
         foreach ($this->metrics as $metric) {


### PR DESCRIPTION
If your service has no metrics, it shows errors in apache logs : 
+ PHP Warning:  simplexml_load_string(): Entity: line 1: parser error : Start tag expected, '&lt;' not found in /usr/share/centreon/www/class/centreonGraphService.class.php on line 233, referer: https://10.30.2.131/centreon/main.php?p=20201&o=svcd&host_name=cga-centreon34-centos7-poller-2&service_description=Partitioning
+ PHP Warning:  simplexml_load_string(): ERROR: can't make an xport without contents in /usr/share/centreon/www/class/centreonGraphService.class.php on line 233, referer: https://10.30.2.131/centreon/main.php?p=20201&o=svcd&host_name=cga-centreon34-centos7-poller-2&service_description=Partitioning
+ PHP Warning:  simplexml_load_string(): ^ in /usr/share/centreon/www/class/centreonGraphService.class.php on line 233, referer: https://10.30.2.131/centreon/main.php?p=20201&o=svcd&host_name=cga-centreon34-centos7-poller-2&service_description=Partitioning
