### PR TITLE
fix(monitoring): Custom MACRO not interpreted in URL in host real time

### DIFF
--- a/www/include/monitoring/status/Hosts/xml/hostXML.php
+++ b/www/include/monitoring/status/Hosts/xml/hostXML.php
@@ -375,7 +375,7 @@ while ($data = $DBRESULT->fetchRow()) {
         $str = str_replace("\$HOSTSTATE\$", $obj->statusHost[$data['state']], $str);
 
         $str = str_replace("\$INSTANCEADDRESS\$", $instanceObj->getParam($data['instance_name'], 'ns_ip_address'), $str);
-        $obj->XML->writeElement("hnu", CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["notes_url"], $str)));
+        $obj->XML->writeElement("hnu", CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], $str)));
     } else {
         $obj->XML->writeElement("hnu", "none");
     }


### PR DESCRIPTION
Correct call to replaceMacroInString function using name of object to translate custom macro

ref: #5846