### PR TITLE
fix(MON)Graphs streched in IE

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -2142,17 +2142,17 @@ textarea.default-textarea {
 
 /* -- Views Performance page -- */
 .graph-options {
-  display: flex;
-  justify-content: flex-end;
-  margin-bottom: 2px;
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 2px;
 }
 
 .graphZone {
-  margin-bottom: 40px;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: space-between;
+    margin-bottom: 40px;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    justify-content: space-between;
 }
 
 .graphZone.col2 .graph {


### PR DESCRIPTION
Css properties added to fix an issue with Internet Explorer 11, in Montoring->Perfomance, the second graph added was many times wider than the first one.

ref: MON-2052 #5081 #5683