### PR TITLE
API for commands arguments descriptions 

### DIFF
--- a/doc/en/api/clapi/objects/commands.rst
+++ b/doc/en/api/clapi/objects/commands.rst
@@ -94,3 +94,11 @@ comment     Comments regarding the command
 .. note::
   You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
+
+Describe_Args
+-------------
+
+If you want to change all arguments descriptions for a command, use the **DESCRIBE_ARGS** command::
+
+  [root@centreon ~]# ./centreon -u admin -p centreon -o CMD -a describe_args -v 'check_centreon_ping;ARG1:count;ARG2:warning;ARG3:critical'
+

--- a/doc/fr/api/clapi/objects/commands.rst
+++ b/doc/fr/api/clapi/objects/commands.rst
@@ -94,3 +94,11 @@ comment     Comments regarding the command
 .. note::
   You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
+
+Describe_Args
+-------------
+
+If you want to change all arguments descriptions for a command, use the **DESCRIBE_ARGS** command::
+
+  [root@centreon ~]# ./centreon -u admin -p centreon -o CMD -a describe_args -v 'check_centreon_ping;ARG1:count;ARG2:warning;ARG3:critical'
+

--- a/www/class/centreon-clapi/centreonCommand.class.php
+++ b/www/class/centreon-clapi/centreonCommand.class.php
@@ -197,7 +197,7 @@ class CentreonCommand extends CentreonObject
      */
     public function describe_args($descriptions)
     {
-        $data = explode($this->delim, $descriptions);
+        $data = explode($this->delim, trim($descriptions, $this->delim));
         if (count($data) < 1) {
             throw new CentreonClapiException(self::MISSINGPARAMETER);
         }

--- a/www/class/centreon-clapi/centreonCommand.class.php
+++ b/www/class/centreon-clapi/centreonCommand.class.php
@@ -188,6 +188,36 @@ class CentreonCommand extends CentreonObject
         }
     }
 
+
+    /**
+     * Set command arguments descriptions
+     *
+     * @param string $descriptions
+     * @throws CentreonClapiException
+     */
+    public function describe_args($descriptions)
+    {
+        $data = explode($this->delim, $descriptions);
+        if (count($data) < 1) {
+            throw new CentreonClapiException(self::MISSINGPARAMETER);
+        }
+        $objUniqueName = array_shift($data);
+        if (($objectId = $this->getObjectId($objUniqueName)) != 0) {
+
+            $sql = "DELETE FROM command_arg_description WHERE cmd_id = ?";
+            $this->db->query($sql, array($objectId));
+
+            foreach ($data as $description) {
+                list($arg, $desc) = explode(':', $description, 2);
+                $sql = "INSERT INTO command_arg_description (cmd_id, macro_name, macro_description) VALUES (?,?,?)";
+                $this->db->query($sql, array($objectId, $arg, $desc));
+            }
+        } else {
+            throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $objUniqueName);
+        }
+    }
+
+
     /**
      * Returns command id
      *
@@ -254,8 +284,14 @@ class CentreonCommand extends CentreonObject
                         . $v . "\n";
                 }
             }
+
+            echo $this->action . $this->delim
+                . "DESCRIBE_ARGS" . $this->delim
+                . $element[$this->object->getUniqueLabelField()] . $this->delim
+                . implode(';', $this->getArgsDescriptions($element['command_id'])) . "\n";
         }
     }
+
 
     /**
      * Get clapi action name from db column name
@@ -277,7 +313,7 @@ class CentreonCommand extends CentreonObject
     }
 
 
-        /**
+    /**
      * This method gat the list of command containt a specific macro
      * @param int $iIdCommand
      * @param string $sType
@@ -356,5 +392,26 @@ class CentreonCommand extends CentreonObject
             $aReturn[$row['command_macro_name']] = $arr;
         }
         return $aReturn;
+    }
+
+
+    /**
+     * Export command_arg_description
+     * @param int $command_id
+     *
+     * @return array
+     */
+    protected function getArgsDescriptions($command_id)
+    {
+        $sql = "SELECT macro_name, macro_description
+        		FROM command_arg_description
+        		WHERE cmd_id = ?
+        		ORDER BY macro_name";
+        $res = $this->db->query($sql, array($command_id));
+
+        $args_desc = array();
+        while ($row = $res->fetch()) $args_desc[] = $row['macro_name'] . ':' . trim($row['macro_description']);
+        unset($res);
+        return $args_desc;
     }
 }


### PR DESCRIPTION
I'm using Centreon 2.8.16

The API still doesn't handle commands arguments descriptions.

See this old issue : https://github.com/centreon/centreon-clapi/issues/83
The fix added export process for graph_id & command_comment, but nothing for the descriptions of arguments...

I propose a new command in the API to set all arguments descriptions for a given command.
I have tested update, export and import successfully.