### PR TITLE
Fix (CLAPI) : uninitialized array causing php warning

### DIFF
--- a/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
+++ b/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
@@ -404,11 +404,10 @@ class CentreonCentbrokerCfg extends CentreonObject
             "AND config_key = 'name' " .
             "AND config_group = ? ";
         $res = $this->db->query($sql, array($configId, $tagName));
-
+        $listName[] = array();
         while ($list = $res->fetch()) {
             $listName[] = $list['config_value'];
         }
-
         if (in_array($args[1], $listName)) {
             throw new CentreonClapiException(self::OBJECTALREADYEXISTS);
         }


### PR DESCRIPTION
When $res->fetch() brings nothing, $listName is undefined and generates this warning :
PHP Warning:  in_array() expects parameter 2 to be array, null given in /usr/share/centreon/www/class/centreon-clapi/centreonCentbrokerCfg.class.php on line 411
So I suggest to initialize it as an empty array before.