### PR TITLE
Don't generate blank line in centcore.cmd

### DIFF
--- a/www/include/monitoring/external_cmd/functions.php
+++ b/www/include/monitoring/external_cmd/functions.php
@@ -63,7 +63,7 @@ function write_command($cmd, $poller)
     }
     setlocale(LC_CTYPE, 'en_US.UTF-8');
 
-    $str = "echo ". escapeshellarg("EXTERNALCMD:$poller:[" . time() . "]" . $cmd . "\n") . " >> " . $destination;
+    $str = "echo ". escapeshellarg("EXTERNALCMD:$poller:[" . time() . "]" . $cmd) . " >> " . $destination;
     return passthru($str);
 }
 


### PR DESCRIPTION
Hello,

Blank line are generated by the web application and pushed to centcore.cmd.
Centcore will remove this blank line but it's not efficient to generate 2 lines for one command.

To reproduce:

    Stop centcore
    Launch command from the web interface (schedule downtime, force check, ...)
    Check the file centcore.cmd
    A blank line is present on each command

Regards.