### PR TITLE
Allow people to use another user that has root privileges when installing centreon

### DIFF
--- a/www/install/steps/functions.php
+++ b/www/install/steps/functions.php
@@ -37,6 +37,10 @@ function getTemplate($dir) {
  * @return mixed
  */
 function myConnect() {
+    $root_user = "";
+    if (isset($_SESSION['root_user']) && $_SESSION['root_user']) {
+        $root_user = $_SESSION['root_user'];
+    }
     $pass = "";
     if (isset($_SESSION['root_password']) && $_SESSION['root_password']) {
         $pass = $_SESSION['root_password'];
@@ -49,7 +53,7 @@ function myConnect() {
     if (isset($_SESSION['DB_PORT']) && $_SESSION['DB_PORT']) {
         $port = $_SESSION['DB_PORT'];
     }
-    return mysql_connect($host.':'.$port, 'root', $pass);
+    return mysql_connect($host.':'.$port, $root_user, $pass);
 }
 
 /**

--- a/www/install/steps/process/process_step6.php
+++ b/www/install/steps/process/process_step6.php
@@ -41,7 +41,7 @@ foreach ($_POST as $key => $value) {
     $_SESSION[$key] = $value;
 }
 
-$mandatoryFields = array('CONFIGURATION_DB', 'STORAGE_DB', 'DB_USER', 'DB_PASS', 'db_pass_confirm');
+$mandatoryFields = array('CONFIGURATION_DB', 'STORAGE_DB', 'DB_USER', 'DB_PASS', 'db_pass_confirm', 'root_user');
 $strError = '';
 foreach ($mandatoryFields as $field) {
     if ($_POST[$field] == '') {

--- a/www/install/steps/step6.php
+++ b/www/install/steps/step6.php
@@ -38,7 +38,7 @@ DEFINE('STEP_NUMBER', 6);
 DEFINE('DEFAULT_CONF_NAME', 'centreon');
 DEFINE('DEFAULT_STORAGE_NAME', 'centreon_storage');
 DEFINE('DEFAULT_UTILS_NAME', 'centreon_status');
-DEFINE('DEFAULT_root_user', 'root');
+DEFINE('DEFAULT_ROOT_USER', 'root');
 DEFINE('DEFAULT_DB_USER', 'centreon');
 DEFINE('DEFAULT_PORT', '3306');
 
@@ -50,8 +50,8 @@ $title = _('Database information');
 
 $defaults = array('ADDRESS' => '', 
                 'DB_PORT' => DEFAULT_PORT,
-                'root_user' => DEFAULT_root_user,
-                'root_password' => '', 
+                'ROOT_USER' => DEFAULT_ROOT_USER,
+                'ROOT_PASSWORD' => '', 
                 'CONFIGURATION_DB' => DEFAULT_CONF_NAME, 
                 'STORAGE_DB' => DEFAULT_STORAGE_NAME,
                 'DB_USER' => DEFAULT_DB_USER,
@@ -89,14 +89,14 @@ $contents = "
         <tr>
             <td class='formlabel'>"._('User with root privileges').$star."</td>
             <td class='formvalue'>
-                <input type='text' name='root_user' value='".$defaults['root_user']."' />
+                <input type='text' name='root_user' value='".$defaults['ROOT_USER']."' />
                 <label class='field_msg'></label>
             </td>
         </tr>
         <tr>
             <td class='formlabel'>"._('User with root privileges password')."</td>
             <td class='formvalue'>
-                <input type='password' name='root_password' value='".$defaults['root_password']."' />
+                <input type='password' name='root_password' value='".$defaults['ROOT_PASSWORD']."' />
                 <label class='field_msg'></label>
             </td>
         </tr>

--- a/www/install/steps/step6.php
+++ b/www/install/steps/step6.php
@@ -38,6 +38,7 @@ DEFINE('STEP_NUMBER', 6);
 DEFINE('DEFAULT_CONF_NAME', 'centreon');
 DEFINE('DEFAULT_STORAGE_NAME', 'centreon_storage');
 DEFINE('DEFAULT_UTILS_NAME', 'centreon_status');
+DEFINE('DEFAULT_root_user', 'root');
 DEFINE('DEFAULT_DB_USER', 'centreon');
 DEFINE('DEFAULT_PORT', '3306');
 
@@ -49,6 +50,7 @@ $title = _('Database information');
 
 $defaults = array('ADDRESS' => '', 
                 'DB_PORT' => DEFAULT_PORT,
+                'root_user' => DEFAULT_root_user,
                 'root_password' => '', 
                 'CONFIGURATION_DB' => DEFAULT_CONF_NAME, 
                 'STORAGE_DB' => DEFAULT_STORAGE_NAME,
@@ -85,7 +87,14 @@ $contents = "
             </td>
         </tr>
         <tr>
-            <td class='formlabel'>"._('Root password')."</td>
+            <td class='formlabel'>"._('User with root privileges').$star."</td>
+            <td class='formvalue'>
+                <input type='text' name='root_user' value='".$defaults['root_user']."' />
+                <label class='field_msg'></label>
+            </td>
+        </tr>
+        <tr>
+            <td class='formlabel'>"._('User with root privileges password')."</td>
             <td class='formvalue'>
                 <input type='password' name='root_password' value='".$defaults['root_password']."' />
                 <label class='field_msg'></label>


### PR DESCRIPTION
in some cases the root user is not usable. 
Not sure about the variables naming standards (DEFAULT_root_user or DEFAULT_ROOT_USER) and the label can perhaps be more understandable

i've set $root_user = "" in functions.php while i've made it mandatory to fill the field in step6.php. Not the smartest move...