### PR TITLE
Update centreonGraph.class - Display PNG content at web browser output instead of downloading it

### DIFF
--- a/www/class/centreonGraph.class.php
+++ b/www/class/centreonGraph.class.php
@@ -1423,18 +1423,18 @@ class CentreonGraph
             );
             if (is_resource($process)) {
 
-				header("Content-Type: image/png");
+		header("Content-Type: image/png");
 				
-				fwrite($pipes[0], $commandLine);
-				fclose($pipes[0]);
+		fwrite($pipes[0], $commandLine);
+		fclose($pipes[0]);
 
-				if( $str = fopen("php://output","w") ) {
-					stream_copy_to_stream($pipes[1],$str);
-					fclose($str);
-				}  
+		if( $str = fopen("php://output","w") ) {
+			stream_copy_to_stream($pipes[1],$str);
+			fclose($str);
+		}  
 
-				fclose($pipes[1]);
-				$return_value = proc_close($process);
+		fclose($pipes[1]);
+		$return_value = proc_close($process);
             }
         } else {
             return $commandLine;

--- a/www/class/centreonGraph.class.php
+++ b/www/class/centreonGraph.class.php
@@ -1427,8 +1427,8 @@ class CentreonGraph
 		fwrite($pipes[0], $commandLine);
 		fclose($pipes[0]);
 
-		if( $str = fopen("php://output","w") ) {
-			stream_copy_to_stream($pipes[1],$str);
+		if( $str = fopen("php://output", "w") ) {
+			stream_copy_to_stream($pipes[1], $str);
 			fclose($str);
 		}  
 

--- a/www/class/centreonGraph.class.php
+++ b/www/class/centreonGraph.class.php
@@ -1422,15 +1422,19 @@ class CentreonGraph
                 null
             );
             if (is_resource($process)) {
-                fwrite($pipes[0], $commandLine);
-                fclose($pipes[0]);
 
-                $str = stream_get_contents($pipes[1]);
-                $return_value = proc_close($process);
+				header("Content-Type: image/png");
+				
+				fwrite($pipes[0], $commandLine);
+				fclose($pipes[0]);
 
-                /* Force no compress for image */
-                $this->setHeaders(false, mb_strlen($str, '8bit'));
-                print $str;
+				if( $str = fopen("php://output","w") ) {
+					stream_copy_to_stream($pipes[1],$str);
+					fclose($str);
+				}  
+
+				fclose($pipes[1]);
+				$return_value = proc_close($process);
             }
         } else {
             return $commandLine;

--- a/www/class/centreonGraph.class.php
+++ b/www/class/centreonGraph.class.php
@@ -1422,7 +1422,6 @@ class CentreonGraph
                 null
             );
             if (is_resource($process)) {
-
 		header("Content-Type: image/png");
 				
 		fwrite($pipes[0], $commandLine);


### PR DESCRIPTION
Display PNG content at web browser output instead of downloading it, so we can use png hover url in Network Weathermap integration.