### PR TITLE
fix(clapi): fix broker endpoint ids offset

### DIFF
--- a/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
+++ b/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
@@ -421,7 +421,7 @@ class CentreonCentbrokerCfg extends CentreonObject
             . "AND config_group = ? ";
         $res = $this->db->query($sql, array($configId, $tagName));
         $row = $res->fetch();
-        $i = isset($row['max_id']) ? $row['max_id'] + 1 : 1;
+        $i = isset($row['max_id']) ? $row['max_id'] + 1 : 0;
         unset($res);
 
         $sql = "INSERT INTO cfg_centreonbroker_info "


### PR DESCRIPTION
Ids start at 0 when using the web UI, were starting from 1 from CLAPI.

Refs: #5011 
