### PR TITLE
fix(clapi): fix resource setparam export

### DIFF
--- a/www/class/centreon-clapi/centreonResourceCfg.class.php
+++ b/www/class/centreon-clapi/centreonResourceCfg.class.php
@@ -373,7 +373,7 @@ class CentreonResourceCfg extends CentreonObject
                     $value = CentreonUtils::convertLineBreak($value);
                     echo $this->action . $this->delim
                         . "setparam" . $this->delim
-                        . $element[$this->object->getUniqueLabelField()] . $this->delim
+                        . $element[$this->object->getPrimaryKey()] . $this->delim
                         . $parameter . $this->delim
                         . $value . "\n";
                 }


### PR DESCRIPTION
When importing resource macro, CLAPI is expecting macro's id to be provided with setparam action.

Refs: #6221 