### PR TITLE
fix(clapi): fix acl group setcontact export

### DIFF
--- a/www/class/centreon-clapi/centreonACLGroup.class.php
+++ b/www/class/centreon-clapi/centreonACLGroup.class.php
@@ -288,7 +288,7 @@ class CentreonACLGroup extends CentreonObject
             array(
                 'object' => 'CONTACT',
                 'relClass' => 'Centreon_Object_Relation_Acl_Group_Contact',
-                'objectFieldName' => 'contact_name'
+                'objectFieldName' => 'contact_alias'
             ),
             array(
                 'object' => 'CONTACTGROUP',


### PR DESCRIPTION
When importing ACL groups, CLAPI is expecting contact alias to be provided with setcontact action.

Refs: #6223