### PR TITLE
Add API Command for Host getinstance

### DIFF
--- a/doc/en/api/clapi/objects/hosts.rst
+++ b/doc/en/api/clapi/objects/hosts.rst
@@ -315,6 +315,14 @@ In order to set the instance from which a host will be monitored, use the **SETI
   [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a setinstance -v "Centreon-Server;Poller 1" 
 
 
+Getinstance
+-----------
+
+To determine the instance from which a host will be monitored, use the **GETINSTANCE** action::
+
+  [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a getinstance -v "Centreon-Server" 
+  2;Poller 1
+
 Getmacro
 --------
 

--- a/doc/fr/api/clapi/objects/hosts.rst
+++ b/doc/fr/api/clapi/objects/hosts.rst
@@ -314,6 +314,15 @@ In order to set the instance from which a host will be monitored, use the **SETI
   [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a setinstance -v "Centreon-Server;Poller 1" 
 
 
+Getinstance
+-----------
+
+To determine the instance from which a host will be monitored, use the **GETINSTANCE** action::
+
+  [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a getinstance -v "Centreon-Server" 
+  2;Poller 1
+
+
 Getmacro
 --------
 

--- a/www/class/centreon-clapi/centreonHost.class.php
+++ b/www/class/centreon-clapi/centreonHost.class.php
@@ -317,6 +317,40 @@ class CentreonHost extends CentreonObject
             . "AND service_id NOT IN (SELECT service_service_id FROM host_service_relation)"
         );
     }
+    
+    /**
+     * List instance (poller) for host
+     *
+     * @param string $parameters
+     * @throws CentreonClapiException
+     */
+    public function getinstance ($parameters)
+    {
+        $params = explode($this->delim, $parameters);
+        if ($parameters == '') {
+            throw new CentreonClapiException(self::MISSINGPARAMETER);
+        }
+        if (($hostId = $this->getObjectId($params[self::ORDER_UNIQUENAME])) != 0) {
+            $relObj = new \Centreon_Object_Relation_Instance_Host();
+            $fields = array('id', 'name');
+            $elems = $relObj->getMergedParameters(
+                $fields,
+                array(),
+                -1,
+                0,
+                "host_name",
+                "ASC",
+                array('host_id' => $hostId),
+                'AND'
+            );
+            
+            foreach ($elems as $elem) {
+                echo $elem['id'] . $this->delim . $elem['name'] . "\n";
+            }
+        } else {
+            throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $params[self::ORDER_UNIQUENAME]);
+        }
+    }
 
     /**
      * Tie host to instance (poller)


### PR DESCRIPTION
This PR adds the corresponding "getinstance" command to go with "setinstance" on Host.

```
./centreon -u admin -p password -o HOST -a getinstance -v "TEST-HOST"
1;Central
```

Documentation added.