### PR TITLE
API for commands arguments descriptions (resubmit)

### DIFF
--- a/doc/en/api/clapi/objects/commands.rst
+++ b/doc/en/api/clapi/objects/commands.rst
@@ -95,10 +95,20 @@ comment     Comments regarding the command
   You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
 
-Describe_Args
--------------
+Getargumentdescr
+----------------
 
-If you want to change all arguments descriptions for a command, use the **DESCRIBE_ARGS** command::
+To retrieve the argument descriptions for a command, use the **getargumentdescr** command:
 
-  [root@centreon ~]# ./centreon -u admin -p centreon -o CMD -a describe_args -v 'check_centreon_ping;ARG1:count;ARG2:warning;ARG3:critical'
+  [root@centreon ~]# ./centreon -u admin -p centreon -o CMD -a getargumentdesc -v 'test-cmd'
+  ARG0;First Argument
+  ARG1;Second Argument
+
+
+Setargumentdescr
+----------------
+
+If you want to change all arguments descriptions for a command, use the **setargumentdescr** command::
+
+  [root@centreon ~]# ./centreon -u admin -p centreon -o CMD -a setargumentdescr -v 'check_centreon_ping;ARG1:count;ARG2:warning;ARG3:critical'
 

--- a/doc/en/api/clapi/objects/commands.rst
+++ b/doc/en/api/clapi/objects/commands.rst
@@ -94,3 +94,11 @@ comment     Comments regarding the command
 .. note::
   You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
+
+Describe_Args
+-------------
+
+If you want to change all arguments descriptions for a command, use the **DESCRIBE_ARGS** command::
+
+  [root@centreon ~]# ./centreon -u admin -p centreon -o CMD -a describe_args -v 'check_centreon_ping;ARG1:count;ARG2:warning;ARG3:critical'
+

--- a/doc/fr/api/clapi/objects/commands.rst
+++ b/doc/fr/api/clapi/objects/commands.rst
@@ -95,10 +95,20 @@ comment     Comments regarding the command
   You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
 
-Describe_Args
--------------
+Getargumentdescr
+----------------
 
-If you want to change all arguments descriptions for a command, use the **DESCRIBE_ARGS** command::
+To retrieve the argument descriptions for a command, use the **getargumentdescr** command:
 
-  [root@centreon ~]# ./centreon -u admin -p centreon -o CMD -a describe_args -v 'check_centreon_ping;ARG1:count;ARG2:warning;ARG3:critical'
+  [root@centreon ~]# ./centreon -u admin -p centreon -o CMD -a getargumentdesc -v 'test-cmd'
+  ARG0;First Argument
+  ARG1;Second Argument
+
+
+Setargumentdescr
+----------------
+
+If you want to change all arguments descriptions for a command, use the **setargumentdescr** command::
+
+  [root@centreon ~]# ./centreon -u admin -p centreon -o CMD -a setargumentdescr -v 'check_centreon_ping;ARG1:count;ARG2:warning;ARG3:critical'
 

--- a/doc/fr/api/clapi/objects/commands.rst
+++ b/doc/fr/api/clapi/objects/commands.rst
@@ -94,3 +94,11 @@ comment     Comments regarding the command
 .. note::
   You need to generate your configuration file and restart monitoring engine in order to apply changes.
 
+
+Describe_Args
+-------------
+
+If you want to change all arguments descriptions for a command, use the **DESCRIBE_ARGS** command::
+
+  [root@centreon ~]# ./centreon -u admin -p centreon -o CMD -a describe_args -v 'check_centreon_ping;ARG1:count;ARG2:warning;ARG3:critical'
+

--- a/www/class/centreon-clapi/centreonCommand.class.php
+++ b/www/class/centreon-clapi/centreonCommand.class.php
@@ -197,7 +197,7 @@ class CentreonCommand extends CentreonObject
      */
     public function describe_args($descriptions)
     {
-        $data = explode($this->delim, $descriptions);
+        $data = explode($this->delim, trim($descriptions, $this->delim));
         if (count($data) < 1) {
             throw new CentreonClapiException(self::MISSINGPARAMETER);
         }

--- a/www/class/centreon-clapi/centreonCommand.class.php
+++ b/www/class/centreon-clapi/centreonCommand.class.php
@@ -188,6 +188,24 @@ class CentreonCommand extends CentreonObject
         }
     }
 
+    /**
+     * Get command arguments descriptions
+     *
+     * @param string $objUniqueName
+     * @throws CentreonClapiException
+     */
+    public function getargumentdesc($objUniqueName) {
+        if ($objUniqueName != "" && ($objectId = $this->getObjectId($objUniqueName)) != 0) {
+            $sql = "SELECT macro_name, macro_description FROM command_arg_description WHERE cmd_id = ?";
+            $res = $this->db->query($sql, array($objectId));
+            
+            foreach($res as $param) {
+                echo $param['macro_name'] . $this->delim . $param['macro_description'] . "\n";
+            }
+        } else {
+            throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $objUniqueName);
+        }
+    }
 
     /**
      * Set command arguments descriptions
@@ -195,7 +213,7 @@ class CentreonCommand extends CentreonObject
      * @param string $descriptions
      * @throws CentreonClapiException
      */
-    public function describe_args($descriptions)
+    public function setargumentdescr($descriptions)
     {
         $data = explode($this->delim, trim($descriptions, $this->delim));
         if (count($data) < 1) {
@@ -285,10 +303,13 @@ class CentreonCommand extends CentreonObject
                 }
             }
 
-            echo $this->action . $this->delim
-                . "DESCRIBE_ARGS" . $this->delim
-                . $element[$this->object->getUniqueLabelField()] . $this->delim
-                . implode(';', $this->getArgsDescriptions($element['command_id'])) . "\n";
+            $argDescriptions = $this->getArgsDescriptions($element['command_id']);
+            if (sizeof($argDescriptions) > 0) {
+                echo $this->action . $this->delim
+                    . "setargumentdescr" . $this->delim
+                    . $element[$this->object->getUniqueLabelField()] . $this->delim
+                    . implode(';', $argDescriptions) . "\n";
+            }
         }
     }
 

--- a/www/class/centreon-clapi/centreonCommand.class.php
+++ b/www/class/centreon-clapi/centreonCommand.class.php
@@ -188,6 +188,36 @@ class CentreonCommand extends CentreonObject
         }
     }
 
+
+    /**
+     * Set command arguments descriptions
+     *
+     * @param string $descriptions
+     * @throws CentreonClapiException
+     */
+    public function describe_args($descriptions)
+    {
+        $data = explode($this->delim, $descriptions);
+        if (count($data) < 1) {
+            throw new CentreonClapiException(self::MISSINGPARAMETER);
+        }
+        $objUniqueName = array_shift($data);
+        if (($objectId = $this->getObjectId($objUniqueName)) != 0) {
+
+            $sql = "DELETE FROM command_arg_description WHERE cmd_id = ?";
+            $this->db->query($sql, array($objectId));
+
+            foreach ($data as $description) {
+                list($arg, $desc) = explode(':', $description, 2);
+                $sql = "INSERT INTO command_arg_description (cmd_id, macro_name, macro_description) VALUES (?,?,?)";
+                $this->db->query($sql, array($objectId, $arg, $desc));
+            }
+        } else {
+            throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $objUniqueName);
+        }
+    }
+
+
     /**
      * Returns command id
      *
@@ -254,8 +284,14 @@ class CentreonCommand extends CentreonObject
                         . $v . "\n";
                 }
             }
+
+            echo $this->action . $this->delim
+                . "DESCRIBE_ARGS" . $this->delim
+                . $element[$this->object->getUniqueLabelField()] . $this->delim
+                . implode(';', $this->getArgsDescriptions($element['command_id'])) . "\n";
         }
     }
+
 
     /**
      * Get clapi action name from db column name
@@ -277,7 +313,7 @@ class CentreonCommand extends CentreonObject
     }
 
 
-        /**
+    /**
      * This method gat the list of command containt a specific macro
      * @param int $iIdCommand
      * @param string $sType
@@ -356,5 +392,26 @@ class CentreonCommand extends CentreonObject
             $aReturn[$row['command_macro_name']] = $arr;
         }
         return $aReturn;
+    }
+
+
+    /**
+     * Export command_arg_description
+     * @param int $command_id
+     *
+     * @return array
+     */
+    protected function getArgsDescriptions($command_id)
+    {
+        $sql = "SELECT macro_name, macro_description
+        		FROM command_arg_description
+        		WHERE cmd_id = ?
+        		ORDER BY macro_name";
+        $res = $this->db->query($sql, array($command_id));
+
+        $args_desc = array();
+        while ($row = $res->fetch()) $args_desc[] = $row['macro_name'] . ':' . trim($row['macro_description']);
+        unset($res);
+        return $args_desc;
     }
 }


### PR DESCRIPTION
This PR is a resubmission of the work done by @proxyconcept in #5960 with the changes requested.  The credit for the bulk of the work done here lies with him.

The changes I have added are:
- Rename describe_args to setargumentdescr as requested by @lpinsivy 
- Add corresponding getargumentdescr
- Update export code to only add setargumentdescr if any arguments were added.

API addition summary:

```
# ./centreon -u admin -p password -o CMD -a getargumentdesc -v "test-cmd"
ARG0;First Argument
ARG1;Second Argument
```

```
./centreon -u admin -p password -o CMD -a setargumentdescr -v 'test-cmd;ARG0:New First Arg;ARG1:New Second Arg'
```

```
./centreon -u admin -p password -e | grep test-cmd
CMD;ADD;test-cmd;2;echo "$ARG0$" "$ARG1$"
CMD;setparam;test-cmd;enable_shell;0
CMD;setparam;test-cmd;command_activate;1
CMD;setparam;test-cmd;command_locked;0
CMD;setargumentdescr;test-cmd;ARG0:New First Arg;ARG1:New Second Arg
```
