### PR TITLE
Prevent semicolon in last value breaking rest clapi serialization

### DIFF
--- a/www/api/class/centreon_clapi.class.php
+++ b/www/api/class/centreon_clapi.class.php
@@ -175,6 +175,13 @@ class CentreonClapi extends CentreonWebService
         for ($i = 0; $i < count($lines); $i++) {
             if (strpos($lines[$i], ';') !== false) {
                 $tmpLine = explode(';', $lines[$i]);
+                
+                if (count($tmpLine) > count($headers)) {
+                    /* Handle ; in variable (more values than headers) */
+                    $tmpLine[count($headers) - 1] = implode(';', array_slice($tmpLine, count($headers) - 1));
+                    $tmpLine = array_slice($tmpLine, 0, count($headers));
+                }
+                
                 foreach ($tmpLine as &$line) {
                     if (strpos($line, "|") !== false) {
                         $line = explode("|", $line);


### PR DESCRIPTION
At the moment, trying to use the REST API to retrieve a value containing a semicolon causes the serialization to break.  This is broken on the default install by the host-notify-by-jabber command, which contains the HTML entities `&#039;`.

The problem is caused by the semicolon being used to split the values.  This causes there to be more values than headers, and `array_combine` then returns `false` for that item.

To get around this, this PR checks for there being more values than headers, and if so, recombines all of the last items into one value.  This catches the case where the last item contains a semicolon (e.g. the "line" parameter of command).  This will not work if semicolon is present in any field other than the last.

This isn't an ideal solution - it would be better to either have a way to escape semicolons in the CLAPI output, or preventing semicolons being added (unlikely to be possible for things like commands).

Fixes #6110 