### PR TITLE
Avoid PHP notice Undefined index: centreon in notifications.php

### DIFF
--- a/www/include/monitoring/status/Notifications/notifications.php
+++ b/www/include/monitoring/status/Notifications/notifications.php
@@ -47,6 +47,9 @@ $refresh_rate += ($refresh_rate / 2);
 
 $obj = new CentreonXMLBGRequest($sid, 1, 1, 0, 1);
 
+if (!isset($_SESSION['centreon'])) {
+    exit;
+}
 $centreon = $_SESSION['centreon'];
 if (!isset($obj->session_id) || !CentreonSession::checkSession($obj->session_id, $obj->DB)) {
     exit;


### PR DESCRIPTION
Hello,

In httpd error_log, the message below is written multiple times:
[Thu May 03 13:23:42 2018] [error] [client 10.90.17.242] PHP Notice:  Undefined index: centreon in /usr/share/centreon/www/include/monitoring/status/Notifications/notifications.php on line 50, referer: https://centreon.xit.rxcorp.com/centreon/main.php

This pull request is to test if the session $_SESSION['centreon'] is defined (as done in other files /usr/share/centreon/www/include/monitoring/status/TopCounter/xml/statusCounter.php).

Regards,