### PR TITLE
Prevent permission denied centcore cmd for downtimemanager

### DIFF
--- a/www/class/centreonDowntime.Broker.class.php
+++ b/www/class/centreonDowntime.Broker.class.php
@@ -502,7 +502,7 @@ class CentreonDowntimeBroker extends CentreonDowntime
         /* send remote commands */
         $remoteCommands = implode(PHP_EOL, $this->remoteCommands);
         if ($remoteCommands) {
-            file_put_contents($this->remoteCmdFile, $remoteCommands, FILE_APPEND);
+            file_put_contents($this->remoteCmdDir . "/" . time() . "-downtimes", $remoteCommands, FILE_APPEND);
         }
     }
 }

--- a/www/class/centreonDowntime.class.php
+++ b/www/class/centreonDowntime.class.php
@@ -49,6 +49,7 @@ class CentreonDowntime
     protected $localCmdFile = '';
     protected $remoteCommands;
     protected $remoteCmdFile = '';
+    protected $remoteCmdDir = '';
     protected $varlib;
     protected $periods = null;
     protected $downtimes = null;
@@ -65,7 +66,7 @@ class CentreonDowntime
         $this->localCommands = array();
         $this->remoteCommands = array();
         if (!is_null($varlib)) {
-            $this->remoteCmdFile = $varlib . '/centcore.cmd';
+            $this->remoteCmdDir = $varlib . '/centcore';
         }
     }
 


### PR DESCRIPTION
Try to prevent error in ​downtimeManager.log by create an dedicated file for Centcore each time the cron needs to send external commands:

`PHP Warning:  file_put_contents(/var/lib/centreon/centcore.cmd): failed to open stream: Permission denied in /usr/share/centreon/www/class/centreonDowntime.Broker.class.php on line 505`