### PR TITLE
Sort by service name after status in service grid

### DIFF
--- a/www/class/centreonMonitoring.class.php
+++ b/www/class/centreonMonitoring.class.php
@@ -167,7 +167,7 @@ class CentreonMonitoring
                 . " ";
         }
 
-        $rq .= " order by tri asc";
+        $rq .= " order by tri asc, service_name";
         
         $tab = array();
         $DBRESULT = $objXMLBG->DBC->query($rq);


### PR DESCRIPTION
Minor change, sorts services in the "Services Grid" view by service name after status.  Currently they are sorted by status only, which means that two hosts with the same services sometimes get displayed in different orders.