### PR TITLE
chore(build): trigger AutoDiscovery job on successful build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -155,6 +155,7 @@ try {
         error('Delivery stage failure.');
       }
     }
+    build job: 'centreon-autodiscovery/2.4.x', wait: false
     build job: 'centreon-awie/1.0.x', wait: false
     build job: 'centreon-license-manager/1.1.x', wait: false
     build job: 'centreon-poller-display/1.6.x', wait: false


### PR DESCRIPTION
For 2.8.x branch.