### PR TITLE
chore(build): trigger Export (PPE) job on successful build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,6 +156,7 @@ try {
       }
     }
     build job: 'centreon-awie/1.0.x', wait: false
+    build job: 'centreon-export/2.3.x', wait: false
     build job: 'centreon-license-manager/1.1.x', wait: false
     build job: 'centreon-poller-display/1.6.x', wait: false
     build job: 'centreon-pp-manager/2.3.x', wait: false


### PR DESCRIPTION
For the 2.8.x branch.