### PR TITLE
fix(monitoring): remove double encoding of host name

### DIFF
--- a/www/include/monitoring/external_cmd/popup/popup.php
+++ b/www/include/monitoring/external_cmd/popup/popup.php
@@ -35,6 +35,10 @@
 
 require_once realpath(dirname(__FILE__) . "/../../../../../config/centreon.config.php");
 
+require_once _CENTREON_PATH_ . 'vendor/autoload.php';
+$smartyDir = _CENTREON_PATH_ . 'vendor/smarty/smarty/';
+require_once $smartyDir . 'libs/Smarty.class.php';
+
 require_once _CENTREON_PATH_ . "www/class/centreonSession.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreon.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreonDB.class.php";
@@ -65,8 +69,6 @@ if (isset($sid)) {
 }
 
 define('SMARTY_DIR', _CENTREON_PATH_ . 'GPL_LIB/Smarty/libs/');
-
-require_once SMARTY_DIR . "Smarty.class.php";
 
 $o = htmlentities($_GET['o'], ENT_QUOTES, "UTF-8");
 $p = htmlentities($_GET['p'], ENT_QUOTES, "UTF-8");

--- a/www/include/monitoring/status/Services/serviceJS.php
+++ b/www/include/monitoring/status/Services/serviceJS.php
@@ -298,7 +298,7 @@ if (isset($_GET["acknowledge"])) {
                     document.getElementById(decodeURIComponent(keyz))
                 ) {
                     if (document.getElementById(decodeURIComponent(keyz)).checked) {
-                        _getVar += '&select[' + encodeURIComponent(keyz) + ']=1';
+                        _getVar += '&select[' + keyz + ']=1';
                     }
                 }
             }


### PR DESCRIPTION
Fix loading of smarty and remove double encoding of the host name. monitoring/status/Common/commonJS.php @ putInSelectedElem(id)