### PR TITLE
fix(api): API and CLAPI testing

### DIFF
--- a/bin/centreon
+++ b/bin/centreon
@@ -99,6 +99,9 @@ require_once _CLAPI_CLASS_ . "/centreonAPI.class.php";
 require_once _CLAPI_CLASS_ . "/centreonUtils.class.php";
 require_once _CLAPI_LIB_ . "/Centreon/Db/Manager/Manager.php";
 
+error_reporting(0);
+ini_set("display_errors", "Off");
+
 $dbConfig['host'] = $conf_centreon['hostCentreon'];
 $dbConfig['username'] = $conf_centreon['user'];
 $dbConfig['password'] = $conf_centreon['password'];

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -101,5 +101,5 @@ $configFiles = $dependencyInjector['finder']
     ->in(__DIR__ . '/config');
 foreach ($configFiles as $configFile) {
     $configFileName = $configFile->getBasename();
-    require_once __DIR__ . '/config/' . $configFileName;
+    require __DIR__ . '/config/' . $configFileName;
 }

--- a/config/centreon.config.php
+++ b/config/centreon.config.php
@@ -55,4 +55,4 @@ if (file_exists(_CENTREON_ETC_ . '/centreon.conf.php')) {
     }
 }
 
-$classdir = _CENTREON_PATH_.'/www/class';
+$classdir = _CENTREON_PATH_ . '/www/class';

--- a/config/centreon.config.php
+++ b/config/centreon.config.php
@@ -10,6 +10,7 @@ $constants = array(
     '_CENTREON_LOG_' => '@CENTREON_LOG@',
     '_CENTREON_VARLIB_' => '@CENTREON_VARLIB@'
 );
+
 foreach ($constants as $name => $value) {
     if (!defined($name)) {
         define($name, $value);
@@ -19,13 +20,33 @@ foreach ($constants as $name => $value) {
 if (file_exists(_CENTREON_ETC_ . '/centreon.conf.php')) {
     require_once _CENTREON_ETC_ . '/centreon.conf.php';
 
-    define('hostCentreon', $conf_centreon['hostCentreon']);
-    define('hostCentstorage', $conf_centreon['hostCentstorage']);
-    define('user', $conf_centreon['user']);
-    define('password', $conf_centreon['password']);
-    define('db', $conf_centreon['db']);
-    define('dbcstg', $conf_centreon['dbcstg']);
-    define('port', $conf_centreon['port']);
+    if (!defined('hostCentreon')) {
+        define('hostCentreon', $conf_centreon['hostCentreon']);
+    }
+
+    if (!defined('hostCentstorage')) {
+        define('hostCentstorage', $conf_centreon['hostCentstorage']);
+    }
+
+    if (!defined('user')) {
+        define('user', $conf_centreon['user']);
+    }
+
+    if (!defined('password')) {
+        define('password', $conf_centreon['password']);
+    }
+
+    if (!defined('db')) {
+        define('db', $conf_centreon['db']);
+    }
+
+    if (!defined('dbcstg')) {
+        define('dbcstg', $conf_centreon['dbcstg']);
+    }
+
+    if (!defined('port')) {
+        define('port', $conf_centreon['port']);
+    }
 
     if (isset($dependencyInjector)) {
         $dependencyInjector['configuration'] = function ($c) use ($conf_centreon) {
@@ -33,3 +54,5 @@ if (file_exists(_CENTREON_ETC_ . '/centreon.conf.php')) {
         };
     }
 }
+
+$classdir = _CENTREON_PATH_.'/www/class';

--- a/www/api/class/centreon_administration_module.class.php
+++ b/www/api/class/centreon_administration_module.class.php
@@ -34,16 +34,12 @@
  */
 
 require_once dirname(__FILE__) . "/webService.class.php";
+require_once dirname(__FILE__) . '/../interface/di.interface.php';
+require_once dirname(__FILE__) . '/../trait/diAndUtilis.trait.php';
 
-class CentreonAdministrationModule extends CentreonWebService
+class CentreonAdministrationModule extends CentreonWebService implements CentreonWebServiceDiInterface
 {
-    /**
-     * CentreonAdministrationModule constructor.
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
+    use CentreonWebServiceDiAndUtilisTrait;
 
     /**
      * @return int
@@ -54,11 +50,11 @@ class CentreonAdministrationModule extends CentreonWebService
         if (!isset($this->arguments['name'])) {
             throw new \Exception('Missing argument : name');
         } else {
-            $name = $this->arguments['name'];
+            $moduleName = $this->arguments['name'];
         }
 
-        $factory = new \CentreonLegacy\Core\Module\Factory();
-        $moduleInstaller = $factory->newInstaller($name);
+        $factory = new \CentreonLegacy\Core\Module\Factory($this->dependencyInjector, $this->utils);
+        $moduleInstaller = $factory->newInstaller($moduleName);
 
         return $moduleInstaller->install();
     }
@@ -72,11 +68,17 @@ class CentreonAdministrationModule extends CentreonWebService
         if (!isset($this->arguments['name'])) {
             throw new \Exception('Missing argument : name');
         } else {
-            $name = $this->arguments['name'];
+            $moduleName = $this->arguments['name'];
         }
 
-        $factory = new \CentreonLegacy\Core\Module\Factory();
-        $moduleUpgrader = $factory->newUpgrader($name);
+        $moduleId = $this->getModuleId($moduleName);
+
+        if (!$moduleId) {
+            throw new \Exception('The module not installed');
+        }
+
+        $factory = new \CentreonLegacy\Core\Module\Factory($this->dependencyInjector, $this->utils);
+        $moduleUpgrader = $factory->newUpgrader($moduleName, $moduleId);
 
         return $moduleUpgrader->upgrade();
     }
@@ -90,12 +92,43 @@ class CentreonAdministrationModule extends CentreonWebService
         if (!isset($this->arguments['name'])) {
             throw new \Exception('Missing argument : name');
         } else {
-            $name = $this->arguments['name'];
+            $moduleName = $this->arguments['name'];
         }
 
-        $factory = new \CentreonLegacy\Core\Module\Factory();
-        $moduleRemover = $factory->newRemover($name);
+        $moduleId = $this->getModuleId($moduleName);
+
+        if (!$moduleId) {
+            throw new \Exception('The module not installed');
+        }
+
+        $factory = new \CentreonLegacy\Core\Module\Factory($this->dependencyInjector, $this->utils);
+        $moduleRemover = $factory->newRemover($moduleName, $moduleId);
 
         return $moduleRemover->remove();
+    }
+
+    /**
+     * Get module ID if has been installed
+     * 
+     * @param string $moduleName
+     * @return string|null
+     */
+    private function getModuleId($moduleName)
+    {
+        $sql = 'SELECT id FROM modules_informations WHERE name = :name';
+        $params = [
+            'name' => $moduleName,
+        ];
+
+        $result = $this->dependencyInjector['configuration_db']->query($sql, $params);
+
+        $row = $result->fetchRow();
+        $moduleId = null;
+
+        if ($row) {
+            $moduleId = $row['id'];
+        }
+
+        return $moduleId;
     }
 }

--- a/www/api/class/centreon_administration_module.class.php
+++ b/www/api/class/centreon_administration_module.class.php
@@ -74,7 +74,7 @@ class CentreonAdministrationModule extends CentreonWebService implements Centreo
         $moduleId = $this->getModuleId($moduleName);
 
         if (!$moduleId) {
-            throw new \Exception('The module not installed');
+            throw new \Exception('The module is not installed');
         }
 
         $factory = new \CentreonLegacy\Core\Module\Factory($this->dependencyInjector, $this->utils);
@@ -98,7 +98,7 @@ class CentreonAdministrationModule extends CentreonWebService implements Centreo
         $moduleId = $this->getModuleId($moduleName);
 
         if (!$moduleId) {
-            throw new \Exception('The module not installed');
+            throw new \Exception('The module is not installed');
         }
 
         $factory = new \CentreonLegacy\Core\Module\Factory($this->dependencyInjector, $this->utils);
@@ -122,7 +122,7 @@ class CentreonAdministrationModule extends CentreonWebService implements Centreo
 
         $result = $this->dependencyInjector['configuration_db']->query($sql, $params);
 
-        $row = $result->fetchRow();
+        $row = $result->fetch();
         $moduleId = null;
 
         if ($row) {

--- a/www/api/class/centreon_administration_widget.class.php
+++ b/www/api/class/centreon_administration_widget.class.php
@@ -36,18 +36,13 @@
 require_once _CENTREON_PATH_ . "/www/class/centreonDBInstance.class.php";
 require_once _CENTREON_PATH_ . '/www/class/centreonWidget.class.php';
 require_once dirname(__FILE__) . "/webService.class.php";
+require_once dirname(__FILE__) . '/../interface/di.interface.php';
+require_once dirname(__FILE__) . '/../trait/diAndUtilis.trait.php';
 
-class CentreonAdministrationWidget extends CentreonWebService
+class CentreonAdministrationWidget extends CentreonWebService implements CentreonWebServiceDiInterface
 {
-    /**
-     * Constructor
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
+
+    use CentreonWebServiceDiAndUtilisTrait;
 
     /**
      * Get the list of installed widgets
@@ -61,7 +56,7 @@ class CentreonAdministrationWidget extends CentreonWebService
             $q = $this->arguments['q'];
         }
 
-        $factory = new \CentreonLegacy\Core\Widget\Factory();
+        $factory = new \CentreonLegacy\Core\Widget\Factory($this->dependencyInjector, $this->utils);
         $widgetInfo = $factory->newInformation();
         $widgets = $widgetInfo->getAvailableList($q);
 
@@ -92,7 +87,7 @@ class CentreonAdministrationWidget extends CentreonWebService
                 throw new \RestBadRequestException('Error, limit must be numerical');
             }
             $limit = ($this->arguments['page'] - 1) * $this->arguments['page_limit'];
-            $range = array((int)$limit, (int)$this->arguments['page_limit']);
+            $range = array((int) $limit, (int) $this->arguments['page_limit']);
         } else {
             $range = array();
         }
@@ -114,7 +109,7 @@ class CentreonAdministrationWidget extends CentreonWebService
             $name = $this->arguments['name'];
         }
 
-        $factory = new \CentreonLegacy\Core\Widget\Factory();
+        $factory = new \CentreonLegacy\Core\Widget\Factory($this->dependencyInjector, $this->utils);
         $widgetInstaller = $factory->newInstaller($name);
 
         return $widgetInstaller->install();
@@ -132,7 +127,7 @@ class CentreonAdministrationWidget extends CentreonWebService
             $name = $this->arguments['name'];
         }
 
-        $factory = new \CentreonLegacy\Core\Widget\Factory();
+        $factory = new \CentreonLegacy\Core\Widget\Factory($this->dependencyInjector, $this->utils);
         $widgetUpgrader = $factory->newUpgrader($name);
 
         return $widgetUpgrader->upgrade();
@@ -150,7 +145,7 @@ class CentreonAdministrationWidget extends CentreonWebService
             $name = $this->arguments['name'];
         }
 
-        $factory = new \CentreonLegacy\Core\Widget\Factory();
+        $factory = new \CentreonLegacy\Core\Widget\Factory($this->dependencyInjector, $this->utils);
         $widgetInstaller = $factory->newRemover($name);
 
         return $widgetInstaller->remove();

--- a/www/api/class/centreon_clapi.class.php
+++ b/www/api/class/centreon_clapi.class.php
@@ -49,25 +49,33 @@ require_once _CENTREON_PATH_ . '/www/class/centreon-clapi/centreonAPI.class.php'
 /**
  * Class wrapper for CLAPI to expose in REST
  */
-class CentreonClapi extends CentreonWebService
+class CentreonClapi extends CentreonWebService implements CentreonWebServiceDiInterface
 {
 
+    /**
+     * @var \Pimple\Container
+     */
     private $dependencyInjector;
 
     /**
-     * Constructor
+     * {@inheritdoc}
      */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-
     public function finalConstruct(\Pimple\Container $dependencyInjector)
     {
         $this->dependencyInjector = $dependencyInjector;
     }
 
+    /**
+     * Post
+     * 
+     * @global \Centreon $centreon
+     * @global array $conf_centreon
+     * @return array
+     * @throws \RestBadRequestException
+     * @throws \RestNotFoundException
+     * @throws \RestConflictException
+     * @throws \RestInternalServerErrorException
+     */
     public function postAction()
     {
         global $centreon;

--- a/www/api/class/webService.class.php
+++ b/www/api/class/webService.class.php
@@ -37,6 +37,9 @@ require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
 
 class CentreonWebService
 {
+    const RESULT_HTML = 'html';
+    const RESULT_JSON = 'json';
+
     /**
      * @var CentreonDB|null
      */
@@ -177,7 +180,7 @@ class CentreonWebService
      * @param mixed $data The values
      * @param integer $code The HTTP code
      */
-    public static function sendResult($data, $code = 200, $format = 'json')
+    public static function sendResult($data, $code = 200, $format = null)
     {
         switch ($code) {
             case 500:
@@ -213,11 +216,12 @@ class CentreonWebService
         }
 
         switch ($format) {
-            case 'html':
+            case static::RESULT_HTML:
                 header('Content-type: text/html');
                 print $data;
                 break;
-            case 'json':
+            case static::RESULT_JSON:
+            case null:
                 header('Content-type: application/json');
                 print json_encode($data);
                 break;
@@ -289,10 +293,10 @@ class CentreonWebService
 
         /* Initialize the webservice */
         require_once($webService['path']);
-
+        
         $wsObj = new $webService['class']();
 
-        if (method_exists($wsObj, 'finalConstruct')) {
+        if ($wsObj instanceof CentreonWebServiceDiInterface) {
             $wsObj->finalConstruct($dependencyInjector);
         }
 
@@ -301,7 +305,7 @@ class CentreonWebService
         }
 
         if (false === $wsObj->authorize($action, $user, $isInternal)) {
-            static::sendJson('Forbidden', 403);
+            static::sendResult('Forbidden', 403, static::RESULT_JSON);
         }
 
         /* Execute the action */

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -39,6 +39,9 @@ require_once dirname(__FILE__) . '/class/webService.class.php';
 require_once dirname(__FILE__) . '/exceptions.php';
 require_once dirname(__FILE__) . '/interface/di.interface.php';
 
+error_reporting(0);
+ini_set('display_errors', 0);
+
 $pearDB = $dependencyInjector['configuration_db'];
 
 /* Purge old token */

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -33,11 +33,11 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . "/../../config/centreon.config.php");
-require_once _CENTREON_PATH_ . 'bootstrap.php';
+require_once dirname(__FILE__) . '/../../bootstrap.php';
 require_once _CENTREON_PATH_ . 'www/class/centreon.class.php';
 require_once dirname(__FILE__) . '/class/webService.class.php';
 require_once dirname(__FILE__) . '/exceptions.php';
+require_once dirname(__FILE__) . '/interface/di.interface.php';
 
 $pearDB = $dependencyInjector['configuration_db'];
 

--- a/www/api/interface/di.interface.php
+++ b/www/api/interface/di.interface.php
@@ -33,36 +33,14 @@
  *
  */
 
-require_once dirname(__FILE__) . '/../../bootstrap.php';
-require_once _CENTREON_PATH_ . 'www/class/centreonSession.class.php';
-require_once _CENTREON_PATH_ . 'www/class/centreon.class.php';
-require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
-require_once dirname(__FILE__) . '/class/webService.class.php';
-require_once dirname(__FILE__) . '/exceptions.php';
-require_once dirname(__FILE__) . '/interface/di.interface.php';
+use Pimple\Container;
 
+interface CentreonWebServiceDiInterface
+{
 
-$pearDB = new CentreonDB();
-ini_set("session.gc_maxlifetime", "31536000");
-
-CentreonSession::start(1);
-
-if (false === isset($_SESSION["centreon"])) {
-    CentreonWebService::sendResult("Unauthorized", 401);
+    /**
+     * 
+     * @param \Pimple\Container $dependencyInjector
+     */
+    public function finalConstruct(Container $dependencyInjector);
 }
-
-$pearDB = new CentreonDB();
-
-/*
- * Define Centreon var alias
- */
-if (isset($_SESSION["centreon"])) {
-    $centreon = $_SESSION["centreon"];
-    $oreon = $centreon;
-}
-
-if (false === isset($centreon) || false === is_object($centreon)) {
-    CentreonWebService::sendResult("Unauthorized", 401);
-}
-
-CentreonWebService::router($dependencyInjector, $centreon->user, true);

--- a/www/api/internal.php
+++ b/www/api/internal.php
@@ -41,6 +41,8 @@ require_once dirname(__FILE__) . '/class/webService.class.php';
 require_once dirname(__FILE__) . '/exceptions.php';
 require_once dirname(__FILE__) . '/interface/di.interface.php';
 
+error_reporting(0);
+ini_set('display_errors', 0);
 
 $pearDB = new CentreonDB();
 ini_set("session.gc_maxlifetime", "31536000");

--- a/www/api/trait/diAndUtilis.trait.php
+++ b/www/api/trait/diAndUtilis.trait.php
@@ -33,36 +33,30 @@
  *
  */
 
-require_once dirname(__FILE__) . '/../../bootstrap.php';
-require_once _CENTREON_PATH_ . 'www/class/centreonSession.class.php';
-require_once _CENTREON_PATH_ . 'www/class/centreon.class.php';
-require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
-require_once dirname(__FILE__) . '/class/webService.class.php';
-require_once dirname(__FILE__) . '/exceptions.php';
-require_once dirname(__FILE__) . '/interface/di.interface.php';
+use Pimple\Container;
+use CentreonLegacy\Core\Utils\Factory;
 
+trait CentreonWebServiceDiAndUtilisTrait
+{
 
-$pearDB = new CentreonDB();
-ini_set("session.gc_maxlifetime", "31536000");
+    /**
+     * @var \Pimple\Container
+     */
+    private $dependencyInjector;
 
-CentreonSession::start(1);
+    /**
+     * @var \CentreonLegacy\Core\Utils\Factory
+     */
+    private $utils;
 
-if (false === isset($_SESSION["centreon"])) {
-    CentreonWebService::sendResult("Unauthorized", 401);
+    /**
+     * {@inheritdoc}
+     */
+    public function finalConstruct(Container $dependencyInjector)
+    {
+        $this->dependencyInjector = $dependencyInjector;
+
+        $utilsFactory = new Factory($dependencyInjector);
+        $this->utils = $utilsFactory->newUtils();
+    }
 }
-
-$pearDB = new CentreonDB();
-
-/*
- * Define Centreon var alias
- */
-if (isset($_SESSION["centreon"])) {
-    $centreon = $_SESSION["centreon"];
-    $oreon = $centreon;
-}
-
-if (false === isset($centreon) || false === is_object($centreon)) {
-    CentreonWebService::sendResult("Unauthorized", 401);
-}
-
-CentreonWebService::router($dependencyInjector, $centreon->user, true);

--- a/www/class/centreon-clapi/centreonDependency.class.php
+++ b/www/class/centreon-clapi/centreonDependency.class.php
@@ -627,7 +627,7 @@ class CentreonDependency extends CentreonObject
         }
 
         $strParents = implode('|', $parents) . $this->delim;
-        $strChildren .= implode('|', $hostChildren) . "|";
+        $strChildren = implode('|', $hostChildren) . "|";
         $strChildren .= implode('|', $serviceChildren);
         echo str_replace("||", "|", $strParents . trim($strChildren, "|")) . "\n";
     }

--- a/www/class/centreon-clapi/centreonHostGroup.class.php
+++ b/www/class/centreon-clapi/centreonHostGroup.class.php
@@ -240,7 +240,7 @@ class CentreonHostGroup extends CentreonObject
                 $relationTable = array();
                 foreach ($relations as $rel) {
                     $tab = $obj->getIdByParameter($obj->getUniqueLabelField(), array($rel));
-                    if ($tab[0] != '') {
+                    if (isset($tab[0]) && $tab[0] != '') {
                         $relationTable[] = $tab[0];
                     } else {
                         if ($rel != '') {

--- a/www/include/configuration/configObject/traps/listTraps.php
+++ b/www/include/configuration/configObject/traps/listTraps.php
@@ -141,7 +141,7 @@ for ($i = 0; $trap = $DBRESULT->fetchRow(); $i++) {
         "RowMenu_name" => myDecode($trap["traps_name"]),
         "RowMenu_link" => "?p=" . $p . "&o=c&traps_id=" . $trap['traps_id'],
         "RowMenu_desc" => myDecode(substr($trap["traps_oid"], 0, 40)),
-        "RowMenu_status" => $tabStatus[$trap["traps_status"]],
+        "RowMenu_status" => isset($tabStatus[$trap["traps_status"]]) ? $tabStatus[$trap["traps_status"]] : $tabStatus[3],
         "RowMenu_args" => myDecode($trap["traps_args"]),
         "RowMenu_manufacturer" => myDecode($mnftr["alias"]),
         "RowMenu_options" => $moptions


### PR DESCRIPTION
disable all PHP errors in CLAPI (bin/centreon)
add interface and trait insteed checking for method
add missing arguments in Factory constructor
remove loading of centreon.conf.php when bootstrap.php is in use
add moduleId in centreon_administration_module when use methods for upgrading and removing a module
fix undefined variable in centreonDependency.class.php
fix undefined offset in centreonHostGroup.class.php
use sendResult instead sendJson in class CentreonWebService
add default status if missing in traps list

Resolves CP7M-64