### PR TITLE
enh(rt): Standardization of macro replacement methods

### DIFF
--- a/www/class/centreonHost.class.php
+++ b/www/class/centreonHost.class.php
@@ -548,9 +548,10 @@ class CentreonHost
      * @param mixed $hostParam
      * @param string $string
      * @param int $antiLoop
+     * @param array $data
      * @return string
      */
-    public function replaceMacroInString($hostParam, $string, $antiLoop = null)
+    public function replaceMacroInString($hostParam, $string, $antiLoop = null, $data = null)
     {
         if (is_numeric($hostParam)) {
             $host_id = $hostParam;
@@ -571,29 +572,35 @@ class CentreonHost
          * replace if not template
          */
         if ($row['host_register'] == 1) {
-            if (strpos($string, "\$HOSTADDRESS$")) {
-                $string = str_replace("\$HOSTADDRESS\$", $this->getHostAddress($host_id), $string);
-            }
-            if (strpos($string, "\$HOSTNAME$")) {
-                $string = str_replace("\$HOSTNAME\$", $this->getHostName($host_id), $string);
-            }
-            if (strpos($string, "\$HOSTALIAS$")) {
-                $string = str_replace("\$HOSTALIAS\$", $this->getHostAlias($host_id), $string);
-            }
-            if (preg_match("\$INSTANCENAME\$", $string)) {
-                $string = str_replace(
-                    "\$INSTANCENAME\$",
-                    $this->instanceObj->getParam($this->getHostPollerId($host_id), 'name'),
-                    $string
-                );
-            }
-            if (preg_match("\$INSTANCEADDRESS\$", $string)) {
-                $string = str_replace(
-                    "\$INSTANCEADDRESS\$",
-                    $this->instanceObj->getParam($this->getHostPollerId($host_id), 'ns_ip_address'),
-                    $string
-                );
-            }
+            $string = str_replace(
+                "\$HOSTADDRESS\$",
+                count($data['address']) ? $data['address'] : $this->getHostAddress($host_id),
+                $string
+            );
+            $string = str_replace(
+                "\$HOSTNAME\$",
+                count($data["name"]) ? $data["name"] : $this->getHostName($host_id),
+                $string
+            );
+            $string = str_replace(
+                "\$HOSTALIAS\$",
+                count($data["alias"]) ? $data["alias"] : $this->getHostAlias($host_id),
+                $string
+            );
+            $string = str_replace(
+                "\$INSTANCENAME\$",
+                count($data['instance_name'])
+                    ? $data['instance_name']
+                    : $this->instanceObj->getParam($this->getHostPollerId($host_id), 'name'),
+                $string
+            );
+            $string = str_replace(
+                "\$INSTANCEADDRESS\$",
+                count($data['instance_name'])
+                    ? $data['instance_name']
+                    : $this->instanceObj->getParam($this->getHostPollerId($host_id), 'ns_ip_address'),
+                $string
+            );
         }
         unset($row);
 

--- a/www/class/centreonService.class.php
+++ b/www/class/centreonService.class.php
@@ -293,9 +293,10 @@ class CentreonService
      *  @param string $string
      *  @param int $antiLoop
      *  @param int $instanceId
+     *  @param array $data
      *  @return string
      */
-    public function replaceMacroInString($svc_id, $string, $antiLoop = null, $instanceId = null)
+    public function replaceMacroInString($svc_id, $string, $antiLoop = null, $instanceId = null, $data = null)
     {
         $rq = "SELECT service_register FROM service WHERE service_id = '" . $svc_id . "' LIMIT 1";
         $DBRES = $this->db->query($rq);
@@ -308,19 +309,49 @@ class CentreonService
          * replace if not template
          */
         if ($row['service_register'] == 1) {
-            if (preg_match('/\$SERVICEDESC\$/', $string)) {
-                $string = str_replace("\$SERVICEDESC\$", $this->getServiceDesc($svc_id), $string);
-            }
-            if (!is_null($instanceId) && preg_match("\$INSTANCENAME\$", $string)) {
-                $string = str_replace("\$INSTANCENAME\$", $this->instanceObj->getParam($instanceId, 'name'), $string);
-            }
-            if (!is_null($instanceId) && preg_match("\$INSTANCEADDRESS\$", $string)) {
-                $string = str_replace(
-                    "\$INSTANCEADDRESS\$",
-                    $this->instanceObj->getParam($instanceId, 'ns_ip_address'),
-                    $string
-                );
-            }
+            $string = str_replace(
+                "\$SERVICEDESC\$",
+                count($data['description']) 
+                    ? $data['description'] 
+                    : $this->getServiceDesc($svc_id),
+                $string
+            );
+            $string = str_replace(
+                "\$SERVICESTATEID\$",
+                count($data['state']) 
+                    ? $data['state'] 
+                    : $this->getParameters($svc_id, 'state'),
+                $string
+            );
+            $string = str_replace(
+                "\$HOSTADDRESS\$",
+                count($data['address']) ? $data['address'] : "",
+                $string
+            );
+            $string = str_replace(
+                "\$HOSTNAME\$",
+                count($data["name"]) ? $data["name"] : "",
+                $string
+            );
+            $string = str_replace(
+                "\$HOSTALIAS\$",
+                count($data["alias"]) ? $data["alias"] : "",
+                $string
+            );
+            $string = str_replace(
+                "\$INSTANCENAME\$",
+                count($data['instance_name'])
+                    ? $data['instance_name']
+                    : $this->instanceObj->getParam($instanceId, 'name'),
+                $string
+            );
+            $string = str_replace(
+                "\$INSTANCEADDRESS\$",
+                count($data['instance_name'])
+                    ? $data['instance_name']
+                    : $this->instanceObj->getParam($instanceId, 'ns_ip_address'),
+                $string
+            );
         }
         $matches = array();
         $pattern = '|(\$_SERVICE[0-9a-zA-Z\_\-]+\$)|';

--- a/www/include/monitoring/status/Hosts/xml/hostXML.php
+++ b/www/include/monitoring/status/Hosts/xml/hostXML.php
@@ -357,45 +357,41 @@ while ($data = $DBRESULT->fetchRow()) {
     $obj->XML->writeElement("delim", $delim);
 
     $hostObj = new CentreonHost($obj->DB);
-    if ($data["notes"] != "") {
-        $obj->XML->writeElement("hnn", CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], str_replace("\$HOSTNAME\$", $data["name"], str_replace("\$HOSTADDRESS\$", $data["address"], $data["notes"])))));
-    } else {
-        $obj->XML->writeElement("hnn", "none");
-    }
+    $hostNotesUrl = ($data["h_notes_url"] != "")
+        ? CentreonUtils::escapeSecure(
+            $hostObj->replaceMacroInString(
+                $data["name"],
+                $data["h_notes_url"],
+                null,
+                $data
+            )
+        )
+        : "none";
+    $obj->XML->writeElement("hnu", $hostNotesUrl);
 
-    if ($data["notes_url"] != "") {
-        $str = $data['notes_url'];
-        $str = str_replace("\$HOSTNAME\$", $data['name'], $str);
-        $str = str_replace("\$HOSTALIAS\$", $data['alias'], $str);
-        $str = str_replace("\$HOSTADDRESS\$", $data['address'], $str);
-        $str = str_replace("\$HOSTNOTES\$", $data['notes'], $str);
-        $str = str_replace("\$INSTANCENAME\$", $data['instance_name'], $str);
+    $hostActionUrl = ($data["h_action_url"] != "")
+        ? CentreonUtils::escapeSecure(
+            $hostObj->replaceMacroInString(
+                $data["name"],
+                $data["h_action_url"],
+                null,
+                $data
+            )
+        )
+        : "none";
+    $obj->XML->writeElement("hau", $hostActionUrl);
 
-        $str = str_replace("\$HOSTSTATEID\$", $data['state'], $str);
-        $str = str_replace("\$HOSTSTATE\$", $obj->statusHost[$data['state']], $str);
-
-        $str = str_replace("\$INSTANCEADDRESS\$", $instanceObj->getParam($data['instance_name'], 'ns_ip_address'), $str);
-        $obj->XML->writeElement("hnu", CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], $str)));
-    } else {
-        $obj->XML->writeElement("hnu", "none");
-    }
-
-    if ($data["action_url"] != "") {
-        $str = $data['action_url'];
-        $str = str_replace("\$HOSTNAME\$", $data['name'], $str);
-        $str = str_replace("\$HOSTALIAS\$", $data['alias'], $str);
-        $str = str_replace("\$HOSTADDRESS\$", $data['address'], $str);
-        $str = str_replace("\$HOSTNOTES\$", $data['notes'], $str);
-        $str = str_replace("\$INSTANCENAME\$", $data['instance_name'], $str);
-
-        $str = str_replace("\$HOSTSTATEID\$", $data['state'], $str);
-        $str = str_replace("\$HOSTSTATE\$", $obj->statusHost[$data['state']], $str);
-
-        $str = str_replace("\$INSTANCEADDRESS\$", $instanceObj->getParam($data['instance_name'], 'ns_ip_address'), $str);
-        $obj->XML->writeElement("hau", CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], $str)));
-    } else {
-        $obj->XML->writeElement("hau", "none");
-    }
+    $hostNotes = ($data["h_notes"] != "")
+        ? CentreonUtils::escapeSecure(
+            $hostObj->replaceMacroInString(
+                $data["name"],
+                $data["h_notes"],
+                null,
+                $data
+            )
+        )
+        : "none";
+    $obj->XML->writeElement("hnn", $hostNotes);
 
     $obj->XML->endElement();
 }

--- a/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -431,45 +431,42 @@ if (!PEAR::isError($DBRESULT)) {
             $obj->XML->text(CentreonUtils::escapeSecure(urlencode($data["name"])), true, false);
             $obj->XML->endElement();
 
-            $hostNotesUrl = "none";
-            if ($data["h_notes_url"]) {
-                $hostNotesUrl = str_replace("\$HOSTNAME\$", $data["name"], $data["h_notes_url"]);
-                $hostNotesUrl = str_replace("\$HOSTALIAS\$", $data["alias"], $hostNotesUrl);
-                $hostNotesUrl = str_replace("\$HOSTADDRESS\$", $data["address"], $hostNotesUrl);
-                $hostNotesUrl = str_replace("\$INSTANCENAME\$", $data["instance_name"], $hostNotesUrl);
-                $hostNotesUrl = str_replace("\$HOSTSTATE\$", $obj->statusHost[$data["host_state"]], $hostNotesUrl);
-                $hostNotesUrl = str_replace("\$HOSTSTATEID\$", $data["host_state"], $hostNotesUrl);
-                $hostNotesUrl = str_replace(
-                    "\$INSTANCEADDRESS\$",
-                    $instanceObj->getParam($data["instance_name"], "ns_ip_address"),
-                    $hostNotesUrl
-                );
-            }
-            $obj->XML->writeElement(
-                "hnu",
-                CentreonUtils::escapeSecure($obj->hostObj->replaceMacroInString($data["name"], $hostNotesUrl))
-            );
+            $hostNotesUrl = ($data["h_notes_url"] != "")
+                ? CentreonUtils::escapeSecure(
+                    $obj->hostObj->replaceMacroInString(
+                        $data["name"],
+                        $data["h_notes_url"],
+                        null,
+                        $data
+                    )
+                )
+                : "none";
+            $obj->XML->writeElement("hnu", $hostNotesUrl);
 
-            $hostActionUrl = "none";
-            if ($data["h_action_url"]) {
-                $hostActionUrl = str_replace("\$HOSTNAME\$", $data["name"], $data["h_action_url"]);
-                $hostActionUrl = str_replace("\$HOSTALIAS\$", $data["alias"], $hostActionUrl);
-                $hostActionUrl = str_replace("\$HOSTADDRESS\$", $data["address"], $hostActionUrl);
-                $hostActionUrl = str_replace("\$INSTANCENAME\$", $data["instance_name"], $hostActionUrl);
-                $hostActionUrl = str_replace("\$HOSTSTATE\$", $obj->statusHost[$data["host_state"]], $hostActionUrl);
-                $hostActionUrl = str_replace("\$HOSTSTATEID\$", $data["host_state"], $hostActionUrl);
-                $hostActionUrl = str_replace(
-                    "\$INSTANCEADDRESS\$",
-                    $instanceObj->getParam($data["instance_name"], "ns_ip_address"),
-                    $hostActionUrl
-                );
-            }
-            $obj->XML->writeElement(
-                "hau",
-                CentreonUtils::escapeSecure($obj->hostObj->replaceMacroInString($data["name"], $hostActionUrl))
-            );
+            $hostActionUrl = ($data["h_action_url"] != "")
+                ? CentreonUtils::escapeSecure(
+                    $obj->hostObj->replaceMacroInString(
+                        $data["name"],
+                        $data["h_action_url"],
+                        null,
+                        $data
+                    )
+                )
+                : "none";
+            $obj->XML->writeElement("hau", $hostActionUrl);
 
-            $obj->XML->writeElement("hnn", CentreonUtils::escapeSecure($data["h_notes"]));
+            $hostNotes = ($data["h_notes"] != "")
+                ? CentreonUtils::escapeSecure(
+                    $obj->hostObj->replaceMacroInString(
+                        $data["name"],
+                        $data["h_notes"],
+                        null,
+                        $data
+                    )
+                )
+                : "none";
+            $obj->XML->writeElement("hnn", $hostNotes);
+
             $obj->XML->writeElement("hico", $data["h_icon_images"]);
             $obj->XML->writeElement("hip", CentreonUtils::escapeSecure($data["address"]));
             $obj->XML->writeElement("hdtm", $data["h_scheduled_downtime_depth"]);
@@ -538,97 +535,64 @@ if (!PEAR::isError($DBRESULT)) {
         $obj->XML->writeElement("ackXsl", "./include/monitoring/acknowlegement/xsl/popupForAck.xsl");
 
         if ($data["notes"] != "") {
-            $data["notes"] = str_replace("\$SERVICEDESC\$", $data["description"], $data["notes"]);
-            $data["notes"] = str_replace("\$HOSTNAME\$", $data["name"], $data["notes"]);
-            if (isset($data["alias"]) && $data["alias"]) {
-                $data["notes"] = str_replace("\$HOSTALIAS\$", $data["alias"], $data["notes"]);
-            }
-            if (isset($data['address']) && $data['address']) {
-                $data["notes"] = str_replace("\$HOSTADDRESS\$", $data['address'], $data["notes"]);
-            }
-            if (isset($data['instance_name']) && $data['instance_name']) {
-                $data["notes"] = str_replace("\$INSTANCENAME\$", $data['instance_name'], $data['notes']);
-                $data["notes"] = str_replace(
-                    "\$INSTANCEADDRESS\$",
-                    $instanceObj->getParam($data['instance_name'], 'ns_ip_address'),
-                    $data["notes"]
-                );
-            }
-            $obj->XML->writeElement("snn", CentreonUtils::escapeSecure($data["notes"]));
+            $data["notes"] = str_replace(
+                "\$SERVICESTATE\$",
+                $obj->statusService[$data["state"]],
+                $data["notes"]
+            );
+            $data["notes"] = CentreonUtils::escapeSecure(
+                $obj->serviceObj->replaceMacroInString(
+                    $data["service_id"],
+                    $data["notes"],
+                    null,
+                    null,
+                    $data
+                )
+            );
         } else {
-            $obj->XML->writeElement("snn", 'none');
+            $data["notes"] = "none";
         }
+        $obj->XML->writeElement("snn", $data["notes"]);
 
         if ($data["notes_url"] != "") {
-            $data["notes_url"] = str_replace("\$SERVICEDESC\$", $data["description"], $data["notes_url"]);
-            $data["notes_url"] = str_replace("\$SERVICESTATEID\$", $data["state"], $data["notes_url"]);
             $data["notes_url"] = str_replace(
                 "\$SERVICESTATE\$",
                 $obj->statusService[$data["state"]],
                 $data["notes_url"]
             );
-            $data["notes_url"] = str_replace("\$HOSTNAME\$", $data["name"], $data["notes_url"]);
-            if (isset($data["alias"]) && $data["alias"]) {
-                $data["notes_url"] = str_replace("\$HOSTALIAS\$", $data["alias"], $data["notes_url"]);
-            }
-            if (isset($data['address']) && $data['address']) {
-                $data["notes_url"] = str_replace("\$HOSTADDRESS\$", $data['address'], $data["notes_url"]);
-            }
-            if (isset($data['instance_name']) && $data['instance_name']) {
-                $data["notes_url"] = str_replace("\$INSTANCENAME\$", $data['instance_name'], $data['notes_url']);
-                $data["notes_url"] = str_replace(
-                    "\$INSTANCEADDRESS\$",
-                    $instanceObj->getParam($data['instance_name'], 'ns_ip_address'),
-                    $data["notes_url"]
-                );
-            }
-            $obj->XML->writeElement("snu", CentreonUtils::escapeSecure($obj->serviceObj->replaceMacroInString($data["service_id"], $data["notes_url"])));
-        } else {
-            $obj->XML->writeElement("snu", 'none');
-        }
-
-        if ($data["action_url"] != "") {
-            $data["action_url"] = str_replace("\$SERVICEDESC\$", $data["description"], $data["action_url"]);
-            $data["action_url"] = str_replace("\$SERVICESTATEID\$", $data["state"], $data["action_url"]);
-            $data["action_url"] = str_replace("\$SERVICESTATE\$", $obj->statusService[$data["state"]], $data["action_url"]);
-            $data["action_url"] = str_replace("\$HOSTNAME\$", $data["name"], $data["action_url"]);
-            if (isset($data["alias"]) && $data["alias"]) {
-                $data["action_url"] = str_replace("\$HOSTALIAS\$", $data["alias"], $data["action_url"]);
-            }
-            if (isset($data['address']) && $data['address']) {
-                $data["action_url"] = str_replace("\$HOSTADDRESS\$", $data['address'], $data["action_url"]);
-            }
-            if (isset($data['instance_name']) && $data['instance_name']) {
-                $data["action_url"] = str_replace("\$INSTANCENAME\$", $data['instance_name'], $data['action_url']);
-                $data["action_url"] = str_replace(
-                    "\$INSTANCEADDRESS\$",
-                    $instanceObj->getParam($data['instance_name'], 'ns_ip_address'),
-                    $data["action_url"]
-                );
-            }
-            $obj->XML->writeElement(
-                "sau",
-                CentreonUtils::escapeSecure(
-                    $obj->serviceObj->replaceMacroInString($data["service_id"], $data["action_url"])
+            $data["notes_url"] = CentreonUtils::escapeSecure(
+                $obj->serviceObj->replaceMacroInString(
+                    $data["service_id"],
+                    $data["notes_url"],
+                    null,
+                    null,
+                    $data
                 )
             );
         } else {
-            $obj->XML->writeElement("sau", 'none');
+            $data["notes_url"] = "none";
         }
+        $obj->XML->writeElement("snu", $data["notes_url"]);
 
-        if ($data["notes"] != "") {
-            $data["notes"] = str_replace("\$SERVICEDESC\$", $data["description"], $data["notes"]);
-            $data["notes"] = str_replace("\$HOSTNAME\$", $data["name"], $data["notes"]);
-            if (isset($data["alias"]) && $data["alias"]) {
-                $data["notes"] = str_replace("\$HOSTALIAS\$", $data["alias"], $data["notes"]);
-            }
-            if (isset($data['address']) && $data['address']) {
-                $data["notes"] = str_replace("\$HOSTADDRESS\$", $data['address'], $data["notes"]);
-            }
-            $obj->XML->writeElement("sn", CentreonUtils::escapeSecure($data["notes"]));
+        if ($data["action_url"] != "") {
+            $data["action_url"] = str_replace(
+                "\$SERVICESTATE\$",
+                $obj->statusService[$data["state"]],
+                $data["action_url"]
+            );
+            $data["action_url"] = CentreonUtils::escapeSecure(
+                $obj->serviceObj->replaceMacroInString(
+                    $data["service_id"],
+                    $data["action_url"],
+                    null,
+                    null,
+                    $data
+                )
+            );
         } else {
-            $obj->XML->writeElement("sn", 'none');
+            $data["action_url"] = "none";
         }
+        $obj->XML->writeElement("sau", $data["action_url"]);
 
         $obj->XML->writeElement("fd", $data["flap_detection"]);
         $obj->XML->writeElement("ha", $data["h_acknowledged"]);


### PR DESCRIPTION
- Upgrade method replaceMacroInString for centreonHost.class.php and centreonService.class.php classes to have possibility to use predefined values from an array
- clean code in hostXML.php and serviceXML.php and offer possibility to replace the same macros list

/!\ Should be tested on a bench machine

