### PR TITLE
fix(conf): trap generation reindexing pollers id

### DIFF
--- a/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+++ b/www/include/configuration/configGenerateTraps/formGenerateTraps.php
@@ -69,7 +69,7 @@ $n = count($tab_nagios_server);
  * Display all server options
  */
 if ($n > 1) {
-    $tab_nagios_server = array_merge(array(0 => _("All Pollers")), $tab_nagios_server);
+    $tab_nagios_server = array(0 => _("All Pollers")) + $tab_nagios_server;
 }
 
 /*


### PR DESCRIPTION
Fix trap generation form reindexing pollers id when adding All Pollers entry.

Fix: https://github.com/centreon/centreon/issues/6205