### PR TITLE
Fix untracked error when using centreon-central in a docker environment

### DIFF
--- a/www/install/steps/step8.php
+++ b/www/install/steps/step8.php
@@ -44,15 +44,6 @@ $title = _('Installation finished');
 
 $contents = '<div>'._('Congratulations, you have successfully installed Centreon!').'</div>';
 
-$centreon_path = realpath(dirname(__FILE__) . '/../../../');
-
-if (false === is_dir($centreon_path . '/installDir')) {
-    $contents .= '<br>Warning : The installation directory cannot be move. Please create the directory ' . $centreon_path . '/installDir and give it the rigths to apache user to write.';
-} else {
-    $name = 'install-' . $_SESSION['version'] . '-' . date('Ymd_His');
-    @rename(str_replace('steps', '', getcwd()), $centreon_path . '/installDir/' . $name);
-}
-
 session_destroy();
 require_once ("process/advertising.php");
 $template->assign('step', STEP_NUMBER);
@@ -62,3 +53,11 @@ $template->assign('finish', 1);
 $template->assign('blockPreview', 1);
 $template->display('content.tpl');
 
+$centreon_path = realpath(dirname(__FILE__) . '/../../../');
+
+if (false === is_dir($centreon_path . '/installDir')) {
+    $contents .= '<br>Warning : The installation directory cannot be move. Please create the directory ' . $centreon_path . '/installDir and give it the rigths to apache user to write.';
+} else {
+    $name = 'install-' . $_SESSION['version'] . '-' . date('Ymd_His');
+    system("mv ". realpath(str_replace('steps', '', getcwd())) . " " .  $centreon_path . '/installDir/' . $name);
+}


### PR DESCRIPTION
Hi, 

I was experiencing an issue when trying to create some image for the current version of Centreon web in a dockerized environment. 
My issue was simple. The www/install wasn't moved to ../installDir/ bot nothing told me that. 
In order to discover it, I was need to replace the @rename by a rename syntaxe. 
Then I found the error was an "Invalid cross-device link" error. 
This seems to be a php error on a dockerized environment. However i've replaced the line my a system call to move the install directory at the end of the step8.php file. 

With those changes I was able to get my dockerized environment running well. 

Regards, 