### PR TITLE
Fix untracked error when using centreon-central in a docker environment

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -609,7 +609,11 @@ input[type="submit"] {
     top: 45px;
     right: 10px;
 }
-
+#centreon-warning{
+    background: orange;
+    line-height: 30px;
+    padding-left: 30px;
+}
 form#AjaxBankBasic {
     padding-bottom: 0px;
 }

--- a/www/include/core/menu/menu.php
+++ b/www/include/core/menu/menu.php
@@ -305,6 +305,14 @@ if ($is_admin) {
 $tpl->assign('amIadmin', $centreon->user->admin);
 
 /*
+ * Install directory present
+ */
+if (is_dir(realpath(dirname(__FILE__) . '/../../../install'))) {
+    $tpl->assign('displayWarning', 1);
+    $tpl->assign('WarningMessage', '<b>Warning</b> : The installation directory has not been deleted! For security reasons, administrator would have to remove it manually.');
+}
+
+/*
  * Display
  */
 $tpl->display("BlockHeader.ihtml");

--- a/www/include/core/menu/templates/BlockHeader.ihtml
+++ b/www/include/core/menu/templates/BlockHeader.ihtml
@@ -1,9 +1,4 @@
 <div id="header">
-	{if $displayWarning == 1}
-	<div id="centreon-warning">
-		{$WarningMessage}
-	</div>
-	{/if}
 	<div id="centreon_logo">
 		<img src='{$urlLogo}' title='Centreon Logo' id="logo" />
 	</div>
@@ -104,6 +99,11 @@
 	</div>
 	<div id="centreonMsg"></div>
 </div>
+{if $displayWarning == 1}
+<div id="centreon-warning">
+	{$WarningMessage}
+</div>
+{/if}
 {literal}
 <script type='text/javascript'>
 /*

--- a/www/include/core/menu/templates/BlockHeader.ihtml
+++ b/www/include/core/menu/templates/BlockHeader.ihtml
@@ -1,4 +1,9 @@
 <div id="header">
+	{if $displayWarning == 1}
+	<div id="centreon-warning">
+		{$WarningMessage}
+	</div>
+	{/if}
 	<div id="centreon_logo">
 		<img src='{$urlLogo}' title='Centreon Logo' id="logo" />
 	</div>

--- a/www/install/step_upgrade/functions.php
+++ b/www/install/step_upgrade/functions.php
@@ -123,4 +123,25 @@ function aff_footer()
     <?php
 }
 
+/**
+ * Recursively removes a folder along with all its files and directories
+ * 
+ * @param String $path 
+ * @return Boolean True if the directory was removed, False otherwise
+ */
+function rrmdir($path) {
+    // Open the source directory to read in files
+    $i = new DirectoryIterator($path);
+
+    foreach($i as $f) {
+        if($f->isFile()) {
+            unlink($f->getRealPath());
+        } else if(!$f->isDot() && $f->isDir()) {
+            rrmdir($f->getRealPath());
+        }
+    }
+
+    return rmdir($path);
+}
+
 ?>

--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -49,12 +49,11 @@ $contents = sprintf(
 
 $centreon_install_dir = realpath(dirname(__FILE__) . '../../install');
 
-if (rrmdir($centreon_install_dir)) {
-    return;
+if (!is_dir($centreon_install_dir) || rrmdir($centreon_install_dir)) {
+    $contents .= '<br>Warning : The installation directory cannot be delete. Please give it the rigths to apache user to write'
+        . $centreon_install_dir . '.';
 }
 
-$contents .= '<br>Warning : The installation directory cannot be delete. Please give it the rigths to apache user to write'
-                . $centreon_install_dir . '.';
 
 $template->assign('step', STEP_NUMBER);
 $template->assign('title', $title);

--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -56,11 +56,11 @@ if (rrmdir($centreon_install_dir)) {
 $contents .= '<br>Warning : The installation directory cannot be delete. Please give it the rigths to apache user to write'
                 . $centreon_install_dir . '.';
 
-session_destroy();
-
 $template->assign('step', STEP_NUMBER);
 $template->assign('title', $title);
 $template->assign('content', $contents);
 $template->assign('finish', 1);
 $template->assign('blockPreview', 1);
 $template->display('content.tpl');
+
+session_destroy();

--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -47,13 +47,6 @@ $contents = sprintf(
     $_SESSION['CURRENT_VERSION']
 );
 
-$centreon_install_dir = realpath(dirname(__FILE__) . '/../../install');
-
-if (!is_dir($centreon_install_dir) || rrmdir($centreon_install_dir)) {
-    $contents .= '<br><b>Warning</b> : The installation directory cannot be delete. Please give it the rigths to apache user to write <b>'
-        . $centreon_install_dir . '<\b>';
-}
-
 $template->assign('step', STEP_NUMBER);
 $template->assign('title', $title);
 $template->assign('content', $contents);
@@ -62,3 +55,6 @@ $template->assign('blockPreview', 1);
 $template->display('content.tpl');
 
 session_destroy();
+
+# Removing installation directory
+rrmdir(realpath(dirname(__FILE__) . '/../../install'));

--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -47,16 +47,6 @@ $contents = sprintf(
     $_SESSION['CURRENT_VERSION']
 );
 
-$centreon_path = realpath(dirname(__FILE__) . '/../../../');
-
-if (false === is_dir($centreon_path . '/installDir')) {
-    $contents .= '<br>Warning : The installation directory cannot be move. Please create the directory '
-        . $centreon_path . '/installDir and give it the rigths to apache user to write.';
-} else {
-    $name = 'install-' . $_SESSION['CURRENT_VERSION'] . '-' . date('Ymd_His');
-    @rename(str_replace('step_upgrade', '', getcwd()), $centreon_path . '/installDir/' . $name);
-}
-
 session_destroy();
 
 $template->assign('step', STEP_NUMBER);
@@ -65,3 +55,13 @@ $template->assign('content', $contents);
 $template->assign('finish', 1);
 $template->assign('blockPreview', 1);
 $template->display('content.tpl');
+
+$centreon_path = realpath(dirname(__FILE__) . '/../../../');
+
+if (false === is_dir($centreon_path . '/installDir')) {
+    $contents .= '<br>Warning : The installation directory cannot be move. Please create the directory '
+        . $centreon_path . '/installDir and give it the rigths to apache user to write.';
+} else {
+    $name = 'install-' . $_SESSION['CURRENT_VERSION'] . '-' . date('Ymd_His');
+    system('mv '. str_replace('step_upgrade', '', getcwd()) . ' ' . $centreon_path . '/installDir/' . $name);
+}

--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -56,12 +56,11 @@ $template->assign('finish', 1);
 $template->assign('blockPreview', 1);
 $template->display('content.tpl');
 
-$centreon_path = realpath(dirname(__FILE__) . '/../../../');
+$centreon_install_dir = realpath(dirname(__FILE__) . '../../');
 
-if (false === is_dir($centreon_path . '/installDir')) {
-    $contents .= '<br>Warning : The installation directory cannot be move. Please create the directory '
-        . $centreon_path . '/installDir and give it the rigths to apache user to write.';
-} else {
-    $name = 'install-' . $_SESSION['CURRENT_VERSION'] . '-' . date('Ymd_His');
-    system('mv '. str_replace('step_upgrade', '', getcwd()) . ' ' . $centreon_path . '/installDir/' . $name);
+if (rrmdir($centreon_install_dir)) {
+    return;
 }
+
+$contents .= '<br>Warning : The installation directory cannot be delete. Please give it the rigths to apache user to write'
+                . $centreon_install_dir . '.';

--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -47,13 +47,12 @@ $contents = sprintf(
     $_SESSION['CURRENT_VERSION']
 );
 
-$centreon_install_dir = realpath(dirname(__FILE__) . '../../install');
+$centreon_install_dir = realpath(dirname(__FILE__) . '/../../install');
 
 if (!is_dir($centreon_install_dir) || rrmdir($centreon_install_dir)) {
-    $contents .= '<br>Warning : The installation directory cannot be delete. Please give it the rigths to apache user to write'
-        . $centreon_install_dir . '.';
+    $contents .= '<br><b>Warning</b> : The installation directory cannot be delete. Please give it the rigths to apache user to write <b>'
+        . $centreon_install_dir . '<\b>';
 }
-
 
 $template->assign('step', STEP_NUMBER);
 $template->assign('title', $title);

--- a/www/install/steps/functions.php
+++ b/www/install/steps/functions.php
@@ -261,4 +261,25 @@ function getDatabaseVariable($variable) {
     return $value;
 }
 
+/**
+ * Recursively removes a folder along with all its files and directories
+ * 
+ * @param String $path 
+ * @return Boolean True if the directory was removed, False otherwise
+ */
+function rrmdir($path) {
+    // Open the source directory to read in files
+    $i = new DirectoryIterator($path);
+
+    foreach($i as $f) {
+        if($f->isFile()) {
+            unlink($f->getRealPath());
+        } else if(!$f->isDot() && $f->isDir()) {
+            rrmdir($f->getRealPath());
+        }
+    }
+
+    return rmdir($path);
+}
+
 ?>

--- a/www/install/steps/step8.php
+++ b/www/install/steps/step8.php
@@ -53,11 +53,11 @@ $template->assign('finish', 1);
 $template->assign('blockPreview', 1);
 $template->display('content.tpl');
 
-$centreon_path = realpath(dirname(__FILE__) . '/../../../');
+$centreon_install_dir = realpath(dirname(__FILE__) . '../../');
 
-if (false === is_dir($centreon_path . '/installDir')) {
-    $contents .= '<br>Warning : The installation directory cannot be move. Please create the directory ' . $centreon_path . '/installDir and give it the rigths to apache user to write.';
-} else {
-    $name = 'install-' . $_SESSION['version'] . '-' . date('Ymd_His');
-    system('mv '. realpath(str_replace('steps', '', getcwd())) . ' ' .  $centreon_path . '/installDir/' . $name);
+if (rrmdir($centreon_install_dir)) {
+    return;
 }
+
+$contents .= '<br>Warning : The installation directory cannot be delete. Please give it the rigths to apache user to write'
+                . $centreon_install_dir . '.';

--- a/www/install/steps/step8.php
+++ b/www/install/steps/step8.php
@@ -45,19 +45,15 @@ $template = getTemplate('./templates');
 $title = _('Installation finished');
 
 $contents = '<div>'._('Congratulations, you have successfully installed Centreon!').'</div>';
-
-$centreon_install_dir = realpath(dirname(__FILE__) . '/../../install');
-
-if (!is_dir($centreon_install_dir) || rrmdir($centreon_install_dir)) {
-    $contents .= '<br><b>Warning</b> : The installation directory cannot be delete. Please give it the rigths to apache user to write <b>'
-        . $centreon_install_dir . '<\b>';
-}
-               
+          
 $template->assign('step', STEP_NUMBER);
 $template->assign('title', $title);
-$template->assign('content', $contents);
 $template->assign('finish', 1);
 $template->assign('blockPreview', 1);
+$template->assign('content', $contents);
 $template->display('content.tpl');
 
 session_destroy();
+
+# Removing installation directory
+rrmdir(realpath(dirname(__FILE__) . '/../../install'));

--- a/www/install/steps/step8.php
+++ b/www/install/steps/step8.php
@@ -46,13 +46,12 @@ $title = _('Installation finished');
 
 $contents = '<div>'._('Congratulations, you have successfully installed Centreon!').'</div>';
 
-$centreon_install_dir = dirname(__FILE__) . '../../install';
+$centreon_install_dir = realpath(dirname(__FILE__) . '/../../install');
 
 if (!is_dir($centreon_install_dir) || rrmdir($centreon_install_dir)) {
-    $contents .= '<br>Warning : The installation directory cannot be delete. Please give it the rigths to apache user to write'
-        . $centreon_install_dir . '.';
+    $contents .= '<br><b>Warning</b> : The installation directory cannot be delete. Please give it the rigths to apache user to write <b>'
+        . $centreon_install_dir . '<\b>';
 }
-
                
 $template->assign('step', STEP_NUMBER);
 $template->assign('title', $title);

--- a/www/install/steps/step8.php
+++ b/www/install/steps/step8.php
@@ -59,5 +59,5 @@ if (false === is_dir($centreon_path . '/installDir')) {
     $contents .= '<br>Warning : The installation directory cannot be move. Please create the directory ' . $centreon_path . '/installDir and give it the rigths to apache user to write.';
 } else {
     $name = 'install-' . $_SESSION['version'] . '-' . date('Ymd_His');
-    system("mv ". realpath(str_replace('steps', '', getcwd())) . " " .  $centreon_path . '/installDir/' . $name);
+    system('mv '. realpath(str_replace('steps', '', getcwd())) . ' ' .  $centreon_path . '/installDir/' . $name);
 }

--- a/www/install/steps/step8.php
+++ b/www/install/steps/step8.php
@@ -38,6 +38,8 @@ DEFINE('STEP_NUMBER', 8);
 $_SESSION['step'] = STEP_NUMBER;
 
 require_once 'functions.php';
+require_once ("process/advertising.php");
+
 $template = getTemplate('./templates');
 
 $title = _('Installation finished');
@@ -52,12 +54,12 @@ if (rrmdir($centreon_install_dir)) {
 
 $contents .= '<br>Warning : The installation directory cannot be delete. Please give it the rigths to apache user to write'
                 . $centreon_install_dir . '.';
-
-session_destroy();
-require_once ("process/advertising.php");
+               
 $template->assign('step', STEP_NUMBER);
 $template->assign('title', $title);
 $template->assign('content', $contents);
 $template->assign('finish', 1);
 $template->assign('blockPreview', 1);
 $template->display('content.tpl');
+
+session_destroy();

--- a/www/install/steps/step8.php
+++ b/www/install/steps/step8.php
@@ -46,14 +46,13 @@ $title = _('Installation finished');
 
 $contents = '<div>'._('Congratulations, you have successfully installed Centreon!').'</div>';
 
-$centreon_install_dir = realpath(dirname(__FILE__) . '../../install');
+$centreon_install_dir = dirname(__FILE__) . '../../install';
 
-if (rrmdir($centreon_install_dir)) {
-    return;
+if (!is_dir($centreon_install_dir) || rrmdir($centreon_install_dir)) {
+    $contents .= '<br>Warning : The installation directory cannot be delete. Please give it the rigths to apache user to write'
+        . $centreon_install_dir . '.';
 }
 
-$contents .= '<br>Warning : The installation directory cannot be delete. Please give it the rigths to apache user to write'
-                . $centreon_install_dir . '.';
                
 $template->assign('step', STEP_NUMBER);
 $template->assign('title', $title);

--- a/www/install/steps/step8.php
+++ b/www/install/steps/step8.php
@@ -44,15 +44,6 @@ $title = _('Installation finished');
 
 $contents = '<div>'._('Congratulations, you have successfully installed Centreon!').'</div>';
 
-$centreon_path = realpath(dirname(__FILE__) . '/../../../');
-
-if (false === is_dir($centreon_path . '/installDir')) {
-    $contents .= '<br>Warning : The installation directory cannot be move. Please create the directory ' . $centreon_path . '/installDir and give it the rigths to apache user to write.';
-} else {
-    $name = 'install-' . $_SESSION['version'] . '-' . date('Ymd_His');
-    @rename(str_replace('steps', '', getcwd()), $centreon_path . '/installDir/' . $name);
-}
-
 session_destroy();
 require_once ("process/advertising.php");
 $template->assign('step', STEP_NUMBER);
@@ -62,3 +53,11 @@ $template->assign('finish', 1);
 $template->assign('blockPreview', 1);
 $template->display('content.tpl');
 
+$centreon_path = realpath(dirname(__FILE__) . '/../../../');
+
+if (false === is_dir($centreon_path . '/installDir')) {
+    $contents .= '<br>Warning : The installation directory cannot be move. Please create the directory ' . $centreon_path . '/installDir and give it the rigths to apache user to write.';
+} else {
+    $name = 'install-' . $_SESSION['version'] . '-' . date('Ymd_His');
+    system("mv ". realpath(str_replace('steps', '', getcwd())) . " " .  $centreon_path . '/installDir/' . $name);
+}


### PR DESCRIPTION
Hi,

I was experiencing an issue when trying to create some image for the current version of Centreon web in a dockerized environment.

My issue was simple. The www/install wasn't moved to ../installDir/ bot nothing told me that.
In order to discover it, I was need to replace the @rename by a rename syntaxe.
Then I found the error was an "Invalid cross-device link" error.
This seems to be a php error on a dockerized environment. However i've replaced the line my a system call to move the install directory at the end of the step8.php file.

With those changes I was able to get my dockerized environment running well.

Furhtermore I did the same for the upgrade part.

Regards,