### PR TITLE
fix(pagination): remove history limiting check

### DIFF
--- a/www/include/common/autoNumLimit.php
+++ b/www/include/common/autoNumLimit.php
@@ -63,12 +63,7 @@ if (isset($_POST['limit']) && $_POST['limit']) {
 
 $_SESSION[$sessionLimitKey] = $limit;
 
-if (!empty($centreon->historyLimit) &&
-    !empty($centreon->historyLimit[$url]) &&
-    $limit != $centreon->historyLimit[$url]
-) {
-    $num = 0;
-} elseif (isset($_POST['num']) && $_POST['num']) {
+if (isset($_POST['num']) && $_POST['num']) {
     $num = $_POST['num'];
 } elseif (isset($_GET['num']) && $_GET['num']) {
     $num = $_GET['num'];


### PR DESCRIPTION
The history limit is being updated in www/main.php after the current page has loaded, so the autoNumLimit.php file sets a wrong $num on the first load of the pagination results.