### PR TITLE
fix(acl): do not get severity of parents if present on actual object

### DIFF
--- a/cron/centAcl-Func.php
+++ b/cron/centAcl-Func.php
@@ -176,6 +176,7 @@ function getServiceTemplateCategoryList($service_id = null)
         foreach ($svcCatCache[$service_id] as $ct_id => $flag) {
             $tabCategory[$ct_id] = $ct_id;
         }
+        return $tabCategory;
     }
 
     /*


### PR DESCRIPTION
If severities are present on actual object, do not try to get severities from templates