### PR TITLE
Listing modules : manage the license expiration date

### DIFF
--- a/www/include/options/oreon/modules/listModules.ihtml
+++ b/www/include/options/oreon/modules/listModules.ihtml
@@ -21,7 +21,7 @@
 	</tr>
 
 	{foreach from=$modules key=name item=properties}
-	<tr class='list_one'>
+	<tr class='list_one' data-module-name="{$properties.name}">
 		<td class="ListColLeft">
 			<a href="?p={$p}&o=w&name={$properties.name}">{$properties.name}</a>
 		</td>

--- a/www/include/options/oreon/modules/listModules.ihtml
+++ b/www/include/options/oreon/modules/listModules.ihtml
@@ -55,10 +55,3 @@
 <script type="text/javascript" src="./include/common/javascript/jquery/plugins/fileUpload/jquery.fileupload.js"></script>
 <script type="text/javascript" src="./include/common/javascript/jquery/plugins/fileUpload/jquery.fileupload-ui.js"></script>
 <script type="text/javascript" src="./include/options/oreon/modules/listModules.js"></script>
-
-{literal}
-<script>
-    //formatting the tags containing a class isTimestamp
-    formatDateMoment();
-</script>
-{/literal}

--- a/www/include/options/oreon/modules/listModules.js
+++ b/www/include/options/oreon/modules/listModules.js
@@ -10,6 +10,7 @@ function CheckModule()
         },
         success: function (data) {
             displayResults(data);
+            formatDateMoment();
         }
     });
 }

--- a/www/include/options/oreon/modules/listModules.js
+++ b/www/include/options/oreon/modules/listModules.js
@@ -85,6 +85,11 @@ function displayResults(moduleList)
             jQuery('#action_'+ moduleName).prepend(customActionIcon);
         }
 
+        if (module['licenseExpiration']) {
+            jQuery('tr[data-module-name="' + moduleName + '"] .ListColCenter.isTimestamp')
+                .html(module['licenseExpiration']);
+        }
+
         if (tooltipReferer) {
             jQuery(tooltipReferer).qtip({
                 content: statusMessage,

--- a/www/include/options/oreon/modules/moduleDependenciesValidator.php
+++ b/www/include/options/oreon/modules/moduleDependenciesValidator.php
@@ -52,8 +52,12 @@ foreach ($modules as $module) {
         $warning = false;
         $critical = false;
 
-        if (file_exists($checklistDir.'requirements.php')) {
-            require_once $checklistDir.'requirements.php';
+        if (file_exists($checklistDir . 'requirements.php')) {
+            require_once $checklistDir . 'requirements.php';
+            // Necessary to implement the expiration date column in list modules page
+            if (isset($licenseExpiration)) {
+                $response[$module]['licenseExpiration'] = $licenseExpiration;
+            }
             if ($critical || $warning) {
                 if ($critical) {
                     $response[$module]['status'] = 'critical';

--- a/www/include/options/oreon/modules/moduleDependenciesValidator.php
+++ b/www/include/options/oreon/modules/moduleDependenciesValidator.php
@@ -3,34 +3,34 @@
  * Copyright 2005-2015 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
- * 
- * This program is free software; you can redistribute it and/or modify it under 
- * the terms of the GNU General Public License as published by the Free Software 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
  * Foundation ; either version 2 of the License.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along with 
+ *
+ * You should have received a copy of the GNU General Public License along with
  * this program; if not, see <http://www.gnu.org/licenses>.
- * 
- * Linking this program statically or dynamically with other modules is making a 
- * combined work based on this program. Thus, the terms and conditions of the GNU 
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
- * 
- * As a special exception, the copyright holders of this program give Centreon 
- * permission to link this program with independent modules to produce an executable, 
- * regardless of the license terms of these independent modules, and to copy and 
- * distribute the resulting executable under terms of Centreon choice, provided that 
- * Centreon also meet, for each linked independent module, the terms  and conditions 
- * of the license of that module. An independent module is a module which is not 
- * derived from this program. If you modify this program, you may extend this 
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
  * do not wish to do so, delete this exception statement from your version.
- * 
+ *
  * For more information : contact@centreon.com
- * 
+ *
  */
 
 /* Load conf */


### PR DESCRIPTION
The column containing the expiration date of a module was linked to the old licensing system.
It is now possible to manage this date directly in the modules.