### PR TITLE
Use @PHP_BIN@ macro everywhere

### DIFF
--- a/bin/centreon
+++ b/bin/centreon
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!@PHP_BIN@
 <?php
 /**
  * Copyright 2005-2015 CENTREON

--- a/bin/export-mysql-indexes
+++ b/bin/export-mysql-indexes
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!@PHP_BIN@
 <?php
 $help = "NAME
     export-mysql-indexes - MySQL indexes export tool

--- a/bin/generateSqlLite
+++ b/bin/generateSqlLite
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!@PHP_BIN@
 <?php
 require_once realpath(dirname(__FILE__) . "/../config/centreon.config.php");
 

--- a/bin/import-mysql-indexes
+++ b/bin/import-mysql-indexes
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!@PHP_BIN@
 <?php
 $help = "NAME
     import-mysql-indexes - MySQL indexes import tool

--- a/cron/downtimeManager.php
+++ b/cron/downtimeManager.php
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!@PHP_BIN@
 <?php
 /**
  * Copyright 2005-2015 Centreon

--- a/libinstall/check_pear.php
+++ b/libinstall/check_pear.php
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!@PHP_BIN@
 <?php
 /*
  * Centreon is developped with GPL Licence 2.0 :

--- a/libinstall/clean_session.php
+++ b/libinstall/clean_session.php
@@ -1,4 +1,4 @@
-#!/usr/bin/env php
+#!@PHP_BIN@
 <?php
 /*
  * Centreon is developped with GPL Licence 2.0 :


### PR DESCRIPTION
This will ensure that the correct PHP runtime will be used when binaries are run.