### PR TITLE
fix(ldap): manage multiple ldap group with same dn

### DIFF
--- a/www/class/centreonContactgroup.class.php
+++ b/www/class/centreonContactgroup.class.php
@@ -162,8 +162,9 @@ class CentreonContactgroup
         /*
          * Check if contactgroup is not in databas
          */
-        $queryCheck = "SELECT cg_id FROM contactgroup
-            WHERE cg_name = '" . $this->db->escape($cg_name) . "'";
+        $queryCheck = "SELECT cg_id FROM contactgroup " .
+            "WHERE cg_name = '" . $this->db->escape($cg_name) . "' " .
+            "AND ar_id = " . $this->db->escape($cg_id);
         $res = $this->db->query($queryCheck);
         if ($res->numRows() == 1) {
             $row = $res->fetchRow();


### PR DESCRIPTION
if there are multiple ldap configuration, and each ldap has several same
ldap groups DN, it is now possible to link all those contactgroup in an
acl access group