### PR TITLE
enh(centcore): Use Remote Server to send conf and external commands

### DIFF
--- a/lib/perl/centreon/script.pm
+++ b/lib/perl/centreon/script.pm
@@ -43,7 +43,7 @@ use centreon::common::db;
 use centreon::common::lock;
 
 use vars qw($centreon_config);
-use vars qw($mysql_user $mysql_passwd $mysql_host $mysql_database_oreon $mysql_database_ods $mysql_database_ndo);
+use vars qw($mysql_user $mysql_passwd $mysql_host $mysql_database_oreon $mysql_database_ods $mysql_database_ndo $instance_mode);
 
 $SIG{__DIE__} = sub {
     return unless defined $^S and $^S == 0; # Ignore errors in eval
@@ -62,7 +62,8 @@ sub new {
        centstorage_db_conn => 0,
        severity => "info",
        noconfig => 0,
-       noroot => 0
+       noroot => 0,
+       instance_mode => "central"
       );
     my $self = {%defaults, %options};
 
@@ -114,6 +115,7 @@ sub init {
            password => $self->{centreon_config}->{db_passwd},
            logger => $self->{logger});
     }
+    $self->{instance_mode} = $instance_mode;
 }
 
 sub DESTROY {

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -414,8 +414,15 @@ sub sendExternalCommand($$){
             my $count = 0;
             foreach my $cmd1 (split(/\n/, $cmd)) {
                 if ($count >= 200) {
-                    $cmd2 = "$self->{ssh} -q ". $server_info->{ns_ip_address} ." -p $port \"$self->{echo} '".$cmd_line."' >> ".$command_file."\"";
-                    $self->{logger}->writeLogInfo("External command : ".$server_info->{ns_ip_address}." ($id) : \"".$cmd_line."\"");
+                    if (defined($server_info->{remote_id}) && $server_info->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
+                        my $remote_server = $self->getServerConfig($server_info->{remote_id});
+                        $cmd_line =~ s/^\s+|\s+$//g;
+                        $cmd2 = "$self->{ssh} -q " . $remote_server->{ns_ip_address} . " -p $port \"$self->{echo} 'EXTERNALCMD:$id:" . $cmd_line . "' > " . $self->{cmdDir} . time() . "-sendcmd\"";
+                        $self->{logger}->writeLogInfo("Send external command using Remote Server: ".$remote_server->{ns_ip_address});
+                    } else {
+                        $cmd2 = "$self->{ssh} -q ". $server_info->{ns_ip_address} ." -p $port \"$self->{echo} '".$cmd_line."' >> ".$command_file."\"";
+                        $self->{logger}->writeLogInfo("External command : ".$server_info->{ns_ip_address}." ($id) : \"".$cmd_line."\"");
+                    }
                     ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd2, logger => $self->{logger}, timeout => $self->{cmd_timeout});
                     $cmd_line = "";
                     $count = 0;
@@ -425,8 +432,15 @@ sub sendExternalCommand($$){
                 $count++;
             }
             if ($count gt 0) {
-                $cmd2 = "$self->{ssh} -q ". $server_info->{ns_ip_address} ." -p $port \"$self->{echo} '".$cmd_line."' >> ".$command_file."\"";
-                $self->{logger}->writeLogInfo("External command : ".$server_info->{ns_ip_address}." ($id) : \"".$cmd_line."\"");
+                if (defined($server_info->{remote_id}) && $server_info->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
+                    my $remote_server = $self->getServerConfig($server_info->{remote_id});
+                    $cmd_line =~ s/^\s+|\s+$//g;
+                    $cmd2 = "$self->{ssh} -q " . $remote_server->{ns_ip_address} . " -p $port \"$self->{echo} 'EXTERNALCMD:$id:" . $cmd_line . "' > " . $self->{cmdDir} . time() . "-sendcmd\"";
+                    $self->{logger}->writeLogInfo("Send external command using Remote Server: ".$remote_server->{ns_ip_address});
+                } else {
+                    $cmd2 = "$self->{ssh} -q ". $server_info->{ns_ip_address} ." -p $port \"$self->{echo} '".$cmd_line."' >> ".$command_file."\"";
+                    $self->{logger}->writeLogInfo("External command : ".$server_info->{ns_ip_address}." ($id) : \"".$cmd_line."\"");
+                }
                 ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd2, logger => $self->{logger}, timeout => $self->{cmd_timeout});
                 $cmd_line = "";
                 $count = 0;
@@ -504,6 +518,7 @@ sub sendConfigFile($){
 
     my $cfg_dir = $self->getNagiosConfigurationField($id, "cfg_dir");
     my $server_info = $self->getServerConfig($id);
+    my ($origin, $dest, $remote_server);
     my $port = checkSSHPort($server_info->{ssh_port});
 
     if (!defined($cfg_dir) || $cfg_dir =~ //) {
@@ -511,45 +526,63 @@ sub sendConfigFile($){
         return;
     }
 
-    my $origin = $self->{centreonDir} . "/filesGeneration/engine/".$id."/*";
-    my $dest = $server_info->{'ns_ip_address'}.":$cfg_dir";
+    if (defined($server_info->{remote_id}) && $server_info->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
+        $self->{logger}->writeLogError("use Remote Server to send configuration");
 
-    # Send data with SCP
-    $self->{logger}->writeLogInfo("Start: Send config files on poller $id");
-    $cmd = "$self->{scp} -P $port $origin $dest 2>&1";
+        $origin = $self->{centreonDir} . "/filesGeneration/engine/" . $id;
+        $remote_server = $self->getServerConfig($server_info->{remote_id});
+        $dest = $remote_server->{'ns_ip_address'} . ":" . $self->{centreonDir} . "/filesGeneration/engine";
+        $cmd = "$self->{scp} -r -P $port $origin $dest 2>&1";
+    } else {
+        $self->{logger}->writeLogError("direct access");
+
+        $origin = $self->{centreonDir} . "/filesGeneration/engine/" . $id . "/*";
+        $dest = $server_info->{'ns_ip_address'}.":$cfg_dir";
+
+        # Send data with SCP
+        $self->{logger}->writeLogInfo("Start: Send config files on poller $id");
+        $cmd = "$self->{scp} -P $port $origin $dest 2>&1";
+    }
 
     ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
-                                                                  logger => $self->{logger},
-                                                                  timeout => 300
-                                                                  );
+                                                          logger => $self->{logger},
+                                                          timeout => 300
+                                                          );
 
     $self->{logger}->writeLogInfo("Result : $stdout");
     $self->{logger}->writeLogInfo("End: Send config files on poller $id");
 
     # Send configuration for Centreon Broker
-    if ( -e $self->{centreonDir}  . "/filesGeneration/broker/".$id) {
+    if ( -e $self->{centreonDir}  . "/filesGeneration/broker/" . $id) {
         # Check availability of broker files.
         my $count = 0;
-        opendir(my $dh, $self->{centreonDir} . "/filesGeneration/broker/".$id);
+        opendir(my $dh, $self->{centreonDir} . "/filesGeneration/broker/" . $id);
         while(readdir $dh) {
             $count++;
         }
         closedir $dh;
 
         if ($count > 2) {
-            $self->{logger}->writeLogDebug("Start: Send Centreon Broker config files on poller $id");
-
             if ($server_info->{localhost} == 0) {
-                $cfg_dir = $server_info->{'centreonbroker_cfg_path'};
-                $origin = $self->{centreonDir} . "/filesGeneration/broker/".$id."/*.*";
-                $dest = $server_info->{ns_ip_address}.":$cfg_dir";
-                $cmd = "$self->{scp} -P $port $origin $dest 2>&1";
+                if (defined($server_info->{remote_id}) && $server_info->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
+                    $self->{logger}->writeLogDebug("Start: Send Centreon Broker config files on poller $id using Remote Server");
+                    $origin = $self->{centreonDir} . "/filesGeneration/broker/" . $id;
+                    $dest = $remote_server->{'ns_ip_address'} . ":" . $self->{centreonDir} . "/filesGeneration/broker";
+                    $cmd = "$self->{scp} -r -P $port $origin $dest 2>&1";
+                } else {
+                    $self->{logger}->writeLogDebug("Start: Send Centreon Broker config files on poller $id");
+                    $cfg_dir = $server_info->{'centreonbroker_cfg_path'};
+                    $origin = $self->{centreonDir} . "/filesGeneration/broker/" . $id . "/*.*";
+                    $dest = $server_info->{ns_ip_address}.":$cfg_dir";
+                    $cmd = "$self->{scp} -P $port $origin $dest 2>&1";
+                }
                 ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
                                                                       logger => $self->{logger},
                                                                       timeout => 300
                                                                       );
                 $self->{logger}->writeLogInfo("Result : $stdout");
             } else {
+                $self->{logger}->writeLogDebug("Start: Send Centreon Broker config files on poller $id");
                 $cmd = "cp $origin $cfg_dir 2>&1";
                 ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
                                                                       logger => $self->{logger},
@@ -559,6 +592,14 @@ sub sendConfigFile($){
             }
             $self->{logger}->writeLogDebug("End: Send Centreon Broker config files on poller $id");
         }
+    }
+    if (defined($server_info->{remote_id}) && $server_info->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
+        $self->{logger}->writeLogDebug("Send command on Remote Server to apply configuration");
+        $cmd = "$self->{ssh} -p $port " . $remote_server->{'ns_ip_address'}  . " 'echo \"SENDCFGFILE:" . $id . "\" > $self->{cmdDir}/" . time() . "-sendcmd'";
+        ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
+                                                              logger => $self->{logger},
+                                                              timeout => 300
+                                                              );
     }
 }
 
@@ -608,10 +649,11 @@ sub sendExportFile($){
 #   - restart
 #   - stop
 #
-sub initEngine($$){
+sub initEngine($$$){
     my $self = shift;
     my $id = $_[0];
     my $options = $_[1];
+    my $action = $_[2];
     my ($lerror, $cmd, $stdout);
 
     # Get configuration
@@ -626,7 +668,14 @@ sub initEngine($$){
 
     if (defined($conf->{ns_ip_address}) && $conf->{ns_ip_address}) {
         # Launch command
-        $cmd = "$self->{ssh} -p $port ". $conf->{ns_ip_address} ." $self->{sudo} $self->{service} ".$conf->{init_script}." ".$options;
+        if (defined($conf->{remote_id}) && $conf->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
+            my $remote_server = $self->getServerConfig($conf->{remote_id});
+            $action =~ s/^\s+|\s+$//g;
+            $cmd = "$self->{ssh} -p $port ". $remote_server->{ns_ip_address} ." 'echo \"$action\"  > $self->{cmdDir}" . time() . "-sendcmd'";
+            $self->{logger}->writeLogDebug("Send command using Remote Server");
+        } else {
+            $cmd = "$self->{ssh} -p $port ". $conf->{ns_ip_address} ." $self->{sudo} $self->{service} ".$conf->{init_script}." ".$options;
+        }
         ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd, logger => $self->{logger}, timeout => 120);
     } else {
         $self->{logger}->writeLogError("Cannot $options Engine for poller $id");
@@ -654,9 +703,15 @@ sub syncTraps($) {
         # Get configuration
         my $ns_server = $self->getServerConfig($id);
         my $port = checkSSHPort($ns_server->{ssh_port});
+        my $remote_server;
 
         if ($id != 0 && $ns_server->{localhost} == 0) {
-            $cmd = "$self->{scp} -P $port /etc/snmp/centreon_traps/$id/centreontrapd.sdb $ns_server->{ns_ip_address}:$ns_server->{snmp_trapd_path_conf} 2>&1";
+            if (defined($ns_server->{remote_id}) && $ns_server->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
+                $remote_server = $self->getServerConfig($ns_server->{remote_id});
+                $cmd = "$self->{scp} -r -P $port /etc/snmp/centreon_traps/$id/centreontrapd.sdb $remote_server->{'ns_ip_address'}:/etc/snmp/centreon_traps/";
+            } else {
+                $cmd = "$self->{scp} -P $port /etc/snmp/centreon_traps/$id/centreontrapd.sdb $ns_server->{ns_ip_address}:$ns_server->{snmp_trapd_path_conf} 2>&1";
+            }
             $self->{logger}->writeLogDebug($cmd);
             
             ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
@@ -666,6 +721,12 @@ sub syncTraps($) {
             if (defined($stdout) && $stdout){
                 $self->{logger}->writeLogInfo("Result : $stdout");
             }
+
+            $cmd = "$self->{ssh} " . $remote_server->{'ns_ip_address'}  . " 'echo \"SYNCTRAP:" . $id . "\" > $self->{cmdDir}/" . time() . "-sendcmd'";
+            ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
+                                                                  logger => $self->{logger},
+                                                                  timeout => 300
+                                                                  );
         }
     } else {
         # synchronize Archives for all pollers
@@ -776,7 +837,7 @@ sub updateEngineInformation($$$) {
 ## Reload CentreonTrapd Daemon
 #
 sub initCentreonTrapd {
-    my ($self, $id, $start_type) = @_;
+    my ($self, $id, $start_type, $action) = @_;
     my ($lerror, $stdout, $cmd);
 
     # Get configuration
@@ -794,7 +855,14 @@ sub initCentreonTrapd {
                                                                   timeout => 120
                                                                   );
         } else {
+            if (defined($ns_server->{remote_id}) && $ns_server->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
+            my $remote_server = $self->getServerConfig($ns_server->{remote_id});
+            $action =~ s/^\s+|\s+$//g;
+            $cmd = "$self->{ssh} -p $port ". $remote_server->{ns_ip_address} ." 'echo \"$action\"  > $self->{cmdDir}" . time() . "-sendcmd'";
+            $self->{logger}->writeLogDebug("Send command using Remote Server");
+        } else {
             $cmd = "$self->{ssh} -p $port ". $ns_server->{ns_ip_address} ." $self->{sudo} $self->{service} ".$ns_server->{init_script_centreontrapd}. " " . $start_type;
+        }
             $self->{logger}->writeLogDebug($cmd);
             ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
                                                                   logger => $self->{logger},
@@ -820,15 +888,15 @@ sub parseRequest($){
     
     # Checks keys for launching commands 
     if ($action =~ /^RESTART\:([0-9]*)/){
-        $self->initEngine($1, "restart");
+        $self->initEngine($1, "restart", $action);
     } elsif ($action =~ /^RELOAD\:([0-9]*)/){
-        $self->initEngine($1, "reload");
+        $self->initEngine($1, "reload", $action);
     } elsif ($action =~ /^FORCERELOAD\:([0-9]*)/){
-        $self->initEngine($1, "force-reload");
+        $self->initEngine($1, "force-reload", $action);
     } elsif ($action =~ /^START\:([0-9]*)/){
-        $self->initEngine($1, "start");
+        $self->initEngine($1, "start"), $action;
     } elsif ($action =~ /^STOP\:([0-9]*)/){
-        $self->initEngine($1, "stop");
+        $self->initEngine($1, "stop", $action);
     } elsif ($action =~ /^SENDCFGFILE\:([0-9]*)/){
         $self->sendConfigFile($1);
     } elsif ($action =~ /^SENDEXPORTFILE\:([0-9]*)/){
@@ -839,9 +907,9 @@ sub parseRequest($){
     } elsif ($action =~ /^SYNCTRAP\:([0-9]*)/){
         $self->syncTraps($1);
     } elsif ($action =~ /^RESTARTCENTREONTRAPD\:([0-9]*)/){
-        $self->initCentreonTrapd($1, 'restart');
+        $self->initCentreonTrapd($1, 'restart', $action);
     } elsif ($action =~ /^RELOADCENTREONTRAPD\:([0-9]*)/){
-        $self->initCentreonTrapd($1, 'reload');
+        $self->initCentreonTrapd($1, 'reload', $action);
     } elsif ($action =~ /^EXTERNALCMD\:([0-9]*)\:(.*)/){
         $self->storeCommands($1, $2);
     } elsif ($action =~ /^GETINFOS\:([0-9]*)/){
@@ -927,7 +995,7 @@ sub run {
                                                       force => 0,
                                                       logger => $self->{logger});
     $self->checkDebugFlag();
-        
+    $self->{logger}->writeLogInfo("Instance type: " . $self->{instance_mode});    
     while ($self->{stop}) {
         if ($self->{reload} == 0) {
             $self->{logger}->writeLogInfo("Reload in progress...");

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -894,7 +894,7 @@ sub parseRequest($){
     } elsif ($action =~ /^FORCERELOAD\:([0-9]*)/){
         $self->initEngine($1, "force-reload", $action);
     } elsif ($action =~ /^START\:([0-9]*)/){
-        $self->initEngine($1, "start"), $action;
+        $self->initEngine($1, "start", $action);
     } elsif ($action =~ /^STOP\:([0-9]*)/){
         $self->initEngine($1, "stop", $action);
     } elsif ($action =~ /^SENDCFGFILE\:([0-9]*)/){

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -729,6 +729,9 @@ sub syncTraps($) {
                                                                       logger => $self->{logger},
                                                                       timeout => 300
                                                                       );
+                if (defined($stdout) && $stdout){
+                    $self->{logger}->writeLogInfo("Result : $stdout");
+                }
             }
         }
     } else {

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -708,6 +708,7 @@ sub syncTraps($) {
         if ($id != 0 && $ns_server->{localhost} == 0) {
             if (defined($ns_server->{remote_id}) && $ns_server->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
                 $remote_server = $self->getServerConfig($ns_server->{remote_id});
+                $port = checkSSHPort($remote_server->{ssh_port});
                 $cmd = "$self->{scp} -r -P $port /etc/snmp/centreon_traps/$id/centreontrapd.sdb $remote_server->{'ns_ip_address'}:/etc/snmp/centreon_traps/";
             } else {
                 $cmd = "$self->{scp} -P $port /etc/snmp/centreon_traps/$id/centreontrapd.sdb $ns_server->{ns_ip_address}:$ns_server->{snmp_trapd_path_conf} 2>&1";
@@ -722,11 +723,13 @@ sub syncTraps($) {
                 $self->{logger}->writeLogInfo("Result : $stdout");
             }
 
-            $cmd = "$self->{ssh} " . $remote_server->{'ns_ip_address'}  . " 'echo \"SYNCTRAP:" . $id . "\" > $self->{cmdDir}/" . time() . "-sendcmd'";
-            ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
-                                                                  logger => $self->{logger},
-                                                                  timeout => 300
-                                                                  );
+            if (defined($ns_server->{remote_id}) && $ns_server->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
+                $cmd = "$self->{ssh} " . $remote_server->{'ns_ip_address'}  . " 'echo \"SYNCTRAP:" . $id . "\" > $self->{cmdDir}/" . time() . "-sendcmd'";
+                ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
+                                                                      logger => $self->{logger},
+                                                                      timeout => 300
+                                                                      );
+            }
         }
     } else {
         # synchronize Archives for all pollers

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -418,9 +418,9 @@ sub sendExternalCommand($$){
                         my $remote_server = $self->getServerConfig($server_info->{remote_id});
                         $cmd_line =~ s/^\s+|\s+$//g;
                         $cmd2 = "$self->{ssh} -q " . $remote_server->{ns_ip_address} . " -p $port \"$self->{echo} 'EXTERNALCMD:$id:" . $cmd_line . "' > " . $self->{cmdDir} . time() . "-sendcmd\"";
-                        $self->{logger}->writeLogInfo("Send external command using Remote Server: ".$remote_server->{ns_ip_address});
+                        $self->{logger}->writeLogInfo("Send external command using Remote Server: " . $remote_server->{ns_ip_address});
                     } else {
-                        $cmd2 = "$self->{ssh} -q ". $server_info->{ns_ip_address} ." -p $port \"$self->{echo} '".$cmd_line."' >> ".$command_file."\"";
+                        $cmd2 = "$self->{ssh} -q " . $server_info->{ns_ip_address} . " -p $port \"$self->{echo} '" . $cmd_line."' >> " . $command_file . "\"";
                         $self->{logger}->writeLogInfo("External command : ".$server_info->{ns_ip_address}." ($id) : \"".$cmd_line."\"");
                     }
                     ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd2, logger => $self->{logger}, timeout => $self->{cmd_timeout});
@@ -436,17 +436,17 @@ sub sendExternalCommand($$){
                     my $remote_server = $self->getServerConfig($server_info->{remote_id});
                     $cmd_line =~ s/^\s+|\s+$//g;
                     $cmd2 = "$self->{ssh} -q " . $remote_server->{ns_ip_address} . " -p $port \"$self->{echo} 'EXTERNALCMD:$id:" . $cmd_line . "' > " . $self->{cmdDir} . time() . "-sendcmd\"";
-                    $self->{logger}->writeLogInfo("Send external command using Remote Server: ".$remote_server->{ns_ip_address});
+                    $self->{logger}->writeLogInfo("Send external command using Remote Server: " . $remote_server->{ns_ip_address});
                 } else {
-                    $cmd2 = "$self->{ssh} -q ". $server_info->{ns_ip_address} ." -p $port \"$self->{echo} '".$cmd_line."' >> ".$command_file."\"";
-                    $self->{logger}->writeLogInfo("External command : ".$server_info->{ns_ip_address}." ($id) : \"".$cmd_line."\"");
+                    $cmd2 = "$self->{ssh} -q " . $server_info->{ns_ip_address} . " -p $port \"$self->{echo} '" . $cmd_line . "' >> " . $command_file . "\"";
+                    $self->{logger}->writeLogInfo("External command : " . $server_info->{ns_ip_address} . " ($id) : \"" . $cmd_line . "\"");
                 }
                 ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd2, logger => $self->{logger}, timeout => $self->{cmd_timeout});
                 $cmd_line = "";
                 $count = 0;
             } 
             if ($lerror == -1) {
-                $self->{logger}->writeLogError("Could not write into pipe file ".$command_file." on poller ".$id);
+                $self->{logger}->writeLogError("Could not write into pipe file " . $command_file . " on poller " . $id);
             }
         }
 
@@ -671,7 +671,7 @@ sub initEngine($$$){
         if (defined($conf->{remote_id}) && $conf->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
             my $remote_server = $self->getServerConfig($conf->{remote_id});
             $action =~ s/^\s+|\s+$//g;
-            $cmd = "$self->{ssh} -p $port ". $remote_server->{ns_ip_address} ." 'echo \"$action\"  > $self->{cmdDir}" . time() . "-sendcmd'";
+            $cmd = "$self->{ssh} -p $port " . $remote_server->{ns_ip_address} . " 'echo \"$action\"  > $self->{cmdDir}" . time() . "-sendcmd'";
             $self->{logger}->writeLogDebug("Send command using Remote Server");
         } else {
             $cmd = "$self->{ssh} -p $port ". $conf->{ns_ip_address} ." $self->{sudo} $self->{service} ".$conf->{init_script}." ".$options;
@@ -878,13 +878,13 @@ sub initCentreonTrapd {
                                                                   );
         } else {
             if (defined($ns_server->{remote_id}) && $ns_server->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
-            my $remote_server = $self->getServerConfig($ns_server->{remote_id});
-            $action =~ s/^\s+|\s+$//g;
-            $cmd = "$self->{ssh} -p $port ". $remote_server->{ns_ip_address} ." 'echo \"$action\"  > $self->{cmdDir}" . time() . "-sendcmd'";
-            $self->{logger}->writeLogDebug("Send command using Remote Server");
-        } else {
-            $cmd = "$self->{ssh} -p $port ". $ns_server->{ns_ip_address} ." $self->{sudo} $self->{service} ".$ns_server->{init_script_centreontrapd}. " " . $start_type;
-        }
+                my $remote_server = $self->getServerConfig($ns_server->{remote_id});
+                $action =~ s/^\s+|\s+$//g;
+                $cmd = "$self->{ssh} -p $port " . $remote_server->{ns_ip_address} . " 'echo \"$action\"  > $self->{cmdDir}" . time() . "-sendcmd'";
+                $self->{logger}->writeLogDebug("Send command using Remote Server");
+            } else {
+                $cmd = "$self->{ssh} -p $port ". $ns_server->{ns_ip_address} ." $self->{sudo} $self->{service} ".$ns_server->{init_script_centreontrapd}. " " . $start_type;
+            }
             $self->{logger}->writeLogDebug($cmd);
             ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
                                                                   logger => $self->{logger},

--- a/src/CentreonRemote/Application/Clapi/CentreonRemoteServer.php
+++ b/src/CentreonRemote/Application/Clapi/CentreonRemoteServer.php
@@ -49,7 +49,7 @@ class CentreonRemoteServer implements CentreonClapiServiceInterface
         echo 'Done'. "\n";
 
         echo "\n Set 'remote' instance type...";
-        system("sed -i -r 's/central/remote/g' " . _CENTREON_ETC_ . "/conf.pm");
+        system("sed -i -r 's/(\$instance_mode?\s+=?\s+")([a-z]+)(";)/\1remote\3/' " . _CENTREON_ETC_ . "/conf.pm");
         echo 'Done'. "\n";
 
         echo "\n Notifying Master...";
@@ -72,7 +72,7 @@ class CentreonRemoteServer implements CentreonClapiServiceInterface
         echo 'Done'. "\n";
 
         echo "\n Restore 'central' instance type...";
-        system("sed -i -r 's/remote/central/g' " . _CENTREON_ETC_ . "/conf.pm");
+        system("sed -i -r 's/(\$instance_mode?\s+=?\s+")([a-z]+)(";)/\1central\3/' " . _CENTREON_ETC_ . "/conf.pm");
         echo 'Done'. "\n";
 
         echo "\n Centreon Remote disabling finished.\n";

--- a/src/CentreonRemote/Application/Clapi/CentreonRemoteServer.php
+++ b/src/CentreonRemote/Application/Clapi/CentreonRemoteServer.php
@@ -48,6 +48,10 @@ class CentreonRemoteServer implements CentreonClapiServiceInterface
         $result = $this->getDi()['centreon.db-manager']->getRepository(InformationsRepository::class)->authorizeMaster($ip);
         echo 'Done'. "\n";
 
+        echo "\n Set 'remote' instance type...";
+        system("sed -i -r 's/central/remote/g' " . _CENTREON_ETC_ . "/conf.pm");
+        echo 'Done'. "\n";
+
         echo "\n Notifying Master...";
         $result = $this->getDi()['centreon.notifymaster']->pingMaster($ip);
         echo (!empty($result['status']) && $result['status'] == 'success') ? 'Success' : 'Fail' . "\n";
@@ -65,6 +69,10 @@ class CentreonRemoteServer implements CentreonClapiServiceInterface
 
         echo "\n Restoring Actions...";
         $result = $this->getDi()['centreon.db-manager']->getRepository(InformationsRepository::class)->toggleRemote('no');
+        echo 'Done'. "\n";
+
+        echo "\n Restore 'central' instance type...";
+        system("sed -i -r 's/remote/central/g' " . _CENTREON_ETC_ . "/conf.pm");
         echo 'Done'. "\n";
 
         echo "\n Centreon Remote disabling finished.\n";


### PR DESCRIPTION
* CLAPI enableREmote define Remote Server variable in /etc/centreon/conf.pm
* CLAPI disableREmote set Centreon variable in /etc/centreon/conf.pm
* Centcore on Central Server forward external commands to Remote Server attached to Poller if defined
*  Centcore on Central Server synchronise configuration folders with Remote Server attached to Poller if defined, and forward associated external command
* Centcore on Remote Server apply commands