### PR TITLE
enh(copyright): update copyright date calculation code and change mailto link

### DIFF
--- a/www/include/core/login/login.php
+++ b/www/include/core/login/login.php
@@ -120,6 +120,7 @@ $tpl = initSmartyTpl($path.'/include/core/login/template/', $tpl);
 $tpl->assign('loginMessages', $loginMessages);
 $tpl->assign('centreonVersion', 'v. '.$release['value']);
 $tpl->assign('currentDate', date("d/m/Y"));
+$tpl->assign('copyrightYear', date("Y"));
 
 // Redirect User
 $redirect = filter_input(

--- a/www/include/core/login/template/login.ihtml
+++ b/www/include/core/login/template/login.ihtml
@@ -3,7 +3,7 @@
     <head>
         <title>Centreon - IT & Network Monitoring</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-        <meta name="Generator" content="Centreon - Copyright (C) 2005 - 2018 Open Source Matters. All rights reserved." />
+        <meta name="Generator" content="Centreon - Copyright (C) 2005 - {$copyrightYear} Open Source Matters. All rights reserved." />
         <meta name="robots" content="index, nofollow" />
         <meta http-equiv="refresh" content="840">
         <link href="./Themes/Centreon-2/login.css" rel="stylesheet" type="text/css">
@@ -38,7 +38,7 @@
                 </div>
                 <div class="LoginInvitVersion">
                     <span id="LoginInvitcpy">
-                        &copy; <a href="mailto:contact@centreon.com">Centreon</a> 2005 - 2018
+                        &copy; <a href="https://www.centreon.com">Centreon</a> 2005 - {$copyrightYear}
                     </span>
                     <br>
                     <span>


### PR DESCRIPTION
Change copyright date calculation code and replace mailto link by a direct link to our website - in order to avoid that some final user send email directly to Centreon