### PR TITLE
fix(access): Fix a blank page when login with a non-admin user

### DIFF
--- a/src/Centreon/Domain/Repository/TopologyRepository.php
+++ b/src/Centreon/Domain/Repository/TopologyRepository.php
@@ -48,7 +48,7 @@ class TopologyRepository extends ServiceEntityRepository
                 $topologyUrls[] = $topologyUrl['topology_url'];
             }
         } else {
-            if (count($user->access->accessGroups) > 0){
+            if (count($user->access->getAccessGroups()) > 0){
                 $query = "SELECT DISTINCT acl_group_topology_relations.acl_topology_id "
                     . "FROM acl_group_topology_relations, acl_topology, acl_topology_relations "
                     . "WHERE acl_topology_relations.acl_topo_id = acl_topology.acl_topo_id "


### PR DESCRIPTION
Call the getAccessGroups method of CentreonACL.class.php from TopologyRepository.php instead of accessing the private property accessGroups directly