### PR TITLE
fix(db): escaping the regex which broke the query

### DIFF
--- a/www/include/configuration/configNagios/DB-Func.php
+++ b/www/include/configuration/configNagios/DB-Func.php
@@ -181,6 +181,7 @@ function multipleNagiosInDB($nagios = array(), $nbrDup = array())
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $val = null;
             foreach ($row as $key2 => $value2) {
+                $value2 = $pearDB->escape($value2);
                 $key2 == "nagios_name" ? ($nagios_name = $value2 = $value2 . "_" . $i) : null;
                 $val ? $val .= ($value2 != null ? (", '" . $value2 . "'") : ", NULL")
                     : $val .= ($value2 != null ? ("'" . $value2 . "'") : "NULL");


### PR DESCRIPTION
when inserting data from a duplicate poller two regex are broking the query : 
` ,- '~!$%^&\\*"|' <>?,()=', `
and  ` '~$^&"|' <>', `
where the single quotes after the pipes weren't escaped
