### PR TITLE
fix(remote-server) Minor fixes for remote server worker

### DIFF
--- a/src/CentreonRemote/Application/Clapi/CentreonWorker.php
+++ b/src/CentreonRemote/Application/Clapi/CentreonWorker.php
@@ -118,7 +118,7 @@ class CentreonWorker implements CentreonClapiServiceInterface
          */
         $params = unserialize($task->getParams())['params'];
         $centreonPath = trim($params['centreon_path'], '/');
-        $centreonPath = (isset($centreonPath) && strcmp($centreonPath, '') != 0) ? $centreonPath : '/centreon';
+        $centreonPath = $centreonPath ? $centreonPath : '/centreon';
         $url = "{$params['remote_ip']}/{$centreonPath}/api/external.php?object=centreon_task_service&action=AddImportTaskWithParent";
 
         try {

--- a/src/CentreonRemote/Application/Clapi/CentreonWorker.php
+++ b/src/CentreonRemote/Application/Clapi/CentreonWorker.php
@@ -126,7 +126,8 @@ class CentreonWorker implements CentreonClapiServiceInterface
             $res = $curl->post($url, ['parent_id' => $task->getId()]);
 
             if ($curl->error) {
-                echo "Curl error while creating parent task\n";
+                printf("Curl error while creating parent task: %s\n", $curl->error_message);
+                printf("url called: %s\n", $url);
             }
         } catch (\ErrorException $e) {
             echo "Curl error while creating parent task\n";

--- a/src/CentreonRemote/Application/Clapi/CentreonWorker.php
+++ b/src/CentreonRemote/Application/Clapi/CentreonWorker.php
@@ -118,6 +118,7 @@ class CentreonWorker implements CentreonClapiServiceInterface
          */
         $params = unserialize($task->getParams())['params'];
         $centreonPath = trim($params['centreon_path'], '/');
+        $centreonPath = (isset($centreonPath) && strcmp($centreonPath, '') != 0) ? $centreonPath : '/centreon';
         $url = "{$params['remote_ip']}/{$centreonPath}/api/external.php?object=centreon_task_service&action=AddImportTaskWithParent";
 
         try {


### PR DESCRIPTION
* Prevent empty centreon_path for Poller Display migration because poller configuration is present and the user don't use the wizard (centreon_path => NULL in database)
* Add more debug information