### PR TITLE
enh(remote-server): Add light form to edit contact on a Remote Server

### DIFF
--- a/www/include/configuration/configObject/contact/formContact.php
+++ b/www/include/configuration/configObject/contact/formContact.php
@@ -68,6 +68,14 @@ require_once _CENTREON_PATH_ . 'www/class/centreonContactgroup.class.php';
 
 $initialValues = array();
 
+/*
+ * Check if this server is a Remote Server to hide some part of form
+ */
+$DBRESULT = $pearDB->query("SELECT i.value FROM informations i WHERE i.key = 'isRemote'");
+$isRemote = array_map("myDecode", $DBRESULT->fetchRow());
+$DBRESULT->closeCursor();
+$isRemote = (strcmp($isRemote['value'], 'yes') == 0) ? true : false;
+
 $cct = array();
 if (($o == "c" || $o == "w") && $contact_id) {
     /**
@@ -619,7 +627,9 @@ if ($o != "mc") {
     $ret = $form->getSubmitValues();
     $form->addRule('contact_name', _("Compulsory Name"), 'required');
     $form->addRule('contact_alias', _("Compulsory Alias"), 'required');
-    $form->addRule('contact_email', _("Valid Email"), 'required');
+    if ($isRemote == false) {
+        $form->addRule('contact_email', _("Valid Email"), 'required');
+    }
     $form->addRule('contact_oreon', _("Required Field"), 'required');
     $form->addRule('contact_lang', _("Required Field"), 'required');
     if ($centreon->user->admin) {
@@ -627,8 +637,9 @@ if ($o != "mc") {
     }
     $form->addRule('contact_auth_type', _("Required Field"), 'required');
 
-    if (isset($ret["contact_enable_notifications"]["contact_enable_notifications"])
-        && $ret["contact_enable_notifications"]["contact_enable_notifications"] == 1
+    if ((isset($ret["contact_enable_notifications"]["contact_enable_notifications"])
+        && $ret["contact_enable_notifications"]["contact_enable_notifications"] == 1)
+        && ($isRemote == false)
     ) {
         if (isset($ret["contact_template_id"]) && $ret["contact_template_id"] == '') {
             $form->addRule('timeperiod_tp_id', _("Compulsory Period"), 'required');
@@ -758,7 +769,11 @@ if ($valid) {
         $tpl->assign('ldap', $centreon->optGen['ldap_auth_enable']);
     }
     $tpl->assign('auth_type', $contactAuthType);
-    $tpl->display("formContact.ihtml");
+    if ($isRemote == false) {
+        $tpl->display("formContact.ihtml");
+    } else {
+        $tpl->display("formContactLight.ihtml");
+    }
 }
 ?>
 <script type="text/javascript" src="./include/common/javascript/keygen.js"></script>

--- a/www/include/configuration/configObject/contact/formContact.php
+++ b/www/include/configuration/configObject/contact/formContact.php
@@ -74,7 +74,7 @@ $initialValues = array();
 $DBRESULT = $pearDB->query("SELECT i.value FROM informations i WHERE i.key = 'isRemote'");
 $isRemote = array_map("myDecode", $DBRESULT->fetchRow());
 $DBRESULT->closeCursor();
-$isRemote = (strcmp($isRemote['value'], 'yes') == 0) ? true : false;
+$isRemote = ($isRemote['value'] === 'yes') ? true : false;
 
 $cct = array();
 if (($o == "c" || $o == "w") && $contact_id) {

--- a/www/include/configuration/configObject/contact/formContactLight.ihtml
+++ b/www/include/configuration/configObject/contact/formContactLight.ihtml
@@ -47,7 +47,6 @@
         {/if}
         {if $displayAdminFlag == 1}
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="admin"> {$form.contact_admin.label}</td><td class="FormRowValue">{$form.contact_admin.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="reach_api"> {$form.reach_api.label}</td><td class="FormRowValue">{$form.reach_api.html}</td></tr>
         <tr class="list_two">
             <td class="FormRowField">
                 <img class="helpTooltip" name="reach_api_rt">
@@ -68,6 +67,13 @@
         {if $o == "a" || $o == "c"}
             <tr class="list_lvl_2"><td class="ListColLvl2_name" colspan="2">{$form.required._note}</td></tr>
         {/if}
+        <tr class="list_lvl_1">
+            <td class="ListColLvl1_name" colspan="2">
+                <h4>{$form.header.furtherInfos}</h4>
+            </td>
+        </tr>
+        <tr class="list_one"><td class="FormRowField">{$form.contact_activate.label}</td><td class="FormRowValue">{$form.contact_activate.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField">{$form.contact_comment.label}</td><td class="FormRowValue">{$form.contact_comment.html}</td></tr>
         {if $o == "a" || $o == "c"}
             <tr class="list_lvl_2"><td class="ListColLvl2_name" colspan="2">{$form.required._note}</td></tr>
         {/if}

--- a/www/include/configuration/configObject/contact/formContactLight.ihtml
+++ b/www/include/configuration/configObject/contact/formContactLight.ihtml
@@ -1,0 +1,84 @@
+{$form.javascript}
+<form {$form.attributes}>
+<div id="validFormTop">
+  {if $o == "a" || $o == "c" || $o == "mc"}
+      <p class="oreonbutton">{$form.submitC.html}{$form.submitMC.html}{$form.submitA.html}&nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
+  {else if $o == "w"}
+      <p class="oreonbutton">{$form.change.html}</p>
+  {/if}
+</div>
+    <table class="formTable table">
+        <tr class="ListHeader">
+            <td class="FormHeader" colspan="2">
+                <h3>| {$form.header.title}</h3>
+            </td>
+        </tr>
+        <tr class="list_lvl_1">
+            <td class="ListColLvl1_name" colspan="2">
+                <h4>{$form.header.information}</h4>
+            </td>
+        </tr>
+        {if $o != "mc"}
+            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="alias"> {$form.contact_alias.label}</td><td class="FormRowValue">{$form.contact_alias.html}</td></tr>
+            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="contact_name"> {$form.contact_name.label}</td><td class="FormRowValue">{$form.contact_name.html}</td></tr>
+        {/if}
+        <tr class="list_lvl_1">
+            <td class="ListColLvl1_name" colspan="2">
+                <h4>{$form.header.oreon}</h4>
+            </td>
+        </tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreon_login"> {$form.contact_oreon.label}</td><td class="FormRowValue">{$form.contact_oreon.html}</td></tr>
+        {if $auth_type != 'ldap'}
+        <tr class="list_two">
+            <td class="FormRowField"><img class="helpTooltip" name="password"> {$form.contact_passwd.label}</td>
+            <td class="FormRowValue">{$form.contact_passwd.html} {$form.contact_gen_passwd.html}</td>
+        </tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="password2"> {$form.contact_passwd2.label}</td><td class="FormRowValue">{$form.contact_passwd2.html}</td></tr>
+        {/if}
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="language"> {$form.contact_lang.label}</td><td class="FormRowValue">{$form.contact_lang.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="location"> {$form.contact_location.label}</td><td class="FormRowValue">{$form.contact_location.html}</td></tr>
+        <tr class="list_two">
+            <td class="FormRowField"><img class="helpTooltip" name="autologin_key"> {$form.contact_autologin_key.label}</td>
+            <td class="FormRowValue">{$form.contact_autologin_key.html} {$form.contact_gen_akey.html}</td>
+        </tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="auth_type"> {$form.contact_auth_type.label}</td><td class="FormRowValue">{$form.contact_auth_type.html}</td></tr>
+        {if $ldap == "1" }
+            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ldap_dn"> {$form.contact_ldap_dn.label}</td><td class="FormRowValue">{$form.contact_ldap_dn.html}</td></tr>
+        {/if}
+        {if $displayAdminFlag == 1}
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="admin"> {$form.contact_admin.label}</td><td class="FormRowValue">{$form.contact_admin.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="reach_api"> {$form.reach_api.label}</td><td class="FormRowValue">{$form.reach_api.html}</td></tr>
+        <tr class="list_two">
+            <td class="FormRowField">
+                <img class="helpTooltip" name="reach_api_rt">
+                {$form.reach_api_rt.label}
+            </td>
+            <td class="FormRowValue">{$form.reach_api_rt.html}</td>
+        </tr>
+        {/if}
+        <tr class="list_lvl_1">
+            <td class="ListColLvl1_name" colspan="2">
+                <h4>{$form.header.acl}</h4>
+            </td>
+        </tr>
+        {if $o == "mc"}
+            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_acl.label}</td><td class="FormRowValue">{$form.mc_mod_acl.html}</td></tr>
+        {/if}
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="aclgroups"> {$form.contact_acl_groups.label}</td><td class="FormRowValue">{$form.contact_acl_groups.html}</td></tr>
+        {if $o == "a" || $o == "c"}
+            <tr class="list_lvl_2"><td class="ListColLvl2_name" colspan="2">{$form.required._note}</td></tr>
+        {/if}
+        {if $o == "a" || $o == "c"}
+            <tr class="list_lvl_2"><td class="ListColLvl2_name" colspan="2">{$form.required._note}</td></tr>
+        {/if}
+    </table>
+    <div id="validForm">
+    {if $o == "a" || $o == "c" || $o == "mc"}
+        <p class="oreonbutton">{$form.submitC.html}{$form.submitMC.html}{$form.submitA.html}&nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
+    {else if $o == "w"}
+        <p class="oreonbutton">{$form.change.html}</p>
+    {/if}
+    </div>
+    {$form.hidden}
+</form>
+{$helptext}


### PR DESCRIPTION
Because not all configuration is exported on a Remote Server, it is impossible to edit a contact because notification commands are required in the form.

This light form allows to configure new Centreon user to log in the web interface on a Remote Server and add them to ACL.