### PR TITLE
fix(acl): Host number calculation with ACL is not correct in HG summary

### DIFF
--- a/www/include/monitoring/status/HostGroups/xml/hostGroupXML.php
+++ b/www/include/monitoring/status/HostGroups/xml/hostGroupXML.php
@@ -115,7 +115,7 @@ if ($obj->is_admin) {
     $rq1 .= $searchStr .
         "GROUP BY hg.name, h.state";
 } else {
-    $rq1 = "SELECT hg.name as alias, h.state, count(h.host_id) AS nb " .
+    $rq1 = "SELECT hg.name as alias, h.state, count(DISTINCT h.host_id) AS nb " .
         "FROM centreon_acl acl, hosts_hostgroups hhg, hosts h, hostgroups hg " .
         "WHERE hg.hostgroup_id = hhg.hostgroup_id " .
         "AND hhg.host_id = h.host_id " .


### PR DESCRIPTION
For users with ACL, the SQL request get the list of all host / service couple and not only host list.