### PR TITLE
fix(backup): fix missing trim for PHP files to backup

### DIFF
--- a/cron/centreon-backup.pl
+++ b/cron/centreon-backup.pl
@@ -320,7 +320,7 @@ sub getPHPConfFile() {
 	for (@ini) {
 	    chomp;
 	    s/,$//;
-	    push(@tab_php_ini, @ini);
+	    push(@tab_php_ini, $_);
     }
 
 	return @tab_php_ini;


### PR DESCRIPTION
RESOLVE: MON-2917

There was a missing trim that made the cp of PHP configuration files fail.