### PR TITLE
Select the correct default-active monitoring filter value

### DIFF
--- a/www/include/monitoring/status/Services/serviceGrid.php
+++ b/www/include/monitoring/status/Services/serviceGrid.php
@@ -150,7 +150,6 @@ $form->addElement(
     $aTypeAffichageLevel2,
     array('id' => 'typeDisplay2', 'onChange' => "displayingLevel2(this.value);")
 );
-$form->setDefaults(array('typeDisplay2' => 'pb'));
 
 foreach (array('o1', 'o2') as $option) {
     $attrs = array('onchange' => "javascript: setO(this.form.elements['$option'].value); submit();");

--- a/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+++ b/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
@@ -116,8 +116,6 @@ $form->addElement(
     array('id' => 'typeDisplay2', 'onChange' => "displayingLevel2(this.value);")
 );
 
-$form->setDefaults(array('typeDisplay2' => 'pb'));
-
 $tpl->assign("order", strtolower($order));
 $tab_order = array("sort_asc" => "sort_desc", "sort_desc" => "sort_asc");
 $tpl->assign("tab_order", $tab_order);

--- a/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
@@ -183,8 +183,6 @@ $form->addElement(
     array('id' => 'typeDisplay2', 'onChange' => "displayingLevel2(this.value);")
 );
 
-$form->setDefaults(array('typeDisplay2' => 'pb'));
-
 $attrs = array('onchange' => "javascript: setO(this.form.elements['o1'].value); submit();");
 $form->addElement('select', 'o1', null, array(
     null => _("More actions..."),


### PR DESCRIPTION
Hi,

This quickly closes #6162, selecting the _All_ `Diplay details` filter value as the default value in the following view :
-  Monitoring > Status Details > Services Grid
-  Monitoring > Status Details > Services by Hostgroup
-  Monitoring > Status Details > Services by Servicegroup

Thank you :+1: 

_this replaces PR #6573 which I messed-up..._