### PR TITLE
fix(externalcmd): Create centcore file by action

### DIFF
--- a/www/class/centreonExternalCommand.class.php
+++ b/www/class/centreonExternalCommand.class.php
@@ -126,7 +126,7 @@ class CentreonExternalCommand
             if ($this->debug) {
                 print "COMMAND BEFORE SEND: $str_remote";
             }
-            $result = file_put_contents($varlib . '/centcore/' . time() . '-externalcommand', $str_remote, FILE_APPEND);
+            $result = file_put_contents($varlib . '/centcore/' . microtime(true) . '-externalcommand.cmd', $str_remote, FILE_APPEND);
             $return_remote = ($result !== false) ? 0 : 1;
         }
 

--- a/www/class/centreonExternalCommand.class.php
+++ b/www/class/centreonExternalCommand.class.php
@@ -126,7 +126,7 @@ class CentreonExternalCommand
             if ($this->debug) {
                 print "COMMAND BEFORE SEND: $str_remote";
             }
-            $result = file_put_contents($varlib . '/centcore.cmd', $str_remote, FILE_APPEND);
+            $result = file_put_contents($varlib . '/centcore/' . time() . '-externalcommand', $str_remote, FILE_APPEND);
             $return_remote = ($result !== false) ? 0 : 1;
         }
 


### PR DESCRIPTION
To remove concurrent access to centcore.cmd file, create a file in /var/lib/centreon/centcore by action