### PR TITLE
fix(acl): service_id is no longer NULL

### DIFF
--- a/www/include/configuration/configObject/host/listHost.php
+++ b/www/include/configuration/configObject/host/listHost.php
@@ -241,7 +241,7 @@ $aclCond = '';
 if (!$centreon->user->admin) {
     $aclFrom = ", {$aclDbName}.centreon_acl acl";
     $aclCond =
-        ' AND h.host_id = acl.host_id AND acl.service_id IS NULL '
+        ' AND h.host_id = acl.host_id AND acl.service_id = 0 '
         . 'AND acl.group_id IN (' . $acl->getAccessGroupsString() . ') ';
 }
 


### PR DESCRIPTION
Since PR #6366, all values for host are: <host_id>,0 and not <host_id>,NULL