### PR TITLE
fix(acl): Prevent PHP Notice undefined offset

### DIFF
--- a/cron/centAcl.php
+++ b/cron/centAcl.php
@@ -497,7 +497,7 @@ try {
                         foreach ($hgResCache[$res2['acl_res_id']] as $hgId) {
                             if (isset($hostHGRelation[$hgId])) {
                                 foreach ($hostHGRelation[$hgId] as $host_id) {
-                                    if ($hostCache[$host_id]) {
+                                    if (isset($hostCache[$host_id])) {
                                         $Host[$host_id] = $hostCache[$host_id];
                                     } else {
                                         print "Host $host_id unknown !\n";


### PR DESCRIPTION
Prevent:
PHP Notice:  Undefined offset: 4 in /usr/share/centreon/cron/centAcl.php on line 434
PHP Notice:  Undefined offset: 14 in /usr/share/centreon/cron/centAcl.php on line 434
PHP Notice:  Undefined offset: 12 in /usr/share/centreon/cron/centAcl.php on line 434
PHP Notice:  Undefined offset: 10 in /usr/share/centreon/cron/centAcl.php on line 434
PHP Notice:  Undefined offset: 8 in /usr/share/centreon/cron/centAcl.php on line 434
PHP Notice:  Undefined offset: 74 in /usr/share/centreon/cron/centAcl.php on line 434
PHP Notice:  Undefined offset: 82 in /usr/share/centreon/cron/centAcl.php on line 434
PHP Notice:  Undefined offset: 72 in /usr/share/centreon/cron/centAcl.php on line 434
PHP Notice:  Undefined offset: 80 in /usr/share/centreon/cron/centAcl.php on line 434
PHP Notice:  Undefined offset: 70 in /usr/share/centreon/cron/centAcl.php on line 434