### PR TITLE
fix(doc): add clean yum cache command for 18.10 upgrade

### DIFF
--- a/doc/en/upgrade/from_packages.rst
+++ b/doc/en/upgrade/from_packages.rst
@@ -61,9 +61,13 @@ Run the following command: ::
 Updating the Centreon solution
 ==============================
 
+Clean yum cache: ::
+
+    # yum clean all
+
 Upgrade all components: ::
 
-    # yum update centreon*
+    # yum update centreon\*
 
 .. note::
     Accept new GPG keys from repositories as needed.

--- a/doc/fr/upgrade/from_packages.rst
+++ b/doc/fr/upgrade/from_packages.rst
@@ -62,9 +62,13 @@ Exécutez la commande suivante : ::
 Mise à jour de la solution Centreon
 ===================================
 
+Mettez à jour le cache de yum : ::
+
+    # yum clean all
+
 Mettez à jour l'ensemble des composants : ::
 
-    # yum update centreon*
+    # yum update centreon\*
 
 .. note::
     Acceptez les nouvelles clés GPG des dépôts si nécessaire.


### PR DESCRIPTION
Without this command, centos scl repository is not taken
into account, and upgrade process fails