### PR TITLE
MON-3298 enhance utf-8 check

### DIFF
--- a/www/class/centreonXML.class.php
+++ b/www/class/centreonXML.class.php
@@ -109,21 +109,10 @@ class CentreonXML
      */
     protected function is_utf8($string)
     {
-        if (strlen($string) > 1024) {
-            $res = $this->is_utf8(substr($string, 0, 1024));
-            $res += $this->is_utf8(substr($string, 1025));
-        } else {
-            $res = 0;
-            $res += preg_match('%^(?:[\x09\x0A\x0D\x20-\x7E] |
-                                     [\xC2-\xDF][\x80-\xBF] |
-                                     \xE0[\xA0-\xBF][\x80-\xBF] |
-                                     [\xE1-\xEC\xEE\xEF][\x80-\xBF]{2})*$%xs', $string);
-            $res += preg_match('%^(?:\xED[\x80-\x9F][\x80-\xBF] |
-                                    \xF0[\x90-\xBF][\x80-\xBF]{2})*$%xs', $string);
-            $res += preg_match('%^(?:[\xF1-\xF3][\x80-\xBF]{3})*$%xs', $string);
-            $res += preg_match('%^(?:\xF4[\x80-\x8F][\x80-\xBF]{2})*$%xs', $string);
+        if(mb_detect_encoding($string, "UTF-8", true) == "UTF-8") {
+            return 1;
         }
-        return $res;
+        return 0;
     }
 
     /*


### PR DESCRIPTION
UTF-8 encoding control use lot of memory and engine conf generation fails when there are few thousands of resources
we'd better use the default php implementation instead (mb_detect_encoding)