### PR TITLE
[DOC] Correction commande incorrecte

### DIFF
--- a/doc/fr/administration_guide/partitioning/user/exploitation.rst
+++ b/doc/fr/administration_guide/partitioning/user/exploitation.rst
@@ -23,7 +23,7 @@ La ligne de commande exécute la procédure suivante:
   
 La migration de la table est effectuée en utilisant l'option '-m'::
 
-  # php /usr/share/centreon-partitioning/bin/centreon-partitioning.php -m /etc/centreon/centreon-partitioning/partitioning-data_bin.xml
+  # php /usr/share/centreon/bin/centreon-partitioning.php -m data_bin
 
 Si la migration de la table est ok l'ancienne table peut être supprimée avec la commande suivante::
 


### PR DESCRIPTION
il semble que le paramètre attendu après le "-m" soit le nom de la table et non le nom du fichier de définition xml.

Avec la commande originale : 
<code># php /usr/share/centreon/bin/centreon-partitioning.php -m /etc/centreon/centreon-partitioning/partitioni
ng-data_bin.xml
[Fri, 21 Dec 18 08:58:44 +0000] PARTITIONING STARTED
[Fri, 21 Dec 18 08:58:44 +0000] Config file '/usr/share/centreon//config/partition.d/partitioning-/etc/centreon/centre
on-partitioning/partitioning-data_bin.xml.xml' does not exist
[Fri, 21 Dec 18 08:58:44 +0000] PARTITIONING EXITED
</code>