### PR TITLE
fix(secu): Authenticated Remote Code Execution in getStats.php

### DIFF
--- a/www/include/Administration/corePerformance/getStats.php
+++ b/www/include/Administration/corePerformance/getStats.php
@@ -79,7 +79,7 @@ foreach ($_GET as $key => $get) {
 
 function escape_command($command)
 {
-    return preg_replace("/[\\\$|`]/", "", $command);
+    return preg_replace("/[\\\\$|`]/", "", $command);
 }
 
     require_once realpath(dirname(__FILE__) . "/../../../../config/centreon.config.php");
@@ -230,6 +230,7 @@ if (!$session->rowCount()) {
     /*
  * get all template infos
  */
+    //TODO: use a whitelist for $_GET["key"], it's too dangerous to use as is
     $command_line .= " --interlaced --imgformat PNG --width=400 --height=150 --title='".$title[$_GET["key"]]."' --vertical-label='".$_GET["key"]."' --slope-mode  --rigid --alt-autoscale-max ";
 
     /*


### PR DESCRIPTION
Due to the way preg_replace handles backslahes, the expression:

    function escape_command($command)
    {
        return preg_replace("/[\\\$|`]/", "", $command);
    }

wouldn't work as expected because 3 backslashes are needed to properly refer to the backslash inside the regex.

Therefore the following GET parameter would lead to arbitrary remote code execution:
http://x.x.x.x/centreon/include/Administration/corePerformance/getStats.php?key=active_service_check&ns_id=1=/var/lib/centreon/nagios-perf/perfmon-1/nagios_active_service_execution.rrd:Min:AVERAGE \%26 touch /tmp/das \%26

Because it would be interpreted as \&#039; which still makes it valid for a shell to execute.

I'm not very confident in the multiple layers of filtering in this PHP file. It really needs to NOT use GET parameters.

PLEASE NOTE THAT THIS PULL REQUEST IS TO INFORM YOU OF A SECURITY PROBLEM AND HAS NOT BEEN PROPERLY TESTED.