### PR TITLE
fix(secu): Type juggling can lead to authentication bypass in (very) …

### DIFF
--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -154,7 +154,7 @@ class CentreonAuth
      */
     protected function checkPassword($password, $token = "", $autoimport = false)
     {
-        if ((strlen($password) == 0 || $password == "") && $token == "") {
+        if ((strlen($password) == 0 || $password === "") && $token === "") {
             $this->passwdOk = 0;
             return;
         }
@@ -198,7 +198,7 @@ class CentreonAuth
                 if ($this->passwdOk == -1) {
                     $this->passwdOk = 0;
                     if (isset($this->userInfos["contact_passwd"])
-                        && $this->userInfos["contact_passwd"] == $this->myCrypt($password)) {
+                        && $this->userInfos["contact_passwd"] === $this->myCrypt($password)) {
                         $this->passwdOk = 1;
                         if (isset($this->ldap_store_password[$arId]) && $this->ldap_store_password[$arId]) {
                             $this->pearDB->query("UPDATE `contact`
@@ -223,12 +223,12 @@ class CentreonAuth
         } elseif ($this->userInfos["contact_auth_type"] == ""
             || $this->userInfos["contact_auth_type"] == "local" || $this->autologin) {
             if ($this->autologin && $this->userInfos["contact_autologin_key"]
-                && $this->userInfos["contact_autologin_key"] == $token) {
+                && $this->userInfos["contact_autologin_key"] === $token) {
                 $this->passwdOk = 1;
-            } elseif (!empty($password) && $this->userInfos["contact_passwd"] == $password && $this->autologin) {
+            } elseif (!empty($password) && $this->userInfos["contact_passwd"] === $password && $this->autologin) {
                 $this->passwdOk = 1;
             } elseif (!empty($password)
-                && $this->userInfos["contact_passwd"] == $this->myCrypt($password)
+                && $this->userInfos["contact_passwd"] === $this->myCrypt($password)
                 && $this->autologin == 0) {
                 $this->passwdOk = 1;
             } else {
@@ -241,13 +241,13 @@ class CentreonAuth
          */
         if ($this->passwdOk == 2) {
             if ($this->autologin && $this->userInfos["contact_autologin_key"]
-                && $this->userInfos["contact_autologin_key"] == $token) {
+                && $this->userInfos["contact_autologin_key"] === $token) {
                 $this->passwdOk = 1;
             } elseif (!empty($password) && isset($this->userInfos["contact_passwd"])
-                && $this->userInfos["contact_passwd"] == $password && $this->autologin) {
+                && $this->userInfos["contact_passwd"] === $password && $this->autologin) {
                 $this->passwdOk = 1;
             } elseif (!empty($password) && isset($this->userInfos["contact_passwd"])
-                && $this->userInfos["contact_passwd"] == $this->myCrypt($password) && $this->autologin == 0) {
+                && $this->userInfos["contact_passwd"] === $this->myCrypt($password) && $this->autologin == 0) {
                 $this->passwdOk = 1;
             } else {
                 $this->passwdOk = 0;


### PR DESCRIPTION
…rare cases

The '==' operator is a loose comparison operator, whereas the '===' does a strict comparison.
The truth table of the '==' operator is quite ugly (https://www.owasp.org/images/6/6b/PHPMagicTricks-TypeJuggling.pdf) and can lead to undesirable integer promotion results.

For instance, when loose comparing something that looks like integers, PHP will promote both strings to integers.

Example: if the user's token starts with "0e" and is followed by numbers, it is bypassable by the string "00" because in PHP, ("0e123456" == "00") is TRUE.
    http://192.168.56.3/centreon/index.php?p=1&autologin=1&useralias=admin&token=00

Altough, the probabilty this can happen to e.g. the token is very low:
    1/62 * (2/62) * (10/62)^6

PLEASE NOTE THAT THIS PULL REQUEST IS TO INFORM YOU OF A SECURITY PROBLEM AND HAS NOT BEEN PROPERLY TESTED.