### PR TITLE
fix(secu): Unauthenticated Arbitraty File Upload in licenseUpload.php

### DIFF
--- a/www/include/options/oreon/modules/licenseUpload.php
+++ b/www/include/options/oreon/modules/licenseUpload.php
@@ -46,7 +46,7 @@ if ($licenseModuleName !== $moduleName) {
 } else {
     // Directory for put license files
     $licensePath = '/etc/centreon/license.d/';
-    $destination = $licensePath . $licenseFileInfos['name'];
+    $destination = $licensePath . $licenseModuleName . $extensionFileLicense;
 
     if (move_uploaded_file($licenseFileInfos['tmp_name'], $destination)) {
         responseUploadJsonFormat("The license has been successfully uploaded");


### PR DESCRIPTION
There were no real checks on the file extension provided by the user.
This allows an unauthenticated malicious actor to upload any type of files :
    curl http://192.168.56.3/centreon/include/options/oreon/modules/licenseUpload.php --form 'licensefile=@rce.php' --form 'module=rce.php'

NOTE
----
By combining this vulnerability with any SQL injection, this results in a RCE by adding the script to the centreon.topology table:
    INSERT INTO centreon.topology VALUES(666, 'evil', NULL, 666, 666, 1, 1, '/etc/centreon/license.d/rce.php', NULL, NULL, 1, NULL, NULL, NULL, 0, 1)

RCE is thus achieved by navigating to the menu page corresponding to the newly uploaded script:
    http://192.168.56.3/centreon/main.php?p=666

PLEASE NOTE THAT THIS PULL REQUEST IS TO INFORM YOU OF A SECURITY PROBLEM AND HAS NOT BEEN PROPERLY TESTED.