### PR TITLE
fix(secu): Authenticated SQL injection in makeXML_ListServices.php

### DIFF
--- a/www/include/views/graphs/common/makeXML_ListServices.php
+++ b/www/include/views/graphs/common/makeXML_ListServices.php
@@ -71,7 +71,7 @@ if (isset($_SESSION['centreon'])) {
     $mx_l = strlen($s_datas[""]);
 
 if (isset($_GET["host_id"]) && $_GET["host_id"] != 0) {
-    $pq_sql = $pearDBO->query("SELECT id index_id, service_description FROM index_data WHERE host_id='".$_GET['host_id']."'ORDER BY service_description");
+    $pq_sql = $pearDBO->query("SELECT id index_id, service_description FROM index_data WHERE host_id='" . $pearDBO->escape($_GET['host_id']) . "'ORDER BY service_description");
     while ($fw_sql = $pq_sql->fetchRow()) {
         $fw_sql["service_description"] = str_replace($a_this, $a_that, $fw_sql["service_description"]);
         $s_datas[$fw_sql["index_id"]] = $fw_sql["service_description"]."&nbsp;&nbsp;&nbsp;";


### PR DESCRIPTION
Unescaped direct use of a $_GET parameter inside a non prepared statement allowing stacked queries.

For instance, exploitable (when authenticated) with this request:
http://192.168.56.3/centreon/include/views/graphs/common/makeXML_ListServices.php?host_id=1'; DO SLEEP(5); -- -

PLEASE NOTE THAT THIS PULL REQUEST IS TO INFORM YOU OF A SECURITY PROBLEM AND HAS NOT BEEN PROPERLY TESTED.