### PR TITLE
fix(secu): Authenticated RCE in minPlayCommand.php

### DIFF
--- a/www/include/configuration/configObject/command/minPlayCommand.php
+++ b/www/include/configuration/configObject/command/minPlayCommand.php
@@ -137,7 +137,7 @@ if ($error_msg != "") {
         if (preg_match("/\.\./", $command)) {
             $msg = _("Directory traversal detected");
         } else {
-            $msg = exec($command, $stdout, $status);
+            $msg = exec(escapeshellcmd($command), $stdout, $status);
             $msg = join("<br/>", $stdout);
             if ($status == 1) {
                 $status = _("WARNING");


### PR DESCRIPTION
Concatenation of unsanitized command_hostaddress GET parameter to shell_exec leads to remote code execution.

Note: there is too much crafting/filtering going on in this module to be confident in anything:
* GET variables are filtered earlier, e.g. "'" becomes "&#39;"
* GET command_line is urldecoded
* some args are escapeshellargs()
* some commands are escapeshellcmd()
* AFTER that there are some str_replace (which is what I abused)
* then there's a path traversal check
* then the command is executed

Exploitation example
====================
http://192.168.56.103/centreon/main.php?p=60801&type=2&min=1&command_line=/usr/lib64/nagios/plugins%20@DOLLAR@HOSTADDRESS@DOLLAR@&command_hostaddress=$(touch%20/tmp/coucou);
(note: need to set POST variables o1 and o2 to 'p')

[root@centreon-central ~]# find /tmp/ -type f
/tmp/systemd-private-7b84d445a6284536b1db91a498bafc4d-rh-php71-php-fpm.service-iTZJzF/tmp/coucou