### PR TITLE
fix(secu): Token generation uses predictable generator

### DIFF
--- a/www/api/index.php
+++ b/www/api/index.php
@@ -93,7 +93,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' &&
     }
 
     /* Insert Token in API webservice session table */
-    $token = base64_encode(openssl_random_pseudo_bytes(32)); //note: PHP7 has random_bytes()
+    $token = base64_encode(random_bytes(32));
     $res = $pearDB->prepare("INSERT INTO ws_token (contact_id, token, generate_date) VALUES (?, ?, NOW())");
     $res->execute(array($auth->userInfos['contact_id'], $token));
 

--- a/www/api/index.php
+++ b/www/api/index.php
@@ -93,7 +93,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' &&
     }
 
     /* Insert Token in API webservice session table */
-    $token = base64_encode(uniqid('', true));
+    $token = base64_encode(openssl_random_pseudo_bytes(32)); //note: PHP7 has random_bytes()
     $res = $pearDB->prepare("INSERT INTO ws_token (contact_id, token, generate_date) VALUES (?, ?, NOW())");
     $res->execute(array($auth->userInfos['contact_id'], $token));
 


### PR DESCRIPTION
Not really exploitable, but [uniqid()](http://php.net/uniqid) is a rather predictable generator, even with the added entropy.
When dealing with authentication it's better to use a cryptographically secure generator such as [openssl_random_pseudo_bytes](http://www.php.net/manual/en/function.openssl-random-pseudo-bytes.php) or [random_bytes()](http://php.net/manual/en/function.random-bytes.php).