### PR TITLE
fix(secu): Risky file include in brokerPerformance.php may lead to st…

### DIFF
--- a/www/include/Administration/brokerPerformance/brokerPerformance.php
+++ b/www/include/Administration/brokerPerformance/brokerPerformance.php
@@ -265,6 +265,12 @@ try {
         $statsfile = $row['cache_directory'] . '/' . $row['config_name'] . '-stats.json';
         if ($defaultPoller != $selectedPoller) {
             $statsfile = _CENTREON_VARLIB_ . '/broker-stats/broker-stats-' . $selectedPoller . '.dat';
+
+            /* security: verify that the file is in the correct path */
+            $statsfile = realpath($statsfile);
+            if (substr($statsfile, 0, strlen(_CENTREON_VARLIB_)) !== _CENTREON_VARLIB_ ) {
+                $statsfile = "";
+            }
         }
         if (!file_exists($statsfile) || !is_readable($statsfile)) {
             $perf_err[$row['config_name']] = _('Cannot open statistics file');


### PR DESCRIPTION
…ored XSS

Because there are no path checks, the file_get_contents on a user-supplied variable is abusable as long as it's a .dat file.

This could result in a XSS if combined with https://github.com/gquere/centreon/commit/03ae19250e0f1eb32cf25205b005c979b4923ab0

XSS Example
-----------

If the attacker uploads a bla.dat file in /etc/centreon/license.d/bla.dat using the previously mentioned arbitraty file upload vulnerability, and if this file contains something like:
{
   "endpoint central-broker-master-inputfhsdhkfhsd <script>alert('coucou')</script>" : {
      "central-broker-master-input-1" : {
      }
   }
}

Then this would trigger an XSS when visiting the URL:
    http://x.x.x.x/centreon/main.php?p=50501&pollers=1/../../../../../etc/centreon/license.d/bla
Which could be obfuscated as:
    http://x.x.x.x/centreon/main.php?p=50501&pollers=1%2F%2E%2E%2F%2E%2E%2F%2E%2E%2F%2E%2E%2F%2E%2E%2Fetc%2Fcentreon%2Flicense%2Ed%2Fbla