### PR TITLE
fix(CLAPI): check for "Reach API *" fields in user instead of "Reach …

### DIFF
--- a/www/class/centreon-clapi/centreonAPI.class.php
+++ b/www/class/centreon-clapi/centreonAPI.class.php
@@ -517,41 +517,41 @@ class CentreonAPI
         $DBRESULT = $this->DB->query("SELECT *
                  FROM contact
                  WHERE contact_alias = '" . $this->login . "'
-                 AND contact_activate = '1'
-                 AND contact_oreon = '1'");
+                 AND contact_activate = '1'");
+
         if ($DBRESULT->rowCount()) {
             $row = $DBRESULT->fetchRow();
 
-            if ($row['contact_admin'] == 1) {
-                $algo = $this->dependencyInjector['utils']->detectPassPattern($row['contact_passwd']);
-                if (!$algo) {
-                    if ($useSha1) {
-                        $row['contact_passwd'] = 'sha1__' . $row['contact_passwd'];
-                    } else {
-                        $row['contact_passwd'] = 'md5__' . $row['contact_passwd'];
-                    }
+            if (!$row['reach_api'] && !$row['reach_api_rt']) {
+                print "You don't have permissions for CLAPI.\n";
+                exit(1);
+            }
+
+            $algo = $this->dependencyInjector['utils']->detectPassPattern($row['contact_passwd']);
+            if (!$algo) {
+                if ($useSha1) {
+                    $row['contact_passwd'] = 'sha1__' . $row['contact_passwd'];
+                } else {
+                    $row['contact_passwd'] = 'md5__' . $row['contact_passwd'];
                 }
-                if ($row['contact_passwd'] == $pass) {
+            }
+            if ($row['contact_passwd'] == $pass) {
+                \CentreonClapi\CentreonUtils::setUserId($row['contact_id']);
+                return 1;
+            } elseif ($row['contact_auth_type'] == 'ldap') {
+                $CentreonLog = new \CentreonUserLog(-1, $this->DB);
+                $centreonAuth = new \CentreonAuthLDAP(
+                    $this->DB,
+                    $CentreonLog,
+                    $this->login,
+                    $this->password,
+                    $row,
+                    $row['ar_id']
+                );
+                if ($centreonAuth->checkPassword() == 1) {
                     \CentreonClapi\CentreonUtils::setUserId($row['contact_id']);
                     return 1;
-                } elseif ($row['contact_auth_type'] == 'ldap') {
-                    $CentreonLog = new \CentreonUserLog(-1, $this->DB);
-                    $centreonAuth = new \CentreonAuthLDAP(
-                        $this->DB,
-                        $CentreonLog,
-                        $this->login,
-                        $this->password,
-                        $row,
-                        $row['ar_id']
-                    );
-                    if ($centreonAuth->checkPassword() == 1) {
-                        \CentreonClapi\CentreonUtils::setUserId($row['contact_id']);
-                        return 1;
-                    }
                 }
-            } else {
-                print "Centreon CLAPI is for admin users only.\n";
-                exit(1);
             }
         }
         print "Invalid credentials.\n";

--- a/www/include/configuration/configObject/contact/formContact.php
+++ b/www/include/configuration/configObject/contact/formContact.php
@@ -72,9 +72,14 @@ $initialValues = array();
  * Check if this server is a Remote Server to hide some part of form
  */
 $DBRESULT = $pearDB->query("SELECT i.value FROM informations i WHERE i.key = 'isRemote'");
-$isRemote = array_map("myDecode", $DBRESULT->fetchRow());
-$DBRESULT->closeCursor();
-$isRemote = ($isRemote['value'] === 'yes') ? true : false;
+$result = $DBRESULT->fetchRow();
+if ($result === false) {
+    $isRemote = false;
+} else {
+    $isRemote = array_map("myDecode", $DBRESULT->fetchRow());
+    $DBRESULT->closeCursor();
+    $isRemote = ($isRemote['value'] === 'yes') ? true : false;
+}
 
 $cct = array();
 if (($o == "c" || $o == "w") && $contact_id) {


### PR DESCRIPTION
…Centreon Front-end" when using CLAPI

- remove check for "contact_oreon" field
- remove check for "contact_admin" field
- add check whether at least on of reach_api/reach_api_rt field is active
- fix warning in user form