### PR TITLE
optimize ldap sync at config generation (Fix #6949)

### DIFF
--- a/www/class/centreonContactgroup.class.php
+++ b/www/class/centreonContactgroup.class.php
@@ -224,7 +224,7 @@ class CentreonContactgroup
         $cgres = $this->db->query($query);
         $ar_id = -1;
         $ldapConn = null;
-        while ($cgrow = $cgres->fetchRow()) {
+        while ($cgrow = $cgres->fetch()) {
             if (isset($ldapServerConnError[$cgrow['ar_id']])) {
                 continue;
             }

--- a/www/include/configuration/configGenerate/xml/generateFiles.php
+++ b/www/include/configuration/configGenerate/xml/generateFiles.php
@@ -109,7 +109,7 @@ try {
 
     # Sync contactgroups to ldap
     $cgObj = new CentreonContactgroup($pearDB);
-    $cgObj->syncWithLdap();
+    $cgObj->syncWithLdapConfigGen();
 
     # Generate configuration
     if ($pollers == '0') {


### PR DESCRIPTION
Some rules about Centreon and LDAP:
- Users need to be connected at last one time to centreon UI. Otherwise, the user don't get notification from centreon-engine. (we could add import users directly from a LDAP contact group linked in centreon)
- Centreon doesn't manage contact group name changed. We cannot know if a "group X" in "OU=X" is the same than "group X" in "OU=Y". 
- Centreon manage if an user added/moved in LDAP groups configured in Centreon.

In the global ldap sync, we should manage:
- users is disabled in LDAP (need to map a ldap attribute in centreon config), it should be disabled in centreon