### PR TITLE
feat(build): add a post module installation script that will regenerate the autoloader.

### DIFF
--- a/bin/centreon-post-module-install.sh
+++ b/bin/centreon-post-module-install.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+@PHP_BIN@ @INSTALL_DIR_CENTREON@/bin/composer --working-dir=@INSTALL_DIR_CENTREON@ dump-autoload -o


### PR DESCRIPTION
Useful when modules require their classes to be loaded through the autoloader.