### PR TITLE
enh(UI): Indent the third level menu

### DIFF
--- a/www/front_src/src/styles/partials/_side-nav.scss
+++ b/www/front_src/src/styles/partials/_side-nav.scss
@@ -181,7 +181,6 @@ a {
             background: $turquoise-centreon-primary;
             color: $white-color;
           }
-          
         }
         &:hover {
           .collapsed-level-item-link {
@@ -395,7 +394,7 @@ a {
       font-size: 0.8rem;
       background-color: $white-color;
       display: block;
-      padding: 3px 10px 3px 47px;
+      padding: 3px 10px 3px 56px;
       border-bottom: 1px solid #f7f7f7;
       text-align: left;
     }
@@ -437,11 +436,7 @@ a {
       .collapsed-level-item {
         background-color: $white-color;
         .collapsed-level-item-link {
-          padding: 8px 10px 8px 47px;
-          // &:hover {
-          //   color: $white-color;
-          //   background-color: #0a78a5;
-          // }
+          padding: 8px 10px 8px 56px;
         }
       }
     }


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Enhancment of menu visibility by indenting the third-level elements.
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

Fixes # (issue)

<h2> Type of change </h2>

Please delete options that are not relevant.

- [ ] New functionality - enhancment (non-breaking change)

<h2> Target serie </h2>

Please delete series that are not relevant.

- [ ] 18.10.x

<h2> How this pull request can be tested ? </h2>

Open the left menu bar then you should see that the third level menu items are indented.

Any **relevant details** of the configuration to perform the test should be added.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
- [ ] I have updated the **release note** in dedicated temporary section **\***

**\*** updating the release note results in adding the **pull request id** and **description** at the end of the file. **Product Managers** will rework it for the release. Release notes can be found [here](https://github.com/centreon/centreon/tree/master/doc/en/release_notes).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
