### PR TITLE
fix(secu): rce vulnerability when using command's testing feature

### DIFF
--- a/doc/en/release_notes/centreon-18.10/centreon-18.10.4.rst
+++ b/doc/en/release_notes/centreon-18.10/centreon-18.10.4.rst
@@ -7,3 +7,4 @@ Enhancements
 
 Bug Fixes
 =========
+fix(secu): Authenticated RCE in minPlayCommand.php (PR/#7230)

--- a/www/include/configuration/configObject/command/minPlayCommand.php
+++ b/www/include/configuration/configObject/command/minPlayCommand.php
@@ -103,7 +103,11 @@ while (preg_match("/@DOLLAR@ARG([0-9]+)@DOLLAR@/", $resource_def, $matches) and 
         }
         if (preg_match("/@DOLLAR@HOSTADDRESS@DOLLAR@/", $resource_def, $matches)) {
             if (isset($_GET["command_hostaddress"])) {
-                $resource_def = str_replace("@DOLLAR@HOSTADDRESS@DOLLAR@", $_GET["command_hostaddress"], $resource_def);
+                $resource_def = str_replace(
+                    "@DOLLAR@HOSTADDRESS@DOLLAR@",
+                    $_GET["command_hostaddress"],
+                    $resource_def
+                );
             } else {
                 $error_msg .= "\$HOSTADDRESS\$";
             }

--- a/www/include/configuration/configObject/command/minPlayCommand.php
+++ b/www/include/configuration/configObject/command/minPlayCommand.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -54,9 +54,11 @@ $resource_def = escapeshellcmd($resource_def);
 
 /* Get resources in DB and replace by the value */
 while (preg_match("/@DOLLAR@USER([0-9]+)@DOLLAR@/", $resource_def, $matches) and $error_msg == "") {
-    $query = "SELECT resource_line FROM cfg_resource WHERE resource_name = '\$USER" . $matches[1] . "\$' LIMIT 1";
-    $DBRESULT = $pearDB->query($query);
-    $resource = $DBRESULT->fetchRow();
+    $query = "SELECT resource_line FROM cfg_resource WHERE resource_name = :matches LIMIT 1";
+    $DBRESULT = $pearDB->prepare($query);
+    $DBRESULT->bindValue(':matches', "\$USER" . $matches[1] . "\$" , PDO::PARAM_STR);
+    $DBRESULT->execute();
+    $resource = $DBRESULT->fetch();
     if (!isset($resource["resource_line"])) {
         $error_msg .= "\$USER" . $matches[1] . "\$";
     } else {
@@ -84,10 +86,11 @@ while (preg_match("/@DOLLAR@ARG([0-9]+)@DOLLAR@/", $resource_def, $matches) and 
         $resource_def = str_replace("@DOLLAR@ARG" . $match_id . "@DOLLAR@", $args[$match_id], $resource_def);
         $resource_def = str_replace('$', '@DOLLAR@', $resource_def);
         if (preg_match("/@DOLLAR@USER([0-9]+)@DOLLAR@/", $resource_def, $matches)) {
-            $query = "SELECT resource_line FROM cfg_resource " .
-                "WHERE resource_name = '\$USER" . $matches[1] . "\$' LIMIT 1";
-            $DBRESULT = $pearDB->query($query);
-            $resource = $DBRESULT->fetchRow();
+            $query = "SELECT resource_line FROM cfg_resource WHERE resource_name = :matches LIMIT 1";
+            $DBRESULT = $pearDB->prepare($query);
+            $DBRESULT->bindValue(':matches', "\$USER" . $matches[1] . "\$", PDO::PARAM_STR);
+            $DBRESULT->execute();
+            $resource = $DBRESULT->fetch();
             if (!isset($resource["resource_line"])) {
                 $error_msg .= "\$USER" . $match_id . "\$";
             } else {
@@ -137,7 +140,7 @@ if ($error_msg != "") {
         if (preg_match("/\.\./", $command)) {
             $msg = _("Directory traversal detected");
         } else {
-            $msg = exec($command, $stdout, $status);
+            $msg = exec(escapeshellcmd($command), $stdout, $status);
             $msg = join("<br/>", $stdout);
             if ($status == 1) {
                 $status = _("WARNING");


### PR DESCRIPTION
Original author : @gquere
Adding : bindValue methods to prevent SQL injection and PSR2 

<h1> Authenticated RCE</h1>

<h2> An RCE was exploitable in minPlayCommand.php </h2>

* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.
Check :
https://github.com/centreon/centreon/pull/7099

Fixes # (issue) : none

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Ask me in private please.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
- [x] I have updated the **release note** in dedicated temporary section. **\***

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
