### PR TITLE
Mon 2999 menu tooltip

### DIFF
--- a/www/front_src/src/App.js
+++ b/www/front_src/src/App.js
@@ -9,6 +9,7 @@ import ReactRoute from './components/router/reactRoute';
 
 import { classicRoutes, reactRoutes } from "./route-maps";
 import NavigationComponent from "./components/navigation";
+import Tooltip from "./components/tooltip";
 import Footer from "./components/footer";
 import Fullscreen from 'react-fullscreen-crossbrowser';
 import queryString from 'query-string';
@@ -116,6 +117,7 @@ class App extends Component {
           {!min && // do not display menu if min=1
             <NavigationComponent/>
           }
+          <Tooltip/>
           <div id="content">
             {!min && // do not display header if min=1
               <Header/>

--- a/www/front_src/src/components/navigation/index.js
+++ b/www/front_src/src/components/navigation/index.js
@@ -174,103 +174,108 @@ class NavigationComponent extends Component {
             onMouseLeave={this.mouseLeftTheMenu}
           >
             {Object.entries(menuItems).map(([levelOneKey, levelOneProps]) => (
-              levelOneProps.label ? (<li onMouseOver={this.mouseIsMovingOverTheMenu.bind(this, levelOneProps.label)} class={"menu-item" + (levelOneProps.active ? " active" : "")}>
-                <span
-                  onDoubleClick={() => {this.handleDoubleClick(levelOneKey, levelOneProps)}}
-                  onClick={() => {this.collapseLevelTwo(levelOneKey)}}
-                  style={{ cursor: "pointer" }}
-                  class="menu-item-link dropdown-toggle"
-                  id={"menu" + levelOneKey}
+              levelOneProps.label ? (
+                <li
+                  onMouseOver={this.mouseIsMovingOverTheMenu.bind(this, levelOneProps.label)} 
+                  class={"menu-item" + (levelOneProps.active ? " active" : "")}
                 >
-                  <span class={`iconmoon icon-${levelOneProps.menu_id.toLowerCase()}`}>
-                    <span class={"menu-item-name"}><Translate value={levelOneProps.label}/></span>
+                  <span
+                    onDoubleClick={() => {this.handleDoubleClick(levelOneKey, levelOneProps)}}
+                    onClick={() => {this.collapseLevelTwo(levelOneKey)}}
+                    style={{ cursor: "pointer" }}
+                    class="menu-item-link dropdown-toggle"
+                    id={"menu" + levelOneKey}
+                  >
+                    <span class={`iconmoon icon-${levelOneProps.menu_id.toLowerCase()}`}>
+                      <span class={"menu-item-name"}><Translate value={levelOneProps.label}/></span>
+                    </span>
                   </span>
-                </span>
-                <ul
-                  class="collapse collapsed-items list-unstyled"
-                  style={{ display: (levelOneProps.toggled && active) ? "block" : "none" }}
-                >
-                  {Object.entries(levelOneProps.children).map(([levelTwoKey, levelTwoProps]) => {
-                    const urlOptions = levelTwoKey.slice(1) +
-                      (levelTwoProps.options !== null ? levelTwoProps.options : '')
-                    if (levelTwoProps.label) {
-                      return (
-                        <li
-                          class={
-                            "collapsed-item" + (levelTwoProps.collapsed || (pageId == urlOptions) ? " active" : "")
-                          }
-                        >
-                          {Object.keys(levelTwoProps.children).length > 0 ? (
-                            <span
-                              style={{ cursor: "pointer" }}
-                              onClick={() => {this.collapseLevelThree(levelOneKey, levelTwoKey)}}
-                              class="collapsed-level-item-link"
-                            >
-                              <Translate value={levelTwoProps.hasOwnProperty('label') ? levelTwoProps.label : ''}/>
-                            </span>
-                          ) : (
-                              <Link
-                                onClick={() => {
-                                  this.goToPage(
-                                    routeMap.module + "?p=" + urlOptions,
-                                    levelOneKey
-                                  )
-                                }}
-                                className={`collapsed-level-item-link img-none ${(pageId == urlOptions) ? "active" : ""}`}
-                                to={routeMap.module + "?p=" + urlOptions}
+                  <ul
+                    class="collapse collapsed-items list-unstyled"
+                    style={{ display: (levelOneProps.toggled && active) ? "block" : "none" }}
+                  >
+                    {Object.entries(levelOneProps.children).map(([levelTwoKey, levelTwoProps]) => {
+                      const urlOptions = levelTwoKey.slice(1) +
+                        (levelTwoProps.options !== null ? levelTwoProps.options : '')
+                      if (levelTwoProps.label) {
+                        return (
+                          <li
+                            class={
+                              "collapsed-item" + (levelTwoProps.collapsed || (pageId == urlOptions) ? " active" : "")
+                            }
+                          >
+                            {Object.keys(levelTwoProps.children).length > 0 ? (
+                              <span
+                                style={{ cursor: "pointer" }}
+                                onClick={() => {this.collapseLevelThree(levelOneKey, levelTwoKey)}}
+                                class="collapsed-level-item-link"
                               >
-                                <Translate value={levelTwoProps.label}/>
-                              </Link>
-                            )}
+                                <Translate value={levelTwoProps.hasOwnProperty('label') ? levelTwoProps.label : ''}/>
+                              </span>
+                            ) : (
+                                <Link
+                                  onClick={() => {
+                                    this.goToPage(
+                                      routeMap.module + "?p=" + urlOptions,
+                                      levelOneKey
+                                    )
+                                  }}
+                                  className={`collapsed-level-item-link img-none ${(pageId == urlOptions) ? "active" : ""}`}
+                                  to={routeMap.module + "?p=" + urlOptions}
+                                >
+                                  <Translate value={levelTwoProps.label}/>
+                                </Link>
+                              )}
 
-                          <ul class="collapse-level collapsed-level-items first-level list-unstyled">
-                            {Object.entries(levelTwoProps.children).map(([levelThreeKey, levelThreeProps]) => {
-                              return (
-                                <React.Fragment>
-                                  {Object.keys(levelTwoProps.children).length > 1 &&
-                                    <span class="collapsed-level-title">
-                                      <Translate value={levelThreeKey}/>
-                                    </span>
-                                  }
-                                  {Object.entries(levelThreeProps).map(([levelFourKey, levelFourProps]) => {
-                                    const urlOptions = levelFourKey.slice(1) +
-                                      (levelFourProps.options !== null ? levelFourProps.options : '')
-                                    if (levelFourProps.label) {
-                                      return (
-                                        <li
-                                          class={"collapsed-level-item" + (pageId == urlOptions ? " active" : "")}
-                                        >
-                                          <Link
-                                            onClick={() => {
-                                              this.goToPage(
-                                                routeMap.module + "?p=" + urlOptions,
-                                                levelOneKey
-                                              )
-                                            }}
-                                            className="collapsed-level-item-link"
-                                            to={routeMap.module + "?p=" + urlOptions}
-                                          >
-                                            <Translate value={levelFourProps.label}/>
-                                          </Link>
-                                        </li>
-                                      );
-                                    } else {
-                                      return null
+                            <ul class="collapse-level collapsed-level-items first-level list-unstyled">
+                              {Object.entries(levelTwoProps.children).map(([levelThreeKey, levelThreeProps]) => {
+                                return (
+                                  <React.Fragment>
+                                    {Object.keys(levelTwoProps.children).length > 1 &&
+                                      <span class="collapsed-level-title">
+                                        <Translate value={levelThreeKey}/>
+                                      </span>
                                     }
-                                  }
-                                  )}
-                                </React.Fragment>
-                              )
-                            })}
-                          </ul>
-                        </li>
-                      );
-                    } else {
-                      return null
-                    }
-                  })}
-                </ul>
-              </li>) : null
+                                    {Object.entries(levelThreeProps).map(([levelFourKey, levelFourProps]) => {
+                                      const urlOptions = levelFourKey.slice(1) +
+                                        (levelFourProps.options !== null ? levelFourProps.options : '')
+                                      if (levelFourProps.label) {
+                                        return (
+                                          <li
+                                            class={"collapsed-level-item" + (pageId == urlOptions ? " active" : "")}
+                                          >
+                                            <Link
+                                              onClick={() => {
+                                                this.goToPage(
+                                                  routeMap.module + "?p=" + urlOptions,
+                                                  levelOneKey
+                                                )
+                                              }}
+                                              className="collapsed-level-item-link"
+                                              to={routeMap.module + "?p=" + urlOptions}
+                                            >
+                                              <Translate value={levelFourProps.label}/>
+                                            </Link>
+                                          </li>
+                                        );
+                                      } else {
+                                        return null
+                                      }
+                                    }
+                                    )}
+                                  </React.Fragment>
+                                )
+                              })}
+                            </ul>
+                          </li>
+                        );
+                      } else {
+                        return null
+                      }
+                    })}
+                  </ul>
+                </li>
+              ) : null
             ))}
           </ul>
           <div class="toggle-sidebar-wrap">

--- a/www/front_src/src/components/navigation/index.js
+++ b/www/front_src/src/components/navigation/index.js
@@ -11,11 +11,7 @@ import routeMap from "../../route-maps/route-map";
 import { Translate } from 'react-redux-i18n';
 import { setNavigation } from "../../redux/actions/navigationActions";
 import { connect } from "react-redux";
-
-import Tooltip from "../tooltip";
-import { reactRoutes } from "../../route-maps";
-
-
+import { updateTooltip } from '../../redux/actions/tooltipActions';
 
 class NavigationComponent extends Component {
   navService = axios("internal.php?object=centreon_menu&action=menu");
@@ -27,10 +23,7 @@ class NavigationComponent extends Component {
     active: false,
     initiallyCollapsed: false,
     selectedMenu: {},
-    menuItems: [],
-    isMouseInside: false,
-    leftPosition: "0",
-    topPosition: "0"
+    menuItems: []
   };
 
   UNSAFE_componentWillMount = () => {
@@ -126,195 +119,168 @@ class NavigationComponent extends Component {
     history.push(route);
   };
 
-  //show information tooltip  when hover on folded in menu elements
-  mouseEnter = (e) => {
-    this.setState({
-      isMouseInside: true
+  // hide tooltip for the first-level folded menu items
+  mouseLeftTheMenu = event => {
+    const { updateTooltip } = this.props;
+    updateTooltip({
+      toggled: false
     });
-  }
+  };
 
-  //hide information tooltip  when hover on folded in menu elements
-  mouseLeave = () => {
-    this.setState({
-      isMouseInside: false,
+  // show tooltip for the first-level folded menu items by setting toggled to true
+  // updating the x, y properties of tooltip in order to display it on client cursor position
+  // show related label by setting label to label
+  mouseIsMovingOverTheMenu = (label, {  clientY }) => {
+    const { updateTooltip } = this.props;
+    updateTooltip({
+      toggled: true,
+      x: 50,
+      y: clientY,
+      label
     });
-  }
-  //TODO : trying to show information tooltip on the mouse coords
-  mouseMove = (e) => {
+  };
 
-    let { leftPosition, topPosition } = this.state;
-
-    this.setState({
-      leftPosition:e.screenX,
-      topPosition:e.screenY
-    });
-
-    console.log('coords x :' + leftPosition + ' coords y :' +  topPosition)
-  }
 
   render() {
     const { active, menuItems } = this.state;
-    let { leftPosition, topPosition } = this.state;
     const pageId = this.props.history.location.search.split("p=")[1];
 
     return (
-      <React.Fragment>
-        <nav class={"sidebar" + (active ? " active" : "")} id="sidebar">
-          <div class="sidebar-inner">
-            <div class="sidebar-logo" onClick={this.toggleNavigation}>
-              <span>
-                <img
-                  class="sidebar-logo-image"
-                  src={logo}
-                  width="254"
-                  height="57"
-                  alt=""
-                />
-              </span>
-            </div>
-            <div class="sidebar-logo-mini" onClick={this.toggleNavigation}>
-              <span>
-                <img
-                  class="sidebar-logo-mini-image"
-                  src={miniLogo}
-                  width="23"
-                  height="21"
-                  alt=""
-                />
-              </span>
-            </div>
-            <ul class="menu menu-items list-unstyled components">
-              {Object.entries(menuItems).map(([levelOneKey, levelOneProps]) => (
-                levelOneProps.label ? (<li class={"menu-item" + (levelOneProps.active ? " active" : "")}>
-                  <span
-                    onDoubleClick={() => {this.handleDoubleClick(levelOneKey, levelOneProps)}}
-                    onClick={() => {this.collapseLevelTwo(levelOneKey)}}
-                    onMouseEnter={this.mouseEnter}
-                    onMouseLeave={this.mouseLeave}
-                    onMouseMove={this.mouseMove}
-                    style={{ cursor: "pointer" }}
-                    class="menu-item-link dropdown-toggle"
-                    id={"menu" + levelOneKey}
-                  >
-                    <span class={`iconmoon icon-${levelOneProps.menu_id.toLowerCase()}`}>
-                      <span class={"menu-item-name"}><Translate value={levelOneProps.label}/></span>
-                    </span>
-                  </span>
-                  <ul
-                    class="collapse collapsed-items list-unstyled"
-                    style={{ display: (levelOneProps.toggled && active) ? "block" : "none" }}
-                  >
-                    {Object.entries(levelOneProps.children).map(([levelTwoKey, levelTwoProps]) => {
-                      const urlOptions = levelTwoKey.slice(1) +
-                        (levelTwoProps.options !== null ? levelTwoProps.options : '')
-                      if (levelTwoProps.label) {
-                        return (
-                          <li
-                            class={
-                              "collapsed-item" + (levelTwoProps.collapsed || (pageId == urlOptions) ? " active" : "")
-                            }
-                          >
-                            {Object.keys(levelTwoProps.children).length > 0 ? (
-                              <span
-                                style={{ cursor: "pointer" }}
-                                onClick={() => {this.collapseLevelThree(levelOneKey, levelTwoKey)}}
-                                class="collapsed-level-item-link"
-                              >
-                                <Translate value={levelTwoProps.hasOwnProperty('label') ? levelTwoProps.label : ''}/>
-                              </span>
-                            ) : (
-                                <Link
-                                  onClick={() => {
-                                    this.goToPage(
-                                      routeMap.module + "?p=" + urlOptions,
-                                      levelOneKey
-                                    )
-                                  }}
-                                  className={`collapsed-level-item-link img-none ${(pageId == urlOptions) ? "active" : ""}`}
-                                  to={routeMap.module + "?p=" + urlOptions}
-                                >
-                                  <Translate value={levelTwoProps.label}/>
-                                </Link>
-                              )}
-
-                            <ul class="collapse-level collapsed-level-items first-level list-unstyled">
-                              {Object.entries(levelTwoProps.children).map(([levelThreeKey, levelThreeProps]) => {
-                                return (
-                                  <React.Fragment>
-                                    {Object.keys(levelTwoProps.children).length > 1 &&
-                                      <span class="collapsed-level-title">
-                                        <Translate value={levelThreeKey}/>
-                                      </span>
-                                    }
-                                    {Object.entries(levelThreeProps).map(([levelFourKey, levelFourProps]) => {
-                                      const urlOptions = levelFourKey.slice(1) +
-                                        (levelFourProps.options !== null ? levelFourProps.options : '')
-                                      if (levelFourProps.label) {
-                                        return (
-                                          <li
-                                            class={"collapsed-level-item" + (pageId == urlOptions ? " active" : "")}
-                                          >
-                                            <Link
-                                              onClick={() => {
-                                                this.goToPage(
-                                                  routeMap.module + "?p=" + urlOptions,
-                                                  levelOneKey
-                                                )
-                                              }}
-                                              className="collapsed-level-item-link"
-                                              to={routeMap.module + "?p=" + urlOptions}
-                                            >
-                                              <Translate value={levelFourProps.label}/>
-                                            </Link>
-                                          </li>
-                                        );
-                                      } else {
-                                        return null
-                                      }
-                                    }
-                                    )}
-                                  </React.Fragment>
-                                )
-                              })}
-                            </ul>
-                          </li>
-                        );
-                      } else {
-                        return null
-                      }
-                    })}
-                  </ul>
-                </li>) : null
-              ))}
-            </ul>
-            <div class="toggle-sidebar-wrap">
-              <span
-                class="toggle-sidebar-icon"
-                onClick={() => {this.toggleNavigation()}}
+      <nav class={"sidebar" + (active ? " active" : "")} id="sidebar">
+        <div class="sidebar-inner">
+          <div class="sidebar-logo" onClick={this.toggleNavigation}>
+            <span>
+              <img
+                class="sidebar-logo-image"
+                src={logo}
+                width="254"
+                height="57"
+                alt=""
               />
-            </div>
+            </span>
           </div>
-        </nav>
+          <div class="sidebar-logo-mini" onClick={this.toggleNavigation}>
+            <span>
+              <img
+                class="sidebar-logo-mini-image"
+                src={miniLogo}
+                width="23"
+                height="21"
+                alt=""
+              />
+            </span>
+          </div>
+          <ul class="menu menu-items list-unstyled components"
+            onMouseLeave={this.mouseLeftTheMenu}
+          >
+            {Object.entries(menuItems).map(([levelOneKey, levelOneProps]) => (
+              levelOneProps.label ? (<li onMouseOver={this.mouseIsMovingOverTheMenu.bind(this, levelOneProps.label)} class={"menu-item" + (levelOneProps.active ? " active" : "")}>
+                <span
+                  onDoubleClick={() => {this.handleDoubleClick(levelOneKey, levelOneProps)}}
+                  onClick={() => {this.collapseLevelTwo(levelOneKey)}}
+                  style={{ cursor: "pointer" }}
+                  class="menu-item-link dropdown-toggle"
+                  id={"menu" + levelOneKey}
+                >
+                  <span class={`iconmoon icon-${levelOneProps.menu_id.toLowerCase()}`}>
+                    <span class={"menu-item-name"}><Translate value={levelOneProps.label}/></span>
+                  </span>
+                </span>
+                <ul
+                  class="collapse collapsed-items list-unstyled"
+                  style={{ display: (levelOneProps.toggled && active) ? "block" : "none" }}
+                >
+                  {Object.entries(levelOneProps.children).map(([levelTwoKey, levelTwoProps]) => {
+                    const urlOptions = levelTwoKey.slice(1) +
+                      (levelTwoProps.options !== null ? levelTwoProps.options : '')
+                    if (levelTwoProps.label) {
+                      return (
+                        <li
+                          class={
+                            "collapsed-item" + (levelTwoProps.collapsed || (pageId == urlOptions) ? " active" : "")
+                          }
+                        >
+                          {Object.keys(levelTwoProps.children).length > 0 ? (
+                            <span
+                              style={{ cursor: "pointer" }}
+                              onClick={() => {this.collapseLevelThree(levelOneKey, levelTwoKey)}}
+                              class="collapsed-level-item-link"
+                            >
+                              <Translate value={levelTwoProps.hasOwnProperty('label') ? levelTwoProps.label : ''}/>
+                            </span>
+                          ) : (
+                              <Link
+                                onClick={() => {
+                                  this.goToPage(
+                                    routeMap.module + "?p=" + urlOptions,
+                                    levelOneKey
+                                  )
+                                }}
+                                className={`collapsed-level-item-link img-none ${(pageId == urlOptions) ? "active" : ""}`}
+                                to={routeMap.module + "?p=" + urlOptions}
+                              >
+                                <Translate value={levelTwoProps.label}/>
+                              </Link>
+                            )}
 
-        {this.state.isMouseInside ?
-          <Tooltip
-            type="right"
-            text="tooltip right"
-            style={{ left: `${leftPosition}px`, top: `${topPosition}px` }}
-          />
-        : null}
-
-        {/* TODO : want to map the 1st menu entries and put right text in related tooltip on each menu element
-        {this.state.isMouseInside ?
-          {Object.entries(menuItems).map((levelOneProps) => (
-            <Tooltip
-              type="right"
-              text={{levelOneProps.label}}
-              style={{ left: `${leftPosition}px`, top: `${topPosition}px` }}
+                          <ul class="collapse-level collapsed-level-items first-level list-unstyled">
+                            {Object.entries(levelTwoProps.children).map(([levelThreeKey, levelThreeProps]) => {
+                              return (
+                                <React.Fragment>
+                                  {Object.keys(levelTwoProps.children).length > 1 &&
+                                    <span class="collapsed-level-title">
+                                      <Translate value={levelThreeKey}/>
+                                    </span>
+                                  }
+                                  {Object.entries(levelThreeProps).map(([levelFourKey, levelFourProps]) => {
+                                    const urlOptions = levelFourKey.slice(1) +
+                                      (levelFourProps.options !== null ? levelFourProps.options : '')
+                                    if (levelFourProps.label) {
+                                      return (
+                                        <li
+                                          class={"collapsed-level-item" + (pageId == urlOptions ? " active" : "")}
+                                        >
+                                          <Link
+                                            onClick={() => {
+                                              this.goToPage(
+                                                routeMap.module + "?p=" + urlOptions,
+                                                levelOneKey
+                                              )
+                                            }}
+                                            className="collapsed-level-item-link"
+                                            to={routeMap.module + "?p=" + urlOptions}
+                                          >
+                                            <Translate value={levelFourProps.label}/>
+                                          </Link>
+                                        </li>
+                                      );
+                                    } else {
+                                      return null
+                                    }
+                                  }
+                                  )}
+                                </React.Fragment>
+                              )
+                            })}
+                          </ul>
+                        </li>
+                      );
+                    } else {
+                      return null
+                    }
+                  })}
+                </ul>
+              </li>) : null
+            ))}
+          </ul>
+          <div class="toggle-sidebar-wrap">
+            <span
+              class="toggle-sidebar-icon"
+              onClick={() => {this.toggleNavigation()}}
             />
-          ))}
-        : null} */}
-      </React.Fragment>
+          </div>
+        </div>
+      </nav>
     );
   }
 }
@@ -322,7 +288,8 @@ class NavigationComponent extends Component {
 const mapStateToProps = () => {}
 
 const mapDispatchToProps = {
-  setNavigation
+  setNavigation,
+  updateTooltip
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(NavigationComponent));

--- a/www/front_src/src/components/navigation/index.js
+++ b/www/front_src/src/components/navigation/index.js
@@ -12,6 +12,10 @@ import { Translate } from 'react-redux-i18n';
 import { setNavigation } from "../../redux/actions/navigationActions";
 import { connect } from "react-redux";
 
+import Tooltip from "../tooltip";
+import { reactRoutes } from "../../route-maps";
+
+
 
 class NavigationComponent extends Component {
   navService = axios("internal.php?object=centreon_menu&action=menu");
@@ -23,7 +27,10 @@ class NavigationComponent extends Component {
     active: false,
     initiallyCollapsed: false,
     selectedMenu: {},
-    menuItems: []
+    menuItems: [],
+    isMouseInside: false,
+    leftPosition: "0",
+    topPosition: "0"
   };
 
   UNSAFE_componentWillMount = () => {
@@ -119,144 +126,195 @@ class NavigationComponent extends Component {
     history.push(route);
   };
 
+  //show information tooltip  when hover on folded in menu elements
+  mouseEnter = (e) => {
+    this.setState({
+      isMouseInside: true
+    });
+  }
+
+  //hide information tooltip  when hover on folded in menu elements
+  mouseLeave = () => {
+    this.setState({
+      isMouseInside: false,
+    });
+  }
+  //TODO : trying to show information tooltip on the mouse coords
+  mouseMove = (e) => {
+
+    let { leftPosition, topPosition } = this.state;
+
+    this.setState({
+      leftPosition:e.screenX,
+      topPosition:e.screenY
+    });
+
+    console.log('coords x :' + leftPosition + ' coords y :' +  topPosition)
+  }
+
   render() {
     const { active, menuItems } = this.state;
+    let { leftPosition, topPosition } = this.state;
     const pageId = this.props.history.location.search.split("p=")[1];
 
     return (
-      <nav class={"sidebar" + (active ? " active" : "")} id="sidebar">
-        <div class="sidebar-inner">
-          <div class="sidebar-logo" onClick={this.toggleNavigation}>
-            <span>
-              <img
-                class="sidebar-logo-image"
-                src={logo}
-                width="254"
-                height="57"
-                alt=""
-              />
-            </span>
-          </div>
-          <div class="sidebar-logo-mini" onClick={this.toggleNavigation}>
-            <span>
-              <img
-                class="sidebar-logo-mini-image"
-                src={miniLogo}
-                width="23"
-                height="21"
-                alt=""
-              />
-            </span>
-          </div>
-          <ul class="menu menu-items list-unstyled components">
-            {Object.entries(menuItems).map(([levelOneKey, levelOneProps]) => (
-              levelOneProps.label ? (<li class={"menu-item" + (levelOneProps.active ? " active" : "")}>
-                <span
-                  onDoubleClick={() => {this.handleDoubleClick(levelOneKey, levelOneProps)}}
-                  onClick={() => {this.collapseLevelTwo(levelOneKey)}}
-                  style={{ cursor: "pointer" }}
-                  class="menu-item-link dropdown-toggle"
-                  id={"menu" + levelOneKey}
-                >
-                  <span class={`iconmoon icon-${levelOneProps.menu_id.toLowerCase()}`}>
-                    <span class={"menu-item-name"}><Translate value={levelOneProps.label}/></span>
+      <React.Fragment>
+        <nav class={"sidebar" + (active ? " active" : "")} id="sidebar">
+          <div class="sidebar-inner">
+            <div class="sidebar-logo" onClick={this.toggleNavigation}>
+              <span>
+                <img
+                  class="sidebar-logo-image"
+                  src={logo}
+                  width="254"
+                  height="57"
+                  alt=""
+                />
+              </span>
+            </div>
+            <div class="sidebar-logo-mini" onClick={this.toggleNavigation}>
+              <span>
+                <img
+                  class="sidebar-logo-mini-image"
+                  src={miniLogo}
+                  width="23"
+                  height="21"
+                  alt=""
+                />
+              </span>
+            </div>
+            <ul class="menu menu-items list-unstyled components">
+              {Object.entries(menuItems).map(([levelOneKey, levelOneProps]) => (
+                levelOneProps.label ? (<li class={"menu-item" + (levelOneProps.active ? " active" : "")}>
+                  <span
+                    onDoubleClick={() => {this.handleDoubleClick(levelOneKey, levelOneProps)}}
+                    onClick={() => {this.collapseLevelTwo(levelOneKey)}}
+                    onMouseEnter={this.mouseEnter}
+                    onMouseLeave={this.mouseLeave}
+                    onMouseMove={this.mouseMove}
+                    style={{ cursor: "pointer" }}
+                    class="menu-item-link dropdown-toggle"
+                    id={"menu" + levelOneKey}
+                  >
+                    <span class={`iconmoon icon-${levelOneProps.menu_id.toLowerCase()}`}>
+                      <span class={"menu-item-name"}><Translate value={levelOneProps.label}/></span>
+                    </span>
                   </span>
-                </span>
-                <ul
-                  class="collapse collapsed-items list-unstyled"
-                  style={{ display: (levelOneProps.toggled && active) ? "block" : "none" }}
-                >
-                  {Object.entries(levelOneProps.children).map(([levelTwoKey, levelTwoProps]) => {
-                    const urlOptions = levelTwoKey.slice(1) +
-                      (levelTwoProps.options !== null ? levelTwoProps.options : '')
-                    if (levelTwoProps.label) {
-                      return (
-                        <li
-                          class={
-                            "collapsed-item" + (levelTwoProps.collapsed || (pageId == urlOptions) ? " active" : "")
-                          }
-                        >
-                          {Object.keys(levelTwoProps.children).length > 0 ? (
-                            <span
-                              style={{ cursor: "pointer" }}
-                              onClick={() => {this.collapseLevelThree(levelOneKey, levelTwoKey)}}
-                              class="collapsed-level-item-link"
-                            >
-                              <Translate value={levelTwoProps.hasOwnProperty('label') ? levelTwoProps.label : ''}/>
-                            </span>
-                          ) : (
-                              <Link
-                                onClick={() => {
-                                  this.goToPage(
-                                    routeMap.module + "?p=" + urlOptions,
-                                    levelOneKey
-                                  )
-                                }}
-                                className={`collapsed-level-item-link img-none ${(pageId == urlOptions) ? "active" : ""}`}
-                                to={routeMap.module + "?p=" + urlOptions}
+                  <ul
+                    class="collapse collapsed-items list-unstyled"
+                    style={{ display: (levelOneProps.toggled && active) ? "block" : "none" }}
+                  >
+                    {Object.entries(levelOneProps.children).map(([levelTwoKey, levelTwoProps]) => {
+                      const urlOptions = levelTwoKey.slice(1) +
+                        (levelTwoProps.options !== null ? levelTwoProps.options : '')
+                      if (levelTwoProps.label) {
+                        return (
+                          <li
+                            class={
+                              "collapsed-item" + (levelTwoProps.collapsed || (pageId == urlOptions) ? " active" : "")
+                            }
+                          >
+                            {Object.keys(levelTwoProps.children).length > 0 ? (
+                              <span
+                                style={{ cursor: "pointer" }}
+                                onClick={() => {this.collapseLevelThree(levelOneKey, levelTwoKey)}}
+                                class="collapsed-level-item-link"
                               >
-                                <Translate value={levelTwoProps.label}/>
-                              </Link>
-                            )}
+                                <Translate value={levelTwoProps.hasOwnProperty('label') ? levelTwoProps.label : ''}/>
+                              </span>
+                            ) : (
+                                <Link
+                                  onClick={() => {
+                                    this.goToPage(
+                                      routeMap.module + "?p=" + urlOptions,
+                                      levelOneKey
+                                    )
+                                  }}
+                                  className={`collapsed-level-item-link img-none ${(pageId == urlOptions) ? "active" : ""}`}
+                                  to={routeMap.module + "?p=" + urlOptions}
+                                >
+                                  <Translate value={levelTwoProps.label}/>
+                                </Link>
+                              )}
 
-                          <ul class="collapse-level collapsed-level-items first-level list-unstyled">
-                            {Object.entries(levelTwoProps.children).map(([levelThreeKey, levelThreeProps]) => {
-                              return (
-                                <React.Fragment>
-                                  {Object.keys(levelTwoProps.children).length > 1 &&
-                                    <span class="collapsed-level-title">
-                                      <Translate value={levelThreeKey}/>
-                                    </span>
-                                  }
-                                  {Object.entries(levelThreeProps).map(([levelFourKey, levelFourProps]) => {
-                                    const urlOptions = levelFourKey.slice(1) +
-                                      (levelFourProps.options !== null ? levelFourProps.options : '')
-                                    if (levelFourProps.label) {
-                                      return (
-                                        <li
-                                          class={"collapsed-level-item" + (pageId == urlOptions ? " active" : "")}
-                                        >
-                                          <Link
-                                            onClick={() => {
-                                              this.goToPage(
-                                                routeMap.module + "?p=" + urlOptions,
-                                                levelOneKey
-                                              )
-                                            }}
-                                            className="collapsed-level-item-link"
-                                            to={routeMap.module + "?p=" + urlOptions}
-                                          >
-                                            <Translate value={levelFourProps.label}/>
-                                          </Link>
-                                        </li>
-                                      );
-                                    } else {
-                                      return null
+                            <ul class="collapse-level collapsed-level-items first-level list-unstyled">
+                              {Object.entries(levelTwoProps.children).map(([levelThreeKey, levelThreeProps]) => {
+                                return (
+                                  <React.Fragment>
+                                    {Object.keys(levelTwoProps.children).length > 1 &&
+                                      <span class="collapsed-level-title">
+                                        <Translate value={levelThreeKey}/>
+                                      </span>
                                     }
-                                  }
-                                  )}
-                                </React.Fragment>
-                              )
-                            })}
-                          </ul>
-                        </li>
-                      );
-                    } else {
-                      return null
-                    }
-                  })}
-                </ul>
-              </li>) : null
-            ))}
-          </ul>
-          <div class="toggle-sidebar-wrap">
-            <span
-              class="toggle-sidebar-icon"
-              onClick={() => {this.toggleNavigation()}}
-            />
+                                    {Object.entries(levelThreeProps).map(([levelFourKey, levelFourProps]) => {
+                                      const urlOptions = levelFourKey.slice(1) +
+                                        (levelFourProps.options !== null ? levelFourProps.options : '')
+                                      if (levelFourProps.label) {
+                                        return (
+                                          <li
+                                            class={"collapsed-level-item" + (pageId == urlOptions ? " active" : "")}
+                                          >
+                                            <Link
+                                              onClick={() => {
+                                                this.goToPage(
+                                                  routeMap.module + "?p=" + urlOptions,
+                                                  levelOneKey
+                                                )
+                                              }}
+                                              className="collapsed-level-item-link"
+                                              to={routeMap.module + "?p=" + urlOptions}
+                                            >
+                                              <Translate value={levelFourProps.label}/>
+                                            </Link>
+                                          </li>
+                                        );
+                                      } else {
+                                        return null
+                                      }
+                                    }
+                                    )}
+                                  </React.Fragment>
+                                )
+                              })}
+                            </ul>
+                          </li>
+                        );
+                      } else {
+                        return null
+                      }
+                    })}
+                  </ul>
+                </li>) : null
+              ))}
+            </ul>
+            <div class="toggle-sidebar-wrap">
+              <span
+                class="toggle-sidebar-icon"
+                onClick={() => {this.toggleNavigation()}}
+              />
+            </div>
           </div>
-        </div>
-      </nav>
+        </nav>
+
+        {this.state.isMouseInside ?
+          <Tooltip
+            type="right"
+            text="tooltip right"
+            style={{ left: `${leftPosition}px`, top: `${topPosition}px` }}
+          />
+        : null}
+
+        {/* TODO : want to map the 1st menu entries and put right text in related tooltip on each menu element
+        {this.state.isMouseInside ?
+          {Object.entries(menuItems).map((levelOneProps) => (
+            <Tooltip
+              type="right"
+              text={{levelOneProps.label}}
+              style={{ left: `${leftPosition}px`, top: `${topPosition}px` }}
+            />
+          ))}
+        : null} */}
+      </React.Fragment>
     );
   }
 }

--- a/www/front_src/src/components/tooltip/index.js
+++ b/www/front_src/src/components/tooltip/index.js
@@ -1,33 +1,24 @@
-//import React, { Component } from 'react';
 import React from 'react';
+import {connect} from "react-redux";
 
-//class Tooltip extends Component {
-const Tooltip  = (props) => {
-    let template = null;
+const Tooltip = ({x, y, label, toggled}) => (
+    <div className={`tooltip ${toggled ? ' ' : 'hidden'}`}
+        style={
+            {
+                top:y,
+                left:x
+            }
+        }
+    >{label}</div>
+)
 
-    switch(props.type){
-        case 'right':
-            template = (
-                <div
-                    className="tooltip right"
-                >
-                    {props.text}
-                </div>
-            );
-            break;
-        case 'bottom':
-            template = (
-                <div
-                    className="tooltip bottom"
-                >
-                    {props.text}
-                </div>
-            )
-            break;
-        default:
-            template = null
+const mapStateToProps = ({tooltip}) => (
+    {
+        x:tooltip.x,
+        y:tooltip.y,
+        label:tooltip.label,
+        toggled:tooltip.toggled
     }
-    return template;
-}
+)
 
-export default Tooltip;
+export default connect(mapStateToProps, null)(Tooltip)

--- a/www/front_src/src/components/tooltip/index.js
+++ b/www/front_src/src/components/tooltip/index.js
@@ -1,0 +1,33 @@
+//import React, { Component } from 'react';
+import React from 'react';
+
+//class Tooltip extends Component {
+const Tooltip  = (props) => {
+    let template = null;
+
+    switch(props.type){
+        case 'right':
+            template = (
+                <div
+                    className="tooltip right"
+                >
+                    {props.text}
+                </div>
+            );
+            break;
+        case 'bottom':
+            template = (
+                <div
+                    className="tooltip bottom"
+                >
+                    {props.text}
+                </div>
+            )
+            break;
+        default:
+            template = null
+    }
+    return template;
+}
+
+export default Tooltip;

--- a/www/front_src/src/redux/actions/tooltipActions.js
+++ b/www/front_src/src/redux/actions/tooltipActions.js
@@ -1,0 +1,6 @@
+export const UPDATE_TOOLTIP = "@tooltip/UPDATE_TOOLTIP";
+
+export const updateTooltip = data => ({
+  type: UPDATE_TOOLTIP,
+  data
+});

--- a/www/front_src/src/redux/reducers/index.js
+++ b/www/front_src/src/redux/reducers/index.js
@@ -6,6 +6,7 @@ import pollerWizardReducer from "./pollerWizardReducer";
 import navigationReducer from "./navigationReducer";
 import refreshReducer from "./refreshReducer";
 import axiosReducer from "./axiosReducer";
+import tooltipReducer from './tooltipReducer';
 
 export default combineReducers({
   form: formReducer,
@@ -13,5 +14,6 @@ export default combineReducers({
   i18n: i18nReducer,
   navigation: navigationReducer,
   intervals: refreshReducer,
-  remoteData: axiosReducer
+  remoteData: axiosReducer,
+  tooltip: tooltipReducer
 });

--- a/www/front_src/src/redux/reducers/tooltipReducer.js
+++ b/www/front_src/src/redux/reducers/tooltipReducer.js
@@ -1,0 +1,19 @@
+import * as actions from '../actions/tooltipActions';
+
+const initialState = {
+    toggled: false,
+    label: "",
+    x: 0,
+    y: 0
+}
+
+const tooltipReducer = (state = initialState, action) => {
+    if(action.type === actions.UPDATE_TOOLTIP){
+        const {data} = action;
+        return {...state, ...data};
+    }else {
+        return state;
+    }
+}
+
+export default tooltipReducer;

--- a/www/front_src/src/styles/_main.scss
+++ b/www/front_src/src/styles/_main.scss
@@ -13,6 +13,7 @@
 @import "partials/helpers";
 @import "partials/mixins";
 @import "partials/loader";
+@import "partials/tooltip";
 
 html,
 body {

--- a/www/front_src/src/styles/partials/_side-nav.scss
+++ b/www/front_src/src/styles/partials/_side-nav.scss
@@ -13,6 +13,7 @@
   text-align: center;
   background: #e0e0e0;
   transition: all 0.2s;
+  z-index: 777;
   .sidebar-logo {
     display: none;
   }

--- a/www/front_src/src/styles/partials/_tooltip.scss
+++ b/www/front_src/src/styles/partials/_tooltip.scss
@@ -1,0 +1,17 @@
+.tooltip {
+    position: absolute;
+    background-color: #232f39;
+    width: 100px;
+    z-index: 999;
+    left: 40px;
+    top: 59px;
+    padding: 8px;
+    font-family: 'Open Sans', Arial, Tahoma, Helvetica, sans-serif;
+    font-size: 10px;
+    border-radius: 3px;
+    color: white;
+    text-align: center;
+}
+.sidebar.active + .tooltip {
+    display: none;
+}

--- a/www/front_src/src/styles/partials/_tooltip.scss
+++ b/www/front_src/src/styles/partials/_tooltip.scss
@@ -1,17 +1,32 @@
 .tooltip {
     position: absolute;
     background-color: #232f39;
-    width: 100px;
+    color: white;
+    min-width: 80px;
     z-index: 999;
-    left: 40px;
-    top: 59px;
     padding: 8px;
     font-family: 'Open Sans', Arial, Tahoma, Helvetica, sans-serif;
     font-size: 10px;
     border-radius: 3px;
-    color: white;
     text-align: center;
+    display: block;
+    animation: 0.3s fadeIn;
+    animation-fill-mode: forwards;
+    opacity: 0;
+    pointer-events: none;
+    &.hidden {
+       display: none;
+    }
 }
-.sidebar.active + .tooltip {
+nav.sidebar.active + .tooltip {
     display: none;
+}
+
+@keyframes fadeIn {
+    90% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
 }


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

The little darkgrey tooltip was added to the folded menu items in order to show the menu labels.

Fixes # (issue)

<h2> Type of change </h2>

Please delete options that are not relevant.

- [x] New functionality (non-breaking change)

<h2> Target serie </h2>

Please delete series that are not relevant.

- [ ] 2.8.x
- [x ] 18.10.x
- [ ] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

The left side menu should be folded in
Hover the menu item
The tooltip with related menu label (menu entry title) should be visible
when the menu is folded out the tooltip shouldn' appear


Any **relevant details** of the configuration to perform the test should be added.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
- [ ] I have updated the **release note** in dedicated temporary section **\***

**\*** updating the release note results in adding the **pull request id** and **description** at the end of the file. **Product Managers** will rework it for the release. Release notes can be found [here](https://github.com/centreon/centreon/tree/master/doc/en/release_notes).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
