### PR TITLE
enh(ui) : indent third level menu

### DIFF
--- a/www/front_src/src/styles/partials/_side-nav.scss
+++ b/www/front_src/src/styles/partials/_side-nav.scss
@@ -181,7 +181,6 @@ a {
             background: $turquoise-centreon-primary;
             color: $white-color;
           }
-          
         }
         &:hover {
           .collapsed-level-item-link {
@@ -395,7 +394,7 @@ a {
       font-size: 0.8rem;
       background-color: $white-color;
       display: block;
-      padding: 3px 10px 3px 47px;
+      padding: 3px 10px 3px 56px;
       border-bottom: 1px solid #f7f7f7;
       text-align: left;
     }
@@ -437,11 +436,7 @@ a {
       .collapsed-level-item {
         background-color: $white-color;
         .collapsed-level-item-link {
-          padding: 8px 10px 8px 47px;
-          // &:hover {
-          //   color: $white-color;
-          //   background-color: #0a78a5;
-          // }
+          padding: 8px 10px 8px 56px;
         }
       }
     }


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>


Indentation of third level menu for better delimitation of levels.


<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

Please delete series that are not relevant.

- [X] 18.10.x
- [X] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Open the left menu then see if the third level menu items are a little bit indented.

Any **relevant details** of the configuration to perform the test should be added.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon

**\*** updating the release note results in adding the **pull request id** and **description** at the end of the file. **Product Managers** will rework it for the release. Release notes can be found [here](https://github.com/centreon/centreon/tree/master/doc/en/release_notes).

<h5> Centreon team only </h5>

- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
