### PR TITLE
enh(ui) : tooltip in folded menu hover

### DIFF
--- a/www/front_src/src/App.js
+++ b/www/front_src/src/App.js
@@ -9,6 +9,7 @@ import ReactRoute from './components/router/reactRoute';
 
 import { classicRoutes, reactRoutes } from "./route-maps";
 import NavigationComponent from "./components/navigation";
+import Tooltip from "./components/tooltip";
 import Footer from "./components/footer";
 import Fullscreen from 'react-fullscreen-crossbrowser';
 import queryString from 'query-string';
@@ -119,6 +120,7 @@ class App extends Component {
           {!min && // do not display menu if min=1
             <NavigationComponent/>
           }
+          <Tooltip/>
           <div id="content">
             {!min && // do not display header if min=1
               <Header/>

--- a/www/front_src/src/components/navigation/index.js
+++ b/www/front_src/src/components/navigation/index.js
@@ -12,6 +12,8 @@ import { Translate } from 'react-redux-i18n';
 import { setNavigation } from "../../redux/actions/navigationActions";
 import { connect } from "react-redux";
 
+import { updateTooltip } from '../../redux/actions/tooltipActions';
+
 
 class NavigationComponent extends Component {
   navService = axios("internal.php?object=centreon_menu&action=menu");
@@ -119,6 +121,28 @@ class NavigationComponent extends Component {
     history.push(route);
   };
 
+  // hide tooltip for the first-level folded menu items
+  mouseLeftTheMenu = event => {
+    const { updateTooltip } = this.props;
+    updateTooltip({
+      toggled: false
+    });
+  };
+
+  // show tooltip for the first-level folded menu items by setting toggled to true
+  // updating the x, y properties of tooltip in order to display it on client cursor position
+  // show related label by setting label to label
+  mouseIsMovingOverTheMenu = (label, {  clientY }) => {
+    const { updateTooltip } = this.props;
+    updateTooltip({
+      toggled: true,
+      x: 50,
+      y: clientY,
+      label
+    });
+  };
+
+
   render() {
     const { active, menuItems } = this.state;
     const pageId = this.props.history.location.search.split("p=")[1];
@@ -148,9 +172,16 @@ class NavigationComponent extends Component {
               />
             </span>
           </div>
-          <ul class="menu menu-items list-unstyled components">
+          <ul
+            class="menu menu-items list-unstyled components"
+            onMouseLeave={this.mouseLeftTheMenu}
+          >
             {Object.entries(menuItems).map(([levelOneKey, levelOneProps]) => (
-              levelOneProps.label ? (<li class={"menu-item" + (levelOneProps.active ? " active" : "")}>
+              levelOneProps.label ? (
+                <li
+                  onMouseOver={this.mouseIsMovingOverTheMenu.bind(this, levelOneProps.label)}
+                  class={"menu-item" + (levelOneProps.active ? " active" : "")}
+                >
                 <span
                   onDoubleClick={() => {this.handleDoubleClick(levelOneKey, levelOneProps)}}
                   onClick={() => {this.collapseLevelTwo(levelOneKey)}}
@@ -264,7 +295,8 @@ class NavigationComponent extends Component {
 const mapStateToProps = () => {}
 
 const mapDispatchToProps = {
-  setNavigation
+  setNavigation,
+  updateTooltip
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(withRouter(NavigationComponent));

--- a/www/front_src/src/components/tooltip/index.js
+++ b/www/front_src/src/components/tooltip/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import {connect} from "react-redux";
+
+const Tooltip = ({x, y, label, toggled}) => (
+    <div className={`tooltip ${toggled ? ' ' : 'hidden'}`}
+        style={
+            {
+                top:y,
+                left:x
+            }
+        }
+    >{label}</div>
+)
+
+const mapStateToProps = ({tooltip}) => (
+    {
+        x:tooltip.x,
+        y:tooltip.y,
+        label:tooltip.label,
+        toggled:tooltip.toggled
+    }
+)
+
+export default connect(mapStateToProps, null)(Tooltip)

--- a/www/front_src/src/redux/actions/tooltipActions.js
+++ b/www/front_src/src/redux/actions/tooltipActions.js
@@ -1,0 +1,6 @@
+export const UPDATE_TOOLTIP = "@tooltip/UPDATE_TOOLTIP";
+
+export const updateTooltip = data => ({
+  type: UPDATE_TOOLTIP,
+  data
+});

--- a/www/front_src/src/redux/reducers/index.js
+++ b/www/front_src/src/redux/reducers/index.js
@@ -5,11 +5,13 @@ import { i18nReducer } from 'react-redux-i18n';
 import pollerWizardReducer from "./pollerWizardReducer";
 import navigationReducer from "./navigationReducer";
 import refreshReducer from "./refreshReducer";
+import tooltipReducer from './tooltipReducer';
 
 export default combineReducers({
   form: formReducer,
   pollerForm: pollerWizardReducer,
   i18n: i18nReducer,
   navigation: navigationReducer,
-  intervals: refreshReducer
+  intervals: refreshReducer,
+  tooltip: tooltipReducer
 });

--- a/www/front_src/src/redux/reducers/tooltipReducer.js
+++ b/www/front_src/src/redux/reducers/tooltipReducer.js
@@ -1,0 +1,19 @@
+import * as actions from '../actions/tooltipActions';
+
+const initialState = {
+    toggled: false,
+    label: "",
+    x: 0,
+    y: 0
+}
+
+const tooltipReducer = (state = initialState, action) => {
+    if(action.type === actions.UPDATE_TOOLTIP){
+        const {data} = action;
+        return {...state, ...data};
+    }else {
+        return state;
+    }
+}
+
+export default tooltipReducer;

--- a/www/front_src/src/styles/_main.scss
+++ b/www/front_src/src/styles/_main.scss
@@ -13,6 +13,7 @@
 @import "partials/helpers";
 @import "partials/mixins";
 @import "partials/loader";
+@import "partials/tooltip";
 
 html,
 body {

--- a/www/front_src/src/styles/partials/_side-nav.scss
+++ b/www/front_src/src/styles/partials/_side-nav.scss
@@ -13,6 +13,7 @@
   text-align: center;
   background: #e0e0e0;
   transition: all 0.2s;
+  z-index: 2;
   .sidebar-logo {
     display: none;
   }
@@ -181,7 +182,6 @@ a {
             background: $turquoise-centreon-primary;
             color: $white-color;
           }
-          
         }
         &:hover {
           .collapsed-level-item-link {
@@ -395,7 +395,7 @@ a {
       font-size: 0.8rem;
       background-color: $white-color;
       display: block;
-      padding: 3px 10px 3px 47px;
+      padding: 3px 10px 3px 56px;
       border-bottom: 1px solid #f7f7f7;
       text-align: left;
     }
@@ -437,11 +437,7 @@ a {
       .collapsed-level-item {
         background-color: $white-color;
         .collapsed-level-item-link {
-          padding: 8px 10px 8px 47px;
-          // &:hover {
-          //   color: $white-color;
-          //   background-color: #0a78a5;
-          // }
+          padding: 8px 10px 8px 56px;
         }
       }
     }

--- a/www/front_src/src/styles/partials/_tooltip.scss
+++ b/www/front_src/src/styles/partials/_tooltip.scss
@@ -1,0 +1,32 @@
+.tooltip {
+    position: absolute;
+    background-color: #232f39;
+    color: white;
+    min-width: 80px;
+    z-index: 999;
+    padding: 8px;
+    font-family: 'Open Sans', Arial, Tahoma, Helvetica, sans-serif;
+    font-size: 10px;
+    border-radius: 3px;
+    text-align: center;
+    display: block;
+    animation: 0.3s fadeIn;
+    animation-fill-mode: forwards;
+    opacity: 0;
+    pointer-events: none;
+    &.hidden {
+       display: none;
+    }
+}
+nav.sidebar.active + .tooltip {
+    display: none;
+}
+
+@keyframes fadeIn {
+    90% {
+        opacity: 0;
+    }
+    100% {
+        opacity: 1;
+    }
+}


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

I added a tooltip with menu first level entries description.
How to test :
Hover on folded menu items (icons), the tooltip with description should appear.
When menu is opened - the tooltip dissapear.
When mouse leave the menu items the tooltip dissapear.

Fixes # (issue): None

<h2> Type of change </h2>

- [x] New functionality (non-breaking change)

<h2> Target serie </h2>

- [x] 18.10.x

<h2> How this pull request can be tested ? </h2>

I added a tooltip with menu first level entries description.
How to test :
Hover on folded menu items (icons), the tooltip with description should appear.
When menu is opened - the tooltip dissapear.
When mouse leave the menu items the tooltip dissapear.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon

<h5> Centreon team only </h5>

- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
