### PR TITLE
enh(config): enh locked objects listing

### DIFF
--- a/www/include/configuration/configObject/command/listCommand.ihtml
+++ b/www/include/configuration/configObject/command/listCommand.ihtml
@@ -10,6 +10,7 @@
       </tr>
       <tr>
         <td><input type="text" name="searchC" value="{$searchC}"></td>
+        <td class="checkbox"><input type='checkbox' name='displayLocked' {$displayLockedChecked}/> <h4>{$displayLocked}</h4></td>
         <td><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
       </tr>
     </tbody>

--- a/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
+++ b/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
@@ -12,6 +12,7 @@
         </tr>
         <tr>
           <td><input type="text" name="searchHT" value="{$searchHT}"></td>
+          <td class="checkbox"><input type='checkbox' name='displayLocked' {$displayLockedChecked}/> <h4>{$displayLocked}</h4></td>
           <td><input type='submit' value='{t}Search{/t}' class="btc bt_success"/></td>
         </tr>
       </tbody>

--- a/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
+++ b/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
@@ -11,6 +11,7 @@
       </tr>
       <tr>
         <td><input type="text" name="searchST" value="{$searchST}"></td>
+        <td class="checkbox"><input type='checkbox' name='displayLocked' {$displayLockedChecked}/> <h4>{$displayLocked}</h4></td>
         <td><input type="submit" value="{t}Search{/t}" class="btc bt_success"></td>
       </tr>
       </tbody>


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Add the possibility to display/hide locked commands, service templates and host templates from configuration listings.

Locked host templates hidden : 
![image](https://user-images.githubusercontent.com/23257354/54043727-98d97500-41cd-11e9-9bce-a2687203a217.png)

Locked host template displayed : 
![image](https://user-images.githubusercontent.com/23257354/54043747-a4c53700-41cd-11e9-9d0b-069f511ec864.png)

It makes the listing more clear by hidding locked objects brought by the Plugin Packs.

<h2> Type of change </h2>

Please delete options that are not relevant.

- [x] New functionality (non-breaking change)

<h2> Target serie </h2>

Please delete series that are not relevant.

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Go to those pages : 
 - Host templates : http://fqdn/centreon/main.php?p=60103
 - Service templates : http://fqdn/centreon/main.php?p=60206
 - Commands : http://fqdn/centreon/main.php?p=60801

On each pages, tick the "Display locked" checkbox and click on "Search".

Add filters and use pagination.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
- [ ] I have updated the **release note** in dedicated temporary section **\***

**\*** updating the release note results in adding the **pull request id** and **description** at the end of the file. **Product Managers** will rework it for the release. Release notes can be found [here](https://github.com/centreon/centreon/tree/master/doc/en/release_notes).
