### PR TITLE
enh(git): adding centreon-build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ www/include/core/menu/templates/*.tpl
 !filesGeneration/export/.keep
 filesGeneration/export/*
 coverage-report/
+centreon-build/


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

adding centreon-build/ to .gitignore file

Fixes # (issue): none

<h2> Type of change </h2>

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [X] 18.10.x
- [X] 19.04.x (master)

- [X] I have **rebased** my development branch on the base branch (master, maintenance).
