### PR TITLE
enh(centcore): Add default timeout and correct bug

### DIFF
--- a/www/include/Administration/parameters/DB-Func.php
+++ b/www/include/Administration/parameters/DB-Func.php
@@ -299,7 +299,7 @@ function updateCentcoreConfigData($db, $form, $centreon)
     updateOption(
         $db,
         "centcore_cmd_timeout",
-        isset($ret["centcore_cmd_timeout"]) && $ret['centcore_cmd_timeout'] ? $ret['centcore_cmd_timeout'] : 0
+        isset($ret["centcore_cmd_timeout"]) && $ret['centcore_cmd_timeout'] ? $ret['centcore_cmd_timeout'] : 60
     );
     updateOption(
         $db,

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -140,6 +140,7 @@ INSERT INTO `options` (`key`, `value`) VALUES
 ('selectPaginationSize', 60),
 ('display_downtime_chart','0'),
 ('display_comment_chart','0'),
+('centcore_cmd_timeout', '60'),
 ('centcore_illegal_characters', '`');
 
 --

--- a/www/install/php/Update-18.10.5.php
+++ b/www/install/php/Update-18.10.5.php
@@ -1,0 +1,52 @@
+<?php
+/*
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
+ *
+ * For more information : contact@centreon.com
+ *
+ *
+ */
+
+/*
+ * Correct centcore cmd timeout or add it if missing
+ */
+$query = "SELECT options.value FROM options WHERE options.key = 'centcore_cmd_timeout'";
+$result = $pearDB->query($query);
+$row = $result->fetch();
+
+if ($row) {
+    // update only if value is 0
+    $query = "UPDATE options SET options.value = '60' WHERE options.key = 'centcore_cmd_timeout' AND options.value == '0'";
+    $result = $pearDB->query($query);
+} elseif(!isset($row)) {
+    // if entry is missing insert 60
+    $query = "INSERT INTO options VALUES('centcore_cmd_timeout', '60')";
+    $result = $pearDB->query($query);
+}


### PR DESCRIPTION
<h2> Description </h2>

Correct bug when user save form without value for timeout
Add 60s by default for timeout during installation

<h2> Type of change </h2>

Please delete options that are not relevant.

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

Please delete series that are not relevant.

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Test an ugrade
* Test fresh install
* Execute external request

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests covers 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
