### PR TITLE
fix(generateMetricImage): export splitted graphs

### DIFF
--- a/www/include/views/graphs/generateGraphs/generateMetricImage.php
+++ b/www/include/views/graphs/generateGraphs/generateMetricImage.php
@@ -71,9 +71,6 @@ if (isset($_GET['index'])) {
     $query = 'SELECT id FROM index_data
         WHERE host_id = ' . $hostId . ' AND service_id = ' . $svcId;
     $res = $pearDBO->query($query);
-    if (PEAR::isError($res)) {
-        CentreonGraph::displayError();
-    }
     $row = $res->fetchRow();
     if (!$row) {
         CentreonGraph::displayError();

--- a/www/include/views/graphs/generateGraphs/generateMetricImage.php
+++ b/www/include/views/graphs/generateGraphs/generateMetricImage.php
@@ -101,8 +101,6 @@ if (isset($_GET["metric"])) {
 $obj->setRRDOption("start", $obj->checkArgument("start", $_GET, time() - (60*60*48)));
 $obj->setRRDOption("end", $obj->checkArgument("end", $_GET, time()));
 
-//$obj->GMT->getMyGMTFromSession($obj->session_id, $pearDB);
-
 /**
  * Template Management
  */


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Remove unused code
Fix the graph export for splitted charts

Fixes #7312 

<h2> Type of change </h2>

Please delete options that are not relevant.

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

Please delete series that are not relevant.

- [ ] 18.10.x
- [ ] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Go to Monitoring -> Performances -> Graphs
2. Select a service that has several metrics
3. Display those by splitting the main graph
4. Try to export

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
