### PR TITLE
fix(centreonGraph) Correct wrong newline in legend

### DIFF
--- a/www/class/centreonGraph.class.php
+++ b/www/class/centreonGraph.class.php
@@ -972,8 +972,9 @@ class CentreonGraph
                     if (isset($tm["warn"]) && !empty($tm["warn"]) && $tm["warn"] != 0) {
                         $this->addArgument(
                             "HRULE:" . $tm["warn"] . $tm["ds_color_area_warn"] . ":Warning  \: " .
-                            $this->humanReadable($tm["warn"], $tm["unit"]) . "\\l "
+                            $this->humanReadable($tm["warn"], $tm["unit"])
                         );
+                        $this->addArgument("COMMENT:\\l");
                     }
                     if (isset($tm["crit"]) && !empty($tm["crit"]) && $tm["crit"] != 0) {
                         $this->addArgument(


### PR DESCRIPTION
Hi,

<h2> Description </h2>

This PR is a fix to #7310, removing strange character in graphs legend, making it a true newline.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

See #7310 : generate a graph and be sure legend items Warning and Critical are on 2 lines, without a `\l` strange character.

Thank you !

Edit : issue still present in 19.04.3.