### PR TITLE
Use httpd24-httpd service in the documentation.

### DIFF
--- a/doc/en/administration_guide/parameters.rst
+++ b/doc/en/administration_guide/parameters.rst
@@ -64,7 +64,7 @@ Define needed information:
 .. image:: /_static/images/adminstration/proxy_configuration.png
     :align: center
 
-Once you defined settings, test your configuration by clicking on the 
+Once you defined settings, test your configuration by clicking on the
 **Text Proxy Configuration** button. If your configuration is correct,
 a message will indicate success:
 
@@ -89,7 +89,7 @@ This part covers the general options of the real time monitoring interface.
 * **Start script for broker daemon** field contains the path to the init script of the broker
 * **Directory + Mailer Binary** field contains the path to the executable file for sending  e-mails
 * **Maximum number of hosts to show** and **Maximum number of services to show** lists contain the maximum number of hosts or services to be displayed in the overall view (menu: **Home > Home**)
-* **Page refresh interval** field defines the data refreshment interval in the overall view 
+* **Page refresh interval** field defines the data refreshment interval in the overall view
 * The boxes in the **Default acknowledgment settings** and **Default downtime settings** categories define the options by default that will be checked or not during definition of an acknowledgment or of a downtime
 
 
@@ -172,7 +172,7 @@ Then restart Apache :
 
 ::
 
-  service httpd restart
+  systemctl restart httpd24-httpd
 
 
 *******

--- a/doc/en/developer/translatecentreon.rst
+++ b/doc/en/developer/translatecentreon.rst
@@ -79,7 +79,7 @@ Change rights on directory::
 
 Restart Apache::
 
-    $ sudo service httpd restart
+    $ sudo service httpd24-httpd restart
 
 Connect to your Centreon web interface, edit your profile and select new language:
 

--- a/doc/en/faq/performance.rst
+++ b/doc/en/faq/performance.rst
@@ -132,7 +132,7 @@ Create groups using commands::
 
 Restart Apache process::
 
-    # /etc/init.d/httpd restart
+    # systemctl restart httpd24-httpd
 
 Start RRDCacheD process::
 

--- a/doc/en/faq/remote_server.rst
+++ b/doc/en/faq/remote_server.rst
@@ -142,7 +142,7 @@ Solving data extraction problems
          Docs: man:systemd-sysv-generator(8)
        CGroup: /system.slice/centcore.service
                └─32385 /usr/bin/perl /usr/share/centreon/bin/centcore --logfile=/var/log/centreon/centcore.log --severity=error --config=/etc/centreon/conf.pm
-    
+
     Warning: Journal has been rotated since unit was started. Log output is incomplete or unavailable.
 
 If it is not running,
@@ -167,10 +167,10 @@ Or if the **/var/log/centreon/centcore.log** file on the central Centreon server
 includes: ::
 
     2018-11-08 13:54:10 - Receiving die: Timeout by signal ALARM
-    
+
     2018-11-08 13:54:10 - Dont die...
     2018-11-08 13:54:10 - Receiving die: Timeout by signal ALARM
-    
+
     2018-11-08 13:54:10 - Dont die...
     2018-11-08 13:54:10 - Timeout by signal ALARM
 
@@ -250,24 +250,20 @@ You should receive an authentication token or a **Bad credentials** message.
 Check the Apache process (httpd) is up and running on the Remote Server
 by running this command on the Remote Server: ::
 
-    # systemctl status httpd
-    ● httpd.service - The Apache HTTP Server
-       Loaded: loaded (/usr/lib/systemd/system/httpd.service; enabled; vendor preset: disabled)
-       Active: active (running) since mer. 2018-11-14 15:01:52 GMT; 5min ago
-         Docs: man:httpd(8)
-          man:apachectl(8)
-      Process: 18653 ExecStop=/bin/kill -WINCH ${MAINPID} (code=exited, status=0/SUCCESS)
-      Process: 9241 ExecReload=/usr/sbin/httpd $OPTIONS -k graceful (code=exited, status=0/SUCCESS)
-     Main PID: 19836 (httpd)
-       Status: "Total requests: 5; Current requests/sec: 0; Current traffic:   0 B/sec"
-       CGroup: /system.slice/httpd.service
-               ├─19836 /usr/sbin/httpd -DFOREGROUND
-               ├─19838 /usr/sbin/httpd -DFOREGROUND
+    # systemctl status httpd24-httpd
+    ● httpd24-httpd.service - The Apache HTTP Server
+       Loaded: loaded (/usr/lib/systemd/system/httpd24-httpd.service; enabled; vendor preset: disabled)
+       Active: active (running) since ven. 2019-03-22 14:29:06 CET; 2min 0s ago
+     Main PID: 3735 (httpd)
+       Status: "Total requests: 0; Idle/Busy workers 100/0;Requests/sec: 0; Bytes served/sec:   0 B/sec"
+       CGroup: /system.slice/httpd24-httpd.service
+               ├─3735 /opt/rh/httpd24/root/usr/sbin/httpd -DFOREGROUND
+               ├─3736 /opt/rh/httpd24/root/usr/sbin/httpd -DFOREGROUND
                ...
 
 If it is not running, restart the **httpd** process: ::
 
-    # systemctl restart httpd
+    # systemctl restart httpd24-httpd
 
 Check that the Remote Server parameters are complete and valid
 with this command on the Central Server: ::
@@ -310,7 +306,7 @@ Then generate the Remote Server configuration from the central Centreon server.
          Docs: man:systemd-sysv-generator(8)
        CGroup: /system.slice/centcore.service
                └─32385 /usr/bin/perl /usr/share/centreon/bin/centcore --logfile=/var/log/centreon/centcore.log --severity=error --config=/etc/centreon/conf.pm
-    
+
     Warning: Journal has been rotated since unit was started. Log output is incomplete or unavailable.
 
 If it is not running:
@@ -349,10 +345,10 @@ Or if the **/var/log/centreon/centcore.log** file on the central Centreon server
 includes: ::
 
     2018-11-08 13:54:10 - Receiving die: Timeout by signal ALARM
-    
+
     2018-11-08 13:54:10 - Dont die...
     2018-11-08 13:54:10 - Receiving die: Timeout by signal ALARM
-    
+
     2018-11-08 13:54:10 - Dont die...
     2018-11-08 13:54:10 - Timeout by signal ALARM
 
@@ -407,7 +403,7 @@ Then generate the Remote Server configuration from the central Centreon server.
          Docs: man:systemd-sysv-generator(8)
        CGroup: /system.slice/centcore.service
                └─32385 /usr/bin/perl /usr/share/centreon/bin/centcore --logfile=/var/log/centreon/centcore.log --severity=error --config=/etc/centreon/conf.pm
-    
+
     Warning: Journal has been rotated since unit was started. Log output is incomplete or unavailable.
 
 If it is not running:

--- a/doc/en/installation/common/install_packages.rst
+++ b/doc/en/installation/common/install_packages.rst
@@ -122,7 +122,7 @@ Launching services during system bootup
 
 To make services start automatically during system bootup, run these commands on the central server::
 
-    # systemctl enable httpd
+    # systemctl enable httpd24-httpd
     # systemctl enable snmpd
     # systemctl enable snmptrapd
     # systemctl enable rh-php71-php-fpm
@@ -141,7 +141,7 @@ Concluding the installation
 Before starting the web installation process, you will need to execute the following commands::
 
     # systemctl start rh-php71-php-fpm
-    # systemctl start httpd
+    # systemctl start httpd24-httpd
     # systemctl start mysqld
     # systemctl start cbd
     # systemctl start snmpd

--- a/doc/en/installation/from_sources.rst
+++ b/doc/en/installation/from_sources.rst
@@ -16,7 +16,7 @@ Most CentOS users will find easier to install Centreon Web by using
 
 CentOS and RHEL environments do not possess as standard on archives all the
 dependencies necessary for the installation of Centreon. You should add the
-*RPM Forge* repository.
+*RPM Forge* and *Software Collections* repositories.
 
 el7 system:
 
@@ -38,17 +38,19 @@ Then perform the following commands:
 
   $ rpm --import RPM-GPG-KEY.dag.txt
   $ rpm -Uvh rpmforge-release-0.5.3-1.el7.rf.x86_64.rpm
+  $ yum install centos-release-scl
 
 You can now install the necessary prerequisites::
 
   $ yum update
   $ yum upgrade
-  $ yum install httpd gd fontconfig-devel libjpeg-devel libpng-devel gd-devel perl-GD perl-DateTime \
-      openssl-devel perl-DBD-MySQL mysql-server mysql-devel php php-mysql php-gd php-ldap php-xml php-mbstring \
+  $ yum install httpd24-httpd gd fontconfig-devel libjpeg-devel libpng-devel gd-devel perl-GD perl-DateTime \
+      openssl-devel perl-DBD-MySQL mysql-server mysql-devel rh-php71-php rh-php71-php-mysql rh-php71-php-gd \
+      rh-php71-php-ldap rh-php71-php-xml rh-php71-php-mbstring rh-php71-php-snmp \
       perl-Config-IniFiles perl-DBI perl-DBD-MySQL rrdtool perl-rrdtool perl-Crypt-DES perl-Digest-SHA1 \
-      perl-Digest-HMAC net-snmp-utils perl-Socket6 perl-IO-Socket-INET6 net-snmp net-snmp-libs php-snmp \
+      perl-Digest-HMAC net-snmp-utils perl-Socket6 perl-IO-Socket-INET6 net-snmp net-snmp-libs \
       dmidecode lm_sensors perl-Net-SNMP net-snmp-perl fping cpp gcc gcc-c++ libstdc++ glib2-devel \
-      php-pear nagios-plugins
+      rh-php71-php-pear nagios-plugins
 
 Additional commands are necessary to configure the environment correctly:
 

--- a/doc/en/installation/prerequisites.rst
+++ b/doc/en/installation/prerequisites.rst
@@ -222,23 +222,25 @@ Users and groups
 
 Description of software and linked users:
 
-+-----------------+----------------+-----------------+-----------------------+
-| Software        | Service        | User            | Comment               |
-+=================+================+=================+=======================+
-| Apache          | httpd          | apache          | automatic start       |
-+-----------------+----------------+-----------------+-----------------------+
-| MySQL (MariaDB) | mysqld (mysql) | mysql           | automatic start       |
-+-----------------+----------------+-----------------+-----------------------+
-| Centreon        | centcore       | centreon        | automatic start       |
-+-----------------+----------------+-----------------+-----------------------+
-| Centreon        | centreontrapd  | centreon        | automatic start       |
-+-----------------+----------------+-----------------+-----------------------+
-| Centreon Broker | cbwd           | centreon-broker | automatic start       |
-+-----------------+----------------+-----------------+-----------------------+
-| Centreon Broker | cbd            | centreon-broker | automatic start       |
-+-----------------+----------------+-----------------+-----------------------+
-| Centreon Engine | centengine     | centreon-engine | automatic start       |
-+-----------------+----------------+-----------------+-----------------------+
++-----------------+------------------+-----------------+-----------------------+
+| Software        | Service          | User            | Comment               |
++=================+==================+=================+=======================+
+| Apache          | httpd24-httpd    | apache          | automatic start       |
++-----------------+------------------+-----------------+-----------------------+
+| PHP-FPM         | rh-php71-php-fpm | apache          | automatic start       |
++-----------------+------------------+-----------------+-----------------------+
+| MySQL (MariaDB) | mysqld (mysql)   | mysql           | automatic start       |
++-----------------+------------------+-----------------+-----------------------+
+| Centreon        | centcore         | centreon        | automatic start       |
++-----------------+------------------+-----------------+-----------------------+
+| Centreon        | centreontrapd    | centreon        | automatic start       |
++-----------------+------------------+-----------------+-----------------------+
+| Centreon Broker | cbwd             | centreon-broker | automatic start       |
++-----------------+------------------+-----------------+-----------------------+
+| Centreon Broker | cbd              | centreon-broker | automatic start       |
++-----------------+------------------+-----------------+-----------------------+
+| Centreon Engine | centengine       | centreon-engine | automatic start       |
++-----------------+------------------+-----------------+-----------------------+
 
 Description of optional software and linked users:
 

--- a/doc/en/upgrade/from_packages.rst
+++ b/doc/en/upgrade/from_packages.rst
@@ -13,7 +13,7 @@ This chapter describes how to upgrade your platform to version Centreon 18.10.
 .. warning::
     This procedure only applies to Centreon platforms installed from Centreon 3.4
     packages on **Red Hat / CentOS version 7** distributions.
-    
+
     If this is not the case, refer to the procedure in :ref:`migration<upgradecentreon1810>`.
 
 To upgrade your Centreon MAP server, refer to the `related documentation
@@ -85,7 +85,7 @@ Restart the services by running the following commands: ::
 
     # systemctl enable rh-php71-php-fpm
     # systemctl start rh-php71-php-fpm
-    # systemctl restart httpd
+    # systemctl restart httpd24-httpd
     # systemctl restart cbd
     # systemctl restart centengine
 

--- a/doc/fr/administration_guide/parameters.rst
+++ b/doc/fr/administration_guide/parameters.rst
@@ -43,7 +43,7 @@ La fenêtre suivante s'affiche :
 * Le champ **Adresses des clients SSO de confiance** indique quelles sont les adresses IP/DNS des clients de confiance pour le SSO (correspond à l'adresse du reverse proxy). Chaque client de confiance est séparé par une virgule.
 * Le champ **Adresses des clients de bloqués** indique quelles sont les adresses IP/DNS des clients qui seront refusés.
 * Le champ **Entête HTTP SSO** indique la variable de l'en-tête qui sera utilisée comme login/pseudo.
-* Le champ **Chaine de recherche (pattern) pour l'authentification (login)** indique l'expression rationnelle (pattern) de recherche pour l'utilisateur. 
+* Le champ **Chaine de recherche (pattern) pour l'authentification (login)** indique l'expression rationnelle (pattern) de recherche pour l'utilisateur.
 * Le champ **Chaine de remplacement (pattern) pour l'authentification (login)** indique la chaine de remplacement.
 * Le champ **Timezone par défaut de l'hôte** permet de définit un timezone par défaut pour application du décalage horaire
 * Le champ **Adresse mail de contact du support (de la plate-forme de supervision)** indique l'adresse email de support **Centre des services du client** pour la plate-forme Centreon. Cette adresse mail sera affichée en bas de page sur le lien **Centre des services**
@@ -179,7 +179,7 @@ Puis redémarrez le serveur Apache :
 
 ::
 
-  service httpd restart
+  systemctl restart httpd24-httpd
 
 
 *******

--- a/doc/fr/developper/translatecentreon.rst
+++ b/doc/fr/developper/translatecentreon.rst
@@ -79,7 +79,7 @@ Change rights on directory::
 
 Restart Apache::
 
-    $ sudo service httpd restart
+    $ sudo systemctl restart httpd24-httpd
 
 Connect to your Centreon web interface, edit your profil and select new language:
 

--- a/doc/fr/faq/performance.rst
+++ b/doc/fr/faq/performance.rst
@@ -10,7 +10,7 @@ Ce chapitre est un guide pour optimiser Centreon
 Bases de données
 ****************
 
-Le serveur de base de données est l'un des éléments centraux de Centreon. 
+Le serveur de base de données est l'un des éléments centraux de Centreon.
 Sa performance a un impact direct sur l'utilisateur de l'interface web.
 Centreon utilise deux ou trois bases de données en fonction de votre broker:
 
@@ -20,8 +20,8 @@ Centreon utilise deux ou trois bases de données en fonction de votre broker:
 Index
 =====
 
-Les bases de données utilisent des index pour accélérer les requêtes. Dans le 
-cas où des index sont manquants les requêtes sont plus longues à être exécutées. 
+Les bases de données utilisent des index pour accélérer les requêtes. Dans le
+cas où des index sont manquants les requêtes sont plus longues à être exécutées.
 
 .. _synchronizing-indexes:
 
@@ -58,7 +58,7 @@ L'option ``-s`` ou ``--sync`` doit être utilisée pour mettre à jour la base d
 Si vous avez besoin de définir l'utilisateur et le mot de passe, utiliser respectivement
 les options ``-u`` et ``-p``.
 
-Optimisations InnoDB 
+Optimisations InnoDB
 ====================
 
 Cette section n'est pas encore documentée.
@@ -66,7 +66,7 @@ Cette section n'est pas encore documentée.
 Schema des Bases de données
 ===========================
 
-Le schema de la base de données Centreon peut être consulté ici : 
+Le schema de la base de données Centreon peut être consulté ici :
 
 .. image:: ../database/centreon.png
 
@@ -81,7 +81,7 @@ RRDCacheD
 
 RRDCacheD est un processus qui permet de limiter les E/S disque lors de la mise à jour des graphiques
 de performance et/ou des graphiques de statut (fichiers RRDs).
-Pour cela, le processus RRDCacheD est appelé par le module Centreon Broker et mutualise les écritures 
+Pour cela, le processus RRDCacheD est appelé par le module Centreon Broker et mutualise les écritures
 sur disque plutôt que d'enregistrer une à une les données issues de la collecte.
 
 Installation
@@ -107,7 +107,7 @@ Options générales
 Concernant les autres options importantes :
 
 +--------+-----------------------------------------------------------------------------------+
-| Option | Description                                                                       |   
+| Option | Description                                                                       |
 +========+===================================================================================+
 | -w     | Les données sont écrites sur le disques toutes les x secondes (ici 3600s donc 1h) |
 +--------+-----------------------------------------------------------------------------------+
@@ -135,7 +135,7 @@ Créer les groupes en exécutant les commandes suivantes ::
 
 Redémarrer le processus Apache pour prendre en compte les modifications ::
 
-    # /etc/init.d/httpd restart
+    # systemctl restart httpd24-httpd
 
 Démarrer le processus RRDCacheD ::
 
@@ -159,7 +159,7 @@ Interface web Centreon
 ======================
 
 La mise en place de rrdcached fait que les graphiques ne sont plus mis à jours en temps réel.
-Il est donc possible de voir un petit blanc sur la droite de certains graphiques. 
+Il est donc possible de voir un petit blanc sur la droite de certains graphiques.
 Cela veut dire que les données sont encore dans le cache du processus, cela est normal !
 
 .. warning::

--- a/doc/fr/faq/remote_server.rst
+++ b/doc/fr/faq/remote_server.rst
@@ -32,7 +32,7 @@ Redémarrez le processus **cbd** sur le Remote Server : ::
 
     # systemctl restart cbd
 
-Redémarrez le moteur de supervision sur chaque collecteur (y compris du Remote 
+Redémarrez le moteur de supervision sur chaque collecteur (y compris du Remote
 Server lui-même) : ::
 
     # systemctl restart centengine
@@ -146,7 +146,7 @@ Résolution des problèmes d'extraction des données
          Docs: man:systemd-sysv-generator(8)
        CGroup: /system.slice/centcore.service
                └─32385 /usr/bin/perl /usr/share/centreon/bin/centcore --logfile=/var/log/centreon/centcore.log --severity=error --config=/etc/centreon/conf.pm
-    
+
     Warning: Journal has been rotated since unit was started. Log output is incomplete or unavailable.
 
 Si tel n'est pas le cas,
@@ -172,10 +172,10 @@ Ou que le fichier **/var/log/centreon/centcore.log** du serveur Centreon Central
 contient : ::
 
     2018-11-08 13:54:10 - Receiving die: Timeout by signal ALARM
-    
+
     2018-11-08 13:54:10 - Dont die...
     2018-11-08 13:54:10 - Receiving die: Timeout by signal ALARM
-    
+
     2018-11-08 13:54:10 - Dont die...
     2018-11-08 13:54:10 - Timeout by signal ALARM
 
@@ -258,23 +258,19 @@ Vérifiez que le processus Apache (httpd) est en cours d'exécution sur le Remot
 Server en exécutant la commande suivante sur le Remote Server : ::
 
     # systemctl status httpd
-    ● httpd.service - The Apache HTTP Server
-       Loaded: loaded (/usr/lib/systemd/system/httpd.service; enabled; vendor preset: disabled)
-       Active: active (running) since mer. 2018-11-14 15:01:52 GMT; 5min ago
-         Docs: man:httpd(8)
-          man:apachectl(8)
-      Process: 18653 ExecStop=/bin/kill -WINCH ${MAINPID} (code=exited, status=0/SUCCESS)
-      Process: 9241 ExecReload=/usr/sbin/httpd $OPTIONS -k graceful (code=exited, status=0/SUCCESS)
-     Main PID: 19836 (httpd)
-       Status: "Total requests: 5; Current requests/sec: 0; Current traffic:   0 B/sec"
-       CGroup: /system.slice/httpd.service
-               ├─19836 /usr/sbin/httpd -DFOREGROUND
-               ├─19838 /usr/sbin/httpd -DFOREGROUND
+    ● httpd24-httpd.service - The Apache HTTP Server
+       Loaded: loaded (/usr/lib/systemd/system/httpd24-httpd.service; enabled; vendor preset: disabled)
+       Active: active (running) since ven. 2019-03-22 14:29:06 CET; 2min 0s ago
+     Main PID: 3735 (httpd)
+       Status: "Total requests: 0; Idle/Busy workers 100/0;Requests/sec: 0; Bytes served/sec:   0 B/sec"
+       CGroup: /system.slice/httpd24-httpd.service
+               ├─3735 /opt/rh/httpd24/root/usr/sbin/httpd -DFOREGROUND
+               ├─3736 /opt/rh/httpd24/root/usr/sbin/httpd -DFOREGROUND
                ...
 
 si tel n'est pas le cas, redémarrez le processus **httpd** via la commande : ::
 
-    # systemctl restart httpd
+    # systemctl restart httpd24-httpd
 
 Vérifiez que les paramètres du Remote Server sont complets et corrects en
 exécutant la requête suivant sur le serveur Centreon Central : ::
@@ -320,7 +316,7 @@ Puis régénérez la configuration du Remote Server depuis le serveur Centreon c
          Docs: man:systemd-sysv-generator(8)
        CGroup: /system.slice/centcore.service
                └─32385 /usr/bin/perl /usr/share/centreon/bin/centcore --logfile=/var/log/centreon/centcore.log --severity=error --config=/etc/centreon/conf.pm
-    
+
     Warning: Journal has been rotated since unit was started. Log output is incomplete or unavailable.
 
 Si tel n'est pas le cas :
@@ -364,13 +360,13 @@ Remote Server s'arrête à la ligne : ::
 Ou le fichier **/var/log/centreon/centcore.log** du Remote Server contient : ::
 
     2018-11-08 13:54:10 - Receiving die: Timeout by signal ALARM
-    
+
     2018-11-08 13:54:10 - Dont die...
     2018-11-08 13:54:10 - Receiving die: Timeout by signal ALARM
-    
+
     2018-11-08 13:54:10 - Dont die...
     2018-11-08 13:54:10 - Timeout by signal ALARM
-    
+
     2018-11-08 13:54:10 - Killing child process [3926] ...
     2018-11-08 13:54:10 - Killed
 
@@ -427,7 +423,7 @@ central.
          Docs: man:systemd-sysv-generator(8)
        CGroup: /system.slice/centcore.service
                └─32385 /usr/bin/perl /usr/share/centreon/bin/centcore --logfile=/var/log/centreon/centcore.log --severity=error --config=/etc/centreon/conf.pm
-    
+
     Warning: Journal has been rotated since unit was started. Log output is incomplete or unavailable.
 
 Si tel n'est pas le cas :

--- a/doc/fr/installation/common/install_packages.rst
+++ b/doc/fr/installation/common/install_packages.rst
@@ -39,7 +39,7 @@ Dépôt Centreon
 --------------
 
 Afin d'installer les logiciels Centreon à partir des dépôts, vous devez au
-préalable installer le fichier lié au dépôt. Exécutez la commande suivante. 
+préalable installer le fichier lié au dépôt. Exécutez la commande suivante.
 
 Installation : ::
 
@@ -127,7 +127,7 @@ Activer le lancement automatique de services au démarrage.
 
 Lancer les commandes suivantes sur le serveur Central : ::
 
-    # systemctl enable httpd
+    # systemctl enable httpd24-httpd
     # systemctl enable snmpd
     # systemctl enable snmptrapd
     # systemctl enable rh-php71-php-fpm
@@ -148,7 +148,7 @@ Avant de démarrer la configuration via l'interface web les commandes suivantes
 doivent être exécutées : ::
 
     # systemctl start rh-php71-php-fpm
-    # systemctl start httpd
+    # systemctl start httpd24-httpd
     # systemctl start mysqld
     # systemctl start cbd
     # systemctl start snmpd

--- a/doc/fr/installation/from_sources.rst
+++ b/doc/fr/installation/from_sources.rst
@@ -16,7 +16,8 @@ en utilisant :ref:`les paquets fournis par Centreon <install_from_packages>`.
 
 Les environnements CentOS et RHEL ne possèdent pas en standard sur
 dépôts l'intégralité des dépendances nécessaires à l'installation
-de Centreon. Vous devez ajouter le dépôt *RPM Forge*
+de Centreon. Vous devez ajouter les dépôts *RPM Forge* et
+*Software Collections*.
 
 Système el7 :
 
@@ -40,6 +41,7 @@ Puis exécutez les commandes suivantes :
 
     $ rpm --import RPM-GPG-KEY.dag.txt
     $ rpm -Uvh rpmforge-release-0.5.3-1.el7.rf.x86_64.rpm
+    $ yum install centos-release-scl
 
 Vous pouvez maintenant installer les dépendances nécessaires :
 
@@ -47,12 +49,13 @@ Vous pouvez maintenant installer les dépendances nécessaires :
 
     $ yum update
     $ yum upgrade
-    $ yum install httpd gd fontconfig-devel libjpeg-devel libpng-devel gd-devel perl-GD perl-DateTime \
-        openssl-devel perl-DBD-MySQL mysql-server mysql-devel php php-mysql php-gd php-ldap php-xml php-mbstring \
+    $ yum install httpd24-httpd gd fontconfig-devel libjpeg-devel libpng-devel gd-devel perl-GD perl-DateTime \
+        openssl-devel perl-DBD-MySQL mysql-server mysql-devel rh-php71-php rh-php71-php-mysql rh-php71-php-gd \
+        rh-php71-php-ldap rh-php71-php-xml rh-php71-php-mbstring rh-php71-php-snmp \
         perl-Config-IniFiles perl-DBI perl-DBD-MySQL rrdtool perl-rrdtool perl-Crypt-DES perl-Digest-SHA1 \
-        perl-Digest-HMAC net-snmp-utils perl-Socket6 perl-IO-Socket-INET6 net-snmp net-snmp-libs php-snmp \
+        perl-Digest-HMAC net-snmp-utils perl-Socket6 perl-IO-Socket-INET6 net-snmp net-snmp-libs \
         dmidecode lm_sensors perl-Net-SNMP net-snmp-perl fping cpp gcc gcc-c++ libstdc++ glib2-devel \
-        php-pear nagios-plugins
+        rh-php71-php-pear nagios-plugins
 
 Des commandes additionnelles sont nécessaires pour configurer correctement l'environnement :
 

--- a/doc/fr/installation/prerequisites.rst
+++ b/doc/fr/installation/prerequisites.rst
@@ -228,23 +228,25 @@ Utilisateurs et groupes
 
 Description des logiciels et utilisateurs liés :
 
-+-----------------+----------------+-----------------+-----------------------+
-| Logiciel        | Service        | Utilisateur     | Commentaire           |
-+=================+================+=================+=======================+
-| Apache          | httpd          | apache          | démarrage automatique |
-+-----------------+----------------+-----------------+-----------------------+
-| MySQL (MariaDB) | mysqld (mysql) | mysql           | démarrage automatique |
-+-----------------+----------------+-----------------+-----------------------+
-| Centreon        | centcore       | centreon        | démarrage automatique |
-+-----------------+----------------+-----------------+-----------------------+
-| Centreon        | centreontrapd  | centreon        | démarrage automatique |
-+-----------------+----------------+-----------------+-----------------------+
-| Centreon Broker | cbwd           | centreon-broker | démarrage automatique |
-+-----------------+----------------+-----------------+-----------------------+
-| Centreon Broker | cbd            | centreon-broker | démarrage automatique |
-+-----------------+----------------+-----------------+-----------------------+
-| Centreon Engine | centengine     | centreon-engine | démarrage automatique |
-+-----------------+----------------+-----------------+-----------------------+
++-----------------+------------------+-----------------+-----------------------+
+| Logiciel        | Service          | Utilisateur     | Commentaire           |
++=================+==================+=================+=======================+
+| Apache          | httpd24-httpd    | apache          | démarrage automatique |
++-----------------+------------------+-----------------+-----------------------+
+| PHP-FPM         | rh-php71-php-fpm | apache          | démarrage automatique |
++-----------------+------------------+-----------------+-----------------------+
+| MySQL (MariaDB) | mysqld (mysql)   | mysql           | démarrage automatique |
++-----------------+------------------+-----------------+-----------------------+
+| Centreon        | centcore         | centreon        | démarrage automatique |
++-----------------+------------------+-----------------+-----------------------+
+| Centreon        | centreontrapd    | centreon        | démarrage automatique |
++-----------------+------------------+-----------------+-----------------------+
+| Centreon Broker | cbwd             | centreon-broker | démarrage automatique |
++-----------------+------------------+-----------------+-----------------------+
+| Centreon Broker | cbd              | centreon-broker | démarrage automatique |
++-----------------+------------------+-----------------+-----------------------+
+| Centreon Engine | centengine       | centreon-engine | démarrage automatique |
++-----------------+------------------+-----------------+-----------------------+
 
 Description des logiciels optionnels et utilisateurs liés :
 

--- a/doc/fr/upgrade/from_packages.rst
+++ b/doc/fr/upgrade/from_packages.rst
@@ -15,10 +15,10 @@ Centreon 18.10.
     Cette procédure ne s'applique que pour une plate-forme Centreon installée à
     partir des dépôts Centreon 3.4 sur des distributions **Red Hat / CentOS en
     version 7**.
-    
+
     Si cela n'est pas le cas, se référer à la procédure de :ref:`migration<upgradecentreon1810>`.
 
-Pour mettre à jour votre serveur Centreon Map, référez-vous à la `documentation associée 
+Pour mettre à jour votre serveur Centreon Map, référez-vous à la `documentation associée
 <https://documentation.centreon.com/docs/centreon-map-4/en/latest/upgrade/index.html>`_.
 
 Pour mettre à jour votre serveur Centreon MBI, référez-vous à la `documentation associée
@@ -88,7 +88,7 @@ Redémarrez les services en Executer les commandes suivantes : ::
 
     # systemctl enable rh-php71-php-fpm
     # systemctl start rh-php71-php-fpm
-    # systemctl restart httpd
+    # systemctl restart httpd24-httpd
     # systemctl restart cbd
     # systemctl restart centengine
 


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Replace standard *httpd* service with *httpd24-httpd* in the documentation.

<h2> Type of change </h2>

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

Please delete series that are not relevant.

- [ ] 2.8.x
- [ ] 18.10.x
- [X] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Follow documentation for prerequisites, installation, upgrade, performance (normal and remote server). Centreon should work as expected without further tweaking of _httpd_ and/or _httpd24-httpd_ services.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] ~I have made sure that the **unit tests** related to the story are successful.~
- [ ] ~I have made sure that **unit tests covers 80%** of the code written for the story.~
- [ ] ~I have made sure that **acceptance tests** related to the story are successful (**local and CI**)~
