### PR TITLE
fix(doc) Restart php-fpm instead of Apache for changes in php.ini

### DIFF
--- a/doc/en/installation/common/install_packages.rst
+++ b/doc/en/installation/common/install_packages.rst
@@ -104,9 +104,9 @@ You are required to set the PHP time zone. Run the command::
 .. note::
     Change **Europe/Paris** to your time zone.
 
-After saving the file, please do not forget to restart the Apache server::
+After saving the file, please do not forget to restart the PHP-FPM server::
 
-    # systemctl restart httpd
+    # systemctl restart rh-php71-php-fpm
 
 Configuring/disabling the firewall
 ----------------------------------

--- a/doc/fr/installation/common/install_packages.rst
+++ b/doc/fr/installation/common/install_packages.rst
@@ -106,9 +106,9 @@ La timezone par défaut de PHP doit être configurée. Executer la commande suiv
 .. note::
     Changez **Europe/Paris** par votre fuseau horaire.
 
-Après avoir réalisé la modification, redémarrez le service Apache : ::
+Après avoir réalisé la modification, redémarrez le service PHP-FPM : ::
 
-    # systemctl restart httpd
+    # systemctl restart rh-php71-php-fpm
 
 Pare-feu
 --------


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

It is an update in the documentation to restart the type of service responsible for the timezone change described in the documentation. Because a new include file is created for PHP, the service that needs to be reinitialized is PHP-FPM.

Fixes # (issue)

<h2> Type of change </h2>

Please delete options that are not relevant.

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

Please delete series that are not relevant.

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

All changes to php settings are managed by the PHP-FPM service.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
