### PR TITLE
fix(monitoring filters): status filter dropdown doesn't lose it's value

### DIFF
--- a/www/include/core/header/header.php
+++ b/www/include/core/header/header.php
@@ -101,7 +101,9 @@ foreach ($_GET as $key => $value) {
     if ($a) {
         $args .= '&';
     }
-    $args .= "$key=$value";
+    if (is_string($value)) {
+        $args .= "$key=$value";
+    }
     $a++;
 }
 $args .= "'";

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -418,6 +418,7 @@ if ((!isset($_GET['o']) || empty($_GET['o'])) && isset($_SESSION['monitoring_ser
     $form->setDefaults(array('statusFilter' => $_SESSION['monitoring_service_status_filter']));
     $sDefaultOrder = "1";
 }
+$defaultStatusFilter = isset($_GET['statusFilter']) ? $_GET['statusFilter'] : '';
 
 $form->addElement(
     'select',
@@ -528,6 +529,7 @@ $tpl->display("service.ihtml");
         _sid = '<?php echo $sid ?>';
         _tm = <?php echo $tM ?>;
         _o = '<?php echo $o; ?>';
+        _defaultStatusFilter = '<?php echo $defaultStatusFilter; ?>';
         _sDefaultOrder = '<?php echo $sDefaultOrder; ?>';
         sSetOrderInMemory = '<?php echo $sSetOrderInMemory; ?>';
 
@@ -553,6 +555,9 @@ $tpl->display("service.ihtml");
             } else {
                 jQuery("#statusService option[value='svc_unhandled']").prop('selected', true);
                 jQuery("#statusFilter option[value='']").prop('selected', true);
+            }
+            if(_defaultStatusFilter != '') {
+                jQuery("#statusFilter option[value='"+_defaultStatusFilter+"']").prop('selected', true);
             }
         }
         filterStatus(document.getElementById('statusFilter').value, 1);

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -525,13 +525,13 @@ $tpl->display("service.ihtml");
     });
 
     function preInit() {
-        _keyPrefix = '<?php echo $keyPrefix; ?>';
-        _sid = '<?php echo $sid ?>';
-        _tm = <?php echo $tM ?>;
-        _o = '<?php echo $o; ?>';
-        _defaultStatusFilter = '<?php echo $defaultStatusFilter; ?>';
-        _sDefaultOrder = '<?php echo $sDefaultOrder; ?>';
-        sSetOrderInMemory = '<?php echo $sSetOrderInMemory; ?>';
+        _keyPrefix = '<?= $keyPrefix; ?>';
+        _sid = '<?= $sid ?>';
+        _tm = <?= $tM ?>;
+        _o = '<?= $o; ?>';
+        _defaultStatusFilter = '<?= $defaultStatusFilter; ?>';
+        _sDefaultOrder = '<?= $sDefaultOrder; ?>';
+        sSetOrderInMemory = '<?= $sSetOrderInMemory; ?>';
 
         if (_sDefaultOrder == "0") {
             if (_o == 'svc') {
@@ -556,7 +556,7 @@ $tpl->display("service.ihtml");
                 jQuery("#statusService option[value='svc_unhandled']").prop('selected', true);
                 jQuery("#statusFilter option[value='']").prop('selected', true);
             }
-            if(_defaultStatusFilter != '') {
+            if (_defaultStatusFilter != '') {
                 jQuery("#statusFilter option[value='"+_defaultStatusFilter+"']").prop('selected', true);
             }
         }

--- a/www/include/monitoring/status/Services/templates/service.ihtml
+++ b/www/include/monitoring/status/Services/templates/service.ihtml
@@ -45,7 +45,6 @@
     <tr class="ToolbarTR">
         <td>
         <span class="consol_button">{$form.o1.html}</span>
-        <input name="p" value="{$p}" type="hidden">
 
         <div class="Toolbar_TDSelectAction_Top">
             <span class="consol_button">


### PR DESCRIPTION
<h1> Fix monitoring services filter </h1>

<h2> status filter dropdown doesn't lose it's value </h2>

- check dropdown from $_GET parameters and use it
- remove duplicated parameters from form
- check if parameter is string when adding it to parameters in URL (for redirecting)

Fixes #3570

<h2> Type of change </h2>

- [X] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [X] 18.10.x
- [X] 19.04.x (master)
