### PR TITLE
fix(graph): no-unit series now trigger a second axis

### DIFF
--- a/www/include/views/graphs/javascript/centreon-graph.js
+++ b/www/include/views/graphs/javascript/centreon-graph.js
@@ -153,10 +153,7 @@
           }
         },
         y: {
-          padding: {bottom: 0, top: 0},
-          tick: {
-            format: this.getAxisTickFormat(this.getBase())
-          }
+          padding: {bottom: 0, top: 0}
         }
       };
       /* Add Y axis range */
@@ -168,11 +165,14 @@
       }
 
       var parsedData = this.buildMetricData(data);
-
       axis = jQuery.extend(true, {}, axis, parsedData.axis);
+      // Of course no-unit series are 1000 based
+      axis.y.tick = {
+        format: this.getAxisTickFormat(axis.y.label ? this.getBase() : 1000)
+      };
       if (axis.hasOwnProperty('y2')) {
         axis.y2.tick = {
-          format: this.getAxisTickFormat(this.getBase())
+          format: this.getAxisTickFormat(axis.y2.label ? this.getBase() : 1000)
         };
       }
 
@@ -207,7 +207,7 @@
             value: function (value, ratio, id) {
               /* Test if the curve is inversed */
               var fct = self.getAxisTickFormat(
-                self.getBase(),
+                self.getBase(id),
                 self.isInversed(id)
               );
               return fct(value);
@@ -332,16 +332,18 @@
         column.unshift(name);
         data.columns.push(column);
         legend = dataRaw.data[i].label;
+        // Remember that unit can be empty
         if (dataRaw.data[i].unit) {
           legend += '(' + dataRaw.data[i].unit + ')';
-          if (units.hasOwnProperty(dataRaw.data[i].unit) === false) {
-            units[dataRaw.data[i].unit] = [];
-          }
-          units[dataRaw.data[i].unit].push(name);
           axis[axesName] = {
             label: dataRaw.data[i].unit
           };
         }
+        // these no-unit series also go to their own axis
+        if (units.hasOwnProperty(dataRaw.data[i].unit) === false) {
+          units[dataRaw.data[i].unit] = [];
+        }
+        units[dataRaw.data[i].unit].push(name);
         data.names[name] = legend;
         data.types[name] = convertType.hasOwnProperty(dataRaw.data[i].type) !== -1 ?
           convertType[dataRaw.data[i].type] : dataRaw.data[i].type;
@@ -706,7 +708,13 @@
      * @param {String} id - The curve id
      * @return {Integer} - 1000 or 1024
      */
-    getBase: function () {
+    getBase: function (id) {
+      // Of course no-unit series are 1000 based
+      for (var e in this.chartData.data) {
+        if((this.chartData.data[e].data[0] === id) && this.chartData.data[e].unit === "") {
+          return 1000;
+        }
+      }
       if (this.chartData.base) {
         return this.chartData.base;
       }
@@ -729,7 +737,7 @@
         if (legends.hasOwnProperty(legend) && self.ids.hasOwnProperty(legend)) {
           curveId = self.ids[legend];
           var fct = self.getAxisTickFormat(
-              self.getBase(),
+              self.getBase(curveId),
               self.isInversed(curveId)
           );
           legendDiv = jQuery('<div>').addClass('chart-legend')
@@ -821,7 +829,7 @@
         }
         var curveId = self.ids[legendName];
         var fct = self.getAxisTickFormat(
-          self.getBase(),
+          self.getBase(curveId),
           self.isInversed(curveId)
         );
         jQuery(el).find('.extra').remove();


### PR DESCRIPTION
Hi,

<h2> Description </h2>

Issue is detailed in #7330.
This PR solves it making no-unit series having their own y-axis.
Leading to this beautiful graph example :

![ex1](https://user-images.githubusercontent.com/40244829/55068125-5b0b9600-5081-11e9-9682-9f5d6a7417d7.png)

Fixes #7330

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

As detailed in #7330, generate graphs with several series, some with a unit, some without unit.
Be then sure that series without unit are on their own y-axis.

Thank you 👍