### PR TITLE
fix(graph): display thresholds in Split chart mode

### DIFF
--- a/www/class/centreonGraph.class.php
+++ b/www/class/centreonGraph.class.php
@@ -331,6 +331,9 @@ class CentreonGraph
         } elseif ($metrics != "") {
             $this->metricsEnabled = array($metrics);
         }
+        if (is_array($this->metricsEnabled) && (count($this->metricsEnabled) == 1)) {
+            $this->onecurve = true;
+        }
     }
 
     /**


### PR DESCRIPTION
Hi,

<h2> Description </h2>

This PR activates thresholds display on graphs when in Split chart mode, so when there is only one curve per graph.

Fixes #7342
Should also close #7235.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Display a graph with several curves, and with at least with thresholds.
With all curves on the same graph, thresholds are not displayed.
Go in Split chart mode, and verify here that thresholds are correctly shown.

Thank you 👍 