### PR TITLE
fix(remote-server): check HTTP return code

### DIFF
--- a/src/CentreonRemote/Domain/Service/NotifyMasterService.php
+++ b/src/CentreonRemote/Domain/Service/NotifyMasterService.php
@@ -101,7 +101,9 @@ class NotifyMasterService
                         $details = self::TIMEOUT;
                         break;
                     default:
-                        $details = self::UNKNOWN_ERROR;
+                        $details = ($this->getCurl()->http_status_code) ?
+                            'HTTP code: ' . $this->getCurl()->http_status_code :
+                            self::UNKNOWN_ERROR;
                         break;
                 }
 


### PR DESCRIPTION
<h2> Description </h2>

If the call to the API to the Centreon Central Server from the Remote Server during enableRemote command return 40x or 50x error, the error message was not explicite

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Use Centreon 18.10.x version
- On Centreon Central server enable HTTPS and disable HTTP
- Follow documentation and execute command:

`/usr/share/centreon/bin/centreon -u admin -p centreon -a enableRemote -o CentreonRemoteServer -v $IP`

- you will receive a 'Fail: Unknown Error' before the patch

```
Starting Centreon Remote enable process:
Limiting Menu Access...SuccessLimiting Actions...Done
Authorizing Master...Done
Set 'remote' instance type...Done
Notifying Master...Fail: Unknown Error
Centreon Remote enabling finished.
```

- you will receive failed with HTTP return code

```
Starting Centreon Remote enable process:
Limiting Menu Access...SuccessLimiting Actions...Done
Authorizing Master...Done
Set 'remote' instance type...Done
Notifying Master...Fail: HTTP code: 404
Centreon Remote enabling finished.
```

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
