### PR TITLE
fix(install) Get the ip address of an existing connection to set the permission correctly

### DIFF
--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -64,7 +64,7 @@ $host = "localhost";
 // if database server is not on localhost...
 if ($parameters['address'] != "127.0.0.1" && $parameters['address'] != "localhost") {
     $getIpQuery = $link->prepare(
-        'SELECT host FROM information_schema.processlist WHERE ID=connection_id()'
+        'SELECT host FROM information_schema.processlist WHERE ID = connection_id()'
     );
     $getIpQuery->execute();
     // The result example (172.17.0.1:38216), use the explode function to remove port

--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -64,7 +64,7 @@ $host = "localhost";
 // if database server is not on localhost...
 if ($parameters['address'] != "127.0.0.1" && $parameters['address'] != "localhost") {
     $getIpQuery = $link->prepare(
-        'select host from information_schema.processlist WHERE ID=connection_id()'
+        'SELECT host FROM information_schema.processlist WHERE ID=connection_id()'
     );
     $getIpQuery->execute();
     // The result example (172.17.0.1:38216), use the explode function to remove port

--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -63,7 +63,7 @@ $dbPass = $parameters['db_password'];
 $host = "localhost";
 // if database server is not on localhost...
 if ($parameters['address'] != "127.0.0.1" && $parameters['address'] != "localhost") {
-    $host = $_SERVER['SERVER_ADDR'];
+    $host = explode(" ", $link->getAttribute(PDO::ATTR_CONNECTION_STATUS))[0];
 }
 $query = "GRANT ALL PRIVILEGES ON `%s`.* TO `" . $dbUser . "`@`" . $host .
     "` IDENTIFIED BY '" . $dbPass . "' WITH GRANT OPTION";

--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -63,7 +63,12 @@ $dbPass = $parameters['db_password'];
 $host = "localhost";
 // if database server is not on localhost...
 if ($parameters['address'] != "127.0.0.1" && $parameters['address'] != "localhost") {
-    $host = explode(" ", $link->getAttribute(PDO::ATTR_CONNECTION_STATUS))[0];
+    $getIpQuery = $link->prepare(
+        'select host from information_schema.processlist WHERE ID=connection_id()'
+    );
+    $getIpQuery->execute();
+    // The result example (172.17.0.1:38216), use the explode function to remove port
+    $host = explode(":", $getIpQuery->fetchAll(PDO::FETCH_COLUMN)[0])[0];
 }
 $query = "GRANT ALL PRIVILEGES ON `%s`.* TO `" . $dbUser . "`@`" . $host .
     "` IDENTIFIED BY '" . $dbPass . "' WITH GRANT OPTION";


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

When an installation of the Centreon is done using the database server (MySQL) on an external server and it is on another network being accessed only via NAT, an ip address is mistakenly assigned in the user permission `centreon` of MySQL.

Currently it uses a server variable to get the client ip (`$_SERVER['SERVER_ADDR']`). however, when the server is in another network location, the ip that needs to be allocated in the user's permission is the network gateway (which does the NAT).

As for getting to this `centreon` user creation function, it is necessary to have the connection using valid `root`, I am taking into account that there is a valid connection and functioning as `root`. ~~So, I have a attribute available in the PDO connection object and with that, I use an attribute available `PDO::ATTR_CONNECTION_STATUS` in the object to get the valid ip address of the client for the connection.~~

Using mysql directly is more effective, the PDO was returning me the ip of the server.

```
mysql> select host from information_schema.processlist WHERE ID=connection_id();
+------------------+
| host             |
+------------------+
| 172.17.0.1:45842 |
+------------------+
```
This way, I use the Mysql information table and I can capture the ip of the current session.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

I came up with this problem using environments where I used MariaDB on docker instances in networks other than the Centreon installation. For example, I have the MariaDB docker on the 172.17.0.0/24 network and the Centreon installation on a Vagrant on the 10.1.0.0/24 network.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
