### PR TITLE
enh(remote-server): Add possibility to use HTTP/HTTPS from RS to CC

### DIFF
--- a/doc/en/administration_guide/poller/enable_remote.rst
+++ b/doc/en/administration_guide/poller/enable_remote.rst
@@ -4,7 +4,7 @@ Enabling the Remote Server option
 
 Connect to your **Remoter Server** and execute following command::
 
-    # /usr/share/centreon/bin/centreon -u admin -p centreon -a enableRemote -o CentreonRemoteServer -v @IP_CENTREON_CENTRAL
+    # /usr/share/centreon/bin/centreon -u admin -p centreon -a enableRemote -o CentreonRemoteServer -v @IP_CENTREON_CENTRAL;<not check SSL CA on Central>;<HTTP method>;<TCP port>;<not check SSL CA on Remote>;
 
 Replace **@IP_CENTREON_CENTRAL** by the IP of the Centreon server seen by the
 poller. You can define multiple IP address using a coma as separator.
@@ -14,8 +14,18 @@ poller. You can define multiple IP address using a coma as separator.
       **https://@IP_CENTREON_CENTRAL**.
     * To use non default port, replace **@IP_CENTREON_CENTRAL** by
       **@IP_CENTREON_CENTRAL:<port>**.
-    * To disable SSL certificate validation, replace **@IP_CENTREON_CENTRAL**
-      by **@IP_CENTREON_CENTRAL;1**
+
+For the **<not check SSL CA on Central>** option you can put **1** to do not
+check the SS CA on the Centreon Central Server if HTTPS is enabled, or put **0**.
+
+The **<HTTP method>** is to define how the Centreon Central server can contact
+the Remote server: HTTP or HTTPS.
+
+The **<TCP port>** is to define on wich TCP port the entreon Central server can
+contact the Remote server.
+
+For the **<not check SSL CA on Remote>** option you can put **1** to do not
+check the SS CA on the Remote server if HTTPS is enabled, or put **0**.
 
 This command will enable **Remote Server** mode::
 

--- a/doc/en/administration_guide/poller/enable_remote.rst
+++ b/doc/en/administration_guide/poller/enable_remote.rst
@@ -6,9 +6,16 @@ Connect to your **Remoter Server** and execute following command::
 
     # /usr/share/centreon/bin/centreon -u admin -p centreon -a enableRemote -o CentreonRemoteServer -v @IP_CENTREON_CENTRAL
 
+Replace **@IP_CENTREON_CENTRAL** by the IP of the Centreon server seen by the
+poller. You can define multiple IP address using a coma as separator.
+
 .. note::
-    Replace **@IP_CENTREON_CENTRAL** by the IP of the Centreon server seen by the poller.
-    You can define multiple IP address using a coma as separator.
+    * To use HTTPS, replace **@IP_CENTREON_CENTRAL** by
+      **https://@IP_CENTREON_CENTRAL**.
+    * To use non default port, replace **@IP_CENTREON_CENTRAL** by
+      **@IP_CENTREON_CENTRAL:<port>**.
+    * To disable SSL certificate validation, replace **@IP_CENTREON_CENTRAL**
+      by **@IP_CENTREON_CENTRAL;1**
 
 This command will enable **Remote Server** mode::
 

--- a/doc/fr/administration_guide/poller/enable_remote.rst
+++ b/doc/fr/administration_guide/poller/enable_remote.rst
@@ -5,11 +5,29 @@ Activer l'option Remote Server
 Connectez-vous à votre serveur ayant la fonction **Remote Server** et exécutez
 la commande suivante ::
 
-    # /usr/share/centreon/bin/centreon -u admin -p centreon -a enableRemote -o CentreonRemoteServer -v @IP_CENTREON_CENTRAL
+    # /usr/share/centreon/bin/centreon -u admin -p centreon -a enableRemote -o CentreonRemoteServer -v @IP_CENTREON_CENTRAL;<not check SSL CA on Central>;<HTTP method>;<TCP port>;<not check SSL CA on Remote>;
 
 .. note::
     Remplacez **@IP_CENTREON_CENTRAL** par l'IP du serveur Centreon vu par le collecteur.
     Vous pouvez définir plusieurs adresse IP en utilisant la virgule comme séparateur.
+
+.. note::
+    * Pour utiliser HTTPS, remplacez **@IP_CENTREON_CENTRAL** par
+      **https://@IP_CENTREON_CENTRAL**.
+    * Pour utilsier un autre port TCP, remplacez **@IP_CENTREON_CENTRAL** par
+      **@IP_CENTREON_CENTRAL:<port>**.
+
+Pour ne pas contrôler le sertificat SSL sur le serveur Centreon Central,
+mettre à **1** l'option **<not check SSL CA on Central>**, sinon **0**.
+
+L'option **<HTTP method>** permet de définir la méthode de connexion pour
+contacter le Remote Server : HTTP ou HTTPS.
+
+L'option **<TCP port>** permet de définir sur quel port TCP communiquer avec le
+Remote Server.
+
+Pour ne pas contrôler le sertificat SSL sur le Remote server, mettre à **1**
+l'option **<not check SSL CA on Central>**, sinon **0**.
 
 Cette commande va activer le mode **Remote Server** ::
 

--- a/src/CentreonRemote/Application/Clapi/CentreonRemoteServer.php
+++ b/src/CentreonRemote/Application/Clapi/CentreonRemoteServer.php
@@ -38,11 +38,26 @@ class CentreonRemoteServer implements CentreonClapiServiceInterface
      */
     public function enableRemote(string $string_ip)
     {
-        /* Check if user wants to disable SS certificate validation */
+        /* Set default value */
         $noCheckCertificate = false;
-        if (preg_match('/(.*);1$/', $string_ip, $matches)) {
-            $string_ip = $matches[1];
-            $noCheckCertificate = true;
+        $data = array(
+            'remoteHttpMethod'         => 'http',
+            'remoteHttpPort'           => null,
+            'remoteNoCheckCertificate' => false,
+        );
+
+        /* Check CLAPI */
+        $options = explode (';', $string_ip);
+
+        if (count($options) == 5) {
+            $string_ip = $options[0];
+            $noCheckCertificate = $options[1];
+            $data['remoteHttpMethod'] = $options[2];
+            $data['remoteHttpPort'] = $options[3];
+            $data['remoteNoCheckCertificate'] = $options[4];
+        } elseif (count($options) > 1) {
+            echo "Argument error number. Check your commmand";
+            return 1;
         }
 
         /* Extract host from URI */
@@ -60,7 +75,7 @@ class CentreonRemoteServer implements CentreonClapiServiceInterface
 
         echo "Limiting Menu Access...";
         $result = $this->getDi()['centreon.db-manager']->getRepository(TopologyRepository::class)->disableMenus();
-        echo (($result) ? 'Success' . "\n" : 'Fail') . "\n";
+        echo (($result) ? 'Success' : 'Fail') . "\n";
 
         echo "Limiting Actions...";
         $this->getDi()['centreon.db-manager']->getRepository(InformationsRepository::class)->toggleRemote('yes');
@@ -81,7 +96,11 @@ class CentreonRemoteServer implements CentreonClapiServiceInterface
         echo "Notifying Master...";
         $result = "";
         foreach ($ipList as $ip) {
-            $result = $this->getDi()['centreon.notifymaster']->pingMaster($ip, $noCheckCertificate);
+            $result = $this->getDi()['centreon.notifymaster']->pingMaster(
+                $ip,
+                $noCheckCertificate,
+                $data
+            );
             if (!empty($result['status']) && $result['status'] == 'success') {
                 echo "Success\n";
                 break;

--- a/src/CentreonRemote/Application/Clapi/CentreonWorker.php
+++ b/src/CentreonRemote/Application/Clapi/CentreonWorker.php
@@ -144,15 +144,20 @@ class CentreonWorker implements CentreonClapiServiceInterface
         $params = unserialize($task->getParams())['params'];
         $centreonPath = trim($params['centreon_path'], '/');
         $centreonPath = $centreonPath ? $centreonPath : '/centreon';
-        $url = "{$params['remote_ip']}/{$centreonPath}/api/external.php?"
-            . "object=centreon_task_service&action=AddImportTaskWithParent";
+        $url = $params['http_method'] ? $params['http_method'] . "://" : "";
+        $url .= $params['remote_ip'];
+        $url .= $params['http_port'] ? ":" . $params['http_port'] : "";
+        $url .= "/{$centreonPath}/api/external.php?object=centreon_task_service&action=AddImportTaskWithParent";
 
         try {
             $curl = new \CentreonRestHttp;
             $res = $curl->call(
                 $url,
                 'POST',
-                ['parent_id' => $task->getId()]
+                ['parent_id' => $task->getId()],
+                null,
+                false,
+                $params['no_check_certificate']
             );
         } catch (\Exception $e) {
             echo "Error while creating parent task on $url\n";

--- a/src/CentreonRemote/Domain/Service/NotifyMasterService.php
+++ b/src/CentreonRemote/Domain/Service/NotifyMasterService.php
@@ -89,7 +89,6 @@ class NotifyMasterService
 
             if ($noCheckCertificate) {
                 $this->getCurl()->setOpt(CURLOPT_SSL_VERIFYPEER, false);
-                $this->getCurl()->setOpt(CURLOPT_SSL_VERIFYPEER, false);
             }
 
             $this->getCurl()->post($url, $curlData);

--- a/src/CentreonRemote/Domain/Service/NotifyMasterService.php
+++ b/src/CentreonRemote/Domain/Service/NotifyMasterService.php
@@ -66,7 +66,7 @@ class NotifyMasterService
      * @return array
      * @throws \ErrorException
      */
-    public function pingMaster($ip)
+    public function pingMaster($ip, $noCheckCertificate = false)
     {
 
         $url = "{$ip}/centreon/api/external.php?object=centreon_remote_server&action=addToWaitList";
@@ -86,6 +86,11 @@ class NotifyMasterService
                 'app_key' => $applicationKey->getValue(),
                 'version' => $version->getValue(),
             ];
+
+            if ($noCheckCertificate) {
+                $this->getCurl()->setOpt(CURLOPT_SSL_VERIFYPEER, false);
+                $this->getCurl()->setOpt(CURLOPT_SSL_VERIFYPEER, false);
+            }
 
             $this->getCurl()->post($url, $curlData);
 

--- a/src/CentreonRemote/Domain/Service/NotifyMasterService.php
+++ b/src/CentreonRemote/Domain/Service/NotifyMasterService.php
@@ -83,8 +83,11 @@ class NotifyMasterService
 
         try {
             $curlData = [
-                'app_key' => $applicationKey->getValue(),
-                'version' => $version->getValue(),
+                'app_key'              => $applicationKey->getValue(),
+                'version'              => $version->getValue(),
+                'http_method'          => $data['remoteHttpMethod'] ?? 'http',
+                'http_port'            => $data['remoteHttpPort'] ?? '',
+                'no_check_certificate' => $data['remoteNoCheckCertificate'] ?? 0,
             ];
 
             if ($noCheckCertificate) {


### PR DESCRIPTION
<h2> Description </h2>

Add the possibility to use HTTP/HTTPS and change the TCP port for communication between the Remote Server and the Centreon Central Server during enableRemote option.
Add also the possibility to disable SSL certificate validation.

<h2> Type of change </h2>

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Enable only HTTPS on Centreon Central Server
Install a Remote Server following documentation
Enable the Remote Server

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
