### PR TITLE
fix(host search): fix search parameters

### DIFF
--- a/www/include/configuration/configObject/host/listHost.ihtml
+++ b/www/include/configuration/configObject/host/listHost.ihtml
@@ -67,7 +67,7 @@
 			<a href="{$elemArr[elem].RowMenu_link}"><img src="{$elemArr[elem].RowMenu_icone}" class="ico-18  margin_right" />{$elemArr[elem].RowMenu_name}</a>
 		</td>
 		<td class="ListColCenter">
-            <a href='./main.php?p=602&Search=&searchH={$elemArr[elem].RowMenu_name}&searchS='>
+            <a href='./main.php?p=602&search=&searchH={$elemArr[elem].RowMenu_name}&searchS='>
 		        <img src="./img/icons/all_services.png" class="ico-16" title='{$HelpServices}'>
 		    </a>
 		</td>

--- a/www/include/configuration/configObject/host/listHost.ihtml
+++ b/www/include/configuration/configObject/host/listHost.ihtml
@@ -67,7 +67,7 @@
 			<a href="{$elemArr[elem].RowMenu_link}"><img src="{$elemArr[elem].RowMenu_icone}" class="ico-18  margin_right" />{$elemArr[elem].RowMenu_name}</a>
 		</td>
 		<td class="ListColCenter">
-            <a href='./main.php?p=602&search_h={$elemArr[elem].RowMenu_name}&search_s='>
+            <a href='./main.php?p=602&Search=&searchH={$elemArr[elem].RowMenu_name}&searchS='>
 		        <img src="./img/icons/all_services.png" class="ico-16" title='{$HelpServices}'>
 		    </a>
 		</td>

--- a/www/include/configuration/configObject/service/listServiceByHost.php
+++ b/www/include/configuration/configObject/service/listServiceByHost.php
@@ -84,7 +84,7 @@ if (isset($_POST['Search'])) {
     $centreon->historySearch[$url]["searchS"] = $searchS;
     isset($_POST["statusHostFilter"]) ? $hostStatus = 1 : $hostStatus = 0;
     $centreon->historySearch[$url]["hostStatus"] = $hostStatus;
-} elseif (isset($_GET['Search'])) {
+} elseif (isset($_GET['search'])) {
     $centreon->historySearch[$url] = array();
     $template = $_GET['template'] ?? '';
     $centreon->historySearch[$url]['template'] = $template;

--- a/www/include/configuration/configObject/service/listServiceByHost.php
+++ b/www/include/configuration/configObject/service/listServiceByHost.php
@@ -88,7 +88,7 @@ if (isset($_POST['Search'])) {
     $centreon->historySearch[$url] = array();
     $template = $_GET['template'] ?? '';
     $centreon->historySearch[$url]['template'] = $template;
-    $status = $_GET["status"] ?? '';
+    $status = $_GET["status"] ?? -1;
     $centreon->historySearch[$url]["status"] = $status;
     $searchH = $_GET["searchH"];
     $centreon->historySearch[$url]["searchH"] = $searchH;

--- a/www/include/configuration/configObject/service/listServiceByHost.php
+++ b/www/include/configuration/configObject/service/listServiceByHost.php
@@ -72,29 +72,18 @@ if (isset($_POST["status"])) {
     $status = $_GET["status"];
 }
 
-if (isset($_POST['Search'])) {
-    $centreon->historySearch[$url] = array();
-    $template = $_POST["template"];
-    $centreon->historySearch[$url]["template"] = $template;
-    $status = $_POST["status"];
-    $centreon->historySearch[$url]["status"] = $status;
-    $searchH = $_POST["searchH"];
-    $centreon->historySearch[$url]["searchH"] = $searchH;
-    $searchS = $_POST["searchS"];
-    $centreon->historySearch[$url]["searchS"] = $searchS;
-    isset($_POST["statusHostFilter"]) ? $hostStatus = 1 : $hostStatus = 0;
-    $centreon->historySearch[$url]["hostStatus"] = $hostStatus;
-} elseif (isset($_GET['search'])) {
-    $centreon->historySearch[$url] = array();
-    $template = $_GET['template'] ?? '';
+if (isset($_POST['search']) || isset($_GET['search'])) {
+    $data = isset($_POST['search']) ? $_POST : $_GET;
+    $centreon->historySearch[$url] = [];
+    $template = $data['template'] ?? '';
     $centreon->historySearch[$url]['template'] = $template;
-    $status = $_GET["status"] ?? -1;
+    $status = $data["status"] ?? -1;
     $centreon->historySearch[$url]["status"] = $status;
-    $searchH = $_GET["searchH"];
+    $searchH = $data["searchH"];
     $centreon->historySearch[$url]["searchH"] = $searchH;
-    $searchS = $_GET["searchS"] ?? null;
+    $searchS = $data["searchS"] ?? null;
     $centreon->historySearch[$url]["searchS"] = $searchS;
-    isset($_POST["statusHostFilter"]) ? $hostStatus = 1 : $hostStatus = 0;
+    isset($data["statusHostFilter"]) ? $hostStatus = 1 : $hostStatus = 0;
     $centreon->historySearch[$url]["hostStatus"] = $hostStatus;
 } else {
     if (isset($centreon->historySearch[$url]['template'])) {

--- a/www/include/configuration/configObject/service/listServiceByHost.php
+++ b/www/include/configuration/configObject/service/listServiceByHost.php
@@ -92,7 +92,7 @@ if (isset($_POST['Search'])) {
     $centreon->historySearch[$url]["status"] = $status;
     $searchH = $_GET["searchH"];
     $centreon->historySearch[$url]["searchH"] = $searchH;
-    $searchS = $_GET["searchS"] ?? '';
+    $searchS = $_GET["searchS"] ?? null;
     $centreon->historySearch[$url]["searchS"] = $searchS;
     isset($_POST["statusHostFilter"]) ? $hostStatus = 1 : $hostStatus = 0;
     $centreon->historySearch[$url]["hostStatus"] = $hostStatus;

--- a/www/include/configuration/configObject/service/listServiceByHost.php
+++ b/www/include/configuration/configObject/service/listServiceByHost.php
@@ -86,13 +86,13 @@ if (isset($_POST['Search'])) {
     $centreon->historySearch[$url]["hostStatus"] = $hostStatus;
 } elseif (isset($_GET['Search'])) {
     $centreon->historySearch[$url] = array();
-    $template = $_GET['template'];
+    $template = $_GET['template'] ?? '';
     $centreon->historySearch[$url]['template'] = $template;
-    $status = $_GET["status"];
+    $status = $_GET["status"] ?? '';
     $centreon->historySearch[$url]["status"] = $status;
     $searchH = $_GET["searchH"];
     $centreon->historySearch[$url]["searchH"] = $searchH;
-    $searchS = $_GET["searchS"];
+    $searchS = $_GET["searchS"] ?? '';
     $centreon->historySearch[$url]["searchS"] = $searchS;
     isset($_POST["statusHostFilter"]) ? $hostStatus = 1 : $hostStatus = 0;
     $centreon->historySearch[$url]["hostStatus"] = $hostStatus;

--- a/www/include/core/header/htmlHeader.php
+++ b/www/include/core/header/htmlHeader.php
@@ -125,7 +125,7 @@ print "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
     if (isset($_GET["search"])) {
         $searchStr .= "search_host=" . htmlentities($_GET["search"], ENT_QUOTES, "UTF-8");
     }
-    if (isset($centreon->historySearch[$url]) && !isset($_GET["Search"])) {
+    if (isset($centreon->historySearch[$url]) && !isset($_GET["search"])) {
         $searchStr .= "search_host=" . (
                 is_array($centreon->historySearch[$url]) && isset($centreon->historySearch[$url]['searchH']) ?
                     $centreon->historySearch[$url]['searchH'] :

--- a/www/include/core/header/htmlHeader.php
+++ b/www/include/core/header/htmlHeader.php
@@ -125,8 +125,12 @@ print "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
     if (isset($_GET["search"])) {
         $searchStr .= "search_host=" . htmlentities($_GET["search"], ENT_QUOTES, "UTF-8");
     }
-    if (isset($centreon->historySearch[$url]) && !isset($_GET["search"])) {
-        $searchStr .= "search_host=" . $centreon->historySearch[$url];
+    if (isset($centreon->historySearch[$url]) && !isset($_GET["Search"])) {
+        $searchStr .= "search_host=" . (
+                is_array($centreon->historySearch[$url]) && isset($centreon->historySearch[$url]['searchH']) ?
+                    $centreon->historySearch[$url]['searchH'] :
+                    $centreon->historySearch[$url]
+            );
     }
 
     $searchStrSVC = "";


### PR DESCRIPTION
- replace search_h and search_s with searchH and searchS
- add empty Search parameter
- make additional checks for historySearch (fix warnings)
- make additional checks in header (fix warnings)

<h1> Fix search parameters </h1>

<h2> fix typos of parameters and warnings for non-existing properties </h2>


Fixes 3568
<h2> Type of change </h2>

- [X] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [ ] 2.8.x
- [X] 18.10.x
- [X] 19.04.x (master)
