### PR TITLE
enh(remote-server): Add possibility to use HTTP/HTTPS from CC to RS 

### DIFF
--- a/src/CentreonRemote/Application/Clapi/CentreonWorker.php
+++ b/src/CentreonRemote/Application/Clapi/CentreonWorker.php
@@ -144,15 +144,20 @@ class CentreonWorker implements CentreonClapiServiceInterface
         $params = unserialize($task->getParams())['params'];
         $centreonPath = trim($params['centreon_path'], '/');
         $centreonPath = $centreonPath ? $centreonPath : '/centreon';
-        $url = "{$params['remote_ip']}/{$centreonPath}/api/external.php?"
-            . "object=centreon_task_service&action=AddImportTaskWithParent";
+        $url = $params['http_method'] ? $params['http_method'] . "://" : "";
+        $url .= $params['remote_ip'];
+        $url .= $params['http_port'] ? ":" . $params['http_port'] : "";
+        $url .= "/{$centreonPath}/api/external.php?object=centreon_task_service&action=AddImportTaskWithParent";
 
         try {
             $curl = new \CentreonRestHttp;
             $res = $curl->call(
                 $url,
                 'POST',
-                ['parent_id' => $task->getId()]
+                ['parent_id' => $task->getId()],
+                null,
+                false,
+                $params['no_check_certificate']
             );
         } catch (\Exception $e) {
             echo "Error while creating parent task on $url\n";

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -236,10 +236,27 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         /** @var $pollerConfigurationBridge PollerConfigurationRequestBridge */
         $pollerConfigurationBridge = $this->getDi()['centreon_remote.poller_config_bridge'];
 
-        $httpMethod = parse_url($this->arguments['server_ip'], PHP_URL_SCHEME) ?: 'http';
-        $httpPort = parse_url($this->arguments['server_ip'], PHP_URL_PORT) ?: '';
+        // extract HTTP method and port from form or database if registred
+        $httpMethod = "";
+        $httpPort = "";
         $serverIP = parse_url($this->arguments['server_ip'], PHP_URL_HOST) ?: $this->arguments['server_ip'];
         $serverName = substr($this->arguments['server_name'], 0, 40);
+
+        $dbAdapter = $this->getDi()['centreon.db-manager']->getAdapter('configuration_db');
+        $sql = 'SELECT * FROM `remote_servers` WHERE `ip` = ?';
+        $dbAdapter->query($sql, [$serverIP]);
+        $hasIpInTable = (bool) $dbAdapter->count();
+
+        if (!$hasIpInTable) {
+            $httpMethod = parse_url($this->arguments['server_ip'], PHP_URL_SCHEME) ?: 'http';
+            $httpPort = parse_url($this->arguments['server_ip'], PHP_URL_PORT) ?: '';
+        } else {
+            $result = $dbAdapter->results();
+            $remoteData = reset($result);
+            $httpMethod = $remoteData->http_method;
+            $httpPort = $remoteData->http_port;
+            $noCheckCertificate = $remoteData->no_check_certificate;
+        }
 
         $serverConfigurationService->setCentralIp($this->arguments['centreon_central_ip']);
         $serverConfigurationService->setServerIp($serverIP);
@@ -337,7 +354,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
      *
      * @param $serverIP
      */
-    private function addServerToListOfRemotes($serverIP, $centreonPath, $httpMethod = 'http', $httpPort = null, $noCheckCertificate = 0)
+    private function addServerToListOfRemotes($serverIP, $centreonPath, $httpMethod, $httpPort, $noCheckCertificate)
     {
         $dbAdapter = $this->getDi()['centreon.db-manager']->getAdapter('configuration_db');
         $date = date('Y-m-d H:i:s');
@@ -347,10 +364,9 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         $hasIpInTable = (bool) $dbAdapter->count();
 
         if ($hasIpInTable) {
-            $sql = 'UPDATE `remote_servers` SET `is_connected` = ?, `connected_at` = ?, `centreon_path` = ?, ' .
-                'http_method = ?, http_port = ?, no_check_certificate = ? ' .
+            $sql = 'UPDATE `remote_servers` SET `is_connected` = ?, `connected_at` = ?, `centreon_path` = ? ' .
                 'WHERE `ip` = ?';
-            $data = ['1', $date, $centreonPath, $httpMethod, $httpPort, $noCheckCertificate, $serverIP];
+            $data = ['1', $date, $centreonPath, $serverIP];
             $dbAdapter->query($sql, $data);
         } else {
             $data = [

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -238,7 +238,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
 
         $httpMethod = parse_url($this->arguments['server_ip'], PHP_URL_SCHEME) ?: 'http';
         $httpPort = parse_url($this->arguments['server_ip'], PHP_URL_PORT) ?: '';
-        $serverIP = parse_url($this->arguments['server_ip'], PHP_URL_HOST);
+        $serverIP = parse_url($this->arguments['server_ip'], PHP_URL_HOST) ?: $this->arguments['server_ip'];
         $serverName = substr($this->arguments['server_name'], 0, 40);
 
         $serverConfigurationService->setCentralIp($this->arguments['centreon_central_ip']);
@@ -337,7 +337,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
      *
      * @param $serverIP
      */
-    private function addServerToListOfRemotes($serverIP, $centreonPath, $httpMethod, $httpPort, $noCheckCertificate)
+    private function addServerToListOfRemotes($serverIP, $centreonPath, $httpMethod = 'http', $httpPort = null, $noCheckCertificate = 0)
     {
         $dbAdapter = $this->getDi()['centreon.db-manager']->getAdapter('configuration_db');
         $date = date('Y-m-d H:i:s');
@@ -348,19 +348,22 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
 
         if ($hasIpInTable) {
             $sql = 'UPDATE `remote_servers` SET `is_connected` = ?, `connected_at` = ?, `centreon_path` = ?, ' .
-                'http_method = ?, http_port = ?, no_check_certificate = ?' .
+                'http_method = ?, http_port = ?, no_check_certificate = ? ' .
                 'WHERE `ip` = ?';
-            $data = ['1', $date, $centreonPath, $httpPort, $noCheckCertificate, $serverIP];
+            $data = ['1', $date, $centreonPath, $httpMethod, $httpPort, $noCheckCertificate, $serverIP];
             $dbAdapter->query($sql, $data);
         } else {
             $data = [
-                'ip'            => $serverIP,
-                'app_key'       => '',
-                'version'       => '',
-                'is_connected'  => '1',
-                'created_at'    => $date,
-                'connected_at'  => $date,
-                'centreon_path' => $centreonPath,
+                'ip'                   => $serverIP,
+                'app_key'              => '',
+                'version'              => '',
+                'is_connected'         => '1',
+                'created_at'           => $date,
+                'connected_at'         => $date,
+                'centreon_path'        => $centreonPath,
+                'http_method'          => $httpMethod,
+                'http_port'            => $httpPort ?: null,
+                'no_check_certificate' => $noCheckCertificate ?: 0
             ];
             $dbAdapter->insert('remote_servers', $data);
         }

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -218,7 +218,8 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
 
         $openBrokerFlow = isset($this->arguments['open_broker_flow']) && $this->arguments['open_broker_flow'] === true;
         $centreonPath = $this->arguments['centreon_folder'] ?? '/centreon/';
-        $noCheckCertificate = isset($this->arguments['no_check_certificate']) && $this->arguments['no_check_certificate'] === true;
+        $noCheckCertificate = isset($this->arguments['no_check_certificate'])
+            && $this->arguments['no_check_certificate'] === true;
         $serverWizardIdentity = new ServerWizardIdentity;
         $isRemoteConnection = $serverWizardIdentity->requestConfigurationIsRemote();
         $configurationServiceName = $isRemoteConnection ?

--- a/src/CentreonRemote/Application/Webservice/CentreonRemoteServer.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonRemoteServer.php
@@ -85,14 +85,17 @@ class CentreonRemoteServer extends CentreonWebServiceAbstract
         }
 
         $createdAt = date('Y-m-d H:i:s');
-        $insertQuery = 'INSERT INTO `remote_servers` (`ip`, `app_key`, `version`, `is_connected`, `created_at`) ';
-        $insertQuery .= "VALUES (:ip, :app_key, :version, 0, '{$createdAt}')";
+        $insertQuery = 'INSERT INTO `remote_servers` (`ip`, `app_key`, `version`, `is_connected`, `created_at`, `http_method`, `http_port`, `no_check_certificate`) ';
+        $insertQuery .= "VALUES (:ip, :app_key, :version, 0, '{$createdAt}', :http_method, :http_port, :no_check_certificate)";
 
         $insert = $this->pearDB->prepare($insertQuery);
         $bindings = [
-            ':ip'      => $ip,
-            ':app_key' => $_POST['app_key'],
-            ':version' => $_POST['version'],
+            ':ip'                   => $ip,
+            ':app_key'              => $_POST['app_key'],
+            ':version'              => $_POST['version'],
+            ':http_method'          => $_POST['http_method'] ?? 'http',
+            ':http_port'            => $_POST['http_port'] ?? null,
+            ':no_check_certificate' => $_POST['no_check_certificate'] ?? 0,
         ];
 
         try {

--- a/src/CentreonRemote/Domain/Service/ConfigurationWizard/LinkedPollerConfigurationService.php
+++ b/src/CentreonRemote/Domain/Service/ConfigurationWizard/LinkedPollerConfigurationService.php
@@ -225,7 +225,8 @@ class LinkedPollerConfigurationService
             $linkedPollersOfRemote = array_column($linkedResults, 'id');
 
             // Get IP of remote
-            $queryRemoteData = "SELECT ns.ns_ip_address as ip, rs.centreon_path FROM nagios_server as ns " .
+            $queryRemoteData = "SELECT ns.ns_ip_address as ip, rs.centreon_path, rs.http_method, rs.http_port, " .
+                " rs.no_check_certificate FROM nagios_server as ns " .
                 " JOIN remote_servers as rs ON rs.ip = ns.ns_ip_address " .
                 " WHERE ns.id = {$remoteID}";
             $remoteDataStatement = $this->db->query($queryRemoteData);
@@ -235,10 +236,13 @@ class LinkedPollerConfigurationService
             $pollerIDsToExport = array_diff($linkedPollersOfRemote, $pollerIDs);
 
             $exportParams = [
-                'server'        => $remoteID,
-                'pollers'       => $pollerIDsToExport,
-                'remote_ip'     => $remoteDataResults[0]['ip'],
-                'centreon_path' => $remoteDataResults[0]['centreon_path'],
+                'server'               => $remoteID,
+                'pollers'              => $pollerIDsToExport,
+                'remote_ip'            => $remoteDataResults[0]['ip'],
+                'centreon_path'        => $remoteDataResults[0]['centreon_path'],
+                'http_method'          => $remoteDataResults[0]['http_method'],
+                'http_port'            => $remoteDataResults[0]['http_port'],
+                'no_check_certificate' => $remoteDataResults[0]['no_check_certificate'],
             ];
             $this->taskService->addTask(Task::TYPE_EXPORT, ['params' => $exportParams]);
         }

--- a/www/class/centreonRestHttp.class.php
+++ b/www/class/centreonRestHttp.class.php
@@ -83,7 +83,7 @@ class CentreonRestHttp
      * @param bool $throwContent
      * @return array The result content
      */
-    public function call($url, $method = 'GET', $data = null, $headers = array(), $throwContent = false)
+    public function call($url, $method = 'GET', $data = null, $headers = array(), $throwContent = false, $noCheckCertificate = 0)
     {
         /* Add content type to headers */
         $headers[] = 'Content-type: ' . $this->contentType;
@@ -96,6 +96,10 @@ class CentreonRestHttp
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 30);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        if ($noCheckCertificate) {
+            curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+        }
 
         if (!is_null($this->proxy)) {
             curl_setopt($ch, CURLOPT_PROXY, $this->proxy);

--- a/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
+++ b/www/front_src/src/components/forms/remoteServer/RemoteServerFormStepOne.js
@@ -3,6 +3,7 @@ import { Field, reduxForm as connectForm } from "redux-form";
 import InputField from "../../form-fields/InputField";
 import SelectField from "../../form-fields/SelectField";
 import RadioField from "../../form-fields/PreselectedRadioField";
+import CheckboxField from "../../form-fields/CheckboxField";
 import {Translate} from 'react-redux-i18n';
 import {I18n} from "react-redux-i18n";
 
@@ -111,6 +112,11 @@ class RemoteServerFormStepOne extends Component {
                   placeholder="/centreon/"
                   label={I18n.t("Centreon Web Folder on Remote") + ":"}
                 />
+                <Field
+                  name="no_check_certificate"
+                  component={CheckboxField}
+                  label={I18n.t("Do not check SSL certificate validation")}
+                />
               </div>
             ) : null}
 
@@ -174,6 +180,11 @@ class RemoteServerFormStepOne extends Component {
                   type="text"
                   placeholder="/centreon/"
                   label={I18n.t("Centreon Web Folder on Remote") + ":"}
+                />
+                <Field
+                  name="no_check_certificate"
+                  component={CheckboxField}
+                  label={I18n.t("Do not check SSL certificate validation")}
                 />
               </div>
             ) : null}

--- a/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -79,9 +79,11 @@ $pollers = explode(',', $_POST['poller']);
 // Add task to export files if there is a remote
 $idBindString = str_repeat('?,', count($pollers));
 $idBindString = rtrim($idBindString, ',');
-$queryRemotes = "SELECT ns.id, ns.ns_ip_address as ip, rs.centreon_path FROM nagios_server as ns
-    JOIN remote_servers as rs ON rs.ip = ns.ns_ip_address
-    WHERE ns.id IN({$idBindString})";
+$queryRemotes = "SELECT ns.id, ns.ns_ip_address AS ip,
+    rs.centreon_path, rs.http_method, rs.http_port, rs.no_check_certificate
+    FROM nagios_server AS ns
+    JOIN remote_servers AS rs ON rs.ip = ns.ns_ip_address
+    WHERE ns.id IN ({$idBindString})";
 
 $remotesStatement = $pearDB->query($queryRemotes, $pollers);
 $remotesResults = $remotesStatement->fetchAll(PDO::FETCH_ASSOC);
@@ -93,10 +95,13 @@ if (!empty($remotesResults)) {
         $linkedResults = $linkedStatement->fetchAll(PDO::FETCH_ASSOC);
 
         $exportParams = [
-            'server'        => $remote['id'],
-            'remote_ip'     => $remote['ip'],
-            'centreon_path' => $remote['centreon_path'],
-            'pollers' => []
+            'server'               => $remote['id'],
+            'remote_ip'            => $remote['ip'],
+            'centreon_path'        => $remote['centreon_path'],
+            'http_method'          => $remote['http_method'],
+            'http_port'            => $remode['http_port'] ?: null,
+            'no_check_certificate' => $remote['no_check_certificate'],
+            'pollers'              => []
         ];
 
         if (!empty($linkedResults)) {

--- a/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -99,7 +99,7 @@ if (!empty($remotesResults)) {
             'remote_ip'            => $remote['ip'],
             'centreon_path'        => $remote['centreon_path'],
             'http_method'          => $remote['http_method'],
-            'http_port'            => $remode['http_port'] ?: null,
+            'http_port'            => $remote['http_port'] ?: null,
             'no_check_certificate' => $remote['no_check_certificate'],
             'pollers'              => []
         ];

--- a/www/include/configuration/configServers/formServers.ihtml
+++ b/www/include/configuration/configServers/formServers.ihtml
@@ -20,17 +20,22 @@
       </td>
     </tr>
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="name"> {$form.name.label}</td><td class="FormRowValue">{$form.name.html}</td></tr>
-    <tr class="list_lvl_1">
-      <td class="ListColLvl1_name" colspan="2">
-        <h4>{$genOpt_nagios_version}</h4>
-      </td>
-    </tr>
 		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ns_ip_address"> {$form.ns_ip_address.label}</td><td class="FormRowValue">{$form.ns_ip_address.html}</td></tr>
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="localhost"> {$form.localhost.label}</td><td class="FormRowValue">{$form.localhost.html}</td></tr>
 		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="is_default"> {$form.is_default.label}</td><td class="FormRowValue">{$form.is_default.html}</td></tr>
 		{if $form.remote_id.label}
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="remote_id"> {$form.remote_id.label}</td><td class="FormRowValue">{$form.remote_id.html}</td></tr>
 		{/if}
+    {if $form.header.Remote_Configuration.label}
+    <tr class="list_lvl_1">
+      <td class="ListColLvl1_name" colspan="2">
+        <h4>{$form.header.Remote_Configuration}</h4>
+      </td>
+      <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="http_method"> {$form.http_method.label}</td><td class="FormRowValue">{$form.http_method.html}</td></tr>
+      <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="http_port"> {$form.http_port.label}</td><td class="FormRowValue">{$form.http_port.html}</td></tr>
+      <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="no_check_certificate"> {$form.no_check_certificate.label}</td><td class="FormRowValue">{$form.no_check_certificate.html}</td></tr>
+    </tr>
+    {/if}
 		<tr class="list_lvl_1">
       <td class="ListColLvl1_name" colspan="2">
         <h4>{$form.header.SSH_Informations}</h4>

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -72,6 +72,13 @@ if (($o == SERVER_MODIFY || $o == SERVER_WATCH) && $server_id) {
     } elseif (in_array($cfg_server['ns_ip_address'], $remotesServerIPs)) {
         $serverType = "remote";
     }
+
+    if ($serverType == "remote") {
+        $DBRESULT = $pearDB->query("SELECT http_method, http_port, no_check_certificate " .
+            "FROM `remote_servers` WHERE `ip` = '" . $cfg_server['ns_ip_address'] . "' LIMIT 1");
+        $cfg_server = array_merge($cfg_server, array_map("myDecode", $DBRESULT->fetchRow()));
+        $DBRESULT->closeCursor();
+    }
 }
 
 /*
@@ -136,6 +143,23 @@ $form->addElement('header', 'SSH_Informations', _("SSH Information"));
 $form->addElement('header', 'Nagios_Informations', _("Monitoring Engine Information"));
 $form->addElement('header', 'Misc', _("Miscelleneous"));
 $form->addElement('header', 'Centreontrapd', _("Centreon Trap Collector"));
+
+/*
+ * form for Remote Server
+ */
+if (strcmp($serverType, 'remote') ==  0) {
+    $form->addElement('header', 'Remote_Configuration', _("Remote Server Configuration"));
+    $aMethod = array(
+        'http' => 'http',
+        'https' => 'https'
+    );
+    $form->addElement('select', 'http_method', _("HTTP Method"), $aMethod);
+    $form->addElement('text', 'http_port', _("HTTP Port"), $attrsText3);
+    $Tab = array();
+    $Tab[] = $form->createElement('radio', 'no_check_certificate', null, _("Yes"), '1');
+    $Tab[] = $form->createElement('radio', 'no_check_certificate', null, _("No"), '0');
+    $form->addGroup($Tab, 'no_check_certificate', _("Do not check SSL certificate validation"), '&nbsp;');
+}
 
 /*
  * Poller Configuration basic information

--- a/www/include/configuration/configServers/help.php
+++ b/www/include/configuration/configServers/help.php
@@ -30,3 +30,15 @@ $help['pollercmd'] = dgettext(
         . "Make sure to have sufficient rights for the Apache user to run these commands."
 );
 $help['description'] = dgettext("help", "Short description of the poller");
+$help['http_method'] = dgettext(
+    "help",
+    "What kind of method is needed to contact the Remote Server (HTTP/HTTPS)?"
+);
+$help['http_port'] = dgettext(
+    "help",
+    "On which TCP port is listening the Remote Server?"
+);
+$help['no_check_certificate'] = dgettext(
+    "help",
+    "Do not check the validity of the SSL certificate of the Remote Server"
+);

--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -2377,7 +2377,10 @@ CREATE TABLE IF NOT EXISTS `remote_servers` (
   `is_connected` TINYINT(1) NOT NULL DEFAULT 0,
   `created_at` TIMESTAMP NOT NULL,
   `connected_at` TIMESTAMP NULL,
-  `centreon_path` VARCHAR(255) NULL
+  `centreon_path` VARCHAR(255) NULL,
+  `http_method` enum('http','https') NOT NULL DEFAULT 'http',
+  `http_port` int(11) DEFAULT NULL,
+  `no_check_certificate` enum('0','1') NOT NULL DEFAULT '1'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 

--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -2380,7 +2380,7 @@ CREATE TABLE IF NOT EXISTS `remote_servers` (
   `centreon_path` VARCHAR(255) NULL,
   `http_method` enum('http','https') NOT NULL DEFAULT 'http',
   `http_port` int(11) DEFAULT NULL,
-  `no_check_certificate` enum('0','1') NOT NULL DEFAULT '1'
+  `no_check_certificate` enum('0','1') NOT NULL DEFAULT '0'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 

--- a/www/install/sql/centreon/Update-DB-19.04.0.sql
+++ b/www/install/sql/centreon/Update-DB-19.04.0.sql
@@ -22,7 +22,7 @@ DELETE FROM topology WHERE topology_name = "CSS" AND topology_parent = 501 AND t
 -- removing unfriendly title from Logs menu
 DELETE FROM topology WHERE topology_name = "Visualisation" AND topology_parent = 508 AND topology_page = 50801;
 
-
-
-
-
+-- Add HTTPS connexion to Remote Server
+ALTER TABLE remote_servers ADD COLUMN `http_method` enum('http','https') NOT NULL DEFAULT 'http';
+ALTER TABLE remote_servers ADD COLUMN `http_port` int(11) NULL DEFAULT NULL;
+ALTER TABLE remote_servers ADD COLUMN `no_check_certificate` enum('0','1') NOT NULL DEFAULT '1';

--- a/www/install/sql/centreon/Update-DB-19.04.0.sql
+++ b/www/install/sql/centreon/Update-DB-19.04.0.sql
@@ -25,4 +25,4 @@ DELETE FROM topology WHERE topology_name = "Visualisation" AND topology_parent =
 -- Add HTTPS connexion to Remote Server
 ALTER TABLE remote_servers ADD COLUMN `http_method` enum('http','https') NOT NULL DEFAULT 'http';
 ALTER TABLE remote_servers ADD COLUMN `http_port` int(11) NULL DEFAULT NULL;
-ALTER TABLE remote_servers ADD COLUMN `no_check_certificate` enum('0','1') NOT NULL DEFAULT '1';
+ALTER TABLE remote_servers ADD COLUMN `no_check_certificate` enum('0','1') NOT NULL DEFAULT '0';


### PR DESCRIPTION
<h2> Description </h2>

Add the possibility to use HTTP/HTTPS and change the TCP port for communication between the Centreon Central Server and the Remote Server during addTask to import
Add also the possibility to disable SSL certificate validation.

Complete PR #7349

<h2> Type of change </h2>

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Enable only HTTPS on Remote Server
Generate configuration of the Remote Server

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
