### PR TITLE
fix(UI): correctly compute downtime duration & end date

### DIFF
--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -61,8 +61,9 @@ function initDatepicker(className, altFormat, defaultDate, idName, timestampToSe
             // finding all the alternative field
             var altName = jQuery(this).attr("name");
             if (typeof(altName) != "undefined") {
-                var alternativeField = "input[name=alternativeDate" + altName[0].toUpperCase() + altName.slice(1) + "]";
-                var value = $(this) && $(this).val() ? $(this).val() : defaultDate;
+                var alternativeName = "alternativeDate" + altName[0].toUpperCase() + altName.slice(1);
+                var alternativeField = "input[name=" + alternativeName + "]";
+                var value = $('input[name='+alternativeName+']').val() ? new Date($('input[name='+alternativeName+']').val()) : ($(this) && $(this).val() ? $(this).val() : defaultDate);
                 jQuery(this).datepicker({
                     //formatting the hidden fields using a specific format
                     altField: alternativeField,

--- a/www/include/monitoring/downtime/AddDowntime.php
+++ b/www/include/monitoring/downtime/AddDowntime.php
@@ -283,11 +283,30 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
         )
     );
 
+    $durationScale = array(
+        'd' => 86400,
+        'h' => 3600,
+        'm' => 60,
+        's' => 1,
+    );
     $defaultDuration = 3600;
-    if (isset($centreon->optGen['monitoring_dwt_duration']) && $centreon->optGen['monitoring_dwt_duration']) {
+    $defaultScale = 's';
+    if (isset($centreon->optGen['monitoring_dwt_duration']) &&
+        $centreon->optGen['monitoring_dwt_duration']
+    ) {
         $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
+        if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
+            $centreon->optGen['monitoring_dwt_duration_scale']
+        ) {
+            $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
+        }
     }
     $form->setDefaults(array('duration' => $defaultDuration));
+    $form->setDefaults(
+        array(
+            "alternativeDateEnd" => $centreonGMT->getDate("Y-m-d", time() + $defaultDuration * $durationScale[$defaultScale], $gmt)
+        )
+    );
 
     $form->addElement(
         'select',
@@ -320,7 +339,7 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
         $gmt = date_default_timezone_get();
     }
     $data["start_time"] = $centreonGMT->getDate("G:i", time(), $gmt);
-    $data["end_time"] = $centreonGMT->getDate("G:i", time() + 7200, $gmt);
+    $data["end_time"] = $centreonGMT->getDate("G:i", time() + $defaultDuration * $durationScale[$defaultScale], $gmt);
     $data["host_or_hg"] = 1;
     $data["with_services"] = $centreon->optGen['monitoring_dwt_svc'];
 

--- a/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -139,10 +139,17 @@ if (!$gmt) {
     $gmt = date_default_timezone_get();
 }
 
+$defaultDuration = 3600;
+if (isset($centreon->optGen['monitoring_dwt_duration']) &&
+    $centreon->optGen['monitoring_dwt_duration']
+) {
+    $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
+}
+
 $form->setDefaults(
     array(
         "start_time" => $centreonGMT->getDate("G:i", time(), $gmt),
-        "end_time" => $centreonGMT->getDate("G:i", time() + 7200, $gmt)
+        "end_time" => $centreonGMT->getDate("G:i", time() + $defaultDuration, $gmt)
     )
 );
 
@@ -156,12 +163,6 @@ $form->addElement(
         'disabled' => 'true'
     )
 );
-$defaultDuration = 3600;
-if (isset($centreon->optGen['monitoring_dwt_duration']) &&
-    $centreon->optGen['monitoring_dwt_duration']
-) {
-    $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
-}
 $form->setDefaults(array('duration' => $defaultDuration));
 
 $scaleChoices = array(

--- a/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -263,7 +263,11 @@ $form->addElement(
         'class' => 'alternativeDate'
     )
 );
-
+$form->setDefaults(
+    array(
+        "alternativeDateEnd" => $centreonGMT->getDate("Y-m-d", time() + $defaultDuration, $gmt)
+    )
+);
 
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $renderer->setRequiredTemplate('{$label}&nbsp;<font color="red" size="1">*</font>');

--- a/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -139,17 +139,29 @@ if (!$gmt) {
     $gmt = date_default_timezone_get();
 }
 
+$durationScale = array(
+    'd' => 86400,
+    'h' => 3600,
+    'm' => 60,
+    's' => 1,
+);
 $defaultDuration = 3600;
+$defaultScale = 's';
 if (isset($centreon->optGen['monitoring_dwt_duration']) &&
     $centreon->optGen['monitoring_dwt_duration']
 ) {
     $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
+    if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
+        $centreon->optGen['monitoring_dwt_duration_scale']
+    ) {
+        $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
+    }
 }
 
 $form->setDefaults(
     array(
         "start_time" => $centreonGMT->getDate("G:i", time(), $gmt),
-        "end_time" => $centreonGMT->getDate("G:i", time() + $defaultDuration, $gmt)
+        "end_time" => $centreonGMT->getDate("G:i", time() + $defaultDuration * $durationScale[$defaultScale], $gmt)
     )
 );
 
@@ -265,7 +277,7 @@ $form->addElement(
 );
 $form->setDefaults(
     array(
-        "alternativeDateEnd" => $centreonGMT->getDate("Y-m-d", time() + $defaultDuration, $gmt)
+        "alternativeDateEnd" => $centreonGMT->getDate("Y-m-d", time() + $defaultDuration * $durationScale[$defaultScale], $gmt)
     )
 );
 


### PR DESCRIPTION
Hi,

<h2> Description </h2>

This PR solves a datepicker issue where end date of downtime is wrongly computed when downtime is across several days.
All details given in #7337.

Fixes #7337.

While here, also fixes #5963, setting default downtime duration to the configured global option.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Set a downtime and verify that the default fixed duration is the one set in Administration / Parameters / Monitoring / Default downtime settings / Duration.

Set it long enough so that downtime will be across 2 days. Set a downtime again and verify that the downtime end date is correctly computed.

Thank you 👍 