### PR TITLE
fix(UI): correctly toggle edit when widgets load

### DIFF
--- a/www/include/home/customViews/index.ihtml
+++ b/www/include/home/customViews/index.ihtml
@@ -869,6 +869,9 @@ jQuery(function () {
                 window.location.reload();
             }
           },
+          load: function( event, ui ) {
+              toggleEdit(defaultShow);
+          },
           activate: function( event, ui ) {
             tabLoops++;
             columnClass = null;

--- a/www/include/home/customViews/index.ihtml
+++ b/www/include/home/customViews/index.ihtml
@@ -579,7 +579,7 @@ function toggleEdit(show) {
     jQuery('#actionBar').hide();
     jQuery('.portlet-header').each(function(index) {
       var widgetTitle = jQuery(this).find('.widgetTitle').text().trim();
-      if (widgetTitle == 'Click to edit' || widgetTitle == '') {
+      if (widgetTitle == 'Click to edit') {
         jQuery(this).hide();
       } else {
         jQuery(this).find('.ui-icon-wrench').hide();

--- a/www/include/home/customViews/index.ihtml
+++ b/www/include/home/customViews/index.ihtml
@@ -582,7 +582,8 @@ function toggleEdit(show) {
       if (widgetTitle == 'Click to edit' || widgetTitle == '') {
         jQuery(this).hide();
       } else {
-        jQuery(this).find('.ui-icon').hide();
+        jQuery(this).find('.ui-icon-wrench').hide();
+        jQuery(this).find('.ui-icon-trash').hide();
       }
     });
     $el.find('img').attr('src','./img/icons/edit_mode.png');
@@ -591,7 +592,8 @@ function toggleEdit(show) {
       $el.addClass('edit');
     jQuery('.portlet-header').each(function() {
         jQuery(this).show();
-        jQuery(this).find('.ui-icon').show();
+        jQuery(this).find('.ui-icon-wrench').show();
+        jQuery(this).find('.ui-icon-trash').show();
     });
     $el.find('img').attr('src','./img/icons/no_edit_mode.png');
   }

--- a/www/include/home/customViews/index.ihtml
+++ b/www/include/home/customViews/index.ihtml
@@ -869,7 +869,7 @@ jQuery(function () {
             }
           },
           load: function( event, ui ) {
-              toggleEdit(defaultShow);
+              toggleEdit(jQuery('.toggleEdit').hasClass('edit'));
           },
           activate: function( event, ui ) {
             tabLoops++;

--- a/www/include/home/customViews/index.ihtml
+++ b/www/include/home/customViews/index.ihtml
@@ -671,7 +671,6 @@ function removeUsergroupFromView(usergroup_id) {
 
 jQuery(function () {
   jQuery('#tabs').tabs();
-  toggleEdit(defaultShow);
 
   /* Initialize buttons */
   jQuery('.addView').button({icon: "ui-icon-plus"}).on('click', function () {


### PR DESCRIPTION
Hi,

<h2> Description </h2>

When widgets page load, edit mode is disabled, but every widget edit mode remains enabled, as shown in the screenshot below. This PR then fixes this.

![55336917-01023a80-549e-11e9-940c-2866a4f4099c](https://user-images.githubusercontent.com/40244829/59961621-7a785a80-94da-11e9-9a5e-8526823786cc.png)

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Display widgets pages and be sure edit buttons are hidden for every widget.

Thank you 👍

Edit : issue still present in 19.10.1.