### PR TITLE
Improve ceip install update

### DIFF
--- a/cron/centreon-send-stats.php
+++ b/cron/centreon-send-stats.php
@@ -40,6 +40,10 @@ if ($sendStatistics && $isRemote !== 'yes') {
         'timezone' => $timez
     );
 
-    $returnData = $http->call(CENTREON_STATS_URL, 'POST', $data, array(), true);
-    echo "statusCode :" . $returnData['statusCode'] . ',body : ' . $returnData['body'];
+    try {
+        $returnData = $http->call(CENTREON_STATS_URL, 'POST', $data, array(), true);
+        echo "statusCode :" . $returnData['statusCode'] . ',body : ' . $returnData['body'];
+    } catch (Exception $e) {
+        echo 'Caught exception: ',  $e->getMessage(), "\n";
+    }
 }

--- a/cron/centreon-send-stats.php
+++ b/cron/centreon-send-stats.php
@@ -44,6 +44,6 @@ if ($sendStatistics && $isRemote !== 'yes') {
         $returnData = $http->call(CENTREON_STATS_URL, 'POST', $data, array(), true);
         echo "statusCode :" . $returnData['statusCode'] . ',body : ' . $returnData['body'];
     } catch (Exception $e) {
-        echo 'Caught exception: ',  $e->getMessage(), "\n";
+        echo 'Caught exception: ' .  $e->getMessage() . '\n';
     }
 }

--- a/www/install/step_upgrade/process/process_step5.php
+++ b/www/install/step_upgrade/process/process_step5.php
@@ -37,15 +37,18 @@ session_start();
 require_once __DIR__ . '/../../../../bootstrap.php';
 
 $parameters = filter_input_array(INPUT_POST);
-if ((int)$parameters["send_statistics"] == 1) {
-    $query = "INSERT INTO options (`key`, `value`) VALUES ('send_statistics', '1')";
-} else {
-    $query = "INSERT INTO options (`key`, `value`) VALUES ('send_statistics', '0')";
-}
 
-$db = $dependencyInjector['configuration_db'];
-$db->query("DELETE FROM options WHERE `key` = 'send_statistics'");
-$db->query($query);
+if ($parameters) {
+    if ((int)$parameters["send_statistics"] == 1) {
+        $query = "INSERT INTO options (`key`, `value`) VALUES ('send_statistics', '1')";
+    } else {
+        $query = "INSERT INTO options (`key`, `value`) VALUES ('send_statistics', '0')";
+    }
+
+    $db = $dependencyInjector['configuration_db'];
+    $db->query("DELETE FROM options WHERE `key` = 'send_statistics'");
+    $db->query($query);
+}
 
 $name = 'install-' . $_SESSION['CURRENT_VERSION'] . '-' . date('Ymd_His');
 $completeName = $centreon_path . '/installDir/' . $name;

--- a/www/install/step_upgrade/process/process_step5.php
+++ b/www/install/step_upgrade/process/process_step5.php
@@ -39,7 +39,7 @@ require_once __DIR__ . '/../../../../bootstrap.php';
 $parameters = filter_input_array(INPUT_POST);
 
 if ($parameters) {
-    if ((int)$parameters["send_statistics"] == 1) {
+    if ((int)$parameters["send_statistics"] === 1) {
         $query = "INSERT INTO options (`key`, `value`) VALUES ('send_statistics', '1')";
     } else {
         $query = "INSERT INTO options (`key`, `value`) VALUES ('send_statistics', '0')";

--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -51,7 +51,7 @@ $template = getTemplate('templates');
 
 /* If CEIP is disabled and if is major version of Centreon ask again */
 $aVersion = explode ('.', $_SESSION['CURRENT_VERSION']);
-if (($stat === false || (int)$stat['value'] != 1) && (int)$aVersion[2] == 0) {
+if ((int)$stat['value'] != 1 && (int)$aVersion[2] === 0) {
     $stat = false;
 }
 

--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -49,6 +49,12 @@ $res = $db->query("SELECT `value` FROM `options` WHERE `key` = 'send_statistics'
 $stat = $res->fetch();
 $template = getTemplate('templates');
 
+/* If CEIP is disabled and if is major version of Centreon ask again */
+$aVersion = explode ('.', $_SESSION['CURRENT_VERSION']);
+if (($stat === false || (int)$stat['value'] != 1) && (int)$aVersion[2] == 0) {
+    $stat = false;
+}
+
 $title = _('Upgrade finished');
 
 $centreon_path = realpath(dirname(__FILE__) . '/../../../');

--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -49,7 +49,7 @@ $res = $db->query("SELECT `value` FROM `options` WHERE `key` = 'send_statistics'
 $stat = $res->fetch();
 $template = getTemplate('templates');
 
-/* If CEIP is disabled and if is major version of Centreon ask again */
+/* If CEIP is disabled and if it's a major version of Centreon ask again */
 $aVersion = explode ('.', $_SESSION['CURRENT_VERSION']);
 if ((int)$stat['value'] != 1 && (int)$aVersion[2] === 0) {
     $stat = false;


### PR DESCRIPTION
<h2> Description </h2>

- Fix bug on update, manage $parameters["send_statistics"] only if form appears or keep last value in DB.
- Ask to participate to CEIP on major release version if 'send_statistics' never exist in DB or if it was disabled.
- Prevent centreonRestHTTP exception in logs:

```
# /opt/rh/rh-php71/root/bin/php /usr/share/centreon/cron/centreon-send-stats.php
PHP Fatal error:  Uncaught RestNotFoundException: Page not found in /usr/share/centreon/www/class/centreonRestHttp.class.php:185
Stack trace:
#0 /usr/share/centreon/cron/centreon-send-stats.php(43): CentreonRestHttp->call('https://sstatis...', 'POST', Array, Array, true)
#1 {main}
  thrown in /usr/share/centreon/www/class/centreonRestHttp.class.php on line 185
```

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Have a Centreon version 18.10.x (x > 0) and update to 18.10.y (y > x), the participation to CEIP must appears if value is not present in DB

Update to 19.04:
- if program is disabled or not present, CEIP program is displayed
- if program is enable, nothing appears

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I I have made corresponding changes to the **documentation**.
- [x] I I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
