### PR TITLE
Mon 3659 mediawiki configuration and pagination

### DIFF
--- a/www/class/centreon-knowledge/procedures.class.php
+++ b/www/class/centreon-knowledge/procedures.class.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2011 MERETHIS
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give MERETHIS
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of MERETHIS choice, provided that
- * MERETHIS also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -151,11 +151,12 @@ class procedures
      */
     public function getMyHostID($host_name = null)
     {
-        $query = "SELECT host_id FROM host " .
+        $dbResult = $this->centreon_DB->query(
+            "SELECT host_id FROM host " .
             "WHERE host_name = '" . $host_name . "' " .
-            "LIMIT 1 ";
-        $DBRESULT = $this->centreon_DB->query($query);
-        $row = $DBRESULT->fetchRow();
+            "LIMIT 1 "
+        );
+        $row = $dbResult->fetch();
         if ($row["host_id"]) {
             return $row["host_id"];
         }
@@ -171,22 +172,26 @@ class procedures
     {
         $tplArr = array();
 
-        $DBRESULT = $this->centreon_DB->query("SELECT service_description, service_template_model_stm_id
-                                                FROM service
-                                                WHERE service_id = '" . $service_id . "' LIMIT 1");
-        $row = $DBRESULT->fetchRow();
+        $dbResult = $this->centreon_DB->query(
+            "SELECT service_description, service_template_model_stm_id " .
+            "FROM service " .
+            "WHERE service_id = '" . $service_id . "' LIMIT 1"
+        );
+        $row = $dbResult->fetch();
         if (isset($row['service_template_model_stm_id']) && $row['service_template_model_stm_id'] != "") {
-            $DBRESULT->closeCursor();
+            $dbResult->closeCursor();
             $service_id = $row["service_template_model_stm_id"];
             if ($row["service_description"]) {
                 $tplArr[$service_id] = html_entity_decode($row["service_description"], ENT_QUOTES);
             }
             while (1) {
-                $DBRESULT = $this->centreon_DB->query("SELECT service_description, service_template_model_stm_id
-                                                        FROM service
-                                                        WHERE service_id = '" . $service_id . "' LIMIT 1");
-                $row = $DBRESULT->fetchRow();
-                $DBRESULT->closeCursor();
+                $dbResult = $this->centreon_DB->query(
+                    "SELECT service_description, service_template_model_stm_id " .
+                    "FROM service " .
+                    "WHERE service_id = '" . $service_id . "' LIMIT 1"
+                );
+                $row = $dbResult->fetch();
+                $dbResult->closeCursor();
                 if ($row["service_description"]) {
                     $tplArr[$service_id] = html_entity_decode($row["service_description"], ENT_QUOTES);
                 } else {
@@ -215,15 +220,19 @@ class procedures
         }
 
         $tplArr = array();
-        $DBRESULT = $this->centreon_DB->query("SELECT host_tpl_id
-                                              FROM `host_template_relation`
-                                              WHERE host_host_id = '" . $host_id . "'
-                                              ORDER BY `order`");
-        while ($row = $DBRESULT->fetchRow()) {
-            $DBRESULT2 = $this->centreon_DB->query("SELECT host_name
-                                                    FROM host
-                                                    WHERE host_id = '" . $row['host_tpl_id'] . "' LIMIT 1");
-            $hTpl = $DBRESULT2->fetchRow();
+        $dbResult = $this->centreon_DB->query(
+            "SELECT host_tpl_id " .
+            "FROM `host_template_relation` " .
+            "WHERE host_host_id = '" . $host_id . "' " .
+            "ORDER BY `order`"
+        );
+        while ($row = $dbResult->fetch()) {
+            $dbResult2 = $this->centreon_DB->query(
+                "SELECT host_name " .
+                "FROM host " .
+                "WHERE host_id = '" . $row['host_tpl_id'] . "' LIMIT 1"
+            );
+            $hTpl = $dbResult2->fetch();
             $tplArr[$row['host_tpl_id']] = html_entity_decode($hTpl["host_name"], ENT_QUOTES);
         }
         unset($row);
@@ -241,20 +250,22 @@ class procedures
         /*
          * Get Host Informations
          */
-        $DBRESULT = $this->centreon_DB->query("SELECT host_name, host_id, host_register, ehi_icon_image
-                                                FROM host, extended_host_information ehi
-                                                WHERE host.host_id = ehi.host_host_id
-                                                ORDER BY host_name");
-        while ($data = $DBRESULT->fetchRow()) {
+        $dbResult = $this->centreon_DB->query(
+            "SELECT host_name, host_id, host_register, ehi_icon_image " .
+            "FROM host, extended_host_information ehi " .
+            "WHERE host.host_id = ehi.host_host_id " .
+            "ORDER BY host_name"
+        );
+        while ($data = $dbResult->fetch()) {
             if ($data["host_register"] == 1) {
                 $this->hostList[$data["host_name"]] = $data["host_id"];
             } else {
                 $this->hostTplList[$data["host_name"]] = $data["host_id"];
             }
-            $this->hostIconeList["Host_:_" . $data["host_name"]] =
-                "./img/media/" . $this->getImageFilePath($data["ehi_icon_image"]);
+            $this->hostIconeList["Host_:_" . $data["host_name"]]
+                = "./img/media/" . $this->getImageFilePath($data["ehi_icon_image"]);
         }
-        $DBRESULT->closeCursor();
+        $dbResult->closeCursor();
         unset($data);
     }
 
@@ -267,16 +278,22 @@ class procedures
     public function getImageFilePath($image_id)
     {
         if (isset($image_id) && $image_id) {
-            $DBRESULT2 = $this->centreon_DB->query("SELECT img_path, dir_alias
-                                                   FROM view_img vi, view_img_dir vid, view_img_dir_relation vidr
-                                                   WHERE vi.img_id = " . $image_id . "
-                                                   AND vidr.img_img_id = vi.img_id
-                                                   AND vid.dir_id = vidr.dir_dir_parent_id LIMIT 1");
-            $row2 = $DBRESULT2->fetchRow();
-            if (isset($row2["dir_alias"]) && isset($row2["img_path"]) && $row2["dir_alias"] && $row2["img_path"]) {
+            $dbResult2 = $this->centreon_DB->query(
+                "SELECT img_path, dir_alias " .
+                "FROM view_img vi, view_img_dir vid, view_img_dir_relation vidr " .
+                "WHERE vi.img_id = " . $image_id . " " .
+                "AND vidr.img_img_id = vi.img_id " .
+                "AND vid.dir_id = vidr.dir_dir_parent_id LIMIT 1"
+            );
+            $row2 = $dbResult2->fetch();
+            if (isset($row2["dir_alias"])
+                && isset($row2["img_path"])
+                && $row2["dir_alias"]
+                && $row2["img_path"]
+            ) {
                 return $row2["dir_alias"] . "/" . $row2["img_path"];
             }
-            $DBRESULT2->closeCursor();
+            $dbResult2->closeCursor();
             unset($row2);
         } else {
             return "../icones/16x16/server_network.gif";
@@ -290,13 +307,15 @@ class procedures
      */
     public function setServiceInformations()
     {
-        $DBRESULT = $this->centreon_DB->query("SELECT service_description, service_id, service_register
-                                                FROM service WHERE service_register = '0'
-                                                ORDER BY service_description");
-        while ($data = $DBRESULT->fetchRow()) {
+        $dbResult = $this->centreon_DB->query(
+            "SELECT service_description, service_id, service_register " .
+            "FROM service WHERE service_register = '0' " .
+            "ORDER BY service_description"
+        );
+        while ($data = $dbResult->fetch()) {
             $this->serviceTplList["Service_:_" . $data["service_description"]] = $data["service_id"];
         }
-        $DBRESULT->closeCursor();
+        $dbResult->closeCursor();
         unset($data);
     }
 

--- a/www/class/centreon-knowledge/procedures_Proxy.class.php
+++ b/www/class/centreon-knowledge/procedures_Proxy.class.php
@@ -1,13 +1,35 @@
 <?php
 /*
- * MERETHIS
+ * Copyright 2005-2019 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
  *
- * Source Copyright 2005-2010 MERETHIS
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
  *
- * Unauthorized reproduction, copy and distribution
- * are not allowed.
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
  *
- * For more information : contact@merethis.com
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give CENTREON
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
+ *
+ * For more information : contact@centreon.com
  *
  */
 
@@ -61,8 +83,10 @@ class procedures_Proxy
      */
     private function getHostId($hostName)
     {
-        $result = $this->DB->query("SELECT host_id FROM host WHERE host_name LIKE '" . $hostName . "' ");
-        $row = $result->fetchRow();
+        $result = $this->DB->query(
+            "SELECT host_id FROM host WHERE host_name LIKE '" . $hostName . "' "
+        );
+        $row = $result->fetch();
         $hostId = 0;
         if ($row["host_id"]) {
             $hostId = $row["host_id"];
@@ -80,29 +104,31 @@ class procedures_Proxy
         /*
          * Get Services attached to hosts
          */
-        $query = "SELECT s.service_id " .
+        $result = $this->DB->query(
+            "SELECT s.service_id " .
             "FROM host h, service s, host_service_relation hsr " .
             "WHERE hsr.host_host_id = h.host_id " .
             "AND hsr.service_service_id = service_id " .
             "AND h.host_name LIKE '" . $hostName . "' " .
-            "AND s.service_description LIKE '" . $serviceDescription . "' ";
-        $result = $this->DB->query($query);
-        while ($row = $result->fetchRow()) {
+            "AND s.service_description LIKE '" . $serviceDescription . "' "
+        );
+        while ($row = $result->fetch()) {
             return $row["service_id"];
         }
         $result->closeCursor();
         /*
          * Get Services attached to hostgroups
          */
-        $query = "SELECT s.service_id " .
+        $result = $this->DB->query(
+            "SELECT s.service_id " .
             "FROM hostgroup_relation hgr, host h, service s, host_service_relation hsr " .
             "WHERE hgr.host_host_id = h.host_id " .
             "AND hsr.hostgroup_hg_id = hgr.hostgroup_hg_id " .
             "AND h.host_name LIKE '" . $hostName . "' " .
             "AND service_id = hsr.service_service_id " .
-            "AND service_description LIKZ '" . $serviceDescription . "' ";
-        $result = $this->DB->query($query);
-        while ($row = $result->fetchRow()) {
+            "AND service_description LIKE '" . $serviceDescription . "' "
+        );
+        while ($row = $result->fetch()) {
             return $row["service_id"];
         }
         $result->closeCursor();

--- a/www/class/centreon-knowledge/wiki.class.php
+++ b/www/class/centreon-knowledge/wiki.class.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2017 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give Centreon
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of Centreon choice, provided that
- * Centreon also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -33,7 +33,7 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . "/../../../config/centreon.config.php");
+require_once realpath(__DIR__ . "/../../../config/centreon.config.php");
 require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
 
 class Wiki
@@ -58,8 +58,10 @@ class Wiki
 
         $options = array();
 
-        $res = $this->db->query("SELECT * FROM `options` WHERE options.key LIKE 'kb_%'");
-        while ($opt = $res->fetchRow()) {
+        $res = $this->db->query(
+            "SELECT * FROM `options` WHERE options.key LIKE 'kb_%'"
+        );
+        while ($opt = $res->fetch()) {
             $options[$opt["key"]] = html_entity_decode($opt["value"], ENT_QUOTES, "UTF-8");
         }
         $res->closeCursor();

--- a/www/class/centreon-knowledge/wikiApi.class.php
+++ b/www/class/centreon-knowledge/wikiApi.class.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2017 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give Centreon
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of Centreon choice, provided that
- * Centreon also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -33,11 +33,9 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . "/../../../config/centreon.config.php");
+require_once realpath(__DIR__ . "/../../../config/centreon.config.php");
 require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreon-knowledge/wiki.class.php";
-
-//require_once _CENTREON_PATH_ . "/www/class/centreon-knowledge/procedures.class.php";
 
 class WikiApi
 {
@@ -428,15 +426,17 @@ class WikiApi
      */
     public function updateLinkForHost($hostName)
     {
-        $querySelect = "SELECT host_id FROM host WHERE host_name LIKE '" . $hostName . "'";
-        $resHost = $this->db->query($querySelect);
-        $tuple = $resHost->fetchRow();
+        $resHost = $this->db->query(
+            "SELECT host_id FROM host WHERE host_name LIKE '" . $hostName . "'"
+        );
+        $tuple = $resHost->fetch();
 
         $valueToAdd = './include/configuration/configKnowledge/proxy/proxy.php?host_name=$HOSTNAME$';
-        $queryUpdate = "UPDATE extended_host_information "
+        $this->db->query(
+            "UPDATE extended_host_information "
             . "SET ehi_notes_url = '" . $valueToAdd . "' "
-            . "WHERE host_host_id = '" . $tuple['host_id'] . "'";
-        $this->db->query($queryUpdate);
+            . "WHERE host_host_id = '" . $tuple['host_id'] . "'"
+        );
     }
 
     /**
@@ -445,21 +445,23 @@ class WikiApi
      */
     public function updateLinkForService($hostName, $serviceDescription)
     {
-        $query = "SELECT service_id " .
+        $resService = $this->db->query(
+            "SELECT service_id " .
             "FROM service, host, host_service_relation " .
             "WHERE host.host_name LIKE '" . $hostName . "' " .
             "AND service.service_description LIKE '" . $serviceDescription . "' " .
             "AND host_service_relation.host_host_id = host.host_id " .
-            "AND host_service_relation.service_service_id = service.service_id ";
-        $resService = $this->db->query($query);
-        $tuple = $resService->fetchRow();
+            "AND host_service_relation.service_service_id = service.service_id "
+        );
+        $tuple = $resService->fetch();
 
         $valueToAdd = './include/configuration/configKnowledge/proxy/proxy.php?' .
             'host_name=$HOSTNAME$&service_description=$SERVICEDESC$';
-        $queryUpdate = "UPDATE extended_service_information " .
+        $this->db->query(
+            "UPDATE extended_service_information " .
             "SET esi_notes_url = '" . $valueToAdd . "' " .
-            "WHERE service_service_id = '" . $tuple['service_id'] . "' ";
-        $this->db->query($queryUpdate);
+            "WHERE service_service_id = '" . $tuple['service_id'] . "' "
+        );
     }
 
     /**
@@ -467,16 +469,19 @@ class WikiApi
      */
     public function updateLinkForServiceTemplate($serviceName)
     {
-        $query = "SELECT service_id FROM service WHERE service_description LIKE '" . $serviceName . "' ";
-        $resService = $this->db->query($query);
-        $tuple = $resService->fetchRow();
+        $resService = $this->db->query(
+            "SELECT service_id FROM service " .
+            "WHERE service_description LIKE '" . $serviceName . "' "
+        );
+        $tuple = $resService->fetch();
 
         $valueToAdd = './include/configuration/configKnowledge/proxy/proxy.php?' .
             'host_name=$HOSTNAME$&service_description=$SERVICEDESC$';
-        $queryUpdate = "UPDATE extended_service_information " .
+        $this->db->query(
+            "UPDATE extended_service_information " .
             "SET esi_notes_url = '" . $valueToAdd . "' " .
-            "WHERE service_service_id = '" . $tuple['service_id'] . "' ";
-        $this->db->query($queryUpdate);
+            "WHERE service_service_id = '" . $tuple['service_id'] . "' "
+        );
     }
 
     /**

--- a/www/include/common/autoNumLimit.php
+++ b/www/include/common/autoNumLimit.php
@@ -52,12 +52,12 @@ if (isset($_POST['limit']) && $_POST['limit']) {
     $limit = $_SESSION[$sessionLimitKey];
 } else {
     if (($p >= 200 && $p < 300) || ($p >= 20000 && $p < 30000)) {
-        $DBRESULT = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
-        $gopt = $DBRESULT->fetch();
+        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewMonitoring'");
+        $gopt = $dbResult->fetch();
         $limit = myDecode($gopt['value']);
     } else {
-        $DBRESULT = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
-        $gopt = $DBRESULT->fetch();
+        $dbResult = $pearDB->query("SELECT * FROM `options` WHERE `key` = 'maxViewConfiguration'");
+        $gopt = $dbResult->fetch();
         $limit = myDecode($gopt['value']);
     }
 }

--- a/www/include/common/pagination.php
+++ b/www/include/common/pagination.php
@@ -43,7 +43,7 @@ global $num, $limit, $search, $url, $pearDB, $search_type_service, $search_type_
        $host_name, $hostgroup, $rows, $p, $gopt, $pagination, $poller, $template, $search_output, $search_service;
 
 $type = $_REQUEST["type"] ?? null;
-$o = $_GET["o"] ?? $o = null;
+$o = $_GET["o"] ?? null;
 
 //saving current pagination filter value and current displayed page
 $centreon->historyPage[$url] = $num;
@@ -175,7 +175,6 @@ for ($i2 = 0, $iEnd = $num; ($iEnd < ($rows / $limit - 1)) && ($i2 < (5 + $i)); 
 
 if ($rows != 0) {
     for ($i = $iStart; $i <= $iEnd; $i++) {
-
         $urlPage = "main.php?p=" . $p . "&num=" . $i . "&limit=" . $limit . "&poller=" . $poller .
             "&template=" . $template . "&search=" . $search . "&type=" . $type . "&o=" . $o . $url_var;
         $pageArr[$i] = array(
@@ -288,12 +287,8 @@ $form->setDefaults(array("p" => $p, "search" => $search, "num" => $num));
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 
-if (isset($_GET['host_name'])) {
-    $host_name = $_GET['host_name'];
-} elseif (!isset($host_name) || $host_name == "") {
-    $host_name = null;
-}
-isset($_GET["status"]) ? $status = $_GET["status"] : $status = null;
+$host_name = $_GET['host_name'] ?? null;
+$status = $_GET["status"] ?? null;
 isset($order) ? true : $order = null;
 
 $tpl->assign("host_name", $host_name);

--- a/www/include/configuration/configKnowledge/display-hostTemplates.php
+++ b/www/include/configuration/configKnowledge/display-hostTemplates.php
@@ -36,7 +36,7 @@
  *
  */
 
-if (!isset($oreon)) {
+if (!isset($centreon)) {
     exit();
 }
 
@@ -46,7 +46,7 @@ require_once $centreon_path . '/bootstrap.php';
 $pearDB = $dependencyInjector['configuration_db'];
 
 if (!isset($limit) || !$limit) {
-    $limit = $oreon->optGen["maxViewConfiguration"];
+    $limit = $centreon->optGen["maxViewConfiguration"];
 }
 
 if (isset($_POST['num']) && $_POST['num'] == 0) {

--- a/www/include/configuration/configKnowledge/display-hostTemplates.php
+++ b/www/include/configuration/configKnowledge/display-hostTemplates.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2009 MERETHIS
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give MERETHIS
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of MERETHIS choice, provided that
- * MERETHIS also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -64,7 +64,11 @@ if (isset($_POST['searchHostTemplate'])) {
 
 $order = "ASC";
 $orderby = "host_name";
-if (isset($_REQUEST['order']) && $_REQUEST['order'] && isset($_REQUEST['orderby']) && $_REQUEST['orderby']) {
+if (isset($_REQUEST['order'])
+    && $_REQUEST['order']
+    && isset($_REQUEST['orderby'])
+    && $_REQUEST['orderby']
+) {
     $order = $_REQUEST['order'];
     $orderby = $_REQUEST['orderby'];
 }
@@ -78,9 +82,7 @@ set_include_path(get_include_path() . PATH_SEPARATOR . $modules_path);
 
 require_once $centreon_path . "/www/class/centreon-knowledge/procedures.class.php";
 
-/*
- * Smarty template Init
- */
+// Smarty template Init
 $tpl = new Smarty();
 $tpl = initSmartyTpl($modules_path, $tpl);
 
@@ -91,9 +93,7 @@ try {
     $currentPage = "hostTemplates";
     require_once $modules_path . 'search.php';
 
-    /*
-     * Init Status Template
-     */
+    // Init Status Template
     $status = array(
         0 => "<font color='orange'> " . _("No wiki page defined") . " </font>",
         1 => "<font color='green'> " . _("Wiki page defined") . " </font>"
@@ -114,19 +114,19 @@ try {
     if (isset($_REQUEST['searchHostTemplate']) && $_REQUEST['searchHostTemplate']) {
         $query .= " AND host.host_name LIKE '%" . $_REQUEST['searchHostTemplate'] . "%' ";
     }
-    $query .= " ORDER BY $orderby $order LIMIT " . $num * $limit . ", " . $limit;
-    $DBRESULT = $pearDB->query($query);
+    $query .= " ORDER BY " . $orderby . " " . $order . " LIMIT " . $num * $limit . ", " . $limit;
+    $dbResult = $pearDB->query($query);
 
     $rows = $pearDB->query("SELECT FOUND_ROWS()")->fetchColumn();
 
     $selection = array();
-    while ($data = $DBRESULT->fetchRow()) {
+    while ($data = $dbResult->fetch()) {
         if ($data["host_register"] == 0) {
             $selection[$data["host_name"]] = $data["host_id"];
         }
         $proc->hostIconeList[$data["host_name"]] = "./img/media/" . $proc->getImageFilePath($data["ehi_icon_image"]);
     }
-    $DBRESULT->closeCursor();
+    $dbResult->closeCursor();
     unset($data);
 
     /*
@@ -147,8 +147,8 @@ try {
         }
 
         if (isset($_REQUEST['searchTemplatesWithNoProcedure'])) {
-            if ($diff[$key] == 1 ||
-                $proc->hostTemplateHasProcedure($key, $tplArr, PROCEDURE_INHERITANCE_MODE) == true
+            if ($diff[$key] == 1
+                || $proc->hostTemplateHasProcedure($key, $tplArr, PROCEDURE_INHERITANCE_MODE) == true
             ) {
                 $rows--;
                 unset($diff[$key]);
@@ -166,11 +166,11 @@ try {
             foreach ($tplArr as $key1 => $value1) {
                 if ($firstTpl) {
                     $tplStr .= " <a href='" . $WikiURL .
-                        "/index.php?title=Host-Template:$value1' target = '_blank' > " . $value1 . "</a > ";
+                        "/index.php?title=Host-Template:" . $value1 . "' target = '_blank' > " . $value1 . "</a > ";
                     $firstTpl = 0;
                 } else {
                     $tplStr .= "&nbsp;|&nbsp;<a href = '" . $WikiURL .
-                        "/index.php?title=Host-Template:$value1' target = '_blank' > " . $value1 . "</a > ";
+                        "/index.php?title=Host-Template:" . $value1 . "' target = '_blank' > " . $value1 . "</a > ";
                 }
             }
         }
@@ -178,7 +178,7 @@ try {
         unset($tplStr);
     }
 
-    include("./include/common/checkPagination.php");
+    include "./include/common/checkPagination.php";
 
     if (isset($templateHostArray)) {
         $tpl->assign("templateHostArray", $templateHostArray);
@@ -196,16 +196,12 @@ try {
      * Send template in order to open
      */
 
-    /*
-     * translations
-     */
+    // translations
     $tpl->assign("status_trans", _("Status"));
     $tpl->assign("actions_trans", _("Actions"));
     $tpl->assign("template_trans", _("Template"));
 
-    /*
-     * Template
-     */
+    // Template
     $tpl->assign("lineTemplate", $line);
     $tpl->assign('limit', $limit);
 
@@ -213,9 +209,7 @@ try {
     $tpl->assign('orderby', $orderby);
     $tpl->assign('defaultOrderby', 'host_name');
 
-    /*
-     * Apply a template definition
-     */
+    // Apply a template definition
 
     $tpl->display($modules_path . "templates/display.ihtml");
 } catch (\Exception $e) {

--- a/www/include/configuration/configKnowledge/display-hosts.php
+++ b/www/include/configuration/configKnowledge/display-hosts.php
@@ -36,7 +36,7 @@
  *
  */
 
-if (!isset($oreon)) {
+if (!isset($centreon)) {
     exit();
 }
 
@@ -46,7 +46,7 @@ require_once $centreon_path . '/bootstrap.php';
 $pearDB = $dependencyInjector['configuration_db'];
 
 if (!isset($limit) || !$limit) {
-    $limit = $oreon->optGen["maxViewConfiguration"];
+    $limit = $centreon->optGen["maxViewConfiguration"];
 }
 
 if (isset($_POST['searchHost'])) {

--- a/www/include/configuration/configKnowledge/display-hosts.php
+++ b/www/include/configuration/configKnowledge/display-hosts.php
@@ -176,7 +176,7 @@ try {
                     $firstTpl = 0;
                 } else {
                     $tplStr .= "&nbsp;|&nbsp;<a href='" . $WikiURL .
-                        "/index.php?title=Host:" . $value1 ."' target='_blank'>" . $value1 . "</a>";
+                        "/index.php?title=Host:" . $value1 . "' target='_blank'>" . $value1 . "</a>";
                 }
             }
         }

--- a/www/include/configuration/configKnowledge/display-hosts.php
+++ b/www/include/configuration/configKnowledge/display-hosts.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 CENTREON
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give MERETHIS
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of MERETHIS choice, provided that
- * MERETHIS also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -49,10 +49,6 @@ if (!isset($limit) || !$limit) {
     $limit = $oreon->optGen["maxViewConfiguration"];
 }
 
-if (isset($_POST['num']) && $_POST['num'] == 0) {
-    $_GET['num'] = 0;
-}
-
 if (isset($_POST['searchHost'])) {
     if (!isset($_POST['searchHasNoProcedure']) && isset($_GET['searchHasNoProcedure'])) {
         unset($_REQUEST['searchHasNoProcedure']);
@@ -64,7 +60,11 @@ if (isset($_POST['searchHost'])) {
 
 $order = "ASC";
 $orderby = "host_name";
-if (isset($_REQUEST['order']) && $_REQUEST['order'] && isset($_REQUEST['orderby']) && $_REQUEST['orderby']) {
+if (isset($_REQUEST['order'])
+    && $_REQUEST['order']
+    && isset($_REQUEST['orderby'])
+    && $_REQUEST['orderby']
+) {
     $order = $_REQUEST['order'];
     $orderby = $_REQUEST['orderby'];
 }
@@ -78,9 +78,7 @@ set_include_path(get_include_path() . PATH_SEPARATOR . $modules_path);
 
 require_once $centreon_path . "/www/class/centreon-knowledge/procedures.class.php";
 
-/*
- * Smarty template Init
- */
+// Smarty template Init
 $tpl = new Smarty();
 $tpl = initSmartyTpl($modules_path, $tpl);
 
@@ -104,8 +102,8 @@ try {
     $proc->setHostInformations();
     $proc->setServiceInformations();
 
-    $query = "SELECT SQL_CALC_FOUND_ROWS host_name, host_id, host_register, ehi_icon_image ";
-    $query .= " FROM extended_host_information ehi, host ";
+    $query = "SELECT SQL_CALC_FOUND_ROWS host_name, host_id, host_register, ehi_icon_image " .
+        "FROM extended_host_information ehi, host ";
     if (isset($_REQUEST['searchPoller']) && $_REQUEST['searchPoller']) {
         $query .= " JOIN ns_host_relation nhr ON nhr.host_host_id = host.host_id ";
     }
@@ -123,19 +121,19 @@ try {
     if (isset($_REQUEST['searchHost']) && $_REQUEST['searchHost']) {
         $query .= " AND host_name LIKE '%" . $pearDB->escape($_REQUEST['searchHost']) . "%'";
     }
-    $query .= " ORDER BY $orderby $order LIMIT " . $num * $limit . ", " . $limit;
-    $DBRESULT = $pearDB->query($query);
+    $query .= " ORDER BY " . $orderby . " " . $order . " LIMIT " . $num * $limit . ", " . $limit;
+    $dbResult = $pearDB->query($query);
 
     $rows = $pearDB->query("SELECT FOUND_ROWS()")->fetchColumn();
 
     $selection = array();
-    while ($data = $DBRESULT->fetchRow()) {
+    while ($data = $dbResult->fetch()) {
         if ($data["host_register"] == 1) {
             $selection[$data["host_name"]] = $data["host_id"];
         }
         $proc->hostIconeList[$data["host_name"]] = "./img/media/" . $proc->getImageFilePath($data["ehi_icon_image"]);
     }
-    $DBRESULT->closeCursor();
+    $dbResult->closeCursor();
     unset($data);
 
     /*
@@ -173,12 +171,12 @@ try {
             $firstTpl = 1;
             foreach ($tplArr as $key1 => $value1) {
                 if ($firstTpl) {
-                    $tplStr .= "<a href='" . $WikiURL . "/index.php?title=Host:$value1' target='_blank'>" .
-                        $value1 . "</a>";
+                    $tplStr .= "<a href='" . $WikiURL .
+                        "/index.php?title=Host:" . $value1 . "' target='_blank'>" . $value1 . "</a>";
                     $firstTpl = 0;
                 } else {
-                    $tplStr .= "&nbsp;|&nbsp;<a href='" . $WikiURL . "/index.php?title=Host:$value1' target='_blank'>" .
-                        $value1 . "</a>";
+                    $tplStr .= "&nbsp;|&nbsp;<a href='" . $WikiURL .
+                        "/index.php?title=Host:" . $value1 ."' target='_blank'>" . $value1 . "</a>";
                 }
             }
         }
@@ -186,7 +184,7 @@ try {
         unset($tplStr);
     }
 
-    include("./include/common/checkPagination.php");
+    include "./include/common/checkPagination.php";
 
     if (isset($templateHostArray)) {
         $tpl->assign("templateHostArray", $templateHostArray);
@@ -195,7 +193,6 @@ try {
 
     $WikiVersion = getWikiVersion($WikiURL . '/api.php');
     $tpl->assign("WikiVersion", $WikiVersion);
-
     $tpl->assign("WikiURL", $WikiURL);
     $tpl->assign("content", $diff);
     $tpl->assign("status", $status);
@@ -206,16 +203,12 @@ try {
      * Send template in order to open
      */
 
-    /*
-     * translations
-     */
+    // translations
     $tpl->assign("status_trans", _("Status"));
     $tpl->assign("actions_trans", _("Actions"));
     $tpl->assign("template_trans", _("Template"));
 
-    /*
-     * Template
-     */
+    // Template
     $tpl->assign("lineTemplate", $line);
     $tpl->assign('limit', $limit);
 
@@ -223,9 +216,7 @@ try {
     $tpl->assign('orderby', $orderby);
     $tpl->assign('defaultOrderby', 'host_name');
 
-    /*
-     * Apply a template definition
-     */
+    // Apply a template definition
     $tpl->display($modules_path . "templates/display.ihtml");
 } catch (\Exception $e) {
     $tpl->assign('errorMsg', $e->getMessage());

--- a/www/include/configuration/configKnowledge/display-serviceTemplates.php
+++ b/www/include/configuration/configKnowledge/display-serviceTemplates.php
@@ -84,7 +84,7 @@ require_once $centreon_path . "/www/class/centreon-knowledge/procedures.class.ph
 
 // Smarty template Init
 $tpl = new Smarty();
-$tpl = initSmartyTpl($path, $tpl);
+$tpl = initSmartyTpl($modules_path, $tpl);
 
 try {
     $conf = getWikiConfig($pearDB);
@@ -166,11 +166,11 @@ try {
             foreach ($tplArr as $key1 => $value1) {
                 if ($firstTpl) {
                     $tplStr .= "<a href='" . $WikiURL .
-                        " / index . php ? title = Service - Template : $value1' target='_blank'>" . $value1 . "</a>";
+                        "/index.php?title=Service-Template:" . $value1 . "' target='_blank'>" . $value1 . "</a>";
                     $firstTpl = 0;
                 } else {
                     $tplStr .= "&nbsp;|&nbsp;<a href='" . $WikiURL .
-                        " / index . php ? title = Service - Template : $value1' target='_blank'>" . $value1 . "</a>";
+                        "/index.php?title=Service-Template:" . $value1 . "' target='_blank'>" . $value1 . "</a>";
                 }
             }
         }
@@ -184,7 +184,7 @@ try {
         $tpl->assign("templateHostArray", $templateHostArray);
     }
 
-    $WikiVersion = getWikiVersion($WikiURL . ' / api . php');
+    $WikiVersion = getWikiVersion($WikiURL . '/api.php');
     $tpl->assign("WikiVersion", $WikiVersion);
     $tpl->assign("WikiURL", $WikiURL);
     $tpl->assign("content", $diff);

--- a/www/include/configuration/configKnowledge/display-serviceTemplates.php
+++ b/www/include/configuration/configKnowledge/display-serviceTemplates.php
@@ -36,7 +36,7 @@
  *
  */
 
-if (!isset($oreon)) {
+if (!isset($centreon)) {
     exit();
 }
 
@@ -46,7 +46,7 @@ require_once $centreon_path . '/bootstrap.php';
 $pearDB = $dependencyInjector['configuration_db'];
 
 if (!isset($limit) || !$limit) {
-    $limit = $oreon->optGen["maxViewConfiguration"];
+    $limit = $centreon->optGen["maxViewConfiguration"];
 }
 
 if (isset($_POST['num']) && $_POST['num'] == 0) {

--- a/www/include/configuration/configKnowledge/display-serviceTemplates.php
+++ b/www/include/configuration/configKnowledge/display-serviceTemplates.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2009 MERETHIS
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give MERETHIS
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of MERETHIS choice, provided that
- * MERETHIS also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -64,7 +64,11 @@ if (isset($_POST['searchServiceTemplate'])) {
 
 $order = "ASC";
 $orderby = "service_description";
-if (isset($_REQUEST['order']) && $_REQUEST['order'] && isset($_REQUEST['orderby']) && $_REQUEST['orderby']) {
+if (isset($_REQUEST['order'])
+    && $_REQUEST['order']
+    && isset($_REQUEST['orderby'])
+    && $_REQUEST['orderby']
+) {
     $order = $_REQUEST['order'];
     $orderby = $_REQUEST['orderby'];
 }
@@ -78,9 +82,7 @@ set_include_path(get_include_path() . PATH_SEPARATOR . $modules_path);
 
 require_once $centreon_path . "/www/class/centreon-knowledge/procedures.class.php";
 
-/*
- * Smarty template Init
- */
+// Smarty template Init
 $tpl = new Smarty();
 $tpl = initSmartyTpl($path, $tpl);
 
@@ -106,9 +108,7 @@ try {
     $proc->setHostInformations();
     $proc->setServiceInformations();
 
-    /*
-     * Get Services Template Informations
-     */
+    // Get Services Template Informations
     $query = "SELECT SQL_CALC_FOUND_ROWS service_description, service_id " .
         "FROM service " .
         "WHERE service_register = '0' " .
@@ -116,17 +116,17 @@ try {
     if (isset($_REQUEST['searchServiceTemplate']) && $_REQUEST['searchServiceTemplate']) {
         $query .= " AND service_description LIKE '%" . $_REQUEST['searchServiceTemplate'] . "%' ";
     }
-    $query .= "ORDER BY $orderby $order LIMIT " . $num * $limit . ", " . $limit;
-    $DBRESULT = $pearDB->query($query);
+    $query .= "ORDER BY " . $orderby . " " . $order . " LIMIT " . $num * $limit . ", " . $limit;
+    $dbResult = $pearDB->query($query);
     $rows = $pearDB->query("SELECT FOUND_ROWS()")->fetchColumn();
 
     $selection = array();
-    while ($data = $DBRESULT->fetchRow()) {
+    while ($data = $dbResult->fetch()) {
         $data["service_description"] = str_replace("#S#", "/", $data["service_description"]);
         $data["service_description"] = str_replace("#BS#", "\\", $data["service_description"]);
         $selection[$data["service_description"]] = $data["service_id"];
     }
-    $DBRESULT->closeCursor();
+    $dbResult->closeCursor();
     unset($data);
 
     /*
@@ -146,8 +146,8 @@ try {
         }
 
         if (isset($_REQUEST['searchTemplatesWithNoProcedure'])) {
-            if ($diff[$key] == 1 ||
-                $proc->serviceTemplateHasProcedure($key, $tplArr, PROCEDURE_INHERITANCE_MODE) == true
+            if ($diff[$key] == 1
+                || $proc->serviceTemplateHasProcedure($key, $tplArr, PROCEDURE_INHERITANCE_MODE) == true
             ) {
                 $rows--;
                 unset($diff[$key]);
@@ -178,7 +178,7 @@ try {
         unset($tplStr);
     }
 
-    include("./include/common/checkPagination.php");
+    include "./include/common/checkPagination.php";
 
     if (isset($templateHostArray)) {
         $tpl->assign("templateHostArray", $templateHostArray);
@@ -196,16 +196,12 @@ try {
      * Send template in order to open
      */
 
-    /*
-     * translations
-     */
+    // translations
     $tpl->assign("status_trans", _("Status"));
     $tpl->assign("actions_trans", _("Actions"));
     $tpl->assign("template_trans", _("Template"));
 
-    /*
-     * Template
-     */
+    // Template
     $tpl->assign("lineTemplate", $line);
     $tpl->assign('limit', $limit);
 
@@ -213,9 +209,7 @@ try {
     $tpl->assign('orderby', $orderby);
     $tpl->assign('defaultOrderby', 'service_description');
 
-    /*
-     * Apply a template definition
-     */
+    // Apply a template definition
 
     $tpl->display($modules_path . "templates/display.ihtml");
 } catch (\Exception $e) {

--- a/www/include/configuration/configKnowledge/display-services.php
+++ b/www/include/configuration/configKnowledge/display-services.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2009 MERETHIS
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give MERETHIS
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of MERETHIS choice, provided that
- * MERETHIS also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -49,13 +49,10 @@ if (!isset($limit) || !$limit) {
     $limit = $oreon->optGen["maxViewConfiguration"];
 }
 
-if (isset($_POST['search'])) {
-    $_GET['search'] = $_POST['search'];
-}
-
+/*
 if (isset($_POST['num']) && $_POST['num'] == 0) {
     $_GET['num'] = 0;
-}
+}*/
 
 if (isset($_POST['searchHost'])) {
     if (!isset($_POST['searchHasNoProcedure']) && isset($_GET['searchHasNoProcedure'])) {
@@ -68,7 +65,11 @@ if (isset($_POST['searchHost'])) {
 
 $order = "ASC";
 $orderby = "host_name";
-if (isset($_REQUEST['order']) && $_REQUEST['order'] && isset($_REQUEST['orderby']) && $_REQUEST['orderby']) {
+if (isset($_REQUEST['order'])
+    && $_REQUEST['order']
+    && isset($_REQUEST['orderby'])
+    && $_REQUEST['orderby']
+) {
     $order = $_REQUEST['order'];
     $orderby = $_REQUEST['orderby'];
 }
@@ -82,9 +83,7 @@ set_include_path(get_include_path() . PATH_SEPARATOR . $modules_path);
 
 require_once $centreon_path . "/www/class/centreon-knowledge/procedures.class.php";
 
-/*
- * Smarty template Init
- */
+// Smarty template Init
 $tpl = new Smarty();
 $tpl = initSmartyTpl($modules_path, $tpl);
 
@@ -168,12 +167,12 @@ try {
         $query .= "AND s2.service_description LIKE '%" . $_REQUEST['searchService'] . "%' ";
     }
     $query .= " ) as t1 ";
-    $query .= " ORDER BY $orderby $order LIMIT " . $num * $limit . ", " . $limit;
+    $query .= " ORDER BY " . $orderby . " " . $order . " LIMIT " . $num * $limit . ", " . $limit;
 
     $res = $pearDB->query($query);
 
     $serviceList = array();
-    while ($row = $res->fetchRow()) {
+    while ($row = $res->fetch()) {
         $row['service_description'] = str_replace("#S#", "/", $row['service_description']);
         $row['service_description'] = str_replace("#BS#", "\\", $row['service_description']);
         if (isset($row['host_id']) && $row['host_id']) {
@@ -209,8 +208,8 @@ try {
         }
 
         if (isset($_REQUEST['searchTemplatesWithNoProcedure'])) {
-            if ($diff[$key] == 1 ||
-                $proc->serviceHasProcedure($key_nospace, $tplArr, PROCEDURE_INHERITANCE_MODE) == true
+            if ($diff[$key] == 1
+                || $proc->serviceHasProcedure($key_nospace, $tplArr, PROCEDURE_INHERITANCE_MODE) == true
             ) {
                 $rows--;
                 unset($diff[$key]);
@@ -234,8 +233,8 @@ try {
                 } else {
                     $tplStr .= "&nbsp;|&nbsp;";
                 }
-                $tplStr .= "<a href='" . $WikiURL . "/index.php?title=Service_:_$value1' target='_blank'>" .
-                    $value1 . "</a>";
+                $tplStr .= "<a href='" . $WikiURL .
+                    "/index.php?title=Service_:_" . $value1 . "' target='_blank'>" . $value1 . "</a>";
             }
         }
         $templateHostArray[$key] = $tplStr;
@@ -243,7 +242,7 @@ try {
         $i++;
     }
 
-    include("./include/common/checkPagination.php");
+    include "./include/common/checkPagination.php";
 
     if (isset($templateHostArray)) {
         $tpl->assign("templateHostArray", $templateHostArray);
@@ -262,16 +261,12 @@ try {
      * Send template in order to open
      */
 
-    /*
-     * translations
-     */
+    // translations
     $tpl->assign("status_trans", _("Status"));
     $tpl->assign("actions_trans", _("Actions"));
     $tpl->assign("template_trans", _("Template"));
 
-    /*
-     * Template
-     */
+    // Template
     $tpl->assign("lineTemplate", $line);
     $tpl->assign('limit', $limit);
 
@@ -279,10 +274,7 @@ try {
     $tpl->assign('orderby', $orderby);
     $tpl->assign('defaultOrderby', 'host_name');
 
-    /*
-     * Apply a template definition
-     */
-
+    // Apply a template definition
     $tpl->display($modules_path . "templates/display.ihtml");
 } catch (\Exception $e) {
     $tpl->assign('errorMsg', $e->getMessage());

--- a/www/include/configuration/configKnowledge/display-services.php
+++ b/www/include/configuration/configKnowledge/display-services.php
@@ -49,11 +49,6 @@ if (!isset($limit) || !$limit) {
     $limit = $centreon->optGen["maxViewConfiguration"];
 }
 
-/*
-if (isset($_POST['num']) && $_POST['num'] == 0) {
-    $_GET['num'] = 0;
-}*/
-
 if (isset($_POST['searchHost'])) {
     if (!isset($_POST['searchHasNoProcedure']) && isset($_GET['searchHasNoProcedure'])) {
         unset($_REQUEST['searchHasNoProcedure']);

--- a/www/include/configuration/configKnowledge/display-services.php
+++ b/www/include/configuration/configKnowledge/display-services.php
@@ -36,7 +36,7 @@
  *
  */
 
-if (!isset($oreon)) {
+if (!isset($centreon)) {
     exit();
 }
 
@@ -46,7 +46,7 @@ require_once $centreon_path . '/bootstrap.php';
 $pearDB = $dependencyInjector['configuration_db'];
 
 if (!isset($limit) || !$limit) {
-    $limit = $oreon->optGen["maxViewConfiguration"];
+    $limit = $centreon->optGen["maxViewConfiguration"];
 }
 
 /*

--- a/www/include/configuration/configKnowledge/pagination.php
+++ b/www/include/configuration/configKnowledge/pagination.php
@@ -47,8 +47,6 @@ global $bNewChart, $num, $limit, $search, $url, $pearDB, $search_type_service,
 $type = $_REQUEST["type"] ?? null;
 $o = $_GET["o"] ?? null;
 
-$searchString = "";
-
 //saving current pagination filter value and current displayed page
 $centreon->historyPage[$url] = $num;
 $centreon->historyLastUrl = $url;

--- a/www/include/configuration/configKnowledge/pagination.php
+++ b/www/include/configuration/configKnowledge/pagination.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 CENTREON
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -35,19 +35,20 @@
  * SVN : $Id: pagination.php 10473 2010-05-19 21:25:56Z jmathis $
  *
  */
-global $oreon;
+global $centreon;
 
-if (!isset($oreon)) {
+if (!isset($centreon)) {
     exit();
 }
 
 global $bNewChart, $num, $limit, $search, $url, $pearDB, $search_type_service,
        $search_type_host, $host_name, $rows, $p, $gopt, $pagination, $poller, $order, $orderby;
 
-isset($_GET["type"]) ? $type = $_GET["type"] : $stype = null;
-isset($_GET["o"]) ? $o = $_GET["o"] : $o = null;
+$type = $_REQUEST["type"] ?? null;
+$o = $_GET["o"] ?? null;
 
 $searchString = "";
+/*
 if (isset($_REQUEST)) {
     foreach ($_REQUEST as $key => $value) {
         if (preg_match("/^search/", $key)) {
@@ -55,25 +56,31 @@ if (isset($_REQUEST)) {
         }
     }
 }
+*/
 
+/*
 if (isset($_GET["num"])) {
     $num = (int)$_GET["num"];
 } else {
-    if (!isset($_GET["num"]) && isset($oreon->historyPage[$url]) && $oreon->historyPage[$url]) {
-        $num = (int)$oreon->historyPage[$url];
+    if (!isset($_GET["num"]) && isset($centreon->historyPage[$url]) && $centreon->historyPage[$url]) {
+        $num = (int)$centreon->historyPage[$url];
     } else {
         $num = 0;
     }
 }
+*/
+
+$centreon->historyPage[$url] = $num;
+$centreon->historyLastUrl = $url;
 
 $tab_order = array("sort_asc" => "sort_desc", "sort_desc" => "sort_asc");
 
 if (isset($_GET["search_type_service"])) {
     $search_type_service = $_GET["search_type_service"];
-    $oreon->search_type_service = $_GET["search_type_service"];
+    $centreon->search_type_service = $_GET["search_type_service"];
 } else {
-    if (isset($oreon->search_type_service)) {
-        $search_type_service = $oreon->search_type_service;
+    if (isset($centreon->search_type_service)) {
+        $search_type_service = $centreon->search_type_service;
     } else {
         $search_type_service = null;
     }
@@ -81,22 +88,24 @@ if (isset($_GET["search_type_service"])) {
 
 if (isset($_GET["search_type_host"])) {
     $search_type_host = $_GET["search_type_host"];
-    $oreon->search_type_host = $_GET["search_type_host"];
+    $centreon->search_type_host = $_GET["search_type_host"];
 } else {
-    if (isset($oreon->search_type_host)) {
-        $search_type_host = $oreon->search_type_host;
+    if (isset($centreon->search_type_host)) {
+        $search_type_host = $centreon->search_type_host;
     } else {
         $search_type_host = null;
     }
 }
 
-if (!isset($_GET["search_type_host"]) && !isset($oreon->search_type_host) &&
-    !isset($_GET["search_type_service"]) && !isset($oreon->search_type_service)
+if (!isset($_GET["search_type_host"])
+    && !isset($centreon->search_type_host)
+    && !isset($_GET["search_type_service"])
+    && !isset($centreon->search_type_service)
 ) {
     $search_type_host = 1;
-    $oreon->search_type_host = 1;
+    $centreon->search_type_host = 1;
     $search_type_service = 1;
-    $oreon->search_type_service = 1;
+    $centreon->search_type_service = 1;
 }
 
 $url_var = "";
@@ -119,21 +128,22 @@ if ($num >= $page_max && $rows) {
 }
 
 $pageArr = array();
-$istart = 0;
-for ($i = 5, $istart = $num; $istart && $i > 0; $i--) {
-    $istart--;
+$iStart = 0;
+for ($i = 5, $iStart = $num; $iStart && $i > 0; $i--) {
+    $iStart--;
 }
 
-for ($i2 = 0, $iend = $num; ($iend < ($rows / $limit - 1)) && ($i2 < (5 + $i)); $i2++) {
-    $iend++;
+for ($i2 = 0, $iEnd = $num; ($iEnd < ($rows / $limit - 1)) && ($i2 < (5 + $i)); $i2++) {
+    $iEnd++;
 }
 
 
 if ($rows != 0) {
-    for ($i = $istart; $i <= $iend; $i++) {
+    for ($i = $iStart; $i <= $iEnd; $i++) {
         $pageArr[$i] = array(
-            "url_page" => "./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby . "&num=$i&limit=" .
-                $limit . $searchString . "&type=" . $type . "&o=" . $o . $url_var,
+            "url_page" => "./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby .
+                "&num=" . $i . "&limit=" . $limit . "&type=" . $type .
+                "&o=" . $o . " " . $url_var,
             "label_page" => "<b>" . ($i + 1) . "</b>",
             "num" => $i
         );
@@ -153,7 +163,7 @@ if ($rows != 0) {
         $tpl->assign(
             'pagePrev',
             ("./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby . "&num=$prev&limit=" .
-                $limit . $searchString . "&type=" . $type . "&o=" . $o . $url_var)
+                $limit . "&type=" . $type . "&o=" . $o . $url_var)
         );
     }
 
@@ -161,7 +171,7 @@ if ($rows != 0) {
         $tpl->assign(
             'pageNext',
             ("./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby . "&num=$next&limit=" .
-                $limit . $searchString . "&type=" . $type . "&o=" . $o . $url_var)
+                $limit . "&type=" . $type . "&o=" . $o . $url_var)
         );
     }
 
@@ -176,7 +186,7 @@ if ($rows != 0) {
         $tpl->assign(
             'firstPage',
             ("./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby . "&num=0&limit=" .
-                $limit . $searchString . "&type=" . $type . "&o=" . $o . $url_var)
+                $limit . "&type=" . $type . "&o=" . $o . $url_var)
         );
     }
 
@@ -184,7 +194,7 @@ if ($rows != 0) {
         $tpl->assign(
             'lastPage',
             ("./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby . "&num=" . ($pageNumber - 1) .
-                "&limit=" . $limit . $searchString . "&type=" . $type . "&o=" . $o . $url_var)
+                "&limit=" . $limit . "&type=" . $type . "&o=" . $o . $url_var)
         );
     }
 
@@ -207,14 +217,14 @@ if ($rows != 0) {
 }
 
 ?>
-    <script type="text/javascript">
-        function setL(_this) {
-            var _l = document.getElementsByName('l');
-            document.forms['form'].elements['limit'].value = _this;
-            _l[0].value = _this;
-            _l[1].value = _this;
-        }
-    </SCRIPT>
+<script type="text/javascript">
+    function setL(_this) {
+        var _l = document.getElementsByName('l');
+        document.forms['form'].elements['limit'].value = _this;
+        _l[0].value = _this;
+        _l[1].value = _this;
+    }
+</script>
 <?php
 $form = new HTML_QuickFormCustom(
     'select_form',
@@ -247,12 +257,12 @@ $form->setDefaults(array("p" => $p, "search" => $search, "num" => $num));
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 
-isset($_GET["host_name"]) ? $host_name = $_GET["host_name"] : $host_name = null;
-isset($_GET["status"]) ? $status = $_GET["status"] : $status = null;
+$host_name = $_GET["host_name"] ?? null;
+$status = $_GET["status"] ?? null;
 
 $tpl->assign("host_name", $host_name);
 $tpl->assign("status", $status);
-$tpl->assign("limite", $limite);
+$tpl->assign("limite", isset($limite) ? $limite : null);
 $tpl->assign("begin", $num);
 $tpl->assign("end", $limit);
 $tpl->assign("pagin_page", _("Page"));

--- a/www/include/configuration/configKnowledge/pagination.php
+++ b/www/include/configuration/configKnowledge/pagination.php
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give MERETHIS
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of MERETHIS choice, provided that
- * MERETHIS also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -48,28 +48,8 @@ $type = $_REQUEST["type"] ?? null;
 $o = $_GET["o"] ?? null;
 
 $searchString = "";
-/*
-if (isset($_REQUEST)) {
-    foreach ($_REQUEST as $key => $value) {
-        if (preg_match("/^search/", $key)) {
-            $searchString .= "&$key=$value";
-        }
-    }
-}
-*/
 
-/*
-if (isset($_GET["num"])) {
-    $num = (int)$_GET["num"];
-} else {
-    if (!isset($_GET["num"]) && isset($centreon->historyPage[$url]) && $centreon->historyPage[$url]) {
-        $num = (int)$centreon->historyPage[$url];
-    } else {
-        $num = 0;
-    }
-}
-*/
-
+//saving current pagination filter value and current displayed page
 $centreon->historyPage[$url] = $num;
 $centreon->historyLastUrl = $url;
 
@@ -78,23 +58,19 @@ $tab_order = array("sort_asc" => "sort_desc", "sort_desc" => "sort_asc");
 if (isset($_GET["search_type_service"])) {
     $search_type_service = $_GET["search_type_service"];
     $centreon->search_type_service = $_GET["search_type_service"];
+} elseif (isset($centreon->search_type_service)) {
+    $search_type_service = $centreon->search_type_service;
 } else {
-    if (isset($centreon->search_type_service)) {
-        $search_type_service = $centreon->search_type_service;
-    } else {
-        $search_type_service = null;
-    }
+    $search_type_service = null;
 }
 
 if (isset($_GET["search_type_host"])) {
     $search_type_host = $_GET["search_type_host"];
     $centreon->search_type_host = $_GET["search_type_host"];
+} elseif (isset($centreon->search_type_host)) {
+    $search_type_host = $centreon->search_type_host;
 } else {
-    if (isset($centreon->search_type_host)) {
-        $search_type_host = $centreon->search_type_host;
-    } else {
-        $search_type_host = null;
-    }
+    $search_type_host = null;
 }
 
 if (!isset($_GET["search_type_host"])
@@ -109,8 +85,41 @@ if (!isset($_GET["search_type_host"])
 }
 
 $url_var = "";
-$url_var .= "&search_type_service=" . $search_type_service;
-$url_var .= "&search_type_host=" . $search_type_host;
+
+if (isset($search_type_service)) {
+    $url_var .= "&search_type_service=" . $search_type_service;
+}
+if (isset($search_type_host)) {
+    $url_var .= "&search_type_host=" . $search_type_host;
+}
+
+if (isset($_REQUEST['searchHost']) && $_REQUEST['searchHost']) {
+    $url_var .= "&searchHost=" . $_REQUEST['searchHost'];
+}
+
+if (isset($_REQUEST['searchHostgroup']) && $_REQUEST['searchHostgroup']) {
+    $url_var .= "&searchHostgroup=" . $_REQUEST['searchHostgroup'];
+}
+
+if (isset($_REQUEST['searchPoller']) && $_REQUEST['searchPoller']) {
+    $url_var .= "&searchPoller=" . $_REQUEST['searchPoller'];
+}
+
+if (isset($_REQUEST['searchService']) && $_REQUEST['searchService']) {
+    $url_var .= "&searchService=" . $_REQUEST['searchService'];
+}
+
+if (isset($_REQUEST['searchServicegroup']) && $_REQUEST['searchServicegroup']) {
+    $url_var .= "&searchServicegroup=" . $_REQUEST['searchServicegroup'];
+}
+
+if (isset($_REQUEST['searchHostTemplate']) && $_REQUEST['searchHostTemplate']) {
+    $url_var .= "&searchHostTemplate=" . $_REQUEST['searchHostTemplate'];
+}
+
+if (isset($_REQUEST['searchServiceTemplate']) && $_REQUEST['searchServiceTemplate']) {
+    $url_var .= "&searchServiceTemplate=" . $_REQUEST['searchServiceTemplate'];
+}
 
 if (isset($_GET["sort_types"])) {
     $url_var .= "&sort_types=" . $_GET["sort_types"];
@@ -137,13 +146,13 @@ for ($i2 = 0, $iEnd = $num; ($iEnd < ($rows / $limit - 1)) && ($i2 < (5 + $i)); 
     $iEnd++;
 }
 
-
 if ($rows != 0) {
     for ($i = $iStart; $i <= $iEnd; $i++) {
+        $urlPage = "main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby .
+        "&num=" . $i . "&limit=" . $limit . "&type=" . $type .
+        "&o=" . $o . $url_var;
         $pageArr[$i] = array(
-            "url_page" => "./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby .
-                "&num=" . $i . "&limit=" . $limit . "&type=" . $type .
-                "&o=" . $o . " " . $url_var,
+            "url_page" => $urlPage,
             "label_page" => "<b>" . ($i + 1) . "</b>",
             "num" => $i
         );
@@ -162,7 +171,7 @@ if ($rows != 0) {
     if (($prev = $num - 1) >= 0) {
         $tpl->assign(
             'pagePrev',
-            ("./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby . "&num=$prev&limit=" .
+            ("./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby . "&num=" . $prev . "&limit=" .
                 $limit . "&type=" . $type . "&o=" . $o . $url_var)
         );
     }
@@ -170,7 +179,7 @@ if ($rows != 0) {
     if (($next = $num + 1) < ($rows / $limit)) {
         $tpl->assign(
             'pageNext',
-            ("./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby . "&num=$next&limit=" .
+            ("./main.php?p=" . $p . "&order=" . $order . "&orderby=" . $orderby . "&num=" . $next . "&limit=" .
                 $limit . "&type=" . $type . "&o=" . $o . $url_var)
         );
     }
@@ -240,9 +249,7 @@ $selLim = $form->addElement(
 );
 $selLim->setSelected($limit);
 
-/*
- * Element we need when we reload the page
- */
+// Element we need when we reload the page
 $form->addElement('hidden', 'p');
 $form->addElement('hidden', 'search');
 $form->addElement('hidden', 'num');
@@ -251,9 +258,7 @@ $form->addElement('hidden', 'type');
 $form->addElement('hidden', 'sort_types');
 $form->setDefaults(array("p" => $p, "search" => $search, "num" => $num));
 
-/*
- * Init QuickForm
- */
+// Init QuickForm
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 

--- a/www/include/configuration/configKnowledge/popup_form.php
+++ b/www/include/configuration/configKnowledge/popup_form.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2005-2009 MERETHIS
+ * Copyright 2005-2019 CENTREON
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give MERETHIS
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of MERETHIS choice, provided that
- * MERETHIS also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -62,7 +62,7 @@ if (isset($_GET["session_id"]) && $_GET["session_id"] != "") {
     require_once "centreon-knowledge/procedures.class.php";
 
     /*
-         * Init procedures Object
+     * Init procedures Object
      */
     $proc = new procedures(
         $pearDB
@@ -81,7 +81,7 @@ if (isset($_GET["session_id"]) && $_GET["session_id"] != "") {
         }
 
         /*
-             * HTML
+         * HTML
          */
         print "<form method='GET' action='./popup.php'>";
         print "Based Template : ";
@@ -103,7 +103,7 @@ if (isset($_GET["session_id"]) && $_GET["session_id"] != "") {
             }
         }
         /*
-             * HTML
+         * HTML
          */
         print "<form method='GET' action='./popup.php'>";
         print "Based Template : ";
@@ -126,7 +126,7 @@ if (isset($_GET["session_id"]) && $_GET["session_id"] != "") {
         }
 
         /*
-             * HTML
+         * HTML
          */
         print "<form method='GET' action='./popup.php'>";
         print "Based Template : ";
@@ -150,7 +150,7 @@ if (isset($_GET["session_id"]) && $_GET["session_id"] != "") {
         }
 
         /*
-             * HTML
+         * HTML
          */
         print "<form method='GET' action='./popup.php'>";
         print "Based Template : ";

--- a/www/include/configuration/configKnowledge/proxy/proxy.php
+++ b/www/include/configuration/configKnowledge/proxy/proxy.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2005-2009 MERETHIS
+ * Copyright 2005-2019 CENTREON
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give MERETHIS
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of MERETHIS choice, provided that
- * MERETHIS also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you

--- a/www/include/configuration/configKnowledge/search.php
+++ b/www/include/configuration/configKnowledge/search.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2011 MERETHIS
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 CENTREON
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -19,11 +19,11 @@
  * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
  *
- * As a special exception, the copyright holders of this program give MERETHIS
+ * As a special exception, the copyright holders of this program give CENTREON
  * permission to link this program with independent modules to produce an executable,
  * regardless of the license terms of these independent modules, and to copy and
- * distribute the resulting executable under terms of MERETHIS choice, provided that
- * MERETHIS also meet, for each linked independent module, the terms  and conditions
+ * distribute the resulting executable under terms of CENTREON choice, provided that
+ * CENTREON also meet, for each linked independent module, the terms  and conditions
  * of the license of that module. An independent module is a module which is not
  * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
@@ -33,10 +33,9 @@
  *
  */
 
-if (!isset($oreon)) {
+if (!isset($centreon)) {
     exit;
 }
-
 
 require_once $centreon_path . '/bootstrap.php';
 $pearDB = $dependencyInjector['configuration_db'];
@@ -115,8 +114,9 @@ $tpl->assign('searchTemplatesWithNoProcedure', $checked2);
  * Get Poller List
  */
 if ($searchOptions['poller']) {
-    $query = "SELECT id, name FROM nagios_server ORDER BY name";
-    $res = $pearDB->query($query);
+    $res = $pearDB->query(
+        "SELECT id, name FROM nagios_server ORDER BY name"
+    );
     $searchPoller = "<option value='0'></option>";
     while ($row = $res->fetchRow()) {
         if (isset($_REQUEST['searchPoller']) && $row['id'] == $_REQUEST['searchPoller']) {
@@ -132,8 +132,9 @@ if ($searchOptions['poller']) {
  * Get Hostgroup List
  */
 if ($searchOptions['hostgroup']) {
-    $query = "SELECT hg_id, hg_name FROM hostgroup ORDER BY hg_name";
-    $res = $pearDB->query($query);
+    $res = $pearDB->query(
+        "SELECT hg_id, hg_name FROM hostgroup ORDER BY hg_name"
+    );
     $searchHostgroup = "<option value='0'></option>";
     while ($row = $res->fetchRow()) {
         if (isset($_REQUEST['searchHostgroup']) && $row['hg_id'] == $_REQUEST['searchHostgroup']) {
@@ -149,8 +150,9 @@ if ($searchOptions['hostgroup']) {
  * Get Servicegroup List
  */
 if ($searchOptions['servicegroup']) {
-    $query = "SELECT sg_id, sg_name FROM servicegroup ORDER BY sg_name";
-    $res = $pearDB->query($query);
+    $res = $pearDB->query(
+        "SELECT sg_id, sg_name FROM servicegroup ORDER BY sg_name"
+    );
     $searchServicegroup = "<option value='0'></option>";
     while ($row = $res->fetchRow()) {
         if (isset($_REQUEST['searchServicegroup']) && $row['sg_id'] == $_REQUEST['searchServicegroup']) {

--- a/www/include/configuration/configKnowledge/templates/display.ihtml
+++ b/www/include/configuration/configKnowledge/templates/display.ihtml
@@ -224,6 +224,9 @@
     <input type='hidden' id='num' name='num' value='0'>
     <input type='hidden' id='orderby' name='orderby' value='{$orderby}'>
     <input type='hidden' id='order' name='order' value='{$order}'>
+    <!--input type='hidden' id='host' name='host' value='{$host}'>
+    <input type='hidden' id='hostgroup' name='hostgroup' value='{$hostgroup}'>
+    <input type='hidden' id='poller' name='poller' value='{$poller}'-->
 </form>
 
 {literal}

--- a/www/include/configuration/configKnowledge/templates/display.ihtml
+++ b/www/include/configuration/configKnowledge/templates/display.ihtml
@@ -224,9 +224,6 @@
     <input type='hidden' id='num' name='num' value='0'>
     <input type='hidden' id='orderby' name='orderby' value='{$orderby}'>
     <input type='hidden' id='order' name='order' value='{$order}'>
-    <!--input type='hidden' id='host' name='host' value='{$host}'>
-    <input type='hidden' id='hostgroup' name='hostgroup' value='{$hostgroup}'>
-    <input type='hidden' id='poller' name='poller' value='{$poller}'-->
 </form>
 
 {literal}

--- a/www/include/core/header/htmlHeader.php
+++ b/www/include/core/header/htmlHeader.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2016 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -126,7 +126,11 @@ print "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
         $searchStr .= "search_host=" . htmlentities($_GET["search"], ENT_QUOTES, "UTF-8");
     }
     if (isset($centreon->historySearch[$url]) && !isset($_GET["search"])) {
-        $searchStr .= "search_host=" . $centreon->historySearch[$url];
+        if (!is_array($centreon->historySearch[$url])) {
+            $searchStr .= "search_host=" . $centreon->historySearch[$url];
+        } elseif (isset($centreon->historySearch[$url]['search'])) {
+            $searchStr .= "search_host=" . $centreon->historySearch[$url]['search'];
+        }
     }
 
     $searchStrSVC = "";

--- a/www/install/step_upgrade/step5.php
+++ b/www/install/step_upgrade/step5.php
@@ -50,7 +50,7 @@ $stat = $res->fetch();
 $template = getTemplate('templates');
 
 /* If CEIP is disabled and if it's a major version of Centreon ask again */
-$aVersion = explode ('.', $_SESSION['CURRENT_VERSION']);
+$aVersion = explode('.', $_SESSION['CURRENT_VERSION']);
 if ((int)$stat['value'] != 1 && (int)$aVersion[2] === 0) {
     $stat = false;
 }


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

- Pagination and filters fix for the "configuration > knowledgeBase" pages

- fix the broken serviceTemplate's  wikiURL
- correct the getServiceId() method's query
- replace $oreon with $centreon
- style, psr2 and license update
- remove the php notice array to string conversion in the htmlHeader.php file
- fix $o in the ternary of the common/pagination.php file


<h2> Type of change </h2>

- [X] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [X] 18.10.x
- [X] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Save a filter and check that when you change the pagination filter, the filter fields aren't empty and the displayed results are what they should be


<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X]   I have  **rebased** my development branch on the base branch (master, maintenance).
