### PR TITLE
fix(rrd): broker config generate external values

### DIFF
--- a/www/class/config-generate/broker.class.php
+++ b/www/class/config-generate/broker.class.php
@@ -175,9 +175,11 @@ class Broker extends AbstractObjectXML
             foreach ($resultParameters as $key => $value) {
                 // We search the BlockId
                 $blockId = 0;
+                $configGroupdId = null;
                 for ($i = count($value); $i > 0; $i--) {
                     if (isset($value[$i]['config_key']) && $value[$i]['config_key'] == 'blockId') {
                         $blockId = $value[$i]['config_value'];
+                        $configGroupId = $value[$i]['config_group_id'];
                         break;
                     }
                 }
@@ -220,6 +222,16 @@ class Broker extends AbstractObjectXML
                             $subvalue['config_value'];
                     }
                     $flow_count++;
+                }
+                
+                // Check if we need to add values from external
+                foreach ($this->cacheExternalValue as $key2 => $value2) {
+                    if (preg_match('/^(.+)_' . $blockId . '$/', $key2, $matches)) {
+                        if (!isset($object[$configGroupId][$key][$matches[1]])) {
+                            $object[$configGroupId][$key][$matches[1]] =
+                                $this->getInfoDb($value2);
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Broker configuration doesn't generate rrdcached external information in a new install. 

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Install a new centreon. (Or delete rrdcached external information: delete from cfg_centreonbroker_info where config_key IN ('path', 'port') AND config_group_id = 0 AND config_group = 'output')

Add rrdcached configuration in 'Administration > Paramaters > rrdtool' and generate configuration for the central server:
* before the patch: you don't have rrdcached information in /etc/centreon-broker/central-rrd.xml file
* after the patch: you have  rrdcached information in /etc/centreon-broker/central-rrd.xml file

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X]   I have   **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
