### PR TITLE
fix(widget) : widget params on public view #7383

### DIFF
--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -658,7 +658,7 @@ class CentreonCustomView
     {
         //get all widget parameters from the view that is being added
         if (isset($userId) && $userId) {
-            $query = 'SELECT * FROM widget_views wv LEFT JOIN widget_preferences wp ON wp.widget_view_id=wv.widget_view_id ' .
+            $query = 'SELECT * FROM widget_views wv LEFT JOIN widget_preferences wp ON wp.widget_view_id = wv.widget_view_id ' .
                 'LEFT JOIN custom_view_user_relation cvur ON cvur.custom_view_id=wv.custom_view_id ' .
                 'WHERE cvur.custom_view_id = :viewId and cvur.locked = 0';
             $stmt = $this->db->prepare($query);

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -680,7 +680,7 @@ class CentreonCustomView
 
                 $dbResult2 = $stmt2->execute();
                 if (!$dbResult2) {
-                    throw new \Exception("An error occured");
+                    throw new \Exception("An error occured when adding user's Id : " . $userId . " parameters to the widget's Id : " . $viewId);
                 }
             }
         }

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -665,7 +665,7 @@ class CentreonCustomView
             $stmt->bindParam(':viewId', $viewId, PDO::PARAM_INT);
             $dbResult = $stmt->execute();
             if (!$dbResult) {
-                throw new \Exception("An error occured");
+                throw new \Exception("An error occured when retreiving user's Id : " . userId . " parameters of the widget's Id : " . $viewId);
             }
 
             //add every widget parameters for the current user

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -658,21 +658,18 @@ class CentreonCustomView
     {
         //get all widget parameters from the view that is being added
         if (isset($userId) && $userId) {
-            $query = 'SELECT * FROM widget_views wv LEFT JOIN widget_preferences wp ON wp.widget_view_id = wv.widget_view_id ' .
+            $stmt = $this->db->prepare('SELECT * FROM widget_views wv LEFT JOIN widget_preferences wp ON wp.widget_view_id = wv.widget_view_id ' .
                 'LEFT JOIN custom_view_user_relation cvur ON cvur.custom_view_id=wv.custom_view_id ' .
-                'WHERE cvur.custom_view_id = :viewId and cvur.locked = 0';
-            $stmt = $this->db->prepare($query);
+                'WHERE cvur.custom_view_id = :viewId and cvur.locked = 0');
             $stmt->bindParam(':viewId', $viewId, PDO::PARAM_INT);
             $dbResult = $stmt->execute();
             if (!$dbResult) {
-                throw new \Exception("An error occured when retreiving user's Id : " . userId . " parameters of the widget's Id : " . $viewId);
+                throw new \Exception("An error occured when retreiving user's Id : " . userId . " parameters of the widgets from the view: Id = " . $viewId);
             }
 
             //add every widget parameters for the current user
             while ($row = $stmt->fetch()) {
-                $query2 = 'INSERT INTO widget_preferences VALUES (:widget_view_id, :parameter_id, :preference_value, :user_id)';
-
-                $stmt2 = $this->db->prepare($query2);
+                $stmt2 = $this->db->prepare('INSERT INTO widget_preferences VALUES (:widget_view_id, :parameter_id, :preference_value, :user_id)');
                 $stmt2->bindParam(':widget_view_id', $row['widget_view_id'], PDO::PARAM_INT);
                 $stmt2->bindParam(':parameter_id', $row['parameter_id'], PDO::PARAM_INT);
                 $stmt2->bindParam(':preference_value', $row['preference_value'], PDO::PARAM_STR);
@@ -680,7 +677,7 @@ class CentreonCustomView
 
                 $dbResult2 = $stmt2->execute();
                 if (!$dbResult2) {
-                    throw new \Exception("An error occured when adding user's Id : " . $userId . " parameters to the widget's Id : " . $viewId);
+                    throw new \Exception("An error occured when adding user's Id : " . $userId . " parameters to the widgets from the view: Id = " . $viewId);
                 }
             }
         }


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:

if someone create a public view, every single user that is going to load it into its own home page will have widgets with no parameters. This PR add a new function that handles that (couldn't find one that does that. We only have a sync function but that doesn't serve the same purpose

* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

Fixes #7383 

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

just check the issue, it explains it well

Any **relevant details** of the configuration to perform the test should be added.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
