### PR TITLE
enh(core): enhance logger lib to handle utf8, add possibility to pass…

### DIFF
--- a/lib/perl/centreon/common/db.pm
+++ b/lib/perl/centreon/common/db.pm
@@ -176,11 +176,13 @@ sub kill {
 }
 
 # Connection initializer
-sub connect() {
-    my $self = shift;
+sub connect {
+    my ($self, %options) = @_;
     my $logger = $self->{logger};
     my $status = 0;
 
+    my $connect_options = {};
+    $connect_options = $options{connect_options} if (defined($options{connect_options}) && ref($options{connect_options}) eq "HASH");
     while (1) {
         $self->{port} = 3306 if (!defined($self->{port}) && $self->{type} eq 'mysql');
         if ($self->{type} =~ /SQLite/i) {
@@ -189,7 +191,7 @@ sub connect() {
                     .":".$self->{db},
                 $self->{user},
                 $self->{password},
-                { "RaiseError" => 0, "PrintError" => 0, "AutoCommit" => 1 }
+                { "RaiseError" => 0, "PrintError" => 0, "AutoCommit" => 1, %{$connect_options} }
             );
         } else {
             $self->{instance} = DBI->connect(
@@ -199,7 +201,7 @@ sub connect() {
                     .":".$self->{port},
                 $self->{user},
                 $self->{password},
-                { "RaiseError" => 0, "PrintError" => 0, "AutoCommit" => 1 }
+                { "RaiseError" => 0, "PrintError" => 0, "AutoCommit" => 1, %{$connect_options} }
             );
         }
         if (defined($self->{instance})) {

--- a/lib/perl/centreon/common/logger.pm
+++ b/lib/perl/centreon/common/logger.pm
@@ -64,6 +64,7 @@ use strict;
 use warnings;
 use Sys::Syslog qw(:standard :macros);
 use IO::Handle;
+use Encode;
 
 my %severities = (1 => LOG_INFO,
                   2 => LOG_ERR,
@@ -199,6 +200,8 @@ sub writeLog($$$%) {
     if (($self->{severity} & $severity) == 0) {
         return;
     }
+
+    $newmsg = encode('UTF-8', $newmsg);
     if ($self->{log_mode} == 0) {
         print "$newmsg\n";
     } elsif ($self->{log_mode} == 1) {


### PR DESCRIPTION
… connection options to perl db lib

<h1> Pull Request Template </h1>

<h2> Description </h2>

- Can use 'mysql_enable_utf8' for DBI connect
- Can display correctly utf-8 (log file and terminal)

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

You can test it with last version of centreon-auto-discovery-server for example:
- create an host with characters like: centreonétest
- try to check it with following command: perl centreon_autodisco.pl --filter-host="centreonétest"

It should do the discovery rule.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
