### PR TITLE
fix(widget) : widget params on public view

### DIFF
--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -658,21 +658,27 @@ class CentreonCustomView
     {
         //get all widget parameters from the view that is being added
         if (isset($userId) && $userId) {
-            $query = 'SELECT * FROM widget_views wv LEFT JOIN widget_preferences wp ON wp.widget_view_id=wv.widget_view_id ' .
+            $stmt = $this->db->prepare(
+                'SELECT * FROM widget_views wv ' .
+                'LEFT JOIN widget_preferences wp ON wp.widget_view_id = wv.widget_view_id ' .
                 'LEFT JOIN custom_view_user_relation cvur ON cvur.custom_view_id=wv.custom_view_id ' .
-                'WHERE cvur.custom_view_id = :viewId and cvur.locked = 0';
-            $stmt = $this->db->prepare($query);
+                'WHERE cvur.custom_view_id = :viewId and cvur.locked = 0'
+            );
             $stmt->bindParam(':viewId', $viewId, PDO::PARAM_INT);
             $dbResult = $stmt->execute();
             if (!$dbResult) {
-                throw new \Exception("An error occured");
+                throw new \Exception(
+                    "An error occurred when retrieving user's Id : " . userId .
+                    " parameters of the widgets from the view: Id = " . $viewId
+                );
             }
 
             //add every widget parameters for the current user
             while ($row = $stmt->fetch()) {
-                $query2 = 'INSERT INTO widget_preferences VALUES (:widget_view_id, :parameter_id, :preference_value, :user_id)';
-
-                $stmt2 = $this->db->prepare($query2);
+                $stmt2 = $this->db->prepare(
+                    'INSERT INTO widget_preferences ' .
+                    'VALUES (:widget_view_id, :parameter_id, :preference_value, :user_id)'
+                );
                 $stmt2->bindParam(':widget_view_id', $row['widget_view_id'], PDO::PARAM_INT);
                 $stmt2->bindParam(':parameter_id', $row['parameter_id'], PDO::PARAM_INT);
                 $stmt2->bindParam(':preference_value', $row['preference_value'], PDO::PARAM_STR);
@@ -680,7 +686,10 @@ class CentreonCustomView
 
                 $dbResult2 = $stmt2->execute();
                 if (!$dbResult2) {
-                    throw new \Exception("An error occured");
+                    throw new \Exception(
+                        "An error occurred when adding user's Id : " . $userId .
+                        " parameters to the widgets from the view: Id = " . $viewId
+                    );
                 }
             }
         }

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -657,7 +657,7 @@ class CentreonCustomView
     public function addPublicViewWidgetParams($viewId, $userId)
     {
         //get all widget parameters from the view that is being added
-        if (isset($userId) && !empty($userId)) {
+        if (!empty($userId)) {
             $stmt = $this->db->prepare(
                 'SELECT * FROM widget_views wv ' .
                 'LEFT JOIN widget_preferences wp ON wp.widget_view_id = wv.widget_view_id ' .

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -657,7 +657,7 @@ class CentreonCustomView
     public function addPublicViewWidgetParams($viewId, $userId)
     {
         //get all widget parameters from the view that is being added
-        if (isset($userId) && $userId) {
+        if (isset($userId) && !empty($userId)) {
             $stmt = $this->db->prepare(
                 'SELECT * FROM widget_views wv ' .
                 'LEFT JOIN widget_preferences wp ON wp.widget_view_id = wv.widget_view_id ' .

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -662,7 +662,7 @@ class CentreonCustomView
                 'SELECT * FROM widget_views wv ' .
                 'LEFT JOIN widget_preferences wp ON wp.widget_view_id = wv.widget_view_id ' .
                 'LEFT JOIN custom_view_user_relation cvur ON cvur.custom_view_id = wv.custom_view_id ' .
-                'WHERE cvur.custom_view_id = :view_id AND cvur.is_owner = 1 AND cvur.user_id = wp.user_id'
+                'WHERE cvur.custom_view_id = :viewId AND cvur.is_owner = 1 AND cvur.user_id = wp.user_id'
             );
             $stmt->bindParam(':viewId', $viewId, PDO::PARAM_INT);
             $dbResult = $stmt->execute();
@@ -677,12 +677,12 @@ class CentreonCustomView
             while ($row = $stmt->fetch()) {
                 $stmt2 = $this->db->prepare(
                     'INSERT INTO widget_preferences ' .
-                    'VALUES (:widget_view_id, :parameter_id, :preference_value, :user_id)'
+                    'VALUES (:widgetViewId, :parameterId, :preferenceValue, :userId)'
                 );
-                $stmt2->bindParam(':widget_view_id', $row['widget_view_id'], PDO::PARAM_INT);
-                $stmt2->bindParam(':parameter_id', $row['parameter_id'], PDO::PARAM_INT);
-                $stmt2->bindParam(':preference_value', $row['preference_value'], PDO::PARAM_STR);
-                $stmt2->bindParam(':user_id', $userId, PDO::PARAM_INT);
+                $stmt2->bindParam(':widgetViewId', $row['widget_view_id'], PDO::PARAM_INT);
+                $stmt2->bindParam(':parameterId', $row['parameter_id'], PDO::PARAM_INT);
+                $stmt2->bindParam(':preferenceValue', $row['preference_value'], PDO::PARAM_STR);
+                $stmt2->bindParam(':userId', $userId, PDO::PARAM_INT);
 
                 $dbResult2 = $stmt2->execute();
                 if (!$dbResult2) {
@@ -725,11 +725,12 @@ class CentreonCustomView
             }
 
             // select user already share
-            $query = 'SELECT user_id FROM custom_view_user_relation ' .
+            $stmt = $this->db->prepare(
+                'SELECT user_id FROM custom_view_user_relation ' .
                 'WHERE custom_view_id = :viewId ' .
                 'AND user_id <> :userId ' .
-                'AND usergroup_id IS NULL ';
-            $stmt = $this->db->prepare($query);
+                'AND usergroup_id IS NULL '
+            );
             $stmt->bindParam(':viewId', $params['custom_view_id'], PDO::PARAM_INT);
             $stmt->bindParam(':userId', $userId, PDO::PARAM_INT);
             $dbResult = $stmt->execute();
@@ -744,10 +745,11 @@ class CentreonCustomView
             // check if the view is share at a new user
             foreach ($sharedUsers as $sharedUserId => $locked) {
                 if (isset($oldSharedUsers[$sharedUserId])) {
-                    $query = 'UPDATE custom_view_user_relation SET is_share = 1, locked = :isLocked ' .
+                    $stmt = $this->db->prepare(
+                        'UPDATE custom_view_user_relation SET is_share = 1, locked = :isLocked ' .
                         'WHERE user_id = :userId ' .
-                        'AND custom_view_id = :viewId';
-                    $stmt = $this->db->prepare($query);
+                        'AND custom_view_id = :viewId'
+                    );
                     $stmt->bindParam(':isLocked', $locked, PDO::PARAM_INT);
                     $stmt->bindParam(':userId', $sharedUserId, PDO::PARAM_INT);
                     $stmt->bindParam(':viewId', $params['custom_view_id'], PDO::PARAM_INT);
@@ -757,10 +759,11 @@ class CentreonCustomView
                     }
                     unset($oldSharedUsers[$sharedUserId]);
                 } else {
-                    $query = 'INSERT INTO custom_view_user_relation ' .
+                    $stmt = $this->db->prepare(
+                        'INSERT INTO custom_view_user_relation ' .
                         '(custom_view_id, user_id, locked, is_consumed, is_share ) ' .
-                        'VALUES ( :viewId, :sharedUser, :isLocked, 0, 1) ';
-                    $stmt = $this->db->prepare($query);
+                        'VALUES ( :viewId, :sharedUser, :isLocked, 0, 1) '
+                    );
                     $stmt->bindParam(':viewId', $params['custom_view_id'], PDO::PARAM_INT);
                     $stmt->bindParam(':sharedUser', $sharedUserId, PDO::PARAM_INT);
                     $stmt->bindParam(':isLocked', $locked, PDO::PARAM_INT);
@@ -787,24 +790,26 @@ class CentreonCustomView
             }
 
             // delete widget preferences for old user
-            $query = 'DELETE FROM widget_preferences ' .
+            $stmt = $this->db->prepare(
+                'DELETE FROM widget_preferences ' .
                 'WHERE widget_view_id IN (SELECT wv.widget_view_id FROM widget_views wv ' .
                 'WHERE wv.custom_view_id = ? ) ' .
-                'AND user_id IN (' . $userIdKey . ') ';
-            $stmt = $this->db->prepare($query);
+                'AND user_id IN (' . $userIdKey . ') '
+            );
             $dbResult = $stmt->execute($queryValue);
             if (!$dbResult) {
                 throw new \Exception($stmt->errorInfo());
             }
 
             // delete view / user relation
-            $query = 'DELETE FROM custom_view_user_relation ' .
+            $stmt = $this->db->prepare(
+                'DELETE FROM custom_view_user_relation ' .
                 'WHERE custom_view_id = ? ' .
-                'AND user_id IN (' . $userIdKey . ') ';
-            $stmt = $this->db->prepare($query);
+                'AND user_id IN (' . $userIdKey . ') '
+            );
             $dbResult = $stmt->execute($queryValue);
             if (!$dbResult) {
-                throw new \Exception("An error occured");
+                throw new \Exception("An error occurred");
             }
 
             ////////////////////////////

--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -661,14 +661,14 @@ class CentreonCustomView
             $stmt = $this->db->prepare(
                 'SELECT * FROM widget_views wv ' .
                 'LEFT JOIN widget_preferences wp ON wp.widget_view_id = wv.widget_view_id ' .
-                'LEFT JOIN custom_view_user_relation cvur ON cvur.custom_view_id=wv.custom_view_id ' .
-                'WHERE cvur.custom_view_id = :viewId and cvur.locked = 0'
+                'LEFT JOIN custom_view_user_relation cvur ON cvur.custom_view_id = wv.custom_view_id ' .
+                'WHERE cvur.custom_view_id = :view_id AND cvur.is_owner = 1 AND cvur.user_id = wp.user_id'
             );
             $stmt->bindParam(':viewId', $viewId, PDO::PARAM_INT);
             $dbResult = $stmt->execute();
             if (!$dbResult) {
                 throw new \Exception(
-                    "An error occurred when retrieving user's Id : " . userId .
+                    "An error occurred when retrieving user's Id : " . $userId .
                     " parameters of the widgets from the view: Id = " . $viewId
                 );
             }


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

If the view is being added for the first time, we make sure that the widget parameters are going to be set
Get all widget's parameters from the view that is being added and add every widget parameters to the current user

Fixes # (issue)

<h2> Type of change </h2>

- [X] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [X] 18.10.x
- [X] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

you can test this pull request by creating a new view with various widgets on it and configure them so that they do not show the default data and/or the warning message telling you ton configure them. 

When done, just make your view public so that people can add this view to their home page. 

Switch to another user, try to load the public view, you'll notice that every single widget in the view is not configured. 

this fixes #7320 and #7383
I've forgot to test what happens if the view creator made an unlocked sharing to a specific user and then someone adds this view from the public views list (i'm thinking about that because of the `locked=0` condition in the query (might want to change that for `is_owner=1` . I'll test that later today and update the thread. (thx @tanguyvda )

<h2> Checklist </h2>

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X]   I have   **rebased** my development branch on the base branch (master, maintenance).