### PR TITLE
upgrade(core): add missing SQL upgrade script

### DIFF
--- a/www/install/sql/centreon/Update-DB-2.8.26_to_2.8.27.sql
+++ b/www/install/sql/centreon/Update-DB-2.8.26_to_2.8.27.sql
@@ -1,0 +1,5 @@
+-- Change version of Centreon
+UPDATE `informations` SET `value` = '2.8.27' WHERE CONVERT( `informations`.`key` USING utf8 ) = 'version' AND CONVERT ( `informations`.`value` USING utf8 ) = '2.8.26' LIMIT 1;
+
+-- Add default illegal characters for centcore external commands
+INSERT INTO `options` (`key`, `value`) VALUES ('centcore_illegal_characters', '`');

--- a/www/install/sql/centreon/Update-DB-2.8.27_to_18.10.0.sql
+++ b/www/install/sql/centreon/Update-DB-2.8.27_to_18.10.0.sql
@@ -1,5 +1,5 @@
 -- Change version of Centreon
-UPDATE `informations` SET `value` = '18.10.0' WHERE CONVERT( `informations`.`key` USING utf8 ) = 'version' AND CONVERT ( `informations`.`value` USING utf8 ) = '2.8.26' LIMIT 1;
+UPDATE `informations` SET `value` = '18.10.0' WHERE CONVERT( `informations`.`key` USING utf8 ) = 'version' AND CONVERT ( `informations`.`value` USING utf8 ) = '2.8.27' LIMIT 1;
 
 -- Create remote servers table for keeping track of remote instances
 CREATE TABLE IF NOT EXISTS `remote_servers` (


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

The 2.8.27 has been released but the 18.10.x branch has not been updated. Therefore the **Update-DB-2.8.26_to_2.8.27.sql** was missing on the 18.10.x branch.

The **Update-DB-2.8.26_to_18.10.0.sql** has been renamed to **Update-DB-2.8.27_to_18.10.0.sql** and updated.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [ ] 18.10.x

<h2> How this pull request can be tested ? </h2>

Update a 2.8.27 version of Centreon Web to the latest 18.10.x and everything should work

Any **relevant details** of the configuration to perform the test should be added.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
