### PR TITLE
fix(bug): partial backup didn't backup the right partition for data_b…

### DIFF
--- a/cron/centreon-backup-mysql.sh
+++ b/cron/centreon-backup-mysql.sh
@@ -51,6 +51,7 @@ SAVE_LAST_FILE="backup.last"
 DO_ARCHIVE=1
 INIT_SCRIPT="" # try to find it
 PARTITION_NAME="centreon_storage/data_bin centreon_storage/logs"
+MNTOPTIONS="-o nouuid"
 
 ###
 # Check MySQL launch
@@ -236,7 +237,7 @@ $INIT_SCRIPT start
 ###
 output_log "Mount LVM snapshot"
 mkdir -p "$SNAPSHOT_MOUNT"
-mount /dev/$vg_name/dbbackup "$SNAPSHOT_MOUNT"
+mount $MNTOPTIONS /dev/$vg_name/dbbackup "$SNAPSHOT_MOUNT"
 if [ $? -eq 0 ]; then
     output_log "Device mounted successfully"
 else
@@ -253,12 +254,13 @@ concat_datadir=$(echo "$datadir" | sed "s#^${mount_point}##")
 ar_exclude_file=""
 last_save_time=$(cat "$SAVE_LAST_DIR/$SAVE_LAST_FILE")
 
-if [ $OPT_PARTIAL -eq 1 ] ; then
+if [ $OPT_PARTIAL -eq 1 ] && [ -n "$last_save_time" ] ; then
+    minutes=$((($save_timestamp - $last_save_time) / 60))
     for table in $PARTITION_NAME ; do
     	tmp_dir=$(dirname "$table")
     	tmp_name=$(basename "$table")
     	tmp_path=$(echo "$SNAPSHOT_MOUNT/$concat_datadir/$tmp_dir" | sed "s#/\+#/#g")
-    	for tmp_file in $(find "$tmp_path" -name "$tmp_name*" -type f); do
+     	for tmp_file in $(find "$tmp_path" -name "$tmp_name*" -mmin +$minutes -type f); do 
     		ar_exclude_file="$ar_exclude_file \"$tmp_file\""
     	done
     done


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

When we enabled the partial backup from lvm snapshot, we can restore the partial backup because : - the partial backup method backup ibdata but not the new partitions ; - When we restore the full and the partial, we have a ibdata that need the new partitions not backuped - The tables logs and data_bin doesn't exist anymore in the innodb engine

So now I fix the issue following the smooth-db-backup.sh

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Enable the backup LVM partial and full. 2. Wait to have one full and one partial 3. Try to restore following theses commands : - mysqladmin shutdown - rm -rf /var/lib/mysql/* - tar -xzf 2018-02-28-mysql-full.tar.gz --strip-components=3 -C /var/lib/mysql/ - tar -xzf 2019-03-01-mysql-partial.tar.gz --strip-components=3 -C /var/lib/mysql/ - restart mysql

Try do it without this fix, you'll have the following error :
mysql > desc data_bin;
Table 'centreon_storage.data_bin' doesn't exist in engine

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
