### PR TITLE
feat(core): centreon_health script to gather various data

### DIFF
--- a/bin/centreon_health
+++ b/bin/centreon_health
@@ -1,0 +1,54 @@
+#!/usr/bin/env perl
+
+use warnings;
+use centreon::script::centreon_health;
+
+centreon::script::centreon_health->new()->run();
+
+__END__
+
+=head1 NAME
+
+centreon_health - a tool/script to gather informations about Centreon ("noroot" script)
+
+=head1 SYNOPSIS
+
+centreon_health [options]
+
+=head1 OPTIONS
+
+=over 8
+
+=item B<--centstorage-db> <value>
+
+Specify the name of your centstorage db if not standard
+(default: centreon_storage).
+
+=item B<--centreon-branch> <value>
+
+Specify centreon version (X.Y format) if older than 2.8
+(default: 2.8).
+
+=item B<--check-protocol> <value>
+
+Specify favorite check protocol (will be implemented later, 'snmp' is the only one available for now)
+
+=item B<--snmp-community> <value>
+
+Specify snmp community to execute plugins
+
+=item B<--output-type> <value>
+
+Specify output type. Can be: 'MARKDOWN', 'JSON', 'TEXT' or 'DUMPER' (last if for debugging only, raw perl struct)
+
+=item B<--skip-*>
+
+Skip check that might be long (rrd and db e.g) on large setup or overkill in some situation
+Can be : --skip-rrd, --skip-db, --skip-logs
+
+=head1 DESCRIPTION
+
+B<centreon_health> will gather some informations about centreon global metrics
+sample usage: su - centreon -c "/usr/share/centreon/bin/centreon_health --skip-logs"
+
+=cut

--- a/lib/perl/centreon/health/checkbroker.pm
+++ b/lib/perl/centreon/health/checkbroker.pm
@@ -1,0 +1,103 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checkbroker;
+
+use strict;
+use warnings;
+use JSON;
+use POSIX qw(strftime);
+use centreon::common::misc;
+use centreon::health::ssh;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub json_parsing {
+    my ($self, %options) = @_;
+    
+    my $json_content = JSON->new->decode($options{json_content});
+    foreach my $key (keys %$json_content) {
+	if ($key =~ m/^endpoint/) {
+	foreach my $broker_metric (keys %{$json_content->{$key}}) {
+		next if ($broker_metric !~ m/version|event_processing|last_connection|queued|state/);
+		$self->{output}->{$options{poller_name}}->{$options{file_name}}->{$broker_metric} = ($broker_metric =~ m/^last_connection/ && $json_content->{$key}->{$broker_metric} != -1) 
+										? strftime("%m/%d/%Y %H:%M:%S",localtime($json_content->{$key}->{$broker_metric}))
+										: $json_content->{$key}->{$broker_metric} ;
+	    }
+	} elsif ($key =~ m/version/) {
+	    $self->{output}->{$options{poller_name}}->{$options{file_name}}->{$key} = $json_content->{$key};
+	}
+
+    }
+
+    return $self->{output} 
+
+}
+
+sub run {
+    my $self = shift;
+    my ($centreon_db, $server_list, $centreon_version) = @_;
+
+    my $sth;
+
+    if ($centreon_version ne "2.8") {
+	$self->{output}->{not_compliant} = "Incompatible file format, work only with JSON format";
+	return $self->{output}
+    }
+
+    return if ($centreon_version ne "2.8");
+    foreach my $server (keys %$server_list) {
+	$sth = $centreon_db->query("SELECT config_name, cache_directory 
+					FROM cfg_centreonbroker 
+					WHERE stats_activate='1' 
+					AND ns_nagios_server=".$centreon_db->quote($server)."");
+
+	if ($server_list->{$server}->{localhost} eq "YES") {
+            while (my $row = $sth->fetchrow_hashref()) {
+	        my ($lerror, $stdout) = centreon::common::misc::backtick(command => "cat " . $row->{cache_directory} . "/" . $row->{config_name} . "-stats.json");
+		$self->{output} = $self->json_parsing(json_content => $stdout,
+						      poller_name => $server_list->{$server}->{name},
+						      file_name => $row->{config_name}. "-stats.json");
+	    }
+	} else {
+            while (my $row = $sth->fetchrow_hashref()) {
+		my $stdout = centreon::health::ssh->new->main(host => $server_list->{$server}->{address},
+                                                              port => $server_list->{$server}->{ssh_port},
+                                                              userdata => $row->{cache_directory} . "/" . $row->{config_name} . "-stats.json",
+                                                              command => "cat " . $row->{cache_directory} . "/" . $row->{config_name} . "-stats.json");
+                $self->{output} = $self->json_parsing(json_content => $stdout,
+                                                      poller_name => $server_list->{$server}->{name},
+                                                      file_name => $row->{config_name}. "-stats.json");
+
+            }
+        }
+       
+    }
+    return $self->{output}
+}
+
+1;

--- a/lib/perl/centreon/health/checkdb.pm
+++ b/lib/perl/centreon/health/checkdb.pm
@@ -1,0 +1,95 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checkdb;
+
+use strict;
+use warnings;
+use POSIX qw(strftime);
+use centreon::health::misc;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+    my ($centreon_db, $centstorage_db, $centstorage_db_name, $flag, $logger) = @_;
+    my $size = 0;
+    my ($sth, $status);
+
+    foreach my $db_name ('centreon', $centstorage_db_name) {
+        $sth = $centreon_db->query("SELECT table_schema AS db_name, SUM(data_length+index_length) AS db_size 
+                                    FROM information_schema.tables
+				    WHERE table_schema=".$centreon_db->quote($db_name)."");
+        while (my $row = $sth->fetchrow_hashref) {
+            $self->{output}->{db_size}->{$row->{db_name}} = centreon::health::misc::format_bytes(bytes_value => $row->{db_size});
+        }
+        next if $db_name !~ /$centstorage_db_name/;
+        foreach my $table ('data_bin', 'logs', 'log_archive_host', 'log_archive_service', 'downtimes') {
+
+            $sth = $centreon_db->query("SELECT table_name, SUM(data_length+index_length) AS table_size
+                                        FROM information_schema.tables
+                                        WHERE table_schema=".$centreon_db->quote($db_name)."
+	    			        AND table_name=".$centreon_db->quote($table)."");
+
+            while (my $row = $sth->fetchrow_hashref()) {
+                $self->{output}->{table_size}->{$row->{table_name}} = centreon::health::misc::format_bytes(bytes_value =>$row->{table_size});
+            }
+	    
+	    next if ($table =~ m/downtimes/);
+            $sth = $centreon_db->query("SELECT MAX(CONVERT(PARTITION_DESCRIPTION, SIGNED INTEGER)) as lastPart 
+					FROM INFORMATION_SCHEMA.PARTITIONS 
+					WHERE TABLE_NAME='" . $table . "' 
+					AND TABLE_SCHEMA='" . $db_name . "' GROUP BY TABLE_NAME;");
+
+            while (my $row = $sth->fetchrow_hashref()) {
+	        $self->{output}->{partitioning_last_part}->{$table} = defined($row->{lastPart}) ? strftime("%m/%d/%Y %H:%M:%S",localtime($row->{lastPart})) : $table . " has no partitioning !";
+	    }
+	}
+    
+    }
+
+    my $var_list = { 'innodb_file_per_table' => 0,
+		     'open_files_limit' => 0,
+		     'read_only' => 0,
+                     'key_buffer_size' => 1,
+                     'sort_buffer_size' => 1,
+                     'join_buffer_size' => 1,
+                     'read_buffer_size' => 1,
+                     'read_rnd_buffer_size' => 1,
+                     'max_allowed_packet' => 1 };
+
+    foreach my $var (keys %{$var_list}) {
+	my $sth = $centreon_db->query("SHOW GLOBAL VARIABLES LIKE " . $centreon_db->quote($var));
+	my $value = $sth->fetchrow();
+	$self->{output}->{interesting_variables}->{$var} = ($var_list->{$var} == 1) ? centreon::health::misc::format_bytes(bytes_value => $value) : $value;
+    }
+
+    return $self->{output};
+    
+}
+
+1;

--- a/lib/perl/centreon/health/checklogs.pm
+++ b/lib/perl/centreon/health/checklogs.pm
@@ -1,0 +1,102 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checklogs;
+
+use strict;
+use warnings;
+use POSIX qw(strftime);
+use centreon::common::misc;
+use centreon::health::ssh;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{logs_path_broker} = {};
+    $self->{logs_path_engine} = {};
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+    my ($centreon_db, $server_list, $centreon_version, $logger) = @_;
+
+    my $sth;
+    my ($lerror, $stdout);
+
+    foreach my $server (keys %$server_list) {
+        $sth = $centreon_db->query("SELECT log_file
+                                     FROM cfg_nagios
+                                     WHERE nagios_id=" . $centreon_db->quote($server));
+
+        while (my $row = $sth->fetchrow_hashref) {
+            push @{$self->{logs_path_engine}->{engine}->{$server_list->{$server}->{name}}}, $row->{log_file};
+        }
+
+        foreach my $log_file (@{$self->{logs_path_engine}->{engine}->{$server_list->{$server}->{name}}}) {
+            if ($server_list->{$server}->{localhost} eq "YES") {
+                ($lerror, $self->{output}->{$server_list->{$server}->{name}}->{engine}->{$log_file}) = centreon::common::misc::backtick(command => "tail -n20 " . $log_file);
+            } else {
+                $self->{output}->{$server_list->{$server}->{name}}->{engine}->{$log_file} = centreon::health::ssh->new->main(host => $server_list->{$server}->{address},
+ 	 	                                                                                                             port => $server_list->{$server}->{ssh_port},
+           	   	                                                                                                     userdata => $log_file,
+                             		                                                                                     command => "tail -n20 " . $log_file);
+            }
+        }
+
+        $sth = $centreon_db->query("SELECT DISTINCT(config_value) FROM cfg_centreonbroker, cfg_centreonbroker_info
+                                            WHERE config_group='logger' AND config_key='name'
+                                            AND cfg_centreonbroker.config_id=cfg_centreonbroker_info.config_id
+                                            AND cfg_centreonbroker.ns_nagios_server=" . $centreon_db->quote($server));
+
+        while (my $row = $sth->fetchrow_hashref) {
+            push @{$self->{logs_path_broker}->{broker}->{$server_list->{$server}->{name}}}, $row->{config_value};
+        }
+
+        foreach my $log_file (@{$self->{logs_path_broker}->{broker}->{$server_list->{$server}->{name}}}) {
+            if ($server_list->{$server}->{localhost} eq "YES") {
+                ($lerror, $self->{output}->{$server_list->{$server}->{name}}->{broker}->{$log_file}) = centreon::common::misc::backtick(command => "tail -n20 " . $log_file);
+            } else {
+                $self->{output}->{$server_list->{$server}->{name}}->{broker}->{$log_file} = centreon::health::ssh->new->main(host => $server_list->{$server}->{address},
+                                                                              			                             port => $server_list->{$server}->{ssh_port},
+                                                                                                		             userdata => $log_file,
+                                                                                                         		     command => "tail -n20 " . $log_file);
+            }
+        }
+
+	if ($server_list->{$server}->{localhost} eq "YES") {
+             $sth = $centreon_db->query("SELECT `value` FROM options WHERE `key`='debug_path'");
+
+	     my $centreon_log_path = $sth->fetchrow();
+	     ($lerror, $stdout) = centreon::common::misc::backtick(command => "find " . $centreon_log_path . " -type f -name *.log");
+
+	     foreach my $log_file (split '\n', $stdout) {
+	         ($lerror, $self->{output}->{$server_list->{$server}->{name}}->{centreon}->{$log_file}) = centreon::common::misc::backtick(command => "tail -n10 " . $log_file);
+	     }
+	}
+    }
+ 
+    return $self->{output}
+}
+
+1;

--- a/lib/perl/centreon/health/checkmodules.pm
+++ b/lib/perl/centreon/health/checkmodules.pm
@@ -1,0 +1,53 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checkmodules;
+
+use strict;
+use warnings;
+use centreon::health::misc;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+    my ($centreon_db, $logger) = @_;
+    my $size = 0;
+    my ($sth, $status);
+
+    $sth = $centreon_db->query("SELECT name, rname, author, mod_release FROM  modules_informations");
+    while (my $row = $sth->fetchrow_hashref) {
+        $self->{output}->{$row->{name}}{full_name} = $row->{rname};
+        $self->{output}->{$row->{name}}{author} = $row->{author};
+        $self->{output}->{$row->{name}}{version} = $row->{mod_release};
+    }
+
+    return $self->{output};
+    
+}
+
+1;

--- a/lib/perl/centreon/health/checkrrd.pm
+++ b/lib/perl/centreon/health/checkrrd.pm
@@ -1,0 +1,94 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checkrrd;
+
+use strict;
+use warnings;
+use centreon::common::misc;
+use centreon::health::misc;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{rrd_metrics} = undef;
+    $self->{rrd_status} = undef;
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub get_rrd_path {
+    my ($self, %options) = @_;
+    my ($sth, $status);
+
+    $sth = $options{csdb}->query("SELECT RRDdatabase_path, RRDdatabase_status_path FROM config");
+
+    while (my $row = $sth->fetchrow_hashref()) {
+        $self->{rrd_metrics} = $row->{RRDdatabase_path};
+        $self->{rrd_status} = $row->{RRDdatabase_status_path};
+    }
+    
+}
+     
+sub get_rrd_infos {
+    my $self = shift;
+
+    my ($lerror, $size_metrics, $size_status, $count_last_written, $count_outdated_rrd, $count_metrics, $count_status);
+
+    if (-d $self->{rrd_metrics}) {
+        ($lerror, $size_metrics) = centreon::common::misc::backtick(command => "du -sb " . $self->{rrd_metrics});
+        ($lerror, $count_metrics) = centreon::common::misc::backtick(command => "ls -l " . $self->{rrd_metrics} . " | wc -l");
+        ($lerror, $count_last_written) = centreon::common::misc::backtick(command => "find " . $self->{rrd_metrics} . " -type f -mmin 5 | wc -l");
+        ($lerror, $count_outdated_rrd) = centreon::common::misc::backtick(command => "find " . $self->{rrd_metrics} . " -type f -mmin +288000 | wc -l");
+    } else {
+        $count_metrics = 0;
+        $size_metrics = 0;
+	$count_last_written = "ERROR, Directory " . $self->{rrd_metrics} . " does not exist !\n";
+        $count_outdated_rrd = "ERROR, Directory " . $self->{rrd_metrics} . " does not exist !\n";
+    }
+    if (-d $self->{rrd_status}) {
+        ($lerror, $size_status) = centreon::common::misc::backtick(command => "du -sb " . $self->{rrd_status});
+        ($lerror, $count_status) = centreon::common::misc::backtick(command => "ls -l " . $self->{rrd_status} . " | wc -l");
+    } else {
+	$count_status = 0;
+	$size_status = 0;
+    }
+
+    $self->{output}->{$self->{rrd_metrics}}{size} = centreon::health::misc::format_bytes(bytes_value => $size_metrics);
+    $self->{output}->{$self->{rrd_status}}{size} = centreon::health::misc::format_bytes(bytes_value => $size_status);
+    $self->{output}->{rrd_written_last_5m} = $count_last_written;
+    $self->{output}->{rrd_not_updated_since_180d} = $count_outdated_rrd;
+    $self->{output}->{$self->{rrd_metrics}}{count} = $count_metrics;
+    $self->{output}->{$self->{rrd_status}}{count} = $count_status;
+}
+
+sub run {
+    my $self = shift;
+    my ($centstorage_db, $flag, $logger) = @_;
+ 
+    $self->get_rrd_path(csdb => $centstorage_db);
+    $self->get_rrd_infos();
+
+    return $self->{output}
+}
+
+1;

--- a/lib/perl/centreon/health/checkservers.pm
+++ b/lib/perl/centreon/health/checkservers.pm
@@ -1,0 +1,137 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checkservers;
+
+use strict;
+use warnings;
+use integer;
+use POSIX qw(strftime);
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub query_misc {
+    my ($self, %options) = @_;
+    my ($sth, $status);
+
+    ($status, $sth) = $options{cdb}->query($options{query});
+
+    if ($status == -1) {
+        return "Query error - information is not available\n";
+    } else {
+       return $sth->fetchrow()
+    }
+
+}
+
+sub get_servers_informations {
+    my ($self, %options) = @_;
+
+    my $sth = $options{cdb}->query("SELECT id, name, localhost, ns_ip_address, ssh_port
+                                   FROM nagios_server WHERE ns_activate='1'");
+    while (my $row = $sth->fetchrow_hashref()) {
+        $self->{output}->{poller}->{$row->{id}}{name} = $row->{name};
+        $self->{output}->{poller}->{$row->{id}}{localhost} = ($row->{localhost} == 1) ? "YES" : "NO";
+        $self->{output}->{poller}->{$row->{id}}{address} = $row->{ns_ip_address};
+        $self->{output}->{poller}->{$row->{id}}{ssh_port} = (defined($row->{ssh_port})) ? $row->{ssh_port} : "-";
+        $self->{output}->{poller}->{$row->{id}}{id} = $row->{id};
+    }
+
+    foreach my $id (keys %{$self->{output}->{poller}}) {
+        $self->{output}->{global}->{count_poller}++;
+        $sth = $options{csdb}->query("SELECT COUNT(DISTINCT hosts.host_id) as num_hosts, count(DISTINCT services.host_id, services.service_id) as num_services
+                                     FROM hosts, services WHERE services.host_id=hosts.host_id
+                                     AND hosts.enabled=1
+                                     AND services.enabled=1
+                                     AND hosts.instance_id=".$options{cdb}->quote($id)."
+                                     AND hosts.name NOT LIKE '%Module%'");
+
+        while (my $row = $sth->fetchrow_hashref()) {
+            $self->{output}->{poller}{$id}{hosts} = $row->{num_hosts};
+            $self->{output}->{poller}{$id}{services} = $row->{num_services};
+            $self->{output}->{global}{count_hosts} += $row->{num_hosts};
+            $self->{output}->{global}{count_services} += $row->{num_services};
+        }
+
+        $sth = $options{csdb}->query("SELECT COUNT(DISTINCT hosts.host_id) as num_hosts, count(DISTINCT services.host_id, services.service_id) as num_services
+                                     FROM hosts, services WHERE services.host_id=hosts.host_id
+                                     AND hosts.enabled=1
+                                     AND services.enabled=1
+                                     AND hosts.instance_id=".$options{cdb}->quote($id)."");
+
+        $sth = $options{csdb}->query("SELECT *
+                                     FROM instances
+                                     WHERE instance_id = " . $options{cdb}->quote($id) . "");
+
+        while (my $row = $sth->fetchrow_hashref()) {
+            $self->{output}->{poller}{$row->{instance_id}}{uptime} = centreon::health::misc::change_seconds(value => $row->{last_alive} - $row->{start_time});
+            $self->{output}->{poller}{$row->{instance_id}}{running} = ($row->{running} == 1) ? "YES" : "NO";
+            $self->{output}->{poller}{$row->{instance_id}}{start_time} = strftime("%m/%d/%Y %H:%M:%S",localtime($row->{start_time}));
+            $self->{output}->{poller}{$row->{instance_id}}{last_alive} = strftime("%m/%d/%Y %H:%M:%S",localtime($row->{last_alive}));
+            $self->{output}->{poller}{$row->{instance_id}}{last_command_check} = strftime("%m/%d/%Y %H:%M:%S",localtime($row->{last_command_check}));
+            $self->{output}->{poller}{$row->{instance_id}}{engine} = $row->{engine};
+            $self->{output}->{poller}{$row->{instance_id}}{version} = $row->{version};
+        }
+
+        $sth = $options{csdb}->query("SELECT stat_key, stat_value, stat_label 
+                                      FROM nagios_stats
+                                      WHERE instance_id = " . $options{cdb}->quote($id) . "");
+
+        while (my $row = $sth->fetchrow_hashref()) {
+	        $self->{output}->{poller}->{$id}->{engine_stats}->{$row->{stat_label}}->{$row->{stat_key}} = $row->{stat_value}; 
+        }
+
+        $self->{output}->{global}->{hosts_by_poller_avg} = ($self->{output}->{global}->{count_poller} != 0) ? $self->{output}->{global}->{count_hosts} / $self->{output}->{global}->{count_poller} : '0';
+        $self->{output}->{global}->{services_by_poller_avg} = ($self->{output}->{global}->{count_poller} != 0) ? $self->{output}->{global}->{count_services} / $self->{output}->{global}->{count_poller} : '0';
+        $self->{output}->{global}->{services_by_host_avg} = ($self->{output}->{global}->{count_hosts} != 0) ? $self->{output}->{global}->{count_services} / $self->{output}->{global}->{count_hosts} : '0';
+        $self->{output}->{global}->{metrics_by_service_avg} = ($self->{output}->{global}->{count_services} != 0) ? $self->{output}->{global}->{count_metrics} / $self->{output}->{global}->{count_services} : '0';
+    }
+}
+     
+
+sub run {
+    my $self = shift;
+    my ($centreon_db, $centstorage_db, $centreon_version) = @_;
+
+    my $query_misc = {   count_pp => [$centreon_db, $centreon_version eq '2.7' ? "SELECT count(*) FROM mod_pluginpack" : "SELECT count(*) FROM mod_ppm_pluginpack"],
+                            count_downtime => [$centreon_db, "SELECT count(*) FROM downtime"],
+                            count_modules => [$centreon_db, "SELECT count(*) FROM modules_informations"],
+                            centreon_version => [$centreon_db, "SELECT value FROM informations LIMIT 1"],
+                            count_metrics => [$centstorage_db, "SELECT count(*) FROM metrics"] };
+
+    foreach my $info (keys %$query_misc) {
+        my $result = $self->query_misc(cdb => $query_misc->{$info}[0],
+                                        query => $query_misc->{$info}[1] );
+        $self->{output}->{global}->{$info} = $result;
+    }
+
+    $self->get_servers_informations(cdb => $centreon_db, csdb => $centstorage_db);
+
+    return $self->{output}
+}
+
+1;

--- a/lib/perl/centreon/health/checksystems.pm
+++ b/lib/perl/centreon/health/checksystems.pm
@@ -1,0 +1,133 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::checksystems;
+
+use strict;
+use warnings;
+use centreon::common::misc;
+use centreon::health::ssh;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+    $self->{cmd_system_health} = [];
+    $self->{output} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub build_command_hash {
+    my ($self, %options) = @_;
+
+    if ($options{medium} eq "snmp") {
+        $self->{cmd_system_health} = [ { cmd => "/usr/lib/" . $options{plugin_path} . "/plugins/" . $options{plugins} . " --plugin os::linux::snmp::plugin --mode cpu-detailed \\
+							 --hostname localhost \\
+							 --statefile-suffix='_diag-cpu' \\
+							 --filter-perfdata='^(?!(wait|guest|user|softirq|kernel|interrupt|guestnice|idle|steal|system|nice))' \\
+							 --snmp-community " . $options{community} ,
+                                         callback => \&centreon::health::ssh::ssh_callback,
+					 userdata => "cpu_usage" },
+                                       { cmd => "/usr/lib/" . $options{plugin_path} . "/plugins/" . $options{plugins} . " --plugin os::linux::snmp::plugin --mode load \\
+							 --hostname localhost \\
+							 --filter-perfdata='^(?!(load))' \\
+							 --snmp-community " . $options{community},
+                                         callback => \&centreon::health::ssh::ssh_callback,
+                                         userdata => "load" },
+                                       { cmd => "/usr/lib/" . $options{plugin_path} . "/plugins/" . $options{plugins} . " --plugin os::linux::snmp::plugin --mode memory \\
+							 --hostname localhost \\
+							 --filter-perfdata='^(?!(cached|buffer|used))' \\
+							 --snmp-community " . $options{community},
+                                         callback => \&centreon::health::ssh::ssh_callback,
+                                         userdata => "mem_usage" },
+                                       { cmd => "/usr/lib/" . $options{plugin_path} . "/plugins/" . $options{plugins} . " --plugin os::linux::snmp::plugin --mode swap \\
+							 --hostname localhost \\
+							 --filter-perfdata='^(?!(used))' \\
+							 --snmp-community " . $options{community},
+                                         callback => \&centreon::health::ssh::ssh_callback,
+                                         userdata => "swap_usage" },
+                                       { cmd => "/usr/lib/" . $options{plugin_path} . "/plugins/" . $options{plugins} . " --plugin os::linux::snmp::plugin --mode storage \\
+							 --hostname localhost \\
+							 --storage='^(?!(/dev/shm|/sys/fs/cgroup|/boot|/run.*))' --name --regexp \\
+							 --filter-perfdata='^(?!(used))' --statefile-suffix='_diag-storage' \\
+							 --verbose \\
+							 --snmp-community " . $options{community},
+                                        callback => \&centreon::health::ssh::ssh_callback,
+                                        userdata => "storage_usage" },
+                                     ];
+    } else {
+	return -1
+    }
+
+
+}
+
+sub get_remote_infos {
+    my ($self, %options) = @_;
+  
+    
+    return centreon::health::ssh::new->main(host => $options{host}, port => $options{ssh_port}, command_pool => $self->{cmd_system_health}); 
+    
+}
+     
+sub get_local_infos {
+    my ($self, %options) = @_;
+    my ($lerror, $stdout);    
+    
+    my $results;
+
+    foreach my $command (@{$self->{cmd_system_health}}) {
+        ($lerror, $stdout) = centreon::common::misc::backtick(command => $command->{cmd});
+	$results->{$command->{userdata}} = $stdout;
+	while ($stdout =~ m/Buffer creation/) {
+	    # Replay command to bypass cache creation
+	    sleep 1;
+	    ($lerror, $stdout) = centreon::common::misc::backtick(command => $command->{cmd});
+	    $results->{$command->{userdata}} = $stdout;
+	}
+    }
+
+    return $results 
+    
+}
+
+sub run {
+    my $self = shift;
+    my ($server_list, $medium, $community, $centreon_ver) = @_;
+
+    $self->build_command_hash(medium => $medium,
+			      plugins => ($centreon_ver eq 2.8) ? 'centreon_linux_snmp.pl' : 'centreon_plugins.pl',
+			      plugin_path => ($centreon_ver eq 2.8) ? 'centreon' : 'nagios',
+			      community => $community);
+
+    foreach my $server (keys %$server_list) {
+	my $name = $server_list->{$server}->{name};
+	if ($server_list->{$server}->{localhost} eq "NO") {
+	    $self->{output}->{$name} = $self->get_remote_infos(host => $server_list->{$server}->{address}, ssh_port => $server_list->{$server}->{ssh_port});
+        } else {
+	    $self->{output}->{$name} = $self->get_local_infos(poller_name => $name);
+	}
+    }
+    
+    return $self->{output}
+}
+
+1;

--- a/lib/perl/centreon/health/misc.pm
+++ b/lib/perl/centreon/health/misc.pm
@@ -1,0 +1,103 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::misc;
+
+use strict;
+use warnings;
+use Libssh::Session qw(:all);
+
+sub get_ssh_connection {
+    my %options = @_;
+
+    my $session = Libssh::Session->new();
+    if ($session->options(host => $options{host}, port => $options{port}, user => $options{user}) != SSH_OK) {
+        print $session->error() . "\n";
+        return 1
+    }
+
+    if ($session->connect() != SSH_OK) {
+        print $session->error() . "\n";
+        return 1
+    }
+
+    if ($session->auth_publickey_auto() != SSH_AUTH_SUCCESS) {
+        printf("auth issue pubkey: %s\n", $session->error(GetErrorSession => 1));
+        if ($session->auth_password(password => $options{password}) != SSH_AUTH_SUCCESS) {
+            printf("auth issue: %s\n", $session->error(GetErrorSession => 1));
+            return 1
+        }
+    }
+
+    return $session
+
+}
+
+sub change_seconds {
+    my %options = @_;
+    my ($str, $str_append) = ('', '');
+    my $periods = [
+                    { unit => 'y', value => 31556926 },
+                    { unit => 'M', value => 2629743 },
+                    { unit => 'w', value => 604800 },
+                    { unit => 'd', value => 86400 },
+                    { unit => 'h', value => 3600 },
+                    { unit => 'm', value => 60 },
+                    { unit => 's', value => 1 },
+    ];
+    my %values = ('y' => 1, 'M' => 2, 'w' => 3, 'd' => 4, 'h' => 5, 'm' => 6, 's' => 7);
+
+    foreach (@$periods) {
+        next if (defined($options{start}) && $values{$_->{unit}} < $values{$options{start}});
+        my $count = int($options{value} / $_->{value});
+
+        next if ($count == 0);
+        $str .= $str_append . $count . $_->{unit};
+        $options{value} = $options{value} % $_->{value};
+        $str_append = ' ';
+    }
+
+    return $str;
+}
+
+sub format_bytes {
+    my (%options) = @_;
+    my $size = $options{bytes_value};
+    $size =~ s/\D//g;
+
+    if ($size > 1099511627776) {
+        return sprintf("%.0fT", $size / 1099511627776);
+    }
+    elsif ($size > 1073741824) {
+        return sprintf("%.0fG", $size / 1073741824);
+    }
+    elsif ($size > 1048576) {
+        return sprintf("%.0fM", $size / 1048576);
+    }
+    elsif ($size > 1024) {
+        return sprintf("%.0fK", $size / 1024);
+    }
+    else {
+        return sprintf("%.0fB", $size);
+    }
+}
+
+        
+1;

--- a/lib/perl/centreon/health/output.pm
+++ b/lib/perl/centreon/health/output.pm
@@ -1,0 +1,307 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::output;
+
+use strict;
+use warnings;
+use JSON;
+
+sub new {
+    my $class = shift;
+    my $self = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub output_text {
+    my ($self, %options) = @_;
+
+    my $output; 
+
+    $output = "\t ===CENTREON_HEALTH TEXT OUTPUT=== \n\n";
+    $output .=  "\t\t CENTREON OVERVIEW\n\n";
+    $output .=  "Centreon Version: " . $options{data}->{server}->{global}->{centreon_version} . "\n";
+    $output .=  "Number of pollers: " . $options{data}->{server}->{global}->{count_poller} . "\n";
+    $output .=  "Number of hosts: " . $options{data}->{server}->{global}->{count_hosts} . "\n";
+    $output .=  "Number of services: " . $options{data}->{server}->{global}->{count_services} . "\n";
+    $output .=  "Number of metrics: " . $options{data}->{server}->{global}->{count_metrics} . "\n";
+    $output .=  "Number of modules: " . $options{data}->{server}->{global}->{count_modules} . "\n";
+    $output .=  defined($options{data}->{server}->{global}->{count_pp}) ? "Number of plugin-packs: " . $options{data}->{server}->{global}->{count_pp} . "\n" : " Number of plugin-packs: N/A\n";
+    $output .=  "Number of recurrent downtimes: " . $options{data}->{server}->{global}->{count_downtime} . "\n\n";
+
+    $output .=  "\t\t AVERAGE METRICS\n\n";
+    $output .=  "Host / poller (avg): " . $options{data}->{server}->{global}->{hosts_by_poller_avg} . "\n";
+    $output .=  "Service / poller (avg): " . $options{data}->{server}->{global}->{services_by_poller_avg} . "\n";
+    $output .=  "Service / host (avg): " . $options{data}->{server}->{global}->{services_by_host_avg} . "\n";
+    $output .=  "Metrics / service (avg): " . $options{data}->{server}->{global}->{metrics_by_service_avg} . "\n\n";
+
+    if ($options{flag_rrd} != 1 || $options{flag_db} eq "") {
+        $output .=  "\t\t RRD INFORMATIONS\n\n";
+        $output .= "RRD not updated since more than 180 days: " .  $options{data}->{rrd}->{rrd_not_updated_since_180d} . "\n";
+        $output .= "RRD written during last 5 five minutes: " .  $options{data}->{rrd}->{rrd_written_last_5m} . "\n";
+        foreach my $key (sort keys %{$options{data}->{rrd}}) {
+	    next if ($key =~ m/^rrd_/);
+            $output .= "RRD files Count/Size in " . $key . " directory: " . $options{data}->{rrd}->{$key}->{count} . "/" . $options{data}->{rrd}->{$key}->{size} . "\n";
+        }
+	$output .= "\n";
+    }
+
+    if ($options{flag_db} != 1 || $options{flag_db} eq "") {
+        $output .=  "\t\t DATABASES INFORMATIONS\n\n";
+        $output .= "\tDatabases size\n\n";
+        foreach my $database (keys %{$options{data}->{database}->{db_size}}) { 
+	    $output .= "Size of " . $database . " database: " . $options{data}->{database}->{db_size}->{$database} . "\n";
+        }
+        $output .= "\n";
+        $output .= "\tTables size (centreon_storage db)\n\n";
+        foreach my $database (keys %{$options{data}->{database}->{table_size}}) {
+            $output .= "Size of " . $database . " table: " . $options{data}->{database}->{table_size}->{$database} . "\n";
+        }
+        $output .= "\n";
+        $output .= "\tPartitioning check\n\n";
+        foreach my $table (keys %{$options{data}->{database}->{partitioning_last_part}}) {
+            $output .= "Last partition date for " . $table . " table: " . $options{data}->{database}->{partitioning_last_part}->{$table} . "\n";
+        }
+        $output .= "\n";
+    }
+   
+    $output .= "\t\t MODULE INFORMATIONS\n\n";
+    foreach my $module_key (keys %{$options{data}->{module}}) {
+	$output .= "Module " . $options{data}->{module}->{$module_key}->{full_name} . " is installed. (Author: " . $options{data}->{module}->{$module_key}->{author} . " # Codename: " . $module_key . " # Version: " . $options{data}->{module}->{$module_key}->{version} . ")\n";
+    }
+    $output .= "\n";
+
+    $output .= "\t\t CENTREON NODES INFORMATIONS\n\n";
+    
+    foreach my $poller_id (keys %{$options{data}->{server}->{poller}}) {
+        $output .= "\t" . $options{data}->{server}->{poller}->{$poller_id}->{name} . "\n\n";
+	$output .= "Identity: \n";
+	if (defined($options{data}->{server}->{poller}->{$poller_id}->{engine}) && defined($options{data}->{server}->{poller}->{$poller_id}->{version})) { 
+  	    $output .= "    Engine (version): " . $options{data}->{server}->{poller}->{$poller_id}->{engine} . " (" . $options{data}->{server}->{poller}->{$poller_id}->{version} . ")\n";
+            $output .= "    IP Address (SSH port): " . $options{data}->{server}->{poller}->{$poller_id}->{address} . " (" . $options{data}->{server}->{poller}->{$poller_id}->{ssh_port} . ")\n";
+	    $output .= "    Localhost: " . $options{data}->{server}->{poller}->{$poller_id}->{localhost} . "\n"; 
+            $output .= "    Running: " . $options{data}->{server}->{poller}->{$poller_id}->{running} . "\n";
+            $output .= "    Start time: " . $options{data}->{server}->{poller}->{$poller_id}->{start_time} . "\n";
+            $output .= "    Last alive: " . $options{data}->{server}->{poller}->{$poller_id}->{last_alive} . "\n";
+            $output .= "    Uptime: " . $options{data}->{server}->{poller}->{$poller_id}->{uptime} . "\n";
+            $output .= "    Count Hosts/Services - (Last command check): " . $options{data}->{server}->{poller}->{$poller_id}->{hosts} . "/" . $options{data}->{server}->{poller}->{$poller_id}->{services} . " - (" . $options{data}->{server}->{poller}->{$poller_id}->{last_command_check} . ")\n\n";
+        } else {
+	    $output .= "    SKIP Identity for this poller, enabled but does not seems to work correctly ! \n\n";
+        }
+
+        $output .= "Engine stats: \n";
+	foreach my $stat_key (sort keys %{$options{data}->{server}->{poller}->{$poller_id}->{engine_stats}}) {
+	    foreach my $stat_value (sort keys %{$options{data}->{server}->{poller}->{$poller_id}->{engine_stats}->{$stat_key}}) {
+            $output .= "    " . $stat_key . "(" . $stat_value . "): " . $options{data}->{server}->{poller}->{$poller_id}->{engine_stats}->{$stat_key}->{$stat_value} . "\n";
+	    }
+	}
+	$output .= "\n";
+
+        $output .= "Broker stats: \n";
+        foreach my $broker_stat_file (sort keys %{$options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}}) {
+   	    $output .= "    \tFile: " . $broker_stat_file . "\n";
+            $output .= "    Version: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{version} . "\n";
+	    $output .= "    State: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{state} . "\n";
+	    $output .= "    Event proecessing speed " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{event_processing_speed} . "\n";
+            $output .= "    Queued events: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{queued_events} . "\n";
+            $output .= "    Last connection attempts: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{last_connection_attempt} . "\n";
+            $output .= "    Last connection success: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{last_connection_success} . "\n\n";
+	}
+
+	$output .= "System stats: \n"; 
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{cpu_usage}) ? 
+			"    CPU => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{cpu_usage} . "\n" :
+                        "    CPU => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{load}) ? 
+			"    LOAD => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{load} . "\n" :
+			"    LOAD => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{mem_usage}) ?
+			"    MEMORY => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{mem_usage} . "\n" :
+                        "    MEMORY => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{swap_usage}) ? 
+			"    SWAP => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{swap_usage} . "\n" :
+			"    SWAP => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{storage_usage}) ? 
+			"    STORAGE => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{storage_usage} . "\n\n" :
+                        "    STORAGE => Could not gather data \n\n";
+
+	if ($options{flag_logs} != 1 || $options{flag_logs} eq "") {
+            $output .= "\t\t LOGS LAST LINES: \n\n";
+            foreach my $log_topic (sort keys %{$options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}}) {
+	        foreach my $log_file (keys %{$options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$log_topic}}) {
+	            $output .= "    " . $log_file . " (" . $log_topic . ")\n\n";
+		    $output .= $options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$log_topic}->{$log_file} . "\n\n"; 
+	        }
+	        $output .= "\n";
+	    }
+        }
+    }
+    return $output;
+}
+
+sub output_markdown {
+    my ($self, %options) = @_;
+
+    my $output;
+
+    $output = "# CENTREON_HEALTH TEXT OUTPUT\n";
+    $output .=  "## CENTREON OVERVIEW\n\n";
+    $output .=  "  + Centreon Version: " . $options{data}->{server}->{global}->{centreon_version} . "\n";
+    $output .=  "  + Number of pollers: " . $options{data}->{server}->{global}->{count_poller} . "\n";
+    $output .=  "  + Number of hosts: " . $options{data}->{server}->{global}->{count_hosts} . "\n";
+    $output .=  "  + Number of services: " . $options{data}->{server}->{global}->{count_services} . "\n";
+    $output .=  "  + Number of metrics: " . $options{data}->{server}->{global}->{count_metrics} . "\n";
+    $output .=  "  + Number of modules: " . $options{data}->{server}->{global}->{count_modules} . "\n";
+    $output .=  defined($options{data}->{server}->{global}->{count_pp}) ? "  + Number of plugin-packs: " . $options{data}->{server}->{global}->{count_pp} . "\n" : "  + Number of plugin-packs: N/A\n";
+    $output .=  "  + Number of recurrent downtimes: " . $options{data}->{server}->{global}->{count_downtime} . "\n\n";
+    $output .=  "## AVERAGE METRICS\n\n";
+    $output .=  "  + Host / poller (avg): " . $options{data}->{server}->{global}->{hosts_by_poller_avg} . "\n";
+    $output .=  "  + Service / poller (avg): " . $options{data}->{server}->{global}->{services_by_poller_avg} . "\n";
+    $output .=  "  + Service / host (avg): " . $options{data}->{server}->{global}->{services_by_host_avg} . "\n";
+    $output .=  "  + Metrics / service (avg): " . $options{data}->{server}->{global}->{metrics_by_service_avg} . "\n\n";
+
+    if ($options{flag_rrd} != 1 || $options{flag_db} eq "") {
+        $output .=  "## RRD INFORMATIONS\n\n";
+        $output .= "  + RRD not updated since more than 180 days: " .  $options{data}->{rrd}->{rrd_not_updated_since_180d} . "\n";
+        $output .= "  + RRD written during last 5 five minutes: " .  $options{data}->{rrd}->{rrd_written_last_5m} . "\n";
+        foreach my $key (sort keys %{$options{data}->{rrd}}) {
+            next if ($key =~ m/^rrd_/);
+            $output .= "  + RRD files Count/Size in " . $key . " directory: " . $options{data}->{rrd}->{$key}->{count} . "/" . $options{data}->{rrd}->{$key}->{size} . "\n";
+        }
+        $output .= "\n";
+    }
+
+    if ($options{flag_db} != 1 || $options{flag_db} eq "") {
+        $output .=  "## DATABASES INFORMATIONS\n\n";
+        $output .= "### Databases size\n\n";
+        foreach my $database (keys %{$options{data}->{database}->{db_size}}) {
+            $output .= "  + Size of " . $database . " database: " . $options{data}->{database}->{db_size}->{$database} . "\n";
+        }
+        $output .= "\n";
+        $output .= "### Tables size (centreon_storage db)\n\n";
+        foreach my $database (keys %{$options{data}->{database}->{table_size}}) {
+            $output .= "  + Size of " . $database . " table: " . $options{data}->{database}->{table_size}->{$database} . "\n";
+        }
+        $output .= "\n";
+        $output .= "### Partitioning check\n\n";
+        foreach my $table (keys %{$options{data}->{database}->{partitioning_last_part}}) {
+            $output .= "  + Last partition date for " . $table . " table: " . $options{data}->{database}->{partitioning_last_part}->{$table} . "\n";
+        }
+        $output .= "\n";
+    }
+
+    $output .= "## MODULE INFORMATIONS\n\n";
+    foreach my $module_key (keys %{$options{data}->{module}}) {
+        $output .= "  + Module " . $options{data}->{module}->{$module_key}->{full_name} . " is installed. (Author: " . $options{data}->{module}->{$module_key}->{author} . " # Codename: " . $module_key . " # Version: " . $options{data}->{module}->{$module_key}->{version} . ")\n";
+    }
+    $output .= "\n";
+
+    $output .= "## CENTREON NODES INFORMATIONS\n\n";
+
+    foreach my $poller_id (keys %{$options{data}->{server}->{poller}}) {
+        $output .= "### " . $options{data}->{server}->{poller}->{$poller_id}->{name} . "\n\n";
+        $output .= "#### Identity: \n";
+        if (defined($options{data}->{server}->{poller}->{$poller_id}->{engine}) && defined($options{data}->{server}->{poller}->{$poller_id}->{version})) {
+            $output .= "  + Engine (version): " . $options{data}->{server}->{poller}->{$poller_id}->{engine} . " (" . $options{data}->{server}->{poller}->{$poller_id}->{version} . ")\n";
+            $output .= "  + IP Address (SSH port): " . $options{data}->{server}->{poller}->{$poller_id}->{address} . " (" . $options{data}->{server}->{poller}->{$poller_id}->{ssh_port} . ")\n";
+            $output .= "  + Localhost: " . $options{data}->{server}->{poller}->{$poller_id}->{localhost} . "\n";
+            $output .= "  + Running: " . $options{data}->{server}->{poller}->{$poller_id}->{running} . "\n";
+            $output .= "  + Start time: " . $options{data}->{server}->{poller}->{$poller_id}->{start_time} . "\n";
+            $output .= "  + Last alive: " . $options{data}->{server}->{poller}->{$poller_id}->{last_alive} . "\n";
+            $output .= "  + Uptime: " . $options{data}->{server}->{poller}->{$poller_id}->{uptime} . "\n";
+            $output .= "  + Count Hosts/Services - (Last command check): " . $options{data}->{server}->{poller}->{$poller_id}->{hosts} . "/" . $options{data}->{server}->{poller}->{$poller_id}->{services} . " - (" . $options{data}->{server}->{poller}->{$poller_id}->{last_command_check} . ")\n\n";
+
+        } else {
+            $output .= "  + SKIP Identity for this poller, enabled but does not seems to work correctly ! \n\n";
+        }
+
+        $output .= "#### Engine stats: \n";
+        foreach my $stat_key (sort keys %{$options{data}->{server}->{poller}->{$poller_id}->{engine_stats}}) {
+            foreach my $stat_value (sort keys %{$options{data}->{server}->{poller}->{$poller_id}->{engine_stats}->{$stat_key}}) {
+            $output .= "  + " . $stat_key . "(" . $stat_value . "): " . $options{data}->{server}->{poller}->{$poller_id}->{engine_stats}->{$stat_key}->{$stat_value} . "\n";
+            }
+        }
+        $output .= "\n";
+
+        $output .= "#### Broker stats: \n";
+        foreach my $broker_stat_file (sort keys %{$options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}}) {
+            $output .= "##### File: " . $broker_stat_file . "\n";
+            $output .= "  + Version: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{version} . "\n";
+            $output .= "  + State: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{state} . "\n";
+            $output .= "  + Event proecessing speed " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{event_processing_speed} . "\n";
+            $output .= "  + Queued events: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{queued_events} . "\n";
+            $output .= "  + Last connection attempts: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{last_connection_attempt} . "\n";
+            $output .= "  + Last connection success: " . $options{data}->{broker}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$broker_stat_file}->{last_connection_success} . "\n\n";
+        }
+
+        $output .= "#### System stats: \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{cpu_usage}) ?
+                        "  + CPU => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{cpu_usage} . "\n" :
+                        "  + CPU => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{load}) ?
+                        "  + LOAD => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{load} . "\n" :
+                        "  + LOAD => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{mem_usage}) ?
+                        "  + MEMORY => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{mem_usage} . "\n" :
+                        "  + MEMORY => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{swap_usage}) ?
+                        "  + SWAP => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{swap_usage} . "\n" :
+                        "  + SWAP => Could not gather data \n";
+        $output .= defined($options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{storage_usage}) ?
+                        "  + STORAGE => " . $options{data}->{systems}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{storage_usage} . "\n\n" :
+                        "  + STORAGE => Could not gather data \n\n";
+
+        if ($options{flag_logs} != 1 || $options{flag_logs} eq "") {
+            $output .= "## LOGS LAST LINES: \n\n";
+            foreach my $log_topic (sort keys %{$options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}}) {
+                foreach my $log_file (keys %{$options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$log_topic}}) {
+                    $output .= "  + " . $log_file . " (" . $log_topic . ")\n\n";
+                    $output .= $options{data}->{logs}->{$options{data}->{server}->{poller}->{$poller_id}->{name}}->{$log_topic}->{$log_file} . "\n\n";
+                }
+                $output .= "\n";
+            }
+        }
+    }
+    return $output;
+}
+
+
+sub run {
+    my $self = shift;
+    my ($data, $format, $flag_rrd, $flag_db, $flash_logs) = @_;
+
+    if ($format eq "JSON") {
+	my $output = JSON->new->encode($data);
+	print $output;
+    } elsif ($format eq "TEXT") {
+	my $output = $self->output_text(data => $data, flag_rrd => $flag_rrd, flag_db => $flag_db, flag_logs => $flash_logs);
+	print $output;
+    } elsif ($format eq "MARKDOWN") {
+        my $output = $self->output_markdown(data => $data, flag_rrd => $flag_rrd, flag_db => $flag_db, flag_logs => $flash_logs);
+        print $output;
+    } elsif ($format eq "DUMPER") {
+	use Data::Dumper;
+	print Dumper($data);
+    }
+}
+        
+1;

--- a/lib/perl/centreon/health/ssh.pm
+++ b/lib/perl/centreon/health/ssh.pm
@@ -1,0 +1,93 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::health::ssh;
+
+use strict;
+use warnings;
+use Libssh::Session qw(:all);
+
+my $command_results = {};
+
+sub new {
+    my $class = shift @_ || __PACKAGE__;
+    my $self; 
+    $self->{session} = undef;
+    $self->{host} = undef;
+    $self->{port} = undef;
+    $self->{logger} = undef;
+    $self->{data} = {};
+
+    bless $self, $class;
+    return $self;
+}
+
+sub ssh_callback {
+    my (%options) = @_;
+
+    if ($options{exit} == SSH_OK || $options{exit} == SSH_AGAIN) { # AGAIN means timeout
+	chomp($options{stdout});
+        $command_results->{multiple}->{$options{userdata}} = $options{stdout};
+    } else {
+        $command_results->{multiple}->{failed_action} = "Failed action on ssh or plugin";
+	return -1
+    }
+    return 0
+}
+
+sub create_ssh_channel {
+    my ($self, %options) = @_;
+
+    $self->{session} = Libssh::Session->new();
+    if ($self->{session}->options(host => $options{host}, port => $options{port}, user => $options{user}) != SSH_OK) {
+        return 1
+    }
+
+    if ($self->{session}->connect() != SSH_OK) {
+        return 1
+    }
+
+    if ($self->{session}->auth_publickey_auto() != SSH_AUTH_SUCCESS) {
+        printf("auth issue pubkey: %s\n", $self->{session}->error(GetErrorSession => 1));
+        if ($self->{session}->auth_password(password => $options{password}) != SSH_AUTH_SUCCESS) {
+            printf("auth issue: %s\n", $self->{session}->error(GetErrorSession => 1));
+            return 1
+        }
+    }
+    return 0
+}
+
+sub main {
+    my ($self, %options) = @_;
+
+    $self->create_ssh_channel(host => $options{host}, port => $options{port}, user => 'centreon');
+    if (defined($options{command_pool})) {
+        $self->{session}->execute(commands => $options{command_pool}, timeout => 5000, timeout_nodata => 10, parallel => 5);
+	 $self->{data} = $command_results->{multiple};
+    } else {
+    	my $return = $self->{session}->execute_simple(cmd => $options{command}, userdata => $options{userdata}, timeout => 10, timeout_nodata => 5);
+	$command_results->{simple} = $return->{stdout};
+	$self->{data} = $command_results->{simple};
+    }
+
+    return $self->{data}
+}
+        
+1;

--- a/lib/perl/centreon/script/centreon_health.pm
+++ b/lib/perl/centreon/script/centreon_health.pm
@@ -1,0 +1,86 @@
+#
+# Copyright 2017 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::script::centreon_health;
+
+use strict;
+use warnings;
+use POSIX;
+use centreon::script;
+use base qw(centreon::script);
+
+use centreon::health::checkservers;
+use centreon::health::checkrrd;
+use centreon::health::checkdb;
+use centreon::health::checkmodules;
+use centreon::health::checksystems;
+use centreon::health::checkbroker;
+use centreon::health::checklogs;
+use centreon::health::output;
+
+sub new {
+    my $class = shift;
+    my $self = $class->SUPER::new("centreon_health",
+                                   centreon_db_conn => 1,
+                                   centstorage_db_conn => 1,
+				   noroot => 1,
+        			);
+    bless $self, $class;
+
+    $self->add_options(
+	"centstorage-db=s"	=> \$self->{opt_csdb},
+	"centreon-branch=s"	=> \$self->{opt_majorversion},
+	"check-protocol=s"	=> \$self->{opt_checkprotocol},
+	"output-format=s"	=> \$self->{opt_outputformat},
+	"snmp-community=s"	=> \$self->{opt_community},
+	"skip-rrd"		=> \$self->{opt_skiprrd},
+	"skip-db"		=> \$self->{opt_skipdb},
+	"skip-logs"		=> \$self->{opt_skiplogs},
+	"anonymous"		=> \$self->{opt_anonymous}
+    );
+	
+    $self->{data} = {};
+    $self->{final_output} = {};
+    $self->{opt_checkprotocol} = 'snmp';
+    $self->{opt_outputformat} = 'JSON' if (!defined$self->{opt_outputformat}); 
+    $self->{opt_community} = 'public' if (!defined $self->{opt_community});
+    $self->{opt_csdb} = 'centreon_storage' if (!defined $self->{opt_csdb});
+    $self->{opt_majorversion} = '2.8' if (!defined $self->{opt_majorversion});
+
+    return $self;
+}
+
+sub run {
+    my $self = shift;
+    $self->SUPER::run();
+
+    $self->{data}->{rrd} = centreon::health::checkrrd->new->run($self->{csdb}) if (!defined($self->{opt_skiprrd}));
+    $self->{data}->{database} = centreon::health::checkdb->new->run($self->{cdb}, $self->{csdb}, $self->{opt_csdb}) if (!defined($self->{opt_skipdb}));    
+    $self->{data}->{module} = centreon::health::checkmodules->new->run($self->{cdb});
+    $self->{data}->{server} = centreon::health::checkservers->new->run($self->{cdb}, $self->{csdb}, $self->{opt_majorversion});
+    $self->{data}->{systems} = centreon::health::checksystems->new->run($self->{data}->{server}->{poller}, $self->{opt_checkprotocol}, $self->{opt_community}, $self->{opt_majorversion});
+    $self->{data}->{broker} = centreon::health::checkbroker->new->run($self->{cdb}, $self->{data}->{server}->{poller}, $self->{opt_majorversion});
+    $self->{data}->{logs} = centreon::health::checklogs->new->run($self->{cdb}, $self->{data}->{server}->{poller}) if (!defined($self->{opt_skiplogs}));
+
+    centreon::health::output->new->run($self->{data}, $self->{opt_outputformat}, defined($self->{opt_skiprrd}), defined($self->{opt_skipdb}), defined($self->{opt_skiplogs}));
+
+}
+
+1;


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Script that gathers various information useful for centreon diagnostic.
PR made from @Sims24 one (_reworked a little bit_)

Script to quickly gather an overall overview of centreon scope and parameters. Very helpfull when things goes bad. Easily extensible.

Cover following topics : 

- rrd
- database
- module
- server
- systems
- broker
- logs

Centreon version : More complete for 2.8.x, but also manage 2.7.x (el6 and el7).

Offers following output format : 

- MARKDOWN
- JSON
- TEXT 
- DUMPER (debug perl)

Only prerequiste is perl binding for SSH C lib and centreon_plugins for Linux (SNMP) : 

  + el6 

``` 
yum install libssh libssh-devel 
git clone https://github.com/garnier-quentin/perl-libssh
cd perl-libssh/
perl Makefile.PL
make && make install
```

  + el7 

```
yum install perl-Libssh-Session-0.3-1.el7.centos.x86_64
```

Sample output below (skip logs for the sake of clarity) : 

```
[root@centreon-centos7 centreon]# su - centreon -c "/usr/share/centreon/bin/centreon_health --output-format MARKDOWN --skip-logs"
```

# CENTREON_HEALTH TEXT OUTPUT
## CENTREON OVERVIEW

  + Centreon Version: 2.8.17
  + Number of pollers: 2
  + Number of hosts: 17
  + Number of services: 139
  + Number of metrics: 318
  + Number of modules: 4
  + Number of plugin-packs: 35
  + Number of recurrent downtimes: 0

## AVERAGE METRICS

  + Host / poller (avg): 8
  + Service / poller (avg): 69
  + Service / host (avg): 8
  + Metrics / service (avg): 2

## RRD INFORMATIONS

  + RRD not updated since more than 180 days: 0
  + RRD written during last 5 five minutes: 33
  + RRD files Count/Size in /var/lib/centreon/metrics/ directory: 251/95M
  + RRD files Count/Size in /var/lib/centreon/status/ directory: 140/47M

## DATABASES INFORMATIONS

### Databases size

  + Size of centreon_storage database: 856M
  + Size of centreon database: 8M

### Tables size (centreon_storage db)

  + Size of log_archive_host table: 29M
  + Size of downtimes table: 96K
  + Size of data_bin table: 687M
  + Size of log_archive_service table: 36M
  + Size of logs table: 100M

### Partitioning check

  + Last partition date for log_archive_host table: 01/14/2018 00:00:00
  + Last partition date for data_bin table: 01/14/2018 00:00:00
  + Last partition date for log_archive_service table: 01/14/2018 00:00:00
  + Last partition date for logs table: 01/14/2018 00:00:00

### SQL Engine tuning variables

  + Variable innodb_file_per_table = ON
  + Variable join_buffer_size = 4M
  + Variable key_buffer_size = 256M
  + Variable max_allowed_packet = 64M
  + Variable open_files_limit = 32000
  + Variable read_buffer_size = 512K
  + Variable read_only = OFF
  + Variable read_rnd_buffer_size = 256K
  + Variable sort_buffer_size = 32M

## MODULE INFORMATIONS

  + Module Centreon License Manager is installed. (Author: Centreon # Codename: centreon-license-manager # Version: 1.0.1)
  + Module Centreon Plugin Pack Manager is installed. (Author: Centreon # Codename: centreon-pp-manager # Version: 2.2.0)
  + Module Centreon Open Tickets is installed. (Author: Centreon Team # Codename: centreon-open-tickets # Version: 1.2.0)
  + Module Centreon Auto Discovery is installed. (Author: Centreon # Codename: centreon-autodiscovery-server # Version: 2.3.0)

## CENTREON NODES INFORMATIONS

### Central

#### Identity:
  + Engine (version): Centreon Engine (1.7.2)
  + IP Address (SSH port): 127.0.0.1 (22)
  + Localhost: YES
  + Running: YES
  + Start time: 11/09/2017 16:49:33
  + Last alive: 01/04/2018 09:16:51
  + Uptime: 1M 3w 4d 5h 58m 15s
  + Count Hosts/Services - (Last command check): 13/114 - (01/04/2018 09:16:50)

#### Engine stats:
  + Buffer Usage(In_Use): 0
  + Buffer Usage(Max_Used): 3
  + Buffer Usage(Total_Available): 4096
  + Host Actively Checked(Last_15_minutes): 13
  + Host Actively Checked(Last_5_minutes): 13
  + Host Actively Checked(Last_hour): 13
  + Host Actively Checked(Last_minute): 1
  + Host Check Execution Time(Average): 1.468
  + Host Check Execution Time(Max): 10.002
  + Host Check Execution Time(Min): 0.000
  + Host Check Latency(Average): 0.082
  + Host Check Latency(Max): 0.175
  + Host Check Latency(Min): 0.000
  + Hosts Status(Down): 2
  + Hosts Status(Unreachable): 0
  + Hosts Status(Up): 12
  + Service Actively Checked(Last_15_minutes): 98
  + Service Actively Checked(Last_5_minutes): 78
  + Service Actively Checked(Last_hour): 113
  + Service Actively Checked(Last_minute): 7
  + Service Check Execution Time(Average): 7.109
  + Service Check Execution Time(Max): 60.155
  + Service Check Execution Time(Min): 0.003
  + Service Check Latency(Average): 0.092
  + Service Check Latency(Max): 0.208
  + Service Check Latency(Min): 0.002
  + Services Status(Critical): 3
  + Services Status(OK): 63
  + Services Status(Unknown): 47
  + Services Status(Warning): 1

#### Broker stats:
##### File: central-broker-master-stats.json
  + Version: 3.0.8
  + State: connected
  + Event proecessing speed 2.9
  + Queued events: 0
  + Last connection attempts: 12/30/2017 13:43:41
  + Last connection success: 12/30/2017 13:43:41

##### File: central-module-master-stats.json
  + Version: 3.0.8
  + State: connected
  + Event proecessing speed 1.1875
  + Queued events: 540
  + Last connection attempts: 12/30/2017 13:44:40
  + Last connection success: 12/30/2017 13:44:40

##### File: central-rrd-master-stats.json
  + Version: 3.0.8
  + State: listening
  + Event proecessing speed 0
  + Queued events: 0
  + Last connection attempts: -1
  + Last connection success: -1

#### System stats:
  + CPU => OK: CPU Usage: Wait 0.84 %, Guest 0.00 %, User 4.88 %, Soft Irq 0.02 %, Kernel 0.00 %, Interrupt 0.00 %, Guest Nice 0.00 %, Idle 93.30 %, Steal 0.00 %, System 0.96 %, Nice 0.00 % |
  + LOAD => OK: Load average: 0.00, 0.05, 0.08 |
  + MEMORY => OK: Ram Total: 1.80 GB, Used (-buffers/cache): 799.33 MB (43.44%), Buffer: 0.00 B, Cached: 835.89 MB, Shared: 96.30 MB |
  + SWAP => OK: Swap Total: 600.00 MB Used: 43.91 MB (7.32%) Free: 556.08 MB (92.68%) |
  + STORAGE => OK: All storages are ok |
Storage '/' Usage Total: 1.99 GB Used: 1.15 GB (57.88%) Free: 858.37 MB (42.12%)
Storage '/usr' Usage Total: 3.99 GB Used: 2.67 GB (66.81%) Free: 1.32 GB (33.19%)
Storage '/var/lib/mysql' Usage Total: 3.99 GB Used: 3.00 GB (75.14%) Free: 1015.75 MB (24.86%)
Storage '/tmp' Usage Total: 1016.66 MB Used: 258.26 MB (25.40%) Free: 758.40 MB (74.60%)

### Poller

#### Identity:
  + Engine (version): Centreon Engine (1.7.2)
  + IP Address (SSH port): 10.30.2.66 (22)
  + Localhost: NO
  + Running: YES
  + Start time: 10/03/2017 17:14:17
  + Last alive: 01/04/2018 09:16:48
  + Uptime: 3M 1d 9h 35m 22s
  + Count Hosts/Services - (Last command check): 4/25 - (01/04/2018 09:16:48)

#### Engine stats:
  + Buffer Usage(In_Use): 0
  + Buffer Usage(Max_Used): 0
  + Buffer Usage(Total_Available): 4096
  + Host Actively Checked(Last_15_minutes): 3
  + Host Actively Checked(Last_5_minutes): 2
  + Host Actively Checked(Last_hour): 3
  + Host Actively Checked(Last_minute): 0
  + Host Check Execution Time(Average): 0.057
  + Host Check Execution Time(Max): 0.085
  + Host Check Execution Time(Min): 0.005
  + Host Check Latency(Average): 0.143
  + Host Check Latency(Max): 0.182
  + Host Check Latency(Min): 0.073
  + Hosts Status(Down): 0
  + Hosts Status(Unreachable): 0
  + Hosts Status(Up): 3
  + Service Actively Checked(Last_15_minutes): 13
  + Service Actively Checked(Last_5_minutes): 10
  + Service Actively Checked(Last_hour): 13
  + Service Actively Checked(Last_minute): 0
  + Service Check Execution Time(Average): 0.153
  + Service Check Execution Time(Max): 0.305
  + Service Check Execution Time(Min): 0.020
  + Service Check Latency(Average): 0.084
  + Service Check Latency(Max): 0.192
  + Service Check Latency(Min): 0.002
  + Services Status(Critical): 0
  + Services Status(OK): 7
  + Services Status(Unknown): 6
  + Services Status(Warning): 0

#### Broker stats:
##### File: poller-module-stats.json
  + Version: 3.0.7
  + State: connected
  + Event proecessing speed 0.5
  + Queued events: 392
  + Last connection attempts: 12/30/2017 13:44:10
  + Last connection success: 12/30/2017 13:44:10

#### System stats:
  + CPU => OK: CPU Usage: Wait 0.00 %, Guest 0.00 %, User 1.26 %, Soft Irq 0.01 %, Kernel 0.00 %, Interrupt 0.00 %, Guest Nice 0.00 %, Idle 98.42 %, Steal 0.00 %, System 0.31 %, Nice 0.00 % |
  + LOAD => OK: Load average: 0.01, 0.05, 0.05 |
  + MEMORY => OK: Ram Total: 1.80 GB, Used (-buffers/cache): 299.58 MB (16.28%), Buffer: 948.00 KB, Cached: 502.29 MB, Shared: 96.45 MB |
  + SWAP => OK: Swap Total: 820.00 MB Used: 0.00 B (0.00%) Free: 820.00 MB (100.00%) |
  + STORAGE => OK: Storage '/' Total: 6.19 GB Used: 2.09 GB (33.87%) Free: 4.09 GB (66.13%) |
Storage '/' Total: 6.19 GB Used: 2.09 GB (33.87%) Free: 4.09 GB (66.13%)

<h2> Type of change </h2>

- [ ] New functionality (non-breaking change)

<h2> Target serie </h2>

- [ ] 18.10.x
- [ ] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Execute the script and check that information returned are correct.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
