### PR TITLE
enh(ui): only refresh iFrame when click on link

### DIFF
--- a/www/front_src/src/components/pollerMenu/index.js
+++ b/www/front_src/src/components/pollerMenu/index.js
@@ -4,6 +4,7 @@ import config from "../../config";
 import {Translate} from 'react-redux-i18n';
 import {I18n} from "react-redux-i18n";
 import axios from "../../axios";
+import { Link } from "react-router-dom";
 
 import { connect } from "react-redux";
 
@@ -198,14 +199,14 @@ class PollerMenu extends Component {
                   })
                 : null}
                 {allowPollerConfiguration && /* display poller configuration button if user is allowed */
-                  <a href={config.urlBase + "main.php?p=" + POLLER_CONFIGURATION_TOPOLOGY_PAGE}>
+                  <Link to={"/main.php?p=" + POLLER_CONFIGURATION_TOPOLOGY_PAGE}>
                     <button
                       onClick={this.toggle}
                       class="btn btn-big btn-green submenu-top-button"
                     >
                       <Translate value="Configure pollers"/>
                     </button>
-                  </a>
+                  </Link>
                 }
               </ul>
             </div>

--- a/www/front_src/src/components/userMenu/index.js
+++ b/www/front_src/src/components/userMenu/index.js
@@ -4,6 +4,7 @@ import config from "../../config";
 import {Translate} from 'react-redux-i18n';
 import axios from "../../axios";
 import { connect } from "react-redux";
+import { Link } from "react-router-dom";
 
 const EDIT_PROFILE_TOPOLOGY_PAGE = '50104'
 
@@ -110,12 +111,13 @@ class UserMenu extends Component {
                     <span class="submenu-user-name">{fullname}</span>
                     <span class="submenu-user-type"><Translate value="as"/> {username}</span>
                     {allowEditProfile &&
-                      <a
+                      <Link
+                        to={"/main.php?p=" + EDIT_PROFILE_TOPOLOGY_PAGE + "&o=c"}
                         class="submenu-user-edit"
-                        href={config.urlBase + "main.php?p=" + EDIT_PROFILE_TOPOLOGY_PAGE + "&o=c"}
+                        onClick={this.toggle}
                       >
                         <Translate value="Edit profile"/>
-                      </a>
+                      </Link>
                     }
                   </span>
                 </li>

--- a/www/front_src/src/styles/partials/_header.scss
+++ b/www/front_src/src/styles/partials/_header.scss
@@ -276,6 +276,7 @@
         margin-left: 4px;
         color: $white-color;
         float: right;
+        text-decoration-line: underline;
       }
       .submenu-user-button {
         font-size: .785rem;


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

When clicking on configure poller, or Edit Profile the whole page was reloaded.

* Using Link from react-router-dom instead of <a>
* Handle the toggle of the menu once the link clicked
* Update scss file for the "Edit Profile" style

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Click on the **configure pollers** button => only the iFrame should be refreshed and **not** the whole page
- Click on the **Edit profile** link => only the iFrame should be refreshed and **not** the whole page
Any **relevant details** of the configuration to perform the test should be added.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
