### PR TITLE
fix(ui): missing french translations in the graph page

### DIFF
--- a/lang/fr/LC_MESSAGES/messages.po
+++ b/lang/fr/LC_MESSAGES/messages.po
@@ -14748,7 +14748,7 @@ msgid "You can't edit this hostgroup because you don't have access to all its re
 msgstr "Vous ne pouvez pas éditer groupe d'hote car vous n'êtes pas autorisé à accéder à toutes les ressources liées"
 
 msgid "Filter by Host"
-msgstr "Filtrer par les hôtes"
+msgstr "Filtrer par hôtes"
 
 msgid "Filter by Hostgroup"
 msgstr "Filtrer par groupe d'hôtes"
@@ -14757,4 +14757,4 @@ msgid "Filter by Servicegroup"
 msgstr "Filtrer par groupe de services"
 
 msgid "Chart"
-msgstr "Diagramme"
+msgstr "Graphiques"

--- a/lang/fr/LC_MESSAGES/messages.po
+++ b/lang/fr/LC_MESSAGES/messages.po
@@ -14746,3 +14746,15 @@ msgstr "Vous ne pouvez pas éditer ce temps d’arrêt car vous n'êtes pas auto
 
 msgid "You can't edit this hostgroup because you don't have access to all its resources"
 msgstr "Vous ne pouvez pas éditer groupe d'hote car vous n'êtes pas autorisé à accéder à toutes les ressources liées"
+
+msgid "Filter by Host"
+msgstr "Filtrer par les hôtes"
+
+msgid "Filter by Hostgroup"
+msgstr "Filtrer par groupe d'hôtes"
+
+msgid "Filter by Servicegroup"
+msgstr "Filtrer par groupe de services"
+
+msgid "Chart"
+msgstr "Diagramme"


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Part of the graph page texts aren't translated in french

Fixes # ( https://github.com/centreon/centreon/issues/7425 )

<h2> Type of change </h2>

- [X] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [X] 2.8.x
- [X] 18.10.x
- [X] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Change localization to fr_FR.UTF8, then go to page 20401

Any **relevant details** of the configuration to perform the test should be added.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [X] I followed the **coding style guidelines** provided by Centreon
- [X]   I have   **rebased** my development branch on the base branch (master, maintenance).