### PR TITLE
enh(ldap): ldap connection timeout

### DIFF
--- a/doc/en/api/clapi/objects/ldap_servers.rst
+++ b/doc/en/api/clapi/objects/ldap_servers.rst
@@ -113,9 +113,11 @@ ldap_contact_tmpl          Contact template to use on import
 
 ldap_dns_use_domain        Use domain or not (0 or 1)
 
+ldap_connect_timeout       Connection timeout delay (in seconds)
+
 ldap_search_limit          Search size limit
 
-ldap_search_timeout        Timeout delay (in seconds)
+ldap_search_timeout        Search timeout delay (in seconds)
 
 ldap_srv_dns               DNS server (only used when 
                            ldap_dns_use_domain is set to 1)

--- a/doc/fr/api/clapi/objects/ldap_servers.rst
+++ b/doc/fr/api/clapi/objects/ldap_servers.rst
@@ -113,9 +113,11 @@ ldap_contact_tmpl          Contact template to use on import
 
 ldap_dns_use_domain        Use domain or not (0 or 1)
 
+ldap_connect_timeout       Connection timeout delay (in seconds)
+
 ldap_search_limit          Search size limit
 
-ldap_search_timeout        Timeout delay (in seconds)
+ldap_search_timeout        Search timeout delay (in seconds)
 
 ldap_srv_dns               DNS server (only used when 
                            ldap_dns_use_domain is set to 1)

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -443,6 +443,10 @@ msgstr "Active la connexion TLS"
 msgid "Set the domain for search the service"
 msgstr "Configure le domaine pour la recherche du service"
 
+#: centreon-web/www/include/Administration/parameters/ldap/help.php
+msgid "Connection timeout"
+msgstr "Durée maximale de la tentative de connexion avant d'être considérée comme un échec."
+
 #: centreon-web/www/include/Administration/parameters/ldap/help.php:21
 msgid "Search size limit"
 msgstr "Limite du nombre d'objets affichés lors de la recherche."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4375,6 +4375,10 @@ msgstr "Utiliser une connexion TLS"
 msgid "Alternative domain for ldap"
 msgstr "Domaine alternatif pour ldap"
 
+#: centreon-web/www/include/Administration/parameters/ldap/form.php
+msgid "LDAP connection timeout"
+msgstr "Temps maximum de connexion au serveur LDAP"
+
 #: centreon-web/www/include/Administration/parameters/ldap/form.php:106
 msgid "LDAP search size limit"
 msgstr "Taille limite de la recherche LDAP"

--- a/www/class/centreon-clapi/centreonLDAP.class.php
+++ b/www/class/centreon-clapi/centreonLDAP.class.php
@@ -76,6 +76,7 @@ class CentreonLDAP extends CentreonObject
             'ldap_auto_import' => '',
             'ldap_contact_tmpl' => '',
             'ldap_dns_use_domain' => '',
+            'ldap_connect_timeout' => '',
             'ldap_search_limit' => '',
             'ldap_search_timeout' => '',
             'ldap_srv_dns' => '',

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -111,6 +111,15 @@ class CentreonLDAP
             $this->debugImport = false;
         }
 
+        $connectTimeout = 5;
+        $tempConnectTimeout = $this->getLdapHostParameters($arId, 'ldap_connect_timeout');
+        if (count($tempConnectTimeout) > 0) {
+            if (isset($tempConnectTimeout['ari_value'])
+                && !empty($tempConnectTimeout['ari_value'])
+            ) {
+                $connectTimeout = $tempConnectTimeout['ari_value'];
+            }
+        }
         $searchTimeout = 5;
         $tempSearchTimeout = $this->getLdapHostParameters($arId, 'ldap_search_timeout');
         if (count($tempSearchTimeout) > 0) {
@@ -140,6 +149,7 @@ class CentreonLDAP
                 $ldap = array();
                 $ldap['host'] = $entry['target'];
                 $ldap['id'] = $arId;
+                $ldap['connect_timeout'] = $connectTimeout;
                 $ldap['search_timeout'] = $searchTimeout;
                 $ldap['info'] = $this->getInfoUseDnsConnect();
                 $ldap['info']['port'] = $entry['port'];
@@ -157,6 +167,7 @@ class CentreonLDAP
                 $ldap = array();
                 $ldap['host'] = $row['host_address'];
                 $ldap['id'] = $arId;
+                $ldap['connect_timeout'] = $connectTimeout;
                 $ldap['search_timeout'] = $searchTimeout;
                 $ldap['info'] = $this->getInfoConnect($row['ldap_host_id']);
                 $ldap['info'] = array_merge($ldap['info'], $this->getBindInfo($arId));
@@ -212,6 +223,7 @@ class CentreonLDAP
             $this->debug("LDAP Connect : trying url : " . $url);
             $this->setErrorHandler();
             $this->ds = ldap_connect($url);
+            ldap_set_option($this->ds, LDAP_OPT_NETWORK_TIMEOUT, $ldap['connect_timeout']);
             ldap_set_option($this->ds, LDAP_OPT_REFERRALS, 0);
             $protocol_version = 3;
             if (isset($ldap['info']['protocol_version'])) {
@@ -901,6 +913,7 @@ class CentreonLdapAdmin
         $tab = array(
             'ldap_store_password',
             'ldap_auto_import',
+            'ldap_connect_timeout',
             'ldap_search_limit',
             'ldap_search_timeout',
             'ldap_contact_tmpl',

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -113,21 +113,18 @@ class CentreonLDAP
 
         $connectTimeout = 5;
         $tempConnectTimeout = $this->getLdapHostParameters($arId, 'ldap_connect_timeout');
-        if (count($tempConnectTimeout) > 0) {
-            if (isset($tempConnectTimeout['ari_value'])
-                && !empty($tempConnectTimeout['ari_value'])
-            ) {
-                $connectTimeout = $tempConnectTimeout['ari_value'];
-            }
+        if (count($tempConnectTimeout) > 0 && isset($tempConnectTimeout['ari_value'])
+            && !empty($tempConnectTimeout['ari_value'])
+        ) {
+            $connectTimeout = $tempConnectTimeout['ari_value'];
         }
+
         $searchTimeout = 5;
         $tempSearchTimeout = $this->getLdapHostParameters($arId, 'ldap_search_timeout');
-        if (count($tempSearchTimeout) > 0) {
-            if (isset($tempSearchTimeout['ari_value'])
-                && !empty($tempSearchTimeout['ari_value'])
-            ) {
-                $searchTimeout = $tempSearchTimeout['ari_value'];
-            }
+        if (count($tempSearchTimeout) > 0 && isset($tempSearchTimeout['ari_value'])
+            && !empty($tempSearchTimeout['ari_value'])
+        ) {
+            $searchTimeout = $tempSearchTimeout['ari_value'];
         }
 
         /* Get the list of server ldap */

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -113,7 +113,8 @@ class CentreonLDAP
 
         $connectTimeout = 5;
         $tempConnectTimeout = $this->getLdapHostParameters($arId, 'ldap_connect_timeout');
-        if (count($tempConnectTimeout) > 0 && isset($tempConnectTimeout['ari_value'])
+        if (count($tempConnectTimeout) > 0
+            && isset($tempConnectTimeout['ari_value'])
             && !empty($tempConnectTimeout['ari_value'])
         ) {
             $connectTimeout = $tempConnectTimeout['ari_value'];
@@ -121,7 +122,8 @@ class CentreonLDAP
 
         $searchTimeout = 5;
         $tempSearchTimeout = $this->getLdapHostParameters($arId, 'ldap_search_timeout');
-        if (count($tempSearchTimeout) > 0 && isset($tempSearchTimeout['ari_value'])
+        if (count($tempSearchTimeout) > 0
+            && isset($tempSearchTimeout['ari_value'])
             && !empty($tempSearchTimeout['ari_value'])
         ) {
             $searchTimeout = $tempSearchTimeout['ari_value'];

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -114,7 +114,6 @@ class CentreonLDAP
         $connectTimeout = 5;
         $tempConnectTimeout = $this->getLdapHostParameters($arId, 'ldap_connect_timeout');
         if (count($tempConnectTimeout) > 0
-            && isset($tempConnectTimeout['ari_value'])
             && !empty($tempConnectTimeout['ari_value'])
         ) {
             $connectTimeout = $tempConnectTimeout['ari_value'];
@@ -123,7 +122,6 @@ class CentreonLDAP
         $searchTimeout = 5;
         $tempSearchTimeout = $this->getLdapHostParameters($arId, 'ldap_search_timeout');
         if (count($tempSearchTimeout) > 0
-            && isset($tempSearchTimeout['ari_value'])
             && !empty($tempSearchTimeout['ari_value'])
         ) {
             $searchTimeout = $tempSearchTimeout['ari_value'];

--- a/www/include/Administration/parameters/DB-Func.php
+++ b/www/include/Administration/parameters/DB-Func.php
@@ -451,6 +451,12 @@ function updateLdapConfigData($gopt_id = null)
     );
     updateOption(
         $pearDB,
+        "ldap_connect_timeout",
+        isset($ret["ldap_connect_timeout"]) && $ret["ldap_connect_timeout"] != null
+            ? htmlentities($ret["ldap_connect_timeout"], ENT_QUOTES, "UTF-8"): "NULL"
+    );
+    updateOption(
+        $pearDB,
         "ldap_search_timeout",
         isset($ret["ldap_search_timeout"]) && $ret["ldap_search_timeout"] != null
             ? htmlentities($ret["ldap_search_timeout"], ENT_QUOTES, "UTF-8"): "NULL"

--- a/www/include/Administration/parameters/DB-Func.php
+++ b/www/include/Administration/parameters/DB-Func.php
@@ -453,7 +453,7 @@ function updateLdapConfigData($gopt_id = null)
         $pearDB,
         "ldap_connect_timeout",
         isset($ret["ldap_connect_timeout"]) && $ret["ldap_connect_timeout"] != null
-            ? htmlentities($ret["ldap_connect_timeout"], ENT_QUOTES, "UTF-8"): "NULL"
+            ? htmlentities($ret["ldap_connect_timeout"], ENT_QUOTES, "UTF-8") : "NULL"
     );
     updateOption(
         $pearDB,

--- a/www/include/Administration/parameters/ldap/form.ihtml
+++ b/www/include/Administration/parameters/ldap/form.ihtml
@@ -12,6 +12,7 @@
 		<td class="FormRowField"><img class="helpTooltip" name="ldap_auto_import" /><span>{$form.ldap_auto_import.label}</span></td>
 		<td class="FormRowValue">{$form.ldap_auto_import.html}&nbsp;&nbsp;<input type="button" onClick="javascript:location.href='./main.get.php?p=60301&o=li'" class="btc bt_info" value='{$manualImport}'></td>
 	</tr>
+	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="ldap_connect_timeout" /><span>{$form.ldap_connect_timeout.label}</span></td><td class="FormRowValue">{$form.ldap_connect_timeout.html}</td></tr>
 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ldap_search_limit" /><span>{$form.ldap_search_limit.label}</span></td><td class="FormRowValue">{$form.ldap_search_limit.html}</td></tr>
 	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="ldap_search_timeout" /><span>{$form.ldap_search_timeout.label}</span></td><td class="FormRowValue">{$form.ldap_search_timeout.html}</td></tr>
 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ldap_contact_tmpl" /><span>{$form.ldap_contact_tmpl.label}</span></td><td class="FormRowValue">{$form.ldap_contact_tmpl.html}{if $o != 'w'}&nbsp;

--- a/www/include/Administration/parameters/ldap/form.php
+++ b/www/include/Administration/parameters/ldap/form.php
@@ -97,6 +97,7 @@ $form->addGroup($ldapUseDns, 'ldap_srv_dns', _("Use service DNS"), '&nbsp;');
 
 $form->addElement('text', 'ldap_dns_use_domain', _("Alternative domain for ldap"), $attrsText);
 
+$form->addElement('text', 'ldap_connect_timeout', _('LDAP connection timeout'), $attrsText2);
 $form->addElement('text', 'ldap_search_limit', _('LDAP search size limit'), $attrsText2);
 $form->addElement('text', 'ldap_search_timeout', _('LDAP search timeout'), $attrsText2);
 
@@ -183,6 +184,7 @@ $defaultOpt = array('ldap_auth_enable' => '0',
     'ldap_dns_use_tls' => '0',
     'ldap_contact_tmpl' => '0',
     'ldap_default_cg' => '0',
+    'ldap_connect_timeout' => '5',
     'ldap_search_limit' => '60',
     'ldap_search_timeout' => '60');
 $gopt = array();

--- a/www/include/Administration/parameters/ldap/help.php
+++ b/www/include/Administration/parameters/ldap/help.php
@@ -23,6 +23,7 @@ $help['ldap_srv_dns'] = dgettext('help', 'Use the DNS service for get LDAP host'
 $help['ldap_srv_dns_ssl'] = dgettext('help', 'Enable SSL connection');
 $help['ldap_srv_dns_tls'] = dgettext('help', 'Enable TLS connection');
 $help['ldap_dns_use_domain'] = dgettext('help', 'Set the domain for search the service');
+$help['ldap_connect_timeout'] = dgettext('help', 'Connection timeout');
 $help['ldap_search_limit'] = dgettext('help', 'Search size limit');
 $help['ldap_search_timeout'] = dgettext('help', 'Search timeout');
 $help['ldapConf'] = dgettext(

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -73,6 +73,7 @@ INSERT INTO `options` (`key`, `value`) VALUES
 ('ldap_auto_import', '0'),
 ('ldap_srv_dns', '0'),
 ('ldap_dns_use_domain', ''),
+('ldap_connect_timeout','5'),
 ('ldap_search_timeout','60'),
 ('ldap_search_limit','60'),
 ('ldap_last_acl_update', '0'),

--- a/www/install/sql/centreon/Update-DB-19.04.1.sql
+++ b/www/install/sql/centreon/Update-DB-19.04.1.sql
@@ -1,0 +1,2 @@
+-- add default ldap connection timeout value
+INSERT INTO auth_ressource_info (ar_id, ari_name, ari_value) (SELECT ar_id, 'ldap_connect_timeout', '5' FROM auth_ressource);


### PR DESCRIPTION
<h2> Description </h2>
Add a new "connection timeout" parameter to LDAP configuration.

Fixes: #6008
Closes: #6009

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Add severals LDAP configurations with severals wrong LDAP servers entries, and try to do ldapsearch, or edit hosts or services, or reload a poller's configuration.
If no timeout is set, the pages can load indefinitely, reloads can never succeed.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
