### PR TITLE
fix(update): re execute missing PHP update from 2.8.27

### DIFF
--- a/www/install/php/Update-18.10.5_to_18.10.6.php
+++ b/www/install/php/Update-18.10.5_to_18.10.6.php
@@ -1,0 +1,137 @@
+<?php
+/*
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
+ *
+ * For more information : contact@centreon.com
+ *
+ *
+ */
+
+/*
+ * Redo all PHP upgrades from 2.8.26 to 18.10.0 for people migrating from 2.8.27 before PR #7416
+ */
+$result = $pearDB->query(
+    "SELECT `value` FROM `informations` WHERE `key` IN ('appKey', 'isRemote', 'isCentral')"
+);
+
+if ($result->rowCount() == 0) {
+    $uniqueKey = md5(uniqid(rand(), true));
+    $pearDB->query(
+        "INSERT INTO `informations` (`key`,`value`) VALUES ('appKey', '" . $uniqueKey . "')"
+    );
+    $pearDB->query(
+        "INSERT INTO `informations` (`key`,`value`) VALUES ('isRemote', 'no')"
+    );
+    $pearDB->query(
+        "INSERT INTO `informations` (`key`,`value`) VALUES ('isCentral', 'no')"
+    );
+}
+
+// Retrieve current Nagios plugins path.
+$result = $pearDB->query(
+    "SELECT value FROM options WHERE `key`='nagios_path_plugins'"
+);
+$row = $result->fetch();
+
+// Update to new path if necessary.
+if ($row
+    && preg_match('#/usr/lib/nagios/plugins/?#', $row['value'])
+    && is_dir('/usr/lib64/nagios/plugins')
+) {
+    // options table.
+    $pearDB->query(
+        "UPDATE options SET value='/usr/lib64/nagios/plugins/' WHERE `key`='nagios_path_plugins'"
+    );
+
+    // USER1 resource.
+    $pearDB->query(
+        "UPDATE cfg_resource SET resource_line='/usr/lib64/nagios/plugins' " .
+        "WHERE resource_line='/usr/lib/nagios/plugins'"
+    );
+}
+
+/*
+ * fix menu acl when child is checked but its parent is not checked
+ */
+
+// get all acl menu configurations
+$aclTopologies = $pearDB->query(
+    'SELECT acl_topo_id FROM acl_topology'
+);
+while ($aclTopology = $aclTopologies->fetch()) {
+    $aclTopologyId = $aclTopology['acl_topo_id'];
+
+    // get parents of topologies which are at least read only
+    $statement = $pearDB->prepare(
+        'SELECT t.topology_page, t.topology_id, t.topology_parent ' .
+        'FROM acl_topology_relations atr, topology t ' .
+        'WHERE acl_topo_id = :topologyId ' .
+        'AND atr.topology_topology_id = t.topology_id ' .
+        'AND atr.access_right IN (1,2) ' // read/write and read only
+    );
+    $statement->bindParam(':topologyId', $aclTopologyId, \PDO::PARAM_INT);
+    $statement->execute();
+    $topologies = $statement->fetchAll(\PDO::FETCH_UNIQUE | \PDO::FETCH_ASSOC);
+
+    // get missing parent topology relations
+    $aclToInsert = [];
+    foreach ($topologies as $topologyPage => $topologyParameters) {
+        if (isset($topologyParameters['topology_parent'])
+            && !isset($topologies[$topologyParameters['topology_parent']])
+            && !in_array($topologyParameters['topology_parent'], $aclToInsert)
+        ) {
+            if (strlen($topologyPage) === 5) { // level 3
+                $levelOne = substr($topologyPage, 0, 1); // get level 1 from beginning of topology_page
+                if (!isset($aclToInsert[$levelOne])) {
+                    $aclToInsert[] = $levelOne;
+                }
+                $levelTwo = substr($topologyPage, 0, 3); // get level 2 from beginning of topology_page
+                if (!isset($aclToInsert[$levelTwo])) {
+                    $aclToInsert[] = $levelTwo;
+                }
+            } elseif (strlen($topologyPage) === 3) { // level 2
+                $levelOne = substr($topologyPage, 0, 1); // get level 1 from beginning of topology_page
+                if (!isset($aclToInsert[$levelOne])) {
+                    $aclToInsert[] = $levelOne;
+                }
+            }
+        }
+    }
+
+    // insert missing parent topology relations
+    if (count($aclToInsert)) {
+        $statement = $pearDB->query(
+            'INSERT INTO acl_topology_relations(acl_topo_id, topology_topology_id) ' .
+            'SELECT ' . $aclTopologyId  . ', t.topology_id ' .
+            'FROM topology t ' .
+            'WHERE t.topology_page IN (' . implode(',', $aclToInsert) . ')'
+        );
+    }
+}


### PR DESCRIPTION
<h2> Description </h2>

Complete the PR #7416
But the previous PR doesn't make the job for platform already in Centreon 18.10.4 version migrating from 2.8.27.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Install a Centreon 3.4.x version (Centreon Web 2.8.27)
In centreon.informations table, 'appKey, isCentral & isRemote entries are missing

Update to 18.10.5, information must be present.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
