### PR TITLE
enh(config): add a field to set database root user at installation 

### DIFF
--- a/doc/en/installation/common/web_install.rst
+++ b/doc/en/installation/common/web_install.rst
@@ -38,7 +38,8 @@ Provide the information on the admin user, then click on **Next**.
    :align: center
    :scale: 85%
 
-By default, the *localhost* server is defined and the root password is empty. If you use a remote database server, change these entries.
+By default, the *localhost* server is defined, the database root user is set to *root* and the root password is empty.
+If you use a remote database server, change these entries.
 In this case, you only need to define a password for the user accessing the Centreon databases, i.e., *Centreon*. Click on **Next**.
 
 .. image :: /images/user/adbinfo.png

--- a/doc/fr/installation/common/web_install.rst
+++ b/doc/fr/installation/common/web_install.rst
@@ -37,7 +37,8 @@ Définissez les informations concernant l'utilisateur admin, cliquez sur **Next*
    :align: center
    :scale: 65%
 
-Par défaut, le serveur 'localhost' est défini et le mot de passe root est vide. Si vous utilisez un serveur de base de données déporté, il convient de modifier ces deux informations.
+Par défaut, le serveur 'localhost' est défini, l'utilisateur root est défini à *root* et le mot de passe root est vide.
+Si vous utilisez un serveur de base de données déporté, il convient de modifier ces deux informations.
 Dans notre cas, nous avons uniquement besoin de définir un mot de passe pour l'utilisateur accédant aux bases de données Centreon, à savoir 'centreon'.
 
 Cliquez sur **Next**.

--- a/src/CentreonLegacy/Core/Install/Step/AbstractStep.php
+++ b/src/CentreonLegacy/Core/Install/Step/AbstractStep.php
@@ -68,6 +68,7 @@ abstract class AbstractStep implements StepInterface
         $configuration = array(
             'address' => '',
             'port' => '',
+            'root_user' => 'root',
             'root_password' => '',
             'db_configuration' => 'centreon',
             'db_storage' => 'centreon_storage',

--- a/www/install/steps/functions.php
+++ b/www/install/steps/functions.php
@@ -44,7 +44,7 @@ function getTemplate($dir)
 function myConnect()
 {
     $user = "root";
-    if (isset($_SESSION['root_user']) && $_SESSION['root_user']) {
+    if (!empty($_SESSION['root_user'])) {
         $user = $_SESSION['root_user'];
     }
     $pass = "";

--- a/www/install/steps/functions.php
+++ b/www/install/steps/functions.php
@@ -43,6 +43,10 @@ function getTemplate($dir)
  */
 function myConnect()
 {
+    $user = "root";
+    if (isset($_SESSION['root_user']) && $_SESSION['root_user']) {
+        $user = $_SESSION['root_user'];
+    }
     $pass = "";
     if (isset($_SESSION['root_password']) && $_SESSION['root_password']) {
         $pass = $_SESSION['root_password'];
@@ -55,7 +59,7 @@ function myConnect()
     if (isset($_SESSION['DB_PORT']) && $_SESSION['DB_PORT']) {
         $port = $_SESSION['DB_PORT'];
     }
-    return new \PDO('mysql:host=' . $host . ';port=' . $port, 'root', $pass);
+    return new \PDO('mysql:host=' . $host . ';port=' . $port, $user, $pass);
 }
 
 /**

--- a/www/install/steps/functions.php
+++ b/www/install/steps/functions.php
@@ -48,7 +48,7 @@ function myConnect()
         $user = $_SESSION['root_user'];
     }
     $pass = "";
-    if (isset($_SESSION['root_password']) && $_SESSION['root_password']) {
+    if (!empty($_SESSION['root_password'])) {
         $pass = $_SESSION['root_password'];
     }
     $host = "localhost";

--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -49,7 +49,7 @@ $parameters = $step->getDatabaseConfiguration();
 try {
     $link = new \PDO(
         'mysql:host=' . $parameters['address'] . ';port=' . $parameters['port'],
-        'root',
+        $parameters['root_user'],
         $parameters['root_password']
     );
 } catch (\PDOException $e) {

--- a/www/install/steps/process/insertBaseConf.php
+++ b/www/install/steps/process/insertBaseConf.php
@@ -51,7 +51,7 @@ $parameters = $step->getDatabaseConfiguration();
 try {
     $link = new \PDO(
         'mysql:host=' . $parameters['address'] . ';port=' . $parameters['port'],
-        'root',
+        $parameters['root_user'],
         $parameters['root_password']
     );
 } catch (\PDOException $e) {

--- a/www/install/steps/process/installConfigurationDb.php
+++ b/www/install/steps/process/installConfigurationDb.php
@@ -49,7 +49,7 @@ $parameters = $step->getDatabaseConfiguration();
 try {
     $link = new \PDO(
         'mysql:host=' . $parameters['address'] . ';port=' . $parameters['port'],
-        'root',
+        $parameters['root_user'],
         $parameters['root_password']
     );
 } catch (\PDOException $e) {

--- a/www/install/steps/process/installStorageDb.php
+++ b/www/install/steps/process/installStorageDb.php
@@ -51,7 +51,7 @@ $parameters = $step->getDatabaseConfiguration();
 try {
     $link = new \PDO(
         'mysql:host=' . $parameters['address'] . ';port=' . $parameters['port'],
-        'root',
+        $parameters['root_user'],
         $parameters['root_password']
     );
 } catch (\PDOException $e) {

--- a/www/install/steps/process/process_step6.php
+++ b/www/install/steps/process/process_step6.php
@@ -70,9 +70,12 @@ try {
     if ($parameters['port'] == "") {
         $parameters['port'] = "3306";
     }
+    if ($parameters['root_user'] == "") {
+        $parameters['root_user'] = "root";
+    }
     $link = new \PDO(
         'mysql:host=' . $parameters['address'] . ';port=' . $parameters['port'],
-        'root',
+        $parameters['root_user'],
         $parameters['root_password']
     );
 } catch (\PDOException $e) {

--- a/www/install/steps/templates/step6.tpl
+++ b/www/install/steps/templates/step6.tpl
@@ -21,6 +21,13 @@
             </td>
         </tr>
         <tr>
+            <td class='formlabel'>{t}Root user{/t}</td>
+            <td class='formvalue'>
+                <input type='text' name='root_user' value='{$parameters.root_user}' />
+                <label class='field_msg'></label>
+            </td>
+        </tr>
+        <tr>
             <td class='formlabel'>{t}Root password{/t}</td>
             <td class='formvalue'>
                 <input type='password' name='root_password' value='{$parameters.root_password}' />

--- a/www/install/steps/templates/step6.tpl
+++ b/www/install/steps/templates/step6.tpl
@@ -21,7 +21,7 @@
             </td>
         </tr>
         <tr>
-            <td class='formlabel'>{t}Root user{/t}</td>
+            <td class='formlabel'>{t}Root user (default: root){/t}</td>
             <td class='formvalue'>
                 <input type='text' name='root_user' value='{$parameters.root_user}' />
                 <label class='field_msg'></label>


### PR DESCRIPTION
<h2> Description </h2>

Add a field to set database root user at installation if the root user is not actually root.

Closes: #6051 

<h2> Type of change </h2>

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x

<h2> How this pull request can be tested ? </h2>

Install a fresh 19.04.x instance.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
