### PR TITLE
fix(topcounter): Fix the top counter link to check the services in status OK

### DIFF
--- a/www/front_src/src/components/serviceStatusMenu/index.js
+++ b/www/front_src/src/components/serviceStatusMenu/index.js
@@ -104,7 +104,7 @@ class ServiceStatusMenu extends Component {
             <span id="count-svc-unknown">{numeral(data.unknown.unhandled).format("0a")}</span>
           </span>
         </Link>
-        <Link to={"/main.php?p=20201&o=svc_ok&search="} className={classnames(styles["wrap-middle-icon"], styles["round"], styles["round-small"], {[styles[data.ok > 0 ? "green" : "green-bordered"]]: true})}>
+        <Link to={"/main.php?p=20201&o=svc_ok&statusService=svc&search="} className={classnames(styles["wrap-middle-icon"], styles["round"], styles["round-small"], {[styles[data.ok > 0 ? "green" : "green-bordered"]]: true})}>
           <span className={styles["number"]}>
             <span id="count-svc-ok">{numeral(data.ok).format("0a")}</span>
           </span>


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

The link in the top counter does not have the good url when we click services in OK status.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Click on the top counter link to check the services in status OK.
The number of services in the OK status must be identical to the number indicated in the topcounter.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
