### PR TITLE
fix(logs): administration viewLogs, remove the log's undefined notice

### DIFF
--- a/www/include/Administration/configChangelog/viewLogs.php
+++ b/www/include/Administration/configChangelog/viewLogs.php
@@ -178,7 +178,7 @@ $tpl->assign("obj_type", $options);
 $logQuery = "SELECT SQL_CALC_FOUND_ROWS object_id, object_type, object_name, "
     . "action_log_date, action_type, log_contact_id, action_log_id "
     . "FROM log_action";
-$query = $logQuery;
+
 $valuesToBind = [];
 if (!empty($searchO) || !empty($searchU) || $otype != 0) {
     $logQuery .= ' WHERE ';

--- a/www/include/Administration/configChangelog/viewLogs.php
+++ b/www/include/Administration/configChangelog/viewLogs.php
@@ -179,11 +179,11 @@ $logQuery = "SELECT SQL_CALC_FOUND_ROWS object_id, object_type, object_name, "
     . "action_log_date, action_type, log_contact_id, action_log_id "
     . "FROM log_action";
 $query = $logQuery;
+$valuesToBind = [];
 if (!empty($searchO) || !empty($searchU) || $otype != 0) {
     $logQuery .= ' WHERE ';
     $hasMultipleSubRequest = false;
     
-    $valuesToBind = [];
     if (!empty($searchO)) {
         $logQuery .= "object_name LIKE :object_name ";
         $valuesToBind[':object_name'] = "%$searchO%";

--- a/www/include/Administration/configChangelog/viewLogs.php
+++ b/www/include/Administration/configChangelog/viewLogs.php
@@ -186,7 +186,7 @@ if (!empty($searchO) || !empty($searchU) || $otype != 0) {
     
     if (!empty($searchO)) {
         $logQuery .= "object_name LIKE :object_name ";
-        $valuesToBind[':object_name'] = "%$searchO%";
+        $valuesToBind[':object_name'] = "%" . $searchO . "%";
         $hasMultipleSubRequest = true;
     }
     if (!empty($searchU)) {
@@ -218,7 +218,7 @@ $prepareSelect->bindValue(':nbr_element', $limit, \PDO::PARAM_INT);
 
 $rows = 0;
 
-include("./include/common/checkPagination.php");
+include "./include/common/checkPagination.php";
 
 $elemArray = array();
 if ($prepareSelect->execute()) {


### PR DESCRIPTION
<h1> Pull Request Template </h1>

**To be merged only after Centreon 19.04.0 version released**

<h2> Description </h2>

Remove the notice :
`PHP Warning:  Invalid argument supplied for foreach() in `
`/usr/share/centreon/www/include/Administration/configChangelog/viewLogs.php on line 213`

Fixes # (issue)

<h2> Type of change </h2>

- [X] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [X] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Go to Adminsitration > logs and check the PHP logs

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
