### PR TITLE
fix(status details): Fix a double webservice call

### DIFF
--- a/www/include/monitoring/status/Common/commonJS.php
+++ b/www/include/monitoring/status/Common/commonJS.php
@@ -261,7 +261,11 @@ function construct_selecteList_ndo_instance(id){
             xhr = new XMLHttpRequest();
             xhr.open('GET','./include/monitoring/status/Common/updateContactParam.php?uid=<?php echo $centreon->user->user_id; ?>&instance_id='+this.value, true);
             xhr.send(null);
-            xhr.onreadystatechange = function() { monitoring_refresh(); };
+            xhr.onreadystatechange = function() {
+                if (this.readyState === XMLHttpRequest.DONE) {
+                    monitoring_refresh();
+                }
+            };
         };
         var k = document.createElement('option');
         k.value= -1;
@@ -316,7 +320,9 @@ function construct_HostGroupSelectList(id) {
             xhr.open('GET','./include/monitoring/status/Common/updateContactParamHostGroups.php?uid=<?php echo $centreon->user->user_id; ?>&hostgroups='+this.value, true);
             xhr.send(null);
             xhr.onreadystatechange = function() {
-                monitoring_refresh();
+                if (this.readyState === XMLHttpRequest.DONE) {
+                    monitoring_refresh();
+                }
             };
         };
         var k = document.createElement('option');
@@ -405,7 +411,9 @@ function construct_ServiceGroupSelectList(id) {
             xhr.open('GET','./include/monitoring/status/Common/updateContactParamServiceGroups.php?uid=<?php echo $centreon->user->user_id; ?>&servicegroups='+this.value, true);
             xhr.send(null);
             xhr.onreadystatechange = function() {
-                monitoring_refresh();
+                if (this.readyState === XMLHttpRequest.DONE) {
+                    monitoring_refresh();
+                }
             };
         };
         var k = document.createElement('option');


### PR DESCRIPTION
<h2> Description </h2>

When the option for one of the Poller, Servicegroup, or Hostgroup groups is selected, a double Webservice call is performed.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Open de debug tab in your webrowser. In the debug tab select the network tab and change option from one of these lists: Poller, Hostgroup, Servicegroup.
For each change, only one webservice call is performed.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x]  I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
