### PR TITLE
fix(monitoring host): Fix columns on the list page

### DIFF
--- a/www/include/monitoring/status/Hosts/host.php
+++ b/www/include/monitoring/status/Hosts/host.php
@@ -487,7 +487,5 @@ $tpl->display("host.ihtml");
 
     function statusHosts(value, isInit) {
         _o = value;
-        window.clearTimeout(_timeoutID);
-        initM(_tm, _sid, _o);
     }
 </script>

--- a/www/include/monitoring/status/Hosts/hostJS.php
+++ b/www/include/monitoring/status/Hosts/hostJS.php
@@ -239,7 +239,9 @@ if (isset($_GET["acknowledge"])) {
     }
 
     function goM(_time_reload, _sid, _o) {
-
+        if (_on == 0) {
+            return;
+        }
         _lock = 1;
         var proc = new Transformation();
 
@@ -264,6 +266,9 @@ if (isset($_GET["acknowledge"])) {
         }
 
         _lock = 0;
+        if (_timeoutID) { // Kill next execution if in queue
+            clearTimeout(_timeoutID);
+        }
         _timeoutID = cycleVisibilityChange(function(){goM(_time_reload, _sid, _o)}, _time_reload);
         _time_live = _time_reload;
         _on = 1;


### PR DESCRIPTION
<h2> Description </h2>

Go to “Monitoring > Status Details > Hosts”.
Given the “Host status” is on “All”.
Click on the pause button then select “Host problems” in “Host status”. Click on the play button then select “All” in “Host status”.
Two webservice call are performed with the two status and the Host list page have two different results.

Fix issues:

Fix columns on the Host list page (about 'hard state duration' column).
Fix the play button to use the selected status when we click on it.
Fix the refresh feature to avoid to restart play if the pause is actived.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Open de debug tab in your webrowser. In the debug tab select the network tab to see the calls of the webservices.

Go to “Monitoring > Status Details > Hosts”.
Given the “Host status” is on “All”.
Click on the pause button then select “Host problems” in “Host status”. Click on the play button then select “All” in “Host status”.

The Host list page correspond to the right status expected based on the Host status selected.
The pause button works correctly.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
