### PR TITLE
Do not care about *_files module flags

### DIFF
--- a/src/CentreonLegacy/Core/Module/Installer.php
+++ b/src/CentreonLegacy/Core/Module/Installer.php
@@ -40,7 +40,7 @@ use CentreonLegacy\Core\Module\Information;
 use CentreonLegacy\Core\Utils\Utils;
 
 class Installer extends Module
-{   
+{
     /**
      *
      * @return int
@@ -68,21 +68,18 @@ class Installer extends Module
         }
 
         $query = 'INSERT INTO modules_informations ' .
-            '(`name` , `rname` , `mod_release` , `is_removeable` , `infos` , `author` , `lang_files`, ' .
-            '`sql_files`, `php_files`, `svc_tools`, `host_tools`)' .
-            'VALUES ( :name , :rname , :mod_release , :is_removeable , :infos , :author , :lang_files , ' .
-            ':sql_files , :php_files , :svc_tools , :host_tools )';
+            '(`name` , `rname` , `mod_release` , `is_removeable` , `infos` , `author` , ' .
+            '`svc_tools`, `host_tools`)' .
+            'VALUES ( :name , :rname , :mod_release , :is_removeable , :infos , :author , ' .
+            ':svc_tools , :host_tools )';
         $sth = $this->services->get('configuration_db')->prepare($query);
-        
+
         $sth->bindParam(':name', $this->moduleConfiguration['name'], \PDO::PARAM_STR);
         $sth->bindParam(':rname', $this->moduleConfiguration['rname'], \PDO::PARAM_STR);
         $sth->bindParam(':mod_release', $this->moduleConfiguration['mod_release'], \PDO::PARAM_STR);
         $sth->bindParam(':is_removeable', $this->moduleConfiguration['is_removeable'], \PDO::PARAM_STR);
         $sth->bindParam(':infos', $this->moduleConfiguration['infos'], \PDO::PARAM_STR);
         $sth->bindParam(':author', $this->moduleConfiguration['author'], \PDO::PARAM_STR);
-        $sth->bindParam(':lang_files', $this->moduleConfiguration['lang_files'], \PDO::PARAM_STR);
-        $sth->bindParam(':sql_files', $this->moduleConfiguration['sql_files'], \PDO::PARAM_STR);
-        $sth->bindParam(':php_files', $this->moduleConfiguration['php_files'], \PDO::PARAM_STR);
         $sth->bindParam(':svc_tools', $this->moduleConfiguration['svc_tools'], \PDO::PARAM_STR);
         $sth->bindParam(':host_tools', $this->moduleConfiguration['host_tools'], \PDO::PARAM_STR);
 
@@ -107,7 +104,7 @@ class Installer extends Module
         $installed = false;
 
         $sqlFile = $this->getModulePath($this->moduleName) . '/sql/install.sql';
-        if ($this->moduleConfiguration["sql_files"] && $this->services->get('filesystem')->exists($sqlFile)) {
+        if ($this->services->get('filesystem')->exists($sqlFile)) {
             $this->utils->executeSqlFile($sqlFile);
             $installed = true;
         }
@@ -124,7 +121,7 @@ class Installer extends Module
         $installed = false;
 
         $phpFile = $this->getModulePath($this->moduleName) . '/php/install.php';
-        if ($this->moduleConfiguration["php_files"] && $this->services->get('filesystem')->exists($phpFile)) {
+        if ($this->services->get('filesystem')->exists($phpFile)) {
             $this->utils->executePhpFile($phpFile);
             $installed = true;
         }

--- a/src/CentreonLegacy/Core/Module/Remover.php
+++ b/src/CentreonLegacy/Core/Module/Remover.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2005-2017 Centreon
+ * Copyright 2005-2019 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -84,7 +84,7 @@ class Remover extends Module
         $removed = false;
 
         $sqlFile = $this->getModulePath($this->moduleName) . '/sql/uninstall.sql';
-        if ($this->moduleConfiguration["sql_files"] && $this->services->get('filesystem')->exists($sqlFile)) {
+        if ($this->services->get('filesystem')->exists($sqlFile)) {
             $this->utils->executeSqlFile($sqlFile);
             $removed = true;
         }
@@ -101,7 +101,7 @@ class Remover extends Module
         $removed = false;
 
         $phpFile = $this->getModulePath($this->moduleName) . '/php/uninstall.php';
-        if ($this->moduleConfiguration["php_files"] && $this->services->get('filesystem')->exists($phpFile)) {
+        if ($this->services->get('filesystem')->exists($phpFile)) {
             $this->utils->executePhpFile($phpFile);
             $removed = true;
         }

--- a/src/CentreonLegacy/Core/Module/Upgrader.php
+++ b/src/CentreonLegacy/Core/Module/Upgrader.php
@@ -102,9 +102,6 @@ class Upgrader extends Module
             '`is_removeable` = :is_removeable , ' .
             '`infos` = :infos , ' .
             '`author` = :author , ' .
-            '`lang_files` = :lang_files , ' .
-            '`sql_files` = :sql_files , ' .
-            '`php_files` = :php_files , ' .
             '`svc_tools` = :svc_tools , ' .
             '`host_tools` = :host_tools ' .
             'WHERE id = :id';
@@ -116,9 +113,6 @@ class Upgrader extends Module
         $sth->bindParam(':is_removeable', $this->moduleConfiguration['is_removeable'], \PDO::PARAM_STR);
         $sth->bindParam(':infos', $this->moduleConfiguration['infos'], \PDO::PARAM_STR);
         $sth->bindParam(':author', $this->moduleConfiguration['author'], \PDO::PARAM_STR);
-        $sth->bindParam(':lang_files', $this->moduleConfiguration['lang_files'], \PDO::PARAM_STR);
-        $sth->bindParam(':sql_files', $this->moduleConfiguration['sql_files'], \PDO::PARAM_STR);
-        $sth->bindParam(':php_files', $this->moduleConfiguration['php_files'], \PDO::PARAM_STR);
         $sth->bindParam(':svc_tools', $this->moduleConfiguration['svc_tools'], \PDO::PARAM_STR);
         $sth->bindParam(':host_tools', $this->moduleConfiguration['host_tools'], \PDO::PARAM_STR);
         $sth->bindParam(':id', $this->moduleId, \PDO::PARAM_INT);
@@ -160,7 +154,7 @@ class Upgrader extends Module
         $installed = false;
 
         $sqlFile = $path . '/sql/upgrade.sql';
-        if ($conf[$this->moduleName]["sql_files"] && $this->services->get('filesystem')->exists($sqlFile)) {
+        if ($this->services->get('filesystem')->exists($sqlFile)) {
             $this->utils->executeSqlFile($sqlFile);
             $installed = true;
         }
@@ -182,7 +176,7 @@ class Upgrader extends Module
         $phpFile = $path . '/php/upgrade';
         $phpFile = $pre ? $phpFile . '.pre.php' : $phpFile . '.php';
 
-        if ($conf[$this->moduleName]['php_files'] && $this->services->get('filesystem')->exists($phpFile)) {
+        if ($this->services->get('filesystem')->exists($phpFile)) {
             $this->utils->executePhpFile($phpFile);
             $installed = true;
         }

--- a/src/CentreonModule/Tests/Application/Webservice/CentreonModulesWebserviceTest.php
+++ b/src/CentreonModule/Tests/Application/Webservice/CentreonModulesWebserviceTest.php
@@ -58,9 +58,6 @@ class CentreonModulesWebserviceTest extends TestCase
                 'is_removable' => '1',
                 'infos' => '',
                 'author' => '',
-                'lang_files' => '1',
-                'sql_files' => '1',
-                'php_files' => '1',
                 'svc_tools' => '0',
                 'host_tools' => '0',
             ],
@@ -90,7 +87,7 @@ class CentreonModulesWebserviceTest extends TestCase
                 'getList',
             ])
             ->getMock();
-        
+
         $container[\CentreonLegacy\ServiceProvider::CENTREON_LEGACY_MODULE_INFORMATION]
             ->method('getList')
             ->will($this->returnCallback(function () {

--- a/src/CentreonModule/Tests/Infrastructure/Source/ModuleSourceTest.php
+++ b/src/CentreonModule/Tests/Infrastructure/Source/ModuleSourceTest.php
@@ -65,9 +65,6 @@ class ModuleSourceTest extends TestCase
         'infos' => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent id ante neque.',
         'is_removeable' => '1',
         'author' => 'Centreon',
-        'lang_files' => '0',
-        'sql_files' => '1',
-        'php_files' => '0',
         'stability' => 'alpha',
         'last_update' => '2001-01-01',
         'release_note' => 'http://localhost',
@@ -235,7 +232,7 @@ class ModuleSourceTest extends TestCase
 //    {
 //        $moduleSource = new ModuleSource($this->containerWrap);
 //        $result = $this->invokeMethod($moduleSource, 'getModuleConf', [static::getConfFilePath()]);
-//        //'php://filter/read=string.rot13/resource=' . 
+//        //'php://filter/read=string.rot13/resource=' .
 //    }
 
     public static function getConfFilePath(): string

--- a/tests/php/CentreonLegacy/Core/Module/InstallerTest.php
+++ b/tests/php/CentreonLegacy/Core/Module/InstallerTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Centreon
+ * Copyright 2016-2019 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,9 +44,6 @@ class InstallerTest extends \PHPUnit_Framework_TestCase
             'is_removeable' => 1,
             'infos' => 'my module for unit test',
             'author' => 'unit test',
-            'lang_files' => 0,
-            'sql_files' => 1,
-            'php_files' => 1,
             'svc_tools' => null,
             'host_tools' => null
         );
@@ -82,10 +79,10 @@ class InstallerTest extends \PHPUnit_Framework_TestCase
         $this->container->registerProvider(new FilesystemProvider($filesystem));
 
         $query = 'INSERT INTO modules_informations ' .
-            '(`name` , `rname` , `mod_release` , `is_removeable` , `infos` , `author` , `lang_files`, ' .
-            '`sql_files`, `php_files`, `svc_tools`, `host_tools`)' .
-            'VALUES ( :name , :rname , :mod_release , :is_removeable , :infos , :author , :lang_files , ' .
-            ':sql_files , :php_files , :svc_tools , :host_tools )';
+            '(`name` , `rname` , `mod_release` , `is_removeable` , `infos` , `author` , ' .
+            '`svc_tools`, `host_tools`)' .
+            'VALUES ( :name , :rname , :mod_release , :is_removeable , :infos , :author , ' .
+            ':svc_tools , :host_tools )';
         $this->db->addResultSet(
             $query,
             array()

--- a/tests/php/CentreonLegacy/Core/Module/RemoverTest.php
+++ b/tests/php/CentreonLegacy/Core/Module/RemoverTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Centreon
+ * Copyright 2016-2019 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,9 +44,6 @@ class RemoverTest extends \PHPUnit_Framework_TestCase
             'is_removeable' => 1,
             'infos' => 'my module for unit test',
             'author' => 'unit test',
-            'lang_files' => 0,
-            'sql_files' => 1,
-            'php_files' => 1,
             'svc_tools' => null,
             'host_tools' => null
         );

--- a/tests/php/CentreonLegacy/Core/Module/UpgraderTest.php
+++ b/tests/php/CentreonLegacy/Core/Module/UpgraderTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright 2016 Centreon
+ * Copyright 2016-2019 Centreon
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,9 +49,6 @@ class UpgraderTest extends \PHPUnit_Framework_TestCase
             'is_removeable' => 1,
             'infos' => 'my module for unit test',
             'author' => 'unit test',
-            'lang_files' => 0,
-            'sql_files' => 1,
-            'php_files' => 1,
             'svc_tools' => null,
             'host_tools' => null
         );
@@ -66,9 +63,6 @@ class UpgraderTest extends \PHPUnit_Framework_TestCase
             'is_removeable' => 1,
             'infos' => 'my module for unit test',
             'author' => 'unit test',
-            'lang_files' => 0,
-            'sql_files' => 1,
-            'php_files' => 1,
             'svc_tools' => null,
             'host_tools' => null
         );
@@ -91,10 +85,7 @@ class UpgraderTest extends \PHPUnit_Framework_TestCase
                 'release_from' => '1.0.0',
                 'release_to' => '1.0.1',
                 'infos' => 'my module for unit test',
-                'author' => 'unit test',
-                'lang_files' => 0,
-                'sql_files' => 1,
-                'php_files' => 1
+                'author' => 'unit test'
             )
         );
         $this->utils->expects($this->any())
@@ -147,8 +138,7 @@ class UpgraderTest extends \PHPUnit_Framework_TestCase
 
         $query = 'UPDATE modules_informations ' .
             'SET `name` = :name , `rname` = :rname , `is_removeable` = :is_removeable , ' .
-            '`infos` = :infos , `author` = :author , `lang_files` = :lang_files , ' .
-            '`sql_files` = :sql_files , `php_files` = :php_files , ' .
+            '`infos` = :infos , `author` = :author , ' .
             '`svc_tools` = :svc_tools , `host_tools` = :host_tools WHERE id = :id';
         $this->db->addResultSet(
             $query,

--- a/www/class/centreon.class.php
+++ b/www/class/centreon.class.php
@@ -165,15 +165,13 @@ class Centreon
     public function creatModuleList()
     {
         $this->modules = array();
-        $query = "SELECT `name`, `sql_files`, `lang_files`, `php_files` FROM `modules_informations`";
+        $query = "SELECT `name` FROM `modules_informations`";
         $dbResult = CentreonDBInstance::getConfInstance()->query($query);
         while ($result = $dbResult->fetch()) {
             $this->modules[$result["name"]] = array(
                 "name" => $result["name"],
                 "gen" => false,
                 "restart" => false,
-                "sql" => $result["sql_files"],
-                "lang" => $result["lang_files"],
                 "license" => false
             );
 
@@ -254,8 +252,8 @@ class Centreon
          */
         $DBRESULT = CentreonDBInstance::getConfInstance()->query("SELECT * FROM cfg_nagios, nagios_server
                                     WHERE nagios_server.id = cfg_nagios.nagios_server_id
-                                    AND nagios_server.localhost = '1' 
-                                    ORDER BY cfg_nagios.nagios_activate 
+                                    AND nagios_server.localhost = '1'
+                                    ORDER BY cfg_nagios.nagios_activate
                                     DESC LIMIT 1");
         $this->Nagioscfg = $DBRESULT->fetch();
         $DBRESULT = null;

--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -1589,9 +1589,6 @@ CREATE TABLE `modules_informations` (
   `is_removeable` enum('0','1') DEFAULT NULL,
   `infos` text,
   `author` varchar(255) DEFAULT NULL,
-  `lang_files` enum('0','1') DEFAULT NULL,
-  `sql_files` enum('0','1') DEFAULT NULL,
-  `php_files` enum('0','1') DEFAULT NULL,
   `svc_tools` enum('0','1') DEFAULT NULL,
   `host_tools` enum('0','1') DEFAULT NULL,
   PRIMARY KEY (`id`)

--- a/www/install/sql/centreon/Update-DB-19.10.0.sql
+++ b/www/install/sql/centreon/Update-DB-19.10.0.sql
@@ -53,3 +53,10 @@ ALTER TABLE `traps_service_relation` DROP COLUMN `tsr_id`;
 --
 ALTER TABLE `acl_groups` MODIFY COLUMN `acl_group_changed` int(11) NOT NULL DEFAULT 1;
 ALTER TABLE `widget_models` MODIFY COLUMN `description` TEXT NOT NULL;
+
+--
+-- Remove modules *_files flags.
+--
+ALTER TABLE `modules_informations` DROP COLUMN `lang_files`;
+ALTER TABLE `modules_informations` DROP COLUMN `sql_files`;
+ALTER TABLE `modules_informations` DROP COLUMN `php_files`;


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

In the current system, modules have to declare wether they have *lang*, *SQL* or *php* files for install/update/uninstall in their conf.php. This has to be set in addition to the existence of the forementioned files so that they are properly processed.

Experience showed that this is not ideal and flag management might be overlooked, especially in updates' conf.php.

<h2> Type of change </h2>

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x

<h2> How this pull request can be tested ? </h2>

First, modules should have their *_files flags removed from their conf.php.

Then all installations, updates or removals should work normally.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [X] I have made sure that the **unit tests** related to the story are successful.
- [X] I have made sure that **unit tests covers 80%** of the code written for the story.
- [X] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
