### PR TITLE
fix(ui): pagination and results in the administration logs page

### DIFF
--- a/www/class/centreonLogAction.class.php
+++ b/www/class/centreonLogAction.class.php
@@ -156,7 +156,7 @@ class CentreonLogAction
     }
 
     /*
-     *  returns list of modifications
+     *  returns list of host for this service
      */
     public function getHostId($service_id)
     {

--- a/www/include/Administration/configChangelog/viewLogs.ihtml
+++ b/www/include/Administration/configChangelog/viewLogs.ihtml
@@ -28,7 +28,7 @@
 </table>
 <table class="ListTable">
     <tr class="ListHeader">
-        <td class="ListColHeaderCenter" style='width:120px'>{t}Date{/t}</td>
+        <td class="ListColHeaderCenter" style='width:180px'>{t}Date{/t}</td>
         <td class="ListColHeaderCenter" style="white-space:nowrap;">{t}Modificaton type{/t}</td>
         <td class="ListColHeaderCenter" style="white-space:nowrap;">{t}Objects{/t}</td>
         <td class="ListColHeaderCenter" style="white-space:nowrap;">{t}Object Name{/t}</td>

--- a/www/include/Administration/configChangelog/viewLogs.ihtml
+++ b/www/include/Administration/configChangelog/viewLogs.ihtml
@@ -22,7 +22,7 @@
     <tr class="ToolbarTR">
         <td style='width:30%;'><input name="p" value="{$p}" type="hidden">&nbsp;</td>
         {php}
-           include('./include/common/pagination.php');
+           include './include/common/pagination.php';
         {/php}
     </tr>
 </table>

--- a/www/include/Administration/configChangelog/viewLogs.php
+++ b/www/include/Administration/configChangelog/viewLogs.php
@@ -207,17 +207,15 @@ if (!empty($searchO) || !empty($searchU) || $otype != 0) {
         $valuesToBind[':object_type'] = $objects_type_tab[$otype];
     }
 }
-$logQuery .= " ORDER BY action_log_date DESC LIMIT :from, :nbr_element";
+$logQuery .= " ORDER BY action_log_date DESC LIMIT :from, :nbrElement";
 $prepareSelect = $pearDBO->prepare($logQuery);
 foreach ($valuesToBind as $label => $value) {
     $prepareSelect->bindValue($label, $value, \PDO::PARAM_STR);
 }
 $prepareSelect->bindValue(':from', $num * $limit, \PDO::PARAM_INT);
-$prepareSelect->bindValue(':nbr_element', $limit, \PDO::PARAM_INT);
+$prepareSelect->bindValue(':nbrElement', $limit, \PDO::PARAM_INT);
 
 $rows = 0;
-
-include "./include/common/checkPagination.php";
 
 $elemArray = array();
 if ($prepareSelect->execute()) {
@@ -342,6 +340,7 @@ if ($prepareSelect->execute()) {
         }
     }
 }
+include "./include/common/checkPagination.php";
 
 
 /*

--- a/www/include/Administration/configChangelog/viewLogs.php
+++ b/www/include/Administration/configChangelog/viewLogs.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -37,7 +37,7 @@ if (!isset($centreon)) {
     exit();
 }
 
-require_once("./include/common/autoNumLimit.php");
+require_once "./include/common/autoNumLimit.php";
 
 /**
  * Search a contact by username or alias
@@ -52,12 +52,12 @@ function searchUserName($username)
     
     $contactIds = [];
     $prepareContact = $pearDB->prepare(
-        "SELECT contact_id FROM contact "
-        . "WHERE contact_name LIKE :contact_name "
-        . "OR contact_alias LIKE :contact_alias"
+        "SELECT contact_id FROM contact " .
+        "WHERE contact_name LIKE :contact_name " .
+        "OR contact_alias LIKE :contact_alias"
     );
-    $prepareContact->bindValue(':contact_name', "%$username%", \PDO::PARAM_STR);
-    $prepareContact->bindValue(':contact_alias', "%$username%", \PDO::PARAM_STR);
+    $prepareContact->bindValue(':contact_name', "%" . $username . "%", \PDO::PARAM_STR);
+    $prepareContact->bindValue(':contact_alias', "%" . $username . "%", \PDO::PARAM_STR);
     if ($prepareContact->execute()) {
         while ($contact = $prepareContact->fetch(\PDO::FETCH_ASSOC)) {
             $contactIds[] = (int) $contact['contact_id'];
@@ -75,7 +75,7 @@ $path = "./include/Administration/configChangelog/";
  * PHP functions
  */
 require_once "./include/common/common-Func.php";
-require_once("./class/centreonDB.class.php");
+require_once "./class/centreonDB.class.php";
 
 /*
  * Connect to Centstorage Database
@@ -83,12 +83,11 @@ require_once("./class/centreonDB.class.php");
 $pearDBO = new CentreonDB("centstorage");
 
 $contactList = array();
-$DBRES = $pearDB->query(
+$dbResult = $pearDB->query(
     "SELECT contact_id, contact_name, contact_alias FROM contact"
 );
-while ($row = $DBRES->fetchRow()) {
-    $contactList[$row["contact_id"]] =
-        $row["contact_name"] . " (" . $row["contact_alias"] . ")";
+while ($row = $dbResult->fetch()) {
+    $contactList[$row["contact_id"]] = $row["contact_name"] . " (" . $row["contact_alias"] . ")";
 }
 
 $searchO = null;

--- a/www/include/Administration/configChangelog/viewLogs.php
+++ b/www/include/Administration/configChangelog/viewLogs.php
@@ -215,9 +215,8 @@ foreach ($valuesToBind as $label => $value) {
 $prepareSelect->bindValue(':from', $num * $limit, \PDO::PARAM_INT);
 $prepareSelect->bindValue(':nbrElement', $limit, \PDO::PARAM_INT);
 
-$rows = 0;
-
 $elemArray = array();
+$rows = 0;
 if ($prepareSelect->execute()) {
     $rows = $pearDBO->query("SELECT FOUND_ROWS()")->fetchColumn();
     while ($res = $prepareSelect->fetch(\PDO::FETCH_ASSOC)) {
@@ -319,6 +318,21 @@ if ($prepareSelect->execute()) {
                         "hostgroups" => $hostgroups,
                         "badge" => $badge[$tabAction[$res['action_type']]]
                     );
+                } else {
+                    // as the relation may have been deleted since the event,
+                    // some relations can't be found for this service, while events have been saved for it in the DB
+                    $elemArray[] = array(
+                        "date" => $res['action_log_date'],
+                        "type" => $res['object_type'],
+                        "object_name" => $objectName,
+                        "action_log_id" => $res['action_log_id'],
+                        "object_id" => $res['object_id'],
+                        "modification_type" => $tabAction[$res['action_type']],
+                        "author" => $contactList[$res['log_contact_id']],
+                        "change" => $tabAction[$res['action_type']],
+                        "host" => "<i>Linked to a removed resource</i>",
+                        "badge" => $badge[$tabAction[$res['action_type']]]
+                    );
                 }
                 unset($host_name);
                 unset($hg_name);
@@ -367,7 +381,6 @@ $tpl->assign('contact', _("Contact"));
  */
 $tpl->assign('limit', $limit);
 $tpl->assign('rows', $rows);
-
 $tpl->assign('p', $p);
 $tpl->assign('elemArray', $elemArray);
 

--- a/www/include/Administration/configChangelog/viewLogs.php
+++ b/www/include/Administration/configChangelog/viewLogs.php
@@ -330,7 +330,7 @@ if ($prepareSelect->execute()) {
                         "modification_type" => $tabAction[$res['action_type']],
                         "author" => $contactList[$res['log_contact_id']],
                         "change" => $tabAction[$res['action_type']],
-                        "host" => "<i>Linked to a removed resource</i>",
+                        "host" => "<i>Linked resource as changed</i>",
                         "badge" => $badge[$tabAction[$res['action_type']]]
                     );
                 }

--- a/www/include/Administration/configChangelog/viewLogs.php
+++ b/www/include/Administration/configChangelog/viewLogs.php
@@ -330,7 +330,7 @@ if ($prepareSelect->execute()) {
                         "modification_type" => $tabAction[$res['action_type']],
                         "author" => $contactList[$res['log_contact_id']],
                         "change" => $tabAction[$res['action_type']],
-                        "host" => "<i>Linked resource as changed</i>",
+                        "host" => "<i>Linked resource has changed</i>",
                         "badge" => $badge[$tabAction[$res['action_type']]]
                     );
                 }


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

Fix the pagination in the administration > logs page
Fix the rows count to be displayed in the page
Correct the filtering of the results to be displayed

Fixes # (https://github.com/centreon/centreon/issues/7487)

<h2> Type of change </h2>

- [X] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [X] 18.10.x
- [X] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

**Issue 1** -> Go to Administration > logs, and check that the pagination is working properly using the filters of your choice.

**Issue 2** -> All the results in the DB weren't properly displayed, if a host/service relation isn't found, while an event for this resource have been saved in the DB.
For the test : Go to Configuration > Hosts, and create a host with a service template (like OS-Linux-SNMP...)
Reload the poller, then check that events have been added to Administation > logs page.
Then delete the host, and check that the event logs display "Linked resource has changed / " and the name of your service.
Check that the number of displayed results is the same than the "limit" filter.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X]  I have   **rebased**   my development branch on the base branch (master, maintenance).
- [X] I have made sure that the **unit tests** related to the story are successful.
- [X] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
