### PR TITLE
enh(doc): add restriction on SQL strict mode for dedicated server

### DIFF
--- a/doc/en/installation/common/install_packages.rst
+++ b/doc/en/installation/common/install_packages.rst
@@ -48,7 +48,7 @@ The repository is now installed.
 .. note::
     Some may not have the wget package installed. If not perform the following:
     ::
-    
+
         # yum install wget
 
 ************************************
@@ -83,6 +83,10 @@ Run the commands::
 
 .. note::
     **centreon-database** package installs a database server optimized for use with Centreon.
+
+.. note::
+    Centreon does **not** support the SQL STRICT mode yet. Please make sure that it is disabled.
+    For more information on how to disable the mode please check the official `MariaDB documentation <https://mariadb.com/kb/en/library/sql-mode/#strict-mode>`_.
 
 Database management system
 --------------------------

--- a/doc/fr/installation/common/install_packages.rst
+++ b/doc/fr/installation/common/install_packages.rst
@@ -49,7 +49,7 @@ Le dépôt est maintenant installé.
 
 .. note::
     Si le paquet n'est pas installé, exécutez la commande : ::
-    
+
         # yum install wget
 
 *******************************
@@ -84,6 +84,10 @@ Exécutez les commandes : ::
 
 .. note::
     le paquet **centreon-database** installe un serveur de base de données optimisé pour l'utilisation avec Centreon.
+
+.. note::
+    Centreon n'est pas encore **compatible** avec le mode STRICT de SQL. Veuillez vous assurer que le mode soit bien désactivé.
+    Pour plus d'information sur la désactivation du mode vous pouvez consulter la `documentation officielle <https://mariadb.com/kb/en/library/sql-mode/#strict-mode>`_ de MariaDB pour le désactiver
 
 Système de gestion de base de données
 -------------------------------------


### PR DESCRIPTION
>h1> Pull Request Template </h1>

<h2> Description </h2>

In the case of a dedicated SQL server, user must be aware that the
actual Centreon code (SQL request) is not compatible with the SQL
strict mode. Those changes are planned to be done in next releases
Fixes # (issue)

<h2> Type of change </h2>

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Display the documentation and check that restriction has been added for the installation of a dedicated SQL server

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
