### PR TITLE
enh(doc): create distant MySQL root user for installation

### DIFF
--- a/doc/en/installation/common/install_packages.rst
+++ b/doc/en/installation/common/install_packages.rst
@@ -88,6 +88,17 @@ Run the commands::
     Centreon does **not** support the SQL STRICT mode yet. Please make sure that it is disabled.
     For more information on how to disable the mode please check the official `MariaDB documentation <https://mariadb.com/kb/en/library/sql-mode/#strict-mode>`_.
 
+Then create a distant **root** account: ::
+
+    MariaDB [(none)]> GRANT ALL PRIVILEGES ON *.* TO 'root'@'IP' IDENTIFIED BY 'PASSWORD' WITH GRANT OPTION;
+
+.. note::
+    Replace **IP** by the IP address of the Centreon server and **PASSWORD** by
+    the **root** password. Once the installation is complete you can delete this
+    account using: ::
+        
+        MariaDB [(none)]> DROP USER 'root'@'IP';
+
 Database management system
 --------------------------
 

--- a/doc/en/installation/common/install_packages.rst
+++ b/doc/en/installation/common/install_packages.rst
@@ -85,16 +85,17 @@ Run the commands::
     **centreon-database** package installs a database server optimized for use with Centreon.
 
 .. note::
-    Centreon does **not** support the SQL STRICT mode yet. Please make sure that it is disabled.
-    For more information on how to disable the mode please check the official `MariaDB documentation <https://mariadb.com/kb/en/library/sql-mode/#strict-mode>`_.
+    Centreon does **not** support the SQL STRICT mode yet. Please make sure that
+    it is disabled. For more information on how to disable the mode please check
+    the official `MariaDB documentation <https://mariadb.com/kb/en/library/sql-mode/#strict-mode>`_.
 
 Then create a distant **root** account: ::
 
     MariaDB [(none)]> GRANT ALL PRIVILEGES ON *.* TO 'root'@'IP' IDENTIFIED BY 'PASSWORD' WITH GRANT OPTION;
 
 .. note::
-    Replace **IP** by the IP address of the Centreon server and **PASSWORD** by
-    the **root** password. Once the installation is complete you can delete this
+    Replace **IP** by the public IP address of the Centreon server and **PASSWORD**
+    by the **root** password. Once the installation is complete you can delete this
     account using: ::
         
         MariaDB [(none)]> DROP USER 'root'@'IP';

--- a/doc/fr/installation/common/install_packages.rst
+++ b/doc/fr/installation/common/install_packages.rst
@@ -86,17 +86,20 @@ Exécutez les commandes : ::
     le paquet **centreon-database** installe un serveur de base de données optimisé pour l'utilisation avec Centreon.
 
 .. note::
-    Centreon n'est pas encore **compatible** avec le mode STRICT de SQL. Veuillez vous assurer que le mode soit bien désactivé.
-    Pour plus d'information sur la désactivation du mode vous pouvez consulter la `documentation officielle <https://mariadb.com/kb/en/library/sql-mode/#strict-mode>`_ de MariaDB pour le désactiver
+    Centreon n'est pas encore **compatible** avec le mode STRICT de SQL. Veuillez
+    vous assurer que le mode soit bien désactivé. Pour plus d'information sur la
+    désactivation du mode vous pouvez consulter la `documentation officielle
+    <https://mariadb.com/kb/en/library/sql-mode/#strict-mode>`_ de MariaDB pour
+    le désactiver
 
 Puis créer un utisateur **root** distant : ::
 
     MariaDB [(none)]> GRANT ALL PRIVILEGES ON *.* TO 'root'@'IP' IDENTIFIED BY 'PASSWORD' WITH GRANT OPTION;
 
 .. note::
-    Remplacez **IP** par l'adresse IP du serveur Centreon et **PASSWORD**
-    par le mot de passe de l'utilisateur **root**. Une fois l'installation
-    terminée vous pouvez supprimer ce compte via la commande : ::
+    Remplacez **IP** par l'adresse IP publique du serveur Centreon et **PASSWORD**
+    par le mot de passe de l'utilisateur **root**. Une fois l'installation terminée
+    vous pouvez supprimer ce compte via la commande : ::
         
         MariaDB [(none)]> DROP USER 'root'@'IP';
 

--- a/doc/fr/installation/common/install_packages.rst
+++ b/doc/fr/installation/common/install_packages.rst
@@ -89,6 +89,17 @@ Exécutez les commandes : ::
     Centreon n'est pas encore **compatible** avec le mode STRICT de SQL. Veuillez vous assurer que le mode soit bien désactivé.
     Pour plus d'information sur la désactivation du mode vous pouvez consulter la `documentation officielle <https://mariadb.com/kb/en/library/sql-mode/#strict-mode>`_ de MariaDB pour le désactiver
 
+Puis créer un utisateur **root** distant : ::
+
+    MariaDB [(none)]> GRANT ALL PRIVILEGES ON *.* TO 'root'@'IP' IDENTIFIED BY 'PASSWORD' WITH GRANT OPTION;
+
+.. note::
+    Remplacez **IP** par l'adresse IP du serveur Centreon et **PASSWORD**
+    par le mot de passe de l'utilisateur **root**. Une fois l'installation
+    terminée vous pouvez supprimer ce compte via la commande : ::
+        
+        MariaDB [(none)]> DROP USER 'root'@'IP';
+
 Système de gestion de base de données
 -------------------------------------
 


### PR DESCRIPTION
<h2> Description </h2>

Define how to create distant root MySQL user

Fixes #7491

<h2> Type of change </h2>

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Follow actual documentation, you can't perform installation if you don't know how to create distant DBMS root user.

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests covers 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
