### PR TITLE
enh(sec): log failed login attempts (ban post processing)

### DIFF
--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -348,7 +348,10 @@ class CentreonAuth
                 $this->CentreonLog->insertLog(1, "[".$this->source."] No contact found with this login : '$username'");
             }
             $this->error = _('Your credentials are incorrect.');
-            error_log("user " . $username . " not found", 4);
+            //Strangely fresh installs reach this code with empty username when hitting the portal
+            if (strlen($username) > 0) {
+                error_log("user " . $username . " not found", 4);
+            }
         }
     }
 

--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -305,6 +305,7 @@ class CentreonAuth
                 } else {
                     $this->CentreonLog->insertLog(1, "Contact '" . $username . "' doesn't match with password");
                     $this->error = _('Your credentials are incorrect.');
+                    error_log("user " . $username . " password mismatch", 4);
                 }
             } else {
                 $this->CentreonLog->insertLog(
@@ -312,6 +313,7 @@ class CentreonAuth
                     "[".$this->source."] Contact '" . $username . "' is not enable for reaching centreon"
                 );
                 $this->error = _('Your credentials are incorrect.');
+                error_log("user " . $username . " not authorized", 4);
             }
         } elseif (count($this->ldap_auto_import)) {
             /*
@@ -346,6 +348,7 @@ class CentreonAuth
                 $this->CentreonLog->insertLog(1, "[".$this->source."] No contact found with this login : '$username'");
             }
             $this->error = _('Your credentials are incorrect.');
+            error_log("user " . $username . " not found", 4);
         }
     }
 


### PR DESCRIPTION
Hi,

<h2> Description </h2>

This PR simply logs failed login attempts.
Goal is then for the system administrator to be able to use tools such as fail2ban to ban IPs generating too many failed login attempts.
As fail2ban generally already analyzes Apache error log file, these error messages are directly sent to it (thanks to the second option of `error_log` set to `4`).

<h2> Type of change </h2>

- [x] New functionality (non-breaking change)

<h2> Target serie </h2>

- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

`tail -f /var/log/httpd24/error_log`
Make failed login attempts (easy) !

Thank you :+1: 

Edit : still missing from 19.10.0-beta.2.