### PR TITLE
fix(monitoring service): Fix hard_state_duration column

### DIFF
--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -1,4 +1,4 @@
-<?php
+statusServices<?php
 /*
  * Copyright 2005-2015 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
@@ -493,13 +493,14 @@ $tpl->display("service.ihtml");
     function updateSelect() {
         var oldStatus = jQuery('#statusFilter').val();
         var opts = document.getElementById('statusFilter').options;
+        var newTypeOrder = null;
         if (jQuery('#statusService').val() == 'svcpb' || jQuery('#statusService').val() == 'svc_unhandled') {
             opts.length = 0;
             opts[opts.length] = new Option("", "");
             opts[opts.length] = new Option(warning, "warning");
             opts[opts.length] = new Option(critical, "critical");
             opts[opts.length] = new Option(unknown, "unknown");
-            change_type_order(tabSortPb['champ']);
+            newTypeOrder = tabSortPb['champ'];
         } else {
             opts.length = 0;
             opts[opts.length] = new Option("", "");
@@ -508,14 +509,17 @@ $tpl->display("service.ihtml");
             opts[opts.length] = new Option(critical, "critical");
             opts[opts.length] = new Option(unknown, "unknown");
             opts[opts.length] = new Option(pending, "pending");
-            change_type_order(tabSortAll['champ']);
+            newTypeOrder = tabSortAll['champ'];
         }
 
+        // We define the statusFilter before calling ajax
         if (jQuery("#statusFilter option[value='" + oldStatus + "']").length > 0) {
             jQuery("#statusFilter option[value='" + oldStatus + "']").prop('selected', true);
         } else {
             jQuery("#statusFilter option[value='']").prop('selected', true);
         }
+
+        change_type_order(newTypeOrder);
     }
 
 
@@ -579,6 +583,7 @@ $tpl->display("service.ihtml");
     }
 
     function statusServices(value, isInit) {
+        console.log(value, isInit);
         _o = value;
     }
 </script>

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -1,4 +1,4 @@
-statusServices<?php
+<?php
 /*
  * Copyright 2005-2015 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -583,7 +583,6 @@ $tpl->display("service.ihtml");
     }
 
     function statusServices(value, isInit) {
-        console.log(value, isInit);
         _o = value;
     }
 </script>

--- a/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -340,7 +340,7 @@ if ($critRes->rowCount()) {
 
 $isHardStateDurationVisible =
     !($statusService === 'svc'
-        and ($statusFilter === 'ok' || $statusFilter === 'pending')
+        && ($statusFilter === 'ok' || $statusFilter === 'pending')
     );
 
 /* * **************************************************

--- a/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -244,41 +244,45 @@ if ($searchOutput) {
 }
 $request .= $instance_filter;
 
-if (preg_match("/^svc_unhandled/", $statusService)) {
-    if (preg_match("/^svc_unhandled_(warning|critical|unknown)\$/", $statusService, $matches)) {
-        if (isset($matches[1]) && $matches[1] == 'warning') {
-            $request .= " AND s.state = 1 ";
-        }
-        if (isset($matches[1]) && $matches[1] == "critical") {
-            $request .= " AND s.state = 2 ";
-        } elseif (isset($matches[1]) && $matches[1] == "unknown") {
-            $request .= " AND s.state = 3 ";
-        } elseif (isset($matches[1]) && $matches[1] == "pending") {
-            $request .= " AND s.state = 4 ";
-        } else {
-            $request .= " AND s.state != 0 ";
-        }
-    } else {
-        $request .= " AND (s.state != 0 AND s.state != 4) ";
-    }
+if ($statusService == 'svc_unhandled') {
     $request .= " AND s.state_type = 1";
     $request .= " AND s.acknowledged = 0";
     $request .= " AND s.scheduled_downtime_depth = 0";
     $request .= " AND h.acknowledged = 0 AND h.scheduled_downtime_depth = 0 ";
-} elseif ($statusService == "svcpb") {
-    $request .= " AND s.state != 0 AND s.state != 4 ";
 }
 
-if ($statusFilter == "ok") {
-    $request .= " AND s.state = 0";
-} elseif ($statusFilter == "warning") {
-    $request .= " AND s.state = 1";
-} elseif ($statusFilter == "critical") {
-    $request .= " AND s.state = 2";
-} elseif ($statusFilter == "unknown") {
-    $request .= " AND s.state = 3";
-} elseif ($statusFilter == "pending") {
-    $request .= " AND s.state = 4";
+if ($statusService === 'svc_unhandled' || $statusService === 'svcpb') {
+    switch ($statusFilter) {
+        case 'warning':
+            $request .= " AND s.state = 1 ";
+            break;
+        case 'critical':
+            $request .= " AND s.state = 2 ";
+            break;
+        case 'unknown':
+            $request .= " AND s.state = 3 ";
+            break;
+        default:
+            $request .= " AND s.state != 0 AND s.state != 4 ";
+    }
+} elseif ($statusService === 'svc') {
+    switch ($statusFilter) {
+        case 'ok':
+            $request .= " AND s.state = 0";
+            break;
+        case 'warning':
+            $request .= " AND s.state = 1 ";
+            break;
+        case 'critical':
+            $request .= " AND s.state = 2 ";
+            break;
+        case 'unknown':
+            $request .= " AND s.state = 3 ";
+            break;
+        case 'pending':
+            $request .= " AND s.state = 4 ";
+            break;
+    }
 }
 
 /**
@@ -334,6 +338,11 @@ if ($critRes->rowCount()) {
     }
 }
 
+$isHardStateDurationVisible =
+    !($statusService === 'svc'
+        and ($statusFilter === 'ok' || $statusFilter === 'pending')
+    );
+
 /* * **************************************************
  * Create Buffer
  */
@@ -358,6 +367,7 @@ $obj->XML->writeElement("service_not_active_not_passive", _("This service is nei
 $obj->XML->writeElement("service_flapping", _("This Service is flapping"));
 $obj->XML->writeElement("notif_disabled", _("Notification is disabled"));
 $obj->XML->writeElement("use_criticality", $criticalityUsed);
+$obj->XML->writeElement("use_hard_state_duration", $isHardStateDurationVisible ? 1 : 0);
 $obj->XML->endElement();
 
 $host_prev = "";

--- a/www/include/monitoring/status/Services/xsl/service.xsl
+++ b/www/include/monitoring/status/Services/xsl/service.xsl
@@ -13,7 +13,7 @@
         <td class="ListColHeaderCenter" style="white-space:nowrap;" id="current_state"></td>
         <td class="ListColHeaderCenter" style="white-space:nowrap;" id="last_state_change"></td>
         <xsl:for-each select="//i">
-            <xsl:if test="o = 'svc_unhandled' or o = 'svcpb' or o = 'svc_warning' or o = 'svc_critical' or o = 'svc_unknown' or o = 'svc_unhandled_warning' or o = 'svc_unhandled_critical' or o = 'svc_unhandled_unknown'">
+            <xsl:if test="use_hard_state_duration = 1">
                 <td class="ListColHeaderCenter" style="white-space:nowrap;" id="last_hard_state_change">
                     <xsl:value-of select="hard_state_label"/>
                 </td>
@@ -309,7 +309,7 @@
         <td class="ListColRight" style="white-space:nowrap;">
             <xsl:value-of select="d"/>
         </td>
-        <xsl:if test = "//i/o = 'svc_unhandled' or //i/o = 'svcpb' or //i/o = 'svc_warning' or //i/o = 'svc_critical' or //i/o = 'svc_unknown' or //i/o = 'svc_unhandled_warning' or //i/o = 'svc_unhandled_critical' or //i/o = 'svc_unhandled_unknown'">
+        <xsl:if test = "//i/use_hard_state_duration = 1">
             <td class="ListColRight" style="white-space:nowrap;">
                 <xsl:value-of select="last_hard_state_change"/>
             </td>


### PR DESCRIPTION
Fixed statusFilter that changed before the xls call was completed.
Fixed the xls file to display the hard_state_duration column only when the state filter is 'ok' or 'pending'.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
