### PR TITLE
enh(sec): hide all password instances

### DIFF
--- a/www/include/monitoring/objectDetails/common-func.php
+++ b/www/include/monitoring/objectDetails/common-func.php
@@ -133,17 +133,17 @@ function getOptionName($command_with_macro, $executed_command, $macro)
 {
     $macro = str_replace('$', '\$', $macro);
     $pattern = "/(\-\-?[a-zA-Z0-9\-\_]+=?\W+?)\'?" . $macro . "\'?/";
-    if (preg_match($pattern, $command_with_macro, $matches)) {
-        for ($i = 1; $i < count($matches); $i++) {
+    if (preg_match_all($pattern, $command_with_macro, $matches)) {
+        for ($i = 0; $i < count($matches[1]); $i++) {
             /* Prepare pattern */
-            $pattern = $matches[$i];
+            $pattern = $matches[1][$i];
             $pattern = str_replace('/', '\/', $pattern);
             $pattern = str_replace('-', '\-', $pattern);
             $pattern = str_replace('.', '\.', $pattern);
             $pattern = "/(.*\s)?" . $pattern . "\'?([\\x21-\\x7E]+)\'?(\s.*)?/";
              /* Replace value of custom macro password type
                 in executed command line */
-            $executed_command = preg_replace($pattern, "\$1" . $matches[$i] . "***\$3", $executed_command);
+            $executed_command = preg_replace($pattern, "\$1" . $matches[1][$i] . "***\$3", $executed_command);
         }
     }
 


### PR DESCRIPTION
Hi,

<h2> Description </h2>

This PR follows #7079 by @lpinsivy.
A password macro may be used several times in the same command (think about SNMPv3 options `--privpassphrase` and `--authpassphrase` of the Centreon Plugins).
After #7079, only the first occurrence is hidden (replaced by *** in the service details).
This PR then solves this.

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Include the same password macro several time in the same command, and verify in the service details that it is correctly hidden.

Thank you :+1:

Edit : issue still present in 19.10.0-beta.2.