### PR TITLE
Mon 3798 select2 previous search behavior

### DIFF
--- a/www/api/class/centreon_configuration_objects.class.php
+++ b/www/api/class/centreon_configuration_objects.class.php
@@ -74,7 +74,7 @@ class CentreonConfigurationObjects extends CentreonWebService
         }
 
         $defaultValuesParameters = array();
-        $targetedFile = _CENTREON_PATH_ . "/www/class/centreon$target.class.php";
+        $targetedFile = _CENTREON_PATH_ . "/www/class/centreon" . $target . ".class.php";
         if (file_exists($targetedFile)) {
             require_once $targetedFile;
             $calledClass = 'Centreon' . $target;
@@ -104,7 +104,7 @@ class CentreonConfigurationObjects extends CentreonWebService
             throw new RestBadRequestException("Bad parameters");
         }
 
-        # Manage final data
+        // Manage final data
         $finalDatas = array();
         if (count($selectedValues) > 0) {
             $finalDatas = $this->retrieveExternalObjectDatas(

--- a/www/include/common/javascript/centreon/centreon-select2.js
+++ b/www/include/common/javascript/centreon/centreon-select2.js
@@ -311,8 +311,8 @@
           let searchField = self.$elem.data().select2.$container.find(".select2-search__field");
           searchField.val(self.savedSearch);
           searchField.css(
-              {'width': 'auto'}
-              );
+            {'width': 'auto'}
+          );
 
           /* Wait for select2 finish to open */
           setTimeout(function () {

--- a/www/include/common/javascript/centreon/centreon-select2.js
+++ b/www/include/common/javascript/centreon/centreon-select2.js
@@ -308,9 +308,12 @@
 
       this.$elem.on('select2:open', function (e) {
         if (self.savedSearch) {
-          self.$elem.data()
-              .select2.$container.find(".select2-search__field")
-              .val(self.savedSearch);
+          let searchField = self.$elem.data().select2.$container.find(".select2-search__field");
+          searchField.val(self.savedSearch);
+          searchField.css(
+              {'width': 'auto'}
+              );
+
           /* Wait for select2 finish to open */
           setTimeout(function () {
             self.$elem.data().select2.trigger(

--- a/www/include/monitoring/downtime/listDowntime.php
+++ b/www/include/monitoring/downtime/listDowntime.php
@@ -76,24 +76,12 @@ if (isset($_POST['SearchB'])) {
     isset($_GET["view_downtime_cycle"]) ? $view_downtime_cycle = 1 : $view_downtime_cycle = 0;
     $centreon->historySearch[$url]["view_downtime_cycle"] = $view_downtime_cycle;
 } else {
-    if (isset($centreon->historySearch[$url]['search_service'])) {
-        $search_service = $centreon->historySearch[$url]['search_service'];
-    }
-    if (isset($centreon->historySearch[$url]["search_host"])) {
-        $host_name = $centreon->historySearch[$url]["search_host"];
-    }
-    if (isset($centreon->historySearch[$url]["search_output"])) {
-        $search_output = $centreon->historySearch[$url]["search_output"];
-    }
-    if (isset($centreon->historySearch[$url]["search_author"])) {
-        $search_author = $centreon->historySearch[$url]["search_author"];
-    }
-    if (isset($centreon->historySearch[$url]["view_all"])) {
-        $view_all = $centreon->historySearch[$url]["view_all"];
-    }
-    if (isset($centreon->historySearch[$url]["view_downtime_cycle"])) {
-        $view_downtime_cycle = $centreon->historySearch[$url]["view_downtime_cycle"];
-    }
+    $search_service = $centreon->historySearch[$url]['search_service'] ?? null;
+    $host_name = $centreon->historySearch[$url]["search_host"] ?? null;
+    $search_output = $centreon->historySearch[$url]["search_output"] ?? null;
+    $search_author = $centreon->historySearch[$url]["search_author"] ?? null;
+    $view_all = $centreon->historySearch[$url]["view_all"] ?? 0;
+    $view_downtime_cycle = $centreon->historySearch[$url]["view_downtime_cycle"] ?? 0;
 }
 
 /*


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

- Correct the displayed saved researched value in the select2 components.

out of scope : 
- correct undefined variable in the logs when opening the downtime form
- minor style correction

Fixes # (issue)

<h2> Type of change </h2>

- [] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

Open a form using a select2 filter.
Enter three letters of the name to be searched.
Select the occurence.
The popin should close.
Reopen the filter by clicking on it, your last research should be fully diplayed, and the select2 should display the other occurences available.

<h2> Checklist </h2>

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
- [x] I have made sure that the **unit tests** related to the story are successful.
