### PR TITLE
(fix)Prevent SQL error when topology_page is null

### DIFF
--- a/www/include/Administration/parameters/css/form.php
+++ b/www/include/Administration/parameters/css/form.php
@@ -84,7 +84,7 @@ for ($i = 0; $DBRESULT->rowCount() && $elem = $DBRESULT->fetchRow(); $i++) {
 
 $rq = "SELECT topology_id, topology_name, topology_page 
         FROM topology 
-        WHERE topology_parent IS NULL AND topology_show = '1' 
+        WHERE topology_parent IS NULL AND topology_show = '1' AND topology_page IS NOT NULL
         ORDER BY topology_order";
 $DBRESULT = $pearDB->query($rq);
 $tab_menu = array();


### PR DESCRIPTION
<h1>Prevent SQL error when topology_page is null</h1>

<h2> Description </h2>

In some case,you can have topology_page equal NULL in the topology table.
in that case, when you go to the CSS page (in Administration menu), a SQL query fail and your page is blank.

This patch allow to exclude topology_page with null value and the SQL error.


<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Insert a new topology row in database : 

```sql
INSERT INTO topology VALUES (NULL, 'Poller/Remote Wizard', NULL, NULL, NULL, '/poller-wizard/1', NULL, NULL, NULL, 1, NULL, NULL, NULL, 0, 1);
```

* Go to Administration -> CSS

* Without patch : blank page
* With patch : the CSS form

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
