### PR TITLE
(fix)SQL Errors while insert data with auto-increment in strict_mode

### DIFF
--- a/www/include/configuration/configObject/contact/DB-Func.php
+++ b/www/include/configuration/configObject/contact/DB-Func.php
@@ -265,7 +265,7 @@ function multipleContactInDB($contacts = array(), $nbrDup = array())
                     $dbResult = $pearDB->query($query);
                     $fields["contact_aclRelation"] = "";
                     while ($aclRelation = $dbResult->fetch()) {
-                        $query = "INSERT INTO acl_group_contacts_relations VALUES ('', '" .
+                        $query = "INSERT INTO acl_group_contacts_relations VALUES (NULL, '" .
                             $lastId . "', '" . $aclRelation["acl_group_id"] . "')";
                         $pearDB->query($query);
                         $fields["contact_aclRelation"] .= $aclRelation["acl_group_id"] . ",";
@@ -280,7 +280,7 @@ function multipleContactInDB($contacts = array(), $nbrDup = array())
                     $DBRESULT = $pearDB->query($query);
                     $fields["contact_hostNotifCmds"] = "";
                     while ($hostCmd = $DBRESULT->fetch()) {
-                        $query = "INSERT INTO contact_hostcommands_relation VALUES ('', '" .
+                        $query = "INSERT INTO contact_hostcommands_relation VALUES (NULL, '" .
                             $lastId . "', '" . $hostCmd["command_command_id"] . "')";
                         $pearDB->query($query);
                         $fields["contact_hostNotifCmds"] .= $hostCmd["command_command_id"] . ",";
@@ -295,7 +295,7 @@ function multipleContactInDB($contacts = array(), $nbrDup = array())
                     $DBRESULT = $pearDB->query($query);
                     $fields["contact_svNotifCmds"] = "";
                     while ($serviceCmd = $DBRESULT->fetch()) {
-                        $query = "INSERT INTO contact_servicecommands_relation VALUES ('', '" .
+                        $query = "INSERT INTO contact_servicecommands_relation VALUES (NULL, '" .
                             $lastId . "', '" . $serviceCmd["command_command_id"] . "')";
                         $pearDB->query($query);
                         $fields["contact_svNotifCmds"] .= $serviceCmd["command_command_id"] . ",";
@@ -310,7 +310,7 @@ function multipleContactInDB($contacts = array(), $nbrDup = array())
                     $DBRESULT = $pearDB->query($query);
                     $fields["contact_cgNotif"] = "";
                     while ($Cg = $DBRESULT->fetch()) {
-                        $query = "INSERT INTO contactgroup_contact_relation VALUES ('', '" .
+                        $query = "INSERT INTO contactgroup_contact_relation VALUES (NULL, '" .
                             $lastId . "', '" . $Cg["contactgroup_cg_id"] . "')";
                         $pearDB->query($query);
                         $fields["contact_cgNotif"] .= $Cg["contactgroup_cg_id"] . ",";

--- a/www/include/configuration/configObject/contactgroup/DB-Func.php
+++ b/www/include/configuration/configObject/contactgroup/DB-Func.php
@@ -143,7 +143,7 @@ function multipleContactGroupInDB($contactGroups = array(), $nbrDup = array())
                     $dbResult = $pearDB->query($query);
                     $fields["cg_aclRelation"] = "";
                     while ($cgAcl = $dbResult->fetchRow()) {
-                        $query = "INSERT INTO `acl_group_contactgroups_relations` VALUES ('', '" .
+                        $query = "INSERT INTO `acl_group_contactgroups_relations` VALUES (NULL, '" .
                             $maxId["MAX(cg_id)"] . "', '" . $cgAcl['acl_group_id'] . "')";
                         $pearDB->query($query);
                         $fields["cg_aclRelation"] .= $cgAcl["acl_group_id"] . ",";
@@ -154,7 +154,7 @@ function multipleContactGroupInDB($contactGroups = array(), $nbrDup = array())
                     $fields["cg_contacts"] = "";
                     while ($cct = $DBRESULT->fetchRow()) {
                         $query = "INSERT INTO `contactgroup_contact_relation` " .
-                            "VALUES ('', '" . $cct["contact_contact_id"] . "', '" . $maxId["MAX(cg_id)"] . "')";
+                            "VALUES (NULL, '" . $cct["contact_contact_id"] . "', '" . $maxId["MAX(cg_id)"] . "')";
                         $pearDB->query($query);
                         $fields["cg_contacts"] .= $cct["contact_contact_id"] . ",";
                     }

--- a/www/include/configuration/configObject/escalation/DB-Func.php
+++ b/www/include/configuration/configObject/escalation/DB-Func.php
@@ -109,7 +109,7 @@ function multipleEscalationInDB($escalations = array(), $nbrDup = array())
                     while ($cg = $DBRESULT->fetchRow()) {
                         $DBRESULT2 = $pearDB->query(
                             "INSERT INTO escalation_contactgroup_relation "
-                            . "VALUES ('', '" . $maxId["MAX(esc_id)"] . "', '"
+                            . "VALUES (NULL, '" . $maxId["MAX(esc_id)"] . "', '"
                             . $cg["contactgroup_cg_id"] . "')"
                         );
                         $fields["esc_cgs"] .= $cg["contactgroup_cg_id"] . ",";
@@ -124,7 +124,7 @@ function multipleEscalationInDB($escalations = array(), $nbrDup = array())
                     while ($host = $DBRESULT->fetchRow()) {
                         $DBRESULT2 = $pearDB->query(
                             "INSERT INTO escalation_host_relation "
-                            . "VALUES ('', '" . $maxId["MAX(esc_id)"] . "', '"
+                            . "VALUES (NULL, '" . $maxId["MAX(esc_id)"] . "', '"
                             . $host["host_host_id"] . "')"
                         );
                         $fields["esc_hosts"] .= $host["host_host_id"] . ",";
@@ -139,7 +139,7 @@ function multipleEscalationInDB($escalations = array(), $nbrDup = array())
                     while ($hg = $DBRESULT->fetchRow()) {
                         $DBRESULT2 = $pearDB->query(
                             "INSERT INTO escalation_hostgroup_relation "
-                            . "VALUES ('', '" . $maxId["MAX(esc_id)"] . "', '"
+                            . "VALUES (NULL, '" . $maxId["MAX(esc_id)"] . "', '"
                             . $hg["hostgroup_hg_id"] . "')"
                         );
                         $fields["esc_hgs"] .= $hg["hostgroup_hg_id"] . ",";
@@ -154,7 +154,7 @@ function multipleEscalationInDB($escalations = array(), $nbrDup = array())
                     while ($sg = $DBRESULT->fetchRow()) {
                         $DBRESULT2 = $pearDB->query(
                             "INSERT INTO escalation_servicegroup_relation "
-                            . "VALUES ('', '" . $maxId["MAX(esc_id)"] . "', '"
+                            . "VALUES (NULL, '" . $maxId["MAX(esc_id)"] . "', '"
                             . $sg["servicegroup_sg_id"] . "')"
                         );
                         $fields["esc_sgs"] .= $sg["servicegroup_sg_id"] . ",";
@@ -168,7 +168,7 @@ function multipleEscalationInDB($escalations = array(), $nbrDup = array())
                     while ($sv = $DBRESULT->fetchRow()) {
                         $DBRESULT2 = $pearDB->query(
                             "INSERT INTO escalation_service_relation "
-                            . "VALUES ('', '" . $maxId["MAX(esc_id)"] . "', '"
+                            . "VALUES (NULL, '" . $maxId["MAX(esc_id)"] . "', '"
                             . $sv["service_service_id"] . "', '"
                             . $sv["host_host_id"] . "')"
                         );
@@ -184,7 +184,7 @@ function multipleEscalationInDB($escalations = array(), $nbrDup = array())
                     while ($sv = $DBRESULT->fetchRow()) {
                         $DBRESULT2 = $pearDB->query(
                             "INSERT INTO escalation_meta_service_relation "
-                            . "VALUES ('', '" . $maxId["MAX(esc_id)"] . "', '"
+                            . "VALUES (NULL, '" . $maxId["MAX(esc_id)"] . "', '"
                             . $sv["meta_service_meta_id"] . "')"
                         );
                         $fields["esc_metas"] .= $sv["meta_service_meta_id"] . ",";

--- a/www/include/configuration/configObject/host/DB-Func.php
+++ b/www/include/configuration/configObject/host/DB-Func.php
@@ -381,7 +381,7 @@ function multipleHostInDB($hosts = array(), $nbrDup = array())
                     $fields["host_parents"] = "";
                     while ($host = $DBRESULT->fetchRow()) {
                         $DBRESULT1 = $pearDB->query("INSERT INTO host_hostparent_relation 
-                              VALUES ('', '" . $host["host_parent_hp_id"] . "', '" . $maxId["MAX(host_id)"] . "')");
+                              VALUES (NULL, '" . $host["host_parent_hp_id"] . "', '" . $maxId["MAX(host_id)"] . "')");
                         $fields["host_parents"] .= $host["host_parent_hp_id"] . ",";
                     }
                     $fields["host_parents"] = trim($fields["host_parents"], ",");
@@ -420,7 +420,7 @@ function multipleHostInDB($hosts = array(), $nbrDup = array())
                         $mulHostSv = $DBRESULT2->fetchrow();
                         if ($mulHostSv["COUNT(*)"] > 1) {
                             $DBRESULT3 = $pearDB->query("INSERT INTO host_service_relation 
-                VALUES ('', NULL, '" . $maxId["MAX(host_id)"] . "', NULL, '" . $service["service_service_id"] . "')");
+                VALUES (NULL, NULL, '" . $maxId["MAX(host_id)"] . "', NULL, '" . $service["service_service_id"] . "')");
                         } else {
                             $serviceArr[$service["service_service_id"]] = $service["service_service_id"];
                             $serviceNbr[$service["service_service_id"]] = 1;
@@ -436,7 +436,7 @@ function multipleHostInDB($hosts = array(), $nbrDup = array())
                                                     WHERE host_host_id = '" . intval($key) . "'");
                         while ($svs = $DBRESULT->fetchRow()) {
                             $DBRESULT1 = $pearDB->query("INSERT INTO host_service_relation 
-                    VALUES ('', NULL, '" . $maxId["MAX(host_id)"] . "', NULL, '" . $svs["service_service_id"] . "')");
+                    VALUES (NULL, NULL, '" . $maxId["MAX(host_id)"] . "', NULL, '" . $svs["service_service_id"] . "')");
                         }
                     }
 
@@ -449,7 +449,7 @@ function multipleHostInDB($hosts = array(), $nbrDup = array())
                     $fields["host_cgs"] = "";
                     while ($Cg = $DBRESULT->fetchRow()) {
                         $DBRESULT1 = $pearDB->query("INSERT INTO contactgroup_host_relation 
-                                VALUES ('', '" . $maxId["MAX(host_id)"] . "', '" . $Cg["contactgroup_cg_id"] . "')");
+                                VALUES (NULL, '" . $maxId["MAX(host_id)"] . "', '" . $Cg["contactgroup_cg_id"] . "')");
                         $fields["host_cgs"] .= $Cg["contactgroup_cg_id"] . ",";
                     }
                     $fields["host_cgs"] = trim($fields["host_cgs"], ",");
@@ -463,7 +463,7 @@ function multipleHostInDB($hosts = array(), $nbrDup = array())
                     $fields["host_cs"] = "";
                     while ($C = $DBRESULT->fetchRow()) {
                         $DBRESULT1 = $pearDB->query("INSERT INTO contact_host_relation 
-                                        VALUES ('', '" . $maxId["MAX(host_id)"] . "', '" . $C["contact_id"] . "')");
+                                        VALUES (NULL, '" . $maxId["MAX(host_id)"] . "', '" . $C["contact_id"] . "')");
                         $fields["host_cs"] .= $C["contact_id"] . ",";
                     }
                     $fields["host_cs"] = trim($fields["host_cs"], ",");
@@ -476,7 +476,7 @@ function multipleHostInDB($hosts = array(), $nbrDup = array())
                                                 WHERE host_host_id = '" . intval($key) . "'");
                     while ($Hg = $DBRESULT->fetchRow()) {
                         $DBRESULT1 = $pearDB->query("INSERT INTO hostgroup_relation 
-                                    VALUES ('', '" . $Hg["hostgroup_hg_id"] . "', '" . $maxId["MAX(host_id)"] . "')");
+                                    VALUES (NULL, '" . $Hg["hostgroup_hg_id"] . "', '" . $maxId["MAX(host_id)"] . "')");
                     }
 
                     /*

--- a/www/include/configuration/configObject/host_categories/DB-Func.php
+++ b/www/include/configuration/configObject/host_categories/DB-Func.php
@@ -174,7 +174,7 @@ function multipleHostCategoriesInDB($hostcategories = array(), $nbrDup = array()
                     $DBRESULT = $pearDB->query($query);
                     $fields["hc_hosts"] = "";
                     while ($host = $DBRESULT->fetchRow()) {
-                        $query = "INSERT INTO hostcategories_relation VALUES ('', '" . $maxId["MAX(hc_id)"] .
+                        $query = "INSERT INTO hostcategories_relation VALUES (NULL, '" . $maxId["MAX(hc_id)"] .
                             "', '" . $host["host_host_id"] . "')";
                         $pearDB->query($query);
                         $fields["hc_hosts"] .= $host["host_host_id"] . ",";

--- a/www/include/configuration/configObject/host_dependency/DB-Func.php
+++ b/www/include/configuration/configObject/host_dependency/DB-Func.php
@@ -124,7 +124,7 @@ function multipleHostDependencyInDB($dependencies = array(), $nbrDup = array())
                     $DBRESULT = $pearDB->query($query);
                     $fields["dep_serviceChilds"] = "";
                     while ($service = $DBRESULT->fetchRow()) {
-                        $query = "INSERT INTO dependency_serviceChild_relation VALUES ('', '" .
+                        $query = "INSERT INTO dependency_serviceChild_relation VALUES (NULL, '" .
                             $maxId["MAX(dep_id)"] . "', '" . $service["service_service_id"] . "', '" .
                             $service["host_host_id"] . "')";
                         $pearDB->query($query);
@@ -138,7 +138,7 @@ function multipleHostDependencyInDB($dependencies = array(), $nbrDup = array())
                     $fields["dep_hostParents"] = "";
                     while ($host = $DBRESULT->fetchRow()) {
                         $query = "INSERT INTO dependency_hostParent_relation " .
-                            "VALUES ('', '" . $maxId["MAX(dep_id)"] . "', '" . $host["host_host_id"] . "')";
+                            "VALUES (NULL, '" . $maxId["MAX(dep_id)"] . "', '" . $host["host_host_id"] . "')";
                         $pearDB->query($query);
                         $fields["dep_hostParents"] .= $host["host_host_id"] . ",";
                     }
@@ -150,7 +150,7 @@ function multipleHostDependencyInDB($dependencies = array(), $nbrDup = array())
                     $fields["dep_hostChilds"] = "";
                     while ($host = $DBRESULT->fetchRow()) {
                         $query = "INSERT INTO dependency_hostChild_relation " .
-                            "VALUES ('', '" . $maxId["MAX(dep_id)"] . "', '" . $host["host_host_id"] . "')";
+                            "VALUES (NULL, '" . $maxId["MAX(dep_id)"] . "', '" . $host["host_host_id"] . "')";
                         $pearDB->query($query);
                         $fields["dep_hostChilds"] .= $host["host_host_id"] . ",";
                     }

--- a/www/include/configuration/configObject/hostgroup/DB-Func.php
+++ b/www/include/configuration/configObject/hostgroup/DB-Func.php
@@ -186,7 +186,7 @@ function multipleHostGroupInDB($hostGroups = array(), $nbrDup = array())
                     $DBRESULT = $pearDB->query($query);
                     $fields["hg_hosts"] = "";
                     while ($host = $DBRESULT->fetch()) {
-                        $query = "INSERT INTO hostgroup_relation VALUES ('', '" .
+                        $query = "INSERT INTO hostgroup_relation VALUES (NULL, '" .
                             $maxId["MAX(hg_id)"] . "', '" . $host["host_host_id"] . "')";
                         $pearDB->query($query);
                         $fields["hg_hosts"] .= $host["host_host_id"] . ",";
@@ -196,7 +196,7 @@ function multipleHostGroupInDB($hostGroups = array(), $nbrDup = array())
                         "WHERE cghgr.hostgroup_hg_id = '" . $key . "'";
                     $DBRESULT = $pearDB->query($query);
                     while ($cg = $DBRESULT->fetch()) {
-                        $query = "INSERT INTO contactgroup_hostgroup_relation VALUES ('', '" .
+                        $query = "INSERT INTO contactgroup_hostgroup_relation VALUES (NULL, '" .
                             $cg["contactgroup_cg_id"] . "', '" . $maxId["MAX(hg_id)"] . "')";
                         $pearDB->query($query);
                     }

--- a/www/include/configuration/configObject/hostgroup_dependency/DB-Func.php
+++ b/www/include/configuration/configObject/hostgroup_dependency/DB-Func.php
@@ -125,7 +125,7 @@ function multipleHostGroupDependencyInDB($dependencies = array(), $nbrDup = arra
                     $DBRESULT = $pearDB->query($query);
                     $fields["dep_hgParents"] = "";
                     while ($hg = $DBRESULT->fetchRow()) {
-                        $query = "INSERT INTO dependency_hostgroupParent_relation VALUES ('', '" .
+                        $query = "INSERT INTO dependency_hostgroupParent_relation VALUES (NULL, '" .
                             $maxId["MAX(dep_id)"] . "', '" . $hg["hostgroup_hg_id"] . "')";
                         $pearDB->query($query);
                         $fields["dep_hgParents"] .= $hg["hostgroup_hg_id"] . ",";
@@ -137,7 +137,7 @@ function multipleHostGroupDependencyInDB($dependencies = array(), $nbrDup = arra
                     $DBRESULT = $pearDB->query($query);
                     $fields["dep_hgChilds"] = "";
                     while ($hg = $DBRESULT->fetchRow()) {
-                        $query = "INSERT INTO dependency_hostgroupChild_relation VALUES ('', '" .
+                        $query = "INSERT INTO dependency_hostgroupChild_relation VALUES (NULL, '" .
                             $maxId["MAX(dep_id)"] . "', '" . $hg["hostgroup_hg_id"] . "')";
                         $pearDB->query($query);
                         $fields["dep_hgChilds"] .= $hg["hostgroup_hg_id"] . ",";

--- a/www/include/configuration/configObject/meta_service/DB-Func.php
+++ b/www/include/configuration/configObject/meta_service/DB-Func.php
@@ -159,7 +159,7 @@ function multipleMetaServiceInDB($metas = array(), $nbrDup = array())
 
                     while ($Cg = $DBRESULT->fetchRow()) {
                         $query = "INSERT INTO meta_contactgroup_relation " .
-                            "VALUES ('', '" . $maxId["MAX(meta_id)"] . "', '" . $Cg["cg_cg_id"] . "')";
+                            "VALUES (NULL, '" . $maxId["MAX(meta_id)"] . "', '" . $Cg["cg_cg_id"] . "')";
                         $pearDB->query($query);
                     }
                     $DBRESULT = $pearDB->query("SELECT * FROM meta_service_relation WHERE meta_id = '" . $key . "'");

--- a/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
+++ b/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
@@ -116,7 +116,7 @@ function multipleMetaServiceDependencyInDB($dependencies = array(), $nbrDup = ar
                     $DBRESULT = $pearDB->query($query);
                     while ($ms = $DBRESULT->fetchRow()) {
                         $query = "INSERT INTO dependency_metaserviceParent_relation " .
-                            "VALUES ('', '" . $maxId["MAX(dep_id)"] . "', '" . $ms["meta_service_meta_id"] . "')";
+                            "VALUES (NULL, '" . $maxId["MAX(dep_id)"] . "', '" . $ms["meta_service_meta_id"] . "')";
                         $pearDB->query($query);
                     }
                     $DBRESULT->closeCursor();
@@ -124,7 +124,7 @@ function multipleMetaServiceDependencyInDB($dependencies = array(), $nbrDup = ar
                         "WHERE dependency_dep_id = '" . $key . "'";
                     $DBRESULT = $pearDB->query($query);
                     while ($ms = $DBRESULT->fetchRow()) {
-                        $query = "INSERT INTO dependency_metaserviceChild_relation VALUES ('', '" .
+                        $query = "INSERT INTO dependency_metaserviceChild_relation VALUES (NULL, '" .
                             $maxId["MAX(dep_id)"] . "', '" . $ms["meta_service_meta_id"] . "')";
                         $pearDB->query($query);
                     }

--- a/www/include/configuration/configObject/service/DB-Func.php
+++ b/www/include/configuration/configObject/service/DB-Func.php
@@ -564,12 +564,12 @@ function multipleServiceInDB(
                     if (isset($maxId["MAX(service_id)"])) {
                         // Host duplication case -> Duplicate the Service for the Host we create
                         if ($host) {
-                            $query = "INSERT INTO host_service_relation VALUES ('', NULL, '" . $host . "', NULL, '" .
+                            $query = "INSERT INTO host_service_relation VALUES (NULL, NULL, '" . $host . "', NULL, '" .
                                 $maxId["MAX(service_id)"] . "')";
                             $pearDB->query($query);
                             setHostChangeFlag($pearDB, $host, null);
                         } elseif ($hostgroup) {
-                            $query = "INSERT INTO host_service_relation VALUES ('', '" . $hostgroup .
+                            $query = "INSERT INTO host_service_relation VALUES (NULL, '" . $hostgroup .
                                 "', NULL, NULL, '" . $maxId["MAX(service_id)"] . "')";
                             $pearDB->query($query);
                             setHostChangeFlag($pearDB, null, $hostgroup);
@@ -582,13 +582,13 @@ function multipleServiceInDB(
                             $fields["service_hgPars"] = "";
                             while ($service = $DBRESULT->fetchRow()) {
                                 if ($service["host_host_id"]) {
-                                    $query = "INSERT INTO host_service_relation VALUES ('', NULL, '" .
+                                    $query = "INSERT INTO host_service_relation VALUES (NULL, NULL, '" .
                                         $service["host_host_id"] . "', NULL, '" . $maxId["MAX(service_id)"] . "')";
                                     $pearDB->query($query);
                                     setHostChangeFlag($pearDB, $service['host_host_id'], null);
                                     $fields["service_hPars"] .= $service["host_host_id"] . ",";
                                 } elseif ($service["hostgroup_hg_id"]) {
-                                    $query = "INSERT INTO host_service_relation VALUES ('', '" .
+                                    $query = "INSERT INTO host_service_relation VALUES (NULL, '" .
                                         $service["hostgroup_hg_id"] . "', NULL, NULL, '" .
                                         $maxId["MAX(service_id)"] . "')";
                                     $pearDB->query($query);
@@ -608,7 +608,7 @@ function multipleServiceInDB(
                         $DBRESULT = $pearDB->query($query);
                         $fields["service_cs"] = "";
                         while ($C = $DBRESULT->fetchRow()) {
-                            $query = "INSERT INTO contact_service_relation VALUES ('', '" .
+                            $query = "INSERT INTO contact_service_relation VALUES (NULL, '" .
                                 $maxId["MAX(service_id)"] . "', '" . $C["contact_id"] . "')";
                             $pearDB->query($query);
                             $fields["service_cs"] .= $C["contact_id"] . ",";
@@ -623,7 +623,7 @@ function multipleServiceInDB(
                         $DBRESULT = $pearDB->query($query);
                         $fields["service_cgs"] = "";
                         while ($Cg = $DBRESULT->fetchRow()) {
-                            $query = "INSERT INTO contactgroup_service_relation VALUES ('', '" .
+                            $query = "INSERT INTO contactgroup_service_relation VALUES (NULL, '" .
                                 $Cg["contactgroup_cg_id"] . "', '" . $maxId["MAX(service_id)"] . "')";
                             $pearDB->query($query);
                             $fields["service_cgs"] .= $Cg["contactgroup_cg_id"] . ",";
@@ -667,7 +667,7 @@ function multipleServiceInDB(
                         $dbResult = $pearDB->query($query);
                         $fields["service_traps"] = "";
                         while ($traps = $dbResult->fetchRow()) {
-                            $query = "INSERT INTO traps_service_relation VALUES ('', '" .
+                            $query = "INSERT INTO traps_service_relation VALUES (NULL, '" .
                                 $traps["traps_id"] . "', '" . $maxId["MAX(service_id)"] . "')";
                             $pearDB->query($query);
                             $fields["service_traps"] .= $traps["traps_id"] . ",";

--- a/www/include/configuration/configObject/service_dependency/DB-Func.php
+++ b/www/include/configuration/configObject/service_dependency/DB-Func.php
@@ -128,7 +128,7 @@ function multipleServiceDependencyInDB($dependencies = array(), $nbrDup = array(
                     $dbResult = $pearDB->query($query);
                     $fields["dep_hostPar"] = "";
                     while ($host = $dbResult->fetchRow()) {
-                        $query = "INSERT INTO dependency_hostChild_relation VALUES ('', '" . $maxId["MAX(dep_id)"] .
+                        $query = "INSERT INTO dependency_hostChild_relation VALUES (NULL, '" . $maxId["MAX(dep_id)"] .
                             "', '" . $host["host_host_id"] . "')";
                         $pearDB->query($query);
                         $fields["dep_hostPar"] .= $host["host_host_id"] . ",";
@@ -139,7 +139,7 @@ function multipleServiceDependencyInDB($dependencies = array(), $nbrDup = array(
                     $DBRESULT = $pearDB->query($query);
                     $fields["dep_hSvPar"] = "";
                     while ($service = $DBRESULT->fetchRow()) {
-                        $query = "INSERT INTO dependency_serviceParent_relation VALUES ('', '" .
+                        $query = "INSERT INTO dependency_serviceParent_relation VALUES (NULL, '" .
                             $maxId["MAX(dep_id)"] . "', '" . $service["service_service_id"] . "', '" .
                             $service["host_host_id"] . "')";
                         $pearDB->query($query);
@@ -150,7 +150,7 @@ function multipleServiceDependencyInDB($dependencies = array(), $nbrDup = array(
                     $DBRESULT = $pearDB->query($query);
                     $fields["dep_hSvChi"] = "";
                     while ($service = $DBRESULT->fetchRow()) {
-                        $query = "INSERT INTO dependency_serviceChild_relation VALUES ('', '" . $maxId["MAX(dep_id)"] .
+                        $query = "INSERT INTO dependency_serviceChild_relation VALUES (NULL, '" . $maxId["MAX(dep_id)"] .
                             "', '" . $service["service_service_id"] . "', '" . $service["host_host_id"] . "')";
                         $pearDB->query($query);
                         $fields["dep_hSvChi"] .= $service["service_service_id"] . ",";

--- a/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
+++ b/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
@@ -130,7 +130,7 @@ function multipleServiceGroupDependencyInDB($dependencies = array(), $nbrDup = a
                     $fields["dep_sgParents"] = "";
                     while ($sg = $DBRESULT->fetchRow()) {
                         $query = "INSERT INTO dependency_servicegroupParent_relation " .
-                            "VALUES ('', '" . $maxId["MAX(dep_id)"] . "', '" . $sg["servicegroup_sg_id"] . "')";
+                            "VALUES (NULL, '" . $maxId["MAX(dep_id)"] . "', '" . $sg["servicegroup_sg_id"] . "')";
                         $pearDB->query($query);
                         $fields["dep_sgParents"] .= $sg["servicegroup_sg_id"] . ",";
                     }
@@ -142,7 +142,7 @@ function multipleServiceGroupDependencyInDB($dependencies = array(), $nbrDup = a
                     $fields["dep_sgChilds"] = "";
                     while ($sg = $DBRESULT->fetchRow()) {
                         $query = "INSERT INTO dependency_servicegroupChild_relation " .
-                            "VALUES ('', '" . $maxId["MAX(dep_id)"] . "', '" . $sg["servicegroup_sg_id"] . "')";
+                            "VALUES (NULL, '" . $maxId["MAX(dep_id)"] . "', '" . $sg["servicegroup_sg_id"] . "')";
                         $pearDB->query($query);
                         $fields["dep_sgChilds"] .= $sg["servicegroup_sg_id"] . ",";
                     }

--- a/www/include/options/accessLists/actionsACL/DB-Func.php
+++ b/www/include/options/accessLists/actionsACL/DB-Func.php
@@ -171,7 +171,7 @@ function multipleActionInDB($actions = array(), $nbrDup = array())
                         " WHERE acl_action_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
                     while ($cct = $dbResult->fetchRow()) {
-                        $query = "INSERT INTO acl_group_actions_relations VALUES ('', '" .
+                        $query = "INSERT INTO acl_group_actions_relations VALUES (NULL, '" .
                             $maxId["MAX(acl_action_id)"] . "', '" . $cct["acl_group_id"] . "')";
                         $pearDB->query($query);
                     }
@@ -181,7 +181,7 @@ function multipleActionInDB($actions = array(), $nbrDup = array())
                         "WHERE acl_action_rule_id = '" . $key . "'";
                     $dbResult = $pearDB->query($query);
                     while ($acl = $dbResult->fetchRow()) {
-                        $query = "INSERT INTO acl_actions_rules VALUES ('', '" . $maxId["MAX(acl_action_id)"] .
+                        $query = "INSERT INTO acl_actions_rules VALUES (NULL, '" . $maxId["MAX(acl_action_id)"] .
                             "', '" . $acl["acl_action_name"] . "')";
                         $pearDB->query($query);
                     }


### PR DESCRIPTION
<h1>Fix SQL Errors while insert data with auto-increment in strict_mode</h1>

<h2> Description </h2>

While you use a MySQL with strict_mode activate, you are not allowed to insert invalid value (like empty string for INT with autoincrement)

This patch fix the issue : replace empty string by NULL (it's an allowed value for all database to insert an autoincrement value in all mode)

<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Set your database in strict_mode, for example : in my.cnf, `sql_mode='STRICT_TRANS_TABLES'`
* Try to duplicate host

* Without patch : SQL error in logs and host is not duplcated correctly
* With patch : all is OK

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests covers 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
