### PR TITLE
Hostcategory behaviour with select2

### DIFF
--- a/www/class/centreonHostcategories.class.php
+++ b/www/class/centreonHostcategories.class.php
@@ -91,6 +91,10 @@ class CentreonHostcategories
         global $centreon;
         $items = array();
 
+        if (empty($values)) {
+            return $items;
+        }
+    
         # get list of authorized host categories
         if (!$centreon->user->access->admin) {
             $hcAcl = $centreon->user->access->getHostCategories();
@@ -98,15 +102,14 @@ class CentreonHostcategories
 
         $listValues = '';
         $queryValues = array();
-        if (!empty($values)) {
-            foreach ($values as $k => $v) {
-                $listValues .= ':hc' . $v . ',';
-                $queryValues['hc' . $v] = (int)$v;
+        foreach ($values as $k => $v) {
+            $multipleValues = explode(',', $v);
+            foreach ($multipleValues as $item) {
+                $listValues .= ':hcId_' . $item . ', ';
+                $queryValues['hcId_' . $item] = (int)$item;
             }
-            $listValues = rtrim($listValues, ',');
-        } else {
-            $listValues .= '""';
         }
+        $listValues = rtrim($listValues, ', ');
 
         # get list of selected host categories
         $query = 'SELECT hc_id, hc_name FROM hostcategories ' .
@@ -114,10 +117,8 @@ class CentreonHostcategories
 
         $stmt = $this->db->prepare($query);
 
-        if (!empty($queryValues)) {
-            foreach ($queryValues as $key => $id) {
-                $stmt->bindValue(':' . $key, $id, PDO::PARAM_INT);
-            }
+        foreach ($queryValues as $key => $id) {
+            $stmt->bindValue(':' . $key, $id, PDO::PARAM_INT);
         }
         $stmt->execute();
 


### PR DESCRIPTION
The PDO request try to bind a string of multiple id separated with comma, instead of binding each id

this is a complete rip-off of #7119

# Pull Request Template

## Description
this PR fix the described issue in the following pr : https://github.com/centreon/centreon-widget-hostgroup-monitoring/pull/28


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>
to test this PR you first need to use the widget hostgroup-monitoring and add the following patch to it : 
https://github.com/centreon/centreon-widget-hostgroup-monitoring/pull/28

when you install this widget with the aformentioned PR, you're going to be able to filter on one or more host categories. Select at least two of them in the parameters of your widget. 

Save your parameters. 
get back to the widget parameters, you'll have a PDO issue and all your categories will have vanished. 

With this PR, they won't vanish anymore. @sc979 knows what I'm talking about ;)

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
