### PR TITLE
Change backup path for httpd24-httpd

### DIFF
--- a/cron/centreon-backup.pl
+++ b/cron/centreon-backup.pl
@@ -290,11 +290,13 @@ sub cleanOldBackup() {
 ###############################################
 
 sub getApacheDirectory() {
-	if ( -d '/opt/rh/httpd24/root/etc/httpd/conf.d' ) {
-		return '/opt/rh/httpd24/root/etc/httpd/conf.d';
-	} else {
-		print STDERR "Unable to get Apache conf directory\n";
-	}
+    if ( -d '/opt/rh/httpd24/root/etc/httpd/conf.d' ) {
+        return '/opt/rh/httpd24/root/etc/httpd/conf.d';
+    } elsif ( -d '/etc/httpd/conf.d' ) {
+        return '/etc/httpd/conf.d';
+    } else {
+        print STDERR "Unable to get Apache conf directory\n";
+    }
 }
 
 sub getMySQLConfFile() {

--- a/cron/centreon-backup.pl
+++ b/cron/centreon-backup.pl
@@ -290,8 +290,8 @@ sub cleanOldBackup() {
 ###############################################
 
 sub getApacheDirectory() {
-	if ( -d '/etc/httpd/conf.d' ) {
-		return '/etc/httpd/conf.d';
+	if ( -d '/opt/rh/httpd24/root/etc/httpd/conf.d' ) {
+		return '/opt/rh/httpd24/root/etc/httpd/conf.d';
 	} else {
 		print STDERR "Unable to get Apache conf directory\n";
 	}


### PR DESCRIPTION
## Description
Configuration path for apache in 19.04 (httpd24-httpd) is now on /opt/rh/httpd24/root/etc/httpd/conf.d instead of /etc/httpd/conf.d.
This PR try to change the backup script accordingly.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
