### PR TITLE
fix(engine): add possibility to save service_interleave_factor

### DIFF
--- a/www/include/configuration/configNagios/DB-Func.php
+++ b/www/include/configuration/configNagios/DB-Func.php
@@ -634,10 +634,8 @@ function insertNagios($ret = array(), $brokerTab = array())
         $rq .= "NULL, ";
     }
 
-    if (isset($ret["service_interleave_factor"]["service_interleave_factor"])
-        && $ret["service_interleave_factor"]["service_interleave_factor"] != 2
-    ) {
-        $rq .= "'" . $ret["service_interleave_factor"]["service_interleave_factor"] . "',  ";
+    if (isset($ret["service_interleave_factor"]) && $ret["service_interleave_factor"] != null) {
+        $rq .= "'" . htmlentities($ret["service_interleave_factor"], ENT_QUOTES, "UTF-8") . "',  ";
     } else {
         $rq .= "'2', ";
     }
@@ -1573,11 +1571,9 @@ function updateNagios($nagios_id = null)
         $rq .= "max_service_check_spread = NULL, ";
     }
 
-    if (isset($ret["service_interleave_factor"]["service_interleave_factor"])
-        && $ret["service_interleave_factor"]["service_interleave_factor"] != 2
-    ) {
+    if (isset($ret["service_interleave_factor"]) && $ret["service_interleave_factor"] != null) {
         $rq .= "service_interleave_factor = '"
-            . $ret["service_interleave_factor"]["service_interleave_factor"]
+            . htmlentities($ret["service_interleave_factor"], ENT_QUOTES, "UTF-8")
             . "',  ";
     } else {
         $rq .= "service_interleave_factor = '2', ";


### PR DESCRIPTION
## Description

When you edit the Centreon Engine form and modify the Service Interleave Factor
The value stored is '2' and not your value

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Got to "Configuration > Pollers > Engine" and edit a configuration.
Go on "Tuning" tab and change the value of **Service Interleave Factor**
Save the form

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
