### PR TITLE
fix(UI): Correctly compute downtime start/end date/time & duration

### DIFF
--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -38,7 +38,6 @@
  * @param className string : tag class name
  * @param altFormat string : format of the alternative field
  * @param defaultDate string : GMT YYYY-MM-DDTHH:mm:ss timestamp
- * @todo following 2 parameters seem to never be used, to remove ?
  * @param idName string : tag id of the displayed field
  * @param timestampToSet int : timestamp used to make a new date using the user localization and format
  */
@@ -80,7 +79,6 @@ function initDatepicker(className, altFormat, defaultDate, idName, timestampToSe
                 jQuery(this).datepicker();
             }
         });
-    // @todo section then seems to never be used, to remove ?
     } else {
         // setting the displayed and hidden fields with a timestamp value sent from the backend
         var alternativeField = "input[name=alternativeDate" + idName + "]";

--- a/www/include/monitoring/downtime/AddDowntime.php
+++ b/www/include/monitoring/downtime/AddDowntime.php
@@ -37,16 +37,10 @@ if (!isset($centreon)) {
     exit();
 }
 
-include_once _CENTREON_PATH_ . "www/class/centreonGMT.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonDB.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonService.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonHost.class.php";
 
-/*
- * Init GMT class
- */
-$centreonGMT = new CentreonGMT($pearDB);
-$centreonGMT->getMyGMTFromSession(session_id(), $pearDB);
 $hostStr = $centreon->user->access->getHostsString("ID", $pearDBO);
 $hostAclId = preg_split('/,/', str_replace("'", "", $hostStr));
 
@@ -287,6 +281,17 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
     );
 
     $defaultDuration = 7200;
+    $defaultScale = 's';
+    if (isset($centreon->optGen['monitoring_dwt_duration']) &&
+        $centreon->optGen['monitoring_dwt_duration']
+    ) {
+        $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
+        if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
+            $centreon->optGen['monitoring_dwt_duration_scale']
+        ) {
+            $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
+        }
+    }
     $form->setDefaults(array('duration' => $defaultDuration));
 
     $form->addElement(
@@ -296,11 +301,6 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
         array("s" => _("seconds"), "m" => _("minutes"), "h" => _("hours"), "d" => _("days")),
         array('id' => 'duration_scale')
     );
-    $defaultScale = 's';
-    if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
-        $centreon->optGen['monitoring_dwt_duration_scale']) {
-        $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
-    }
     $form->setDefaults(array('duration_scale' => $defaultScale));
 
     $withServices[] = $form->createElement('radio', 'with_services', null, _("Yes"), '1');
@@ -316,13 +316,7 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
     $form->addRule('comment', _("Required Field"), 'required');
 
     $data = array();
-    $gmt = $centreonGMT->getMyGMT();
-    if (!$gmt) {
-        $gmt = date_default_timezone_get();
-    }
 
-    $data["start_time"] = $centreonGMT->getDate("G:i", time(), $gmt);
-    $data["end_time"] = $centreonGMT->getDate("G:i", time() + $defaultDuration, $gmt);
     $data["host_or_hg"] = 1;
     $data["with_services"] = $centreon->optGen['monitoring_dwt_svc'];
 
@@ -578,12 +572,15 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
 
     function setDurationField() {
         var durationField = jQuery('#duration');
+        var durationScaleField = jQuery('#duration_scale');
         var fixedCb = jQuery('#fixed');
 
         if (fixedCb.prop("checked") == true) {
-            durationField.disabled = true;
+            durationField.attr('disabled', true);
+            durationScaleField.attr('disabled', true);
         } else {
-            durationField.disabled = false;
+            durationField.removeAttr('disabled');
+            durationScaleField.removeAttr('disabled');
         }
     }
 </script>

--- a/www/include/monitoring/downtime/template/AddDowntime.ihtml
+++ b/www/include/monitoring/downtime/template/AddDowntime.ihtml
@@ -151,12 +151,12 @@
 {literal}
 
 <script type="text/javascript">
-
-    initDatepicker("datepicker", "mm/dd/yy", "0");
-
-    $(document).ready(function() {
-        turnOnEvents();
+    jQuery(".timepicker").each(function () {
+        $(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
     });
-
+    jQuery(".timepicker").timepicker();
+    initDatepicker();
+    turnOnEvents();
+    updateEndTime();
 </script>
 {/literal}

--- a/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -52,12 +52,6 @@ if (isset($_GET['select'])) {
 $path = _CENTREON_PATH_ . "/www/include/monitoring/external_cmd/popup/";
 
 /*
- * Init GMT
- */
-$centreonGMT = new CentreonGMT($pearDB);
-$centreonGMT->getMyGMTFromSession(session_id(), $pearDB);
-
-/*
  * Smarty template Init
  */
 $tpl = new Smarty();
@@ -134,11 +128,6 @@ $form->addElement(
     _("*The timezone used is configured on your user settings")
 );
 
-$gmt = $centreonGMT->getMyGMT();
-if (!$gmt) {
-    $gmt = date_default_timezone_get();
-}
-
 $form->addElement(
     'text',
     'duration',
@@ -150,6 +139,17 @@ $form->addElement(
     )
 );
 $defaultDuration = 7200;
+$defaultScale = 's';
+if (isset($centreon->optGen['monitoring_dwt_duration']) &&
+    $centreon->optGen['monitoring_dwt_duration']
+) {
+    $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
+    if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
+        $centreon->optGen['monitoring_dwt_duration_scale']
+    ) {
+        $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
+    }
+}
 $form->setDefaults(array('duration' => $defaultDuration));
 
 $scaleChoices = array(
@@ -164,16 +164,11 @@ $form->addElement(
     _("Scale of time"),
     $scaleChoices,
     array(
-        'id' => 'duration_scale'
+        'id' => 'duration_scale',
+        'disabled' => 'true'
     )
 );
-$form->setDefaults(array('duration_scale' => 's'));
-$form->setDefaults(
-    array(
-        "start_time" => $centreonGMT->getDate("G:i", time(), $gmt),
-        "end_time" => $centreonGMT->getDate("G:i", time() + $defaultDuration, $gmt)
-    )
-);
+$form->setDefaults(array('duration_scale' => $defaultScale));
 
 $chckbox[] = $form->addElement(
     'checkbox',
@@ -252,7 +247,6 @@ $form->addElement(
         'class' => 'alternativeDate'
     )
 );
-
 
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $renderer->setRequiredTemplate('{$label}&nbsp;<font color="red" size="1">*</font>');

--- a/www/include/monitoring/external_cmd/popup/templates/massive_downtime.ihtml
+++ b/www/include/monitoring/external_cmd/popup/templates/massive_downtime.ihtml
@@ -61,10 +61,12 @@
 </form>
 {literal}
 <script type="text/javascript">
-    /* initializing datepicker and the alternative format field */
-    initDatepicker("datepicker", "mm/dd/yy", "0");
-
+    jQuery(".timepicker").each(function () {
+        $(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
+    });
     jQuery(".timepicker").timepicker();
+    initDatepicker();
     turnOnEvents();
+    updateEndTime();
 </script>
 {/literal}

--- a/www/include/monitoring/status/Hosts/hostJS.php
+++ b/www/include/monitoring/status/Hosts/hostJS.php
@@ -407,13 +407,15 @@ if (isset($_GET["acknowledge"])) {
     }
 
     function toggleFields(fixed) {
-        var dur;
-        dur = document.getElementById('duration');
+        var durationField = jQuery('#duration');
+        var durationScaleField = jQuery('#duration_scale');
+
         if (fixed.checked) {
-            dur.disabled = true;
-        }
-        else {
-            dur.disabled = false;
+            durationField.attr('disabled', true);
+            durationScaleField.attr('disabled', true);
+        } else {
+            durationField.removeAttr('disabled');
+            durationScaleField.removeAttr('disabled');
         }
     }
 </script>

--- a/www/include/monitoring/status/Services/serviceJS.php
+++ b/www/include/monitoring/status/Services/serviceJS.php
@@ -419,13 +419,15 @@ if (isset($_GET["acknowledge"])) {
     }
 
     function toggleFields(fixed) {
-        var dur;
-        dur = document.getElementById('duration');
+        var durationField = jQuery('#duration');
+        var durationScaleField = jQuery('#duration_scale');
+
         if (fixed.checked) {
-            dur.disabled = true;
-        }
-        else {
-            dur.disabled = false;
+            durationField.attr('disabled', true);
+            durationScaleField.attr('disabled', true);
+        } else {
+            durationField.removeAttr('disabled');
+            durationScaleField.removeAttr('disabled');
         }
     }
 </script>


### PR DESCRIPTION
Hi,

<h2> Description </h2>

This PR sets the default downtime duration to the configured global option
(_Administration  >  Parameters  >  Monitoring > Default downtime settings_).
It then closes #5963.
And it closes #8362.

In addition it correctly computes datepicker end date when default downtime is across several days.
It then closes #7337.

This PR now gets rid of backend GMT / timezone calculation. All dates / times are now computed into corrected timezone thanks to Moment.js, at frontend side. It also gets rid of javascript `Date()` function, and then only uses Moment.js, this to prevent javascript from moving the timestamps back to the local host timezone. All can easily be achieved with Moment.js, so perfect.
Whatever the user timezone is, start/end date/time are now correctly computed.
It then closes #8266.

It also closes #8383.

Finally, this PR corrects some minor downtime user  interface issues.

All these issues are almost related / linked all together, this is why they are corrected through only one change.

Also see the 2 following _host_ and _service_ widgets related PR :
https://github.com/centreon/centreon-widget-host-monitoring/pull/72
https://github.com/centreon/centreon-widget-service-monitoring/pull/129


<h2> Type of change </h2>

- [x] Patch fixing an issue (non-breaking change)

<h2> Target serie </h2>

- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Set a downtime and verify that the default fixed duration is the one set in _Administration > Parameters > Monitoring > Default downtime settings_.

Set it long enough so that downtime will be across 2 or more days. Set a downtime again and verify that the downtime end date is correctly computed.

Also change your user timezone, and verify that default downtime start/end date/time are correctly computed according to your user timezone.

Thank you 👍

Edit : issue still present in 19.10.10.