### PR TITLE
enh(traps): increase trap special command field size 

### DIFF
--- a/bin/generateSqlLite
+++ b/bin/generateSqlLite
@@ -261,7 +261,7 @@ try {
                     `severity_id` int(11) DEFAULT NULL,
                     `manufacturer_id` int(11) DEFAULT NULL,
                     `traps_reschedule_svc_enable` int(11) DEFAULT '0',
-                    `traps_execution_command` varchar(255) DEFAULT NULL,
+                    `traps_execution_command` text DEFAULT NULL,
                     `traps_execution_command_enable` int(11) DEFAULT '0',
                     `traps_submit_result_enable` int(11) DEFAULT '0',
                     `traps_advanced_treatment` int(11) DEFAULT '0',

--- a/doc/en/release_notes/centreon-18.10/centreon-18.10.6.rst
+++ b/doc/en/release_notes/centreon-18.10/centreon-18.10.6.rst
@@ -5,6 +5,8 @@ Centreon Web 18.10.6
 Enhancements
 ------------
 
+* [SNMP Trap] Increase size of special command field to text
+
 Bug fixes
 ---------
 

--- a/doc/en/release_notes/centreon-18.10/centreon-18.10.6.rst
+++ b/doc/en/release_notes/centreon-18.10/centreon-18.10.6.rst
@@ -1,0 +1,22 @@
+####################
+Centreon Web 18.10.6
+####################
+
+Enhancements
+------------
+
+Bug fixes
+---------
+
+Documentation
+-------------
+
+Security fixes
+--------------
+
+Technical
+---------
+
+Known issue
+-----------
+

--- a/doc/fr/release_notes/centreon-18.10/centreon-18.10.6.rst
+++ b/doc/fr/release_notes/centreon-18.10/centreon-18.10.6.rst
@@ -1,0 +1,22 @@
+####################
+Centreon Web 18.10.5
+####################
+
+Enhancements
+------------
+
+Bug fixes
+---------
+
+Documentation
+-------------
+
+Security fixes
+--------------
+
+Technical
+---------
+
+Known issue
+-----------
+

--- a/doc/fr/release_notes/centreon-18.10/centreon-18.10.6.rst
+++ b/doc/fr/release_notes/centreon-18.10/centreon-18.10.6.rst
@@ -1,9 +1,11 @@
 ####################
-Centreon Web 18.10.5
+Centreon Web 18.10.6
 ####################
 
 Enhancements
 ------------
+
+* [SNMP Trap] Increase size of special command field to text
 
 Bug fixes
 ---------

--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -2043,7 +2043,7 @@ CREATE TABLE `traps` (
   `severity_id` int(11) DEFAULT NULL,
   `manufacturer_id` int(11) DEFAULT NULL,
   `traps_reschedule_svc_enable` enum('0','1') DEFAULT '0',
-  `traps_execution_command` varchar(255) DEFAULT NULL,
+  `traps_execution_command` text DEFAULT NULL,
   `traps_execution_command_enable` enum('0','1') DEFAULT '0',
   `traps_submit_result_enable` enum('0','1') DEFAULT '0',
   `traps_advanced_treatment` enum('0','1') DEFAULT '0',

--- a/www/install/sql/centreon/Update-DB-18.10.5_to_18.10.6.sql
+++ b/www/install/sql/centreon/Update-DB-18.10.5_to_18.10.6.sql
@@ -1,0 +1,5 @@
+-- Change version of Centreon
+UPDATE `informations` SET `value` = '18.10.6' WHERE CONVERT( `informations`.`key` USING utf8 ) = 'version' AND CONVERT ( `informations`.`value` USING utf8 ) = '18.10.5' LIMIT 1;
+
+-- Change traps_execution_command from varchar(255) to text
+ALTER TABLE `traps` MODIFY COLUMN `traps_execution_command` text DEFAULT NULL;

--- a/www/install/sql/centreon/Update-DB-19.04.3.sql
+++ b/www/install/sql/centreon/Update-DB-19.04.3.sql
@@ -1,0 +1,2 @@
+# Change traps_execution_command from varchar(255) to text
+ALTER TABLE `traps` MODIFY COLUMN `traps_execution_command` text DEFAULT NULL;

--- a/www/install/sql/centreon/Update-DB-19.04.3.sql
+++ b/www/install/sql/centreon/Update-DB-19.04.3.sql
@@ -1,2 +1,0 @@
-# Change traps_execution_command from varchar(255) to text
-ALTER TABLE `traps` MODIFY COLUMN `traps_execution_command` text DEFAULT NULL;


### PR DESCRIPTION
## Description

Because some commands size are greater than 255, move varchar(255) db storage to text

**Fixes** #7062 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Edit a SNMP trap and add a command definition greater than 255 chars

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
