### PR TITLE
Properly detect that frontend application is built

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -244,7 +244,7 @@ if [ "$silent_install" -ne 1 ] ; then
 	echo -e "\n$(gettext "You will now read Centreon Licence.\\n\\tPress enter to continue.")"
 	read 
 	tput clear 
-	more "$BASE_DIR/LICENSE"
+	more "$BASE_DIR/LICENSE.md"
 
 	yes_no_default "$(gettext "Do you accept GPL license ?")" 
 	if [ "$?" -ne 0 ] ; then 

--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1131,7 +1131,7 @@ function check_composer_dependencies() {
 ## @Globals	INSTALL_DIR_CENTREON
 #----
 function check_frontend_application() {
-    if [ -d "$BASE_DIR/www/template" ] ; then
+    if [ -d "$BASE_DIR/www/static" ] ; then
         echo_success "$(gettext "Frontend application is built")" "$ok"
         return 0
     else


### PR DESCRIPTION
# Pull Request Template

## Description

Starting with Centreon Web 19.04.1, the frontend application build detection is not working anymore in the shell installer.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [X] 19.04.x
- [X] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Install Centreon Web using the shell installer. Installation should go through with the message "Frontend application is built".

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
