### PR TITLE
fix(remote-server): update only properties of selected poller

### DIFF
--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -516,7 +516,8 @@ function updateRemoteServerInformation(array $data)
             : $rq .= "http_port = NULL, ";
         $rq .= "no_check_certificate = '" . $data["no_check_certificate"]["no_check_certificate"] . "', ";
         $rq .= "no_proxy = '" . $data["no_proxy"]["no_proxy"] . "', ";
-        $rq .= "ip = '" . $data["ns_ip_address"]  . "'";
+        $rq .= "ip = '" . $data["ns_ip_address"]  . "' ";
+        $rq .= "WHERE ip = '" . $data["ns_ip_address"]  . "'";
         $pearDB->query($rq);
     }
     $res->closeCursor();

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -515,8 +515,7 @@ function updateRemoteServerInformation(array $data)
             ? $rq .= "http_port = '" . $data["http_port"]  . "', "
             : $rq .= "http_port = NULL, ";
         $rq .= "no_check_certificate = '" . $data["no_check_certificate"]["no_check_certificate"] . "', ";
-        $rq .= "no_proxy = '" . $data["no_proxy"]["no_proxy"] . "', ";
-        $rq .= "ip = '" . $data["ns_ip_address"]  . "' ";
+        $rq .= "no_proxy = '" . $data["no_proxy"]["no_proxy"] . "' ";
         $rq .= "WHERE ip = '" . $data["ns_ip_address"]  . "'";
         $pearDB->query($rq);
     }


### PR DESCRIPTION
## Description

If severals pollers a Remote Server and if a user update properties of one of them, all properties into remote_servers tables are updated

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
