### PR TITLE
fix(remote-server): set task in failed status if an error appears

### DIFF
--- a/src/Centreon/Domain/Entity/Task.php
+++ b/src/Centreon/Domain/Entity/Task.php
@@ -19,6 +19,7 @@ class Task implements EntityInterface
     const STATE_PENDING = 'pending';
     const STATE_PROGRESS = 'inprogress';
     const STATE_COMPLETED = 'completed';
+    const STATE_FAILED = 'failed';
 
     /**
      * Task type


### PR DESCRIPTION
## Description

Before if an error appears during import/export task process
The error was present into centcore.log file but the task was completed in database instead of the task status.
Now logs and task table will display failed status

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
