### PR TITLE
fix(remote-server): do not compare bugfix version on task import

### DIFF
--- a/src/CentreonRemote/Infrastructure/Export/ExportManifest.php
+++ b/src/CentreonRemote/Infrastructure/Export/ExportManifest.php
@@ -103,8 +103,18 @@ class ExportManifest
             throw new Exception(sprintf("Missing data in a manifest file:\n - %s", join("\n - %s", $missingKeys)), static::ERR_CODE_MANIFEST_WRONG_FORMAT);
         }
 
-        if ($this->data['version'] !== $this->version) {
-            throw new Exception(sprintf('The version of the Central %s and of the Remote %s are incompatible', $this->data['version'], $this->version), static::ERR_CODE_INCOMPATIBLE_VERSIONS);
+        # Compare only the major and minor version, not bugfix because no SQL schema changes
+        $centralVersion = preg_replace('/^(\d+\.\d+).*/', '$1', $this->data['version']);
+        $remoteVersion = preg_replace('/^(\d+\.\d+).*/', '$1', $this->version);
+
+        if (!version_compare($centralVersion, $remoteVersion, '==')) {
+            throw new Exception(
+                sprintf('The version of the Central %s and of the Remote %s are incompatible',
+                    $this->data['version'],
+                    $this->version
+                ),
+                static::ERR_CODE_INCOMPATIBLE_VERSIONS
+            );
         }
 
         if (!$this->data['exporters']) {


### PR DESCRIPTION
## Description

Because on bug fixes version the SQL schema can't change, the task import of Remote Server should work on different bug fixes versions between Centreon central server and Remote Server

**Fixes** #7629

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Given a Central server in 19.04.2 and a Remote server in 19.04.0
When I export the configuration of the Remote Server
The import task on my Remote Server should work

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
