### PR TITLE
fix(remote-server): check bam on remote server is http only

### DIFF
--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -299,7 +299,9 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
         if ($isRemoteConnection) {
             $serverConfigurationService->setDbUser($this->arguments['db_user']);
             $serverConfigurationService->setDbPassword($this->arguments['db_password']);
-            if ($serverWizardIdentity->checkBamOnRemoteServer($serverIP, $centreonPath)) {
+            if ($serverWizardIdentity->checkBamOnRemoteServer(
+                $httpMethod . '://' . $serverIP . ':' . $httpPort . trim($centreonPath, '/')))
+            {
                 $serverConfigurationService->shouldInsertBamBrokers();
             }
         }

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -301,8 +301,8 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             $serverConfigurationService->setDbPassword($this->arguments['db_password']);
             if ($serverWizardIdentity->checkBamOnRemoteServer(
                 $httpMethod . '://' . $serverIP . ':' . $httpPort . '/' . trim($centreonPath, '/'),
-				$noCheckCertificate,
-				$noProxy
+                $noCheckCertificate,
+                $noProxy
             )) {
                 $serverConfigurationService->shouldInsertBamBrokers();
             }

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -300,8 +300,10 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             $serverConfigurationService->setDbUser($this->arguments['db_user']);
             $serverConfigurationService->setDbPassword($this->arguments['db_password']);
             if ($serverWizardIdentity->checkBamOnRemoteServer(
-                $httpMethod . '://' . $serverIP . ':' . $httpPort . trim($centreonPath, '/')))
-            {
+                $httpMethod . '://' . $serverIP . ':' . $httpPort . trim($centreonPath, '/'),
+				$noCheckCertificate,
+				$noProxy
+            )) {
                 $serverConfigurationService->shouldInsertBamBrokers();
             }
         }

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -300,7 +300,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
             $serverConfigurationService->setDbUser($this->arguments['db_user']);
             $serverConfigurationService->setDbPassword($this->arguments['db_password']);
             if ($serverWizardIdentity->checkBamOnRemoteServer(
-                $httpMethod . '://' . $serverIP . ':' . $httpPort . trim($centreonPath, '/'),
+                $httpMethod . '://' . $serverIP . ':' . $httpPort . '/' . trim($centreonPath, '/'),
 				$noCheckCertificate,
 				$noProxy
             )) {

--- a/src/CentreonRemote/Domain/Value/ServerWizardIdentity.php
+++ b/src/CentreonRemote/Domain/Value/ServerWizardIdentity.php
@@ -47,7 +47,7 @@ class ServerWizardIdentity
         try {
             $curl = new Curl;
 
-			if ($noCheckCertificate) {
+            if ($noCheckCertificate) {
                 $curl->setOpt(CURLOPT_SSL_VERIFYPEER, false);
             }
 

--- a/src/CentreonRemote/Domain/Value/ServerWizardIdentity.php
+++ b/src/CentreonRemote/Domain/Value/ServerWizardIdentity.php
@@ -33,14 +33,28 @@ class ServerWizardIdentity
      * check if bam is installed on remote server
      *
      * @param string $centreonUrl URL of Centreon of the remote server
+     * @param bool $noCheckCertificate do not check peer SSL certificat
+     * @param bool $noProxy don't use configured proxy
      * @return bool if bam is installed on remote server
      */
-    public function checkBamOnRemoteServer(string $centreonUrl): bool
+    public function checkBamOnRemoteServer(
+        string $centreonUrl,
+        bool $noCheckCertificate = false,
+        bool $noProxy = false): bool
     {
         $centreonUrl .= "/api/external.php?object=centreon_modules_webservice&action=getBamModuleInfo";
 
         try {
             $curl = new Curl;
+
+			if ($noCheckCertificate) {
+                $curl->setOpt(CURLOPT_SSL_VERIFYPEER, false);
+            }
+
+            if ($noProxy) {
+                $curl->setOpt(CURLOPT_PROXY, false);
+            }
+
             $curl->post($centreonUrl);
 
             if ($curl->error) {

--- a/src/CentreonRemote/Domain/Value/ServerWizardIdentity.php
+++ b/src/CentreonRemote/Domain/Value/ServerWizardIdentity.php
@@ -32,18 +32,16 @@ class ServerWizardIdentity
     /**
      * check if bam is installed on remote server
      *
-     * @param string $ip ip address of the remote server
-     * @param string $centreonPath centreon web path on remote server
+     * @param string $centreonUrl URL of Centreon of the remote server
      * @return bool if bam is installed on remote server
      */
-    public function checkBamOnRemoteServer(string $ip, string $centreonPath): bool
+    public function checkBamOnRemoteServer(string $centreonUrl): bool
     {
-        $centreonPath = trim($centreonPath, '/');
-        $url = "{$ip}/{$centreonPath}/api/external.php?object=centreon_modules_webservice&action=getBamModuleInfo";
+        $centreonUrl .= "/api/external.php?object=centreon_modules_webservice&action=getBamModuleInfo";
 
         try {
             $curl = new Curl;
-            $curl->post($url);
+            $curl->post($centreonUrl);
 
             if ($curl->error) {
                 return false;


### PR DESCRIPTION
## Description

When configuration a Remote Server through the wizard several API calls are made.
But one call doesn't used defined HTTP method and port define by user.

**Fixes** #7626

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Given a Remote Server configured with HTTPS and with BAM installed
When I create it through the wizard
No error must be present into logs and BAM broker output must be created

Given a Remote Server configured with HTTPS and with BAM installed
When I export configuration and this configuration must contain BA
The BA are available on Remote Server

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
