### PR TITLE
Enable Broker stats on Remote Server

### DIFF
--- a/src/CentreonRemote/Domain/Resources/RemoteConfig/CfgCentreonBroker.php
+++ b/src/CentreonRemote/Domain/Resources/RemoteConfig/CfgCentreonBroker.php
@@ -23,7 +23,21 @@ class CfgCentreonBroker
             'broker' => [
                 'config_name'            => "{$configName}-broker",
                 'config_filename'        => "central-broker.xml",
-                'config_write_timestamp' => '0',
+                'config_write_timestamp' => '1',
+                'config_write_thread_id' => '0',
+                'config_activate'        => '1',
+                'ns_nagios_server'       => $serverID,
+                'event_queue_max_size'   => '100000',
+                'command_file'           => '',
+                'cache_directory'        => '/var/lib/centreon-broker',
+                'stats_activate'         => '1',
+                'correlation_activate'   => '0',
+                'daemon'                 => '1',
+            ],
+            'rrd' => [
+                'config_name'            => "{$configName}-rrd",
+                'config_filename'        => "central-rrd.xml",
+                'config_write_timestamp' => '1',
                 'config_write_thread_id' => '0',
                 'config_activate'        => '1',
                 'ns_nagios_server'       => $serverID,
@@ -47,20 +61,6 @@ class CfgCentreonBroker
                 'stats_activate'         => '1',
                 'correlation_activate'   => '0',
                 'daemon'                 => '0',
-            ],
-            'rrd' => [
-                'config_name'            => "{$configName}-rrd",
-                'config_filename'        => "central-rrd.xml",
-                'config_write_timestamp' => '0',
-                'config_write_thread_id' => '0',
-                'config_activate'        => '1',
-                'ns_nagios_server'       => $serverID,
-                'event_queue_max_size'   => '100000',
-                'command_file'           => '',
-                'cache_directory'        => '/var/lib/centreon-broker',
-                'stats_activate'         => '1',
-                'correlation_activate'   => '0',
-                'daemon'                 => '1',
             ]
         ];
     }

--- a/src/CentreonRemote/Domain/Resources/RemoteConfig/CfgCentreonBroker.php
+++ b/src/CentreonRemote/Domain/Resources/RemoteConfig/CfgCentreonBroker.php
@@ -22,7 +22,7 @@ class CfgCentreonBroker
         return [
             'broker' => [
                 'config_name'            => "{$configName}-broker",
-                'config_filename'        => "{$configName}-broker.xml",
+                'config_filename'        => "central-broker.xml",
                 'config_write_timestamp' => '0',
                 'config_write_thread_id' => '0',
                 'config_activate'        => '1',
@@ -36,7 +36,7 @@ class CfgCentreonBroker
             ],
             'module' => [
                 'config_name'            => "{$configName}-module",
-                'config_filename'        => "{$configName}-module.xml",
+                'config_filename'        => "central-module.xml",
                 'config_write_timestamp' => '0',
                 'config_write_thread_id' => '0',
                 'config_activate'        => '1',
@@ -50,7 +50,7 @@ class CfgCentreonBroker
             ],
             'rrd' => [
                 'config_name'            => "{$configName}-rrd",
-                'config_filename'        => "{$configName}-rrd.xml",
+                'config_filename'        => "central-rrd.xml",
                 'config_write_timestamp' => '0',
                 'config_write_thread_id' => '0',
                 'config_activate'        => '1',

--- a/www/include/Administration/brokerPerformance/brokerPerformance.php
+++ b/www/include/Administration/brokerPerformance/brokerPerformance.php
@@ -249,7 +249,7 @@ $tpl->assign('poller_name', $pollerName);
 /*
  * Get the stats file name
  */
-$queryStatName = "SELECT config_name, cache_directory "
+$queryStatName = "SELECT config_name, config_filename, cache_directory "
     . "FROM cfg_centreonbroker "
     . "WHERE stats_activate = '1' "
     . "AND ns_nagios_server = :id";
@@ -263,7 +263,8 @@ try {
     $perf_info = array();
     $perf_err = array();
     while ($row = $stmt->fetch()) {
-        $statsfile = $row['cache_directory'] . '/' . $row['config_name'] . '-stats.json';
+        $xmldata = simplexml_load_file('/etc/centreon-broker/' . $row['config_filename'],'SimpleXMLElement',LIBXML_NOCDATA );
+        $statsfile = $xmldata->stats->json_fifo;
         if ($defaultPoller != $selectedPoller) {
             $statsfile = _CENTREON_VARLIB_ . '/broker-stats/broker-stats-' . $selectedPoller . '.dat';
         }

--- a/www/include/Administration/brokerPerformance/brokerPerformance.php
+++ b/www/include/Administration/brokerPerformance/brokerPerformance.php
@@ -263,7 +263,7 @@ try {
     $perf_info = array();
     $perf_err = array();
     while ($row = $stmt->fetch()) {
-        $xmldata = simplexml_load_file('/etc/centreon-broker/' . $row['config_filename'],'SimpleXMLElement',LIBXML_NOCDATA );
+        $xmldata = simplexml_load_file('/etc/centreon-broker/' . $row['config_filename'], 'SimpleXMLElement', LIBXML_NOCDATA);
         $statsfile = $xmldata->stats->json_fifo;
         if ($defaultPoller != $selectedPoller) {
             $statsfile = _CENTREON_VARLIB_ . '/broker-stats/broker-stats-' . $selectedPoller . '.dat';


### PR DESCRIPTION
Hi,

## Description

On a Remote Server, broker stats are not available.
This PR fixes this.

Fixes #7635

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go to a Remote Server and be sure broker stats are available.

Thx 👍

Edit : issue still present in 19.04.2.