### PR TITLE
Mon 3936 use correct ssh port

### DIFF
--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -775,7 +775,7 @@ sub sendExportFile($){
     # Send data with rSync
     $self->{logger}->writeLogInfo('Export files on poller "' . $server_info->{name} . '" (' . $id . ')');
 
-    $cmd = "$self->{rsync} -ra -e 'ssh -o port=$port' $origin $dest 2>&1";
+    $cmd = "$self->{rsync} -ra -e '$self->{ssh} -o port=$port' $origin $dest 2>&1";
     ($lerror, $stdout, $return_code) = centreon::common::misc::backtick(
         command => $cmd,
         logger => $self->{logger},

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -775,7 +775,7 @@ sub sendExportFile($){
     # Send data with rSync
     $self->{logger}->writeLogInfo('Export files on poller "' . $server_info->{name} . '" (' . $id . ')');
 
-    $cmd = "$self->{rsync} -ra --port=$port $origin $dest 2>&1";
+    $cmd = "$self->{rsync} -ra -e 'ssh -o port=$port' $origin $dest 2>&1";
     ($lerror, $stdout, $return_code) = centreon::common::misc::backtick(
         command => $cmd,
         logger => $self->{logger},
@@ -883,7 +883,7 @@ sub syncTraps($) {
             }
 
             if (defined($ns_server->{remote_id}) && $ns_server->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
-                $cmd = "$self->{ssh} " . $remote_server->{'ns_ip_address'}  . " 'echo \"SYNCTRAP:" . $id . "\" >> $self->{cmdDir}/" . time() . "-sendcmd'";
+                $cmd = "$self->{ssh} -p $port " . $remote_server->{'ns_ip_address'}  . " 'echo \"SYNCTRAP:" . $id . "\" >> $self->{cmdDir}/" . time() . "-sendcmd'";
                 ($lerror, $stdout) = centreon::common::misc::backtick(
                     command => $cmd,
                     logger => $self->{logger},
@@ -923,7 +923,7 @@ sub syncTraps($) {
                     $self->{logger}->writeLogInfo("Result : $stdout");
                 }
                 if (defined($ns_server->{remote_id}) && $ns_server->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
-                    $cmd = "$self->{ssh} " . $remote_server->{'ns_ip_address'}  . " 'echo \"SYNCTRAP:" . $id . "\" >> $self->{cmdDir}/" . time() . "-sendcmd'";
+                    $cmd = "$self->{ssh} -p $port " . $remote_server->{'ns_ip_address'}  . " 'echo \"SYNCTRAP:" . $id . "\" >> $self->{cmdDir}/" . time() . "-sendcmd'";
                     ($lerror, $stdout) = centreon::common::misc::backtick(command => $cmd,
                                                                           logger => $self->{logger},
                                                                           timeout => 300

--- a/lib/perl/centreon/script/centreonSyncArchives.pm
+++ b/lib/perl/centreon/script/centreonSyncArchives.pm
@@ -61,12 +61,12 @@ sub run {
                                         password => $self->{centreon_config}->{db_passwd},
                                         force => 0,
                                         logger => $self->{logger});
-    my ($status, $sth) = $cdb->query("SELECT nagios_server.id, nagios_server.ns_ip_address, cfg_nagios.log_archive_path FROM nagios_server, cfg_nagios 
+    my ($status, $sth) = $cdb->query("SELECT nagios_server.id, nagios_server.ns_ip_address, nagios_server.ssh_port, cfg_nagios.log_archive_path FROM nagios_server, cfg_nagios 
                                       WHERE nagios_server.ns_activate = '1' AND nagios_server.localhost = '0' AND nagios_server.id = cfg_nagios.nagios_server_id");
     die("Error SQL Quit") if ($status == -1);
     while ((my $data = $sth->fetchrow_hashref())) {
 		if (defined($data->{log_archive_path}) && $data->{log_archive_path} ne '') {
-			`$self->{rsync} -c $data->{'ns_ip_address'}:$data->{'log_archive_path'}/* $self->{centreon_config}->{VarLib}/log/$data->{'id'}/archives/`;
+			`$self->{rsync} -c -e "ssh -o port=$data->{'ssh_port'}" $data->{'ns_ip_address'}:$data->{'log_archive_path'}/* $self->{centreon_config}->{VarLib}/log/$data->{'id'}/archives/`;
 		} else {
 			$self->{logger}->writeLogError("Can't get archive path for service " . $data->{'id'} . " (" . $data->{'ns_address_ip'} . ")");
 		}		


### PR DESCRIPTION
## Description

Based on PR #7630 to rebase on master and solve conflicts

Using a non default SSH port on a Remote Server leads to the following in `centcore.log`,
on the Central Server :

```
2019-06-18 16:54:19 - INFO - Export files on poller "remote-server" (32)
2019-06-18 16:54:28 - INFO - Result : [sender] io timeout after 6 seconds -- exiting
rsync error: timeout in data send/receive (code 30) at io.c(195) [sender=3.1.2]
```

This is due to a non valid usage of the port option of the rsync command.
While here, I found other SSH and rsync commands not using the configured port, so I fixed them.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Use a non default SSH port for your Remote Server and verify it is correctly used by centcore.

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
