### PR TITLE
enh(api): update output of getparam command on host object

### DIFF
--- a/doc/en/api/api_rest/index.rst
+++ b/doc/en/api/api_rest/index.rst
@@ -650,7 +650,6 @@ Delete host
    }
 
 
-
 Set parameters
 --------------
 
@@ -780,6 +779,141 @@ timezone                             Timezone
    {
      "result": []
    }
+
+
+Get parameters
+--------------
+
+**POST**  ::
+
+ api.domain.tld/centreon/api/index.php?action=action&object=centreon_clapi
+
+
+**Header**
+
++---------------------+------------------------------------------------+
+|  key                |   value                                        |
+|                     |                                                |
++---------------------+------------------------------------------------+
+| Content-Type        | application/json                               |
++---------------------+------------------------------------------------+
+| centreon-auth-token | the value of authToken you got                 |
+|                     | on the response of the authentication part     |
++---------------------+------------------------------------------------+
+
+
+**Body**  ::
+
+  {
+    "action": "getparam",
+    "object": "host",
+    "values": "test;ParameterToGet|ParameterToGet"
+  }
+
+Available parameters
+
+==================================== =================================================================================
+Parameter                            Description
+==================================== =================================================================================
+2d_coords                            2D coordinates (used by statusmap)
+
+3d_coords                            3D coordinates (used by statusmap)
+
+action_url                           Action URL
+
+activate                             Whether or not host is enabled
+
+active_checks_enabled                Whether or not active checks are enabled
+
+address                              Host IP Address
+
+alias                                Alias
+
+check_command                        Check command
+
+check_command_arguments              Check command arguments
+
+check_interval                       Normal check interval
+
+check_freshness                      Check freshness (in seconds)
+
+check_period                         Check period
+
+checks_enabled                       Whether or not checks are enabled
+
+contact_additive_inheritance         Enables contact additive inheritance
+
+cg_additive_inheritance              Enables contactgroup additive inheritance
+
+event_handler                        Event handler command
+
+event_handler_arguments              Event handler command arguments
+
+event_handler_enabled                Whether or not event handler is enabled
+
+first_notification_delay             First notification delay (in seconds)
+
+flap_detection_enabled               Whether or not flap detection is enabled
+
+flap_detection_options               Flap detection options
+
+icon_image                           Icon image
+
+icon_image_alt                       Icon image text
+
+max_check_attempts                   Maximum number of attempt before a HARD state is declared
+
+name                                 Host name
+
+normal_check_interval                value in minutes
+
+notes                                Notes
+
+notes_url                            Notes URL
+
+notifications_enabled                Whether or not notification is enabled
+
+notification_interval                Notification interval
+
+notification_options                 Notification options
+
+notification_period                  Notification period
+
+obsess_over_host                     Whether or not obsess over host option is enabled
+
+passive_checks_enabled               Whether or not passive checks are enabled
+
+process_perf_data                    Process performance data command
+
+retain_nonstatus_information         Whether or not there is non-status retention
+
+retain_status_information            Whether or not there is status retention
+
+retry_check_interval                 Retry check interval
+
+snmp_community                       Snmp Community
+
+snmp_version                         Snmp version
+
+stalking_options                     Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable
+
+statusmap_image                      Status map image (used by statusmap
+
+host_notification_options            Notification options (d,u,r,f,s)
+
+timezone                             Timezone
+==================================== =================================================================================
+
+
+**Response** ::
+
+  {
+    "result": [{
+      "alias": "test",
+      "address": "192.168.56.101",
+      "timezone": "Europe/Berlin"
+    }]
+  }
 
 
 Set instance poller

--- a/doc/en/api/clapi/objects/hosts.rst
+++ b/doc/en/api/clapi/objects/hosts.rst
@@ -204,11 +204,13 @@ Getparam
 In order to get specific parameters on a host configuration, use the **GETPARAM** action::
 
   [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a getparam -v "test;alias"
-  alias : test
-  [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a setparam -v "test;alias|alia|timezone"
-  alias : test
-  timezone : Europe/Berlin
+  alias
+  test
+  [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a getparam -v "test;alias|alia|timezone"
   Object not found:alia
+  [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a getparam -v "test;alias|address|timezone"
+  alias;address;timezone
+  test;192.168.56.101;Europe/Berlin
 
 You may edit the following parameters:
 

--- a/doc/fr/api/api_rest/index.rst
+++ b/doc/fr/api/api_rest/index.rst
@@ -650,7 +650,6 @@ Delete host
    }
 
 
-
 Set parameters
 --------------
 
@@ -780,6 +779,141 @@ timezone                             Timezone
    {
      "result": []
    }
+
+
+Get parameters
+--------------
+
+**POST**  ::
+
+ api.domain.tld/centreon/api/index.php?action=action&object=centreon_clapi
+
+
+**Header**
+
++---------------------+------------------------------------------------+
+|  key                |   value                                        |
+|                     |                                                |
++---------------------+------------------------------------------------+
+| Content-Type        | application/json                               |
++---------------------+------------------------------------------------+
+| centreon-auth-token | the value of authToken you got                 |
+|                     | on the response of the authentication part     |
++---------------------+------------------------------------------------+
+
+
+**Body**  ::
+
+  {
+    "action": "getparam",
+    "object": "host",
+    "values": "test;ParameterToGet|ParameterToGet"
+  }
+
+Available parameters
+
+==================================== =================================================================================
+Parameter                            Description
+==================================== =================================================================================
+2d_coords                            2D coordinates (used by statusmap)
+
+3d_coords                            3D coordinates (used by statusmap)
+
+action_url                           Action URL
+
+activate                             Whether or not host is enabled
+
+active_checks_enabled                Whether or not active checks are enabled
+
+address                              Host IP Address
+
+alias                                Alias
+
+check_command                        Check command
+
+check_command_arguments              Check command arguments
+
+check_interval                       Normal check interval
+
+check_freshness                      Check freshness (in seconds)
+
+check_period                         Check period
+
+checks_enabled                       Whether or not checks are enabled
+
+contact_additive_inheritance         Enables contact additive inheritance
+
+cg_additive_inheritance              Enables contactgroup additive inheritance
+
+event_handler                        Event handler command
+
+event_handler_arguments              Event handler command arguments
+
+event_handler_enabled                Whether or not event handler is enabled
+
+first_notification_delay             First notification delay (in seconds)
+
+flap_detection_enabled               Whether or not flap detection is enabled
+
+flap_detection_options               Flap detection options
+
+icon_image                           Icon image
+
+icon_image_alt                       Icon image text
+
+max_check_attempts                   Maximum number of attempt before a HARD state is declared
+
+name                                 Host name
+
+normal_check_interval                value in minutes
+
+notes                                Notes
+
+notes_url                            Notes URL
+
+notifications_enabled                Whether or not notification is enabled
+
+notification_interval                Notification interval
+
+notification_options                 Notification options
+
+notification_period                  Notification period
+
+obsess_over_host                     Whether or not obsess over host option is enabled
+
+passive_checks_enabled               Whether or not passive checks are enabled
+
+process_perf_data                    Process performance data command
+
+retain_nonstatus_information         Whether or not there is non-status retention
+
+retain_status_information            Whether or not there is status retention
+
+retry_check_interval                 Retry check interval
+
+snmp_community                       Snmp Community
+
+snmp_version                         Snmp version
+
+stalking_options                     Comma separated options: 'o' for OK, 'd' for Down, 'u' for Unreachable
+
+statusmap_image                      Status map image (used by statusmap
+
+host_notification_options            Notification options (d,u,r,f,s)
+
+timezone                             Timezone
+==================================== =================================================================================
+
+
+**Response** ::
+
+  {
+    "result": [{
+      "alias": "test",
+      "address": "192.168.56.101",
+      "timezone": "Europe/Berlin"
+    }]
+  }
 
 
 Set instance poller

--- a/doc/fr/api/clapi/objects/hosts.rst
+++ b/doc/fr/api/clapi/objects/hosts.rst
@@ -199,11 +199,13 @@ Getparam
 In order to get specific parameters on a host configuration, use the **GETPARAM** action::
 
   [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a getparam -v "test;alias"
-  alias : test
-  [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a setparam -v "test;alias|alia|timezone"
-  alias : test
-  timezone : Europe/Berlin
+  alias
+  test
+  [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a getparam -v "test;alias|alia|timezone"
   Object not found:alia
+  [root@centreon ~]# ./centreon -u admin -p centreon -o HOST -a getparam -v "test;alias|address|timezone"
+  alias;address;timezone
+  test;192.168.56.101;Europe/Berlin
 
 You may edit the following parameters:
 

--- a/www/class/centreon-clapi/centreonHost.class.php
+++ b/www/class/centreon-clapi/centreonHost.class.php
@@ -463,10 +463,10 @@ class CentreonHost extends CentreonObject
         if (($objectId = $this->getObjectId($params[self::ORDER_UNIQUENAME])) != 0) {
             $listParam = explode('|', $params[1]);
             foreach ($listParam as $paramSearch) {
-                if (! $paramString) {
-                  $paramString = $paramSearch;
+                if (!$paramString) {
+                    $paramString = $paramSearch;
                 } else {
-                  $paramString = $paramString . $this->delim . $paramSearch;
+                    $paramString = $paramString . $this->delim . $paramSearch;
                 }
                 $field = $paramSearch;
                 if (!in_array($field, $authorizeParam)) {
@@ -548,10 +548,10 @@ class CentreonHost extends CentreonObject
                             $ret = $ret[$field];
                             break;
                     }
-                    if (! $resultString) {
-                      $resultString = $ret;
+                    if (!$resultString) {
+                        $resultString = $ret;
                     } else {
-                      $resultString = $resultString . $this->delim . $ret;
+                        $resultString = $resultString . $this->delim . $ret;
                     }
                 }
             }

--- a/www/class/centreon-clapi/centreonHost.class.php
+++ b/www/class/centreon-clapi/centreonHost.class.php
@@ -463,6 +463,11 @@ class CentreonHost extends CentreonObject
         if (($objectId = $this->getObjectId($params[self::ORDER_UNIQUENAME])) != 0) {
             $listParam = explode('|', $params[1]);
             foreach ($listParam as $paramSearch) {
+                if (! $paramString) {
+                  $paramString = $paramSearch;
+                } else {
+                  $paramString = $paramString . $this->delim . $paramSearch;
+                }
                 $field = $paramSearch;
                 if (!in_array($field, $authorizeParam)) {
                     $unknownParam[] = $field;
@@ -543,7 +548,11 @@ class CentreonHost extends CentreonObject
                             $ret = $ret[$field];
                             break;
                     }
-                    echo $paramSearch . ' : ' . $ret . "\n";
+                    if (! $resultString) {
+                      $resultString = $ret;
+                    } else {
+                      $resultString = $resultString . $this->delim . $ret;
+                    }
                 }
             }
         } else {
@@ -553,6 +562,8 @@ class CentreonHost extends CentreonObject
         if (!empty($unknownParam)) {
             throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . implode('|', $unknownParam));
         }
+        echo $paramString . "\n";
+        echo $resultString . "\n";
     }
 
     /**


### PR DESCRIPTION
# Pull Request Template

## original PR is already reviewed

@smutel 's PR : https://github.com/centreon/centreon/pull/7557
rebased on the 19.04.x
need to be cherry-picked on the master (19.10.x) after successful validation

## Description

**Change the output of the command get param in centreon-clapi.
The output now follow the same output than the other commands.**

**Fixes** #6178

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

**Test of centreon clapi:**

`centreon -u admin -p XXXXX -o host -a getparam -v "Centeon-central;alias|address|timezone"`

**Test of the centreon REST API:**

`curl -H 'centreon-auth-token:xxxxxx' -H "Content-Type: application/json" -d '{"action": "getparam","object": "host","values": "Centeon-central;alias;address|timezone"}' "https://XX.XX.XX.XX/centreon/api/index.php?action=action&object=centreon_clapi"`


#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
