### PR TITLE
fix(front): redirect to login page when user is unauthorized

### DIFF
--- a/www/front_src/src/translations/index.js
+++ b/www/front_src/src/translations/index.js
@@ -12,7 +12,7 @@ export default function setTranslations(store, callback) {
     .all([localePromise, translationsPromise])
     .then(response => {
       let locale = response[0].data.locale;
-      locale = locale != null ? locale.slice(0,2) : navigator.language;
+      locale = locale !== null ? locale.slice(0,2) : navigator.language;
       const translations = response[1].data;
       syncTranslationWithStore(store);
       store.dispatch(loadTranslations(translations));
@@ -20,7 +20,7 @@ export default function setTranslations(store, callback) {
       callback();
     })
     .catch((error) => {
-      if (error.response.status == 401) {
+      if (error.response.status === 401) {
         // redirect to login page
         window.location.href = 'index.php?disconnect=1';
       }

--- a/www/front_src/src/translations/index.js
+++ b/www/front_src/src/translations/index.js
@@ -10,7 +10,7 @@ export default function setTranslations(store, callback) {
 
   Promise
     .all([localePromise, translationsPromise])
-    .then(response => {
+    .then((response) => {
       let locale = response[0].data.locale;
       locale = locale !== null ? locale.slice(0,2) : navigator.language;
       const translations = response[1].data;

--- a/www/front_src/src/translations/index.js
+++ b/www/front_src/src/translations/index.js
@@ -5,17 +5,24 @@ const translationService = axios("internal.php?object=centreon_i18n&action=trans
 const userService = axios("internal.php?object=centreon_topcounter&action=user");
 
 export default function setTranslations(store, callback) {
-    const localePromise = userService.get();
-    const translationsPromise = translationService.get();
-    Promise
-        .all([localePromise, translationsPromise])
-        .then(response => {
-            let locale = response[0].data.locale;
-            locale = locale != null ? locale.slice(0,2) : navigator.language;
-            const translations = response[1].data
-            syncTranslationWithStore(store);
-            store.dispatch(loadTranslations(translations));
-            store.dispatch(setLocale(locale));
-            callback();
-        });
+  const localePromise = userService.get();
+  const translationsPromise = translationService.get();
+
+  Promise
+    .all([localePromise, translationsPromise])
+    .then(response => {
+      let locale = response[0].data.locale;
+      locale = locale != null ? locale.slice(0,2) : navigator.language;
+      const translations = response[1].data;
+      syncTranslationWithStore(store);
+      store.dispatch(loadTranslations(translations));
+      store.dispatch(setLocale(locale));
+      callback();
+    })
+    .catch((error) => {
+      if (error.response.status == 401) {
+        // redirect to login page
+        window.location.href = 'index.php?disconnect=1';
+      }
+    });
 };


### PR DESCRIPTION
## Description

Redirect to login page if user try to access directly to a centreon page without being logged in

**Fixes** MON-3911

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Logout from centreon
* try to access directly to http://<ip_address>/centreon/administration/extensions/manager
* you should be redirected to login page
