### PR TITLE
enh(remote-server): Reduce exported objects and improve process duration

### DIFF
--- a/src/Centreon/Domain/Repository/CommandRepository.php
+++ b/src/Centreon/Domain/Repository/CommandRepository.php
@@ -21,80 +21,6 @@ class CommandRepository extends ServiceEntityRepository
 
         $ids = join(',', $pollerIds);
 
-/*
-        $sql = <<<SQL
-SELECT
-    t1.*
-FROM command AS t1
-INNER JOIN cfg_nagios AS cn1 ON
-    cn1.global_service_event_handler = t1.command_id OR
-    cn1.global_host_event_handler = t1.command_id OR
-    cn1.ocsp_command = t1.command_id OR
-    cn1.ochp_command = t1.command_id OR
-    cn1.host_perfdata_command = t1.command_id OR
-    cn1.service_perfdata_command = t1.command_id OR
-    cn1.host_perfdata_file_processing_command = t1.command_id OR
-    cn1.service_perfdata_file_processing_command = t1.command_id
-WHERE
-    cn1.nagios_id IN ({$ids})
-GROUP BY t1.command_id
-
-UNION
-
-SELECT
-    t2.*
-FROM command AS t2
-INNER JOIN poller_command_relations AS pcr2 ON pcr2.command_id = t2.command_id
-WHERE
-    pcr2.poller_id IN ({$ids})
-GROUP BY t2.command_id
-
-UNION
-
-SELECT
-    t3.*
-FROM command AS t3
-INNER JOIN host AS h3 ON
-    h3.command_command_id = t3.command_id OR
-    h3.command_command_id2 = t3.command_id
-INNER JOIN ns_host_relation AS nhr3 ON nhr3.host_host_id = h3.host_id
-WHERE
-    nhr3.nagios_server_id IN ({$ids})
-GROUP BY t3.command_id
-
-UNION
-
-SELECT
-    t4.*
-FROM command AS t4
-INNER JOIN host AS h4 ON
-    h4.command_command_id = t4.command_id OR
-    h4.command_command_id2 = t4.command_id
-INNER JOIN ns_host_relation AS nhr4 ON nhr4.host_host_id = h4.host_id
-WHERE
-    nhr4.nagios_server_id IN ({$ids})
-GROUP BY t4.command_id
-
-UNION
-
-SELECT
-    t.*
-FROM command AS t
-INNER JOIN service AS s ON
-    s.command_command_id = t.command_id OR
-    s.command_command_id2 = t.command_id
-INNER JOIN host_service_relation AS hsr ON
-    hsr.service_service_id = s.service_id
-LEFT JOIN hostgroup_relation AS hgr ON hgr.hostgroup_hg_id = hsr.hostgroup_hg_id
-LEFT JOIN ns_host_relation AS nhr ON
-	nhr.host_host_id = hsr.host_host_id OR
-	nhr.host_host_id = hgr.host_host_id
-WHERE
-    nhr.nagios_server_id IN ({$ids})
-GROUP BY t.command_id
-SQL;
-*/
-
         $sql = <<<SQL
 SELECT
     t3.command_id, t3.command_name, t3.command_line, t3.graph_id
@@ -174,11 +100,11 @@ SQL;
     {
         $sql = <<<SQL
 TRUNCATE TABLE `command`;
---TRUNCATE TABLE `connector`;
---TRUNCATE TABLE `command_arg_description`;
---TRUNCATE TABLE `command_categories_relation`;
---TRUNCATE TABLE `command_categories`;
---TRUNCATE TABLE `on_demand_macro_command`;
+TRUNCATE TABLE `connector`;
+TRUNCATE TABLE `command_arg_description`;
+TRUNCATE TABLE `command_categories_relation`;
+TRUNCATE TABLE `command_categories`;
+TRUNCATE TABLE `on_demand_macro_command`;
 SQL;
         $stmt = $this->db->prepare($sql);
         $stmt->execute();

--- a/src/Centreon/Domain/Repository/CommandRepository.php
+++ b/src/Centreon/Domain/Repository/CommandRepository.php
@@ -21,6 +21,7 @@ class CommandRepository extends ServiceEntityRepository
 
         $ids = join(',', $pollerIds);
 
+/*
         $sql = <<<SQL
 SELECT
     t1.*
@@ -92,6 +93,36 @@ WHERE
     nhr.nagios_server_id IN ({$ids})
 GROUP BY t.command_id
 SQL;
+*/
+
+        $sql = <<<SQL
+SELECT
+    t3.command_id, t3.command_name, t3.command_line, t3.graph_id
+FROM command AS t3
+INNER JOIN host AS h3 ON
+    h3.command_command_id = t3.command_id
+INNER JOIN ns_host_relation AS nhr3 ON nhr3.host_host_id = h3.host_id
+WHERE
+    nhr3.nagios_server_id IN ({$ids})
+GROUP BY t3.command_id
+
+UNION
+
+SELECT
+    t.command_id, t.command_name, t.command_line, t.graph_id
+FROM command AS t
+INNER JOIN service AS s ON
+    s.command_command_id = t.command_id
+INNER JOIN host_service_relation AS hsr ON
+    hsr.service_service_id = s.service_id
+LEFT JOIN hostgroup_relation AS hgr ON hgr.hostgroup_hg_id = hsr.hostgroup_hg_id
+LEFT JOIN ns_host_relation AS nhr ON
+	nhr.host_host_id = hsr.host_host_id OR
+	nhr.host_host_id = hgr.host_host_id
+WHERE
+    nhr.nagios_server_id IN ({$ids})
+GROUP BY t.command_id
+SQL;
         $stmt = $this->db->prepare($sql);
         $stmt->execute();
 
@@ -121,7 +152,8 @@ SQL;
 
         $sql = <<<SQL
 SELECT
-    t.*
+--    t.*
+    t.command_id, t.command_name, t.command_line, t.graph_id
 FROM command AS t
 WHERE t.command_id IN ({$ids})
 GROUP BY t.command_id
@@ -142,11 +174,11 @@ SQL;
     {
         $sql = <<<SQL
 TRUNCATE TABLE `command`;
-TRUNCATE TABLE `connector`;
-TRUNCATE TABLE `command_arg_description`;
-TRUNCATE TABLE `command_categories_relation`;
-TRUNCATE TABLE `command_categories`;
-TRUNCATE TABLE `on_demand_macro_command`;
+--TRUNCATE TABLE `connector`;
+--TRUNCATE TABLE `command_arg_description`;
+--TRUNCATE TABLE `command_categories_relation`;
+--TRUNCATE TABLE `command_categories`;
+--TRUNCATE TABLE `on_demand_macro_command`;
 SQL;
         $stmt = $this->db->prepare($sql);
         $stmt->execute();

--- a/src/Centreon/Domain/Repository/CommandRepository.php
+++ b/src/Centreon/Domain/Repository/CommandRepository.php
@@ -78,7 +78,6 @@ SQL;
 
         $sql = <<<SQL
 SELECT
---    t.*
     t.command_id, t.command_name, t.command_line, t.graph_id
 FROM command AS t
 WHERE t.command_id IN ({$ids})

--- a/src/Centreon/Domain/Repository/ExtendedHostInformationRepository.php
+++ b/src/Centreon/Domain/Repository/ExtendedHostInformationRepository.php
@@ -9,46 +9,29 @@ class ExtendedHostInformationRepository extends ServiceEntityRepository
     /**
      * Export host's macros
      *
-     * @param int[] $pollerIds
+     * @param int[] $hostList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $hostList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$hostList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $hostList = array_merge($hostList, $templateChainList);
+        }
+
+        $ids = join(',', $hostList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM extended_host_information AS t
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = t.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE t.host_host_id IN ({$ids})
 GROUP BY t.ehi_id
-SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM extended_host_information AS tt
-WHERE tt.host_host_id IN ({$list})
-GROUP BY tt.ehi_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.ehi_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/ExtendedServiceInformationRepository.php
+++ b/src/Centreon/Domain/Repository/ExtendedServiceInformationRepository.php
@@ -9,51 +9,29 @@ class ExtendedServiceInformationRepository extends ServiceEntityRepository
     /**
      * Export host's macros
      *
-     * @todo restriction by poller
-     *
-     * @param int[] $pollerIds
+     * @param int[] $serviceList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM extended_service_information AS t
-INNER JOIN host_service_relation AS hsr ON hsr.service_service_id = t.service_service_id
-LEFT JOIN hostgroup AS hg ON hg.hg_id = hsr.hostgroup_hg_id
-LEFT JOIN hostgroup_relation AS hgr ON hgr.hostgroup_hg_id = hg.hg_id
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = hsr.host_host_id OR hr.host_host_id = hgr.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE t.service_service_id IN ({$ids})
 GROUP BY t.esi_id
-SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM extended_service_information AS tt
-WHERE tt.service_service_id IN ({$list})
-GROUP BY tt.esi_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.esi_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/HostCategoryRelationRepository.php
+++ b/src/Centreon/Domain/Repository/HostCategoryRelationRepository.php
@@ -9,33 +9,29 @@ class HostCategoryRelationRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @param int[] $pollerIds
+     * @param int[] $hostList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $hostList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$hostList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $hostList = array_merge($hostList, $templateChainList);
+        }
+
+        $ids = join(',', $hostList);
 
         $sql = <<<SQL
 SELECT
     t.*
 FROM hostcategories_relation AS t
-LEFT JOIN ns_host_relation AS hr ON hr.host_host_id = t.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE t.host_host_id IN ({$ids})
 SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-OR t.host_host_id IN ({$list})
-SQL;
-        }
 
         $stmt = $this->db->prepare($sql);
         $stmt->execute();

--- a/src/Centreon/Domain/Repository/HostCategoryRepository.php
+++ b/src/Centreon/Domain/Repository/HostCategoryRepository.php
@@ -9,47 +9,30 @@ class HostCategoryRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @param int[] $pollerIds
+     * @param int[] $hostList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $hostList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$hostList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $hostList = array_merge($hostList, $templateChainList);
+        }
+
+        $ids = join(',', $hostList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM hostcategories AS t
 INNER JOIN hostcategories_relation AS hc ON hc.hostcategories_hc_id = t.hc_id
-INNER JOIN host AS h ON h.host_id = hc.host_host_id
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = h.host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE hc.host_host_id IN ({$ids})
 GROUP BY t.hc_id
-SQL;
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM hostcategories AS tt
-INNER JOIN hostcategories_relation AS hc ON hc.hostcategories_hc_id = tt.hc_id AND hc.host_host_id IN ({$list})
-GROUP BY tt.hc_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.hc_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/HostGroupRelationRepository.php
+++ b/src/Centreon/Domain/Repository/HostGroupRelationRepository.php
@@ -9,46 +9,29 @@ class HostGroupRelationRepository extends ServiceEntityRepository
     /**
      * Export host's groups
      *
-     * @param int[] $pollerIds
+     * @param int[] $hostList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $hostList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$hostList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $hostList = array_merge($hostList, $templateChainList);
+        }
+
+        $ids = join(',', $hostList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM hostgroup_relation AS t
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = t.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE t.host_host_id IN ({$ids})
 GROUP BY t.hgr_id
-SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM hostgroup_relation AS tt
-WHERE tt.host_host_id IN ({$list})
-GROUP BY tt.hgr_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.hgr_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/HostGroupRepository.php
+++ b/src/Centreon/Domain/Repository/HostGroupRepository.php
@@ -9,47 +9,30 @@ class HostGroupRepository extends ServiceEntityRepository
     /**
      * Export host's groups
      *
-     * @param int[] $pollerIds
+     * @param int[] $hostList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $hostList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$hostList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $hostList = array_merge($hostList, $templateChainList);
+        }
+
+        $ids = join(',', $hostList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM hostgroup AS t
 INNER JOIN hostgroup_relation AS hg ON hg.hostgroup_hg_id = t.hg_id
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = hg.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE hg.host_host_id IN ({$ids})
 GROUP BY t.hg_id
-SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM hostgroup AS tt
-INNER JOIN hostgroup_relation AS hg ON hg.hostgroup_hg_id = tt.hg_id AND hg.host_host_id IN ({$list})
-GROUP BY tt.hg_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.hg_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/HostServiceRelationRepository.php
+++ b/src/Centreon/Domain/Repository/HostServiceRelationRepository.php
@@ -9,19 +9,19 @@ class HostServiceRelationRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @todo restriction by poller
+     * @todo restriction by service IDs
      *
-     * @param int[] $pollerIds
+     * @param int[] $serviceIds
      * @return array
      */
-    public function export(array $pollerIds, array $ba = null): array
+    public function export(array $serviceIds, array $ba = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceIds) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        $ids = join(',', $serviceIds);
 
         $sql = <<<SQL
 SELECT l.* FROM (

--- a/src/Centreon/Domain/Repository/HostTemplateRelationRepository.php
+++ b/src/Centreon/Domain/Repository/HostTemplateRelationRepository.php
@@ -10,45 +10,29 @@ class HostTemplateRelationRepository extends ServiceEntityRepository
     /**
      * Export host's templates relation
      *
-     * @param int[] $pollerIds
+     * @param int[] $hostList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $hostList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$hostList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $hostList = array_merge($hostList, $templateChainList);
+        }
+
+        $ids = join(',', $hostList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM host_template_relation AS t
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = t.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE t.host_host_id IN ({$ids})
 GROUP BY t.host_host_id, t.host_tpl_id
-SQL;
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM host_template_relation AS tt
-WHERE tt.host_host_id IN ({$list})
-GROUP BY tt.host_host_id, tt.host_tpl_id
-SQL;
-        }
-        
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.host_host_id, l.host_tpl_id
 SQL;
 
         $stmt = $this->db->prepare($sql);
@@ -128,6 +112,61 @@ SQL;
         $stmt = $this->db->prepare($sql);
         $stmt->bindValue(':id', $id, PDO::PARAM_INT);
         $stmt->execute();
+
+        while ($row = $stmt->fetch()) {
+            $result[$row['id']] = $row['id'];
+            
+            $this->getChainByParant($row['id'], $result);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get a chain of the related objects
+     *
+     * @param int[] $hostList
+     * @param int[] $ba
+     * @return array
+     */
+    public function getChainByHostIds(array $hostList, array $ba = null): array
+    {
+        // prevent SQL exception
+        if (!$hostList) {
+            return [];
+        }
+
+        $ids = join(',', $hostList);
+
+        $sql = <<<SQL
+SELECT l.* FROM (
+SELECT
+    t.host_tpl_id AS `id`
+FROM host_template_relation AS t
+INNER JOIN ns_host_relation AS hr ON hr.host_host_id = t.host_host_id
+WHERE hr.host_host_id IN ({$ids})
+GROUP BY t.host_tpl_id
+SQL;
+
+        // Extract BA hosts
+        if ($ba) {
+            foreach ($ba as $key => $val) {
+                $ba[$key] = "'ba_{$val}'";
+            }
+
+            $ba = implode(',', $ba);
+            $sql .= " UNION SELECT t2.host_host_id AS `id`"
+                . " FROM host_service_relation AS t2"
+                . " INNER JOIN service s2 ON s2.service_id = t2.service_service_id"
+                . " AND s2.service_description IN({$ba}) GROUP BY t2.host_host_id";
+        }
+
+        $sql .= ") AS l GROUP BY l.id";
+
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute();
+
+        $result = [];
 
         while ($row = $stmt->fetch()) {
             $result[$row['id']] = $row['id'];

--- a/src/Centreon/Domain/Repository/OnDemandMacroHostRepository.php
+++ b/src/Centreon/Domain/Repository/OnDemandMacroHostRepository.php
@@ -9,46 +9,29 @@ class OnDemandMacroHostRepository extends ServiceEntityRepository
     /**
      * Export host's macros
      *
-     * @param int[] $pollerIds
+     * @param int[] $hostList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $hostList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$hostList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $hostList = array_merge($hostList, $templateChainList);
+        }
+
+        $ids = join(',', $hostList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM on_demand_macro_host AS t
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = t.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE t.host_host_id IN ({$ids})
 GROUP BY t.host_macro_id
-SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM on_demand_macro_host AS tt
-WHERE tt.host_host_id IN ({$list})
-GROUP BY tt.host_macro_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.host_macro_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/OnDemandMacroServiceRepository.php
+++ b/src/Centreon/Domain/Repository/OnDemandMacroServiceRepository.php
@@ -9,51 +9,29 @@ class OnDemandMacroServiceRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @todo restriction by poller
-     *
-     * @param int[] $pollerIds
+     * @param int[] $serviceList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM on_demand_macro_service AS t
-INNER JOIN host_service_relation AS hsr ON hsr.service_service_id = t.svc_svc_id
-LEFT JOIN hostgroup AS hg ON hg.hg_id = hsr.hostgroup_hg_id
-LEFT JOIN hostgroup_relation AS hgr ON hgr.hostgroup_hg_id = hg.hg_id
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = hsr.host_host_id OR hr.host_host_id = hgr.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE t.svc_svc_id IN ({$ids})
 GROUP BY t.svc_macro_id
-SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM on_demand_macro_service AS tt
-WHERE tt.svc_svc_id IN ({$list})
-GROUP BY tt.svc_macro_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.svc_macro_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/ServiceCategoryRelationRepository.php
+++ b/src/Centreon/Domain/Repository/ServiceCategoryRelationRepository.php
@@ -9,51 +9,29 @@ class ServiceCategoryRelationRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @todo restriction by poller
-     *
-     * @param int[] $pollerIds
+     * @param int[] $serviceList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM service_categories_relation AS t
-INNER JOIN host_service_relation AS hsr ON hsr.service_service_id = t.service_service_id
-LEFT JOIN hostgroup AS hg ON hg.hg_id = hsr.hostgroup_hg_id
-LEFT JOIN hostgroup_relation AS hgr ON hgr.hostgroup_hg_id = hg.hg_id
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = hsr.host_host_id OR hr.host_host_id = hgr.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE t.service_service_id IN ({$ids})
 GROUP BY t.scr_id
-SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM service_categories_relation AS tt
-WHERE tt.service_service_id IN ({$list})
-GROUP BY tt.scr_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.scr_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/ServiceCategoryRepository.php
+++ b/src/Centreon/Domain/Repository/ServiceCategoryRepository.php
@@ -8,50 +8,30 @@ class ServiceCategoryRepository extends ServiceEntityRepository
 
     /**
      * Export
-     * @param int[] $pollerIds
+     * @param int[] $serviceLists
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM service_categories AS t
 INNER JOIN service_categories_relation AS scr ON scr.sc_id = t.sc_id
-INNER JOIN host_service_relation AS hsr ON hsr.service_service_id = scr.service_service_id
-LEFT JOIN hostgroup AS hg ON hg.hg_id = hsr.hostgroup_hg_id
-LEFT JOIN hostgroup_relation AS hgr ON hgr.hostgroup_hg_id = hg.hg_id
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = hsr.host_host_id OR hr.host_host_id = hgr.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE scr.service_service_id IN ({$ids})
 GROUP BY t.sc_id
-SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM service_categories AS tt
-INNER JOIN service_categories_relation AS _scr ON _scr.sc_id = tt.sc_id AND _scr.service_service_id IN ({$list})
-GROUP BY tt.sc_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.sc_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/ServiceGroupRelationRepository.php
+++ b/src/Centreon/Domain/Repository/ServiceGroupRelationRepository.php
@@ -9,50 +9,29 @@ class ServiceGroupRelationRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @todo restriction by poller
-     *
-     * @param int[] $pollerIds
+     * @param int[] $serviceList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM servicegroup_relation AS t
-LEFT JOIN hostgroup AS hg ON hg.hg_id = t.hostgroup_hg_id
-LEFT JOIN hostgroup_relation AS hgr ON hgr.hostgroup_hg_id = hg.hg_id
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = t.host_host_id OR hr.host_host_id = hgr.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE t.service_service_id IN ({$ids})
 GROUP BY t.sgr_id
-SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM servicegroup_relation AS tt
-WHERE tt.service_service_id IN ({$list})
-GROUP BY tt.sgr_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.sgr_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/ServiceGroupRepository.php
+++ b/src/Centreon/Domain/Repository/ServiceGroupRepository.php
@@ -9,51 +9,30 @@ class ServiceGroupRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @todo restriction by poller
-     *
-     * @param int[] $pollerIds
+     * @param int[] $serviceList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
 
         $sql = <<<SQL
-SELECT l.* FROM(
 SELECT
     t.*
 FROM servicegroup AS t
 INNER JOIN servicegroup_relation AS sgr ON sgr.servicegroup_sg_id = t.sg_id
-LEFT JOIN hostgroup AS hg ON hg.hg_id = sgr.hostgroup_hg_id
-LEFT JOIN hostgroup_relation AS hgr ON hgr.hostgroup_hg_id = hg.hg_id
-INNER JOIN ns_host_relation AS hr ON hr.host_host_id = sgr.host_host_id OR hr.host_host_id = hgr.host_host_id
-WHERE hr.nagios_server_id IN ({$ids})
+WHERE sgr.service_service_id IN ({$ids})
 GROUP BY t.sg_id
-SQL;
-
-        if ($templateChainList) {
-            $list = join(',', $templateChainList);
-            $sql .= <<<SQL
-
-UNION
-
-SELECT
-    tt.*
-FROM servicegroup AS tt
-INNER JOIN servicegroup_relation AS _sgr ON _sgr.servicegroup_sg_id = tt.sg_id AND _sgr.service_service_id IN ({$list})
-GROUP BY tt.sg_id
-SQL;
-        }
-
-        $sql .= <<<SQL
-) AS l
-GROUP BY l.sg_id
 SQL;
 
         $stmt = $this->db->prepare($sql);

--- a/src/Centreon/Domain/Repository/ServiceRepository.php
+++ b/src/Centreon/Domain/Repository/ServiceRepository.php
@@ -107,8 +107,10 @@ SQL;
         $result = [];
 
         while ($row = $stmt->fetch()) {
-            $result[$row['id']] = $row['id'];
-            $this->getChainByParant($row['id'], $result);
+            if ($row['id']) {
+                $result[$row['id']] = $row['id'];
+                $this->getChainByParant($row['id'], $result);
+            }
         }
 
         return $result;

--- a/src/Centreon/Domain/Repository/TrapGroupRelationRepository.php
+++ b/src/Centreon/Domain/Repository/TrapGroupRelationRepository.php
@@ -9,28 +9,29 @@ class TrapGroupRelationRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @param int[] $pollerIds
+     * @param int[] $serviceList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
-        $list = join(',', $templateChainList ?? []);
-        $sqlFilterList = $list ? " OR tsr.service_id IN ({$list})" : '';
-        $sqlFilter = TrapRepository::exportFilterSql($pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
+
         $sql = <<<SQL
 SELECT
     t.*
 FROM traps_group_relation AS t
-INNER JOIN traps_service_relation AS tsr ON
-    tsr.traps_id = t.traps_id AND
-    (tsr.service_id IN ({$sqlFilter}){$sqlFilterList})
+INNER JOIN traps_service_relation AS tsr ON tsr.traps_id = t.traps_id
+WHERE tsr.service_id IN ($ids)
 GROUP BY t.traps_id, t.traps_group_id
 SQL;
 

--- a/src/Centreon/Domain/Repository/TrapMatchingPropsRepository.php
+++ b/src/Centreon/Domain/Repository/TrapMatchingPropsRepository.php
@@ -9,29 +9,29 @@ class TrapMatchingPropsRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @param int[] $pollerIds
+     * @param int[] $serviceList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
-        $list = join(',', $templateChainList ?? []);
-        $sqlFilterList = $list ? " OR tsr.service_id IN ({$list})" : '';
-        $sqlFilter = TrapRepository::exportFilterSql($pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
 
         $sql = <<<SQL
 SELECT
     t.*
 FROM traps_matching_properties AS t
-INNER JOIN traps_service_relation AS tsr ON
-    tsr.traps_id = t.trap_id AND
-    (tsr.service_id IN ({$sqlFilter}){$sqlFilterList})
+INNER JOIN traps_service_relation AS tsr ON tsr.traps_id = t.trap_id
+WHERE tsr.service_id IN ($ids)
 GROUP BY t.tmo_id
 SQL;
 

--- a/src/Centreon/Domain/Repository/TrapPreexecRepository.php
+++ b/src/Centreon/Domain/Repository/TrapPreexecRepository.php
@@ -9,28 +9,29 @@ class TrapPreexecRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @param int[] $pollerIds
+     * @param int[] $serviceList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
-        $list = join(',', $templateChainList ?? []);
-        $sqlFilterList = $list ? " OR tsr.service_id IN ({$list})" : '';
-        $sqlFilter = TrapRepository::exportFilterSql($pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
+
         $sql = <<<SQL
 SELECT
     t.*
 FROM traps_preexec AS t
-INNER JOIN traps_service_relation AS tsr ON
-    tsr.traps_id = t.trap_id AND
-    (tsr.service_id IN ({$sqlFilter}){$sqlFilterList})
+INNER JOIN traps_service_relation AS tsr ON tsr.traps_id = t.trap_id
+WHERE tsr.service_id IN ($ids)
 GROUP BY t.trap_id
 SQL;
 

--- a/src/Centreon/Domain/Repository/TrapServiceRelationRepository.php
+++ b/src/Centreon/Domain/Repository/TrapServiceRelationRepository.php
@@ -13,22 +13,24 @@ class TrapServiceRelationRepository extends ServiceEntityRepository
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
-        $list = join(',', $templateChainList ?? []);
-        $sqlFilterList = $list ? " OR t.service_id IN ({$list})" : '';
-        $sqlFilter = TrapRepository::exportFilterSql($pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
+
         $sql = <<<SQL
 SELECT
     t.*
 FROM traps_service_relation AS t
-WHERE t.service_id IN ({$sqlFilter}){$sqlFilterList}
+WHERE t.service_id IN ({$ids})
 SQL;
         $stmt = $this->db->prepare($sql);
         $stmt->execute();

--- a/src/Centreon/Domain/Repository/TrapVendorRepository.php
+++ b/src/Centreon/Domain/Repository/TrapVendorRepository.php
@@ -9,29 +9,30 @@ class TrapVendorRepository extends ServiceEntityRepository
     /**
      * Export
      *
-     * @param int[] $pollerIds
+     * @param int[] $serviceList
      * @param array $templateChainList
      * @return array
      */
-    public function export(array $pollerIds, array $templateChainList = null): array
+    public function export(array $serviceList, array $templateChainList = null): array
     {
         // prevent SQL exception
-        if (!$pollerIds) {
+        if (!$serviceList) {
             return [];
         }
 
-        $ids = join(',', $pollerIds);
-        $list = join(',', $templateChainList ?? []);
-        $sqlFilterList = $list ? " OR tsr.service_id IN ({$list})" : '';
-        $sqlFilter = TrapRepository::exportFilterSql($pollerIds);
+        if ($templateChainList) {
+            $serviceList = array_merge($serviceList, $templateChainList);
+        }
+
+        $ids = implode(',', $serviceList);
+
         $sql = <<<SQL
 SELECT
     t.*
 FROM traps_vendor AS t
 INNER JOIN traps AS tr ON tr.manufacturer_id = t.id
-INNER JOIN traps_service_relation AS tsr ON
-    tsr.traps_id = tr.traps_id AND
-    (tsr.service_id IN ({$sqlFilter}){$sqlFilterList})
+INNER JOIN traps_service_relation AS tsr ON tsr.traps_id = tr.traps_id
+WHERE tsr.service_id IN ({$ids})
 GROUP BY t.id
 SQL;
 

--- a/src/CentreonRemote/Domain/Exporter/CommandExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/CommandExporter.php
@@ -43,6 +43,7 @@ class CommandExporter extends ExporterServiceAbstract implements ExporterService
             $this->_dump($command, $this->getFile(static::EXPORT_FILE_COMMAND));
         })();
 
+        /* Not necessary for Remote Server export
         (function () use ($pollerIds) {
             $commandArg = $this->db
                 ->getRepository(Repository\CommandArgDescriptionRepository::class)
@@ -82,6 +83,7 @@ class CommandExporter extends ExporterServiceAbstract implements ExporterService
             ;
             $this->_dump($categoryRelation, $this->getFile(static::EXPORT_FILE_CATEGORY_RELATION));
         })();
+        */
     }
 
     public function exportPartial(): void

--- a/src/CentreonRemote/Domain/Exporter/CommandExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/CommandExporter.php
@@ -42,48 +42,6 @@ class CommandExporter extends ExporterServiceAbstract implements ExporterService
             ;
             $this->_dump($command, $this->getFile(static::EXPORT_FILE_COMMAND));
         })();
-
-        /* Not necessary for Remote Server export
-        (function () use ($pollerIds) {
-            $commandArg = $this->db
-                ->getRepository(Repository\CommandArgDescriptionRepository::class)
-                ->export($pollerIds)
-            ;
-            $this->_dump($commandArg, $this->getFile(static::EXPORT_FILE_COMMAND_ARG));
-        })();
-
-        (function () use ($pollerIds) {
-            $commandMacro = $this->db
-                ->getRepository(Repository\OnDemandMacroCommandRepository::class)
-                ->export($pollerIds)
-            ;
-            $this->_dump($commandMacro, $this->getFile(static::EXPORT_FILE_COMMAND_MACRO));
-        })();
-
-        (function () use ($pollerIds) {
-            $connector = $this->db
-                ->getRepository(Repository\ConnectorRepository::class)
-                ->export($pollerIds)
-            ;
-            $this->_dump($connector, $this->getFile(static::EXPORT_FILE_CONNECTOR));
-        })();
-
-        (function () use ($pollerIds) {
-            $category = $this->db
-                ->getRepository(Repository\CommandCategoryRepository::class)
-                ->export($pollerIds)
-            ;
-            $this->_dump($category, $this->getFile(static::EXPORT_FILE_CATEGORY));
-        })();
-
-        (function () use ($pollerIds) {
-            $categoryRelation = $this->db
-                ->getRepository(Repository\CommandCategoryRelationRepository::class)
-                ->export($pollerIds)
-            ;
-            $this->_dump($categoryRelation, $this->getFile(static::EXPORT_FILE_CATEGORY_RELATION));
-        })();
-        */
     }
 
     public function exportPartial(): void

--- a/src/CentreonRemote/Domain/Exporter/HostExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/HostExporter.php
@@ -87,6 +87,7 @@ class HostExporter extends ExporterServiceAbstract
             $this->_dump($hostGroupRelation, $this->getFile(static::EXPORT_FILE_GROUP_RELATION));
         })();
 
+        /* Not necessary for Remote Server export
         (function () use ($pollerIds, $hostTemplateChain) {
             $hostGroupHgRelation = $this->db
                 ->getRepository(Repository\HostGroupHgRelationRepository::class)
@@ -94,6 +95,7 @@ class HostExporter extends ExporterServiceAbstract
             ;
             $this->_dump($hostGroupHgRelation, $this->getFile(static::EXPORT_FILE_GROUP_HG_RELATION));
         })();
+        */
 
         (function () use ($pollerIds, $hostTemplateChain) {
             $hostInfo = $this->db
@@ -180,6 +182,7 @@ class HostExporter extends ExporterServiceAbstract
             }
         })();
 
+        /* Not necessary for Remote Server export
         // insert group to group relation
         (function () use ($db) {
             $exportPathFile = $this->getFile(static::EXPORT_FILE_GROUP_HG_RELATION);
@@ -189,6 +192,7 @@ class HostExporter extends ExporterServiceAbstract
                 $db->insert('hostgroup_hg_relation', $data);
             }
         })();
+        */
 
         // insert categories
         (function () use ($db) {
@@ -200,7 +204,7 @@ class HostExporter extends ExporterServiceAbstract
             }
         })();
 
-        // insert categories
+        // insert categories relations
         (function () use ($db) {
             $exportPathFile = $this->getFile(static::EXPORT_FILE_CATEGORY_RELATION);
             $result = $this->_parse($exportPathFile);

--- a/src/CentreonRemote/Domain/Exporter/HostExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/HostExporter.php
@@ -110,16 +110,6 @@ class HostExporter extends ExporterServiceAbstract
             $this->_dump($hostGroupRelation, $this->getFile(static::EXPORT_FILE_GROUP_RELATION));
         })();
 
-        /* Not necessary for Remote Server export
-        (function () use ($pollerIds, $hostTemplateChain) {
-            $hostGroupHgRelation = $this->db
-                ->getRepository(Repository\HostGroupHgRelationRepository::class)
-                ->export($pollerIds, $hostTemplateChain)
-            ;
-            $this->_dump($hostGroupHgRelation, $this->getFile(static::EXPORT_FILE_GROUP_HG_RELATION));
-        })();
-        */
-
         // Extract extended information of hosts
         (function () use ($hostList, $hostTemplateChain) {
             $hostInfo = $this->db
@@ -207,18 +197,6 @@ class HostExporter extends ExporterServiceAbstract
                 $db->insert('hostgroup_relation', $data);
             }
         })();
-
-        /* Not necessary for Remote Server export
-        // insert group to group relation
-        (function () use ($db) {
-            $exportPathFile = $this->getFile(static::EXPORT_FILE_GROUP_HG_RELATION);
-            $result = $this->_parse($exportPathFile);
-
-            foreach ($result as $data) {
-                $db->insert('hostgroup_hg_relation', $data);
-            }
-        })();
-        */
 
         // insert categories
         (function () use ($db) {

--- a/src/CentreonRemote/Domain/Exporter/PollerExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/PollerExporter.php
@@ -67,16 +67,6 @@ class PollerExporter extends ExporterServiceAbstract
             $this->_dump($data, $this->getFile(static::EXPORT_FILE_CFG_RESOURCE_INSTANCE_RELATION));
         })();
 
-        /* Not necessary for Remote Server export
-        (function () use ($pollerIds) {
-            $pollerCommand = $this->db
-                ->getRepository(Repository\PollerCommandRelationsRepository::class)
-                ->export($pollerIds)
-            ;
-            $this->_dump($pollerCommand, $this->getFile(static::EXPORT_FILE_POLLER_COMMAND));
-        })();
-        */
-
         (function () use ($pollerIds, $overwritePollerService) {
             $cfgNagios = $this->db
                 ->getRepository(Repository\CfgNagiosRepository::class)
@@ -108,16 +98,6 @@ class PollerExporter extends ExporterServiceAbstract
             $cfgCentreonBrokerInfo = $overwritePollerService->getCfgCentreonBrokerInfo($cfgCentreonBrokerInfo);
             $this->_dump($cfgCentreonBrokerInfo, $this->getFile(static::EXPORT_FILE_CFG_CENTREONBROKER_INFO));
         })();
-
-        /* Not necessary for Remote Server export
-        (function () use ($pollerIds) {
-            $timezone = $this->db
-                ->getRepository(Repository\TimezoneRepository::class)
-                ->export($pollerIds)
-            ;
-            $this->_dump($timezone, $this->getFile(static::EXPORT_FILE_TIMEZONE));
-        })();
-        */
     }
 
     /**

--- a/src/CentreonRemote/Domain/Exporter/PollerExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/PollerExporter.php
@@ -67,6 +67,7 @@ class PollerExporter extends ExporterServiceAbstract
             $this->_dump($data, $this->getFile(static::EXPORT_FILE_CFG_RESOURCE_INSTANCE_RELATION));
         })();
 
+        /* Not necessary for Remote Server export
         (function () use ($pollerIds) {
             $pollerCommand = $this->db
                 ->getRepository(Repository\PollerCommandRelationsRepository::class)
@@ -74,6 +75,7 @@ class PollerExporter extends ExporterServiceAbstract
             ;
             $this->_dump($pollerCommand, $this->getFile(static::EXPORT_FILE_POLLER_COMMAND));
         })();
+        */
 
         (function () use ($pollerIds, $overwritePollerService) {
             $cfgNagios = $this->db
@@ -107,6 +109,7 @@ class PollerExporter extends ExporterServiceAbstract
             $this->_dump($cfgCentreonBrokerInfo, $this->getFile(static::EXPORT_FILE_CFG_CENTREONBROKER_INFO));
         })();
 
+        /* Not necessary for Remote Server export
         (function () use ($pollerIds) {
             $timezone = $this->db
                 ->getRepository(Repository\TimezoneRepository::class)
@@ -114,6 +117,7 @@ class PollerExporter extends ExporterServiceAbstract
             ;
             $this->_dump($timezone, $this->getFile(static::EXPORT_FILE_TIMEZONE));
         })();
+        */
     }
 
     /**

--- a/src/CentreonRemote/Domain/Exporter/ServiceExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/ServiceExporter.php
@@ -120,7 +120,7 @@ class ServiceExporter extends ExporterServiceAbstract
             $this->_dump($serviceCategoryRelation, $this->getFile(static::EXPORT_FILE_CATEGORY_RELATION));
         })();
 
-        // Extract on demande macros data used by services
+        // Extract on demand macros data used by services
         (function () use ($serviceList, $serviceTemplateChain) {
             $serviceMacros = $this->db
                 ->getRepository(Repository\OnDemandMacroServiceRepository::class)

--- a/src/CentreonRemote/Infrastructure/Service/ExportService.php
+++ b/src/CentreonRemote/Infrastructure/Service/ExportService.php
@@ -83,11 +83,14 @@ class ExportService
         $partials = [];
         $interface = ExporterServicePartialInterface::class;
 
+        echo "\n";
         foreach ($this->exporter->all() as $exporterMeta) {
             if ($filterExporters && !in_array($exporterMeta['classname'], $filterExporters)) {
                 continue;
             }
 
+            $datetime = (new \DateTime())->format("Y-m-d H:i:s"); // DEBUG
+            echo "{$datetime} - Start export {$exporterMeta['name']} \n"; // DEBUG
             $exporter = $exporterMeta['factory']();
             $exporter->setCommitment($commitment);
             $exporter->setManifest($manifest);
@@ -102,6 +105,8 @@ class ExportService
 
             // add exporter to manifest
             $manifest->addExporter($exporterMeta['classname']);
+            $datetime = (new \DateTime())->format("Y-m-d H:i:s"); // DEBUG
+            echo "{$datetime} - End export {$exporterMeta['name']} \n"; //DEBUG
         }
 
         // export partial data

--- a/src/CentreonRemote/Infrastructure/Service/ExportService.php
+++ b/src/CentreonRemote/Infrastructure/Service/ExportService.php
@@ -83,7 +83,6 @@ class ExportService
         $partials = [];
         $interface = ExporterServicePartialInterface::class;
 
-        echo "\n";
         foreach ($this->exporter->all() as $exporterMeta) {
             if ($filterExporters && !in_array($exporterMeta['classname'], $filterExporters)) {
                 continue;

--- a/src/CentreonRemote/Infrastructure/Service/ExportService.php
+++ b/src/CentreonRemote/Infrastructure/Service/ExportService.php
@@ -89,8 +89,6 @@ class ExportService
                 continue;
             }
 
-            $datetime = (new \DateTime())->format("Y-m-d H:i:s"); // DEBUG
-            echo "{$datetime} - Start export {$exporterMeta['name']} \n"; // DEBUG
             $exporter = $exporterMeta['factory']();
             $exporter->setCommitment($commitment);
             $exporter->setManifest($manifest);
@@ -105,8 +103,6 @@ class ExportService
 
             // add exporter to manifest
             $manifest->addExporter($exporterMeta['classname']);
-            $datetime = (new \DateTime())->format("Y-m-d H:i:s"); // DEBUG
-            echo "{$datetime} - End export {$exporterMeta['name']} \n"; //DEBUG
         }
 
         // export partial data

--- a/src/CentreonRemote/ServiceProvider.php
+++ b/src/CentreonRemote/ServiceProvider.php
@@ -169,6 +169,7 @@ class ServiceProvider implements AutoloadServiceProviderInterface
             return $service;
         });
         
+        /* Not necessary for Remote Server export
         // Meta services
         $pimple['centreon_remote.exporter']->add(Domain\Exporter\MetaServiceExporter::class, function () use ($pimple) {
             $services = [
@@ -180,6 +181,7 @@ class ServiceProvider implements AutoloadServiceProviderInterface
 
             return $service;
         });
+        */
         
         // Services
         $pimple['centreon_remote.exporter']->add(Domain\Exporter\ServiceExporter::class, function () use ($pimple) {

--- a/src/CentreonRemote/ServiceProvider.php
+++ b/src/CentreonRemote/ServiceProvider.php
@@ -169,20 +169,6 @@ class ServiceProvider implements AutoloadServiceProviderInterface
             return $service;
         });
         
-        /* Not necessary for Remote Server export
-        // Meta services
-        $pimple['centreon_remote.exporter']->add(Domain\Exporter\MetaServiceExporter::class, function () use ($pimple) {
-            $services = [
-                \Centreon\ServiceProvider::CENTREON_DB_MANAGER,
-            ];
-
-            $locator = new ServiceLocator($pimple, $services);
-            $service = new Domain\Exporter\MetaServiceExporter($locator);
-
-            return $service;
-        });
-        */
-        
         // Services
         $pimple['centreon_remote.exporter']->add(Domain\Exporter\ServiceExporter::class, function () use ($pimple) {
             $services = [
@@ -218,20 +204,6 @@ class ServiceProvider implements AutoloadServiceProviderInterface
 
             return $service;
         });
-        
-        /* Not necessary for Remote Server export
-        // Downtimes
-        $pimple['centreon_remote.exporter']->add(Domain\Exporter\DowntimeExporter::class, function () use ($pimple) {
-            $services = [
-                \Centreon\ServiceProvider::CENTREON_DB_MANAGER,
-            ];
-
-            $locator = new ServiceLocator($pimple, $services);
-            $service = new Domain\Exporter\DowntimeExporter($locator);
-
-            return $service;
-        });
-        */
         
         // Graphs
         $pimple['centreon_remote.exporter']->add(Domain\Exporter\GraphExporter::class, function () use ($pimple) {

--- a/src/CentreonRemote/ServiceProvider.php
+++ b/src/CentreonRemote/ServiceProvider.php
@@ -217,6 +217,7 @@ class ServiceProvider implements AutoloadServiceProviderInterface
             return $service;
         });
         
+        /* Not necessary for Remote Server export
         // Downtimes
         $pimple['centreon_remote.exporter']->add(Domain\Exporter\DowntimeExporter::class, function () use ($pimple) {
             $services = [
@@ -228,6 +229,7 @@ class ServiceProvider implements AutoloadServiceProviderInterface
 
             return $service;
         });
+        */
         
         // Graphs
         $pimple['centreon_remote.exporter']->add(Domain\Exporter\GraphExporter::class, function () use ($pimple) {

--- a/src/CentreonRemote/Tests/ServiceProviderTest.php
+++ b/src/CentreonRemote/Tests/ServiceProviderTest.php
@@ -97,11 +97,9 @@ class ServiceProviderTest extends TestCase
     {
         $checkList = [
             Exporter\CommandExporter::class,
-            Exporter\DowntimeExporter::class,
             Exporter\GraphExporter::class,
             Exporter\HostExporter::class,
             Exporter\MediaExporter::class,
-            Exporter\MetaServiceExporter::class,
             Exporter\PollerExporter::class,
             Exporter\ServiceExporter::class,
             Exporter\TimePeriodExporter::class,


### PR DESCRIPTION
## Description

- Use cache to store services IDs list
- Use cache to store hosts IDs list
- Use cache to store SNMP Traps IDs list
- Remove meta-service for export (not available on Remote Server)
- Remote Downtimes for export (not available on Remote Server)
- Export SNMP Traps linked to templates of services

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Make an export with 3K hosts and 20K services, the duration was around 5min30s.
With patch the new duration is about 1min30.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
