### PR TITLE
fix(remote-server): filter output to master on NEB category only

### DIFF
--- a/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputForwardMaster.php
+++ b/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputForwardMaster.php
@@ -142,6 +142,22 @@ class OutputForwardMaster
                 'config_group_id' => '3',
                 'grp_level'       => '0',
             ],
+            [
+                'config_key'      => 'filters',
+                'config_value'    => '',
+                'config_group'    => 'output',
+                'config_group_id' => '3',
+                'grp_level'       => '0',
+                'subgrp_id'       => '1',
+            ],
+            [
+                'config_key'      => 'category',
+                'config_value'    => 'neb',
+                'config_group'    => 'output',
+                'config_group_id' => '3',
+                'grp_level'       => '1',
+                'parent_grp_id'   => '1',
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Description

The actual Centreon Remote default configuration made by the wizard doesn't filter IPv4 output to Centreon central server.
This can generate conflict with RRD on Centreon central server.
This PR create an output to forward data with the NEB filter as category.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
