### PR TITLE
chore(ui): Wrap App into StylesProvider with injectFirst to allow emotion styling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -924,35 +924,6 @@
             "warning": "^4.0.1"
           }
         },
-        "@material-ui/icons": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.0.1.tgz",
-          "integrity": "sha512-03zUfksGXXbaWX2piB1LCmC28eydlT8ah8MbYT4n4mgiX9BTL4HH50lkFn9JIJJSk2oO5kRy4FvpXRGRBI+oxw==",
-          "requires": {
-            "@babel/runtime": "^7.2.0"
-          }
-        },
-        "@material-ui/system": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.3.0.tgz",
-          "integrity": "sha512-VQh3mWZSmzm1JR7Ci35AHKwOhhxHHMrBWCdP4mh7UAwSdjWBE6s2Y9Y0iJiqMoEsHP64vU3W1JpsW2AgkUeHsQ==",
-          "requires": {
-            "@babel/runtime": "^7.2.0",
-            "deepmerge": "^3.0.0",
-            "prop-types": "^15.7.2",
-            "warning": "^4.0.1"
-          }
-        },
-        "@material-ui/utils": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.1.0.tgz",
-          "integrity": "sha512-muwmVU799tzPjzb+Q5E/CTDle0rXwkCAdvMVyU0BfbJhenkUsFmuYiCmbvMVOU1m6F1S5HWfXz8EP4pXwwAvrw==",
-          "requires": {
-            "@babel/runtime": "^7.2.0",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0"
-          }
-        },
         "react-redux": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-6.0.1.tgz",
@@ -1123,6 +1094,14 @@
             "prop-types": "^15.6.2"
           }
         }
+      }
+    },
+    "@material-ui/icons": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.0.1.tgz",
+      "integrity": "sha512-03zUfksGXXbaWX2piB1LCmC28eydlT8ah8MbYT4n4mgiX9BTL4HH50lkFn9JIJJSk2oO5kRy4FvpXRGRBI+oxw==",
+      "requires": {
+        "@babel/runtime": "^7.2.0"
       }
     },
     "@material-ui/styles": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1066,6 +1066,65 @@
       "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.8.2.tgz",
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
+    "@material-ui/core": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-4.2.0.tgz",
+      "integrity": "sha512-kqwoCMpGaj3zJedihUuVZWjISh+T72KAXOwgk6VKNf+APMTB8yLByLSgSLDhXsliRBO/9Pda/0g/KzGY7R+irQ==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "@material-ui/styles": "^4.2.0",
+        "@material-ui/system": "^4.3.0",
+        "@material-ui/types": "^4.1.1",
+        "@material-ui/utils": "^4.1.0",
+        "@types/react-transition-group": "^2.0.16",
+        "clsx": "^1.0.2",
+        "convert-css-length": "^2.0.0",
+        "deepmerge": "^3.0.0",
+        "hoist-non-react-statics": "^3.2.1",
+        "is-plain-object": "^3.0.0",
+        "normalize-scroll-left": "^0.2.0",
+        "popper.js": "^1.14.1",
+        "prop-types": "^15.7.2",
+        "react-transition-group": "^4.0.0",
+        "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "convert-css-length": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/convert-css-length/-/convert-css-length-2.0.1.tgz",
+          "integrity": "sha512-iGpbcvhLPRKUbBc0Quxx7w/bV14AC3ItuBEGMahA5WTYqB8lq9jH0kTXFheCBASsYnqeMFZhiTruNxr1N59Axg=="
+        },
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
+        },
+        "normalize-scroll-left": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.2.0.tgz",
+          "integrity": "sha512-t5oCENZJl8TGusJKoCJm7+asaSsPuNmK6+iEjrZ5TyBj2f02brCRsd4c83hwtu+e5d4LCSBZ0uoDlMjBo+A8yA=="
+        },
+        "react-transition-group": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.2.1.tgz",
+          "integrity": "sha512-IXrPr93VzCPupwm2O6n6C2kJIofJ/Rp5Ltihhm9UfE8lkuVX2ng/SUUl/oWjblybK9Fq2Io7LGa6maVqPB762Q==",
+          "requires": {
+            "@babel/runtime": "^7.4.5",
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2"
+          }
+        }
+      }
+    },
     "@material-ui/styles": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@material-ui/styles/-/styles-4.2.0.tgz",
@@ -1095,27 +1154,18 @@
           "version": "0.7.2",
           "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.2.tgz",
           "integrity": "sha512-RMtr1i6E8MXaBWwhXL3yeOU8JXRnz8GNxHvaUfVvwxokvayUY0zoBeWbKw1S9XkufmGEEdQd228pSZXFkAln8Q=="
-        },
-        "@material-ui/utils": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.1.0.tgz",
-          "integrity": "sha512-muwmVU799tzPjzb+Q5E/CTDle0rXwkCAdvMVyU0BfbJhenkUsFmuYiCmbvMVOU1m6F1S5HWfXz8EP4pXwwAvrw==",
-          "requires": {
-            "@babel/runtime": "^7.2.0",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.0"
-          }
-        },
-        "jss": {
-          "version": "10.0.0-alpha.17",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
-          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
         }
+      }
+    },
+    "@material-ui/system": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-4.3.0.tgz",
+      "integrity": "sha512-VQh3mWZSmzm1JR7Ci35AHKwOhhxHHMrBWCdP4mh7UAwSdjWBE6s2Y9Y0iJiqMoEsHP64vU3W1JpsW2AgkUeHsQ==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "deepmerge": "^3.0.0",
+        "prop-types": "^15.7.2",
+        "warning": "^4.0.1"
       }
     },
     "@material-ui/types": {
@@ -1124,6 +1174,16 @@
       "integrity": "sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==",
       "requires": {
         "@types/react": "*"
+      }
+    },
+    "@material-ui/utils": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-4.1.0.tgz",
+      "integrity": "sha512-muwmVU799tzPjzb+Q5E/CTDle0rXwkCAdvMVyU0BfbJhenkUsFmuYiCmbvMVOU1m6F1S5HWfXz8EP4pXwwAvrw==",
+      "requires": {
+        "@babel/runtime": "^7.2.0",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -4424,6 +4484,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/css-url-regex/-/css-url-regex-1.1.0.tgz",
       "integrity": "sha1-g4NCMMyfdMRX3lnuvRVD/uuDt+w="
+    },
+    "css-vendor": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.5.tgz",
+      "integrity": "sha512-36w+4Cg0zqFIt5TAkaM3proB6XWh5kSGmbddRCPdrRLQiYNfHPTgaWPOlCrcuZIO0iAtrG+5wsHJZ6jj8AUULA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "is-in-browser": "^1.0.2"
+      }
     },
     "css-what": {
       "version": "2.1.3",
@@ -9428,6 +9497,16 @@
         "verror": "1.10.0"
       }
     },
+    "jss": {
+      "version": "10.0.0-alpha.17",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
+      "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
+      "requires": {
+        "@babel/runtime": "^7.3.1",
+        "is-in-browser": "^1.1.3",
+        "tiny-warning": "^1.0.2"
+      }
+    },
     "jss-plugin-camel-case": {
       "version": "10.0.0-alpha.17",
       "resolved": "https://registry.npmjs.org/jss-plugin-camel-case/-/jss-plugin-camel-case-10.0.0-alpha.17.tgz",
@@ -9436,18 +9515,6 @@
         "@babel/runtime": "^7.3.1",
         "hyphenate-style-name": "^1.0.3",
         "jss": "10.0.0-alpha.17"
-      },
-      "dependencies": {
-        "jss": {
-          "version": "10.0.0-alpha.17",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
-          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
       }
     },
     "jss-plugin-default-unit": {
@@ -9457,18 +9524,6 @@
       "requires": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.0.0-alpha.17"
-      },
-      "dependencies": {
-        "jss": {
-          "version": "10.0.0-alpha.17",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
-          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
       }
     },
     "jss-plugin-global": {
@@ -9478,18 +9533,6 @@
       "requires": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.0.0-alpha.17"
-      },
-      "dependencies": {
-        "jss": {
-          "version": "10.0.0-alpha.17",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
-          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
       }
     },
     "jss-plugin-nested": {
@@ -9500,18 +9543,6 @@
         "@babel/runtime": "^7.3.1",
         "jss": "10.0.0-alpha.17",
         "tiny-warning": "^1.0.2"
-      },
-      "dependencies": {
-        "jss": {
-          "version": "10.0.0-alpha.17",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
-          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
       }
     },
     "jss-plugin-props-sort": {
@@ -9521,18 +9552,6 @@
       "requires": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.0.0-alpha.17"
-      },
-      "dependencies": {
-        "jss": {
-          "version": "10.0.0-alpha.17",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
-          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
       }
     },
     "jss-plugin-rule-value-function": {
@@ -9542,18 +9561,6 @@
       "requires": {
         "@babel/runtime": "^7.3.1",
         "jss": "10.0.0-alpha.17"
-      },
-      "dependencies": {
-        "jss": {
-          "version": "10.0.0-alpha.17",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
-          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
       }
     },
     "jss-plugin-vendor-prefixer": {
@@ -9564,27 +9571,6 @@
         "@babel/runtime": "^7.3.1",
         "css-vendor": "^2.0.1",
         "jss": "10.0.0-alpha.17"
-      },
-      "dependencies": {
-        "css-vendor": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-2.0.5.tgz",
-          "integrity": "sha512-36w+4Cg0zqFIt5TAkaM3proB6XWh5kSGmbddRCPdrRLQiYNfHPTgaWPOlCrcuZIO0iAtrG+5wsHJZ6jj8AUULA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "is-in-browser": "^1.0.2"
-          }
-        },
-        "jss": {
-          "version": "10.0.0-alpha.17",
-          "resolved": "https://registry.npmjs.org/jss/-/jss-10.0.0-alpha.17.tgz",
-          "integrity": "sha512-egGIUg+YRu0+U+XXlD0gmVtU/gW5sn7+qmDv7opwK5s8emZBE/VoN55X6CaMrAa0kLeGMldnI43KOWea6M9/mA==",
-          "requires": {
-            "@babel/runtime": "^7.3.1",
-            "is-in-browser": "^1.1.3",
-            "tiny-warning": "^1.0.2"
-          }
-        }
       }
     },
     "jsx-ast-utils": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   "dependencies": {
     "@centreon/react-components": "19.4.0-alpha.126",
     "@material-ui/core": "^4.2.0",
-    "@material-ui/styles": "^4.2.0",
     "axios": "^0.18.0",
     "classnames": "^2.2.6",
     "dom-serializer": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
   },
   "dependencies": {
     "@centreon/react-components": "19.4.0-alpha.126",
+    "@material-ui/core": "^4.2.0",
+    "@material-ui/styles": "^4.2.0",
     "axios": "^0.18.0",
     "classnames": "^2.2.6",
     "dom-serializer": "^0.1.0",

--- a/www/front_src/src/App.js
+++ b/www/front_src/src/App.js
@@ -20,6 +20,8 @@ import styles from './App.scss';
 import footerStyles from './components/footer/footer.scss';
 import contentStyles from './styles/partials/_content.scss';
 
+import { StylesProvider } from '@material-ui/styles';
+
 class App extends Component {
 
   state = {
@@ -96,34 +98,36 @@ class App extends Component {
     const min = this.getMinArgument();
 
     return (
-      <ConnectedRouter history={history}>
-        <div className={styles["wrapper"]}>
-          {!min && // do not display menu if min=1
-            <NavigationComponent/>
-          }
-          <Tooltip/>
-          <div id="content" className={contentStyles['content']}>
-            {!min && // do not display header if min=1
-              <Header/>
+      <StylesProvider injectFirst>
+        <ConnectedRouter history={history}>
+          <div className={styles["wrapper"]}>
+            {!min && // do not display menu if min=1
+              <NavigationComponent/>
             }
-            <div id="fullscreen-wrapper" className={contentStyles['fullscreen-wrapper']}>
-              <Fullscreen
-                enabled={this.state.isFullscreenEnabled}
-                onClose={this.removeFullscreenParams}
-                onChange={isFullscreenEnabled => this.setState({isFullscreenEnabled})}
-              >
-                <div className={styles["main-content"]}>
-                  <MainRouter />
-                </div>
-              </Fullscreen>
+            <Tooltip/>
+            <div id="content" className={contentStyles['content']}>
+              {!min && // do not display header if min=1
+                <Header/>
+              }
+              <div id="fullscreen-wrapper" className={contentStyles['fullscreen-wrapper']}>
+                <Fullscreen
+                  enabled={this.state.isFullscreenEnabled}
+                  onClose={this.removeFullscreenParams}
+                  onChange={isFullscreenEnabled => this.setState({isFullscreenEnabled})}
+                >
+                  <div className={styles["main-content"]}>
+                    <MainRouter />
+                  </div>
+                </Fullscreen>
+              </div>
+              {!min && // do not display footer if min=1
+                <Footer/>
+              }
             </div>
-            {!min && // do not display footer if min=1
-              <Footer/>
-            }
+            <span className={footerStyles["full-screen"]} onClick={this.goFull} />
           </div>
-          <span className={footerStyles["full-screen"]} onClick={this.goFull} />
-        </div>
-      </ConnectedRouter>
+        </ConnectedRouter>
+      <StylesProvider>
     );
   }
 }

--- a/www/front_src/src/App.js
+++ b/www/front_src/src/App.js
@@ -127,7 +127,7 @@ class App extends Component {
             <span className={footerStyles["full-screen"]} onClick={this.goFull} />
           </div>
         </ConnectedRouter>
-      <StylesProvider>
+      </StylesProvider>
     );
   }
 }


### PR DESCRIPTION
## Description

This change is needed to be able to prioritize styling of emotion styled Components over Material-ui.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

