### PR TITLE
Bam 12 show disabled 19.04.x

### DIFF
--- a/src/CentreonRemote/ServiceProvider.php
+++ b/src/CentreonRemote/ServiceProvider.php
@@ -22,6 +22,7 @@ use Curl\Curl;
 
 class ServiceProvider implements AutoloadServiceProviderInterface
 {
+    const CENTREON_REMOTE_EXPORTER = 'centreon_remote.exporter';
 
     /**
      * Register Centron Remote services
@@ -131,9 +132,9 @@ class ServiceProvider implements AutoloadServiceProviderInterface
         //-----------//
         // Exporters
         //-----------//
-        
+
         // Commands
-        $pimple['centreon_remote.exporter']->add(Domain\Exporter\CommandExporter::class, function () use ($pimple) {
+        $pimple[static::CENTREON_REMOTE_EXPORTER]->add(Domain\Exporter\CommandExporter::class, function () use ($pimple) {
             $services = [
                 \Centreon\ServiceProvider::CENTREON_DB_MANAGER,
             ];

--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -1417,6 +1417,16 @@ table.ListTableSmallArg td {
 .ListTable,.ListTableMedium,.ListTableSmall {border-width:1px;}
 .ListTable td,.ListTableMedium td,.ListTableSmall td,.ListTableSmallArg {padding-bottom:2px;padding-top:2px;}
 .ListTable td {padding: 4px;}
+.ListTable td[disabled]::after {
+    content: " (" attr(disabled) ")";
+    font-weight: bold;
+    padding-left: 5px;
+}
+span.show-disabled[disabled]::after {
+    content: " (" attr(disabled) ")";
+    font-weight: bold;
+    float: right;
+}
 .tab .ListTableMedium {
     margin-top:21px;
 }

--- a/www/api/class/centreon_clapi.class.php
+++ b/www/api/class/centreon_clapi.class.php
@@ -240,7 +240,8 @@ class CentreonClapi extends CentreonWebService implements CentreonWebServiceDiIn
      * Removes carriage returns from $item if string
      * @param mixed &$item variable to check
      */
-    private function customAlterString(&$item) {
+    private function customAlterString(&$item)
+    {
         $item = (is_string($item)) ? str_replace(array("\n", "\t", "\r", "<br/>"), '', $item) : $item;
     }
 }

--- a/www/api/class/centreon_configuration_host.class.php
+++ b/www/api/class/centreon_configuration_host.class.php
@@ -80,9 +80,9 @@ class CentreonConfigurationHost extends CentreonConfigurationObjects
         } else {
             $queryValues["hostName"] = '%' . (string)$this->arguments['q'] . '%';
         }
-        $query .= 'SELECT SQL_CALC_FOUND_ROWS DISTINCT host_name, host_id ' .
+        $query .= 'SELECT SQL_CALC_FOUND_ROWS DISTINCT host_name, host_id, host_activate ' .
             'FROM ( ' .
-            '( SELECT DISTINCT h.host_name, h.host_id ' .
+            '( SELECT DISTINCT h.host_name, h.host_id, h.host_activate ' .
             'FROM host h ';
 
         if (isset($this->arguments['hostgroup'])) {
@@ -158,7 +158,8 @@ class CentreonConfigurationHost extends CentreonConfigurationObjects
         while ($data = $stmt->fetch()) {
             $hostList[] = array(
                 'id' => htmlentities($data['host_id']),
-                'text' => $data['host_name']
+                'text' => $data['host_name'],
+                'status' => (bool) $data['host_activate'],
             );
         }
 

--- a/www/api/class/centreon_configuration_hostgroup.class.php
+++ b/www/api/class/centreon_configuration_hostgroup.class.php
@@ -80,8 +80,9 @@ class CentreonConfigurationHostgroup extends CentreonConfigurationObjects
             $queryValues['hgName'] = '%%';
         }
 
-        $queryHostGroup = "SELECT SQL_CALC_FOUND_ROWS DISTINCT hg.hg_name, hg.hg_id, hg.hg_activate FROM hostgroup hg " .
-            "WHERE hg.hg_name LIKE :hgName " . $aclHostGroups . "ORDER BY hg.hg_name ";
+        $queryHostGroup = "SELECT SQL_CALC_FOUND_ROWS DISTINCT "
+            . "hg.hg_name, hg.hg_id, hg.hg_activate FROM hostgroup hg "
+            . "WHERE hg.hg_name LIKE :hgName " . $aclHostGroups . "ORDER BY hg.hg_name ";
 
         if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
             if (!is_numeric($this->arguments['page']) || !is_numeric($this->arguments['page_limit'])) {

--- a/www/api/class/centreon_configuration_hostgroup.class.php
+++ b/www/api/class/centreon_configuration_hostgroup.class.php
@@ -80,7 +80,7 @@ class CentreonConfigurationHostgroup extends CentreonConfigurationObjects
             $queryValues['hgName'] = '%%';
         }
 
-        $queryHostGroup = "SELECT SQL_CALC_FOUND_ROWS DISTINCT hg.hg_name, hg.hg_id FROM hostgroup hg " .
+        $queryHostGroup = "SELECT SQL_CALC_FOUND_ROWS DISTINCT hg.hg_name, hg.hg_id, hg.hg_activate FROM hostgroup hg " .
             "WHERE hg.hg_name LIKE :hgName " . $aclHostGroups . "ORDER BY hg.hg_name ";
 
         if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
@@ -105,7 +105,11 @@ class CentreonConfigurationHostgroup extends CentreonConfigurationObjects
 
         $hostGroupList = array();
         while ($data = $stmt->fetch()) {
-            $hostGroupList[] = array('id' => htmlentities($data['hg_id']), 'text' => $data['hg_name']);
+            $hostGroupList[] = [
+                'id' => htmlentities($data['hg_id']),
+                'text' => $data['hg_name'],
+                'status' => (bool) $data['hg_activate'],
+            ];
         }
 
         return array(

--- a/www/api/class/centreon_configuration_meta.class.php
+++ b/www/api/class/centreon_configuration_meta.class.php
@@ -72,7 +72,7 @@ class CentreonConfigurationMeta extends CentreonConfigurationObjects
             $queryValues['name'] = '%%';
         }
 
-        $queryMeta = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT meta_id, meta_name FROM meta_service ' .
+        $queryMeta = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT meta_id, meta_name, meta_activate FROM meta_service ' .
             'WHERE meta_name LIKE :name ' .
             $aclMetaServices .
             'ORDER BY meta_name ';
@@ -98,7 +98,8 @@ class CentreonConfigurationMeta extends CentreonConfigurationObjects
         while ($data = $stmt->fetch()) {
             $metaList[] = array(
                 'id' => $data['meta_id'],
-                'text' => $data['meta_name']
+                'text' => $data['meta_name'],
+                'status' => (bool) $data['meta_activate'],
             );
         }
 

--- a/www/api/class/centreon_configuration_service.class.php
+++ b/www/api/class/centreon_configuration_service.class.php
@@ -109,7 +109,7 @@ class CentreonConfigurationService extends CentreonConfigurationObjects
             $t = 'host';
         }
 
-        // Check for service type
+        // Check for service with graph
         $g = false;
         if (isset($this->arguments['g'])) {
             $g = $this->arguments['g'];
@@ -188,7 +188,7 @@ class CentreonConfigurationService extends CentreonConfigurationObjects
                 $queryService = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT fullname, service_id, host_id ' .
                     'FROM ( ' .
                     '( SELECT DISTINCT CONCAT(h.host_name, " - ", s.service_description) ' .
-                    'as fullname, s.service_id, h.host_id ' .
+                    'as fullname, s.service_id, h.host_id, s.service_activate ' .
                     'FROM host h, service s, host_service_relation hsr ' .
                     'WHERE hsr.host_host_id = h.host_id ' .
                     'AND hsr.service_service_id = s.service_id ' .
@@ -197,7 +197,7 @@ class CentreonConfigurationService extends CentreonConfigurationObjects
                     'AND CONCAT(h.host_name, " - ", s.service_description) LIKE :description ' .
                     $enableQuery . $aclServices . ') ' .
                     'UNION ALL ( ' .
-                    'SELECT DISTINCT CONCAT("Meta - ", ms.display_name) as fullname, ms.service_id, mh.host_id ' .
+                    'SELECT DISTINCT CONCAT("Meta - ", ms.display_name) as fullname, ms.service_id, mh.host_id, ms.service_activate ' .
                     'FROM host mh, service ms ' .
                     'WHERE mh.host_name = "_Module_Meta" ' .
                     'AND mh.host_register = "2" ' .
@@ -222,7 +222,7 @@ class CentreonConfigurationService extends CentreonConfigurationObjects
                 break;
             case 's':
                 $queryService = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT CONCAT(h.host_name, " - ", ' .
-                    's.service_description) as fullname, s.service_id, h.host_id ' .
+                    's.service_description) as fullname, s.service_id, h.host_id, s.service_activate ' .
                     'FROM host h, service s, host_service_relation hsr ' .
                     'WHERE hsr.host_host_id = h.host_id ' .
                     'AND hsr.service_service_id = s.service_id ' .
@@ -248,7 +248,7 @@ class CentreonConfigurationService extends CentreonConfigurationObjects
                 break;
             case 'm':
                 $queryService = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT CONCAT("Meta - ", ms.display_name) ' .
-                    'as fullname, ms.service_id, mh.host_id ' .
+                    'as fullname, ms.service_id, mh.host_id, ms.service_activate ' .
                     'FROM host mh, service ms ' .
                     'WHERE mh.host_name = "_Module_Meta" ' .
                     'AND mh.host_register = "2" ' .
@@ -281,12 +281,20 @@ class CentreonConfigurationService extends CentreonConfigurationObjects
                 if (service_has_graph($data['host_id'], $data['service_id'], $this->pearDBMonitoring)) {
                     $serviceCompleteName = $data['fullname'];
                     $serviceCompleteId = $data['host_id'] . '-' . $data['service_id'];
-                    $serviceList[] = array('id' => htmlentities($serviceCompleteId), 'text' => $serviceCompleteName);
+                    $serviceList[] = [
+                        'id' => htmlentities($serviceCompleteId),
+                        'text' => $serviceCompleteName,
+                        'status' => (bool) $data['service_activate'],
+                    ];
                 }
             } else {
                 $serviceCompleteName = $data['fullname'];
                 $serviceCompleteId = $data['host_id'] . '-' . $data['service_id'];
-                $serviceList[] = array('id' => htmlentities($serviceCompleteId), 'text' => $serviceCompleteName);
+                $serviceList[] = [
+                    'id' => htmlentities($serviceCompleteId),
+                    'text' => $serviceCompleteName,
+                    'status' => (bool) $data['service_activate'],
+                ];
             }
         }
 

--- a/www/api/class/centreon_configuration_servicegroup.class.php
+++ b/www/api/class/centreon_configuration_servicegroup.class.php
@@ -75,7 +75,7 @@ class CentreonConfigurationServicegroup extends CentreonConfigurationObjects
             $acl = new CentreonACL($userId, $isAdmin);
             $aclServicegroups .= ' AND sg_id IN (' . $acl->getServiceGroupsString('ID') . ') ';
         }
-        $queryContact = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT sg_id, sg_name FROM servicegroup ' .
+        $queryContact = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT sg_id, sg_name, sg_activate FROM servicegroup ' .
             'WHERE sg_name LIKE :name ' .
             $aclServicegroups .
             'ORDER BY sg_name ';
@@ -99,7 +99,11 @@ class CentreonConfigurationServicegroup extends CentreonConfigurationObjects
         $stmt->execute();
         $serviceList = array();
         while ($data = $stmt->fetch()) {
-            $serviceList[] = array('id' => $data['sg_id'], 'text' => $data['sg_name']);
+            $serviceList[] = [
+                'id' => htmlentities($data['sg_id']),
+                'text' => $data['sg_name'],
+                'status' => (bool) $data['sg_activate'],
+            ];
         }
         return array(
             'items' => $serviceList,

--- a/www/lib/HTML/QuickForm/select2.php
+++ b/www/lib/HTML/QuickForm/select2.php
@@ -126,6 +126,12 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
 
     /**
      *
+     * @var boolean
+     */
+    public $_showDisabled;
+
+    /**
+     *
      * @var type
      */
     public $_defaultDatasetOptions;
@@ -160,6 +166,7 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
         $this->_defaultDataset = null;
         $this->_defaultDatasetOptions = array();
         $this->_jsCallback = '';
+        $this->_showDisabled = false;
         $this->parseCustomAttributes($attributes);
 
         $this->_pagination = $centreon->optGen['selectPaginationSize'];
@@ -209,6 +216,10 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
 
         if (isset($attributes['linkedObject'])) {
             $this->_linkedObject = $attributes['linkedObject'];
+        }
+
+        if (isset($attributes['showDisabled'])) {
+            $this->_showDisabled = $attributes['showDisabled'];
         }
     }
 
@@ -311,6 +322,7 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
 
         $ajaxOption = '';
         $defaultData = '';
+        $template = '';
         if ($this->_ajaxSource) {
             $ajaxOption = 'ajax: {
                 url: "' . $this->_availableDatasetRoute . '"
@@ -326,6 +338,20 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
             $this->setDefaultFixedDatas();
         }
 
+        if ($this->_showDisabled === true) {
+            $template = "
+                templateResult: function(state){
+                    let template = state.text;
+
+                    if (state.hasOwnProperty('status') && state.status === false) {
+                        template = jQuery('<span class=\"show-disabled\" disabled=\"". _('disabled') ."\"></span>');
+                        template.text(state.text);
+                    }
+
+                    return template;
+                },";
+        }
+
         $additionnalJs .= ' ' . $this->_jsCallback;
 
         $javascriptString = '<script>
@@ -333,7 +359,7 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
                 var $currentSelect2Object' . $this->getName() .
             ' = jQuery("#' . $this->getName() . '").centreonSelect2({
                     allowClear: ' . $allowClear . ',
-                    pageLimit: ' . $this->_pagination . ',
+                    pageLimit: ' . $this->_pagination . ',' . $template . '
                     select2: {
                         ' . $ajaxOption . '
                         ' . $defaultData . '


### PR DESCRIPTION
<h1> Pull Request Template </h1>

<h2> Description </h2>

PR is related to issue with ID BAM-12 and provide a new functionality of the grid and the select2 to display text `Object name (disabled)` if the status of an object is disabled

Fixes # BAM-12

<h2> Type of change </h2>

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> Target serie </h2>

- [ ] 18.10.x #7538
- [x] 19.04.x
- [ ] 19.04.x (master) #7531

<h2> How this pull request can be tested ? </h2>

You can test the APIs of services and meta-services, but a grid and select2 can be tested only with changes in BAM -> [BAM-12-show-disabled](https://github.com/centreon/centreon-bam/compare/BAM-12-show-disabled-18.10.x)

<h2> Checklist </h2>

<h5> Community contributors & Centreon team </h5>

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented on my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

<h5> Centreon team only </h5>

- [x] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
