### PR TITLE
fix(ui): fix double host name display in host detail

### DIFF
--- a/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -378,7 +378,7 @@
                 {if ($lcaTopo.60101 || $admin == 1) && !$isRemote}
                 <tr class='list_two'>
                     <td class="ListColLeft ColPopup">
-                        <a href='./main.php?p=60101&host_id={$host_id}&o=c'>{$lnk_host_config} {$host_data.host_name}</a>
+                        <a href='./main.php?p=60101&host_id={$host_id}&o=c'>{$lnk_host_config}</a>
                     </td>
                 </tr>
                 {/if}


### PR DESCRIPTION
# Pull Request Template

## Description

In command and shortcut, Configure host link display 2 time host name because host name are displayed in php file (hostDetails.php : 546), and in ihtml file (template/hostDetails.ihtml : 381).
Deleting host name display in ihtml.

Before fix
![image](https://user-images.githubusercontent.com/53344585/61960185-4e626480-afc5-11e9-825a-78df2a00906a.png)

After fix
![image](https://user-images.githubusercontent.com/53344585/61960389-a305df80-afc5-11e9-9cb6-1fff430b3c0e.png)


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [X] 18.10.x
- [X] 19.04.x
- [X] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check any host detail under monitoring before and after fix.
Before, host name is displayed 2 times.
After only 1 time.

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
