### PR TITLE
fix: GMT is null if user don't choose one

### DIFF
--- a/www/class/centreonGMT.class.php
+++ b/www/class/centreonGMT.class.php
@@ -209,6 +209,10 @@ class CentreonGMT
             $gmt = $this->myGMT;
         }
 
+        if (!isset($gmt)) {
+            $gmt = $this->myGMT;
+        }
+
         if (isset($date) && isset($gmt)) {
             $sDate = new DateTime();
             $sDate->setTimestamp($date);

--- a/www/class/centreonGMT.class.php
+++ b/www/class/centreonGMT.class.php
@@ -209,7 +209,7 @@ class CentreonGMT
             $gmt = $this->myGMT;
         }
 
-        if ($gmt == null) {
+        if (($gmt == null) or (empty($gmt))) {
             $gmt = date_default_timezone_get();
         }
 

--- a/www/class/centreonGMT.class.php
+++ b/www/class/centreonGMT.class.php
@@ -209,7 +209,7 @@ class CentreonGMT
             $gmt = $this->myGMT;
         }
 
-        if (($gmt == null) or (empty($gmt))) {
+        if (empty($gmt)) {
             $gmt = date_default_timezone_get();
         }
 

--- a/www/class/centreonGMT.class.php
+++ b/www/class/centreonGMT.class.php
@@ -209,8 +209,8 @@ class CentreonGMT
             $gmt = $this->myGMT;
         }
 
-        if (!isset($gmt)) {
-            $gmt = $this->myGMT;
+        if ($gmt == null) {
+            $gmt = date_default_timezone_get();
         }
 
         if (isset($date) && isset($gmt)) {


### PR DESCRIPTION
# Pull Request Template

## Description

If users don't choose a timezone then the GMT will be set to null 

**Fixes** # (issue)
Needed this fix to allow the export of the column Last check from service and host monitoring widgets
## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

By trying to export either service or host monitoring widget while including Last check column  

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
