### PR TITLE
enh(doc): add warning about PHP version and MySQL 8

### DIFF
--- a/doc/en/installation/common/install_packages.rst
+++ b/doc/en/installation/common/install_packages.rst
@@ -72,6 +72,8 @@ Run the command::
 
     # yum install centreon-base-config-centreon-engine
 
+.. _dedicateddbms:
+
 Installing MySQL on the dedicated server
 ----------------------------------------
 
@@ -91,14 +93,30 @@ Run the commands::
 
 Then create a distant **root** account: ::
 
-    MariaDB [(none)]> GRANT ALL PRIVILEGES ON *.* TO 'root'@'IP' IDENTIFIED BY 'PASSWORD' WITH GRANT OPTION;
+    mysql> CREATE USER 'root'@'IP' IDENTIFIED BY 'PASSWORD';
+    mysql> GRANT ALL PRIVILEGES ON *.* TO 'root'@'IP' WITH GRANT OPTION;
+    mysql> FLUSH PRIVILEGES;
 
 .. note::
     Replace **IP** by the public IP address of the Centreon server and **PASSWORD**
-    by the **root** password. Once the installation is complete you can delete this
-    account using: ::
+    by the **root** password.
+
+.. warning::
+    When running a PHP version before 7.1.16, or PHP 7.2 before 7.2.4, set MySQL 8 Server's default password plugin to
+    mysql_native_password or else you will see errors similar to *The server requested authentication method unknown
+    to the client [caching_sha2_password]* even when caching_sha2_password is not used.
+    
+    This is because MySQL 8 defaults to caching_sha2_password, a plugin that is not recognized by the older PHP
+    releases. Instead, change it by setting *default_authentication_plugin=mysql_native_password* in **my.cnf**.
+    
+    Change the method to store the password using following command: ::
+    
+        mysql> ALTER USER 'root'@'IP' IDENTIFIED WITH mysql_native_password BY 'PASSWORD';
+        mysql> FLUSH PRIVILEGES;
+
+Once the installation is complete you can delete this account using: ::
         
-        MariaDB [(none)]> DROP USER 'root'@'IP';
+    mysql> DROP USER 'root'@'IP';
 
 Database management system
 --------------------------

--- a/doc/en/installation/common/web_install.rst
+++ b/doc/en/installation/common/web_install.rst
@@ -68,6 +68,10 @@ In this case, you only need to define a password for the user accessing the Cent
     
     5. Click on **Refresh**.
 
+.. note::
+    If you use a deported MySQL v8.x DBMS, you may have the following error message: *error*.
+    Please have a look to this :ref:`procedure` to solve this issue.
+
 The Centreon setup wizard configures the databases. Click on **Next**.
 
 .. image:: /images/user/adbconf.png

--- a/doc/fr/installation/common/install_packages.rst
+++ b/doc/fr/installation/common/install_packages.rst
@@ -73,6 +73,8 @@ Exécutez la commande : ::
 
     # yum install centreon-base-config-centreon-engine
 
+.. _dedicateddbms:
+
 Installer MySQL sur un serveur dédié
 ------------------------------------
 
@@ -94,14 +96,32 @@ Exécutez les commandes : ::
 
 Puis créer un utisateur **root** distant : ::
 
-    MariaDB [(none)]> GRANT ALL PRIVILEGES ON *.* TO 'root'@'IP' IDENTIFIED BY 'PASSWORD' WITH GRANT OPTION;
+    mysql> CREATE USER 'root'@'IP' IDENTIFIED BY 'PASSWORD';
+    mysql> GRANT ALL PRIVILEGES ON *.* TO 'root'@'IP' WITH GRANT OPTION;
+    mysql> FLUSH PRIVILEGES;
 
 .. note::
     Remplacez **IP** par l'adresse IP publique du serveur Centreon et **PASSWORD**
-    par le mot de passe de l'utilisateur **root**. Une fois l'installation terminée
-    vous pouvez supprimer ce compte via la commande : ::
+    par le mot de passe de l'utilisateur **root**.
+
+.. warning::
+    Si PHP est utilisé dans une version 7.1 antérieure à la version 7.1.16, ou PHP 7.2 antérieure à 7.2.4, le
+    plugin de mot de passe doit être défini à mysql_native_password pour MySQL 8 Server, car sinon des erreurs
+    similaires à *The server requested authentication method unknown to the client [caching_sha2_password]* peuvent
+    apparaitre, même si caching_sha2_password n'est pas utilisé.
+    
+    Ceci est dû au fait que MySQL 8 utilise par défaut caching_sha2_password, un plugin qui n'est pas reconnu par les
+    anciennes versions de PHP. À la place il faut modifier le paramètre *default_authentication_plugin=
+    mysql_native_password* dans le fichier **my.cnf**.
+    
+    Changez la méthode de stockage du mot de passe, utilisez la commande suivante : ::
+    
+        mysql> ALTER USER 'root'@'IP' IDENTIFIED WITH mysql_native_password BY 'PASSWORD';
+        mysql> FLUSH PRIVILEGES;
+
+Une fois l'installation terminée vous pouvez supprimer ce compte via la commande : ::
         
-        MariaDB [(none)]> DROP USER 'root'@'IP';
+    mysql> DROP USER 'root'@'IP';
 
 Système de gestion de base de données
 -------------------------------------

--- a/doc/fr/installation/common/web_install.rst
+++ b/doc/fr/installation/common/web_install.rst
@@ -66,6 +66,10 @@ Cliquez sur **Next**.
     
     5. Cliquez sur **Refresh**
 
+.. note::
+    Si vous utilisez une base de données déportée MySQL 8.x, vous pouvez avoir l'erreur suivante : *erreur*.
+    Référez-vous à l'aide :ref:`suivante<dedicateddbms>` pour corriger le problème.
+
 L'assistant de configuration configure les bases de données.
 
 Cliquez sur **Next**.

--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -58,8 +58,6 @@ try {
     exit;
 }
 
-$dbUser = $parameters['db_user'];
-$dbPass = $parameters['db_password'];
 $host = "localhost";
 // if database server is not on localhost...
 if ($parameters['address'] != "127.0.0.1" && $parameters['address'] != "localhost") {
@@ -76,11 +74,11 @@ $createUser = "CREATE USER :dbUser@:host IDENTIFIED BY :dbPass";
 $alterQuery = "ALTER USER :dbUser@:host IDENTIFIED WITH mysql_native_password BY :dbPass";
 
 $queryValues = [];
-$queryValues[':dbUser'] = $dbUser;
+$queryValues[':dbUser'] = $parameters['db_user'];
 $queryValues[':host'] = $host;
-$queryValues[':dbPass'] = $dbPass;
+$queryValues[':dbPass'] = $parameters['db_password'];
 
-$query = "GRANT ALL PRIVILEGES ON `%s`.* TO " . $dbUser . "@" . $host . " WITH GRANT OPTION";
+$query = "GRANT ALL PRIVILEGES ON `%s`.* TO " . $parameters['db_user'] . "@" . $host . " WITH GRANT OPTION";
 $flushQuery = "FLUSH PRIVILEGES";
 
 try {


### PR DESCRIPTION
## Description

* Improve distant DBMS account creation for installation
* Add warning about PHP version and MySQL v8

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Install Centreon without DB
Install distant MySQL v8 DBMS
Follow instructions

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
