### PR TITLE
fix(sql): fix tables partitioning with mysql 8

### DIFF
--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -629,7 +629,7 @@ class PartEngine
             $dbType = $dbVersion = null;
             while ($row = $dbResult->fetch()) {
                 switch ($row['Variable_name']) {
-                    case 'version_comment' :
+                    case 'version_comment':
                         $dbType = $row['Value'];
                         break;
                     case 'version' :

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -635,8 +635,6 @@ class PartEngine
                     case 'version':
                         $dbVersion = $row['Value'];
                         break;
-                    default :
-                        break;
                 }
             }
             $dbResult->closeCursor();

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -627,6 +627,7 @@ class PartEngine
                 && (floatval($versionDb["version"]) > 5.9)
             ) {
                 unset($config, $versionDb);
+                
                 return true;
             }
             return false;

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -614,7 +614,12 @@ class PartEngine
         $dbResult = $db->query("SELECT plugin_status FROM INFORMATION_SCHEMA.PLUGINS WHERE plugin_name = 'partition'");
         $config = $dbResult->fetch();
         $dbResult->closeCursor();
-        if ($config["plugin_status"] != "ACTIVE") {
+        if ($config["plugin_status"] == "ACTIVE") {
+            unset($config);
+
+            return true;
+        }
+        elseif (empty($config["plugin_status"])) {
             // as the plugin "partition" was deprecated in mysql 5.9
             // and as it was removed from mysql 8 and replaced by the native partitioning one,
             // we need to check the current version and db before failing this step
@@ -630,11 +635,9 @@ class PartEngine
 
                 return true;
             }
-            return false;
         }
-        unset($config);
 
-        return true;
+        return false;
     }
 
     /**

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -36,6 +36,7 @@
 /**
  *
  * Class that handles MySQL table partitions
+ *
  * @author msugumaran
  *
  */
@@ -181,7 +182,8 @@ class PartEngine
      * Generate query part to build partitions
      *
      * @param MysqlTable $table The table to partition
-     * @param bool       $createPastPartitions If the past partitions need to be created
+     * @param bool $createPastPartitions If the past partitions need to be created
+     *
      * @return string The built partitions query
      */
     private function createDailyPartitions($table, $createPastPartitions): string
@@ -242,7 +244,7 @@ class PartEngine
      *
      * @param MysqlTable $table The table to partition
      * @param CentreonDB $db The database connection
-     * @param bool       $createPastPartitions If the past partitions need to be created
+     * @param bool $createPastPartitions If the past partitions need to be created
      */
     public function createParts($table, $db, $createPastPartitions): void
     {
@@ -316,6 +318,7 @@ class PartEngine
     /**
      *
      * Drop partitions that are older than the retention duration
+     *
      * @param MysqlTable $table
      */
     public function purgeParts($table, $db)
@@ -454,6 +457,7 @@ class PartEngine
 
     /**
      * optimize all partitions for a table
+     *
      * @param MysqlTable $table
      */
     public function optimizeTablePartitions($table, $db)
@@ -492,6 +496,7 @@ class PartEngine
 
     /**
      * list all partitions for a table
+     *
      * @param MysqlTable $table
      */
     public function listParts($table, $db, $throwException = true)
@@ -521,7 +526,7 @@ class PartEngine
             );
         }
 
-        $partitions = array();
+        $partitions = [];
         while ($row = $dbResult->fetch()) {
             if (!is_null($row["PARTITION_NAME"])) {
                 $row["INDEX_LENGTH"] = round($row["INDEX_LENGTH"] / (1024 * 1024), 2);
@@ -540,6 +545,7 @@ class PartEngine
 
     /**
      * Backup Partition
+     *
      * @param MysqlTable $table
      */
     public function backupParts($table, $db)
@@ -606,7 +612,9 @@ class PartEngine
     /**
      *
      * Check if MySQL version is compatible with partitionning.
+     *
      * @param $db The Db singleton
+     *
      * @return boolean
      */
     public function isCompatible($db)
@@ -618,8 +626,7 @@ class PartEngine
             unset($config);
 
             return true;
-        }
-        elseif (empty($config["plugin_status"])) {
+        } elseif (empty($config["plugin_status"])) {
             // as the plugin "partition" was deprecated in mysql 5.9
             // and as it was removed from mysql 8 and replaced by the native partitioning one,
             // we need to check the current version and db before failing this step

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -627,7 +627,7 @@ class PartEngine
 
             return true;
         } elseif (empty($config["plugin_status"])) {
-            // as the plugin "partition" was deprecated in mysql 5.9
+            // as the plugin "partition" was deprecated in mysql 5.7
             // and as it was removed from mysql 8 and replaced by the native partitioning one,
             // we need to check the current version and db before failing this step
             $dbResult = $db->query(
@@ -647,7 +647,7 @@ class PartEngine
             $dbResult->closeCursor();
 
             if (stristr($dbType, "MySQL")
-                && (floatval($dbVersion) > 5.9)
+                && (version_compare($dbVersion, '8.0.0', '>='))
             ) {
                 unset($config, $row);
 

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -60,7 +60,7 @@ class PartEngine
                 AND TABLE_SCHEMA = '" . $table->getSchema() . "'
                 AND PARTITION_DESCRIPTION = 'MAXVALUE'"
             );
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception(
                 "Error : Cannot get partition maxvalue information for table "
                 . $tableName . ", " . $e->getMessage() . "\n"
@@ -72,7 +72,7 @@ class PartEngine
                 $dbResult = $db->query(
                     "ALTER TABLE " . $tableName . " ADD PARTITION (PARTITION `pmax` VALUES LESS THAN MAXVALUE)"
                 );
-            } catch (PDOException $e) {
+            } catch (\PDOException $e) {
                 throw new Exception(
                     "Error: cannot add a maxvalue partition for table "
                     . $tableName . ", " . $e->getMessage() . "\n"
@@ -126,7 +126,7 @@ class PartEngine
 
         try {
             $dbResult = $db->query($request);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception("Error: cannot add a new partition 'p" . ($ntime[5] + 1900) . $month . $day
                 . "' for table " . $tableName . ", " . $e->getMessage() . "\n");
         }
@@ -264,7 +264,7 @@ class PartEngine
 
         try {
             $dbResult = $db->query("use " . $table->getSchema());
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception(
                 "SQL Error: Cannot use database "
                 . $table->getSchema() . "," . $e->getMessage() . "\n"
@@ -273,7 +273,7 @@ class PartEngine
 
         try {
             $dbResult = $db->query($table->getCreateStmt() . $partition_part);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception(
                 "Error : Cannot create table " . $tableName . " with partitions, "
                 . $e->getMessage() . "\n"
@@ -298,7 +298,7 @@ class PartEngine
         $error = false;
         try {
             $dbResult = $db->query($request);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             $error = true;
         }
         if ($error || !$dbResult->rowCount()) {
@@ -342,7 +342,7 @@ class PartEngine
 
         try {
             $dbResult = $db->query($request);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception("Error : Cannot get partitions to purge for table "
                 . $tableName . ", " . $e->getMessage() . "\n");
         }
@@ -351,7 +351,7 @@ class PartEngine
             $request = "ALTER TABLE " . $tableName . " DROP PARTITION `" . $row["PARTITION_NAME"] . "`;";
             try {
                 $dbResult2 =& $db->query($request);
-            } catch (PDOException $e) {
+            } catch (\PDOException $e) {
                 throw new Exception("Error : Cannot drop partition " . $row["PARTITION_NAME"] . " of table "
                     . $tableName . ", " . $e->getMessage() . "\n");
             }
@@ -382,7 +382,7 @@ class PartEngine
         echo "[" . date(DATE_RFC822) . "][migrate] Renaming table " . $tableName . " TO " . $tableName . "_old\n";
         try {
             $dbResult = $db->query("RENAME TABLE " . $tableName . " TO " . $tableName . "_old");
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception(
                 "Error: Cannot rename table " . $tableName
                 . " to " . $tableName . "_old, "
@@ -402,7 +402,7 @@ class PartEngine
         $request = "INSERT INTO " . $tableName . " SELECT * FROM " . $tableName . "_old";
         try {
             $dbResult = $db->query($request);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception(
                 "Error: Cannot copy " . $tableName . "_old data to new table "
                 . $e->getMessage() . "\n"
@@ -423,13 +423,13 @@ class PartEngine
         //verifying if table is partitioned
         try {
             $dbResult = $db->query("use " . $table->getSchema());
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception("Error: cannot use database " . $table->getSchema() . "\n");
         }
 
         try {
             $dbResult = $db->query("SHOW TABLE STATUS LIKE '" . $table->getName() . "'");
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception("Error: cannot get table " . $tableName . " status, " . $e->getMessage() . "\n");
         }
         if (!$dbResult->rowCount()) {
@@ -468,7 +468,7 @@ class PartEngine
         $request .= "AND TABLE_SCHEMA='" . $table->getSchema() . "' ";
         try {
             $dbResult = $db->query($request);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception(
                 "Error : Cannot get table schema information  for "
                 . $tableName . ", " . $e->getMessage() . "\n"
@@ -479,7 +479,7 @@ class PartEngine
             $request = "ALTER TABLE " . $tableName . " OPTIMIZE PARTITION `" . $row["PARTITION_NAME"] . "`;";
             try {
                 $dbResult2 = $db->query($request);
-            } catch (PDOException $e) {
+            } catch (\PDOException $e) {
                 throw new Exception(
                     "Optimize error : Cannot optimize partition " . $row["PARTITION_NAME"]
                     . " of table " . $tableName . ", " . $e->getMessage() . "\n"
@@ -514,7 +514,7 @@ class PartEngine
         $request .= "ORDER BY PARTITION_NAME DESC ";
         try {
             $dbResult = $db->query($request);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception(
                 "Error : Cannot get table schema information  for "
                 . $tableName . ", " . $e->getMessage() . "\n"
@@ -561,7 +561,7 @@ class PartEngine
         $request .= "LIMIT 2";
         try {
             $dbResult = $db->query($request);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception(
                 "Error : Cannot get table schema information  for "
                 . $tableName . ", " . $e->getMessage() . "\n"
@@ -594,7 +594,7 @@ class PartEngine
 
         try {
             $dbResult = $db->query($request);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception(
                 "FATAL : Cannot dump table " . $tableName
                 . " into file " . $filename . ", "
@@ -627,7 +627,7 @@ class PartEngine
                 && (floatval($versionDb["version"]) > 5.9)
             ) {
                 unset($config, $versionDb);
-                
+
                 return true;
             }
             return false;
@@ -651,7 +651,7 @@ class PartEngine
 
         try {
             $dbResult = $db->query($query);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception('Cannot get partition information');
         }
 
@@ -676,7 +676,7 @@ class PartEngine
 
         try {
             $dbResult = $db->query($request);
-        } catch (PDOException $e) {
+        } catch (\PDOException $e) {
             throw new Exception(
                 "Error : Cannot get partition maxvalue information for table "
                 . $table->getName() . ", " . $e->getMessage() . "\n"

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -626,17 +626,29 @@ class PartEngine
             $dbResult = $db->query(
                 "SHOW VARIABLES WHERE Variable_name LIKE 'version%'"
             );
-            $versionDb = $dbResult->fetch();
+            $dbType = $dbVersion = null;
+            while ($row = $dbResult->fetch()) {
+                switch ($row['Variable_name']) {
+                    case 'version_comment' :
+                        $dbType = $row['Value'];
+                        break;
+                    case 'version' :
+                        $dbVersion = $row['Value'];
+                        break;
+                    default :
+                        break;
+                }
+            }
             $dbResult->closeCursor();
-            if (stristr($versionDb['version_comment'], "MySQL")
-                && (floatval($versionDb["version"]) > 5.9)
+
+            if (stristr($dbType, "MySQL")
+                && (floatval($dbVersion) > 5.9)
             ) {
-                unset($config, $versionDb);
+                unset($config, $row);
 
                 return true;
             }
         }
-
         return false;
     }
 

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -49,31 +49,30 @@ class PartEngine
     {
         ;
     }
-    
+
     private function createMaxvaluePartition($db, $tableName, $table)
     {
         # Check if we need to create it
-        $request = "SELECT 1 FROM INFORMATION_SCHEMA.PARTITIONS ";
-        $request .= "WHERE TABLE_NAME='".$table->getName()."' ";
-        $request .= "AND TABLE_SCHEMA='".$table->getSchema()."' ";
-        $request .= "AND PARTITION_DESCRIPTION = 'MAXVALUE' ";
-
         try {
-            $DBRESULT = $db->query($request);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query(
+                "SELECT 1 FROM INFORMATION_SCHEMA.PARTITIONS
+                WHERE TABLE_NAME = '" . $table->getName() . "'
+                AND TABLE_SCHEMA = '" . $table->getSchema() . "'
+                AND PARTITION_DESCRIPTION = 'MAXVALUE'"
+            );
+        } catch (PDOException $e) {
             throw new Exception(
                 "Error : Cannot get partition maxvalue information for table "
                 . $tableName . ", " . $e->getMessage() . "\n"
             );
         }
-        
-        if (!($row = $DBRESULT->fetchRow())) {
-            #print "[".date(DATE_RFC822)."][createMaxvaluePartition] Create new part pmax for table " . $tableName . "\n";
-            $request = "ALTER TABLE ".$tableName;
-            $request .= " ADD PARTITION (PARTITION `pmax` VALUES LESS THAN MAXVALUE)";
+
+        if (!($row = $dbResult->fetch())) {
             try {
-                $DBRESULT = $db->query($request);
-            } catch (\PDOException $e) {
+                $dbResult = $db->query(
+                    "ALTER TABLE " . $tableName . " ADD PARTITION (PARTITION `pmax` VALUES LESS THAN MAXVALUE)"
+                );
+            } catch (PDOException $e) {
                 throw new Exception(
                     "Error: cannot add a maxvalue partition for table "
                     . $tableName . ", " . $e->getMessage() . "\n"
@@ -81,19 +80,19 @@ class PartEngine
             }
         }
     }
-    
+
     private function purgeDailyPartitionCondition($table)
     {
         date_default_timezone_set($table->getTimezone());
         $ltime = localtime();
-        $current_time = mktime(0, 0, 0, $ltime[4]+1, $ltime[3]-$table->getRetention(), $ltime[5]+1900);
+        $current_time = mktime(0, 0, 0, $ltime[4] + 1, $ltime[3] - $table->getRetention(), $ltime[5] + 1900);
 
-        $condition =  "AND CONVERT(PARTITION_DESCRIPTION, SIGNED INTEGER) < " . $current_time . " "
+        $condition = "AND CONVERT(PARTITION_DESCRIPTION, SIGNED INTEGER) < " . $current_time . " "
             . "AND PARTITION_DESCRIPTION != 'MAXVALUE' ";
 
         return $condition;
     }
-    
+
     private function updateAddDailyPartitions($db, $tableName, $month, $day, $year, $hasMaxValuePartition = false)
     {
         $current_time = mktime(0, 0, 0, $month, $day, $year);
@@ -106,8 +105,8 @@ class PartEngine
         if ($day < 10) {
             $day = "0" . $day;
         }
-            
-        print "[".date(DATE_RFC822)."][updateParts] Create new part for table " . $tableName . " : "
+
+        print "[" . date(DATE_RFC822) . "][updateParts] Create new part for table " . $tableName . " : "
             . ($ntime[5] + 1900) . $month . $day . " - Range: $current_time\n";
 
         $partitionQuery = "PARTITION `p" . ($ntime[5] + 1900) . $month . $day
@@ -126,15 +125,15 @@ class PartEngine
         }
 
         try {
-            $DBRESULT = $db->query($request);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($request);
+        } catch (PDOException $e) {
             throw new Exception("Error: cannot add a new partition 'p" . ($ntime[5] + 1900) . $month . $day
                 . "' for table " . $tableName . ", " . $e->getMessage() . "\n");
         }
 
         return $current_time;
     }
-    
+
     private function updateDailyPartitions($db, $tableName, $table, $lastTime)
     {
         $hasMaxValuePartition = $this->hasMaxValuePartition($db, $table);
@@ -142,23 +141,23 @@ class PartEngine
         date_default_timezone_set($table->getTimezone());
         $how_much_forward = 0;
         $ltime = localtime();
-        $current_time = mktime(0, 0, 0, $ltime[4]+1, $ltime[3], $ltime[5]+1900);
-        
+        $current_time = mktime(0, 0, 0, $ltime[4] + 1, $ltime[3], $ltime[5] + 1900);
+
         # Gap when you have a cron not updated
         while ($lastTime < $current_time) {
             $ntime = localtime($lastTime);
             $lastTime = $this->updateAddDailyPartitions(
                 $db,
                 $tableName,
-                $ntime[4]+1,
-                $ntime[3]+1,
-                $ntime[5]+1900,
+                $ntime[4] + 1,
+                $ntime[3] + 1,
+                $ntime[5] + 1900,
                 $hasMaxValuePartition
             );
         }
         while ($current_time < $lastTime) {
             $how_much_forward++;
-            $current_time = mktime(0, 0, 0, $ltime[4]+1, $ltime[3]+$how_much_forward, $ltime[5]+1900);
+            $current_time = mktime(0, 0, 0, $ltime[4] + 1, $ltime[3] + $how_much_forward, $ltime[5] + 1900);
         }
         $num_days_forward = $table->getRetentionForward();
         while ($how_much_forward < $num_days_forward) {
@@ -172,7 +171,7 @@ class PartEngine
             );
             $how_much_forward++;
         }
-        
+
         if (!$hasMaxValuePartition) {
             $this->createMaxvaluePartition($db, $tableName, $table);
         }
@@ -182,7 +181,7 @@ class PartEngine
      * Generate query part to build partitions
      *
      * @param MysqlTable $table The table to partition
-     * @param bool $createPastPartitions If the past partitions need to be created
+     * @param bool       $createPastPartitions If the past partitions need to be created
      * @return string The built partitions query
      */
     private function createDailyPartitions($table, $createPastPartitions): string
@@ -190,14 +189,14 @@ class PartEngine
         date_default_timezone_set($table->getTimezone());
         $ltime = localtime();
 
-        $createPart = " PARTITION BY RANGE(".$table->getColumn().") (";
+        $createPart = " PARTITION BY RANGE(" . $table->getColumn() . ") (";
 
         // Create past partitions if needed (not needed in fresh install)
         $num_days = ($createPastPartitions === true) ? $table->getRetention() : 0;
 
         $append = '';
         while ($num_days >= 0) {
-            $current_time = mktime(0, 0, 0, $ltime[4]+1, $ltime[3]-$num_days, $ltime[5]+1900);
+            $current_time = mktime(0, 0, 0, $ltime[4] + 1, $ltime[3] - $num_days, $ltime[5] + 1900);
             $ntime = localtime($current_time);
             $month = $ntime[4] + 1;
             $day = $ntime[3];
@@ -208,7 +207,7 @@ class PartEngine
                 $day = "0" . $day;
             }
             $createPart .= $append . "PARTITION p" . ($ntime[5] + 1900)
-                . $month . $day . " VALUES LESS THAN (" . $current_time. ")";
+                . $month . $day . " VALUES LESS THAN (" . $current_time . ")";
             $num_days--;
             $append = ',';
         }
@@ -217,7 +216,7 @@ class PartEngine
         $num_days_forward = $table->getRetentionForward();
         $count = 1;
         while ($count <= $num_days_forward) {
-            $current_time = mktime(0, 0, 0, $ltime[4]+1, $ltime[3]+$count, $ltime[5]+1900);
+            $current_time = mktime(0, 0, 0, $ltime[4] + 1, $ltime[3] + $count, $ltime[5] + 1900);
             $ntime = localtime($current_time);
             $month = $ntime[4] + 1;
             $day = $ntime[3];
@@ -228,7 +227,7 @@ class PartEngine
                 $day = "0" . $day;
             }
             $createPart .= $append . "PARTITION p" . ($ntime[5] + 1900)
-                . $month . $day . " VALUES LESS THAN (" . $current_time. ")";
+                . $month . $day . " VALUES LESS THAN (" . $current_time . ")";
             $append = ',';
             $count++;
         }
@@ -243,20 +242,20 @@ class PartEngine
      *
      * @param MysqlTable $table The table to partition
      * @param CentreonDB $db The database connection
-     * @param bool $createPastPartitions If the past partitions need to be created
+     * @param bool       $createPastPartitions If the past partitions need to be created
      */
     public function createParts($table, $db, $createPastPartitions): void
     {
-        $tableName = $table->getSchema().".".$table->getName();
+        $tableName = $table->getSchema() . "." . $table->getName();
         if ($table->exists()) {
-            throw new Exception("Warning: Table ".$tableName." already exists\n");
+            throw new Exception("Warning: Table " . $tableName . " already exists\n");
         }
-        
+
         $partition_part = null;
         if ($table->getType() == 'date' && $table->getDuration() == 'daily') {
             $partition_part = $this->createDailyPartitions($table, $createPastPartitions);
         }
-        
+
         if (is_null($partition_part)) {
             throw new Exception(
                 "SQL Error: Cannot build partition part \n"
@@ -264,8 +263,8 @@ class PartEngine
         }
 
         try {
-            $DBRESULT = $db->query("use " . $table->getSchema());
-        } catch (\PDOException $e) {
+            $dbResult = $db->query("use " . $table->getSchema());
+        } catch (PDOException $e) {
             throw new Exception(
                 "SQL Error: Cannot use database "
                 . $table->getSchema() . "," . $e->getMessage() . "\n"
@@ -273,8 +272,8 @@ class PartEngine
         }
 
         try {
-            $DBRESULT = $db->query($table->getCreateStmt() . $partition_part);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($table->getCreateStmt() . $partition_part);
+        } catch (PDOException $e) {
             throw new Exception(
                 "Error : Cannot create table " . $tableName . " with partitions, "
                 . $e->getMessage() . "\n"
@@ -284,7 +283,7 @@ class PartEngine
             $this->createMaxvaluePartition($db, $tableName, $table);
         }
     }
-    
+
     /**
      * Get last part range max value
      */
@@ -292,26 +291,26 @@ class PartEngine
     {
         $request = "SELECT MAX(CONVERT(PARTITION_DESCRIPTION, SIGNED INTEGER)) as lastPart ";
         $request .= "FROM INFORMATION_SCHEMA.PARTITIONS ";
-        $request .= "WHERE TABLE_NAME='".$table->getName()."' ";
-        $request .= "AND TABLE_SCHEMA='".$table->getSchema()."' ";
+        $request .= "WHERE TABLE_NAME='" . $table->getName() . "' ";
+        $request .= "AND TABLE_SCHEMA='" . $table->getSchema() . "' ";
         $request .= "GROUP BY TABLE_NAME";
 
         $error = false;
         try {
-            $DBRESULT = $db->query($request);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($request);
+        } catch (PDOException $e) {
             $error = true;
         }
-        if ($error || !$DBRESULT->rowCount()) {
+        if ($error || !$dbResult->rowCount()) {
             throw new Exception(
                 "Error: cannot get table " . $table->getSchema() . "." . $table->getName()
                 . " last partition range \n"
             );
         }
-        $row = $DBRESULT->fetchRow();
+        $row = $dbResult->fetch();
 
         // maybe we need to check the value of $row["lastPart"]
-        return($row["lastPart"]);
+        return ($row["lastPart"]);
     }
 
     /**
@@ -325,34 +324,34 @@ class PartEngine
             echo "[" . date(DATE_RFC822) . "][purge] No need to purge\n";
             return true;
         }
-    
+
         if ($table->getType() == 'date' && $table->getDuration() == 'daily') {
             $condition = $this->purgeDailyPartitionCondition($table);
         }
-    
+
         $tableName = $table->getSchema() . "." . $table->getName();
         if (!$table->exists()) {
             throw new Exception("Error: Table " . $tableName . " does not exists\n");
         }
-        
-        $request = "SELECT PARTITION_NAME FROM INFORMATION_SCHEMA.PARTITIONS ";
-        $request .= "WHERE TABLE_NAME='" . $table->getName() . "' ";
-        $request .= "AND TABLE_SCHEMA='" . $table->getSchema() . "' ";
-        $request .= "AND CONVERT(PARTITION_DESCRIPTION, SIGNED INTEGER) IS NOT NULL ";
+
+        $request = "SELECT PARTITION_NAME FROM INFORMATION_SCHEMA.PARTITIONS
+            WHERE TABLE_NAME='" . $table->getName() . "'
+            AND TABLE_SCHEMA='" . $table->getSchema() . "'
+            AND CONVERT(PARTITION_DESCRIPTION, SIGNED INTEGER) IS NOT NULL ";
         $request .= $condition;
 
         try {
-            $DBRESULT = $db->query($request);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($request);
+        } catch (PDOException $e) {
             throw new Exception("Error : Cannot get partitions to purge for table "
                 . $tableName . ", " . $e->getMessage() . "\n");
         }
-        
-        while ($row = $DBRESULT->fetchRow()) {
+
+        while ($row = $dbResult->fetch()) {
             $request = "ALTER TABLE " . $tableName . " DROP PARTITION `" . $row["PARTITION_NAME"] . "`;";
             try {
-                $DBRESULT2 =& $db->query($request);
-            } catch (\PDOException $e) {
+                $dbResult2 =& $db->query($request);
+            } catch (PDOException $e) {
                 throw new Exception("Error : Cannot drop partition " . $row["PARTITION_NAME"] . " of table "
                     . $tableName . ", " . $e->getMessage() . "\n");
             }
@@ -369,41 +368,41 @@ class PartEngine
      */
     public function migrate($table, $db)
     {
-        $tableName = $table->getSchema().".".$table->getName();
+        $tableName = $table->getSchema() . "." . $table->getName();
 
         $db->query("SET bulk_insert_buffer_size= 1024 * 1024 * 256");
-        
+
         if (!$table->exists() || !$table->columnExists()) {
-            throw new Exception("Error: Table ".$table->getSchema().".".$table->getName()." does not exists\n");
+            throw new Exception("Error: Table " . $table->getSchema() . "." . $table->getName() . " does not exists\n");
         }
 
         /*
          * Renaming existing table with the suffix '_old'
          */
-        echo "[".date(DATE_RFC822)."][migrate] Renaming table ".$tableName." TO ".$tableName."_old\n";
+        echo "[" . date(DATE_RFC822) . "][migrate] Renaming table " . $tableName . " TO " . $tableName . "_old\n";
         try {
-            $DBRESULT = $db->query("RENAME TABLE " . $tableName . " TO " . $tableName . "_old");
-        } catch (\PDOException $e) {
+            $dbResult = $db->query("RENAME TABLE " . $tableName . " TO " . $tableName . "_old");
+        } catch (PDOException $e) {
             throw new Exception(
                 "Error: Cannot rename table " . $tableName
                 . " to " . $tableName . "_old, "
                 . $e->getMessage() . "\n"
             );
         }
-        
+
         /*
          * creating new table with the initial name
          */
-        echo "[".date(DATE_RFC822)."][migrate] Creating parts for new table ".$tableName."\n";
+        echo "[" . date(DATE_RFC822) . "][migrate] Creating parts for new table " . $tableName . "\n";
         // create partitions for past and future
         $this->createParts($table, $db, true);
-        
+
         // dumping data from existing table
-        echo "[".date(DATE_RFC822)."][migrate] Insert data from ".$tableName."_old to new table\n";
-        $request = "INSERT INTO " . $tableName . " SELECT * FROM " . $tableName."_old";
+        echo "[" . date(DATE_RFC822) . "][migrate] Insert data from " . $tableName . "_old to new table\n";
+        $request = "INSERT INTO " . $tableName . " SELECT * FROM " . $tableName . "_old";
         try {
-            $DBRESULT = $db->query($request);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($request);
+        } catch (PDOException $e) {
             throw new Exception(
                 "Error: Cannot copy " . $tableName . "_old data to new table "
                 . $e->getMessage() . "\n"
@@ -416,71 +415,71 @@ class PartEngine
      */
     public function updateParts($table, $db)
     {
-        $tableName = $table->getSchema().".".$table->getName();
+        $tableName = $table->getSchema() . "." . $table->getName();
         if (!$table->exists()) {
-            throw new Exception("Update error: Table ".$tableName." does not exists\n");
+            throw new Exception("Update error: Table " . $tableName . " does not exists\n");
         }
-        
+
         //verifying if table is partitioned
         try {
-            $DBRESULT = $db->query("use " . $table->getSchema());
-        } catch (\PDOException $e) {
-            throw new Exception("Error: cannot use database ".$table->getSchema()."\n");
+            $dbResult = $db->query("use " . $table->getSchema());
+        } catch (PDOException $e) {
+            throw new Exception("Error: cannot use database " . $table->getSchema() . "\n");
         }
 
         try {
-            $DBRESULT = $db->query("SHOW TABLE STATUS LIKE '" . $table->getName() . "'");
-        } catch (\PDOException $e) {
-            throw new Exception("Error: cannot get table ".$tableName." status, ".$e->getMessage()."\n");
+            $dbResult = $db->query("SHOW TABLE STATUS LIKE '" . $table->getName() . "'");
+        } catch (PDOException $e) {
+            throw new Exception("Error: cannot get table " . $tableName . " status, " . $e->getMessage() . "\n");
         }
-        if (!$DBRESULT->rowCount()) {
-            throw new Exception("Error: cannot get table ".$tableName." status\n");
+        if (!$dbResult->rowCount()) {
+            throw new Exception("Error: cannot get table " . $tableName . " status\n");
         }
-        $row = $DBRESULT->fetchRow();
-        
+        $row = $dbResult->fetch();
+
         if (!isset($row["Create_options"])) {
-            throw new Exception("Cannot find Create_options for table ".$tableName."\n");
+            throw new Exception("Cannot find Create_options for table " . $tableName . "\n");
         }
         if (!preg_match("/partitioned/", $row["Create_options"])) {
-            throw new Exception("Error: cannot update non partitioned table ".$tableName."\n");
+            throw new Exception("Error: cannot update non partitioned table " . $tableName . "\n");
         }
 
         // Get Last
         $lastTime = $this->getLastPartRange($table, $db);
-        
+
         if ($table->getType() == 'date' && $table->getDuration() == 'daily') {
             $this->updateDailyPartitions($db, $tableName, $table, $lastTime);
         }
     }
-    
+
     /**
      * optimize all partitions for a table
      * @param MysqlTable $table
      */
     public function optimizeTablePartitions($table, $db)
     {
-        $tableName = $table->getSchema().".".$table->getName();
+        $tableName = $table->getSchema() . "." . $table->getName();
         if (!$table->exists()) {
-            throw new Exception("Optimize error: Table ".$tableName." does not exists\n");
+            throw new Exception("Optimize error: Table " . $tableName . " does not exists\n");
         }
 
         $request = "SELECT PARTITION_NAME FROM information_schema.`PARTITIONS` ";
-        $request .= "WHERE `TABLE_NAME`='".$table->getName()."' ";
-        $request .= "AND TABLE_SCHEMA='".$table->getSchema()."' ";
+        $request .= "WHERE `TABLE_NAME`='" . $table->getName() . "' ";
+        $request .= "AND TABLE_SCHEMA='" . $table->getSchema() . "' ";
         try {
-            $DBRESULT = $db->query($request);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($request);
+        } catch (PDOException $e) {
             throw new Exception(
                 "Error : Cannot get table schema information  for "
                 . $tableName . ", " . $e->getMessage() . "\n"
             );
         }
 
-        while ($row = $DBRESULT->fetchRow()) {
-            $request = "ALTER TABLE ".$tableName." OPTIMIZE PARTITION `".$row["PARTITION_NAME"]."`;";
+        while ($row = $dbResult->fetch()) {
+            $request = "ALTER TABLE " . $tableName . " OPTIMIZE PARTITION `" . $row["PARTITION_NAME"] . "`;";
             try {
-                $DBRESULT2 = $db->query($request);
-            } catch (\PDOException $e) {
+                $dbResult2 = $db->query($request);
+            } catch (PDOException $e) {
                 throw new Exception(
                     "Optimize error : Cannot optimize partition " . $row["PARTITION_NAME"]
                     . " of table " . $tableName . ", " . $e->getMessage() . "\n"
@@ -488,17 +487,18 @@ class PartEngine
             }
         }
 
-        $DBRESULT->closeCursor();
+        $dbResult->closeCursor();
     }
+
     /**
      * list all partitions for a table
      * @param MysqlTable $table
      */
-    public function listParts($table, $db, $throwException = TRUE)
+    public function listParts($table, $db, $throwException = true)
     {
-        $tableName = $table->getSchema().".".$table->getName();
+        $tableName = $table->getSchema() . "." . $table->getName();
         if (!$table->exists()) {
-            throw new Exception("Parts list error: Table ".$tableName." does not exists\n");
+            throw new Exception("Parts list error: Table " . $tableName . " does not exists\n");
         }
         $request = "";
         if ($table->getType() == "") {
@@ -509,12 +509,12 @@ class PartEngine
         $request .= "PARTITION_NAME, PARTITION_ORDINAL_POSITION, "
             . "INDEX_LENGTH, DATA_LENGTH, CREATE_TIME, TABLE_ROWS ";
         $request .= "FROM information_schema.`PARTITIONS` ";
-        $request .= "WHERE `TABLE_NAME`='".$table->getName()."' ";
-        $request .= "AND TABLE_SCHEMA='".$table->getSchema()."' ";
+        $request .= "WHERE `TABLE_NAME`='" . $table->getName() . "' ";
+        $request .= "AND TABLE_SCHEMA='" . $table->getSchema() . "' ";
         $request .= "ORDER BY PARTITION_NAME DESC ";
         try {
-            $DBRESULT = $db->query($request);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($request);
+        } catch (PDOException $e) {
             throw new Exception(
                 "Error : Cannot get table schema information  for "
                 . $tableName . ", " . $e->getMessage() . "\n"
@@ -522,7 +522,7 @@ class PartEngine
         }
 
         $partitions = array();
-        while ($row = $DBRESULT->fetchRow()) {
+        while ($row = $dbResult->fetch()) {
             if (!is_null($row["PARTITION_NAME"])) {
                 $row["INDEX_LENGTH"] = round($row["INDEX_LENGTH"] / (1024 * 1024), 2);
                 $row["DATA_LENGTH"] = round($row["DATA_LENGTH"] / (1024 * 1024), 2);
@@ -531,11 +531,11 @@ class PartEngine
             }
         }
         if (!count($partitions) && $throwException) {
-            throw new Exception("No partition found for table ".$tableName."\n");
+            throw new Exception("No partition found for table " . $tableName . "\n");
         } else {
             return $partitions;
         }
-        $DBRESULT->closeCursor();
+        $dbResult->closeCursor();
     }
 
     /**
@@ -544,36 +544,36 @@ class PartEngine
      */
     public function backupParts($table, $db)
     {
-        $tableName = $table->getSchema().".".$table->getName();
+        $tableName = $table->getSchema() . "." . $table->getName();
         if (!$table->exists()) {
-            throw new Exception("Error: Table ".$tableName." does not exists\n");
+            throw new Exception("Error: Table " . $tableName . " does not exists\n");
         }
         $format = "PARTITION_DESCRIPTION";
         if (!is_null($table->getBackupFormat()) && $table->getType() == "date" && $table->getDuration() == 'daily') {
-            $format = "date_format(FROM_UNIXTIME(PARTITION_DESCRIPTION), '".$table->getBackupFormat()."')";
+            $format = "date_format(FROM_UNIXTIME(PARTITION_DESCRIPTION), '" . $table->getBackupFormat() . "')";
         }
-        
+
         $request = "SELECT PARTITION_NAME, PARTITION_DESCRIPTION, "
             . $format . " as filename FROM information_schema.`PARTITIONS` ";
-        $request .= "WHERE `TABLE_NAME`='".$table->getName()."' ";
-        $request .= "AND TABLE_SCHEMA='".$table->getSchema()."' ";
+        $request .= "WHERE `TABLE_NAME`='" . $table->getName() . "' ";
+        $request .= "AND TABLE_SCHEMA='" . $table->getSchema() . "' ";
         $request .= "ORDER BY  PARTITION_ORDINAL_POSITION desc ";
         $request .= "LIMIT 2";
         try {
-            $DBRESULT = $db->query($request);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($request);
+        } catch (PDOException $e) {
             throw new Exception(
                 "Error : Cannot get table schema information  for "
                 . $tableName . ", " . $e->getMessage() . "\n"
             );
         }
         $count = 0;
-        $filename = $table->getBackupFolder()."/".$tableName;
+        $filename = $table->getBackupFolder() . "/" . $tableName;
         $start = "";
         $end = "";
-        while ($row = $DBRESULT->fetchRow()) {
+        while ($row = $dbResult->fetch()) {
             if (!$count) {
-                $filename .= "_".$row["PARTITION_NAME"]."_".$row["filename"];
+                $filename .= "_" . $row["PARTITION_NAME"] . "_" . $row["filename"];
                 $end = $row["PARTITION_DESCRIPTION"];
                 $count++;
             } else {
@@ -583,9 +583,9 @@ class PartEngine
         if ($start == "" || $end == "") {
             throw new Exception("FATAL : Cannot get last partition ranges of table " . $tableName . "\n");
         }
-        $filename .= "_".date("Ymd-hi").".dump";
+        $filename .= "_" . date("Ymd-hi") . ".dump";
 
-        $DBRESULT->closeCursor();
+        $dbResult->closeCursor();
 
         $request = "SELECT * FROM " . $tableName;
         $request .= " WHERE " . $table->getColumn() . " >= " . $start;
@@ -593,8 +593,8 @@ class PartEngine
         $request .= " INTO OUTFILE '" . $filename . "'";
 
         try {
-            $DBRESULT = $db->query($request);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($request);
+        } catch (PDOException $e) {
             throw new Exception(
                 "FATAL : Cannot dump table " . $tableName
                 . " into file " . $filename . ", "
@@ -606,18 +606,20 @@ class PartEngine
     /**
      *
      * Check if MySQL version is compatible with partitionning.
+     * @param $db The Db singleton
+     * @return boolean
      */
     public function isCompatible($db)
     {
-        $DBRESULT = $db->query("SELECT plugin_status FROM INFORMATION_SCHEMA.PLUGINS WHERE plugin_name = 'partition'");
-        $config = $DBRESULT->fetchRow();
-        $DBRESULT->closeCursor();
+        $dbResult = $db->query("SELECT plugin_status FROM INFORMATION_SCHEMA.PLUGINS WHERE plugin_name = 'partition'");
+        $config = $dbResult->fetchRow();
+        $dbResult->closeCursor();
         if ($config["plugin_status"] != "ACTIVE") {
             return (false);
         }
         unset($config);
 
-        return (true);
+        return true;
     }
 
     /**
@@ -633,12 +635,12 @@ class PartEngine
             . 'AND TABLE_SCHEMA="' . $table->getSchema() . '" ';
 
         try {
-            $DBRESULT = $db->query($query);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($query);
+        } catch (PDOException $e) {
             throw new Exception('Cannot get partition information');
         }
 
-        if ($DBRESULT->fetchRow()) {
+        if ($dbResult->fetch()) {
             return true;
         } else {
             return false;
@@ -658,8 +660,8 @@ class PartEngine
         $request .= "AND PARTITION_NAME = 'pmax' ";
 
         try {
-            $DBRESULT = $db->query($request);
-        } catch (\PDOException $e) {
+            $dbResult = $db->query($request);
+        } catch (PDOException $e) {
             throw new Exception(
                 "Error : Cannot get partition maxvalue information for table "
                 . $table->getName() . ", " . $e->getMessage() . "\n"
@@ -667,7 +669,7 @@ class PartEngine
         }
 
         $hasMaxValuePartition = false;
-        if ($DBRESULT->fetchRow()) {
+        if ($dbResult->fetch()) {
             $hasMaxValuePartition = true;
         }
 

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -310,7 +310,7 @@ class PartEngine
         $row = $dbResult->fetch();
 
         // maybe we need to check the value of $row["lastPart"]
-        return ($row["lastPart"]);
+        return $row["lastPart"];
     }
 
     /**

--- a/www/class/centreon-partition/partEngine.class.php
+++ b/www/class/centreon-partition/partEngine.class.php
@@ -632,7 +632,7 @@ class PartEngine
                     case 'version_comment':
                         $dbType = $row['Value'];
                         break;
-                    case 'version' :
+                    case 'version':
                         $dbVersion = $row['Value'];
                         break;
                     default :


### PR DESCRIPTION
# Pull Request Template

## Description

On mysql > 5.9, the plugin “partition” as been deprecated and removed.
Resulting on the failling upgrade/install process, as the Cron job.
We need to adapt our code to remove the plugin presence on mysql > 5.9

`https://docs.oracle.com/cd/E17952_01/mysql-8.0-en/faqs-storage-engines.html`

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
