### PR TITLE
fix(clapi): fix import of contactgroup when linked to ldap

### DIFF
--- a/www/class/centreon-clapi/centreonContactGroup.class.php
+++ b/www/class/centreon-clapi/centreonContactGroup.class.php
@@ -126,7 +126,7 @@ class CentreonContactGroup extends CentreonObject
 
         $objectId = $this->getObjectId($params[self::ORDER_UNIQUENAME]);
         if ($objectId != 0) {
-            if (!preg_match("/^cg_/", $params[1])) {
+            if (!preg_match("/^cg_/", $params[1]) && $params[1] !== 'ar_id') {
                 $params[1] = "cg_" . $params[1];
             }
             $updateParams = array($params[1] => $params[2]);


### PR DESCRIPTION
## Description

If a contactgroup is linked to a ldap server, clapi export/import does not work properly
(cg_ar_id column does not exist)

Refs: MON-4127

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Link Centreon web to ldap server
* Import contact group by linking it to ACL and contact
* Export contactgroup using clapi
* try to import it using clapi