### PR TITLE
Improve sudoers consistency

### DIFF
--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -60,7 +60,7 @@ sub new {
     $self->{rsync} = "rsync";
     $self->{rsyncWT} = $self->{rsync};
     $self->{sudo} = "sudo";
-    $self->{service} = "service";
+    $self->{service} = "/sbin/service";
     $self->{timeout} = 5;
     $self->{cmd_timeout} = 5;
     $self->{illegal_characters} = "";

--- a/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
+++ b/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
@@ -163,7 +163,7 @@ class PollerInteractionService
 
         foreach ($tabServers as $poller) {
             if (isset($poller['localhost']) && $poller['localhost'] == 1) {
-                shell_exec("sudo service {$poller['init_script']} restart");
+                shell_exec("sudo /sbin/service {$poller['init_script']} restart");
             } else {
                 if ($fh = @fopen($centCorePipe, 'a+')) {
                     fwrite($fh, 'RESTART:' . $poller['id'] . "\n");

--- a/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -229,7 +229,7 @@ class CentreonConfigPoller
 
         $msg_restart = "";
         if (isset($host['localhost']) && $host['localhost'] == 1) {
-            $msg_restart = exec("sudo service " . $nagios_init_script . " reload", $stdout, $return_code);
+            $msg_restart = exec("sudo /sbin/service " . $nagios_init_script . " reload", $stdout, $return_code);
         } else {
             exec("echo 'RELOAD:" . $host["id"] . "' >> " . $this->centcore_pipe, $stdout, $return_code);
             $msg_restart .= _("OK: A reload signal has been sent to '" . $host["name"] . "'");
@@ -319,7 +319,7 @@ class CentreonConfigPoller
 
         if (isset($host['localhost']) && $host['localhost'] == 1) {
             $msg_restart = exec(
-                escapeshellcmd("sudo service " . $nagios_init_script . " restart"),
+                escapeshellcmd("sudo /sbin/service " . $nagios_init_script . " restart"),
                 $lines,
                 $return_code
             );

--- a/www/class/centreonBroker.class.php
+++ b/www/class/centreonBroker.class.php
@@ -75,7 +75,7 @@ class CentreonBroker
      */
     protected function execLocalScript($script, $action)
     {
-        shell_exec("sudo service $script $action");
+        shell_exec("sudo /sbin/service $script $action");
     }
         
     /**

--- a/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -151,7 +151,7 @@ try {
     foreach ($poller as $host) {
         if ($ret["restart_mode"] == 1) {
             if (isset($host['localhost']) && $host['localhost'] == 1) {
-                $msg_restart[$host["id"]] = shell_exec("sudo service " . $host['init_script'] . " reload");
+                $msg_restart[$host["id"]] = shell_exec("sudo /sbin/service " . $host['init_script'] . " reload");
             } else {
                 if ($fh = @fopen($centcore_pipe, 'a+')) {
                     fwrite($fh, "RELOAD:" . $host["id"] . "\n");
@@ -174,7 +174,7 @@ try {
             }
         } elseif ($ret["restart_mode"] == 2) {
             if (isset($host['localhost']) && $host['localhost'] == 1) {
-                $msg_restart[$host["id"]] = shell_exec("sudo service " . $host['init_script'] . " restart");
+                $msg_restart[$host["id"]] = shell_exec("sudo /sbin/service " . $host['init_script'] . " restart");
             } else {
                 if ($fh = @fopen($centcore_pipe, 'a+')) {
                     fwrite($fh, "RESTART:" . $host["id"] . "\n");


### PR DESCRIPTION
# Pull Request Template

## Description
we use a specific sudoers file and yet we don't reload/restart our services like we should. 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

try to export your configuration by performing a reload nor a restart. 
it should still reload your services like centengine, cbd or centreontrapd or restart them but cbd (because we don't restart it from the IHM).
to check that, just head over your logfiles on your central/poller/remote server, it should be displayed that your daemon has just been reloaded. 

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
