### PR TITLE
librrd_creates_function_has_problems_with_validation_that_exists_with…

### DIFF
--- a/lib/perl/centreon/script/nagiosPerfTrace.pm
+++ b/lib/perl/centreon/script/nagiosPerfTrace.pm
@@ -96,7 +96,11 @@ sub rrd_process {
             $tab[$j+1] =~ /([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)/;
 
             if (!-e $self->{global_cmd_buffer}) {
-                RRDs::create($self->{global_cmd_buffer}, "-s $self->{interval}", "DS:In_Use:GAUGE:$self->{interval}:0:U", "DS:Max_Used:GAUGE:$self->{interval}:0:U", "DS:Total_Available:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                RRDs::create($self->{global_cmd_buffer}, "-s$self->{interval}", "DS:In_Use:GAUGE:$self->{interval}:0:U", "DS:Max_Used:GAUGE:$self->{interval}:0:U", "DS:Total_Available:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                if (RRDs::error()) {
+                    $error = RRDs::error();
+                    $self->{logger}->writeLogError($error);
+                }
                 RRDs::tune($self->{global_cmd_buffer}, "-h", "In_Use:$self->{heartbeat}");
                 RRDs::tune($self->{global_cmd_buffer}, "-h", "Max_Used:$self->{heartbeat}");
                 RRDs::tune($self->{global_cmd_buffer}, "-h", "Total_Available:$self->{heartbeat}");
@@ -117,7 +121,11 @@ sub rrd_process {
             $tab[$j+1] = trim($tab[$j+1]);
             $tab[$j+1] =~ /([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)\ [sec|%]/;
             if (!-e $self->{global_active_service_latency}) {
-                RRDs::create ($self->{global_active_service_latency}, "-s $self->{interval}", "DS:Min:GAUGE:$self->{interval}:0:U", "DS:Max:GAUGE:$self->{interval}:0:U", "DS:Average:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                RRDs::create ($self->{global_active_service_latency}, "-s$self->{interval}", "DS:Min:GAUGE:$self->{interval}:0:U", "DS:Max:GAUGE:$self->{interval}:0:U", "DS:Average:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                if (RRDs::error()) {
+                    $error = RRDs::error();
+                    $self->{logger}->writeLogError($error);
+                }
                 RRDs::tune($self->{global_active_service_latency}, "-h", "Min:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_service_latency}, "-h", "Max:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_service_latency}, "-h", "Average:$self->{heartbeat}");
@@ -138,7 +146,11 @@ sub rrd_process {
             $tab[$j+1] = trim($tab[$j+1]);
             $tab[$j+1] =~ /([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)\ sec/;
             if (! -e $self->{global_active_service_execution}) {
-                RRDs::create ($self->{global_active_service_execution}, "-s $self->{interval}", "DS:Min:GAUGE:$self->{interval}:0:U", "DS:Max:GAUGE:$self->{interval}:0:U", "DS:Average:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                RRDs::create ($self->{global_active_service_execution}, "-s$self->{interval}", "DS:Min:GAUGE:$self->{interval}:0:U", "DS:Max:GAUGE:$self->{interval}:0:U", "DS:Average:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                if (RRDs::error()) {
+                    $error = RRDs::error();
+                    $self->{logger}->writeLogError($error);
+                }
                 RRDs::tune($self->{global_active_service_execution}, "-h", "Min:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_service_execution}, "-h", "Max:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_service_execution}, "-h", "Average:$self->{heartbeat}");
@@ -160,7 +172,11 @@ sub rrd_process {
             $tab[$j+1] = trim($tab[$j+1]);
             $tab[$j+1] =~ /([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)/;
             if (!-e $self->{global_active_service_last}) {
-                RRDs::create ($self->{global_active_service_last}, "-s $self->{interval}", "DS:Last_Min:GAUGE:$self->{interval}:0:U", "DS:Last_5_Min:GAUGE:$self->{interval}:0:U", "DS:Last_15_Min:GAUGE:$self->{interval}:0:U", "DS:Last_Hour:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                RRDs::create ($self->{global_active_service_last}, "-s$self->{interval}", "DS:Last_Min:GAUGE:$self->{interval}:0:U", "DS:Last_5_Min:GAUGE:$self->{interval}:0:U", "DS:Last_15_Min:GAUGE:$self->{interval}:0:U", "DS:Last_Hour:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                if (RRDs::error()) {
+                    $error = RRDs::error();
+                    $self->{logger}->writeLogError($error);
+                }
                 RRDs::tune($self->{global_active_service_last}, "-h", "Last_Min:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_service_last}, "-h", "Last_5_Min:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_service_last}, "-h", "Last_15_Min:$self->{heartbeat}");
@@ -184,7 +200,11 @@ sub rrd_process {
             $tab[$j+1] = trim($tab[$j+1]);
             $tab[$j+1] =~ /([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)/;
             if (! -e $self->{global_services_states}) {
-                RRDs::create ($self->{global_services_states}, "-s $self->{interval}", "DS:Ok:GAUGE:$self->{interval}:0:U", "DS:Warn:GAUGE:$self->{interval}:0:U", "DS:Unk:GAUGE:$self->{interval}:0:U", "DS:Crit:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                RRDs::create ($self->{global_services_states}, "-s$self->{interval}", "DS:Ok:GAUGE:$self->{interval}:0:U", "DS:Warn:GAUGE:$self->{interval}:0:U", "DS:Unk:GAUGE:$self->{interval}:0:U", "DS:Crit:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                if (RRDs::error()) {
+                    $error = RRDs::error();
+                    $self->{logger}->writeLogError($error);
+                }
                 RRDs::tune($self->{global_services_states}, "-h", "Ok:$self->{heartbeat}");
                 RRDs::tune($self->{global_services_states}, "-h", "Warn:$self->{heartbeat}");
                 RRDs::tune($self->{global_services_states}, "-h", "Unk:$self->{heartbeat}");
@@ -208,7 +228,11 @@ sub rrd_process {
             $tab[$j+1] = trim($tab[$j+1]);
             $tab[$j+1] =~ /([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)\ [sec|%]/;
             if (! -e $self->{global_active_host_latency}) {
-                RRDs::create ($self->{global_active_host_latency}, "-s $self->{interval}", "DS:Min:GAUGE:$self->{interval}:0:U", "DS:Max:GAUGE:$self->{interval}:0:U", "DS:Average:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                RRDs::create ($self->{global_active_host_latency}, "-s$self->{interval}", "DS:Min:GAUGE:$self->{interval}:0:U", "DS:Max:GAUGE:$self->{interval}:0:U", "DS:Average:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                if (RRDs::error()) {
+                    $error = RRDs::error();
+                    $self->{logger}->writeLogError($error);
+                }
                 RRDs::tune($self->{global_active_host_latency}, "-h", "Min:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_host_latency}, "-h", "Max:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_host_latency}, "-h", "Average:$self->{heartbeat}");
@@ -230,7 +254,11 @@ sub rrd_process {
             $tab[$j+1] = trim($tab[$j+1]);
             $tab[$j+1] =~ /([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)\ sec/;
             if (! -e $self->{global_active_host_execution}) {
-                RRDs::create ($self->{global_active_host_execution}, "-s $self->{interval}", "DS:Min:GAUGE:$self->{interval}:0:U", "DS:Max:GAUGE:$self->{interval}:0:U", "DS:Average:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                RRDs::create ($self->{global_active_host_execution}, "-s$self->{interval}", "DS:Min:GAUGE:$self->{interval}:0:U", "DS:Max:GAUGE:$self->{interval}:0:U", "DS:Average:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                if (RRDs::error()) {
+                    $error = RRDs::error();
+                    $self->{logger}->writeLogError($error);
+                }
                 RRDs::tune($self->{global_active_host_execution}, "-h", "Min:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_host_execution}, "-h", "Max:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_host_execution}, "-h", "Average:$self->{heartbeat}");
@@ -252,7 +280,11 @@ sub rrd_process {
             $tab[$j+1] = trim($tab[$j+1]);
             $tab[$j+1] =~ /([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)/;
             if (!-e $self->{global_active_host_last}) {
-                RRDs::create ($self->{global_active_host_last}, "-s $self->{interval}", "DS:Last_Min:GAUGE:$self->{interval}:0:U", "DS:Last_5_Min:GAUGE:$self->{interval}:0:U", "DS:Last_15_Min:GAUGE:$self->{interval}:0:U", "DS:Last_Hour:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                RRDs::create ($self->{global_active_host_last}, "-s$self->{interval}", "DS:Last_Min:GAUGE:$self->{interval}:0:U", "DS:Last_5_Min:GAUGE:$self->{interval}:0:U", "DS:Last_15_Min:GAUGE:$self->{interval}:0:U", "DS:Last_Hour:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                if (RRDs::error()) {
+                    $error = RRDs::error();
+                    $self->{logger}->writeLogError($error);
+                }
                 RRDs::tune($self->{global_active_host_last}, "-h", "Last_Min:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_host_last}, "-h", "Last_5_Min:$self->{heartbeat}");
                 RRDs::tune($self->{global_active_host_last}, "-h", "Last_15_Min:$self->{heartbeat}");
@@ -275,7 +307,11 @@ sub rrd_process {
             $tab[$j+1] = trim($tab[$j+1]);
             $tab[$j+1] =~ /([0-9\.]*)\ \/\ ([0-9\.]*)\ \/\ ([0-9\.]*)/;
             if (!-e $self->{global_hosts_states}) {
-                RRDs::create($self->{global_hosts_states}, "-s $self->{interval}", "DS:Up:GAUGE:$self->{interval}:0:U", "DS:Down:GAUGE:$self->{interval}:0:U", "DS:Unreach:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                RRDs::create($self->{global_hosts_states}, "-s$self->{interval}", "DS:Up:GAUGE:$self->{interval}:0:U", "DS:Down:GAUGE:$self->{interval}:0:U", "DS:Unreach:GAUGE:$self->{interval}:0:U", "RRA:AVERAGE:0.5:1:".$self->{number}, "RRA:AVERAGE:0.5:12:".$self->{number});
+                if (RRDs::error()) {
+                    $error = RRDs::error();
+                    $self->{logger}->writeLogError($error);
+                }
                 RRDs::tune($self->{global_hosts_states}, "-h", "Up:$self->{heartbeat}");
                 RRDs::tune($self->{global_hosts_states}, "-h", "Down:$self->{heartbeat}");
                 RRDs::tune($self->{global_hosts_states}, "-h", "Unreach:$self->{heartbeat}");


### PR DESCRIPTION
# Pull Request Template

## Description

**librrd** creates function has **problems with validation** that exists with ==v1.5 and higher==

* v1.4 - [rrd_utils.c](https://github.com/oetiker/rrdtool-1.x/blob/1.4/src/rrd_utils.c) - **NO has this type of validation**

* v1.5 - [rrd_utils.c](https://github.com/oetiker/rrdtool-1.x/blob/1.5/src/rrd_utils.c) - **has a new validation**
  ```c
  241    if (! isdigit(token[0]))
  242      return "value must be (suffixed) positive number";
   ```

**Fixes** on `nagiosPerfTrace.pm`


* **Elimination** of space in scale parameter
* **Adding** error condition on creation

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 19.10.x (master)

## How this pull request can be tested?

```bash
[root@ndev-vps-05:~]# sudo -u centreon /usr/local/centreon/cron/nagiosPerfTrace --config=/etc/centreon/conf.pm
2019-08-26 20:58:02 - ERROR - opening '/var/lib/centreon/nagios-perf/perfmon-1/nagios_cmd_buffer.rrd': No such file or directory
2019-08-26 20:58:02 - ERROR - opening '/var/lib/centreon/nagios-perf/perfmon-1/nagios_active_service_latency.rrd': No such file or directory
2019-08-26 20:58:02 - ERROR - opening '/var/lib/centreon/nagios-perf/perfmon-1/nagios_active_service_execution.rrd': No such file or directory
2019-08-26 20:58:02 - ERROR - opening '/var/lib/centreon/nagios-perf/perfmon-1/nagios_active_service_last.rrd': No such file or directory
2019-08-26 20:58:02 - ERROR - opening '/var/lib/centreon/nagios-perf/perfmon-1/nagios_services_states.rrd': No such file or directory
2019-08-26 20:58:02 - ERROR - opening '/var/lib/centreon/nagios-perf/perfmon-1/nagios_active_host_latency.rrd': No such file or directory
2019-08-26 20:58:02 - ERROR - opening '/var/lib/centreon/nagios-perf/perfmon-1/nagios_active_host_execution.rrd': No such file or directory
2019-08-26 20:58:02 - ERROR - opening '/var/lib/centreon/nagios-perf/perfmon-1/nagios_active_host_last.rrd': No such file or directory
2019-08-26 20:58:02 - ERROR - opening '/var/lib/centreon/nagios-perf/perfmon-1/nagios_hosts_states.rrd': No such file or directory
```

## Proof of concept for test


```perl
#!/usr/bin/perl
#
# librrd_creates_function_has_problems_with_validation_that_exists_with_v1.5_and_higher.pl
#
# 2019-09-26 - nelbren@nelbren.com
#

use RRDs;

my $tempfile = "/tmp/test.rrd";
my $interval = "300";

print("librrd v$RRDs::VERSION\n");

# Version <= 1.4 https://github.com/oetiker/rrdtool-1.x/blob/1.4/src/rrd_utils.c
print("create with -s $interval (this fail in v>=1.5 and works in v<=1.4)\n");
RRDs::create($tempfile, "-s $interval",  "DS:Test:GAUGE:$interval:0:U", "RRA:AVERAGE:0.5:1:".$interval);
print(" +--> ".RRDs::error()."\n") if (RRDs::error());

# Version >= 1.5 https://github.com/oetiker/rrdtool-1.x/blob/1.5/src/rrd_utils.c
# 241    if (! isdigit(token[0]))
# 242       return "value must be (suffixed) positive number";
print("create with -s$interval (this works in v>=1.5 and works in v<=1.4)\n");
RRDs::create($tempfile, "-s$interval",  "DS:Test:GAUGE:$interval:0:U", "RRA:AVERAGE:0.5:1:".$interval);
print(" +--> ".RRDs::error()."\n") if (RRDs::error());
```

### This problem occurs in `Debian GNU/Linux 10.0`

```bash
[nelbren@ndev-vps-05:~]$ uname -a
Linux ndev-vps-05 4.9.0-6-amd64 #1 SMP Debian 4.9.88-1+deb9u1 (2018-05-07) x86_64 GNU/Linux

[nelbren@ndev-vps-05:~]$ ./librrd_creates_function_has_problems_with_validation_that_exists_with_v1.5_and_higher.pl
librrd v1.5001
create with -s 300 (this fail in v>=1.5 and works in v<=1.4)
 +--> step size: value must be (suffixed) positive number
create with -s300 (this works in v>=1.5 and works in v<=1.4)

```

### This problem does not occur in `centreon-19.04-0.el7.x86_64.iso`

```bash
[root@localhost ~]# uname -a
Linux localhost.localdomain 3.10.0-957.el7.x86_64 #1 SMP Thu Nov 8 23:39:32 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux

[root@localhost ~]# ./librrd_creates_function_has_problems_with_validation_that_exists_with_v1.5_and_higher.pl
perl: warning: Setting locale failed.
perl: warning: Please check that your locale settings:
	LANGUAGE = (unset),
	LC_ALL = (unset),
	LC_CTYPE = "UTF-8",
	LANG = "es_HN.UTF-8"
    are supported and installed on your system.
perl: warning: Falling back to the standard locale ("C").
librrd v1.4008
create with -s 300 (this fail in v>=1.5 and works in v<=1.4)
create with -s300 (this works in v>=1.5 and works in v<=1.4)
```

Greetings by Nelbren!