### PR TITLE
enh(CRON): remove sql error when no LDAP is set

### DIFF
--- a/cron/centAcl.php
+++ b/cron/centAcl.php
@@ -147,8 +147,8 @@ try {
                     $updateSyncTime->execute();
                 }
             }
-            $pearDB->commit();
         }
+        $pearDB->commit();
     } catch (\PDOException $e) {
         $pearDB->rollBack();
         programExit("Error when updating LDAP's reference date for next synchronization");


### PR DESCRIPTION
# Pull Request Template

## Description

When no LDAP is configured, when upgrading, the new fields aren't created (parameters are saved as key/value list in the auth_ressource table)
Resulting in errors in the sql error log.

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Install a fresh Centreon IHM without LDAP configured and execute the CRON command manually (or wait for it).
No errors should appear in the sql-error.log or centAcl.log concerning inexistent LDAP table/field


## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
