### PR TITLE
enh(dropdowns): style default select to be as much like select2 as possible

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -99,9 +99,19 @@ input[type="radio"] {
     vertical-align: middle;
 }
 select {
-    padding: 6px;
+    background: url('../../img/icones/7x7/sort_desc.gif') 96% / 6% no-repeat #fff;
+    min-width: 100px;
+    width: auto;
+    font-family: "Open Sans", Arial, Tahoma, Helvetica, sans-serif;
+    -moz-appearance: none;
+    -webkit-appearance: none;
+    appearance: none;
+    padding: 3px;
+    color: #444;
 }
-
+select::-ms-expand {
+    display: none;
+}
 select[multiple="multiple"] {
     overflow:auto;
 }

--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -100,6 +100,7 @@ input[type="radio"] {
 }
 
 select {
+    background-color: #ffffff;
     background-image: url('../../img/icones/7x7/sort_desc.gif');
     background-repeat: no-repeat, repeat;
     background-position: right 5px top 50%, 0 0;

--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -98,23 +98,25 @@ input[type="checkbox"]  {
 input[type="radio"] {
     vertical-align: middle;
 }
+
 select {
-    background: url('../../img/icones/7x7/sort_desc.gif') 96% / 6% no-repeat #fff;
+    background-image: url('../../img/icones/7x7/sort_desc.gif');
+    background-repeat: no-repeat, repeat;
+    background-position: right 5px top 50%, 0 0;
+    background-size: .65em auto, 100%;
     min-width: 100px;
     width: auto;
     font-family: "Open Sans", Arial, Tahoma, Helvetica, sans-serif;
     -moz-appearance: none;
     -webkit-appearance: none;
     appearance: none;
-    padding: 3px;
-    color: #444;
-}
-select::-ms-expand {
-    display: none;
+    padding: 4px 20px 4px 6px;
+    color: #555;
 }
 select[multiple="multiple"] {
     overflow:auto;
 }
+
 hr          {background-color:#CCC;height:1px;margin: 3px 0;}
 
 option      {padding-left:1px;padding-right:1px;}

--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -104,7 +104,7 @@ select {
     background-repeat: no-repeat, repeat;
     background-position: right 5px top 50%, 0 0;
     background-size: .65em auto, 100%;
-    min-width: 100px;
+    min-width: 30px;
     width: auto;
     font-family: "Open Sans", Arial, Tahoma, Helvetica, sans-serif;
     -moz-appearance: none;


### PR DESCRIPTION
# style default select to be as much like select2 as possible

## Description
Change default style of select tag

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x (master)
