### PR TITLE
Mon pear class not found in graphs

### DIFF
--- a/www/include/views/graphs/generateGraphs/generateMetricImage.php
+++ b/www/include/views/graphs/generateGraphs/generateMetricImage.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/www/include/views/graphs/generateGraphs/generateMetricImage.php
+++ b/www/include/views/graphs/generateGraphs/generateMetricImage.php
@@ -54,7 +54,7 @@ if (!CentreonSession::checkSession($sid, $pearDB)) {
     CentreonGraph::displayError();
 }
 
-if (false === isset($_GET['index']) && false === isset($_GET['svcId'])) {
+if (!isset($_GET['index']) && !isset($_GET['svcId'])) {
     CentreonGraph::displayError();
 }
 
@@ -65,7 +65,7 @@ if (isset($_GET['index'])) {
     $index = $_GET['index'];
 } else {
     list($hostId, $svcId) = explode('_', $_GET['svcId']);
-    if (false === is_numeric($hostId) || false === is_numeric($svcId)) {
+    if (!is_numeric($hostId) || !is_numeric($svcId)) {
         CentreonGraph::displayError();
     }
     $res = $pearDBO->prepare(

--- a/www/include/views/graphs/generateGraphs/generateMetricImage.php
+++ b/www/include/views/graphs/generateGraphs/generateMetricImage.php
@@ -36,9 +36,9 @@
 /**
  * Include config file
  */
-require_once realpath(dirname(__FILE__) . "/../../../../../config/centreon.config.php");
-require_once "$centreon_path/www/class/centreonDB.class.php";
-require_once _CENTREON_PATH_."/www/class/centreonGraph.class.php";
+require_once realpath(__DIR__ . "/../../../../../config/centreon.config.php");
+require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
+require_once _CENTREON_PATH_ . "/www/class/centreonGraph.class.php";
 
 /**
  * Create XML Request Objects
@@ -68,13 +68,18 @@ if (isset($_GET['index'])) {
     if (false === is_numeric($hostId) || false === is_numeric($svcId)) {
         CentreonGraph::displayError();
     }
-    $query = 'SELECT id FROM index_data
-        WHERE host_id = ' . $hostId . ' AND service_id = ' . $svcId;
-    $res = $pearDBO->query($query);
-    if (PEAR::isError($res)) {
+    $res = $pearDBO->prepare(
+        'SELECT id FROM index_data
+        WHERE host_id = :hostId AND service_id = :svcId'
+    );
+    $res->bindValue(':hostId', $hostId, \PDO::PARAM_INT);
+    $res->bindValue(':svcId', $svcId, \PDO::PARAM_INT);
+    $res->execute();
+
+    if (!$res) {
         CentreonGraph::displayError();
     }
-    $row = $res->fetchRow();
+    $row = $res->fetch();
     if (!$row) {
         CentreonGraph::displayError();
     }
@@ -82,7 +87,7 @@ if (isset($_GET['index'])) {
 }
 
 
-require_once _CENTREON_PATH_."www/include/common/common-Func.php";
+require_once _CENTREON_PATH_ . "www/include/common/common-Func.php";
 $contactId = CentreonSession::getUser($sid, $pearDB);
 $obj = new CentreonGraph($contactId, $index, 0, 1);
 
@@ -101,10 +106,8 @@ if (isset($_GET["metric"])) {
 /**
  * Set arguments from GET
  */
-$obj->setRRDOption("start", $obj->checkArgument("start", $_GET, time() - (60*60*48)));
+$obj->setRRDOption("start", $obj->checkArgument("start", $_GET, time() - (60 * 60 * 48)));
 $obj->setRRDOption("end", $obj->checkArgument("end", $_GET, time()));
-
-//$obj->GMT->getMyGMTFromSession($obj->session_id, $pearDB);
 
 /**
  * Template Management


### PR DESCRIPTION
# Pull Request Template

## Description

When trying to export a splitted graph, the back end call a removed class and throw a fatal error in the logs. Resulting in a blank page

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [ ] 19.10.x (master) -> already backported

<h2> How this pull request can be tested ? </h2>

go to performance graphs > choose a host > choose multiple graphs > click on the export png button

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
