### PR TITLE
fix(update): move alter table statement in a php script

### DIFF
--- a/www/install/php/Update-19.04.0.php
+++ b/www/install/php/Update-19.04.0.php
@@ -1,0 +1,61 @@
+<?php
+/*
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
+ *
+ * For more information : contact@centreon.com
+ *
+ *
+ */
+
+include_once __DIR__ . "/../../class/centreonLog.class.php";
+$centreonLog = new CentreonLog();
+
+/**
+ * New configuration options for Centreon Engine
+ */
+try {
+    if (!$pearDB->isColumnExist('cfg_nagios', 'enable_macros_filter')) {
+        //$pearDB = "centreon"
+        //$pearDBO = "realtime"
+        $pearDB->query(
+            "ALTER TABLE `cfg_nagios` ADD COLUMN `enable_macros_filter` ENUM('0', '1') DEFAULT '0'"
+        );
+    }
+    if (!$pearDB->isColumnExist('cfg_nagios', 'macros_filter')) {
+        $pearDB->query(
+            "ALTER TABLE `cfg_nagios` ADD COLUMN `macros_filter` TEXT DEFAULT ''"
+        );
+    }
+} catch (\PDOException $e) {
+    $centreonLog->insertLog(
+        2,
+        "UPGRADE : 19.04.0 Unable to modify centreon engine in the database"
+    );
+}

--- a/www/install/sql/centreon/Update-DB-19.04.0.sql
+++ b/www/install/sql/centreon/Update-DB-19.04.0.sql
@@ -31,7 +31,3 @@ INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`,
 -- Remove old Extensions Page menus
 DELETE FROM `topology` WHERE (`topology_page` = '50701');
 DELETE FROM `topology` WHERE (`topology_page` = '50703');
-
--- New configuration options for Centreon Engine
-ALTER TABLE `cfg_nagios` ADD COLUMN `enable_macros_filter` ENUM('0', '1') DEFAULT '0';
-ALTER TABLE `cfg_nagios` ADD COLUMN `macros_filter` TEXT DEFAULT '';


### PR DESCRIPTION
# Pull Request Template

## Description

When reloading/refreshing the page on install/update step4, the alter_table statement may have already been applied, resulting in an error which won't you acheive the process
![image](https://user-images.githubusercontent.com/34628915/64338332-ce76e380-cfe1-11e9-9ae2-6eaaf9a10b46.png)


**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

upgrade from a 18.10.x and when the 19.10.0 script is processed, create an exception (e.g : inserting an error on the 19.04.2 script should do the trick -> I don't really know how this issue occured). Wait for an error in the update process.
Then remove the previously inserted error in the 19.04.2 script.
Use the refresh button to execute again all the upgrade script.
No error should be displayed and the update is successfull.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
