### PR TITLE
fix(ui): retrieve space before alias in user menu

### DIFF
--- a/www/front_src/src/components/userMenu/index.js
+++ b/www/front_src/src/components/userMenu/index.js
@@ -139,7 +139,7 @@ class UserMenu extends Component {
                     </span>
                     <span className={styles['submenu-user-type']}>
                       <Translate value="as" />
-                      {username}
+                      {` ${username}`}
                     </span>
                     {allowEditProfile && (
                       <Link


### PR DESCRIPTION
## Description

When opening user menu (top right), it is displayed "asadmin" instead of "as admin"

**Fixes** MON-4153

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)
