### PR TITLE
fix(ui): avoid host icon to be flattened

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -124,6 +124,7 @@ input[type="checkbox"]  {
 .md-checkbox label:before, .md-checkbox label:after {
     content: "";
     position: absolute;
+    box-sizing: border-box;
     left: 0;
     top: 0;
 }
@@ -164,9 +165,6 @@ input[type="checkbox"]  {
 }
 .md-checkbox input[type="checkbox"]:disabled:checked + label:before {
     background: rgba(0, 0, 0, 0.26);
-}
-*, *:before, *:after {
-    box-sizing: border-box;
 }
 
 


### PR DESCRIPTION
## Description

Avoid host icon to be flattened in Monitoring > Hosts
![image](https://user-images.githubusercontent.com/11978823/65503490-535c6b00-dec5-11e9-805e-0b9b8b648404.png)

**Fixes** MON-4156

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)