### PR TITLE
fix(install): disable button when installing modules last step

### DIFF
--- a/www/install/steps/templates/step8.tpl
+++ b/www/install/steps/templates/step8.tpl
@@ -80,6 +80,8 @@
                 manageButtons();
             }).complete(function() {
                 installButton.prop('disabled', false);
+                installButton.removeClass('bt_default');
+                installButton.addClass('bt_info');
             });
         });
 

--- a/www/install/steps/templates/step8.tpl
+++ b/www/install/steps/templates/step8.tpl
@@ -44,7 +44,7 @@
     jQuery(function() {
         jQuery("input[type=button]#previous").hide();
         var nextButton = jQuery("input[type=button]#next");
-        nextButton.parent().append('<input class="btc bt_info" type="button" id="installModules" value="Install" style="display: none;"/>');
+        nextButton.parent().append('<input class="btc bt_default bt_info" type="button" id="installModules" value="Install" style="display: none;"/>');
         var installButton = jQuery("input[type=button]#installModules");
         var moduleBoxes = jQuery("input[type=checkbox]");
         moduleBoxes.each(function() {
@@ -57,18 +57,22 @@
         });
 
         installButton.on('click', function() {
-            installButton.prop('disabled', true);
-            installButton.removeClass('bt_info');
-            installButton.addClass('bt_default');
-            var moduleBoxes = jQuery("input[type=checkbox]:checked");
+            installButton.prop('disabled', true)
+                .removeClass('bt_info')
+                .prop('value', 'Installing...');
             var moduleNames = [];
             moduleBoxes.each(function() {
-                moduleNames.push(jQuery(this).attr('id'));
+                if (jQuery(this).prop('checked')) {
+                    moduleNames.push(jQuery(this).attr('id'));
+                }
+                jQuery(this).attr('disabled', 'disabled');
             });
             jQuery.ajax({
                 type: 'POST',
                 url: './steps/process/process_step8.php',
-                data: {'modules':moduleNames}
+                data: {
+                    'modules': moduleNames
+                }
             }).success(function(data) {
                 var data = JSON.parse(data);
                 data.forEach(function(module) {
@@ -79,9 +83,9 @@
                 });
                 manageButtons();
             }).complete(function() {
-                installButton.prop('disabled', false);
-                installButton.removeClass('bt_default');
-                installButton.addClass('bt_info');
+                installButton.prop('disabled', false)
+                    .addClass('bt_info')
+                    .prop('value', 'Install');
             });
         });
 

--- a/www/install/steps/templates/step8.tpl
+++ b/www/install/steps/templates/step8.tpl
@@ -58,6 +58,8 @@
 
         installButton.on('click', function() {
             installButton.prop('disabled', true);
+            installButton.removeClass('bt_info');
+            installButton.addClass('bt_default');
             var moduleBoxes = jQuery("input[type=checkbox]:checked");
             var moduleNames = [];
             moduleBoxes.each(function() {


### PR DESCRIPTION
# Pull Request Template

## Description

Actually the button was already disabled, but CSS was not changed
so that the user sees that it is really disabled.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Proceed with an installation of Centreon. When the last step (asking to install pp-manager, lm and autodicovery) when clicking on install then the button should be grey, not clickable and the text changes to "Installing..."

The checkboxes should also be disabled.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
