### PR TITLE
enh(remote-server): set remote_id/remote_server_centcore_ssh_proxy to NULL/0

### DIFF
--- a/www/class/config-generate-remote/Generate.php
+++ b/www/class/config-generate-remote/Generate.php
@@ -204,12 +204,16 @@ class Generate
 
             $this->getPollerFromId($remoteServerId);
             $this->currentPoller['localhost'] = 1;
+            $this->currentPoller['remote_id'] = 'NULL';
+            $this->currentPoller['remote_server_centcore_ssh_proxy'] = 0;
             $this->configPoller($username);
             Relations\NagiosServer::getInstance($this->dependencyInjector)->add($this->currentPoller, $remoteServerId);
 
             $pollers = $this->getPollersFromRemote($remoteServerId);
             foreach ($pollers as $poller) {
                 $poller['localhost'] = 0;
+                $poller['remote_id'] = 'NULL';
+                $poller['remote_server_centcore_ssh_proxy'] = 0;
                 $this->currentPoller = $poller;
                 $this->configPoller($username);
                 Relations\NagiosServer::getInstance($this->dependencyInjector)->add($poller, $poller['id']);


### PR DESCRIPTION
## Description 
Set _remote_id_ to NULL and _remote_server_centcore_ssh_proxy_ to 0 for the exported pollers configuration.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Do an export/import process and check the database on the remote server.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
