### PR TITLE
fix(security): sanitize host_id and service_id - 2.8.x

### DIFF
--- a/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+++ b/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
@@ -84,7 +84,7 @@ $disable        = $obj->checkArgument("disable", $_GET, "disable");
 $dateFormat     = $obj->checkArgument("date_time_format_status", $_GET, "Y/m/d H:i:s");
 
 $host_id = filter_var(
-    $host_id ? $host_id : null,
+    isset($host_id) ? $host_id : null,
     FILTER_VALIDATE_INT
 );
 

--- a/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+++ b/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
@@ -82,6 +82,16 @@ $enable         = $obj->checkArgument("enable", $_GET, "");
 $disable        = $obj->checkArgument("disable", $_GET, "disable");
 $dateFormat     = $obj->checkArgument("date_time_format_status", $_GET, "Y/m/d H:i:s");
 
+$host_id = filter_var(
+    $host_id ?? null,
+    FILTER_SANITIZE_NUMBER_INT
+);
+
+if (!$host_id) {
+    print "Bad host ID";
+    exit();
+}
+
 /** ***************************************************
  * Get Host status
  */

--- a/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+++ b/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
@@ -88,7 +88,7 @@ $host_id = filter_var(
     FILTER_VALIDATE_INT
 );
 
-if (!$host_id) {
+if ($host_id === false) {
     print _("Bad host ID");
     exit();
 }

--- a/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+++ b/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
@@ -84,7 +84,7 @@ $disable        = $obj->checkArgument("disable", $_GET, "disable");
 $dateFormat     = $obj->checkArgument("date_time_format_status", $_GET, "Y/m/d H:i:s");
 
 $host_id = filter_var(
-    $host_id ?? null,
+    $host_id ? $host_id : null,
     FILTER_VALIDATE_INT
 );
 

--- a/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+++ b/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
@@ -85,12 +85,12 @@ $dateFormat         = $obj->checkArgument("date_time_format_status", $_GET, "Y/m
 
 $tab = preg_split('/\_/', $svc_id);
 $host_id = filter_var(
-    $tab[0] ? $tab[0] : null,
+    isset($tab[0]) ? $tab[0] : null,
     FILTER_VALIDATE_INT
 );
 
 $service_id = filter_var(
-    $tab[1] ? $tab[1] : null,
+    isset($tab[1]) ? $tab[1] : null,
     FILTER_VALIDATE_INT
 );
 

--- a/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+++ b/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
@@ -85,12 +85,12 @@ $dateFormat         = $obj->checkArgument("date_time_format_status", $_GET, "Y/m
 
 $tab = preg_split('/\_/', $svc_id);
 $host_id = filter_var(
-    $tab[0] ?? null,
+    $tab[0] ? $tab[0] : null,
     FILTER_VALIDATE_INT
 );
 
 $service_id = filter_var(
-    $tab[1] ?? null,
+    $tab[1] ? $tab[1] : null,
     FILTER_VALIDATE_INT
 );
 

--- a/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+++ b/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
@@ -83,8 +83,20 @@ $disable        = $obj->checkArgument("disable", $_GET, "disable");
 $dateFormat         = $obj->checkArgument("date_time_format_status", $_GET, "Y/m/d H:i:s");
 
 $tab = preg_split('/\_/', $svc_id);
-$host_id = $tab[0];
-$service_id = $tab[1];
+$host_id = filter_var(
+    $tab[0] ?? null,
+    FILTER_SANITIZE_NUMBER_INT
+);
+
+$service_id = filter_var(
+    $tab[1] ?? null,
+    FILTER_SANITIZE_NUMBER_INT
+);
+
+if (!$host_id || !$service_id) {
+    print "Bad service ID";
+    exit();
+}
 
 /** **************************************************
  * Get Service status

--- a/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+++ b/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
@@ -94,7 +94,7 @@ $service_id = filter_var(
     FILTER_VALIDATE_INT
 );
 
-if (!$host_id || !$service_id) {
+if ($host_id === false || $service_id === false) {
     print _("Bad service ID");
     exit();
 }


### PR DESCRIPTION
# Description

Sanitize host_id and service_id

Based on #7862 but for 2.8.x compatibility

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
