### PR TITLE
fix(ui): fix style of frozen checkboxes

### DIFF
--- a/www/lib/HTML/QuickForm/HTML_QuickForm_checkbox_Custom.php
+++ b/www/lib/HTML/QuickForm/HTML_QuickForm_checkbox_Custom.php
@@ -24,10 +24,10 @@ class HTML_QuickForm_checkbox_Custom extends HTML_QuickForm_checkbox
      */
     public function toHtml()
     {
-        if (empty($this->_text)) {
-            $label = '<label class="empty-label" for="' . $this->getAttribute('id') . '"/>' . $this->_text . '</label>';
-        } elseif ($this->_flagFrozen) {
+        if ($this->_flagFrozen) {
             $label = $this->_text;
+        } elseif (empty($this->_text)) {
+            $label = '<label class="empty-label" for="' . $this->getAttribute('id') . '"/>' . $this->_text . '</label>';
         } else {
             $label = '<label for="' . $this->getAttribute('id') . '">' . $this->_text . '</label>';
         }


### PR DESCRIPTION
## Description

Fix style of checkboxes when form is frozen
![image](https://user-images.githubusercontent.com/11978823/65685756-057d6980-e063-11e9-88b1-23d237c46050.png)
to
![image](https://user-images.githubusercontent.com/11978823/65685788-1b8b2a00-e063-11e9-9f5b-65c1416b29d6.png)

**Fixes** MON-4161

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)
