### PR TITLE
fix(status details): Fix hide password in command line for 2.8.x (#7414)

### DIFF
--- a/www/include/monitoring/objectDetails/common-func.php
+++ b/www/include/monitoring/objectDetails/common-func.php
@@ -105,7 +105,7 @@ function hidePasswordInCommand($commandName, $hostId, $serviceId)
     );
 
     $arrHostMacroPassword = array();
-    while ($row = $sth->fetchRow()) {
+    while ($row = $res->fetchRow()) {
         $arrHostMacroPassword = array_merge(
             $arrHostMacroPassword,
             array($row['host_macro_name'])

--- a/www/include/monitoring/objectDetails/common-func.php
+++ b/www/include/monitoring/objectDetails/common-func.php
@@ -38,115 +38,110 @@ require_once $centreon_path . "www/class/centreonHost.class.php";
 /**
  * Hide value of custom macros defined as password
  * 
- * @param string $command_name The name of the command
- * @param int    $host_id      The ID of the host
- * @param int    $service_id   The ID of the service
+ * @param string $commandName The name of the command
+ * @param int    $hostId      The ID of the host
+ * @param int    $serviceId   The ID of the service
  * 
  * @return string
  */
-function hidePasswordInCommand($command_name, $host_id, $service_id)
+function hidePasswordInCommand($commandName, $hostId, $serviceId)
 {
     global $pearDB;
 
-    if(!isset($command_name) && !isset($service_id)) {
+    if (!isset($commandName) && !isset($serviceId)) {
         return 1;
     }
 
     $pearDBStorage = new CentreonDB('centstorage');
 
-    /* Get command line with macro */
-    $query_command_line = "SELECT command_line FROM command WHERE command_name = '" .
-    $pearDB->escape($command_name) . "'";
-    $res = $pearDB->query($query_command_line);
+    // Get command line with macro
+    $res = $pearDB->query(
+        "SELECT command_line
+        FROM command
+        WHERE command_name = '" . $pearDB->escape($commandName) . "'"
+    );
     $row = $res->fetchRow();
-    $command_line_with_macro = $row['command_line'];
+    $commandLineWithMacros = $row['command_line'];
 
-    /* Get executed command lines */
-    $query_command_name = "SELECT host_id, check_command, command_line "
-        . "FROM services "
-        . "WHERE host_id = '" . $host_id . "' "
-        . "AND service_id = '" . $service_id . "'";
-    $res = $pearDBStorage->query($query_command_name);
+    // Get executed command lines
+    $res = $pearDBStorage->query(
+        "SELECT host_id, check_command, command_line
+        FROM services
+        WHERE host_id = '" . $pearDBStorage->escape($hostId) . "'
+        AND service_id = '" . $pearDBStorage->escape($serviceId) . "'"
+    );
     $row = $res->fetchRow();
-    $executed_check_command = $row['command_line'];
+    $commandLineExecuted = $row['command_line'];
 
-    /* Get list of templates */
-    $arrtSvcTpl = getListTemplates($pearDB, $service_id);
-    $arrSvcTplID = array($service_id);
+    // Get list of templates
+    $arrtSvcTpl = getListTemplates($pearDB, $serviceId);
+    $arrSvcTplID = array($serviceId);
     foreach ($arrtSvcTpl as $svc) {
         $arrSvcTplID[] = $svc['service_id'];
     }
 
     /* Get list of custom macros from services and templates */
-    $query_custom_macro_svc = "SELECT svc_macro_name "
-        . "FROM on_demand_macro_service "
-        . "WHERE is_password = 1 "
-        . "AND svc_svc_id IN ('" . implode('\', \'', $arrSvcTplID) . "')";
-    $res = $pearDB->query($query_custom_macro_svc);
+    $res = $pearDB->query(
+        "SELECT svc_macro_name
+        FROM on_demand_macro_service
+        WHERE is_password = 1
+        AND svc_svc_id IN ('" . implode('\', \'', $arrSvcTplID) . "')"
+    );
 
-    $arrMacroPassword = array();
+    $arrServiceMacroPassword = array();
     while ($row = $res->fetchRow()) {
-        $arrMacroPassword = array_merge (
-            $arrMacroPassword, 
+        $arrServiceMacroPassword = array_merge(
+            $arrServiceMacroPassword,
             array($row['svc_macro_name'])
         );
-        $executed_check_command = getOptionName(
-            $command_line_with_macro, 
-            $executed_check_command, 
-            $row['svc_macro_name']
-        );
     }
 
-    /* Get custom macros from hosts and templates */
-    $query_custom_macro_host = "SELECT host_macro_name "
-        . "FROM on_demand_macro_host "
-        . "WHERE is_password = 1 "
-        . "AND host_host_id IN ('" . implode('\', \'', getHostsTemplates($host_id)) . "')";
-    $res = $pearDB->query($query_custom_macro_host);
+    // Get custom macros from hosts and templates
+    $res = $pearDB->query(
+        "SELECT host_macro_name
+        FROM on_demand_macro_host
+        WHERE is_password = 1
+        AND host_host_id IN ('" . implode('\', \'', getHostsTemplates($host_id)) . "')"
+    );
 
-    while ($row = $res->fetchRow()) {
-        $arrMacroPassword = array_merge(
-            $arrMacroPassword, 
+    $arrHostMacroPassword = array();
+    while ($row = $sth->fetchRow()) {
+        $arrHostMacroPassword = array_merge(
+            $arrHostMacroPassword,
             array($row['host_macro_name'])
         );
-        $executed_check_command = getOptionName(
-            $command_line_with_macro, 
-            $executed_check_command, 
-            $row['host_macro_name']
-        );
     }
 
-    return $executed_check_command;
-}
+    $command = '';
+    $patternMacro = '';
+    $aCommandLineWithMacros = explode(' ', $commandLineWithMacros);
+    $aCommandLineExecuted = explode(' ', $commandLineExecuted);
+    $arrMacroPassword = array_merge($arrServiceMacroPassword, $arrHostMacroPassword);
+    $patternMacro = implode('|', $arrMacroPassword);
+    $patternMacro = str_replace('$', '\\$', $patternMacro);
 
-/**
- * Get the name of the option in the command line corresponding 
- * to the custom macro password type 
- *
- * @param string $command_with_macro Configuration command line
- * @param string $executed_command   Executed command line
- * @param string $macro              The custom macro password type
- * 
- * @return string
- */
-function getOptionName($command_with_macro, $executed_command, $macro) {
-    $macro = str_replace('$', '\$', $macro);
-    $pattern = "/(\-\-?[a-zA-Z0-9\-\_]+=?\W+?)\'?" . $macro . "\'?/";
-    if (preg_match($pattern, $command_with_macro, $matches)) {
-        for ($i = 1; $i < count($matches); $i++) {
-            /* Prepare pattern */
-            $pattern = $matches[$i];
-            $pattern = str_replace('/', '\/', $pattern);
-            $pattern = str_replace('-', '\-', $pattern);
-            $pattern = str_replace('.', '\.', $pattern);
-            $pattern = "/(.*\s)?" . $pattern . "\'?([\\x21-\\x7E]+)\'?(\s.*)?/";
-             /* Replace value of custom macro password type 
-                in executed command line */
-            $executed_command = preg_replace($pattern, "\$1" . $matches[$i] . "***\$3", $executed_command);
+    if (count($arrMacroPassword) && preg_match('/(' . $patternMacro . ')/', $commandLineWithMacros)) {
+        if (count($aCommandLineWithMacros) == count($aCommandLineExecuted)) {
+            for ($i = 0; $i < count($aCommandLineWithMacros); $i++) {
+                if (preg_match_all('/(' . $patternMacro . ')/', $aCommandLineWithMacros[$i], $matches)) {
+                    $pattern = $aCommandLineWithMacros[$i];
+                    foreach ($matches as $match) {
+                        if ($arrMacroPassword[$match[0]]) {
+                            $pattern = preg_replace($match, $pattern);
+                        }
+                    }
+                    $command .= ' ' . preg_replace('/\$_(HOST|SERVICE)[a-zA-Z0-9_-]+\$/', '***', $pattern);
+                } else {
+                    $command .= ' ' . $aCommandLineExecuted[$i];
+                }
+            }
+            return preg_replace('/^ /', '', $command);
+        } else {
+            return _('Unable to hide passwords in command');
         }
+    } else {
+        return $commandLineExecuted;
     }
-
-    return $executed_command;
 }
 
 /**
@@ -159,9 +154,12 @@ function getOptionName($command_with_macro, $executed_command, $macro) {
 function getHostsTemplates($host_id) {
     $pearDBCentreon = new CentreonDB();
 
-    $query = "SELECT host_tpl_id FROM host_template_relation "
-        . "WHERE host_host_id = '" . $host_id . "'";
-    $res = $pearDBCentreon->query($query);
+    $res = $pearDBCentreon->query(
+        "SELECT host_tpl_id
+        FROM host_template_relation
+        WHERE host_host_id = '" . $pearDBStorage->escape($hostId) . "'"
+    );
+
     if ($res->numRows() == 0) {
         return array($host_id);
     } else {

--- a/www/include/monitoring/objectDetails/common-func.php
+++ b/www/include/monitoring/objectDetails/common-func.php
@@ -157,7 +157,7 @@ function getHostsTemplates($host_id) {
     $res = $pearDBCentreon->query(
         "SELECT host_tpl_id
         FROM host_template_relation
-        WHERE host_host_id = " . (int) $hostId;
+        WHERE host_host_id = " . (int) $hostId
     );
 
     if ($res->numRows() == 0) {

--- a/www/include/monitoring/objectDetails/common-func.php
+++ b/www/include/monitoring/objectDetails/common-func.php
@@ -157,7 +157,7 @@ function getHostsTemplates($host_id) {
     $res = $pearDBCentreon->query(
         "SELECT host_tpl_id
         FROM host_template_relation
-        WHERE host_host_id = '" . $pearDBStorage->escape($hostId) . "'"
+        WHERE host_host_id = " . (int) $hostId;
     );
 
     if ($res->numRows() == 0) {


### PR DESCRIPTION
## Description

- Change method + add default message if can't apply method
- Add PDO bindParam method for SQL requests
- Fix PSR2

**Fixes** #7414
Based on #7859

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Create different checks commands
Describe custom macros as password type in host, HTPL, service and STPL
Verify in service status details page if all passwords are replaced by '***'

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
