### PR TITLE
enh(db): allow remote server config to be loaded with mysql strict mode enabled

### DIFF
--- a/src/Centreon/Infrastructure/CentreonLegacyDB/CentreonDBAdapter.php
+++ b/src/Centreon/Infrastructure/CentreonLegacyDB/CentreonDBAdapter.php
@@ -203,7 +203,7 @@ class CentreonDBAdapter
         // (`col_name`, `col_name`,...)
 
         // Construct SQL statement
-        $sql = "LOAD DATA INFILE '$file'";
+        $sql = "LOAD DATA LOCAL INFILE '$file'";
         $sql .= " INTO TABLE $table";
         $sql .= " FIELDS TERMINATED BY '" . $fieldsClause["terminated_by"] . "' ENCLOSED BY '"
             . $fieldsClause["enclosed_by"] . "' ESCAPED BY '" . $fieldsClause["escaped_by"] . "'";

--- a/www/class/centreonDB.class.php
+++ b/www/class/centreonDB.class.php
@@ -111,6 +111,7 @@ class CentreonDB extends \PDO
                     [$this, $this->log, $this->debug],
                 ],
                 PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
+                PDO::MYSQL_ATTR_LOCAL_INFILE => true,
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
             ];
 


### PR DESCRIPTION
## Description

This PR aims to allow Remote Server .infile configuration files to be loaded when MySQL strict mode is enabled on the Remote Server database.

The "LOAD DATA INFILE" has to be replaced by "LOAD DATA LOCAL INFILE".
The "MYSQL_ATTR_LOCAL_INFILE" option of PDO needs to be set to "true".

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Before this patch, try to export and import Remote Server configuration when strict mode is enabled on the Remote Server database.
It will result with the following error :
```
SQLSTATE[22007]: Invalid datetime format: 1366 Incorrect integer value: 'NULL' for column `centreon`.`giv_components_template`.`host_id` at row 1
```
After the patch, no error is rised.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
