### PR TITLE
fix(doc): change grant option for remote server database centreon user

### DIFF
--- a/doc/en/administration_guide/poller/enable_remote.rst
+++ b/doc/en/administration_guide/poller/enable_remote.rst
@@ -33,17 +33,15 @@ use HTTP(S) proxy to contact the Centreon Central server.
 This command will enable **Remote Server** mode::
 
     Starting Centreon Remote enable process:
-
-      Limiting Menu Access...Success
-      Limiting Actions...Done
-
-      Notifying Master...Success
-
-      Set 'remote' instance type...Done
-
-      Centreon Remote enabling finished.
+    Limiting Menu Access...               Success
+    Limiting Actions...                   Done
+    Authorizing Master...                 Done
+    Set 'remote' instance type...         Done
+    Notifying Master...
+    Trying host '10.1.2.3'... Success
+    Centreon Remote enabling finished.
 
 Add rights to centreon database user to use **LOAD DATA INFILE** command::
 
-    # mysql -h <database_server_address> -u root -p
-    MariaDB [(none)]> GRANT FILE on *.* to 'centreon'@'<remote_server_ip>';
+    # mysql -u root -p
+    MariaDB [(none)]> GRANT FILE on *.* to 'centreon'@'localhost';

--- a/doc/fr/administration_guide/poller/enable_remote.rst
+++ b/doc/fr/administration_guide/poller/enable_remote.rst
@@ -35,17 +35,15 @@ mettre à **1** l'option **<no proxy to call Central>**, sinon **0**.
 Cette commande va activer le mode **Remote Server** ::
 
     Starting Centreon Remote enable process:
+    Limiting Menu Access...               Success
+    Limiting Actions...                   Done
+    Authorizing Master...                 Done
+    Set 'remote' instance type...         Done
+    Notifying Master...
+    Trying host '10.1.2.3'... Success
+    Centreon Remote enabling finished.
 
-      Limiting Menu Access...Success
-      Limiting Actions...Done
+Ajout des droits pour que l'utilisateur de base de données centreon puisse utiliser la commande **LOAD DATA INFILE**::
 
-      Notifying Master...Success
-
-      Set 'remote' instance type...Done
-
-      Centreon Remote enabling finished.
-
-Ajout des droits pour l'utilsateur de base de données centreon d'utiliser la commande **LOAD DATA INFILE**::
-
-    # mysql -h <database_server_address> -u root -p
-    MariaDB [(none)]> GRANT FILE on *.* to 'centreon'@'<remote_server_ip>';
+    # mysql -u root -p
+    MariaDB [(none)]> GRANT FILE on *.* to 'centreon'@'localhost';


### PR DESCRIPTION
## Description 

As Remote Server does not have remote database, the grant option must be done to the "localhost" user.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

If the grant is done to the "server ip" user, the import will result with the following error : 
```
SQLSTATE[28000]: Invalid authorization specification: 1045 Access denied for user 'centreon'@'localhost' (using password: YES)
```

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
