### PR TITLE
Mon 3204 enable session cookie strict mode for 2 8 x

### DIFF
--- a/www/class/centreonSession.class.php
+++ b/www/class/centreonSession.class.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/www/class/centreonSession.class.php
+++ b/www/class/centreonSession.class.php
@@ -56,6 +56,10 @@ class CentreonSession
 
     public function stop()
     {
+        // delete the current cookie using the 'PHP session expiration time' value
+        setcookie(session_name(), "", time() - 31536000);
+
+        // destroy the session
         session_unset();
         session_destroy();
     }

--- a/www/class/centreonSession.class.php
+++ b/www/class/centreonSession.class.php
@@ -56,9 +56,6 @@ class CentreonSession
 
     public function stop()
     {
-        // delete the current cookie using the 'PHP session expiration time' value
-        setcookie(session_name(), "", time() - 31536000);
-
         // destroy the session
         session_unset();
         session_destroy();
@@ -68,6 +65,7 @@ class CentreonSession
     {
         self::stop();
         self::start();
+        // regenerate the session id value
         session_regenerate_id(true);
     }
 

--- a/www/include/core/login/login.php
+++ b/www/include/core/login/login.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/www/include/core/login/processLogin.php
+++ b/www/include/core/login/processLogin.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/www/include/core/login/processLogin.php
+++ b/www/include/core/login/processLogin.php
@@ -79,25 +79,25 @@ if (isset($_POST["centreon_token"])
     $centreonAuth = new CentreonAuthSSO($useralias, $password, $autologin, $pearDB, $CentreonLog, $encryptType, $token, $generalOptions);
     if ($centreonAuth->passwdOk == 1) {
         $centreon = new Centreon($centreonAuth->userInfos);
+        // security fix - regenerate the sid after the login
+        session_regenerate_id();
         $_SESSION["centreon"] = $centreon;
-
-        $DBRESULT = $pearDB->prepare("INSERT INTO `session` (`session_id` , `user_id` , `current_page` , `last_reload`, `ip_address`) VALUES (?, ?, ?, ?, ?)");
-        $pearDB->execute($DBRESULT, array(session_id(), $centreon->user->user_id, '1', time(), $_SERVER["REMOTE_ADDR"]));
+        // saving session data in the DB
+        $dbResult = $pearDB->prepare("INSERT INTO `session` (`session_id` , `user_id` , `current_page` , `last_reload`, `ip_address`) VALUES (?, ?, ?, ?, ?)");
+        $pearDB->execute($dbResult, array(session_id(), $centreon->user->user_id, '1', time(), $_SERVER["REMOTE_ADDR"]));
         if (!isset($_POST["submit"])) {
+            $headerRedirection = "./main.php";
             $minimize = '';
             if (isset ($_GET["min"]) && $_GET["min"] == '1') {
                 $minimize = '&min=1';
             }
             if (isset ($_GET["p"]) && $_GET["p"] != '') {
-                header('Location: main.php?p=' . $_GET["p"] . $minimize);
+                $headerRedirection .= "?p=" . $_GET["p"];
             } else if (isset($centreon->user->default_page) && $centreon->user->default_page != '') {
-                header('Location: main.php?p=' . $centreon->user->default_page . $minimize);
-            } else {
-                header('Location: main.php');
+                $headerRedirection .= "?p=" . $centreon->user->default_page;
             }
-        } else {
-            header("Location: ./main.php");
         }
+        header("Location: " . $headerRedirection . $minimize);
         $connect = true;
     } else {
         $connect = false;

--- a/www/include/core/login/processLogin.php
+++ b/www/include/core/login/processLogin.php
@@ -80,7 +80,7 @@ if (isset($_POST["centreon_token"])
     if ($centreonAuth->passwdOk == 1) {
         $centreon = new Centreon($centreonAuth->userInfos);
         // security fix - regenerate the sid after the login to prevent session fixation
-        session_regenerate_id();
+        session_regenerate_id(true);
         $_SESSION["centreon"] = $centreon;
         // saving session data in the DB
         $dbResult = $pearDB->prepare("INSERT INTO `session` (`session_id` , `user_id` , `current_page` , `last_reload`, `ip_address`) VALUES (?, ?, ?, ?, ?)");

--- a/www/include/core/login/processLogin.php
+++ b/www/include/core/login/processLogin.php
@@ -79,7 +79,7 @@ if (isset($_POST["centreon_token"])
     $centreonAuth = new CentreonAuthSSO($useralias, $password, $autologin, $pearDB, $CentreonLog, $encryptType, $token, $generalOptions);
     if ($centreonAuth->passwdOk == 1) {
         $centreon = new Centreon($centreonAuth->userInfos);
-        // security fix - regenerate the sid after the login
+        // security fix - regenerate the sid after the login to prevent session fixation
         session_regenerate_id();
         $_SESSION["centreon"] = $centreon;
         // saving session data in the DB

--- a/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/www/include/views/graphs/generateGraphs/generateImage.php
@@ -65,7 +65,7 @@ if ((isset($_GET["token"]) || isset($_GET["akey"])) && isset($_GET['username']))
         $res = $pearDB->query("SELECT session_id FROM session WHERE session_id = '".$mySessionId."'");
         if (!$res->numRows()) {
             // security fix - regenerate the sid to prevent session fixation
-            session_regenerate_id();
+            session_regenerate_id(true);
             $mySessionId = session_id();
             $DBRESULT = $pearDB->prepare(
                 "INSERT INTO `session` (`session_id` , `user_id` , `current_page` , `last_reload`, `ip_address`)

--- a/www/index.php
+++ b/www/index.php
@@ -90,7 +90,9 @@ if (file_exists("./install/setup.php")) {
 /*
  * Set PHP Session Expiration time
  */
-ini_set("session.gc_maxlifetime", "31536000");
+ini_set('session.gc_maxlifetime', 31536000);
+// security fix to avoid session fixation hijack
+ini_set('session.use_strict_mode', 1);
 
 CentreonSession::start();
 

--- a/www/index.php
+++ b/www/index.php
@@ -103,10 +103,15 @@ if (isset($_GET["disconnect"])) {
      * Init log class
      */
     if (is_object($centreon)) {
-        $CentreonLog = new CentreonUserLog($centreon->user->get_id(), $pearDB);
+        $userId = $centreon->user->get_id();
+        $CentreonLog = new CentreonUserLog($userId, $pearDB);
         $CentreonLog->insertLog(1, "Contact '".$centreon->user->get_alias()."' logout");
 
+        // delete current session
         $pearDB->query("DELETE FROM session WHERE session_id = '".session_id()."'");
+
+        // delete all user's sessions
+        $pearDB->query("DELETE FROM session WHERE user_id = '" . $userId . "'");
 
         CentreonSession::restart();
     }

--- a/www/index.php
+++ b/www/index.php
@@ -89,11 +89,8 @@ if (file_exists("./install/setup.php")) {
 
 /*
  * Set PHP Session Expiration time
- * These parameters have been moved in the php.ini in Centreon >=18.10.x
  */
 ini_set('session.gc_maxlifetime', 31536000);
-// security fix to avoid session fixation hijack
-ini_set('session.use_strict_mode', 1);
 
 CentreonSession::start();
 

--- a/www/index.php
+++ b/www/index.php
@@ -97,21 +97,16 @@ ini_set('session.use_strict_mode', 1);
 CentreonSession::start();
 
 if (isset($_GET["disconnect"])) {
-    $centreon = & $_SESSION["centreon"];
-    
+    $centreon = &$_SESSION["centreon"];
+
     /*
      * Init log class
      */
     if (is_object($centreon)) {
-        $userId = $centreon->user->get_id();
-        $CentreonLog = new CentreonUserLog($userId, $pearDB);
-        $CentreonLog->insertLog(1, "Contact '".$centreon->user->get_alias()."' logout");
+        $CentreonLog = new CentreonUserLog($centreon->user->get_id(), $pearDB);
+        $CentreonLog->insertLog(1, "Contact '" . $centreon->user->get_alias() . "' logout");
 
-        // delete current session
-        $pearDB->query("DELETE FROM session WHERE session_id = '".session_id()."'");
-
-        // delete all user's sessions
-        $pearDB->query("DELETE FROM session WHERE user_id = '" . $userId . "'");
+        $pearDB->query("DELETE FROM session WHERE session_id = '" . session_id() . "'");
 
         CentreonSession::restart();
     }

--- a/www/index.php
+++ b/www/index.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -89,6 +89,7 @@ if (file_exists("./install/setup.php")) {
 
 /*
  * Set PHP Session Expiration time
+ * These parameters have been moved in the php.ini in Centreon >=18.10.x
  */
 ini_set('session.gc_maxlifetime', 31536000);
 // security fix to avoid session fixation hijack


### PR DESCRIPTION
# Pull Request Template

## Description

- Securing the PHPSESSID cookie from hijack or modifications using the session.strict_mode in the php.ini (these modifications have been removed from current PR; and already merged on centreon-build to be deployed with the next RPMs).

- Regenerating the session_id() value after the login and after the logout

- Minor typo and variable naming corrections

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

-> Please contact me

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
