### PR TITLE
fix(secu): the ini_set session duration param has been moved in php.ini

### DIFF
--- a/www/api/internal.php
+++ b/www/api/internal.php
@@ -44,11 +44,10 @@ error_reporting(-1);
 ini_set('display_errors', 0);
 
 $pearDB = new CentreonDB();
-ini_set("session.gc_maxlifetime", "31536000");
 
 CentreonSession::start(1);
 
-if (false === isset($_SESSION["centreon"])) {
+if (!isset($_SESSION["centreon"])) {
     CentreonWebService::sendResult("Unauthorized", 401);
 }
 
@@ -58,11 +57,10 @@ $pearDB = new CentreonDB();
  * Define Centreon var alias
  */
 if (isset($_SESSION["centreon"])) {
-    $centreon = $_SESSION["centreon"];
-    $oreon = $centreon;
+    $oreon = $centreon = $_SESSION["centreon"];
 }
 
-if (false === isset($centreon) || false === is_object($centreon)) {
+if (!isset($centreon) || !is_object($centreon)) {
     CentreonWebService::sendResult("Unauthorized", 401);
 }
 

--- a/www/include/core/header/header.php
+++ b/www/include/core/header/header.php
@@ -73,8 +73,6 @@ $pearDBO = new CentreonDB("centstorage");
 
 $centreonSession = new CentreonSession();
 
-ini_set("session.gc_maxlifetime", "31536000");
-
 CentreonSession::start();
 
 /*
@@ -136,15 +134,14 @@ if (!isset($_SESSION["centreon"])) {
  * Define Oreon var alias
  */
 if (isset($_SESSION["centreon"])) {
-    $centreon = $_SESSION["centreon"];
-    $oreon = $centreon;
+    $oreon = $centreon = $_SESSION["centreon"];
 }
 if (!isset($centreon) || !is_object($centreon)) {
     exit();
 }
 
 /*
- * Init differents elements we need in a lot of pages
+ * Init different elements we need in a lot of pages
  */
 unset($centreon->Nagioscfg);
 $centreon->initNagiosCFG($pearDB);


### PR DESCRIPTION
# Pull Request Template

## Description

These parameters have been moved in the php.ini file to make these values global.

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

contact me

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
