### PR TITLE
fix(ui): fix style of broker modules options checkboxes

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -1144,6 +1144,16 @@ div.menuLeft {
     padding: 4px 6px;
 }
 
+.table .FormRowValue.flex-row-wrap {
+    display: flex;
+    flex-flow: row wrap;
+    max-width: 80vw;
+}
+
+.table .FormRowValue.flex-row-wrap .md-checkbox-inline {
+    margin: 2px 10px 2px 0px;
+}
+
 /* ------ END : Popover-----*/
 
 /* ------ START : Tabs -----*/

--- a/www/include/configuration/configNagios/formNagios.ihtml
+++ b/www/include/configuration/configNagios/formNagios.ihtml
@@ -264,7 +264,15 @@
                                     {include file="file:$centreon_path/www/include/common/templates/clone.ihtml" cloneId="broker" cloneSet=$cloneSet}
 				</td>
 			</tr>
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="event_broker_options">&nbsp;{$form.event_broker_options.label}</td><td class="FormRowValue">{$form.event_broker_options.html}</td></tr>
+            <tr class="list_two">
+                <td class="FormRowField">
+                    <img class="helpTooltip" name="event_broker_options">
+                    &nbsp;{$form.event_broker_options.label}
+                </td>
+                <td class="FormRowValue flex-row-wrap">
+                    {$form.event_broker_options.html}
+                </td>
+            </tr>
 			<tr class="list_one">
 				<td class="FormRowField"><img class="helpTooltip" name="enable_macros_filter">&nbsp;{$form.enable_macros_filter.label}</td>
 				<td class="FormRowValue">{$form.enable_macros_filter.html}</td>

--- a/www/include/configuration/configNagios/formNagios.php
+++ b/www/include/configuration/configNagios/formNagios.php
@@ -664,30 +664,20 @@ $eventBrokerOptionsData = [];
 // Add checkbox for each of event broker options
 foreach (CentreonMainCfg::EVENT_BROKER_OPTIONS as $bit => $label) {
     if ($bit === -1 || $bit === 0) {
-        $element = $form->createElement(
-            'customcheckbox',
-            $bit,
-            '',
-            _($label),
-            [
-                'onClick' => 'unCheckOthers("event-broker-options", this.name);',
-                'class' => 'event-broker-options'
-            ]
-        );
+        $onClick = 'unCheckOthers("event-broker-options", this.name);';
     } else {
-        $element = $form->createElement(
-            'customcheckbox',
-            $bit,
-            '',
-            _($label),
-            [
-                'onClick' => 'unCheckAllAndNaught("event-broker-options");',
-                'class' => 'event-broker-options'
-            ]
-        );
+        $onClick = 'unCheckOthers("event-broker-options", this.name);';
     }
-    $element->setCheckboxTemplate('<span class="checkbox-inline">{element}</span>');
-    $eventBrokerOptionsData[] = $element;
+    $eventBrokerOptionsData[] = $form->createElement(
+        'checkbox',
+        $bit,
+        '',
+        _($label),
+        [
+            'onClick' => $onClick,
+            'class' => 'event-broker-options'
+        ]
+    );;
 }
 $form->addGroup($eventBrokerOptionsData, 'event_broker_options', _("Broker Module Options"), '&nbsp;');
  // New options for enable whitelist of macros sent to Centreon Broker

--- a/www/include/configuration/configNagios/formNagios.php
+++ b/www/include/configuration/configNagios/formNagios.php
@@ -666,7 +666,7 @@ foreach (CentreonMainCfg::EVENT_BROKER_OPTIONS as $bit => $label) {
     if ($bit === -1 || $bit === 0) {
         $onClick = 'unCheckOthers("event-broker-options", this.name);';
     } else {
-        $onClick = 'unCheckOthers("event-broker-options", this.name);';
+        $onClick = 'unCheckAllAndNaught("event-broker-options");';
     }
     $eventBrokerOptionsData[] = $form->createElement(
         'checkbox',


### PR DESCRIPTION
## Description
Fix style of checkboxes in broker modules options field :
![image](https://user-images.githubusercontent.com/11978823/66101411-0f492480-e5af-11e9-9d0a-454b25a37017.png)

**Fixes** MON-4179

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)