### PR TITLE
fix(install): move SQL update to Centreon 19.10 RC.1

### DIFF
--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -2299,7 +2299,7 @@ CREATE TABLE IF NOT EXISTS `remote_servers` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Create rs_poller_relation for the additional relationship between poller and remote servers
-CREATE TABLE `rs_poller_relation` (
+CREATE TABLE IF NOT EXISTS `rs_poller_relation` (
   `remote_server_id` int(11) NOT NULL,
   `poller_server_id` int(11) NOT NULL,
   KEY `remote_server_id` (`remote_server_id`)

--- a/www/install/sql/centreon/Update-DB-19.10.0-beta.3.sql
+++ b/www/install/sql/centreon/Update-DB-19.10.0-beta.3.sql
@@ -8,13 +8,6 @@ INSERT INTO `widget_parameters_field_type` (`ft_typename`, `is_connector`) VALUE
 ('hostSeverityMulti', 1),
 ('serviceSeverityMulti', 1);
 
--- Create rs_poller_relation for the additional relationship between poller and remote servers
-CREATE TABLE `rs_poller_relation` (
-  `remote_server_id` int(11) NOT NULL,
-  `poller_server_id` int(11) NOT NULL,
-  KEY `remote_server_id` (`remote_server_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation Table For centreon pollers and remote servers';
-
 -- Update broker form
 UPDATE `cb_field` SET `fieldname` = 'rrd_cached_option', `displayname` = 'Enable RRDCached', `description` = 'Enable rrdcached option for Centreon, please see Centreon documentation to configure it.', `fieldtype` = 'radio', `external` = NULL
 WHERE `fieldname` = 'path' AND `displayname` = 'Unix socket';

--- a/www/install/sql/centreon/Update-DB-19.10.0-rc.1.sql
+++ b/www/install/sql/centreon/Update-DB-19.10.0-rc.1.sql
@@ -1,0 +1,7 @@
+-- Create rs_poller_relation for the additional relationship between poller and remote servers
+CREATE TABLE IF NOT EXISTS `rs_poller_relation` (
+  `remote_server_id` int(11) NOT NULL,
+  `poller_server_id` int(11) NOT NULL,
+  KEY `remote_server_id` (`remote_server_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation Table For centreon pollers and remote servers';
+


### PR DESCRIPTION
# Description

Move SQL upate to Centreon 19.10 RC.1

**Fixes** PR/#7849
 
## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

From Centreon 19.10-beta.3 update to RC.1 and check if centreon.rs_poller_relation table exist