### PR TITLE
fix(front): save properly monitoring service status filter

### DIFF
--- a/www/front_src/src/components/serviceStatusMenu/index.js
+++ b/www/front_src/src/components/serviceStatusMenu/index.js
@@ -106,7 +106,7 @@ class ServiceStatusMenu extends Component {
         })}
       >
         <Link
-          to="/main.php?p=20201&o=svc_critical&search="
+          to="/main.php?p=20201&o=svc_unhandled&statusFilter=critical&search="
           className={classnames(
             styles['wrap-middle-icon'],
             styles.round,
@@ -125,7 +125,7 @@ class ServiceStatusMenu extends Component {
           </span>
         </Link>
         <Link
-          to="/main.php?p=20201&o=svc_warning&search="
+          to="/main.php?p=20201&o=svc_unhandled&statusFilter=warning&search="
           className={classnames(
             styles['wrap-middle-icon'],
             styles.round,
@@ -144,7 +144,7 @@ class ServiceStatusMenu extends Component {
           </span>
         </Link>
         <Link
-          to="/main.php?p=20201&o=svc_unknown&search="
+          to="/main.php?p=20201&o=svc_unhandled&statusFilter=unknown&search="
           className={classnames(
             styles['wrap-middle-icon'],
             styles.round,
@@ -165,7 +165,7 @@ class ServiceStatusMenu extends Component {
           </span>
         </Link>
         <Link
-          to="/main.php?p=20201&o=svc_ok&statusService=svc&search="
+          to="/main.php?p=20201&o=svc&statusFilter=ok&search="
           className={classnames(
             styles['wrap-middle-icon'],
             styles.round,
@@ -208,7 +208,7 @@ class ServiceStatusMenu extends Component {
               >
                 <li className={styles['submenu-item']}>
                   <Link
-                    to="/main.php?p=20201&o=svc&search="
+                    to="/main.php?p=20201&o=svc&statusFilter=&search="
                     className={styles['submenu-item-link']}
                   >
                     <div onClick={this.toggle}>
@@ -224,7 +224,7 @@ class ServiceStatusMenu extends Component {
                 </li>
                 <li className={styles['submenu-item']}>
                   <Link
-                    to="/main.php?p=20201&o=svc_critical&search="
+                    to="/main.php?p=20201&o=svc_unhandled&statusFilter=critical&search="
                     className={styles['submenu-item-link']}
                   >
                     <div onClick={this.toggle}>
@@ -247,7 +247,7 @@ class ServiceStatusMenu extends Component {
                 </li>
                 <li className={styles['submenu-item']}>
                   <Link
-                    to="/main.php?p=20201&o=svc_warning&search="
+                    to="/main.php?p=20201&o=svc_unhandled&statusFilter=warning&search="
                     className={styles['submenu-item-link']}
                   >
                     <div onClick={this.toggle}>
@@ -270,7 +270,7 @@ class ServiceStatusMenu extends Component {
                 </li>
                 <li className={styles['submenu-item']}>
                   <Link
-                    to="/main.php?p=20201&o=svc_unknown&search="
+                    to="/main.php?p=20201&o=svc_unhandled&statusFilter=unknown&search="
                     className={styles['submenu-item-link']}
                   >
                     <div onClick={this.toggle}>
@@ -293,7 +293,7 @@ class ServiceStatusMenu extends Component {
                 </li>
                 <li className={styles['submenu-item']}>
                   <Link
-                    to="/main.php?p=20201&o=svc_ok&statusService=svc&search="
+                    to="/main.php?p=20201&o=svc&statusFilter=ok&search="
                     className={styles['submenu-item-link']}
                   >
                     <div onClick={this.toggle}>
@@ -314,7 +314,7 @@ class ServiceStatusMenu extends Component {
                 </li>
                 <li className={styles['submenu-item']}>
                   <Link
-                    to="/main.php?p=20201&o=svc_pending&statusService=svc&search="
+                    to="/main.php?p=20201&o=svc&statusFilter=pending&search="
                     className={styles['submenu-item-link']}
                   >
                     <div onClick={this.toggle}>

--- a/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -392,7 +392,7 @@
                 {if $lcaTopo.20301 || $admin == 1}
                 <tr class='list_two'>
                     <td class="ListColLeft ColPopup">
-                        <a href='./main.php?p=20201&o=svc&host_search={$host_data.host_name}&statusService=svc'>{$lnk_all_services}</a>
+                        <a href='./main.php?p=20201&o=svc&host_search={$host_data.host_name}&statusService=svc&statusFilter='>{$lnk_all_services}</a>
                     </td>
                 </tr>
                 {/if}

--- a/www/include/monitoring/status/HostGroups/xsl/hostGroup.xsl
+++ b/www/include/monitoring/status/HostGroups/xsl/hostGroup.xsl
@@ -69,7 +69,7 @@
                             <xsl:element name="a">
                                 <xsl:attribute name="class">margin_right</xsl:attribute>
                                 <xsl:attribute name="href">
-                                    <xsl:value-of select="hgurl"/>&amp;o=svc_critical</xsl:attribute>
+                                    <xsl:value-of select="hgurl"/>&amp;o=svc&amp;statusFilter=critical</xsl:attribute>
                                 <span>
                                     <xsl:attribute name="class">
                                         state_badge <xsl:value-of select="scc"/>
@@ -82,7 +82,7 @@
                             <xsl:element name="a">
                                 <xsl:attribute name="class">margin_right</xsl:attribute>
                                 <xsl:attribute name="href">
-                                    <xsl:value-of select="hgurl"/>&amp;o=svc_warning</xsl:attribute>
+                                    <xsl:value-of select="hgurl"/>&amp;o=svc&amp;statusFilter=warning</xsl:attribute>
                                 <span>
                                     <xsl:attribute name="class">
                                         state_badge <xsl:value-of select="swc"/>
@@ -95,7 +95,7 @@
                             <xsl:element name="a">
                                 <xsl:attribute name="class">margin_right</xsl:attribute>
                                 <xsl:attribute name="href">
-                                    <xsl:value-of select="hgurl"/>&amp;o=svc_unknown</xsl:attribute>
+                                    <xsl:value-of select="hgurl"/>&amp;o=svc&amp;statusFilter=unknown</xsl:attribute>
                                 <span>
                                     <xsl:attribute name="class">
                                         state_badge <xsl:value-of select="suc"/>
@@ -108,7 +108,7 @@
                             <xsl:element name="a">
                                 <xsl:attribute name="class">margin_right</xsl:attribute>
                                 <xsl:attribute name="href">
-                                    <xsl:value-of select="hgurl"/>&amp;o=svc_ok</xsl:attribute>
+                                    <xsl:value-of select="hgurl"/>&amp;o=svc&amp;statusFilter=ok</xsl:attribute>
                                 <span>
                                     <xsl:attribute name="class">
                                         state_badge <xsl:value-of select="skc"/>
@@ -121,7 +121,7 @@
                             <xsl:element name="a">
                                 <xsl:attribute name="class">margin_right</xsl:attribute>
                                 <xsl:attribute name="href">
-                                    <xsl:value-of select="hgurl"/>&amp;o=svc_pending</xsl:attribute>
+                                    <xsl:value-of select="hgurl"/>&amp;o=svc&amp;statusFilter=pending</xsl:attribute>
                                 <span>
                                     <xsl:attribute name="class">
                                         state_badge <xsl:value-of select="spc"/>

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -412,17 +412,21 @@ $form->addElement(
     $statusList,
     array('id' => 'statusFilter', 'onChange' => "filterStatus(this.value);")
 );
-if ((!isset($_GET['o']) || empty($_GET['o'])) && isset($_SESSION['monitoring_service_status_filter'])) {
-    $form->setDefaults(array('statusFilter' => $_SESSION['monitoring_service_status_filter']));
-}
-$defaultStatusFilter = $_GET['statusFilter'] ?? '';
-$serviceStatusFromO = isset($_GET['o']) && in_array($_GET['o'], array_keys($statusService)) ? $_GET['o'] : null;
+
+$serviceStatusFromO = isset($_GET['o']) && in_array($_GET['o'], array_keys($statusService))
+    ? $_GET['o']
+    : null;
 $defaultStatusService =  $_GET['statusService']
     ?? $_POST['statusService']
     ?? $serviceStatusFromO
     ?: $_SESSION['monitoring_service_status']
     ?? 'svc_unhandled';
 $o = $defaultStatusService;
+
+$defaultStatusFilter = $_GET['statusFilter']
+    ?? $_POST['statusFilter']
+    ?: $_SESSION['monitoring_service_status_filter']
+    ?? '';
 
 $form->addElement(
     'select',
@@ -534,7 +538,9 @@ $tpl->display("service.ihtml");
         if (_defaultStatusService !== '') {
             jQuery("#statusService option[value='" + _defaultStatusService + "']").prop('selected', true);
         }
-
+        if (_defaultStatusFilter !== '') {
+            jQuery("#statusFilter option[value='" + _defaultStatusFilter + "']").prop('selected', true);
+        }
         filterStatus(document.getElementById('statusFilter').value, 1);
     }
 

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -405,14 +405,6 @@ if ($o == "svc") {
     }
 }
 
-$form->addElement(
-    'select',
-    'statusFilter',
-    _('Status'),
-    $statusList,
-    array('id' => 'statusFilter', 'onChange' => "filterStatus(this.value);")
-);
-
 $serviceStatusFromO = isset($_GET['o']) && in_array($_GET['o'], array_keys($statusService))
     ? $_GET['o']
     : null;
@@ -422,6 +414,7 @@ $defaultStatusService =  $_GET['statusService']
     ?: $_SESSION['monitoring_service_status']
     ?? 'svc_unhandled';
 $o = $defaultStatusService;
+$form->setDefaults(array('statusFilter' => $defaultStatusService));
 
 $defaultStatusFilter = $_GET['statusFilter']
     ?? $_POST['statusFilter']
@@ -430,11 +423,21 @@ $defaultStatusFilter = $_GET['statusFilter']
 
 $form->addElement(
     'select',
+    'statusFilter',
+    _('Status'),
+    $statusList,
+    array('id' => 'statusFilter', 'onChange' => "filterStatus(this.value);")
+);
+$form->setDefaults(['statusFilter' => $defaultStatusFilter]);
+
+$form->addElement(
+    'select',
     'statusService',
     _('Service Status'),
     $statusService,
     array('id' => 'statusService', 'onChange' => "statusServices(this.value);")
 );
+$form->setDefaults(['statusService' => $defaultStatusService]);
 
 $criticality = new CentreonCriticality($pearDB);
 $crits = $criticality->getList(null, "level", 'ASC', null, null, true);

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -425,7 +425,7 @@ $o = $defaultStatusService;
 
 $defaultStatusFilter = $_GET['statusFilter']
     ?? $_POST['statusFilter']
-    ?: $_SESSION['monitoring_service_status_filter']
+    ?? $_SESSION['monitoring_service_status_filter']
     ?? '';
 
 $form->addElement(

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -228,8 +228,6 @@ $tpl->assign("mon_status_information", _("Status information"));
 $tab_class = array("0" => "list_one", "1" => "list_two");
 $rows = 10;
 
-$sDefaultOrder = "0";
-
 if (!isset($_GET['o'])) {
     $sSetOrderInMemory = "1";
 } else {
@@ -416,10 +414,15 @@ $form->addElement(
 );
 if ((!isset($_GET['o']) || empty($_GET['o'])) && isset($_SESSION['monitoring_service_status_filter'])) {
     $form->setDefaults(array('statusFilter' => $_SESSION['monitoring_service_status_filter']));
-    $sDefaultOrder = "1";
 }
 $defaultStatusFilter = $_GET['statusFilter'] ?? '';
-$defaultStatusService = $_GET['statusService'] ?? 'svc_unhandled';
+$serviceStatusFromO = isset($_GET['o']) && in_array($_GET['o'], array_keys($statusService)) ? $_GET['o'] : null;
+$defaultStatusService =  $_GET['statusService']
+    ?? $_POST['statusService']
+    ?? $serviceStatusFromO
+    ?: $_SESSION['monitoring_service_status']
+    ?? 'svc_unhandled';
+$o = $defaultStatusService;
 
 $form->addElement(
     'select',
@@ -428,16 +431,6 @@ $form->addElement(
     $statusService,
     array('id' => 'statusService', 'onChange' => "statusServices(this.value);")
 );
-
-/* Get default service status by GET */
-if (isset($_GET['o']) && in_array($_GET['o'], array_keys($statusService))) {
-    $form->setDefaults(array('statusService' => $_GET['o']));
-    /* Get default service status in SESSION */
-} elseif ((!isset($_GET['o']) || empty($_GET['o'])) && isset($_SESSION['monitoring_service_status'])) {
-    $o = $_SESSION['monitoring_service_status'];
-    $form->setDefaults(array('statusService' => $_SESSION['monitoring_service_status']));
-    $sDefaultOrder = "1";
-}
 
 $criticality = new CentreonCriticality($pearDB);
 $crits = $criticality->getList(null, "level", 'ASC', null, null, true);
@@ -536,33 +529,12 @@ $tpl->display("service.ihtml");
         _o = '<?= $o; ?>';
         _defaultStatusFilter = '<?= $defaultStatusFilter; ?>';
         _defaultStatusService = '<?= $defaultStatusService; ?>';
-        _sDefaultOrder = '<?= $sDefaultOrder; ?>';
         sSetOrderInMemory = '<?= $sSetOrderInMemory; ?>';
 
         if (_defaultStatusService !== '') {
             jQuery("#statusService option[value='" + _defaultStatusService + "']").prop('selected', true);
         }
 
-        if (_sDefaultOrder == "0") {
-            if (_o == 'svc') {
-                jQuery("#statusFilter option[value='']").prop('selected', true);
-            } else if (_o == 'svc_ok') {
-                jQuery("#statusFilter option[value='ok']").prop('selected', true);
-            } else if (_o == 'svc_warning') {
-                jQuery("#statusFilter option[value='warning']").prop('selected', true);
-            } else if (_o == 'svc_critical') {
-                jQuery("#statusFilter option[value='critical']").prop('selected', true);
-            } else if (_o == 'svc_unknown') {
-                jQuery("#statusFilter option[value='unknown']").prop('selected', true);
-            } else if (_o == 'svc_pending') {
-                jQuery("#statusFilter option[value='pending']").prop('selected', true);
-            } else {
-                jQuery("#statusFilter option[value='']").prop('selected', true);
-            }
-            if (_defaultStatusFilter != '') {
-                jQuery("#statusFilter option[value='" + _defaultStatusFilter + "']").prop('selected', true);
-            }
-        }
         filterStatus(document.getElementById('statusFilter').value, 1);
     }
 

--- a/www/include/monitoring/status/Services/xsl/serviceGrid.xsl
+++ b/www/include/monitoring/status/Services/xsl/serviceGrid.xsl
@@ -35,7 +35,7 @@
                     </td>
                     <td class="ListColLeft" style="white-space:nowrap;width:37px;">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;statusFilter=&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
                             <xsl:element name="img">
                                 <xsl:attribute name="src">./img/icons/view.png</xsl:attribute>
                                 <xsl:attribute name="class">ico-18</xsl:attribute>

--- a/www/include/monitoring/status/Services/xsl/serviceSummary.xsl
+++ b/www/include/monitoring/status/Services/xsl/serviceSummary.xsl
@@ -29,7 +29,7 @@
 		</td>
 		<td class="ListColLeft" style="white-space:nowrap;width:37px;">
 			<xsl:element name="a">
-			  	<xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
+			  	<xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;statusFilter=&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
 					<xsl:element name="img">
 					  	<xsl:attribute name="src">./img/icons/view.png</xsl:attribute>
 						<xsl:attribute name="class">ico-18</xsl:attribute>
@@ -52,7 +52,7 @@
 		<td class="ListColLeft">
                     <xsl:if test="sc >= 1">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc_critical&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=critical&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">state_badge <xsl:value-of select="scc"/></xsl:attribute>
                             </xsl:element>
@@ -61,7 +61,7 @@
                     </xsl:if>
                     <xsl:if test="sw >= 1">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc_warning&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=warning&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">state_badge <xsl:value-of select="swc"/></xsl:attribute>
                             </xsl:element>
@@ -70,7 +70,7 @@
                     </xsl:if>
                     <xsl:if test="su >= 1">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc_unknown&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=unknown&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">state_badge <xsl:value-of select="suc"/></xsl:attribute>
                             </xsl:element>
@@ -79,7 +79,7 @@
                     </xsl:if>
                     <xsl:if test="sk >= 1">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc_ok&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=ok&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">state_badge <xsl:value-of select="skc"/></xsl:attribute>
                             </xsl:element>
@@ -88,7 +88,7 @@
                     </xsl:if>
                     <xsl:if test="sp >= 1">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc_pending&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=pending&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">state_badge <xsl:value-of select="spc"/></xsl:attribute>
                             </xsl:element>

--- a/www/include/monitoring/status/ServicesHostGroups/xsl/serviceGridByHG.xsl
+++ b/www/include/monitoring/status/ServicesHostGroups/xsl/serviceGridByHG.xsl
@@ -84,7 +84,7 @@
 				</td>
 				<td class="ListColLeft" style="white-space:nowrap;width:37px;">
 					<xsl:element name="a">
-					  	<xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
+					  	<xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;statusFilter=&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
 							<xsl:element name="img">
 							  	<xsl:attribute name="src">./img/icons/view.png</xsl:attribute>
 								<xsl:attribute name="class">ico-18</xsl:attribute>

--- a/www/include/monitoring/status/ServicesHostGroups/xsl/serviceSummaryByHG.xsl
+++ b/www/include/monitoring/status/ServicesHostGroups/xsl/serviceSummaryByHG.xsl
@@ -94,7 +94,7 @@
                         </td>
                         <td class="ListColLeft" style="white-space:nowrap;width:37px;">
                             <xsl:element name="a">
-                                <xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
+                                <xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;statusFilter=&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
                                 <xsl:element name="img">
                                     <xsl:attribute name="src">./img/icons/view.png</xsl:attribute>
                                     <xsl:attribute name="class">ico-18</xsl:attribute>
@@ -119,7 +119,7 @@
                         <td class="ListColLeft">
                             <xsl:if test="sc >= 1">
                                 <xsl:element name="a">
-                                    <xsl:attribute name="href">main.php?o=svc_critical&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                                    <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=critical&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                                     <xsl:element name="span">
                                         <xsl:attribute name="class">state_badge <xsl:value-of select="scc"/></xsl:attribute>
                                     </xsl:element>
@@ -128,7 +128,7 @@
                             </xsl:if>
                             <xsl:if test="sw >= 1">
                                 <xsl:element name="a">
-                                    <xsl:attribute name="href">main.php?o=svc_warning&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                                    <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=warning&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                                     <xsl:element name="span">
                                         <xsl:attribute name="class">state_badge <xsl:value-of select="swc"/></xsl:attribute>
                                     </xsl:element>
@@ -138,7 +138,7 @@
                             
                             <xsl:if test="su >= 1">
                                 <xsl:element name="a">
-                                    <xsl:attribute name="href">main.php?o=svc_unknown&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                                    <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=unknown&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                                     <xsl:element name="span">
                                         <xsl:attribute name="class">state_badge <xsl:value-of select="suc"/></xsl:attribute>
                                     </xsl:element>
@@ -147,7 +147,7 @@
                             </xsl:if>
                             <xsl:if test="sk >= 1">
                                 <xsl:element name="a">
-                                    <xsl:attribute name="href">main.php?o=svc_ok&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                                    <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=ok&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                                     <xsl:element name="span">
                                         <xsl:attribute name="class">state_badge <xsl:value-of select="skc"/></xsl:attribute>
                                     </xsl:element>
@@ -156,7 +156,7 @@
                             </xsl:if>
                             <xsl:if test="sp >= 1">
                                 <xsl:element name="a">
-                                    <xsl:attribute name="href">main.php?o=svc_pending&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                                    <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=pending&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                                     <xsl:element name="span">
                                         <xsl:attribute name="class">state_badge <xsl:value-of select="spc"/></xsl:attribute>
                                     </xsl:element>

--- a/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceGridBySG.xsl
+++ b/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceGridBySG.xsl
@@ -46,7 +46,7 @@
                         </td>
                         <td class="ListColLeft" style="white-space:nowrap;width:37px;">
                             <xsl:element name="a">
-                                <xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
+                                <xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;statusFilter=&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
                                 <xsl:element name="img">
                                     <xsl:attribute name="src">./img/icons/view.png</xsl:attribute>
                                     <xsl:attribute name="class">ico-18</xsl:attribute>

--- a/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceSummaryBySG.xsl
+++ b/www/include/monitoring/status/ServicesServiceGroups/xsl/serviceSummaryBySG.xsl
@@ -40,7 +40,7 @@
 			</td>
 			<td class="ListColLeft" style="white-space:nowrap;width:37px;">
 				<xsl:element name="a">
-				  	<xsl:attribute name="href">main.php?o=svc&amp;p=20201&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
+				  	<xsl:attribute name="href">main.php?o=svc&amp;p=&amp;statusFilter=&amp;host_search=<xsl:value-of select="hnl"/></xsl:attribute>
 						<xsl:element name="img">
 						  	<xsl:attribute name="src">./img/icons/view.png</xsl:attribute>
 							<xsl:attribute name="class">ico-18</xsl:attribute>
@@ -65,7 +65,7 @@
                 <td class="ListColLeft">
                     <xsl:if test="sc >= 1">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc_critical&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=critical&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                             <xsl:attribute name="class">margin_right</xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">state_badge <xsl:value-of select="//sc" /></xsl:attribute>
@@ -75,7 +75,7 @@
                     </xsl:if>
                     <xsl:if test="sw >= 1">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc_warning&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=warning&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                             <xsl:attribute name="class">margin_right</xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">state_badge <xsl:value-of select="//sw" /></xsl:attribute>
@@ -85,7 +85,7 @@
                     </xsl:if>
                     <xsl:if test="su >= 1">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc_unknown&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=unknown&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                             <xsl:attribute name="class">margin_right</xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">state_badge <xsl:value-of select="//su" /></xsl:attribute>
@@ -95,7 +95,7 @@
                     </xsl:if>
                     <xsl:if test="sk >= 1">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc_ok&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=ok&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                             <xsl:attribute name="class">margin_right</xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">state_badge <xsl:value-of select="//sk" /></xsl:attribute>
@@ -105,7 +105,7 @@
                     </xsl:if>
                     <xsl:if test="sp >= 1">
                         <xsl:element name="a">
-                            <xsl:attribute name="href">main.php?o=svc_pending&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
+                            <xsl:attribute name="href">main.php?o=svc&amp;statusFilter=pending&amp;p=20201&amp;host_search=<xsl:value-of select="hn"/></xsl:attribute>
                             <xsl:attribute name="class">margin_right</xsl:attribute>
                             <xsl:element name="span">
                                 <xsl:attribute name="class">state_badge <xsl:value-of select="//sp" /></xsl:attribute>


### PR DESCRIPTION
## Description

Save properly "status filter" in Monitoring > Status details > Services

**Fixes** MON-4181

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)