### PR TITLE
fix(i18n): issue with translation when several modules installed

### DIFF
--- a/src/Centreon/Domain/Service/I18nService.php
+++ b/src/Centreon/Domain/Service/I18nService.php
@@ -149,6 +149,7 @@ class I18nService
 
                 foreach ($files as $file) {
                     $data = array_replace_recursive(
+                        $data,
                         unserialize($file->getContents())
                     );
                 }


### PR DESCRIPTION
# Pull Request Template

## Description

When several modules bringing there own translations are installed then the translation only works for one of them.

**Fixes** NONE

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Install modules that have translations and check that if you change the LANG in the user profile  to French

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
