### PR TITLE
fix(front): optimize select all in select2 component

### DIFF
--- a/www/include/common/javascript/centreon/centreon-select2.js
+++ b/www/include/common/javascript/centreon/centreon-select2.js
@@ -524,19 +524,19 @@
 
       if (this.remoteData) {
         /* Append new elements */
+        option = '';
         for (var i = 0; i < elements.length; i++) {
           item = elements[i];
 
           /* Create DOM option that is pre-selected by default */
-          option = '<option selected value="' + item.id + '"';
+          option += '<option selected value="' + item.id + '"';
           if (item.hide === true) {
             option += ' hidden';
           }
           option += '>' + item.text + '</option>';
-
-          /* Append it to select */
-          self.$elem.append(option);
         }
+        /* Append it to select */
+        self.$elem.append(option);
       } else {
         /* Select existing elements */
         selectedElements = elements.map(function (object) {

--- a/www/include/common/javascript/centreon/centreon-select2.js
+++ b/www/include/common/javascript/centreon/centreon-select2.js
@@ -519,24 +519,23 @@
     selectElements: function (elements) {
       var self = this;
       var item;
-      var option;
       var selectedElements;
 
       if (this.remoteData) {
         /* Append new elements */
-        option = '';
+        let options = '';
         for (var i = 0; i < elements.length; i++) {
           item = elements[i];
 
           /* Create DOM option that is pre-selected by default */
-          option += '<option selected value="' + item.id + '"';
+          options += '<option selected value="' + item.id + '"';
           if (item.hide === true) {
-            option += ' hidden';
+            options += ' hidden';
           }
-          option += '>' + item.text + '</option>';
+          options += '>' + item.text + '</option>';
         }
         /* Append it to select */
-        self.$elem.append(option);
+        self.$elem.append(options);
       } else {
         /* Select existing elements */
         selectedElements = elements.map(function (object) {

--- a/www/lib/HTML/QuickForm/select2.php
+++ b/www/lib/HTML/QuickForm/select2.php
@@ -477,28 +477,28 @@ class HTML_QuickForm_select2 extends HTML_QuickForm_select
         $ajaxDefaultDatas = '$request' . $this->getName() . ' = jQuery.ajax({
             url: "' . $this->_defaultDatasetRoute . '",
         });
-        
+
         $request' . $this->getName() . '.success(function (data) {
+            let options = "";
             for (var d = 0; d < data.length; d++) {
                 var item = data[d];
-                
+
                 // Create the DOM option that is pre-selected by default
-                var option = "<option selected=\"selected\" value=\"" + item.id + "\" ";
+                options += "<option selected=\"selected\" value=\"" + item.id + "\" ";
                 if (item.hide === true) {
-                    option += "hidden";
+                    options += "hidden";
                 }
-                option += ">" + item.text + "</option>";
-              
-                // Append it to the select
-                $currentSelect2Object' . $this->getName() . '.append(option);
+                options += ">" + item.text + "</option>";
             }
- 
+            // Append it to the select
+            $currentSelect2Object' . $this->getName() . '.append(options);
+
             // Update the selected options that are displayed
             $currentSelect2Object' . $this->getName() . '.trigger("change",[{origin:\'select2defaultinit\'}]);
         });
 
         $request' . $this->getName() . '.error(function(data) {
-            
+
         });
         ';
 


### PR DESCRIPTION
## Description

"Select All" option in multiselect component could take several minutes to end when lot of option where loaded.
This PR optimize drastically this load by inserting option using bulk

**Fixes** MON-4197

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)