### PR TITLE
fix(remote-server): add missing host poller relation in export

### DIFF
--- a/www/class/config-generate-remote/Abstracts/AbstractHost.php
+++ b/www/class/config-generate-remote/Abstracts/AbstractHost.php
@@ -221,7 +221,7 @@ abstract class AbstractHost extends AbstractObject
      * @param array $host
      * @return void
      */
-    protected function getHostPoller(array &$host): void
+    protected function getHostPoller(array $host): void
     {
         if (is_null($this->stmtPoller)) {
             $this->stmtPoller = $this->backendInstance->db->prepare(

--- a/www/class/config-generate-remote/Abstracts/AbstractHost.php
+++ b/www/class/config-generate-remote/Abstracts/AbstractHost.php
@@ -235,7 +235,7 @@ abstract class AbstractHost extends AbstractObject
         $pollerId = $this->stmtPoller->fetchAll(PDO::FETCH_COLUMN);
 
         HostPollerRelation::getInstance($this->dependencyInjector)
-                ->addRelation($pollerId[0], $host['host_id']);
+            ->addRelation($pollerId[0], $host['host_id']);
     }
 
     /**

--- a/www/class/config-generate-remote/Abstracts/AbstractHost.php
+++ b/www/class/config-generate-remote/Abstracts/AbstractHost.php
@@ -31,6 +31,7 @@ use ConfigGenerateRemote\TimePeriod;
 use ConfigGenerateRemote\Relations\ContactHostRelation;
 use ConfigGenerateRemote\Relations\ContactGroupHostRelation;
 use ConfigGenerateRemote\Relations\HostTemplateRelation;
+use ConfigGenerateRemote\Relations\HostPollerRelation;
 use ConfigGenerateRemote\Relations\MacroHost;
 
 abstract class AbstractHost extends AbstractObject
@@ -104,6 +105,7 @@ abstract class AbstractHost extends AbstractObject
     protected $stmtHtpl = null;
     protected $stmtContact = null;
     protected $stmtCg = null;
+    protected $stmtPoller = null;
 
     /**
      * Get host extended information
@@ -211,6 +213,29 @@ abstract class AbstractHost extends AbstractObject
                 ->addRelation($host['host_id'], $templateId, $order);
             $order++;
         }
+    }
+
+    /**
+     * Get linked poller
+     *
+     * @param array $host
+     * @return void
+     */
+    protected function getHostPoller(array &$host): void
+    {
+        if (is_null($this->stmtPoller)) {
+            $this->stmtPoller = $this->backendInstance->db->prepare(
+                "SELECT nagios_server_id
+                FROM ns_host_relation
+                WHERE host_host_id = :host_id"
+            );
+        }
+        $this->stmtPoller->bindParam(':host_id', $host['host_id'], PDO::PARAM_INT);
+        $this->stmtPoller->execute();
+        $pollerId = $this->stmtPoller->fetchAll(PDO::FETCH_COLUMN);
+
+        HostPollerRelation::getInstance($this->dependencyInjector)
+                ->addRelation($pollerId[0], $host['host_id']);
     }
 
     /**

--- a/www/class/config-generate-remote/Generate.php
+++ b/www/class/config-generate-remote/Generate.php
@@ -358,6 +358,7 @@ class Generate
         Relations\HostGroupRelation::getInstance($this->dependencyInjector)->reset();
         Relations\HostServiceRelation::getInstance($this->dependencyInjector)->reset();
         Relations\HostTemplateRelation::getInstance($this->dependencyInjector)->reset();
+        Relations\HostPollerRelation::getInstance($this->dependencyInjector)->reset();
         Relations\MacroHost::getInstance($this->dependencyInjector)->reset();
         Relations\NagiosServer::getInstance($this->dependencyInjector)->reset();
         Relations\ServiceCategoriesRelation::getInstance($this->dependencyInjector)->reset();

--- a/www/class/config-generate-remote/Host.php
+++ b/www/class/config-generate-remote/Host.php
@@ -185,6 +185,7 @@ class Host extends AbstractHost
 
         $this->getHostTimezone($host);
         $this->getHostTemplates($host);
+        $this->getHostPoller($host);
         $this->getHostCommands($host);
         $this->getHostPeriods($host);
 

--- a/www/class/config-generate-remote/Relations/HostPollerRelation.php
+++ b/www/class/config-generate-remote/Relations/HostPollerRelation.php
@@ -1,0 +1,49 @@
+<?php
+/*
+ * Copyright 2005 - 2019 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+namespace ConfigGenerateRemote\Relations;
+
+use ConfigGenerateRemote\Abstracts\AbstractObject;
+
+class HostPollerRelation extends AbstractObject
+{
+    protected $table = 'ns_host_relation';
+    protected $generateFilename = 'ns_host_relation.infile';
+    protected $attributesWrite = [
+        'nagios_server_id',
+        'host_host_id',
+    ];
+
+    /**
+     * Add relation between host and poller
+     *
+     * @param integer $pollerId
+     * @param integer $hostId
+     * @return void
+     */
+    public function addRelation(int $pollerId, int $hostId)
+    {
+        $relation = [
+            'nagios_server_id' => $pollerId,
+            'host_host_id' => $hostId,
+        ];
+        $this->generateObjectInFile($relation, $hostId . '.' . $serviceId);
+    }
+}


### PR DESCRIPTION
## Description

Fix Centreon Remote Server configuration export to export now relation between host and poller. Used to send external command through Centcore process

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
