### PR TITLE
fix(sql): update column types of downtimes table

### DIFF
--- a/www/install/sql/centstorage/Update-CSTG-19.10.0-rc.2.sql
+++ b/www/install/sql/centstorage/Update-CSTG-19.10.0-rc.2.sql
@@ -1,0 +1,10 @@
+-- migrate downtimes.start_time & downtimes.end_time column from int(11) to timestamp
+ALTER TABLE `downtimes` ADD COLUMN `start_time2` TIMESTAMP NULL DEFAULT NULL AFTER `start_time`;
+UPDATE `downtimes` SET `start_time2` = FROM_UNIXTIME(`start_time`);
+ALTER TABLE `downtimes` DROP COLUMN `start_time`;
+ALTER TABLE `downtimes` CHANGE `start_time2` `start_time` TIMESTAMP NULL DEFAULT NULL;
+
+ALTER TABLE `downtimes` ADD COLUMN `end_time2` TIMESTAMP NULL DEFAULT NULL AFTER `end_time`;
+UPDATE `downtimes` SET `end_time2` = FROM_UNIXTIME(`end_time`);
+ALTER TABLE `downtimes` DROP COLUMN `end_time`;
+ALTER TABLE `downtimes` CHANGE `end_time2` `end_time` TIMESTAMP NULL DEFAULT NULL;


### PR DESCRIPTION
## Description

broker could not insert max timestamp as end_time.
So start_time & end_time now allow timestamp corresponding to 2038

**Fixes** BAM-740

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)