### PR TITLE
fix(widget): undefined pagination variable when editing custom view

### DIFF
--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -292,15 +292,15 @@ class CentreonWidget
             $matrix[$row][] = $col;
         }
         ksort($matrix);
-        $rowNb = 0;
+        $rowNb = 0; //current row in the foreach
         foreach ($matrix as $row => $cols) {
             if ($rowNb != $row) {
                 break;
             }
             if (count($cols) < $layout) {
-                sort($cols);
+                sort($cols); // number of used columns in this row
                 for ($i = 0; $i < $layout; $i++) {
-                    if ($cols[$i] != $i) {
+                    if (!isset($cols[$i]) || $cols[$i] != $i) {
                         $newPosition = $i . '_' . $rowNb;
                         break;
                     }


### PR DESCRIPTION
# Pull Request Template

## Description

Correct undefined pagination variable when increasing the number of rows of your custom view

**Fixes** # (MON-4165)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Add a view with 1 column.
Add at least two widgets
Then change the view configuration to 2 or 3 columns.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
