### PR TITLE
fix(remote-server): fix simple remote server creation

### DIFF
--- a/src/CentreonRemote/Domain/Service/ConfigurationWizard/PollerConfigurationRequestBridge.php
+++ b/src/CentreonRemote/Domain/Service/ConfigurationWizard/PollerConfigurationRequestBridge.php
@@ -75,7 +75,10 @@ class PollerConfigurationRequestBridge
         if (!$isRemoteServerWizard) {
             $linkedRemotes = isset($_POST['linked_remote_slaves']) ? $_POST['linked_remote_slaves'] : [];
         }
-
+$linkedRemotes = [];
+if (!$isRemoteServerWizard && isset($_POST['linked_remote_slaves'])) {
+    $linkedRemotes = $_POST['linked_remote_slaves'];
+}
         $this->additionalRemotes = $this->getPollersToLink($linkedRemotes); // set and instantiate linked pollers
     }
 

--- a/src/CentreonRemote/Domain/Service/ConfigurationWizard/PollerConfigurationRequestBridge.php
+++ b/src/CentreonRemote/Domain/Service/ConfigurationWizard/PollerConfigurationRequestBridge.php
@@ -72,13 +72,10 @@ class PollerConfigurationRequestBridge
         $isRemoteServerWizard = (new ServerWizardIdentity)->requestConfigurationIsRemote();
 
         $linkedRemotes = [];
-        if (!$isRemoteServerWizard) {
-            $linkedRemotes = isset($_POST['linked_remote_slaves']) ? $_POST['linked_remote_slaves'] : [];
+        if (!$isRemoteServerWizard && isset($_POST['linked_remote_slaves'])) {
+            $linkedRemotes = $_POST['linked_remote_slaves'];
         }
-$linkedRemotes = [];
-if (!$isRemoteServerWizard && isset($_POST['linked_remote_slaves'])) {
-    $linkedRemotes = $_POST['linked_remote_slaves'];
-}
+
         $this->additionalRemotes = $this->getPollersToLink($linkedRemotes); // set and instantiate linked pollers
     }
 

--- a/src/CentreonRemote/Domain/Service/ConfigurationWizard/PollerConfigurationRequestBridge.php
+++ b/src/CentreonRemote/Domain/Service/ConfigurationWizard/PollerConfigurationRequestBridge.php
@@ -71,8 +71,9 @@ class PollerConfigurationRequestBridge
     {
         $isRemoteServerWizard = (new ServerWizardIdentity)->requestConfigurationIsRemote();
 
+        $linkedRemotes = [];
         if (!$isRemoteServerWizard) {
-            $linkedRemotes= isset($_POST['linked_remote_slaves']) ? $_POST['linked_remote_slaves'] : [];
+            $linkedRemotes = isset($_POST['linked_remote_slaves']) ? $_POST['linked_remote_slaves'] : [];
         }
 
         $this->additionalRemotes = $this->getPollersToLink($linkedRemotes); // set and instantiate linked pollers

--- a/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -120,6 +120,7 @@ if (!empty($remotesResults)) {
             WHERE remote_server_id = :remote_id
         ');
         $linkedStatement->bindValue(':remote_id', $remote['id'], \PDO::PARAM_INT);
+        $linkedStatement->execute();
         $linkedResults = $linkedStatement->fetchAll(PDO::FETCH_ASSOC);
 
         $exportParams = [


### PR DESCRIPTION
## Description

- Remote server wizard failed when adding a remote server linked to the central server (without pollers)
- Data was not exported on remote server

**Fixes** BAM-748

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)