### PR TITLE
enh(centcore): handle multiple external commands from central to rs to poller

### DIFF
--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -62,7 +62,7 @@ sub new {
     $self->{sudo} = "sudo";
     $self->{service} = "service";
     $self->{timeout} = 5;
-    $self->{cmd_timeout} = 5;
+    $self->{cmd_timeout} = 10;
     $self->{illegal_characters} = "";
 
     $self->{ssh} .= " -o ConnectTimeout=$self->{timeout} -o StrictHostKeyChecking=yes -o PreferredAuthentications=publickey -o ServerAliveInterval=10 -o ServerAliveCountMax=3 -o Compression=yes ";
@@ -79,8 +79,6 @@ sub new {
 
     $self->{timeSyncPerf} = 0;
     $self->{difTime} = 10;
-
-    %{$self->{commandBuffer}} = ();
 
     $self->set_signal_handlers;
 
@@ -439,116 +437,118 @@ sub removeIllegalCharacters($) {
 
 ################################################
 ## Send an external command on a remote server.
-## Param : id_remote_server, external command
+## Param : Poller/Remote/Central server ID, Array of external commands
 #
 sub sendExternalCommand($$){
     my $self = shift;
     # Init Parameters
-    my ($id, $cmd) = @_;
-    my ($lerror, $return_code, $stdout, $cmd2, $cmd_line);
+    my ($pollerId, $commandArray) = @_;
 
     # Get server informations
-    my $server_info = $self->getServerConfig($id);
-    my $port = checkSSHPort($server_info->{ssh_port});
+    my $serverInfo = $self->getServerConfig($pollerId);
+    my $port = checkSSHPort($serverInfo->{ssh_port});
 
     # Get command file
-    my $command_file = $self->getNagiosConfigurationField($id, "command_file");
+    my $commandFile = $self->getNagiosConfigurationField($pollerId, "command_file");
 
     # check if ip address is defined
-    if (defined($server_info->{ns_ip_address})) {
-        $cmd =~ s/\\/\\\\/g;
-        if ($server_info->{localhost} == 1) {
-            my $result = waitPipe($command_file);
+    if (defined($serverInfo->{ns_ip_address})) {
+        if ($serverInfo->{localhost} == 1) {
+            my $result = waitPipe($commandFile);
 
             if ($result == 0) {
-                # split $cmd in order to send it in multiple line
+                my $multipleCommands = '';
                 my $count = 0;
-                foreach my $cmd1 (split(/\n/, $cmd)) {
-                    if ($count >= 200) {
-                        $cmd2 = "$self->{echo} \"".$cmd_line."\" >> ".$command_file;
-                        $self->{logger}->writeLogInfo("External command on Central Server: ($id) : \"".$cmd_line."\"");
-                        ($lerror, $stdout, $return_code) = centreon::common::misc::backtick(
-                            command => $cmd2,
+                foreach my $command (@{$commandArray}) {
+                    $command =~ s/\\/\\\\/g;
+                    $command = $self->removeIllegalCharacters($command);
+                    $multipleCommands .= $command . "\n";
+                    $count++;
+
+                    if ($count >= 200 || $count == scalar(@{$commandArray})) {
+                        $self->{logger}->writeLogInfo(
+                            "Send external command to local server engine (ID '" . $pollerId . "'):"
+                        );
+                        foreach (split(/\n/, $multipleCommands)) {
+                            $self->{logger}->writeLogInfo("  '" . $_ . "'");
+                        }
+                        my ($lerror, $stdout, $returnCode) = centreon::common::misc::backtick(
+                            command => "$self->{echo} \"" . $multipleCommands."\" >> " . $commandFile,
                             logger => $self->{logger},
                             timeout => $self->{cmd_timeout}
                         );
-                        $cmd_line = "";
+                        if ($lerror != 0 || (defined($returnCode) && $returnCode != 0)) {
+                            $self->{logger}->writeLogError(
+                                "Cannot write into pipe file '" . $commandFile . "'"
+                            );
+                        }
+                        $multipleCommands = '';
                         $count = 0;
-                    } else {
-                        $cmd_line .= $self->removeIllegalCharacters($cmd1) . "\n";
                     }
-                    $count++;
-                }
-                if ($count gt 0) {
-                    $cmd2 = "$self->{echo} \"".$cmd_line."\" >> ".$command_file;
-                    $self->{logger}->writeLogInfo("External command on Central Server: ($id) : \"".$cmd_line."\"");
-                    ($lerror, $stdout, $return_code) = centreon::common::misc::backtick(
-                        command => $cmd2,
-                        logger => $self->{logger},
-                        timeout => $self->{cmd_timeout}
-                    );
-                    $cmd_line = "";
-                    $count = 0;
-                }
-                if ($lerror != 0 || (defined($return_code)  && $return_code != 0)) {
-                    $self->{logger}->writeLogError(
-                        "Could not write into pipe file " . $command_file . " on poller " . $id
-                    );
                 }
             } else {
                 $self->{logger}->writeLogError(
-                    'Cannot write external command on central server : "' . $cmd_line . '"'
+                    "Cannot write external command on local server. File '" . $commandFile . "' not available."
                 );
             }
         } else {
-            $cmd =~ s/\'/\'\\\'\'/g;
-
-            # split $cmd in order to send it in multiple line
+            my $remoteServer = '';
+            my $multipleCommands = '';
             my $count = 0;
-            my $totalCount = 0;
-            my @splittedCommands = split(/\n/, $cmd);
-            my $countCommands = @splittedCommands;
-            foreach my $cmd1 (@splittedCommands) {
-                $cmd_line .= $self->removeIllegalCharacters($cmd1) . "\n";
+            foreach my $command (@{$commandArray}) {
+                $command =~ s/\'/\'\\\'\'/g;
+                $command = $self->removeIllegalCharacters($command);
                 $count++;
-                $totalCount++;
 
-                if ($count >= 200 || $totalCount == $countCommands) {
-                    if (defined($server_info->{remote_id}) && $server_info->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
-                        my $remote_server = $self->getServerConfig($server_info->{remote_id});
-                        $cmd_line =~ s/^\s+|\s+$//g;
-                        $cmd2 = "$self->{ssh} -q " . $remote_server->{ns_ip_address} . " -p $port "
-                            . "\"$self->{echo} 'EXTERNALCMD:$id:" . $cmd_line . "' "
+                if (defined($serverInfo->{remote_id}) && $serverInfo->{remote_id} != 0
+                    && $self->{instance_mode} ne "remote" && $serverInfo->{remote_server_centcore_ssh_proxy} == 1) {
+                    $remoteServer = $self->getServerConfig($serverInfo->{remote_id});
+                    # Add Centcore MACRO when routing to Remote Server
+                    $command = "EXTERNALCMD:" . $pollerId . ":" . $command;
+                    $multipleCommands .= $command . "\n";
+                } else {
+                    $multipleCommands .= $command . "\n";
+                }
+
+                my $commandExec = '';
+                if ($count >= 200 || $count == scalar(@{$commandArray})) {
+                    if (defined($serverInfo->{remote_id}) && $serverInfo->{remote_id} != 0
+                        && $self->{instance_mode} ne "remote" && $serverInfo->{remote_server_centcore_ssh_proxy} == 1
+                    ) {
+                        $multipleCommands =~ s/^\s+|\s+$//g;
+                        $commandExec = "$self->{ssh} -q " . $remoteServer->{ns_ip_address} . " -p $port "
+                            . "\"$self->{echo} '" . $multipleCommands . "' "
                             . ">> " . $self->{cmdDir} . time() . "-sendcmd\"";
                         $self->{logger}->writeLogInfo(
-                            "Send external command using Remote Server: " . $remote_server->{ns_ip_address}
+                            "Send external command to Poller engine '" . $pollerId . "' using Remote Server '"
+                                . $serverInfo->{remote_id} . "'"
                         );
                     } else {
-                        $cmd2 = "$self->{ssh} -q " . $server_info->{ns_ip_address} . " -p $port "
-                            . "\"$self->{echo} '" . $cmd_line."' >> " . $command_file . "\"";
+                        $commandExec = "$self->{ssh} -q " . $serverInfo->{ns_ip_address} . " -p $port "
+                            . "\"$self->{echo} '" . $multipleCommands . "' >> " . $commandFile . "\"";
                         $self->{logger}->writeLogInfo(
-                            "External command : ".$server_info->{ns_ip_address}." ($id) : \"".$cmd_line."\""
-                        );
+                            "Send external command to Poller engine '" . $pollerId . "':"
+                        );                        
+                        foreach (split(/\n/, $multipleCommands)) {
+                            $self->{logger}->writeLogInfo("  '" . $_ . "'");
+                        }
                     }
-                    ($lerror, $stdout, $return_code) = centreon::common::misc::backtick(
-                        command => $cmd2,
+                    
+                    my ($lerror, $stdout, $returnCode) = centreon::common::misc::backtick(
+                        command => $commandExec,
                         logger => $self->{logger},
                         timeout => $self->{cmd_timeout}
                     );
-                    if ($lerror != 0 || (defined($return_code)  && $return_code != 0)) {
-                        $self->{logger}->writeLogError("Could not write into pipe file " . $command_file . " on poller " . $id);
+                    if ($lerror != 0 || (defined($returnCode) && $returnCode != 0)) {
+                        $self->{logger}->writeLogError("Cannot send external command");
                     }
-                    $cmd_line = "";
+                    $multipleCommands = '';
                     $count = 0;
                 }
             }
         }
-
-        if (defined($stdout) && $stdout){
-            $self->{logger}->writeLogInfo("Result : $stdout");
-        }
     } else {
-        $self->{logger}->writeLogError("Ip address not defined for poller $id");
+        $self->{logger}->writeLogError("IP address not defined for poller '" . $pollerId . "'");
     }
 }
 
@@ -1142,10 +1142,7 @@ sub storeCommands($$) {
     my $self = shift;
     my ($poller_id, $command) = @_;
     
-    if (!defined($self->{commandBuffer}{$poller_id})) {
-        $self->{commandBuffer}{$poller_id} = "";
-    }
-    $self->{commandBuffer}{$poller_id} .= $command . "\n";
+    push @{$self->{commandBuffer}->{$poller_id}}, $command;
 }
 
 sub run {
@@ -1176,10 +1173,10 @@ sub run {
                 while (<FILE>){
                     $self->parseRequest($_);
                 }
-                foreach my $poller (keys(%{$self->{commandBuffer}})) {
-                    if (length($self->{commandBuffer}{$poller}) != 0) {
-                        $self->sendExternalCommand($poller, $self->{commandBuffer}{$poller});
-                        $self->{commandBuffer}{$poller} = "";
+                foreach my $poller (keys %{$self->{commandBuffer}}) {
+                    if (scalar(@{$self->{commandBuffer}->{$poller}}) > 0) {
+                        $self->sendExternalCommand($poller, $self->{commandBuffer}->{$poller});
+                        delete $self->{commandBuffer}->{$poller};
                     }
                 }
                 close(FILE);
@@ -1196,10 +1193,10 @@ sub run {
                         while (<FILE>){
                             $self->parseRequest($_);
                         }
-                        foreach my $poller (keys(%{$self->{commandBuffer}})) {
-                            if (length($self->{commandBuffer}{$poller}) != 0) {
-                                $self->sendExternalCommand($poller, $self->{commandBuffer}{$poller});
-                                $self->{commandBuffer}{$poller} = "";
+                        foreach my $poller (keys %{$self->{commandBuffer}}) {
+                            if (scalar(@{$self->{commandBuffer}->{$poller}}) > 0) {
+                                $self->sendExternalCommand($poller, $self->{commandBuffer}->{$poller});
+                                delete $self->{commandBuffer}->{$poller};
                             }
                         }
                         close(FILE);

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -459,13 +459,15 @@ sub sendExternalCommand($$){
             if ($result == 0) {
                 my $multipleCommands = '';
                 my $count = 0;
+                my $totalCount = 0;
                 foreach my $command (@{$commandArray}) {
                     $command =~ s/\\/\\\\/g;
                     $command = $self->removeIllegalCharacters($command);
                     $multipleCommands .= $command . "\n";
                     $count++;
+                    $totalCount++;
 
-                    if ($count >= 200 || $count == scalar(@{$commandArray})) {
+                    if ($count >= 200 || $totalCount == scalar(@{$commandArray})) {
                         $self->{logger}->writeLogInfo(
                             "Send external command to local server engine (ID '" . $pollerId . "'):"
                         );
@@ -495,10 +497,12 @@ sub sendExternalCommand($$){
             my $remoteServer = '';
             my $multipleCommands = '';
             my $count = 0;
+            my $totalCount = 0;
             foreach my $command (@{$commandArray}) {
                 $command =~ s/\'/\'\\\'\'/g;
                 $command = $self->removeIllegalCharacters($command);
                 $count++;
+                $totalCount++;
 
                 if (defined($serverInfo->{remote_id}) && $serverInfo->{remote_id} != 0
                     && $self->{instance_mode} ne "remote" && $serverInfo->{remote_server_centcore_ssh_proxy} == 1) {
@@ -511,7 +515,7 @@ sub sendExternalCommand($$){
                 }
 
                 my $commandExec = '';
-                if ($count >= 200 || $count == scalar(@{$commandArray})) {
+                if ($count >= 200 || $totalCount == scalar(@{$commandArray})) {
                     if (defined($serverInfo->{remote_id}) && $serverInfo->{remote_id} != 0
                         && $self->{instance_mode} ne "remote" && $serverInfo->{remote_server_centcore_ssh_proxy} == 1
                     ) {

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2005-2017 Centreon
+# Copyright 2005-2019 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 # 
@@ -524,14 +524,15 @@ sub sendExternalCommand($$){
                             . "\"$self->{echo} '" . $multipleCommands . "' "
                             . ">> " . $self->{cmdDir} . time() . "-sendcmd\"";
                         $self->{logger}->writeLogInfo(
-                            "Send external command to Poller engine '" . $pollerId . "' using Remote Server '"
-                                . $serverInfo->{remote_id} . "'"
+                            "Send external command to Poller engine '" . $serverInfo->{name} . "' (" 
+                                . $pollerId . ") using Remote Server '" . $remoteServer->{name} . "' (" 
+                                . $remoteId . ")"
                         );
                     } else {
                         $commandExec = "$self->{ssh} -q " . $serverInfo->{ns_ip_address} . " -p $port "
                             . "\"$self->{echo} '" . $multipleCommands . "' >> " . $commandFile . "\"";
                         $self->{logger}->writeLogInfo(
-                            "Send external command to Poller engine '" . $pollerId . "':"
+                            "Send external command to Poller engine '" . $serverInfo->{name} . "' (" . $pollerId . "):"
                         );                        
                         foreach (split(/\n/, $multipleCommands)) {
                             $self->{logger}->writeLogInfo("  '" . $_ . "'");

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -509,10 +509,9 @@ sub sendExternalCommand($$){
                     $remoteServer = $self->getServerConfig($serverInfo->{remote_id});
                     # Add Centcore MACRO when routing to Remote Server
                     $command = "EXTERNALCMD:" . $pollerId . ":" . $command;
-                    $multipleCommands .= $command . "\n";
-                } else {
-                    $multipleCommands .= $command . "\n";
                 }
+
+                $multipleCommands .= $command . "\n";
 
                 my $commandExec = '';
                 if ($count >= 200 || $totalCount == scalar(@{$commandArray})) {


### PR DESCRIPTION
## Description

This PR fixes the behaviour of multiple commands not beeing sent from Central to Pollers when there is a Remote Server in between.
The code has been refactored a bit to use arrays instead of string for commands buffer.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [ ] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Force the control of several services owned by a Poller from a Central, with a Remote Server in between. Only one of the services will be force checked.

With this patch, all services will be force checked.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
