### PR TITLE
enh(sec) Improve authentication messages in login.log

### DIFF
--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -319,7 +319,7 @@ class CentreonAuth
                     $this->CentreonLog->setUID($this->userInfos["contact_id"]);
                     $this->CentreonLog->insertLog(
                         1,
-                        "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication succeeded for '" . $username
+                        "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication succeeded for '" . $username ."'"
                     );
                 } else {
                     //  Take care before modifying this message pattern as it may break tools such as fail2ban

--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -366,7 +366,7 @@ class CentreonAuth
                 }
             }
         } else {
-            if (($this->debug) || (strlen($username) > 0)) {
+            if (strlen($username) > 0) {
                 //  Take care before modifying this message pattern as it may break tools such as fail2ban
                 $this->CentreonLog->insertLog(
                     1,

--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -319,13 +319,13 @@ class CentreonAuth
                     $this->CentreonLog->setUID($this->userInfos["contact_id"]);
                     $this->CentreonLog->insertLog(
                         1,
-                        "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication succeeded for '" . $username ."'"
+                        "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] Authentication succeeded for '" . $username . "'"
                     );
                 } else {
                     //  Take care before modifying this message pattern as it may break tools such as fail2ban
                     $this->CentreonLog->insertLog(
                         1,
-                        "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : password mismatch"
+                        "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] Authentication failed for '" . $username . "' : password mismatch"
                     );
                     $this->error = _('Your credentials are incorrect.');
                 }
@@ -333,7 +333,7 @@ class CentreonAuth
                 //  Take care before modifying this message pattern as it may break tools such as fail2ban
                 $this->CentreonLog->insertLog(
                     1,
-                    "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : not authorized"
+                    "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] Authentication failed for '" . $username . "' : not authorized"
                 );
                 $this->error = _('Your credentials are incorrect.');
             }
@@ -372,7 +372,7 @@ class CentreonAuth
                 //  Take care before modifying this message pattern as it may break tools such as fail2ban
                 $this->CentreonLog->insertLog(
                     1,
-                    "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : not found"
+                    "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] Authentication failed for '" . $username . "' : not found"
                 );
             }
             $this->error = _('Your credentials are incorrect.');

--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -322,6 +322,7 @@ class CentreonAuth
                         "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication succeeded for '" . $username
                     );
                 } else {
+                    //  Take care before modifying this message pattern as it may break tools such as fail2ban
                     $this->CentreonLog->insertLog(
                         1,
                         "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : password mismatch"
@@ -329,6 +330,7 @@ class CentreonAuth
                     $this->error = _('Your credentials are incorrect.');
                 }
             } else {
+                //  Take care before modifying this message pattern as it may break tools such as fail2ban
                 $this->CentreonLog->insertLog(
                     1,
                     "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : not authorized"
@@ -366,6 +368,7 @@ class CentreonAuth
                 }
             }
         } else {
+            //  Take care before modifying this message pattern as it may break tools such as fail2ban
             $this->CentreonLog->insertLog(
                 1,
                 "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : not found"

--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -319,19 +319,19 @@ class CentreonAuth
                     $this->CentreonLog->setUID($this->userInfos["contact_id"]);
                     $this->CentreonLog->insertLog(
                         1,
-                        "[".$this->source."] Contact '" . $username . "' logged in - IP : " . $_SERVER["REMOTE_ADDR"]
+                        "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication succeeded for '" . $username
                     );
                 } else {
                     $this->CentreonLog->insertLog(
                         1,
-                        "Contact '" . $username . "' doesn't match with password"
+                        "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : password mismatch"
                     );
                     $this->error = _('Your credentials are incorrect.');
                 }
             } else {
                 $this->CentreonLog->insertLog(
                     1,
-                    "[".$this->source."] Contact '" . $username . "' is not enable for reaching centreon"
+                    "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : not authorized"
                 );
                 $this->error = _('Your credentials are incorrect.');
             }
@@ -366,12 +366,10 @@ class CentreonAuth
                 }
             }
         } else {
-            if ($this->debug) {
-                $this->CentreonLog->insertLog(
-                    1,
-                    "[".$this->source."] No contact found with this login : '$username'"
-                );
-            }
+            $this->CentreonLog->insertLog(
+                1,
+                "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : not found"
+            );
             $this->error = _('Your credentials are incorrect.');
         }
     }

--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -306,26 +306,24 @@ class CentreonAuth
                 }
             }
 
-            if ($this->userInfos["contact_oreon"]
-                || ($this->userInfos["contact_oreon"] == 0 && $this->source == 'API')
-            ) {
-                /*
-                 * Check password matching
-                 */
-                $this->getCryptFunction();
-                $this->checkPassword($password, $token);
-
-                if ($this->passwdOk == 1) {
+            /*
+             * Check password matching
+             */
+            $this->getCryptFunction();
+            $this->checkPassword($password, $token);
+            if ($this->passwdOk == 1) {
+                if ($this->userInfos["contact_oreon"]
+                    || ($this->userInfos["contact_oreon"] == 0 && $this->source == 'API')
+                ) {
                     $this->CentreonLog->setUID($this->userInfos["contact_id"]);
                     $this->CentreonLog->insertLog(
                         1,
                         "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] Authentication succeeded for '" . $username . "'"
                     );
                 } else {
-                    //  Take care before modifying this message pattern as it may break tools such as fail2ban
                     $this->CentreonLog->insertLog(
                         1,
-                        "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] Authentication failed for '" . $username . "' : password mismatch"
+                        "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] '" . $username . "' is not allowed to reach Centreon"
                     );
                     $this->error = _('Your credentials are incorrect.');
                 }
@@ -333,7 +331,7 @@ class CentreonAuth
                 //  Take care before modifying this message pattern as it may break tools such as fail2ban
                 $this->CentreonLog->insertLog(
                     1,
-                    "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] Authentication failed for '" . $username . "' : not authorized"
+                    "[" . $this->source . "] [" . $_SERVER["REMOTE_ADDR"] . "] Authentication failed for '" . $username . "'"
                 );
                 $this->error = _('Your credentials are incorrect.');
             }

--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -368,11 +368,13 @@ class CentreonAuth
                 }
             }
         } else {
-            //  Take care before modifying this message pattern as it may break tools such as fail2ban
-            $this->CentreonLog->insertLog(
-                1,
-                "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : not found"
-            );
+            if (($this->debug) || (strlen($username) > 0)) {
+                //  Take care before modifying this message pattern as it may break tools such as fail2ban
+                $this->CentreonLog->insertLog(
+                    1,
+                    "[".$this->source."] [".$_SERVER["REMOTE_ADDR"]."] Authentication failed for '" . $username . "' : not found"
+                );
+            }
             $this->error = _('Your credentials are incorrect.');
         }
     }

--- a/www/class/centreonLog.class.php
+++ b/www/class/centreonLog.class.php
@@ -81,7 +81,7 @@ class CentreonUserLog
     public function insertLog($id, $str, $print = 0, $page = 0, $option = 0)
     {
         /*
-         * Construct alerte message
+         * Construct alert message
          * Take care before modifying this message pattern as it may break tools such as fail2ban
          */
         $string = date("Y-m-d H:i:s") . "|" . $this->uid . "|$page|$option|$str";

--- a/www/class/centreonLog.class.php
+++ b/www/class/centreonLog.class.php
@@ -82,6 +82,7 @@ class CentreonUserLog
     {
         /*
          * Construct alerte message
+         * Take care before modifying this message pattern as it may break tools such as fail2ban
          */
         $string = date("Y-m-d H:i:s") . "|" . $this->uid . "|$page|$option|$str";
 

--- a/www/class/centreonLog.class.php
+++ b/www/class/centreonLog.class.php
@@ -83,7 +83,7 @@ class CentreonUserLog
         /*
          * Construct alerte message
          */
-        $string = date("Y-m-d H:i") . "|" . $this->uid . "|$page|$option|$str";
+        $string = date("Y-m-d H:i:s") . "|" . $this->uid . "|$page|$option|$str";
 
         /*
          * Display error on Standard exit


### PR DESCRIPTION
Hi,

## Description

This PR follows PR #7502 (not merged).
Goal is for the system administrator to be able to use tools such as fail2ban to ban IPs generating too many failed login attempts.
First step is then to have correctly formatted authentication messages.
This PR is then rather simple.

Related Fail2Ban PR is here (already merged) : https://github.com/fail2ban/fail2ban/pull/2550

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Generate failed logins and have a look into `/var/log/centreon/login.log`.

Thank you :+1:

Edit : still missing from 19.10.4.