### PR TITLE
fix(monitoring): fix the End date format according to contact language

### DIFF
--- a/www/include/monitoring/downtime/AddDowntime.php
+++ b/www/include/monitoring/downtime/AddDowntime.php
@@ -320,6 +320,8 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
 
     $data["start_time"] = $centreonGMT->getDate("G:i", time(), $gmt);
     $data["end_time"] = $centreonGMT->getDate("G:i", time() + $defaultDuration, $gmt);
+    $data["start"] = strftime("%x",$centreonGMT->getDate("U", time(), $gmt));
+    $data["end"] = strftime("%x",$centreonGMT->getDate("U", time() + $defaultDuration, $gmt));
     $data["host_or_hg"] = 1;
     $data["with_services"] = $centreon->optGen['monitoring_dwt_svc'];
 

--- a/www/include/monitoring/downtime/AddDowntime.php
+++ b/www/include/monitoring/downtime/AddDowntime.php
@@ -320,7 +320,6 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
 
     $data["start_time"] = $centreonGMT->getDate("G:i", time(), $gmt);
     $data["end_time"] = $centreonGMT->getDate("G:i", time() + $defaultDuration, $gmt);
-    $data["end"] = $centreonGMT->getDate("m/d/Y", time() + $defaultDuration, $gmt);
     $data["host_or_hg"] = 1;
     $data["with_services"] = $centreon->optGen['monitoring_dwt_svc'];
 

--- a/www/include/monitoring/downtime/AddDowntime.php
+++ b/www/include/monitoring/downtime/AddDowntime.php
@@ -320,8 +320,6 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
 
     $data["start_time"] = $centreonGMT->getDate("G:i", time(), $gmt);
     $data["end_time"] = $centreonGMT->getDate("G:i", time() + $defaultDuration, $gmt);
-    $data["start"] = strftime("%x",$centreonGMT->getDate("U", time(), $gmt));
-    $data["end"] = strftime("%x",$centreonGMT->getDate("U", time() + $defaultDuration, $gmt));
     $data["host_or_hg"] = 1;
     $data["with_services"] = $centreon->optGen['monitoring_dwt_svc'];
 


### PR DESCRIPTION
## Description

In the "Add downtime" form, the "End Date" format is bloked to m/d/Y while "Start date" format depending to the contact language.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

When connected, change the language since the contact profile and change the language by fr_FR.
Next from the Monitoring > Downtime click on "**Add a downtime**", in the form the "**End date**" format is not equal to the "**Start date**" format.

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
