### PR TITLE
fix(update): take into account the removal of older conf.php

### DIFF
--- a/src/CentreonLegacy/Core/Module/Upgrader.php
+++ b/src/CentreonLegacy/Core/Module/Upgrader.php
@@ -102,14 +102,14 @@ class Upgrader extends Module
 
         $sth = $this->services->get('configuration_db')->prepare($query);
 
-        $sth->bindParam(':name', $this->moduleConfiguration['name'], \PDO::PARAM_STR);
-        $sth->bindParam(':rname', $this->moduleConfiguration['rname'], \PDO::PARAM_STR);
-        $sth->bindParam(':is_removeable', $this->moduleConfiguration['is_removeable'], \PDO::PARAM_STR);
-        $sth->bindParam(':infos', $this->moduleConfiguration['infos'], \PDO::PARAM_STR);
-        $sth->bindParam(':author', $this->moduleConfiguration['author'], \PDO::PARAM_STR);
-        $sth->bindParam(':svc_tools', $this->moduleConfiguration['svc_tools'], \PDO::PARAM_STR);
-        $sth->bindParam(':host_tools', $this->moduleConfiguration['host_tools'], \PDO::PARAM_STR);
-        $sth->bindParam(':id', $this->moduleId, \PDO::PARAM_INT);
+        $sth->bindValue(':name', $this->moduleConfiguration['name'], \PDO::PARAM_STR);
+        $sth->bindValue(':rname', $this->moduleConfiguration['rname'], \PDO::PARAM_STR);
+        $sth->bindValue(':is_removeable', $this->moduleConfiguration['is_removeable'], \PDO::PARAM_STR);
+        $sth->bindValue(':infos', $this->moduleConfiguration['infos'], \PDO::PARAM_STR);
+        $sth->bindValue(':author', $this->moduleConfiguration['author'], \PDO::PARAM_STR);
+        $sth->bindValue(':svc_tools', $this->moduleConfiguration['svc_tools'] ?? '0', \PDO::PARAM_STR);
+        $sth->bindValue(':host_tools', $this->moduleConfiguration['host_tools'] ?? '0', \PDO::PARAM_STR);
+        $sth->bindValue(':id', $this->moduleId, \PDO::PARAM_INT);
 
         $sth->execute();
 
@@ -129,8 +129,8 @@ class Upgrader extends Module
 
         $sth = $this->services->get('configuration_db')->prepare($query);
 
-        $sth->bindParam(':mod_release', $version, \PDO::PARAM_STR);
-        $sth->bindParam(':id', $this->moduleId, \PDO::PARAM_INT);
+        $sth->bindValue(':mod_release', $version, \PDO::PARAM_STR);
+        $sth->bindValue(':id', $this->moduleId, \PDO::PARAM_INT);
 
         $sth->execute();
 

--- a/src/CentreonLegacy/Core/Module/Upgrader.php
+++ b/src/CentreonLegacy/Core/Module/Upgrader.php
@@ -58,8 +58,7 @@ class Upgrader extends Module
         usort($orderedUpgrades, 'version_compare');
         foreach ($orderedUpgrades as $upgradeName) {
             $upgradePath = $upgradesPath . $upgradeName;
-            if (!preg_match('/^(\d+\.\d+\.\d+)/', $upgradeName, $matches) ||
-                !$this->services->get('filesystem')->exists($upgradePath . '/conf.php')) {
+            if (!preg_match('/^(\d+\.\d+\.\d+)/', $upgradeName, $matches)) {
                 continue;
             }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Take into account the removal of older conf.php files that were located in the upgrade directories of te modules (EMS)

**Fixes** NONE

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Upgrade from the 19.04.x to the 19.10.0 with some EMS modules installed.
The WEB upgrade in Administration -> Extensions -> Manager should work

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
