### PR TITLE
fix(upgrade): remove upgrade of bigint columns

### DIFF
--- a/www/install/sql/centstorage/Update-CSTG-19.10.0-rc.2.sql
+++ b/www/install/sql/centstorage/Update-CSTG-19.10.0-rc.2.sql
@@ -1,7 +1,3 @@
--- migrate downtimes.end_time & downtimes.duration columns from int(11) to bigint(20)
-ALTER TABLE `downtimes` MODIFY COLUMN `end_time` BIGINT(20) NULL DEFAULT NULL;
-ALTER TABLE `downtimes` MODIFY COLUMN `duration` BIGINT(20) NULL DEFAULT NULL;
-
 -- Remove useless reporting tables
 ALTER TABLE log_archive_host
   DROP COLUMN UPTimeAverageAck,


### PR DESCRIPTION
## Description

Fixed directly in broker : centreon/centreon-broker#307
It avoid to update columns during upgrade, which can take a long time with lot of data

**Fixes** BAM-750

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)