### PR TITLE
fix(module): finish with upgrade to last version

### DIFF
--- a/src/CentreonLegacy/Core/Module/Upgrader.php
+++ b/src/CentreonLegacy/Core/Module/Upgrader.php
@@ -74,6 +74,9 @@ class Upgrader extends Module
             $this->upgradePhpFiles($upgradePath, false);
         }
 
+        // finally, upgrade to current version
+        $this->upgradeVersion($this->moduleConfiguration['mod_release']);
+
         return $this->moduleId;
     }
 


### PR DESCRIPTION
## Description

If upgrade directory was empty, the last version was not set for the module

**Fixes** MON-4247

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)