### PR TITLE
fix(css): clean cache at each new centreon version

### DIFF
--- a/www/class/centreon.class.php
+++ b/www/class/centreon.class.php
@@ -50,6 +50,7 @@ class Centreon
 
     public $Nagioscfg;
     public $optGen;
+    public $informations;
     public $redirectTo;
     public $modules;
     public $hooks;
@@ -125,6 +126,11 @@ class Centreon
          * Get general options
          */
         $this->initOptGen();
+
+        /*
+         * Get general informations
+         */
+        $this->initInformations();
 
         /*
          * Grab Modules
@@ -273,6 +279,20 @@ class Centreon
         }
         $DBRESULT = null;
         unset($opt);
+    }
+
+    /**
+     * Store centreon informations in session
+     *
+     * @return void
+     */
+    public function initInformations(): void
+    {
+        $this->informations = [];
+        $result = CentreonDBInstance::getConfInstance()->query("SELECT * FROM `informations`");
+        while ($row = $result->fetch()) {
+            $this->informations[$row["key"]] = $row["value"];
+        }
     }
 
     /**

--- a/www/include/core/header/htmlHeader.php
+++ b/www/include/core/header/htmlHeader.php
@@ -37,6 +37,11 @@ if (!isset($centreon)) {
     exit();
 }
 
+// generate version URI parameter to clean css cache at each new version
+$versionParam = isset($centreon->informations) && isset($centreon->informations['version'])
+    ? '?version=' . $centreon->informations['version']
+    : '';
+
 print "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
 
 ?>
@@ -53,9 +58,9 @@ print "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
     <link href="./Themes/Centreon-2/MobileMenu/css/menu.css" rel="stylesheet" type="text/css"/>
     <?php endif; ?>
     <link href="./include/common/javascript/jquery/plugins/jpaginator/jPaginator.css" rel="stylesheet" type="text/css"/>
-    <link href="./Themes/Centreon-2/style.css" rel="stylesheet" type="text/css"/>
-    <link href="./Themes/Centreon-2/centreon-loading.css" rel="stylesheet" type="text/css"/>
-    <link href="./Themes/Centreon-2/responsive-style.css" rel="stylesheet" type="text/css"/>
+    <link href="./Themes/Centreon-2/style.css<?php echo $versionParam; ?>" rel="stylesheet" type="text/css"/>
+    <link href="./Themes/Centreon-2/centreon-loading.css<?php echo $versionParam; ?>" rel="stylesheet" type="text/css"/>
+    <link href="./Themes/Centreon-2/responsive-style.css<?php echo $versionParam; ?>" rel="stylesheet" type="text/css"/>
     <link href="./Themes/Centreon-2/<?php echo $colorfile; ?>" rel="stylesheet" type="text/css"/>
     <link href="./include/common/javascript/jquery/plugins/timepicker/jquery.ui.timepicker.css" rel="stylesheet"
           type="text/css" media="screen"/>


### PR DESCRIPTION
## Description

Clean css cache at each new version to avoid display issues

**Fixes** waiting ticket from @lpinsivy 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)