### PR TITLE
Fix LDAP sync deleting users from groups, closes #7142

### DIFF
--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -505,15 +505,16 @@ class CentreonLDAP
              * we get list of members by group
              */
             $filter = preg_replace('/%s/', $this->getCnFromDn($groupdn), $this->groupSearchInfo['filter']);
-            $result = @ldap_search($this->ds, $this->userSearchInfo['base_search'], $filter);
+            $result = @ldap_search($this->ds, $this->groupSearchInfo['base_search'], $filter);
             if (false === $result) {
                 restore_error_handler();
                 return array();
             }
             $entries = ldap_get_entries($this->ds, $result);
-            $nbEntries = !empty($entries[0]['member']['count']) ? $entries[0]['member']['count'] : 0;
+            $member_attribute = $this->groupSearchInfo['member'];
+            $nbEntries = !empty($entries[0][$member_attribute]['count']) ? $entries[0][$member_attribute]['count'] : 0;
             for ($i = 0; $i < $nbEntries; $i++) {
-                $list[] = $entries[0]['member'][$i];
+                $list[] = $entries[0][$member_attribute][$i];
             }
             restore_error_handler();
         }


### PR DESCRIPTION
When group membership is defined at group level, there were two issues with the `syncWithLdap()` function that is called periodically, specifically within `listUserForGroup()`:
* groups were searched in the the user base DN
* the group member attribute was not respected (a hardcoded value of
  `member` was used)

This patch addresses both issues. The first one is already fixed in 19.04.x (https://github.com/centreon/centreon/commit/849b82652aeefad6583abd9be9634a10f32dd68e) but the second one is still present [in master](https://github.com/centreon/centreon/blob/e8c552cad388c767517bd8f817ed4a467cf7ba4f/www/class/centreonLDAP.class.php#L511). I'll let you guys patch it there too.

The code that is used when a user first logs in makes use of the proper base DN and group member attribute. Because this, users were added to the right groups on their first login, only to be later removed from them.
