### PR TITLE
fix(sec): Correctly hide passwords in command

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -12930,6 +12930,18 @@ msgstr ""
 "Este host no existe en la configuración de Centreon. \n"
 "Por favor, vuelva a cargar la configuración."
 
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to retrieve command"
+msgstr "No se puede recuperar el comando"
+
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to retrieve executed command"
+msgstr "No se puede recuperar el comando ejecutado"
+
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to hide passwords in command"
+msgstr "No se pueden ocultar las contraseñas en el comando"
+
 #: centreon-web/www/include/monitoring/comments/AddHostComment.php:101
 msgid "Add a comment for Host"
 msgstr "Añadir un comentario para un anfitrión"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -13412,6 +13412,18 @@ msgstr ""
 "Cet hôte n'existe pas dans la configuration Centreon. s'il vous plaît "
 "recharger la configuration."
 
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to retrieve command"
+msgstr "Impossible de récupérer la commande"
+
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to retrieve executed command"
+msgstr "Impossible de récupérer la commande exécutée"
+
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to hide passwords in command"
+msgstr "Impossible de cacher les mots de passe dans la commande"
+
 #: centreon-web/www/include/monitoring/comments/AddHostComment.php:101
 msgid "Add a comment for Host"
 msgstr "Ajouter un commentaire pour un hôte"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5259,6 +5259,18 @@ msgstr "Visualizar registros para o serviço %s"
 msgid "The related host no longer exists in Centreon configuration. Please reload the configuration."
 msgstr "O host relacionado não existe mais na configuração do Centreon. Por favor, recarregue a configuração."
 
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to retrieve command"
+msgstr "Não foi possível recuperar o comando"
+
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to retrieve executed command"
+msgstr "Não foi possível recuperar o comando executado"
+
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to hide passwords in command"
+msgstr "Não foi possível ocultar senhas no comando"
+
 #: centreon-web/www/include/views/virtualMetrics/formVirtualMetrics.php:62
 msgid "Host list"
 msgstr "Lista de Host"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -5260,6 +5260,18 @@ msgstr "Visualizar registros para o serviço %s"
 msgid "The related host no longer exists in Centreon configuration. Please reload the configuration."
 msgstr "O host relacionado não existe mais na configuração do Centreon. Por favor, recarregue a configuração."
 
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to retrieve command"
+msgstr "Não foi possível recuperar o comando"
+
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to retrieve executed command"
+msgstr "Não foi possível recuperar o comando executado"
+
+#: centreon-web/www/include/monitoring/objectDetails/common-func.php
+msgid "Unable to hide passwords in command"
+msgstr "Não foi possível ocultar senhas no comando"
+
 #: centreon-web/www/include/views/virtualMetrics/formVirtualMetrics.php:62
 msgid "Host list"
 msgstr "Lista de Host"

--- a/www/include/monitoring/objectDetails/common-func.php
+++ b/www/include/monitoring/objectDetails/common-func.php
@@ -184,7 +184,11 @@ function hidePasswordInCommand($commandName, $hostId, $serviceId)
     }
 
     // Also hide as much as possible passwords from Centreon Plugins options which may be used in non-password macros
-    $commandLineExecuted = preg_replace('/(--([0-9a-z]+-)*password=)[^ ]+/', '$1$pw', $commandLineExecuted);
+    $commandLineExecuted = preg_replace(
+        '/(--([0-9a-z]+-)*password=|--snmp-community=)[^ ]+/',
+        '$1$pw',
+        $commandLineExecuted
+    );
 
     return $commandLineExecuted;
 }

--- a/www/include/monitoring/objectDetails/common-func.php
+++ b/www/include/monitoring/objectDetails/common-func.php
@@ -65,10 +65,11 @@ function hidePasswordInCommand($commandName, $hostId, $serviceId)
     }
 
     // Get executed command lines
-    $sth = $pearDBStorage->prepare("SELECT command_line FROM services
-        WHERE host_id = :host_id
-        AND service_id = :service_id
-        AND check_command = :check_command"
+    $sth = $pearDBStorage->prepare(
+        "SELECT command_line FROM services "
+        . "WHERE host_id = :host_id "
+        . "AND service_id = :service_id "
+        . "AND check_command = :check_command"
     );
     $sth->bindParam(':host_id', $hostId, PDO::PARAM_INT);
     $sth->bindParam(':service_id', $serviceId, PDO::PARAM_INT);
@@ -115,8 +116,12 @@ function hidePasswordInCommand($commandName, $hostId, $serviceId)
                 break;
             } else {
                 $currentMacro = $row['svc_macro_name'];
-                $commandLineWithMacros = str_replace($row['svc_macro_name'],
-                    '$pw', $commandLineWithMacros, $replacedMacros);
+                $commandLineWithMacros = str_replace(
+                    $row['svc_macro_name'],
+                    '$pw',
+                    $commandLineWithMacros,
+                    $replacedMacros
+                );
                 $replacedExecuted = 0;
             }
         }
@@ -159,8 +164,12 @@ function hidePasswordInCommand($commandName, $hostId, $serviceId)
                 break;
             } else {
                 $currentMacro = $row['host_macro_name'];
-                $commandLineWithMacros = str_replace($row['host_macro_name'],
-                    '$pw', $commandLineWithMacros, $replacedMacros);
+                $commandLineWithMacros = str_replace(
+                    $row['host_macro_name'],
+                    '$pw',
+                    $commandLineWithMacros,
+                    $replacedMacros
+                );
                 $replacedExecuted = 0;
             }
         }


### PR DESCRIPTION
Hi,

This fixes the "Unable to hide passwords in command" message in service details page.

It fixes #7949.

We did some debug here with @prohand (thank you !), it ends [from this post](https://github.com/centreon/centreon/pull/7975#issuecomment-544279124) below.

## Description

If a command contains macros which have spaces in their values (which is rather common), this leads to the following message in the service details page :

![Screen Shot 2019-10-17 at 08 20 13](https://user-images.githubusercontent.com/40244829/66982694-febca200-f0b6-11e9-91a9-e6d1ba425025.png)

This PR then solves this. Here's how :

For every password macro :
- A = number of times macro name is found in command_with_macros ;
- B = number of times macro values (*) are replaced in command_executed ;
- if A != B, then throw an error ;
- Return command_executed.

(*) we can have several different values if macro is redefined.

The only case where an error is thrown is then when password used is too simple.
For example _pass_, and the command looks like : `test.pl --password=$_HOSTPWD$`
Otherwise it will succeed.
Use strong passwords and you won't face this case :)

We also try as much as possible to hide passwords from Centreon Plugins options which may be used in non-password macros.

Finally, instead of the `***` pattern to hide the password, we now use `$pw`, which is really convenient when we copy/past the command into a shell.

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Use a command with several macros, several password macros, and macros containing spaces.
Without this PR, you'll receive the "Unable to hide passwords in command" message.
With this PR, all passwords are correctly replaced.

Thank you 👍

Edit : issue still present in 19.10.12.