### PR TITLE
Update french doc

### DIFF
--- a/doc/fr/upgrade/from_packages_1904.rst
+++ b/doc/fr/upgrade/from_packages_1904.rst
@@ -76,6 +76,9 @@ suivante : ::
 
 .. note::
     Changez **Europe/Paris** par votre fuseau horaire.
+ 
+.. warning::
+    N'oubliez pas de reporter les configurations spécifiques qui peuvent être configurées dans /etc/opt/rh/rh-php71/php.ini et/ou /etc/opt/rh/rh-php71/php-fpm.d/centreon.conf
 
 Réalisez les actions suivantes : ::
 


### PR DESCRIPTION
adds a small warning about the old php-fpm configuration

# Pull Request Template

## Description
adds a warning about specific configuration with php-fpm 7.1 that you need to migrate with php-fpm 7.2

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

by reading the doc :D 

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
