### PR TITLE
fix(secu): remove unused http parameters in hostXML.php file for PHP7

### DIFF
--- a/www/include/monitoring/status/Hosts/xml/hostXML.php
+++ b/www/include/monitoring/status/Hosts/xml/hostXML.php
@@ -73,16 +73,16 @@ $o = filter_var($_GET['o'] ?? "h", FILTER_SANITIZE_STRING);
 $p = filter_var($_GET['p'] ?? 2, FILTER_VALIDATE_INT);
 $num = filter_var($_GET['num'] ?? 0, FILTER_VALIDATE_INT);
 $limit = filter_var($_GET['limit'] ?? 20, FILTER_VALIDATE_INT);
-$instance = filter_var($_GET['instance'] ?? $obj->defaultPoller, FILTER_VALIDATE_INT);
-$hostgroup = filter_var($_GET['hostgroups'] ?? $obj->defaultHostgroups, FILTER_VALIDATE_INT);
 $search = filter_var($_GET['search'] ?? "", FILTER_SANITIZE_STRING);
 $order = isset($_GET['order']) && $_GET['order'] === "ASC"
     ? "ASC"
     : "DESC";
-$dateFormat = filter_var($_GET['date_time_format_status'] ?? "Y/m/d H:i:s", FILTER_SANITIZE_STRING);
 $statusHost = filter_var($_GET['statusHost'] ?? "", FILTER_SANITIZE_STRING);
 $statusFilter = filter_var($_GET['statusFilter'] ?? "", FILTER_SANITIZE_STRING);
 $criticalityValue = filter_var($_GET['criticality'] ?? $obj->defaultCriticality, FILTER_SANITIZE_STRING);
+
+$instance = filter_var($obj->defaultPoller, FILTER_VALIDATE_INT);
+$hostgroup = filter_var($obj->defaultHostgroups, FILTER_VALIDATE_INT);
 
 if (isset($_GET['sort_type']) && $_GET['sort_type'] === "host_name") {
     $sort_type = "name";


### PR DESCRIPTION
# Pull Request Template

## Description

remove unused http parameters in hostXML.php file.
**Warning -> rebased on the MON-4314-fix-sql branch**

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

please contact me

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
