### PR TITLE
fix(secu): remove unused http parameters in hostXML.php file for PHP5

### DIFF
--- a/www/include/monitoring/status/Hosts/xml/hostXML.php
+++ b/www/include/monitoring/status/Hosts/xml/hostXML.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -33,7 +33,7 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . "/../../../../../../config/centreon.config.php");
+require_once realpath(__DIR__ . "/../../../../../../config/centreon.config.php");
 include_once _CENTREON_PATH_ . "www/class/centreonXMLBGRequest.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonInstance.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonCriticality.class.php";
@@ -47,18 +47,16 @@ include_once _CENTREON_PATH_ . "www/class/centreonUtils.class.php";
 CentreonSession::start();
 $obj = new CentreonXMLBGRequest(session_id(), 1, 1, 0, 1);
 
-if (isset($_SESSION['centreon'])) {
-    $centreon = $_SESSION['centreon'];
-} else {
+if (!isset($_SESSION['centreon'])) {
     exit;
 }
+$centreon = $_SESSION['centreon'];
+
 $criticality = new CentreonCriticality($obj->DB);
 $instanceObj = new CentreonInstance($obj->DB);
 $media = new CentreonMedia($obj->DB);
 
-if (isset($obj->session_id) && CentreonSession::checkSession($obj->session_id, $obj->DB)) {
-    ;
-} else {
+if (!isset($obj->session_id) || !CentreonSession::checkSession($obj->session_id, $obj->DB)) {
     print "Bad Session ID";
     exit();
 }
@@ -71,14 +69,14 @@ $obj->getDefaultFilters();
 /*
  *  Check Arguments from GET
  */
-$o          = $obj->checkArgument("o", $_GET, "h");
-$p          = $obj->checkArgument("p", $_GET, "2");
-$num        = $obj->checkArgument("num", $_GET, 0);
-$limit      = $obj->checkArgument("limit", $_GET, 20);
-$instance   = $obj->checkArgument("instance", $_GET, $obj->defaultPoller);
+$o = $obj->checkArgument("o", $_GET, "h");
+$p = $obj->checkArgument("p", $_GET, "2");
+$num = $obj->checkArgument("num", $_GET, 0);
+$limit = $obj->checkArgument("limit", $_GET, 20);
+$instance = $obj->checkArgument("instance", $_GET, $obj->defaultPoller);
 $hostgroups = $obj->checkArgument("hostgroups", $_GET, $obj->defaultHostgroups);
-$search     = $obj->checkArgument("search", $_GET, "");
-$order      = $obj->checkArgument("order", $_GET, "ASC");
+$search = $obj->checkArgument("search", $_GET, "");
+$order = $obj->checkArgument("order", $_GET, "ASC");
 $dateFormat = $obj->checkArgument("date_time_format_status", $_GET, "Y/m/d H:i:s");
 
 $statusHost = $obj->checkArgument("statusHost", $_GET, "");
@@ -88,10 +86,10 @@ $statusFilter = $obj->checkArgument("statusFilter", $_GET, "");
 $_SESSION['monitoring_host_status'] = $statusHost;
 $_SESSION['monitoring_host_status_filter'] = $statusFilter;
 
-if (isset($_GET['sort_type']) && $_GET['sort_type'] == "host_name") {
+if (isset($_GET['sort_type']) && $_GET['sort_type'] === "host_name") {
     $sort_type = "name";
 } else {
-    if ($o == "hpb" || $o == "h_unhandled") {
+    if ($o === "hpb" || $o === "h_unhandled") {
         $sort_type  = $obj->checkArgument("sort_type", $_GET, "");
     } else {
         $sort_type  = $obj->checkArgument("sort_type", $_GET, "host_name");
@@ -164,10 +162,13 @@ if ($criticality_id) {
 }
 
 if (!$obj->is_admin) {
-    $rq1 .= " AND h.host_id = centreon_acl.host_id " . $obj->access->queryBuilder("AND", "centreon_acl.group_id", $obj->grouplistStr);
+    $rq1 .= " AND h.host_id = centreon_acl.host_id " .
+        $obj->access->queryBuilder("AND", "centreon_acl.group_id", $obj->grouplistStr);
 }
 if ($search != "") {
-    $rq1 .= " AND (h.name LIKE '%" . CentreonDB::escape($search) . "%' OR h.alias LIKE '%" . CentreonDB::escape($search) . "%' OR h.address LIKE '%" . CentreonDB::escape($search) . "%') ";
+    $rq1 .= " AND (h.name LIKE '%" . CentreonDB::escape($search) .
+        "%' OR h.alias LIKE '%" . CentreonDB::escape($search) .
+        "%' OR h.address LIKE '%" . CentreonDB::escape($search) . "%') ";
 }
 
 if ($statusHost == "h_unhandled") {
@@ -190,60 +191,63 @@ if ($statusFilter == "up") {
 }
 
 if ($hostgroups) {
-    $rq1 .= " AND h.host_id = hhg.host_id AND hg.hostgroup_id IN ($hostgroups) AND hhg.hostgroup_id = hg.hostgroup_id";
+    $rq1 .= " AND h.host_id = hhg.host_id AND hg.hostgroup_id IN (" . $hostgroups . ") AND hhg.hostgroup_id = hg
+        .hostgroup_id";
 }
 
 if ($instance != -1 && !empty($instance)) {
-    $rq1 .= " AND h.instance_id = ".$instance;
+    $rq1 .= " AND h.instance_id = " . $instance;
 }
 $rq1 .= " AND h.enabled = 1 ";
 switch ($sort_type) {
     case 'name':
-        $rq1 .= " ORDER BY h.name ". $order;
+        $rq1 .= " ORDER BY h.name " . $order;
         break;
     case 'current_state':
-        $rq1 .= " ORDER BY h.state ". $order.",h.name ";
+        $rq1 .= " ORDER BY h.state " . $order . ",h.name ";
         break;
     case 'last_state_change':
-        $rq1 .= " ORDER BY h.last_state_change ". $order.",h.name ";
+        $rq1 .= " ORDER BY h.last_state_change " . $order . ",h.name ";
         break;
     case 'last_hard_state_change':
-        $rq1 .= " ORDER BY h.last_hard_state_change ". $order.",h.name ";
+        $rq1 .= " ORDER BY h.last_hard_state_change " . $order . ",h.name ";
         break;
     case 'last_check':
-        $rq1 .= " ORDER BY h.last_check ". $order.",h.name ";
+        $rq1 .= " ORDER BY h.last_check " . $order . ",h.name ";
         break;
     case 'current_check_attempt':
-        $rq1 .= " ORDER BY h.check_attempt ". $order.",h.name ";
+        $rq1 .= " ORDER BY h.check_attempt " . $order . ",h.name ";
         break;
     case 'ip':
         # Not SQL portable
-        $rq1 .= " ORDER BY IFNULL(inet_aton(h.address), h.address) ". $order.",h.name ";
+        $rq1 .= " ORDER BY IFNULL(inet_aton(h.address), h.address) ". $order . ",h.name ";
         break;
     case 'plugin_output':
-        $rq1 .= " ORDER BY h.output ". $order.",h.name ";
+        $rq1 .= " ORDER BY h.output " . $order . ",h.name ";
         break;
     case 'criticality_id':
-        $rq1 .= " ORDER BY isnull $order, criticality $order, h.name ";
+        $rq1 .= " ORDER BY isnull " . $order . ", criticality " . $order . ", h.name ";
         break;
     default:
-        $rq1 .= " ORDER BY isnull $order, criticality $order, h.name ";
+        $rq1 .= " ORDER BY isnull " . $order . ", criticality " . $order . ", h.name ";
         break;
 }
-$rq1 .= " LIMIT ".($num * $limit).",".$limit;
+$rq1 .= " LIMIT " . ($num * $limit) . ", " . $limit;
 
-$ct = 0;
-$flag = 0;
 $DBRESULT = $obj->DBC->query($rq1);
 $numRows = $obj->DBC->numberRows();
 
 /**
  * Get criticality ids
  */
-$critRes = $obj->DBC->query("SELECT value, host_id 
-                                     FROM customvariables
-                                     WHERE name = 'CRITICALITY_ID'
-                                     AND service_id IS NULL");
+$critRes = $obj->DBC->query(
+    "SELECT value, host_id 
+    FROM customvariables
+    WHERE name = 'CRITICALITY_ID'
+    AND service_id IS NULL"
+);
+$ct = 0;
+$flag = 0;
 $criticalityUsed = 0;
 $critCache = array();
 if ($critRes->numRows()) {
@@ -314,7 +318,13 @@ while ($data = $DBRESULT->fetchRow()) {
     $obj->XML->writeElement("hnl", CentreonUtils::escapeSecure(urlencode($data["name"])));
     $obj->XML->writeElement("a", ($data["address"] ? CentreonUtils::escapeSecure($data["address"]) : "N/A"));
     $obj->XML->writeElement("ou", ($data["output"] ? CentreonUtils::escapeSecure($data["output"]) : "N/A"));
-    $obj->XML->writeElement("lc", ($data["last_check"] != 0 ? CentreonDuration::toString(time() - $data["last_check"]) : "N/A"));
+    $obj->XML->writeElement(
+        "lc",
+        ($data["last_check"] != 0
+            ? CentreonDuration::toString(time() - $data["last_check"])
+            : "N/A"
+        )
+    );
     $obj->XML->writeElement("cs", _($obj->statusHost[$data["state"]]), false);
     $obj->XML->writeElement("pha", $data["acknowledged"]);
     $obj->XML->writeElement("pce", $data["passive_checks"]);
@@ -323,14 +333,19 @@ while ($data = $DBRESULT->fetchRow()) {
     $obj->XML->writeElement("lhs", ($hard_duration ? $hard_duration : "N/A"));
     $obj->XML->writeElement("ha", $data["acknowledged"]);
     $obj->XML->writeElement("hdtm", $data["scheduled_downtime_depth"]);
-    $obj->XML->writeElement("hdtmXml", "./include/monitoring/downtime/xml/broker/makeXMLForDowntime.php?hid=".$data['host_id']);
+    $obj->XML->writeElement(
+        "hdtmXml", "./include/monitoring/downtime/xml/broker/makeXMLForDowntime.php?hid=" . $data['host_id']);
     $obj->XML->writeElement("hdtmXsl", "./include/monitoring/downtime/xsl/popupForDowntime.xsl");
-    $obj->XML->writeElement("hackXml", "./include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php?hid=".$data['host_id']);
+    $obj->XML->writeElement(
+        "hackXml", "./include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php?hid=" . $data['host_id']);
     $obj->XML->writeElement("hackXsl", "./include/monitoring/acknowlegement/xsl/popupForAck.xsl");
     $obj->XML->writeElement("hae", $data["active_checks"]);
     $obj->XML->writeElement("hpe", $data["passive_checks"]);
     $obj->XML->writeElement("ne", $data["notify"]);
-    $obj->XML->writeElement("tr", $data["check_attempt"]."/".$data["max_check_attempts"]." (".$obj->stateType[$data["state_type"]].")");
+    $obj->XML->writeElement(
+        "tr",
+        $data["check_attempt"] . "/" . $data["max_check_attempts"] . " (" . $obj->stateType[$data["state_type"]] . ")"
+    );
 
     if (isset($data['criticality']) && $data['criticality'] != '' && isset($critCache[$data['host_id']])) {
         $obj->XML->writeElement("hci", 1); // has criticality
@@ -358,7 +373,23 @@ while ($data = $DBRESULT->fetchRow()) {
 
     $hostObj = new CentreonHost($obj->DB);
     if ($data["notes"] != "") {
-        $obj->XML->writeElement("hnn", CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], str_replace("\$HOSTNAME\$", $data["name"], str_replace("\$HOSTADDRESS\$", $data["address"], $data["notes"])))));
+        $obj->XML->writeElement(
+            "hnn",
+            CentreonUtils::escapeSecure(
+                $hostObj->replaceMacroInString(
+                    $data["name"],
+                    str_replace(
+                        "\$HOSTNAME\$",
+                        $data["name"],
+                        str_replace(
+                            "\$HOSTADDRESS\$",
+                            $data["address"],
+                            $data["notes"]
+                        )
+                    )
+                )
+            )
+        );
     } else {
         $obj->XML->writeElement("hnn", "none");
     }
@@ -374,8 +405,15 @@ while ($data = $DBRESULT->fetchRow()) {
         $str = str_replace("\$HOSTSTATEID\$", $data['state'], $str);
         $str = str_replace("\$HOSTSTATE\$", $obj->statusHost[$data['state']], $str);
 
-        $str = str_replace("\$INSTANCEADDRESS\$", $instanceObj->getParam($data['instance_name'], 'ns_ip_address'), $str);
-        $obj->XML->writeElement("hnu", CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], $str)));
+        $str = str_replace(
+            "\$INSTANCEADDRESS\$",
+            $instanceObj->getParam($data['instance_name'], 'ns_ip_address'),
+            $str
+        );
+        $obj->XML->writeElement(
+            "hnu",
+            CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], $str))
+        );
     } else {
         $obj->XML->writeElement("hnu", "none");
     }
@@ -391,8 +429,14 @@ while ($data = $DBRESULT->fetchRow()) {
         $str = str_replace("\$HOSTSTATEID\$", $data['state'], $str);
         $str = str_replace("\$HOSTSTATE\$", $obj->statusHost[$data['state']], $str);
 
-        $str = str_replace("\$INSTANCEADDRESS\$", $instanceObj->getParam($data['instance_name'], 'ns_ip_address'), $str);
-        $obj->XML->writeElement("hau", CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], $str)));
+        $str = str_replace(
+            "\$INSTANCEADDRESS\$",
+            $instanceObj->getParam($data['instance_name'], 'ns_ip_address'), $str
+        );
+        $obj->XML->writeElement(
+            "hau",
+            CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], $str))
+        );
     } else {
         $obj->XML->writeElement("hau", "none");
     }


### PR DESCRIPTION
# Pull Request Template

## Description

remove unused http parameters in hostXML.php file.
cleaning file

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

please contact me

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
