### PR TITLE
fix(acl): filter access to api using external entry point

### DIFF
--- a/www/api/class/centreon_administration_widget.class.php
+++ b/www/api/class/centreon_administration_widget.class.php
@@ -161,10 +161,13 @@ class CentreonAdministrationWidget extends CentreonWebService implements Centreo
      */
     public function authorize($action, $user, $isInternal = false)
     {
-        if (parent::authorize($action, $user, $isInternal)) {
+        if (
+            parent::authorize($action, $user, $isInternal)
+            || ($user && $user->hasAccessRestApiConfiguration())
+        ) {
             return true;
         }
 
-        return $user->hasAccessRestApiConfiguration();
+        return false;
     }
 }

--- a/www/api/class/centreon_clapi.class.php
+++ b/www/api/class/centreon_clapi.class.php
@@ -229,11 +229,14 @@ class CentreonClapi extends CentreonWebService implements CentreonWebServiceDiIn
      */
     public function authorize($action, $user, $isInternal = false)
     {
-        if (parent::authorize($action, $user, $isInternal)) {
+        if (
+            parent::authorize($action, $user, $isInternal)
+            || ($user && $user->hasAccessRestApiConfiguration())
+        ) {
             return true;
         }
 
-        return $user->hasAccessRestApiConfiguration();
+        return false;
     }
 
     /**

--- a/www/api/class/centreon_configuration_objects.class.php
+++ b/www/api/class/centreon_configuration_objects.class.php
@@ -276,10 +276,13 @@ class CentreonConfigurationObjects extends CentreonWebService
      */
     public function authorize($action, $user, $isInternal = false)
     {
-        if (parent::authorize($action, $user, $isInternal)) {
+        if (
+            parent::authorize($action, $user, $isInternal)
+            || ($user && $user->hasAccessRestApiConfiguration())
+        ) {
             return true;
         }
 
-        return $user->hasAccessRestApiConfiguration();
+        return false;
     }
 }

--- a/www/api/class/centreon_home_customview.class.php
+++ b/www/api/class/centreon_home_customview.class.php
@@ -331,6 +331,13 @@ class CentreonHomeCustomview extends CentreonWebService
      */
     public function authorize($action, $user, $isInternal = false)
     {
-        return true;
+        if (
+            parent::authorize($action, $user, $isInternal)
+            || ($user && $user->hasAccessRestApiConfiguration())
+        ) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/www/api/class/centreon_keepalive.class.php
+++ b/www/api/class/centreon_keepalive.class.php
@@ -71,6 +71,6 @@ class CentreonKeepalive extends CentreonWebService
      */
     public function authorize($action, $user, $isInternal = false)
     {
-        return true;
+        return $isInternal;
     }
 }

--- a/www/api/class/centreon_metric.class.php
+++ b/www/api/class/centreon_metric.class.php
@@ -778,6 +778,13 @@ class CentreonMetric extends CentreonWebService
      */
     public function authorize($action, $user, $isInternal = false)
     {
-        return true;
+        if (
+            parent::authorize($action, $user, $isInternal)
+            || ($user && $user->hasAccessRestApiRealtime())
+        ) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/www/api/class/centreon_proxy.class.php
+++ b/www/api/class/centreon_proxy.class.php
@@ -37,6 +37,6 @@ class CentreonProxy extends CentreonWebService
      */
     public function authorize($action, $user, $isInternal = false)
     {
-        return true;
+        return $isInternal;
     }
 }

--- a/www/api/class/centreon_realtime_base.class.php
+++ b/www/api/class/centreon_realtime_base.class.php
@@ -259,10 +259,13 @@ class CentreonRealtimeBase extends CentreonWebService
      */
     public function authorize($action, $user, $isInternal = false)
     {
-        if (parent::authorize($action, $user, $isInternal)) {
+        if (
+            parent::authorize($action, $user, $isInternal)
+            || ($user && $user->hasAccessRestApiRealtime())
+        ) {
             return true;
         }
 
-        return $user->hasAccessRestApiRealtime();
+        return false;
     }
 }

--- a/www/api/class/centreon_results_acceptor.class.php
+++ b/www/api/class/centreon_results_acceptor.class.php
@@ -246,10 +246,13 @@ class CentreonResultsAcceptor extends CentreonConfigurationObjects
      */
     public function authorize($action, $user, $isInternal)
     {
-        if (parent::authorize($action, $user, $isInternal)) {
+        if (
+            parent::authorize($action, $user, $isInternal)
+            || ($user && $user->hasAccessRestApiConfiguration())
+        ) {
             return true;
         }
 
-        return $user->hasAccessRestApiConfiguration();
+        return false;
     }
 }

--- a/www/api/class/centreon_submit_results.class.php
+++ b/www/api/class/centreon_submit_results.class.php
@@ -330,10 +330,13 @@ class CentreonSubmitResults extends CentreonWebService
      */
     public function authorize($action, $user, $isInternal)
     {
-        if (parent::authorize($action, $user, $isInternal)) {
+        if (
+            parent::authorize($action, $user, $isInternal)
+            || ($user && $user->hasAccessRestApiRealtime())
+        ) {
             return true;
         }
 
-        return $user->hasAccessRestApiConfiguration();
+        return false;
     }
 }

--- a/www/api/class/centreon_topcounter.class.php
+++ b/www/api/class/centreon_topcounter.class.php
@@ -856,9 +856,13 @@ class CentreonTopCounter extends CentreonWebService
      */
     public function authorize($action, $user, $isInternal = false)
     {
-        if (parent::authorize($action, $user, $isInternal)) {
+        if (
+            parent::authorize($action, $user, $isInternal)
+            || ($user && $user->hasAccessRestApiRealtime())
+        ) {
             return true;
         }
-        return $user->hasAccessRestApiConfiguration();
+
+        return false;
     }
 }

--- a/www/api/class/centreon_wiki.class.php
+++ b/www/api/class/centreon_wiki.class.php
@@ -90,10 +90,13 @@ class CentreonWiki extends CentreonWebService
      */
     public function authorize($action, $user, $isInternal = false)
     {
-        if (parent::authorize($action, $user, $isInternal)) {
+        if (
+            parent::authorize($action, $user, $isInternal)
+            || ($user && $user->hasAccessRestApiConfiguration())
+        ) {
             return true;
         }
 
-        return $user->hasAccessRestApiConfiguration();
+        return false;
     }
 }

--- a/www/api/external.php
+++ b/www/api/external.php
@@ -36,10 +36,27 @@
 ini_set('error_reporting', E_ALL & ~E_NOTICE & ~E_STRICT);
 ini_set('display_errors', 'Off');
 
-require_once dirname(__FILE__) . '/../../bootstrap.php';
-require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
-require_once dirname(__FILE__) . '/class/webService.class.php';
+require_once __DIR__ . '/../../bootstrap.php';
+require_once __DIR__ . '/../class/centreon.class.php';
+require_once __DIR__ . '/class/webService.class.php';
 
-$pearDB = new CentreonDB;
+$pearDB = $dependencyInjector['configuration_db'];
 
-CentreonWebService::router($dependencyInjector, null, false);
+$user = null;
+// get user information if a token is provided
+if (isset($_SERVER['HTTP_CENTREON_AUTH_TOKEN'])) {
+    try {
+        $res = $pearDB->prepare(
+            "SELECT c.* FROM ws_token w, contact c WHERE c.contact_id = w.contact_id AND token = ?"
+        );
+        $res->execute(array($_SERVER['HTTP_CENTREON_AUTH_TOKEN']));
+        if ($userInfos = $res->fetch()) {
+            $centreon = new Centreon($userInfos);
+            $user = $centreon->user;
+        }
+    } catch (\PDOException $e) {
+        CentreonWebService::sendResult("Database error", 500);
+    }
+}
+
+CentreonWebService::router($dependencyInjector, $user, false);


### PR DESCRIPTION
## Description

Some webservices was fully accessible using external.php
This PR allow to check access properly before executing webservice

**Fixes** MON-4301

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

curl '<ip_address>/centreon/api/external.php?object=centreon_metric&action=listByService'
==> should be forbidden