### PR TITLE
enh(upgrade): display release notes per section

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -2790,3 +2790,31 @@ ul.module_list {
   white-space: nowrap;
   margin-right: 10px;
 }
+
+#installationContent .accordion {
+  background-color: #d6d5d5;
+  color: #444;
+  cursor: pointer;
+  padding: 5px;
+  text-align: left;
+  border: none;
+  outline: none;
+  transition: 0.4s;
+}
+
+#contentwrapper div.section {
+  padding: 0 10px;
+}
+
+#contentwrapper > div:not(:nth-child(2)) div.section {
+  display: none;
+  padding: 0 10px;
+  background-color: #d6d5d5;
+  overflow: hidden;
+}
+
+.accordion h1:hover {
+  background-color: #c3c3c3;
+  cursor: pointer;
+}
+

--- a/www/install/step_upgrade/step3.php
+++ b/www/install/step_upgrade/step3.php
@@ -66,7 +66,32 @@ $template->display('content.tpl');
     var step3_t;
 
     jQuery(function () {
-        jQuery('#releasenotes').load('RELEASENOTES.html');
+        jQuery('#releasenotes').load('RELEASENOTES.html', function() {
+            /* add accordion class to all div matching centreon-web-* id */
+            jQuery('div[id^="centreon-web-"]').addClass('accordion');
+
+            var acc = document.getElementsByClassName("accordion");
+            var i;
+
+            for (i = 0; i < acc.length; i++) {
+              acc[i].addEventListener("click", function() {
+                /* Toggle between adding and removing the "active" class,
+                to highlight the button that controls the panel */
+                this.classList.toggle("active");
+
+                /* Toggle between hiding and showing the active panel */
+                var panels = this.getElementsByClassName("section");
+                var j;
+                for (j = 0; j < panels.length; j++) {
+                    if (panels[j].style.display === "block") {
+                        panels[j].style.display = "none";
+                    } else {
+                        panels[j].style.display = "block";
+                    }
+                }
+              });
+            }
+        });
         jQuery('#next').attr('disabled', 'disabled');
         timeout_button();
     });


### PR DESCRIPTION
# Pull Request Template

## Description

An user that wants to upgrade to the actual latest Centreon version will get all the 19.10.0 release notes displayed since this commit https://github.com/centreon/centreon/commit/5b035978f9de75a802d54635c7d0db5af3f04769

The goal here is to condense the display of those release notes per clickable sections.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Upgrade to 19.10.x
* Go through the web upgrade
* Step 3 displays the release note

Latest RN version should be opened.
There is a hover on lines to show that those are clickable to display the content of the release note.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
