### PR TITLE
fix(acl): calculate acl extension all time

### DIFF
--- a/cron/centAcl.php
+++ b/cron/centAcl.php
@@ -733,14 +733,14 @@ try {
             $stmt->bindValue(':aclGroupId', $aclGroupId, \PDO::PARAM_INT);
             $stmt->execute();
         }
+    }
 
-        /**
-         * Include module specific ACL evaluation
-         */
-        $extensionsPaths = getModulesExtensionsPaths($pearDB);
-        foreach ($extensionsPaths as $extensionPath) {
-            require_once $extensionPath . 'centAcl.php';
-        }
+    /**
+     * Include module specific ACL evaluation
+     */
+    $extensionsPaths = getModulesExtensionsPaths($pearDB);
+    foreach ($extensionsPaths as $extensionPath) {
+        require_once $extensionPath . 'centAcl.php';
     }
 
     /*


### PR DESCRIPTION
## Description

The ACL extensions calculation is launched only if global Centreon ACL have been changed
Now the ACL extensions calculation is launched all time

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Use module extension with ACL
Change ACL on module
Check if new ACL are applied

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
