### PR TITLE
fix(remote-server): export properly trap matching

### DIFF
--- a/www/class/config-generate-remote/Relations/TrapsMatching.php
+++ b/www/class/config-generate-remote/Relations/TrapsMatching.php
@@ -22,6 +22,7 @@ namespace ConfigGenerateRemote\Relations;
 
 use \PDO;
 use ConfigGenerateRemote\Abstracts\AbstractObject;
+use ConfigGenerateRemote\ServiceCategory;
 
 class TrapsMatching extends AbstractObject
 {
@@ -106,7 +107,7 @@ class TrapsMatching extends AbstractObject
                 continue;
             }
             $this->generateObjectInFile($value, $value['tmo_id']);
-            serviceCategory::getInstance($this->dependencyInjector)->generateObject($value['severity_id']);
+            ServiceCategory::getInstance($this->dependencyInjector)->generateObject($value['severity_id']);
         }
     }
 


### PR DESCRIPTION
## Description

Trap matching cannot be exported on remote server because of a PHP fatal error in centcore logs : 
`2019-10-25 11:13:24 - DEBUG - cmd: /usr/share/centreon//bin/centreon -u <admin_user> -p <admin_md5_password> -w -o CentreonWorker -a processQueue
PHP Fatal error:  Uncaught Error: Class 'ConfigGenerateRemote\Relations\serviceCategory' not found in /usr/share/centreon/www/class/config-generate-remote/Relations/TrapsMatching.php:109
Stack trace:
#0 /usr/share/centreon/www/class/config-generate-remote/Relations/TrapsMatching.php(123): ConfigGenerateRemote\Relations\TrapsMatching->generateObject(607, Array)
#1 /usr/share/centreon/www/class/config-generate-remote/Trap.php(156): ConfigGenerateRemote\Relations\TrapsMatching->getTrapMatchingByTrapId(607)
#2 /usr/share/centreon/www/class/config-generate-remote/Trap.php(172): ConfigGenerateRemote\Trap->generateObject(2694, Array, Array)
#3 /usr/share/centreon/www/class/config-generate-remote/Abstracts/AbstractService.php(160): ConfigGenerateRemote\Trap->getTrapsByServiceId(2694)
#4 /usr/share/centreon/www/class/config-generate-remote/Service.php(226): ConfigGenerateRemote\Abstracts\AbstractService->getTraps(Array)
#5 /usr/share/centreon/www/class/config-generate-remote/Host.php(91): ConfigGenerateRemote\Service->generateFromServi in /usr/share/centreon/www/class/config-generate-remote/Relations/TrapsMatching.php on line 109`

**Fixes**

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)
