### PR TITLE
Add function to try get hostname by client mysql

### DIFF
--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -66,7 +66,7 @@ if ($parameters['address'] != "127.0.0.1" && $parameters['address'] != "localhos
     );
     $getIpQuery->execute();
     // The result example (172.17.0.1:38216), use the explode function to remove port
-    $host = explode(":", $getIpQuery->fetchAll(PDO::FETCH_COLUMN)[0])[0];
+    $host = gethostbyaddr(explode(":", $getIpQuery->fetchAll(PDO::FETCH_COLUMN)[0])[0]);
 }
 
 // Compatibility adaptation for mysql 8 with php7.1 before 7.1.16, or php7.2 before 7.2.4.


### PR DESCRIPTION
# Pull Request Template

## Description

Add function `gethostbyaddr` to try get the hostname of IP address by connection of mysql client.

For example, Docker and Docker-compose changes the IP in each restart and it may happen that ip is not the same as configured in mysql authorization table. That way, if you register the IP hostname, you will have no problem with changing IP.

Ref: https://www.php.net/manual/en/function.gethostbyaddr.php

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
