### PR TITLE
fix(secu): Avoid SQL injections in service by servicegroup pages

### DIFF
--- a/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
@@ -43,7 +43,7 @@ include_once _CENTREON_PATH_ . "www/include/common/common-Func.php";
 include_once _CENTREON_PATH_ . "www/class/centreonService.class.php";
 
 // Create XML Request Objects
- CentreonSession::start();
+CentreonSession::start();
 $obj = new CentreonXMLBGRequest($dependencyInjector, session_id(), 1, 1, 0, 1);
 $svcObj = new CentreonService($obj->DB);
 
@@ -68,8 +68,8 @@ $sgSearch = $obj->checkArgument("sg_search", $_GET, "");
 $sort_type = $obj->checkArgument("sort_type", $_GET, "host_name");
 $order = $obj->checkArgument("order", $_GET, "ASC");
 $dateFormat = $obj->checkArgument("date_time_format_status", $_GET, "Y/m/d H:i:s");
-$queryValues = array();
-$queryValues2 = array();
+$queryValues = [];
+$queryValues2 = [];
 
 // Backup poller selection
 $obj->setInstanceHistory($instance);
@@ -128,7 +128,7 @@ $h_search = '';
 if ($hSearch != "") {
     $h_search .= " AND h.name LIKE :hSearch ";
     // as this partial request is used in two queries, we need to bound it two times using two arrays
-    //to avoid unconsistent number of bound variables in the second query
+    // to avoid incoherent number of bound variables in the second query
     $queryValues['hSearch'] = $queryValues2['hSearch'] = [
         \PDO::PARAM_STR => "%" . $hSearch . "%"
     ];
@@ -145,13 +145,12 @@ if ($instance != -1) {
         \PDO::PARAM_INT => $instance
     ];
 }
-$query .= " ORDER BY sg.name " . $order
-    . " LIMIT :numLimit, :limit";
+$query .= " ORDER BY sg.name " . $order . " LIMIT :numLimit, :limit";
 $queryValues['numLimit'] = [
-    \PDO::PARAM_INT => (int) ($num * $limit)
+    \PDO::PARAM_INT => (int)($num * $limit)
 ];
 $queryValues['limit'] = [
-    \PDO::PARAM_INT => (int) $limit
+    \PDO::PARAM_INT => (int)$limit
 ];
 
 $dbResult = $obj->DBC->prepare($query);
@@ -200,8 +199,8 @@ if ($numRows > 0) {
     if ($sgSearch != "") {
         $sg_search .= "AND sg.name = :sgSearch";
         $queryValues2['sgSearch'] = [
-                \PDO::PARAM_STR => $sgSearch
-            ];
+            \PDO::PARAM_STR => $sgSearch
+        ];
     }
 
     $query2 = "SELECT SQL_CALC_FOUND_ROWS DISTINCT sg.name AS sg_name,
@@ -228,7 +227,7 @@ if ($numRows > 0) {
             $obj->access->queryBuilder("AND", "group_id", $obj->access->getAccessGroupsString()) . " " .
             $obj->access->queryBuilder("AND", "sg.servicegroup_id", $obj->access->getServiceGroupsString("ID")) . " ";
     }
-    $query2 .= $sg_search . $h_search . $s_search . " ORDER BY sg.name, tri ASC";
+    $query2 .= $sg_search . $h_search . $s_search . " ORDER BY sg_name, tri ASC";
 
     $dbResult = $obj->DBC->prepare($query2);
     foreach ($queryValues2 as $bindId => $bindData) {

--- a/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
@@ -56,18 +56,25 @@ if (!isset($obj->session_id) || !CentreonSession::checkSession($obj->session_id,
 $obj->getDefaultFilters();
 
 // Check Arguments From GET tab
-$o = $obj->checkArgument("o", $_GET, "h");
-$p = $obj->checkArgument("p", $_GET, "2");
-$nc = $obj->checkArgument("nc", $_GET, "0");
-$num = $obj->checkArgument("num", $_GET, 0);
-$limit = $obj->checkArgument("limit", $_GET, 20);
-$instance = $obj->checkArgument("instance", $_GET, $obj->defaultPoller);
-$hostgroups = $obj->checkArgument("hostgroups", $_GET, $obj->defaultHostgroups);
-$hSearch = $obj->checkArgument("host_search", $_GET, "");
-$sgSearch = $obj->checkArgument("sg_search", $_GET, "");
-$sort_type = $obj->checkArgument("sort_type", $_GET, "host_name");
-$order = $obj->checkArgument("order", $_GET, "ASC");
-$dateFormat = $obj->checkArgument("date_time_format_status", $_GET, "Y/m/d H:i:s");
+$o = filter_input(INPUT_GET, 'o', FILTER_SANITIZE_STRING, array('options' => array('default' => 'h')));
+$o = filter_input(INPUT_GET, 'o', FILTER_VALIDATE_INT, array('options' => array('default' => 2)));
+$num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
+$limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
+$instance = filter_var($obj->defaultPoller ?? -1, FILTER_VALIDATE_INT);
+$hSearch = filter_input(INPUT_GET, 'host_search', FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
+$sgSearch = filter_input(INPUT_GET, 'sg_search', FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
+$sort_type = filter_input(
+    INPUT_GET,
+    'sort_type',
+    FILTER_SANITIZE_STRING,
+    array('options' => array('default' => 'host_name'))
+);
+$order = filter_input(
+    INPUT_GET,
+    'order',
+    FILTER_VALIDATE_REGEXP,
+    array('options' => array('default' => 'ASC', 'regexp' => '/^(ASC|DESC)$/'))
+);
 $queryValues = [];
 $queryValues2 = [];
 
@@ -191,8 +198,8 @@ if ($numRows > 0) {
         foreach ($value as $hostId) {
             $hostsSql[] = $hostId;
         }
-        $servicegroupsSql1[] = "(sg.servicegroup_id = " . $key . " AND h.host_id IN (" .
-            implode(',', $hostsSql) . ")) ";
+        $servicegroupsSql1[] = "(sg.servicegroup_id = " . $key .
+            " AND h.host_id IN (" . implode(',', $hostsSql) . ")) ";
     }
     $sg_search .= implode(" OR ", $servicegroupsSql1);
     $sg_search .= ") ";

--- a/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
@@ -132,7 +132,7 @@ $h_search = '';
 if ($hSearch != "") {
     $h_search .= " AND h.name LIKE :hSearch ";
     // as this partial request is used in two queries, we need to bound it two times using two arrays
-    //to avoid unconsistent number of bound variables in the second query
+    // to avoid incoherent number of bound variables in the second query
     $queryValues['hSearch'] = $queryValues2['hSearch'] = [
         \PDO::PARAM_STR => "%" . $hSearch . "%"
     ];
@@ -152,10 +152,10 @@ if ($instance != -1) {
 
 $query .= "ORDER BY sg.name " . $order . " LIMIT :numLimit, :limit";
 $queryValues['numLimit'] = [
-    \PDO::PARAM_INT => (int) ($num * $limit)
+    \PDO::PARAM_INT => (int)($num * $limit)
 ];
 $queryValues['limit'] = [
-    \PDO::PARAM_INT => (int) $limit
+    \PDO::PARAM_INT => (int)$limit
 ];
 
 $dbResult = $obj->DBC->prepare($query);


### PR DESCRIPTION
# Pull Request Template

## Description

- avoid SQL injection in service by service group pages
- correct the status 500 when the serviceBySGGridXML.php is called (variable was not bound in the second query)
- clean code

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

please contact me


## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
