### PR TITLE
fix(install): check mariaDB version before using ALTER USER

### DIFF
--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -96,8 +96,7 @@ try {
     $prepareCreate->execute();
 
     // checking mysql version before trying to alter the password plugin
-    $prepareCheckVersion = $link->prepare($checkMysqlVersion);
-    $prepareCheckVersion->execute();
+    $prepareCheckVersion = $link->query($checkMysqlVersion);
     while ($row = $prepareCheckVersion->fetch()) {
         if (!isset($versionNumber) && $row['Variable_name'] === "version") {
             $versionNumber = $row['version'];

--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -69,15 +69,19 @@ if ($parameters['address'] != "127.0.0.1" && $parameters['address'] != "localhos
     $host = explode(":", $getIpQuery->fetchAll(PDO::FETCH_COLUMN)[0])[0];
 }
 
-// Compatibility adaptation for mysql 8 with php7.1 before 7.1.16, or php7.2 before 7.2.4.
-$createUser = "CREATE USER :dbUser@:host IDENTIFIED BY :dbPass";
-$alterQuery = "ALTER USER :dbUser@:host IDENTIFIED WITH mysql_native_password BY :dbPass";
-
 $queryValues = [];
 $queryValues[':dbUser'] = $parameters['db_user'];
 $queryValues[':host'] = $host;
 $queryValues[':dbPass'] = $parameters['db_password'];
 
+// Compatibility adaptation for mysql 8 with php7.1 before 7.1.16, or php7.2 before 7.2.4.
+$createUser = "CREATE USER :dbUser@:host IDENTIFIED BY :dbPass";
+
+// As ALTER USER won't work on a mariaDB < 10.2, we need to check it before trying this request
+$checkMysqlVersion = "SHOW VARIABLES WHERE Variable_name LIKE 'version%'";
+
+// creating the user - mandatory for MySQL DB
+$alterQuery = "ALTER USER :dbUser@:host IDENTIFIED WITH mysql_native_password BY :dbPass";
 $query = "GRANT ALL PRIVILEGES ON `%s`.* TO " . $parameters['db_user'] . "@" . $host . " WITH GRANT OPTION";
 $flushQuery = "FLUSH PRIVILEGES";
 
@@ -90,11 +94,29 @@ try {
     }
     // creating the user
     $prepareCreate->execute();
+
+    // checking mysql version before trying to alter the password plugin
+    $prepareCheckVersion = $link->prepare($checkMysqlVersion);
+    $prepareCheckVersion->execute();
+    while ($row = $prepareCheckVersion->fetch()) {
+        if (!isset($versionNumber) && $row['Variable_name'] === "version") {
+            $versionNumber = $row['version'];
+        } elseif (!isset($versionName) && $row['Variable_name'] === "version_comment") {
+            $versionName = $row['version_comment'];
+        }
+    }
+    if ((strpos($versionName, "MariaDB") !== false && version_compare($versionNumber, '10.2.0') >= 0)
+        || (strpos($versionName, "MySQL") !== false && version_compare($versionNumber, '8.0.0') >= 0)
+    ) {
+        // altering the mysql's password plugin using the ALTER USER request
+        $prepareAlter->execute();
+    }
+
     // granting privileges
     $link->exec(sprintf($query, $parameters['db_configuration']));
     $link->exec(sprintf($query, $parameters['db_storage']));
-    // altering the mysql's password plugin
-    $prepareAlter->execute();
+
+    // enabling the new parameters
     $link->exec($flushQuery);
 } catch (\PDOException $e) {
     $return['msg'] = $e->getMessage();


### PR DESCRIPTION
# Pull Request Template

## Description

As the Centreon wasn't released with the mariaDB 10.2 as expected, the MySQL 8.0 modifications are incompatible with mariaDB 10.1.
As the ALTER USER clause were introduced on the mariaDB 10.2.
Resulting in an error blocking the installation script on a fresh install

**Fixes** # (blocking)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x (master)

<h2> How this pull request can be tested ? </h2>

Try to install a fresh install using the current RPM -> an error occurs and you can't acheive the installation
Apply the fix, then try again -> The installation should work as expected

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
