### PR TITLE
fix(security): do not allow to unhide password macros

### DIFF
--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -550,7 +550,7 @@ jQuery(function() {
         }
         {/literal}{else}{literal}
         if ($passwordCheckbox.is(':checked')) {
-            $passwordCheckbox.parent('span').hide();
+            $passwordCheckbox.closest('span').hide();
         }
         {/literal}{/if}{literal}
     });
@@ -682,7 +682,7 @@ function clonerefreshListener(el){
 
                         if (jQuery(elem).find("input[id^='macroPassword_']").is(':checked')) {
                         	jQuery(elem).find("input[name^='macroValue']").prop('type', 'password');
-                            jQuery(elem).find("input[id^='macroPassword_']").parent('span').hide();
+                            jQuery(elem).find("input[id^='macroPassword_']").closest('span').hide();
                     	}
                     });
                 }

--- a/www/include/configuration/configObject/service/formService.ihtml
+++ b/www/include/configuration/configObject/service/formService.ihtml
@@ -472,7 +472,7 @@ jQuery(function() {
         }
         {/literal}{else}{literal}
         if ($passwordCheckbox.is(':checked')) {
-            $passwordCheckbox.parent('span').hide();
+            $passwordCheckbox.closest('span').hide();
         }
         {/literal}{/if}{literal}
 
@@ -590,7 +590,7 @@ jQuery(function() {
 
                 if (jQuery(elem).find("input[id^='macroPassword_']").is(':checked')) {
                     jQuery(elem).find("input[name^='macroValue']").prop('type', 'password');
-                    jQuery(elem).find("input[id^='macroPassword_']").parent('span').hide();
+                    jQuery(elem).find("input[id^='macroPassword_']").closest('span').hide();
                 }
                 });
         }


### PR DESCRIPTION
## Description

User can unhide password macros...

**Fixes** MON-4445

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)