### PR TITLE
fix(secu): remove unused http parameters in hostgroup xml.php

### DIFF
--- a/www/include/monitoring/status/HostGroups/xml/hostGroupXML.php
+++ b/www/include/monitoring/status/HostGroups/xml/hostGroupXML.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -33,9 +33,7 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . "/../../../../../../config/centreon.config.php");
 require_once realpath(__DIR__ . "/../../../../../../bootstrap.php");
-
 include_once _CENTREON_PATH_ . "www/class/centreonUtils.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonXMLBGRequest.class.php";
 include_once _CENTREON_PATH_ . "www/include/common/common-Func.php";
@@ -47,9 +45,7 @@ CentreonSession::start();
 $obj = new CentreonXMLBGRequest($dependencyInjector, session_id(), 1, 1, 0, 1);
 
 
-if (isset($obj->session_id) && CentreonSession::checkSession($obj->session_id, $obj->DB)) {
-    ;
-} else {
+if (!isset($obj->session_id) || !CentreonSession::checkSession($obj->session_id, $obj->DB)) {
     print "Bad Session ID";
     exit();
 }
@@ -60,7 +56,7 @@ if (isset($obj->session_id) && CentreonSession::checkSession($obj->session_id, $
 $obj->getDefaultFilters();
 
 /*
- * Alias / Name convertion table
+ * Alias / Name conversion table
  */
 $convertTable = array();
 $convertID = array();
@@ -78,19 +74,17 @@ $o = $obj->checkArgument("o", $_GET, "h");
 $p = $obj->checkArgument("p", $_GET, "2");
 $num = $obj->checkArgument("num", $_GET, 0);
 $limit = $obj->checkArgument("limit", $_GET, 20);
-$instance = $obj->checkArgument("instance", $_GET, $obj->defaultPoller);
-$hostgroups = $obj->checkArgument("hostgroups", $_GET, $obj->defaultHostgroups);
+$instance = $obj->defaultPoller;
 $search = $obj->checkArgument("search", $_GET, "");
 $sort_type = $obj->checkArgument("sort_type", $_GET, "host_name");
 $order = $obj->checkArgument("order", $_GET, "ASC");
-$dateFormat = $obj->checkArgument("date_time_format_status", $_GET, "Y/m/d H:i:s");
 
 $groupStr = $obj->access->getAccessGroupsString();
+
 /*
  * Backup poller selection
  */
 $obj->setInstanceHistory($instance);
-$obj->setHostGroupsHistory($hostgroups);
 
 /*
  * Search string
@@ -194,7 +188,7 @@ while ($data = $DBRESULT->fetchRow()) {
 /*
  * Get Pagination Rows
  */
-$stats = isset($stats) ? $stats : [];
+$stats = $stats ?? [];
 $numRows = count($stats);
 
 $obj->XML->startElement("reponse");
@@ -210,9 +204,9 @@ $ct = 0;
 
 if (isset($stats)) {
     foreach ($stats as $name => $stat) {
-        if (($i < (($num + 1) * $limit) && $i >= (($num) * $limit)) &&
-            ((isset($converTable[$name]) && isset($acl[$convertTable[$name]])) || (!isset($acl))) &&
-            $name != "meta_hostgroup"
+        if (($i < (($num + 1) * $limit) && $i >= (($num) * $limit))
+            && ((isset($converTable[$name]) && isset($acl[$convertTable[$name]])) || (!isset($acl)))
+            && $name != "meta_hostgroup"
         ) {
             $class = $obj->getNextLineClass();
             if (isset($stat["h"]) && count($stat["h"])) {

--- a/www/include/monitoring/status/HostGroups/xml/hostGroupXML.php
+++ b/www/include/monitoring/status/HostGroups/xml/hostGroupXML.php
@@ -67,17 +67,27 @@ while ($hg = $DBRESULT->fetchRow()) {
 }
 $DBRESULT->closeCursor();
 
-/*
- *  Check Arguments from GET
- */
-$o = $obj->checkArgument("o", $_GET, "h");
-$p = $obj->checkArgument("p", $_GET, "2");
-$num = $obj->checkArgument("num", $_GET, 0);
-$limit = $obj->checkArgument("limit", $_GET, 20);
-$instance = $obj->defaultPoller;
-$search = $obj->checkArgument("search", $_GET, "");
-$sort_type = $obj->checkArgument("sort_type", $_GET, "host_name");
-$order = $obj->checkArgument("order", $_GET, "ASC");
+// Check Arguments From GET tab
+$o = filter_input(INPUT_GET, 'o', FILTER_SANITIZE_STRING, array('options' => array('default' => 'h')));
+$p = filter_input(INPUT_GET, 'p', FILTER_VALIDATE_INT, array('options' => array('default' => 2)));
+$num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
+$limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
+//if instance value is not set, displaying all active pollers linked resources
+$instance = filter_var($obj->defaultPoller ?? -1, FILTER_VALIDATE_INT);
+
+$search = filter_input(INPUT_GET, 'search', FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
+$sort_type = filter_input(
+    INPUT_GET,
+    'sort_type',
+    FILTER_SANITIZE_STRING,
+    array('options' => array('default' => 'host_name'))
+);
+$order = filter_input(
+    INPUT_GET,
+    'order',
+    FILTER_VALIDATE_REGEXP,
+    array('options' => array('default' => 'ASC', 'regexp' => '/^(ASC|DESC)$/'))
+);
 
 $groupStr = $obj->access->getAccessGroupsString();
 


### PR DESCRIPTION
# Pull Request Template

## Description

Remove or sanitize $_GET parameters to avoid SQL injection in:
hostgroup XML file

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

please contact me.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
