### PR TITLE
fix(secu): remove unused http parameters in services by hostgroup files

### DIFF
--- a/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
+++ b/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
@@ -61,20 +61,31 @@ $_SESSION['monitoring_serviceByHg_status_filter'] = $statusFilter;
 $obj->getDefaultFilters();
 
 // Check Arguments From GET tab
-$o = $obj->checkArgument("o", $_GET, "h");
-$p = $obj->checkArgument("p", $_GET, "2");
-$hg = $obj->checkArgument("hg", $_GET, "");
-$num = $obj->checkArgument("num", $_GET, 0);
-$limit = $obj->checkArgument("limit", $_GET, 20);
-$instance = $obj->checkArgument("instance", $_GET, $obj->defaultPoller);
-$hostgroup = $obj->checkArgument("hg_search", $_GET, "");
-$search = $obj->checkArgument("search", $_GET, "");
-$sort_type = $obj->checkArgument("sort_type", $_GET, "host_name");
-$order = $obj->checkArgument("order", $_GET, "ASC");
-$dateFormat = $obj->checkArgument("date_time_format_status", $_GET, "Y/m/d H:i:s");
+$o = filter_input(INPUT_GET, 'o', FILTER_SANITIZE_STRING, array('options' => array('default' => 'h')));
+$p = filter_input(INPUT_GET, 'p', FILTER_VALIDATE_INT, array('options' => array('default' => 2)));
+$num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
+$limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
+//if instance value is not set, displaying all active pollers linked resources
+$instance = filter_var($obj->defaultPoller ?? -1, FILTER_VALIDATE_INT);
+$hostgroup = filter_input(INPUT_GET, 'hg_search', FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
+$search = filter_input(INPUT_GET, 'search', FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
+$sort_type = filter_input(
+    INPUT_GET,
+    'sort_type',
+    FILTER_SANITIZE_STRING,
+    array('options' => array('default' => 'host_name'))
+);
+$order = filter_input(
+    INPUT_GET,
+    'order',
+    FILTER_VALIDATE_REGEXP,
+    array('options' => array('default' => 'ASC', 'regexp' => '/^(ASC|DESC)$/'))
+);
 $grouplistStr = $obj->access->getAccessGroupsString();
 
-$queryValues = array();
+//saving bound values
+$queryValues = [];
+
 //Get Host status
 $rq1 = "SELECT SQL_CALC_FOUND_ROWS DISTINCT hg.name AS alias, h.host_id id, h.name AS host_name, hgm.hostgroup_id, " .
     "h.state hs, h.icon_image " .

--- a/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
+++ b/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
@@ -33,9 +33,7 @@
  *
  */
 
-require_once realpath(__DIR__ . "/../../../../../../config/centreon.config.php");
 require_once realpath(__DIR__ . "/../../../../../../bootstrap.php");
-
 include_once _CENTREON_PATH_ . "www/class/centreonUtils.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonXMLBGRequest.class.php";
 include_once _CENTREON_PATH_ . "www/include/monitoring/status/Common/common-Func.php";
@@ -47,7 +45,7 @@ CentreonSession::start(1);
 $obj = new CentreonXMLBGRequest($dependencyInjector, session_id(), 1, 1, 0, 1);
 $svcObj = new CentreonService($obj->DB);
 
-if (!isset($obj->session_id) && !CentreonSession::checkSession($obj->session_id, $obj->DB)) {
+if (!isset($obj->session_id) || !CentreonSession::checkSession($obj->session_id, $obj->DB)) {
     print "Bad Session ID";
     exit();
 }

--- a/www/include/monitoring/status/ServicesHostGroups/xml/serviceSummaryByHGXML.php
+++ b/www/include/monitoring/status/ServicesHostGroups/xml/serviceSummaryByHGXML.php
@@ -52,20 +52,31 @@ if (!isset($obj->session_id) || !CentreonSession::checkSession($obj->session_id,
 $obj->getDefaultFilters();
 
 // Check Arguments From GET tab
-$o = $obj->checkArgument("o", $_GET, "h");
-$p = $obj->checkArgument("p", $_GET, "2");
-$hg = $obj->checkArgument("hg", $_GET, "");
-$num = $obj->checkArgument("num", $_GET, 0);
-$limit = $obj->checkArgument("limit", $_GET, 20);
-$instance = $obj->checkArgument("instance", $_GET, $obj->defaultPoller);
-$hostgroup = $obj->checkArgument("hg_search", $_GET, "");
-$search = $obj->checkArgument("search", $_GET, "");
-$sort_type = $obj->checkArgument("sort_type", $_GET, "alias");
-$order = $obj->checkArgument("order", $_GET, "ASC");
-$dateFormat = $obj->checkArgument("date_time_format_status", $_GET, "Y/m/d H:i:s");
+$o = filter_input(INPUT_GET, 'o', FILTER_SANITIZE_STRING, array('options' => array('default' => 'h')));
+$p = filter_input(INPUT_GET, 'p', FILTER_VALIDATE_INT, array('options' => array('default' => 2)));
+$num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
+$limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
+//if instance value is not set, displaying all active pollers linked resources
+$instance = filter_var($obj->defaultPoller ?? -1, FILTER_VALIDATE_INT);
+$hostgroup = filter_input(INPUT_GET, 'hg_search', FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
+$search = filter_input(INPUT_GET, 'search', FILTER_SANITIZE_STRING, array('options' => array('default' => '')));
+$sort_type = filter_input(
+    INPUT_GET,
+    'sort_type',
+    FILTER_SANITIZE_STRING,
+    array('options' => array('default' => 'alias'))
+);
+$order = filter_input(
+    INPUT_GET,
+    'order',
+    FILTER_VALIDATE_REGEXP,
+    array('options' => array('default' => 'ASC', 'regexp' => '/^(ASC|DESC)$/'))
+);
 $grouplistStr = $obj->access->getAccessGroupsString();
 
-$queryValues = array();
+//saving bound values
+$queryValues = [];
+
 // Get Host status
 $rq1 = "SELECT SQL_CALC_FOUND_ROWS DISTINCT h.name AS host_name, hg.name AS hgname, hgm.hostgroup_id, h.host_id, " .
     "h.state, h.icon_image FROM hostgroups hg, hosts_hostgroups hgm, hosts h ";

--- a/www/include/monitoring/status/ServicesHostGroups/xml/serviceSummaryByHGXML.php
+++ b/www/include/monitoring/status/ServicesHostGroups/xml/serviceSummaryByHGXML.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * Copyright 2005-2019 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
@@ -34,7 +33,6 @@
  *
  */
 
-require_once realpath(__DIR__ . "/../../../../../../config/centreon.config.php");
 require_once realpath(__DIR__ . "/../../../../../../bootstrap.php");
 include_once _CENTREON_PATH_ . "www/class/centreonUtils.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonXMLBGRequest.class.php";
@@ -90,7 +88,7 @@ if (!$obj->is_admin) {
 if ($instance != -1) {
     $rq1 .= "AND h.instance_id = :instance ";
     $queryValues[':instance'] = [
-        PDO::PARAM_INT => (int) $instance
+        PDO::PARAM_INT => (int)$instance
     ];
 }
 
@@ -133,10 +131,10 @@ $queryValues[':sort_type'] = [
     PDO::PARAM_STR => $sort_type
 ];
 $queryValues[':numLimit'] = [
-    PDO::PARAM_INT => (int) ($num * $limit)
+    PDO::PARAM_INT => (int)($num * $limit)
 ];
 $queryValues[':limit'] = [
-    PDO::PARAM_INT => (int) $limit
+    PDO::PARAM_INT => (int)$limit
 ];
 
 $DBRESULT = $obj->DBC->prepare($rq1);


### PR DESCRIPTION
# Pull Request Template

## Description

Remove or sanitize $_GET parameters to avoid SQL injection in:
services by hostgroup XML files

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

please contact me.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
