### PR TITLE
fix(UI): replace popin z-index

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -1915,7 +1915,7 @@ span.state_badge {
 /* Style for popin */
 .centreon-popin {
     position: absolute;
-    z-index: 1065;
+    z-index: 5050;
     background-color: white;
     padding: 1em 3em 1em 1em;
     border-radius: 4px;


### PR DESCRIPTION
# Pull Request Template

## Description

In some pages, the centreon popin is behind the scrollbar of the select 2.

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

![image](https://user-images.githubusercontent.com/34628915/68109142-1afb7400-feea-11e9-8add-0de94657cd60.png)

Go to configuration > add > select all availables host in the select2 and check that the popin is properly displayed
  
## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
