### PR TITLE
fix(unattended): unattended failure

### DIFF
--- a/unattended.sh
+++ b/unattended.sh
@@ -128,14 +128,19 @@ print_step_end "OK, timezone set to $timezone"
 print_step_begin "Firewall configuration"
 command -v firewall-cmd > /dev/null 2>&1
 if [ "x$?" '=' x0 ] ; then
-  for svc in http snmp snmptrap ; do
-    firewall-cmd --zone=public --add-service=$svc --permanent > /dev/null 2>&1
-    if [ "x$?" '!=' x0 ] ; then
-      error_and_exit "Could not configure firewall. You might need to run this script as root."
-    fi
-  done
-  firewall-cmd --reload
-  print_step_end
+  firewall-cmd --state > /dev/null 2>&1
+  if [ "x$?" '=' x0 ] ; then
+    for svc in http snmp snmptrap ; do
+      firewall-cmd --zone=public --add-service=$svc --permanent > /dev/null 2>&1
+      if [ "x$?" '!=' x0 ] ; then
+        error_and_exit "Could not configure firewall. You might need to run this script as root."
+      fi
+    done
+    firewall-cmd --reload
+    print_step_end
+  else
+    print_step_end "OK, not active"
+  fi
 else
   print_step_end "OK, not detected"
 fi


### PR DESCRIPTION
the unattended script fails when the firewall is installed but inactive

# Pull Request Template

## Description

The unattended.sh script fails when a firewall is installed but not active.
This PR adds a test to check the firewall status and do not try to configure it if it is not active.
This is a record of the failure: https://asciinema.org/a/iIG8TdptGJa3Rjt58hW9oqQte
The script is ending too early, centreon services are not started and http request to the service (via curl command) fails.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Sart a new VM with a Centos/7 vagrant box, launch the script and check if centreon services are started and available.
https://app.vagrantup.com/centos/boxes/7

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
