### PR TITLE
Poc new update field pollers

### DIFF
--- a/src/Centreon/Domain/Repository/NagiosServerRepository.php
+++ b/src/Centreon/Domain/Repository/NagiosServerRepository.php
@@ -102,7 +102,24 @@ SQL;
     {
         $sql = "UPDATE `nagios_server` SET `updated` = '1' WHERE `id` = :id";
         $stmt = $this->db->prepare($sql);
-        $stmt->bindParam(':id',$id, \PDO::PARAM_INT);
+        $stmt->bindParam(':id', $id, \PDO::PARAM_INT);
         $stmt->execute();
+    }
+
+    /**
+     * Get Central Poller
+     * @return int|null
+     */
+    public function getCentral(): ?int
+    {
+        $query = "SELECT id FROM nagios_server WHERE localhost = '1' LIMIT 1";
+        $stmt = $this->db->prepare($query);
+        $stmt->execute();
+
+        if (!$stmt->rowCount()) {
+            return null;
+        }
+
+        return (int)$stmt->fetch()['id'];
     }
 }

--- a/src/Centreon/Domain/Repository/NagiosServerRepository.php
+++ b/src/Centreon/Domain/Repository/NagiosServerRepository.php
@@ -93,4 +93,16 @@ SQL;
         $stmt = $this->db->prepare($sql);
         $stmt->execute();
     }
+
+    /**
+     * Sets poller as updated (shows that poller needs restarting)
+     * @param int $id id of poller
+     */
+    public function setUpdated(int $id): void
+    {
+        $sql = "UPDATE `nagios_server` SET `updated` = '1' WHERE `id` = :id";
+        $stmt = $this->db->prepare($sql);
+        $stmt->bindParam(':id',$id, \PDO::PARAM_INT);
+        $stmt->execute();
+    }
 }

--- a/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -196,7 +196,7 @@ try {
             }
         }
         $DBRESULT = $pearDB->query("UPDATE `nagios_server` SET `last_restart` = '"
-            . time() . "' WHERE `id` = '" . $host["id"] . "'");
+            . time() . ", `updated` = \"1\" WHERE `id` = '" . $host["id"] . "'");
     }
 
     foreach ($msg_restart as $key => $str) {

--- a/www/include/configuration/configGenerate/xml/restartPollers.php
+++ b/www/include/configuration/configGenerate/xml/restartPollers.php
@@ -196,7 +196,7 @@ try {
             }
         }
         $DBRESULT = $pearDB->query("UPDATE `nagios_server` SET `last_restart` = '"
-            . time() . ", `updated` = \"1\" WHERE `id` = '" . $host["id"] . "'");
+            . time() . "', `updated` = '0' WHERE `id` = '" . $host["id"] . "'");
     }
 
     foreach ($msg_restart as $key => $str) {

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -774,7 +774,7 @@ function updateServer(int $id, $data): void
  */
 function checkChangeState(int $poller_id, int $last_restart): bool
 {
-    global $pearDBO, $conf_centreon;
+    global $pearDBO, $conf_centreon, $pearDB;
 
     if (!isset($last_restart) || $last_restart == "") {
         return false;
@@ -860,5 +860,19 @@ AND (
 REQUEST;
 
     $dbResult = $pearDBO->query($query);
-    return $dbResult->rowCount() ? true : false;
+    if ($dbResult->rowCount()) {
+        // requires restart if storage db has log information about changes
+        return true;
+    } else {
+        // also requires restart if flag updated is set to true
+        $configStmt = $pearDB->prepare("SELECT updated FROM nagios_server WHERE id = :pollerID LIMIT 1");
+        $configStmt->bindValue(':pollerID', $poller_id, \PDO::PARAM_INT);
+        $configStmt->execute();
+        $row = $configStmt->fetch(\PDO::FETCH_ASSOC);
+        if ($row['updated']) {
+            return true;
+        }
+    }
+
+    return false;
 }

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -776,7 +776,7 @@ function checkChangeState(int $poller_id, int $last_restart): bool
 {
     global $pearDBO, $conf_centreon, $pearDB;
 
-    if (!isset($last_restart) || $last_restart == "") {
+    if (!isset($last_restart) || $last_restart === "") {
         return false;
     }
 

--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -1636,6 +1636,7 @@ CREATE TABLE `nagios_server` (
   `centreonbroker_logs_path` VARCHAR(255),
   `remote_id` int(11) NULL,
   `remote_server_centcore_ssh_proxy` enum('0','1') NOT NULL DEFAULT '1',
+  `updated` enum('1','0') NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   CONSTRAINT `nagios_server_remote_id_id` FOREIGN KEY (`remote_id`) REFERENCES `nagios_server` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/www/install/sql/centreon/Update-DB-19.10.0-rc.1.sql
+++ b/www/install/sql/centreon/Update-DB-19.10.0-rc.1.sql
@@ -7,3 +7,6 @@ CREATE TABLE IF NOT EXISTS `rs_poller_relation` (
 
 --new inheritance mode
 INSERT INTO `options` (`key`, `value`) VALUES ('inheritance_mode', '1');
+
+--new updated field of pollers-
+ALTER TABLE `nagios_server` ADD COLUMN `updated` enum('0','1') NOT NULL DEFAULT '0';

--- a/www/install/sql/centreon/Update-DB-19.10.0-rc.1.sql
+++ b/www/install/sql/centreon/Update-DB-19.10.0-rc.1.sql
@@ -7,6 +7,3 @@ CREATE TABLE IF NOT EXISTS `rs_poller_relation` (
 
 --new inheritance mode
 INSERT INTO `options` (`key`, `value`) VALUES ('inheritance_mode', '1');
-
---new updated field of pollers-
-ALTER TABLE `nagios_server` ADD COLUMN `updated` enum('0','1') NOT NULL DEFAULT '0';

--- a/www/install/sql/centreon/Update-DB-20.04.0-beta.1.sql
+++ b/www/install/sql/centreon/Update-DB-20.04.0-beta.1.sql
@@ -1,0 +1,2 @@
+--new updated field of pollers-
+ALTER TABLE `nagios_server` ADD COLUMN `updated` enum('0','1') NOT NULL DEFAULT '0';


### PR DESCRIPTION
# Pull Request Template

## Description

Add a new field to nagios_server table called `updated` which is a flag if the poller needs to be restarted (configuration changed) or not. This allows us manually to mark a poller as need-restart, for example when Business Activity changes.

**Fixes** #BAM-766

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Update Business Activity and check the poller page.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
