### PR TITLE
enh(BE): replace order filter's regexp using whitelist 

### DIFF
--- a/www/include/monitoring/status/HostGroups/xml/hostGroupXML.php
+++ b/www/include/monitoring/status/HostGroups/xml/hostGroupXML.php
@@ -77,17 +77,7 @@ $num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => ar
 $limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
 $instance = filter_input(INPUT_GET, 'instance', FILTER_VALIDATE_INT, array('options' => array('default' => -1)));
 
-$order = filter_input(
-    INPUT_GET,
-    'order',
-    FILTER_VALIDATE_REGEXP,
-    array(
-        'options' => array(
-            'default' => "ASC",
-            'regexp' => '/^(ASC|DESC)$/'
-        )
-    )
-);
+$order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
 
 // string values from the $_GET sanitized using the checkArgument() which call CentreonDB::escape() method
 $o = $obj->checkArgument("o", $_GET, "h");

--- a/www/include/monitoring/status/Hosts/xml/hostXML.php
+++ b/www/include/monitoring/status/Hosts/xml/hostXML.php
@@ -340,10 +340,14 @@ while ($data = $dbResult->fetchRow()) {
     $obj->XML->writeElement("ha", $data["acknowledged"]);
     $obj->XML->writeElement("hdtm", $data["scheduled_downtime_depth"]);
     $obj->XML->writeElement(
-        "hdtmXml", "./include/monitoring/downtime/xml/broker/makeXMLForDowntime.php?hid=" . $data['host_id']);
+        "hdtmXml",
+        "./include/monitoring/downtime/xml/broker/makeXMLForDowntime.php?hid=" . $data['host_id']
+    );
     $obj->XML->writeElement("hdtmXsl", "./include/monitoring/downtime/xsl/popupForDowntime.xsl");
     $obj->XML->writeElement(
-        "hackXml", "./include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php?hid=" . $data['host_id']);
+        "hackXml",
+        "./include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php?hid=" . $data['host_id']
+    );
     $obj->XML->writeElement("hackXsl", "./include/monitoring/acknowlegement/xsl/popupForAck.xsl");
     $obj->XML->writeElement("hae", $data["active_checks"]);
     $obj->XML->writeElement("hpe", $data["passive_checks"]);

--- a/www/include/monitoring/status/Hosts/xml/hostXML.php
+++ b/www/include/monitoring/status/Hosts/xml/hostXML.php
@@ -78,17 +78,7 @@ $p = filter_input(INPUT_GET, 'p', FILTER_VALIDATE_INT, array('options' => array(
 $num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
 $limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
 
-$order = filter_input(
-    INPUT_GET,
-    'order',
-    FILTER_VALIDATE_REGEXP,
-    array(
-        'options' => array(
-            'default' => "ASC",
-            'regexp' => '/^(ASC|DESC)$/'
-        )
-    )
-);
+$order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
 
 // string values from the $_GET sanitized using the checkArgument() which call CentreonDB::escape() method
 $o = $obj->checkArgument("o", $_GET, "h");

--- a/www/include/monitoring/status/Services/xml/serviceGridXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceGridXML.php
@@ -70,17 +70,7 @@ $p = filter_input(INPUT_GET, 'p', FILTER_VALIDATE_INT, array('options' => array(
 $num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
 $limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
 
-$order = filter_input(
-    INPUT_GET,
-    'order',
-    FILTER_VALIDATE_REGEXP,
-    array(
-        'options' => array(
-            'default' => "ASC",
-            'regexp' => '/^(ASC|DESC)$/'
-        )
-    )
-);
+$order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
 
 // string values from the $_GET sanitized using the checkArgument() which call CentreonDB::escape() method
 $o = $obj->checkArgument("o", $_GET, "h");

--- a/www/include/monitoring/status/Services/xml/serviceSummaryXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceSummaryXML.php
@@ -67,17 +67,7 @@ $p = filter_input(INPUT_GET, 'p', FILTER_VALIDATE_INT, array('options' => array(
 $num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
 $limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
 
-$order = filter_input(
-    INPUT_GET,
-    'order',
-    FILTER_VALIDATE_REGEXP,
-    array(
-        'options' => array(
-            'default' => "ASC",
-            'regexp' => '/^(ASC|DESC)$/'
-        )
-    )
-);
+$order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
 
 // string values from the $_GET sanitized using the checkArgument() which call CentreonDB::escape() method
 $o = $obj->checkArgument("o", $_GET, "h");

--- a/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -102,17 +102,7 @@ $num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => ar
 $limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
 $nc = filter_input(INPUT_GET, 'nc', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
 
-$order = filter_input(
-    INPUT_GET,
-    'order',
-    FILTER_VALIDATE_REGEXP,
-    array(
-        'options' => array(
-            'default' => "ASC",
-            'regexp' => '/^(ASC|DESC)$/'
-        )
-    )
-);
+$order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
 
 // string values from the $_GET sanitized using the checkArgument() which call CentreonDB::escape() method
 $o = $obj->checkArgument("o", $_GET, "h");

--- a/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
+++ b/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
@@ -61,17 +61,7 @@ $p = filter_input(INPUT_GET, 'p', FILTER_VALIDATE_INT, array('options' => array(
 $num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
 $limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
 
-$order = filter_input(
-    INPUT_GET,
-    'order',
-    FILTER_VALIDATE_REGEXP,
-    array(
-        'options' => array(
-            'default' => "ASC",
-            'regexp' => '/^(ASC|DESC)$/'
-        )
-    )
-);
+$order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
 
 // string values from the $_GET sanitized using the checkArgument() which call CentreonDB::escape() method
 $o = $obj->checkArgument("o", $_GET, "h");

--- a/www/include/monitoring/status/ServicesHostGroups/xml/serviceSummaryByHGXML.php
+++ b/www/include/monitoring/status/ServicesHostGroups/xml/serviceSummaryByHGXML.php
@@ -61,17 +61,7 @@ $p = filter_input(INPUT_GET, 'p', FILTER_VALIDATE_INT, array('options' => array(
 $num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
 $limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
 
-$order = filter_input(
-    INPUT_GET,
-    'order',
-    FILTER_VALIDATE_REGEXP,
-    array(
-        'options' => array(
-            'default' => "ASC",
-            'regexp' => '/^(ASC|DESC)$/'
-        )
-    )
-);
+$order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
 
 // string values from the $_GET sanitized using the checkArgument() which call CentreonDB::escape() method
 $o = $obj->checkArgument("o", $_GET, "h");

--- a/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
@@ -63,17 +63,7 @@ $p = filter_input(INPUT_GET, 'p', FILTER_VALIDATE_INT, array('options' => array(
 $num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
 $limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
 
-$order = filter_input(
-    INPUT_GET,
-    'order',
-    FILTER_VALIDATE_REGEXP,
-    array(
-        'options' => array(
-            'default' => "ASC",
-            'regexp' => '/^(ASC|DESC)$/'
-        )
-    )
-);
+$order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
 
 // string values from the $_GET sanitized using the checkArgument() which call CentreonDB::escape() method
 $o = $obj->checkArgument("o", $_GET, "h");

--- a/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
@@ -69,17 +69,7 @@ $p = filter_input(INPUT_GET, 'p', FILTER_VALIDATE_INT, array('options' => array(
 $num = filter_input(INPUT_GET, 'num', FILTER_VALIDATE_INT, array('options' => array('default' => 0)));
 $limit = filter_input(INPUT_GET, 'limit', FILTER_VALIDATE_INT, array('options' => array('default' => 20)));
 
-$order = filter_input(
-    INPUT_GET,
-    'order',
-    FILTER_VALIDATE_REGEXP,
-    array(
-        'options' => array(
-            'default' => "ASC",
-            'regexp' => '/^(ASC|DESC)$/'
-        )
-    )
-);
+$order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
 
 // string values from the $_GET sanitized using the checkArgument() which call CentreonDB::escape() method
 $o = $obj->checkArgument("o", $_GET, "h");


### PR DESCRIPTION
# Pull Request Template

## Description

Replace the regexp filter sanitize on the $order parameter with a whitelist.
Correct coding style for the CI

**Fixes** # (CI - 2.8.x)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

1 - test the "order" of the status > monitoring pages

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
