### PR TITLE
fix(breadcrumb): fix breadcrumb url for parent's levels

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "centreon web package",
   "scripts": {
     "build": "webpack --mode production",
-    "build:dev": "webpack --mode development  --config ./webpack.config.dev.js",
+    "build:dev": "webpack --mode development --config ./webpack.config.dev.js",
+    "watch": "webpack --mode=development --config ./webpack.config.dev.js --watch",
     "eslint": "eslint ./www/front_src --ext .js,.jsx",
     "eslint:fix": "npm run eslint -- --fix",
     "test": "jest",

--- a/www/front_src/src/components/breadcrumbWrapper/index.jsx
+++ b/www/front_src/src/components/breadcrumbWrapper/index.jsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 import { connect } from "react-redux";
-import { breadcrumbsSelector } from '../../redux/selectors/navigation/breadcrumbs';
+import breadcrumbsSelector from '../../redux/selectors/navigation/breadcrumbs';
 import { Breadcrumb } from '@centreon/react-components';
 
 function BreadcrumbWrapper({ breadcrumbs, path, children, ...others }) {

--- a/www/front_src/src/redux/selectors/navigation/breadcrumbs.js
+++ b/www/front_src/src/redux/selectors/navigation/breadcrumbs.js
@@ -1,15 +1,32 @@
 import { createSelector } from 'reselect';
 
 /**
+ * get URL from legacy or react pages
+ * @param {Object} item
+ * @return {String} build URL
+ */
+function getUrl(item) {
+  return item.is_react
+    ? item.url
+    : `/main.php?p=${item.page}${item.options !== null ? item.options : ''}`;
+}
+
+/**
  * loop on each group/child to get first url
  * @param {Object} item
  * @return {String|undefined} first url found
  */
 function findFirstUrl(item) {
+  if (item.url) {
+    return getUrl(item);
+  }
+
   if (item.groups) {
     const groupWithUrl = item.groups.find(findFirstUrl);
 
-    return groupWithUrl && groupWithUrl.children ? getFirstUrlInChildren(groupWithUrl) : undefined;
+    return groupWithUrl && groupWithUrl.children
+      ? getFirstUrlInChildren(groupWithUrl)
+      : undefined;
   }
 
   return item.children ? getFirstUrlInChildren(item) : undefined;
@@ -25,25 +42,8 @@ function getFirstUrlInChildren(item) {
     return undefined;
   }
 
-  const childWithUrl = item.children.find((child) => child.url);
-
-  if (childWithUrl) {
-    return getUrl(childWithUrl);
-  }
-
-  if (item.children) {
-    const childWithUrl = item.children.find(findFirstUrl);
-    return childWithUrl ? findFirstUrl(childWithUrl) : undefined;
-  }
-}
-
-/**
- * get URL from legacy or react pages
- * @param {Object} item
- * @return {String} build URL
- */
-function getUrl(item) {
-  return item.is_react ? item.url : `/main.php?p=${item.page}${item.options !== null ? item.options : ''}`;
+  const childrenWithUrl = item.children.find(findFirstUrl);
+  return childrenWithUrl ? findFirstUrl(childrenWithUrl) : undefined;
 }
 
 /**
@@ -52,24 +52,24 @@ function getUrl(item) {
  * @return {Object|null} breadcrumb step information
  */
 function getBreadcrumbStep(item) {
-    const availableUrl = item.url ? getUrl(item) : findFirstUrl(item);
-    return availableUrl
-      ? {
+  const availableUrl = item.url ? getUrl(item) : findFirstUrl(item);
+  return availableUrl
+    ? {
         label: item.label,
         link: availableUrl,
       }
-      : null;
+    : null;
 }
 
 const getNavigationItems = (state) => state.navigation.items;
 
-export const breadcrumbsSelector = createSelector(
+const breadcrumbsSelector = createSelector(
   getNavigationItems,
   (navItems) => {
-    let breadcrumbs = {};
+    const breadcrumbs = {};
 
     // build level 1 breadcrumbs
-    navItems.map((itemLvl1) => {
+    navItems.forEach((itemLvl1) => {
       const stepLvl1 = getBreadcrumbStep(itemLvl1);
       if (stepLvl1 === null) {
         return;
@@ -78,12 +78,12 @@ export const breadcrumbsSelector = createSelector(
         {
           label: stepLvl1.label,
           link: stepLvl1.link,
-        }
+        },
       ];
 
       // build level 2 breadcrumbs
       if (itemLvl1.children) {
-        itemLvl1.children.map((itemLvl2) => {
+        itemLvl1.children.forEach((itemLvl2) => {
           const stepLvl2 = getBreadcrumbStep(itemLvl2);
           if (stepLvl2 === null) {
             return;
@@ -101,9 +101,9 @@ export const breadcrumbsSelector = createSelector(
 
           // build level 3 breadcrumbs
           if (itemLvl2.groups) {
-            itemLvl2.groups.map((groupLvl3) => {
+            itemLvl2.groups.forEach((groupLvl3) => {
               if (groupLvl3.children) {
-                groupLvl3.children.map((itemLvl3) => {
+                groupLvl3.children.forEach((itemLvl3) => {
                   const stepLvl3 = getBreadcrumbStep(itemLvl3);
                   if (stepLvl3 === null) {
                     return;
@@ -133,3 +133,5 @@ export const breadcrumbsSelector = createSelector(
     return breadcrumbs;
   },
 );
+
+export default breadcrumbsSelector;

--- a/www/front_src/src/redux/selectors/navigation/breadcrumbs.test.js
+++ b/www/front_src/src/redux/selectors/navigation/breadcrumbs.test.js
@@ -1,4 +1,4 @@
-import { breadcrumbsSelector } from './breadcrumbs';
+import breadcrumbsSelector from './breadcrumbs';
 
 describe('breadcrumbsSelector', () => {
   it('returns formatted breadcrumbs', () => {
@@ -28,12 +28,85 @@ describe('breadcrumbsSelector', () => {
     const breadcrumbs = breadcrumbsSelector(state);
 
     expect(breadcrumbs).toEqual({
-      '/main.php?p=1': [
-        { label: 'Home', link: '/main.php?p=1' },
-      ],
+      '/main.php?p=1': [{ label: 'Home', link: '/main.php?p=1' }],
       '/home/customViews': [
         { label: 'Home', link: '/main.php?p=1' },
         { label: 'Custom Views', link: '/home/customViews' },
+      ],
+    });
+  });
+
+  it('returns first url found in parent level', () => {
+    const state = {
+      navigation: {
+        items: [
+          {
+            page: '2',
+            label: 'Configuration',
+            is_react: false,
+            url: './include/home/home.php',
+            options: null,
+            children: [
+              {
+                page: '201',
+                label: 'Hosts',
+                is_react: false,
+                url: null,
+                options: null,
+                groups: [
+                  {
+                    label: 'hosts',
+                    children: [
+                      {
+                        page: '20101',
+                        label: 'Hosts',
+                        is_react: true,
+                        url: '/configuration/hosts',
+                        options: null,
+                      },
+                    ],
+                  },
+                ],
+              },
+              {
+                page: '202',
+                label: 'Services',
+                is_react: false,
+                url: null,
+                options: null,
+                groups: [
+                  {
+                    label: 'services',
+                    children: [
+                      {
+                        page: '20102',
+                        label: 'Services',
+                        is_react: true,
+                        url: '/configuration/services',
+                        options: null,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    };
+    const breadcrumbs = breadcrumbsSelector(state);
+
+    expect(breadcrumbs).toEqual({
+      '/main.php?p=2': [{ label: 'Configuration', link: '/main.php?p=2' }],
+      '/configuration/hosts': [
+        { label: 'Configuration', link: '/main.php?p=2' },
+        { label: 'Hosts', link: '/configuration/hosts' },
+        { label: 'Hosts', link: '/configuration/hosts' },
+      ],
+      '/configuration/services': [
+        { label: 'Configuration', link: '/main.php?p=2' },
+        { label: 'Services', link: '/configuration/services' },
+        { label: 'Services', link: '/configuration/services' },
       ],
     });
   });


### PR DESCRIPTION
## Description

When clicking on 2nd level, we could be redirected to an unexpected menu.
This could happen on some configuration entries which redirect to plugin pack page

**Fixes** BAM-778

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)