### PR TITLE
fix(ldap): ldap users using the auto-import cannot login - for 19.04

### DIFF
--- a/www/class/centreonAuth.LDAP.class.php
+++ b/www/class/centreonAuth.LDAP.class.php
@@ -219,7 +219,6 @@ class CentreonAuthLDAP
             $userDisplay = str_replace(array(' ', ','), '_', $userDisplay);
             // Delete parenthesis
             $userDisplay = str_replace(array('(', ')'), '', $userDisplay);
-            $userDisplay = $this->pearDB->escape($userDisplay);
 
             //getting user's email
             $userEmail = $this->contactInfos['contact_email'];

--- a/www/include/Administration/parameters/ldap/form.php
+++ b/www/include/Administration/parameters/ldap/form.php
@@ -56,7 +56,6 @@ $arId = filter_var(
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p . "&o=" . $o);
 $form->addElement('header', 'title', _("Modify General Options"));
 
-
 /**
  * Ldap info
  */
@@ -147,6 +146,7 @@ $form->addElement(
     $LdapContactTplList,
     array('id' => 'ldap_contact_tmpl')
 );
+$form->addRule('ldap_contact_tmpl', _("Compulsory Field"), 'required');
 
 /**
  * Default contactgroup for imported contact
@@ -162,7 +162,6 @@ $attrContactGroup = array(
     'linkedObject' => 'centreonContactgroup'
 );
 $form->addElement('select2', 'ldap_default_cg', _('Default contactgroup'), array(), $attrContactGroup);
-
 
 $form->addElement('header', 'ldapinfo', _("LDAP Information"));
 $form->addElement('header', 'ldapserver', _('LDAP Servers'));

--- a/www/install/php/Update-19.04.5.php
+++ b/www/install/php/Update-19.04.5.php
@@ -47,3 +47,17 @@ try {
         "UPGRADE : 19.04.5 Unable to modify session expiration value"
     );
 }
+
+// remove ldap users missing contact name
+// these users have been added using the auto-import ldap feature
+// and will be re-imported at their next login.
+try {
+    $pearDB->query(
+        "DELETE FROM contact WHERE contact_name is NULL"
+    );
+} catch (\PDOException $e) {
+    $centreonLog->insertLog(
+        2,
+        "UPGRADE : 19.10.5 Unable to delete ldap auto-imported users with empty contact_name"
+    );
+}

--- a/www/install/php/Update-19.04.5.php
+++ b/www/install/php/Update-19.04.5.php
@@ -44,7 +44,7 @@ try {
 } catch (\PDOException $e) {
     $centreonLog->insertLog(
         2,
-        "UPGRADE : 19.04.5 Unable to modify session expiration value"
+        "UPGRADE : 19.04.5 Unable to modify contact autologin key default value"
     );
 }
 

--- a/www/install/php/Update-19.04.5.php
+++ b/www/install/php/Update-19.04.5.php
@@ -58,6 +58,6 @@ try {
 } catch (\PDOException $e) {
     $centreonLog->insertLog(
         2,
-        "UPGRADE : 19.10.5 Unable to delete ldap auto-imported users with empty contact_name"
+        "UPGRADE : 19.04.5 Unable to delete ldap auto-imported users with empty contact_name"
     );
 }


### PR DESCRIPTION
# Pull Request Template

## Description
Correct the double slash added on specific characters of the DN
Add a mandatory rule to avoid auto-import silently fails (only displayed in the ldap.log), when no contact template have been added to the LDAP configuration form

**Fixes** # (support)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

1- auto login fix
Link an LDAP to your centreon, and check that you can manually import a contact.
Enable the auto-import feature
Use the auto-import feature, and login using one of the LDAP account never used
Check that the user have been correctly imported.
Logout
Login again
No error should be displayed in the logs. Each login should be successfull

2- LDAP form mandatory contact template
Go to the contact template page and delete every contact template available.
Go to the LDAP configuration form and check that the contact template field is empty.
Save the form.
A message should be displayed and you should be unable to save the form until a valid contact template is added.

![image](https://user-images.githubusercontent.com/34628915/68663650-5841b080-053f-11ea-8fae-c9cabe5c3ab6.png)

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
