### PR TITLE
Update dependancy.rst

### DIFF
--- a/doc/fr/configuration_guide/advanced_configuration/dependancy.rst
+++ b/doc/fr/configuration_guide/advanced_configuration/dependancy.rst
@@ -34,14 +34,7 @@ Il est possible de définir deux paramètres :
 .. note:: 
     Tous les parents d’un hôte doivent être dans un état non-OK pour que l’hôte lui-même soit considéré comme injoignable. A partir du moment où au moins un chemin d’accès (liaison de dépendance physique) est toujours joignable alors l’ordonnanceur continuera de surveiller cet hôte.
 
-Dans le cas où des relations de parentés ont été définies entre hôtes supervisés par des ordonnanceurs différents,  il est possible :
-
-* D'empêcher l'établissement d'une relation de parenté, lors de la modification du formulaire d’hôte, entre deux hôtes supervisés par deux collecteurs différents.
-* D'autoriser l'établissement de cette relation de parenté. Dans ce cas la dépendance ne sera pas gérée par les moteurs de supervision mais par Centreon Broker qui prendra en compte cette relation au sein de son moteur de corrélation.
-
-Pour empêcher l'établissement de cette relation de parenté, il est nécessaire de cocher la case **Activer le mode strict de gestion des relations de parentés** au sein du menu **Administration > Options**.
-
-A l'inverse si cette case n'est pas cochée alors les liens de parenté entre hôtes appartenant à deux collecteurs différents peuvent être établis.
+Il n'est pas possible d'établir des liens de parentés entre hôte supervisés par deux collecteurs différents.
 
 .. note::
     Ne cochez pas le filtre de notification "Injoignable" sur les hôtes ainsi que sur les contacts pour ne pas recevoir ce type de notification.

--- a/doc/fr/configuration_guide/advanced_configuration/dependancy.rst
+++ b/doc/fr/configuration_guide/advanced_configuration/dependancy.rst
@@ -34,7 +34,7 @@ Il est possible de définir deux paramètres :
 .. note:: 
     Tous les parents d’un hôte doivent être dans un état non-OK pour que l’hôte lui-même soit considéré comme injoignable. A partir du moment où au moins un chemin d’accès (liaison de dépendance physique) est toujours joignable alors l’ordonnanceur continuera de surveiller cet hôte.
 
-Il n'est pas possible d'établir des liens de parentés entre hôte supervisés par deux collecteurs différents.
+Il n'est pas possible d'établir des liens de parentés entre hôtes supervisés par des collecteurs différents.
 
 .. note::
     Ne cochez pas le filtre de notification "Injoignable" sur les hôtes ainsi que sur les contacts pour ne pas recevoir ce type de notification.


### PR DESCRIPTION
## Description

Supprime le passage sur l'option afin de mettre des liens de parentés sur des hôtes supervisés par des collecteurs différents (n'existe pas ou plus et n'est pas présent dans la doc anglaise)
Ajout d'une mention sur le fait que les liens de parentés entre hôte supervisés par des collecteurs différents n'est pas possible

Deleted the text about the option to have dependencies between hosts monitored by different pollers. (not present in the english documentation)
Added a text to specify that this configuration is not possible.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] **Updating documentation (missing information, typo...)**

## Target serie

- [x] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)
