### PR TITLE
enh(BE): remove ACL notice on lvl3 calculation

### DIFF
--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -506,8 +506,9 @@ class CentreonACL
                         // First reading
                         ksort($childrenLvl3);
                         // We keep the tree of the first child
-                        $parentsLvl[$parentLvl1][$parentLvl2] =
-                            array_slice($childrenLvl3, 0, 1, true)[0];
+                        $parentsLvl[$parentLvl1][$parentLvl2] = is_array($childrenLvl3)
+                            ? array_slice($childrenLvl3, 0, 1, true)[0]
+                            : $childrenLvl3;
                         /**
                          * The first child has been processed so we set TRUE
                          * to delete all the following children


### PR DESCRIPTION
# Pull Request Template

## Description

When user's ACL are calculated on a single lvl 3 element, a notice pop in the log

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Add to a user rights to a single lvl3 page. Check that the notice isn't displayed anymore in the php logs

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
