### PR TITLE
fix(ldap): correct double slashes in the saved DN - for master

### DIFF
--- a/www/class/centreonAuth.LDAP.class.php
+++ b/www/class/centreonAuth.LDAP.class.php
@@ -202,7 +202,6 @@ class CentreonAuthLDAP
 
         if ($this->ldap->rebind()) {
             $userDn = $this->ldap->findUserDn($contactAlias);
-            $userDn = $this->pearDB->escape($userDn);
             if (false === $userDn) {
                 $this->CentreonLog->insertLog(3, "LDAP AUTH - Error : No DN for user " . $contactAlias);
                 return false;

--- a/www/install/php/Update-19.10.2.php
+++ b/www/install/php/Update-19.10.2.php
@@ -24,7 +24,7 @@ $centreonLog = new CentreonLog();
 // these users have been added using the auto-import ldap feature and will be re-imported at their next login.
 try {
     $pearDB->query(
-        "DELETE FROM contact WHERE contact_name is NULL"
+        'DELETE FROM contact WHERE contact_name = ""'
     );
 } catch (\PDOException $e) {
     $centreonLog->insertLog(

--- a/www/install/php/Update-19.10.2.php
+++ b/www/install/php/Update-19.10.2.php
@@ -17,3 +17,43 @@
  * For more information : contact@centreon.com
  *
  */
+include_once __DIR__ . "/../../class/centreonLog.class.php";
+$centreonLog = new CentreonLog();
+
+// remove ldap users missing contact name
+// these users have been added using the auto-import ldap feature and will be re-imported at their next login.
+try {
+    $pearDB->query(
+        "DELETE FROM contact WHERE contact_name is NULL"
+    );
+} catch (\PDOException $e) {
+    $centreonLog->insertLog(
+        2,
+        "UPGRADE : 19.10.2 Unable to delete ldap auto-imported users with empty contact_name"
+    );
+}
+
+// correct the DN of manually imported users from an LDAP
+try {
+    // finding the data of contacts linked to an LDAP
+    $stmt = $this->pearDB->query(
+        "SELECT contact_id, contact_name, contact_ldap_dn FROM contact WHERE ar_id is NOT NULL"
+    );
+    while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+        // removing the double slashes if needed and saving the corrected data
+        if (strpos($row['contact_ldap_dn'], "\\\\")) {
+            $newDn = str_replace("\\\\", "\\", $row['contact_ldap_dn']);
+            $updateDB = $this->pearDB->prepare(
+                "UPDATE contact SET contact_ldap_dn = :newDn WHERE contact_id = :contactId"
+            );
+            $updateDB->bindValue(':newDn', $newDn, \PDO::PARAM_STR);
+            $updateDB->bindValue(':contactId', $row['contact_id'], \PDO::PARAM_INT);
+            $updateDB->execute();
+        }
+    }
+} catch (\PDOException $e) {
+    $centreonLog->insertLog(
+        2,
+        "UPGRADE : 19.10.2 Unable to correct the LDAP DN data"
+    );
+}

--- a/www/install/php/Update-19.10.2.php
+++ b/www/install/php/Update-19.10.2.php
@@ -36,16 +36,17 @@ try {
 // correct the DN of manually imported users from an LDAP
 try {
     // finding the data of contacts linked to an LDAP
-    $stmt = $this->pearDB->query(
+    $stmt = $pearDB->query(
         "SELECT contact_id, contact_name, contact_ldap_dn FROM contact WHERE ar_id is NOT NULL"
+    );
+    $updateDB = $pearDB->prepare(
+        "UPDATE contact SET contact_ldap_dn = :newDn WHERE contact_id = :contactId"
     );
     while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
         // removing the double slashes if needed and saving the corrected data
         if (strpos($row['contact_ldap_dn'], "\\\\")) {
             $newDn = str_replace("\\\\", "\\", $row['contact_ldap_dn']);
-            $updateDB = $this->pearDB->prepare(
-                "UPDATE contact SET contact_ldap_dn = :newDn WHERE contact_id = :contactId"
-            );
+
             $updateDB->bindValue(':newDn', $newDn, \PDO::PARAM_STR);
             $updateDB->bindValue(':contactId', $row['contact_id'], \PDO::PARAM_INT);
             $updateDB->execute();


### PR DESCRIPTION
# Pull Request Template

## Description

The DN is escaped twice before inserting its value in the DB.
Resulting on a first successfull connection and the impossibility to connect again using the account.
As the ldapSearch method will use a DN which doesn't exist

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Add to your LDAP specific escaped characters (like : " \, ") and manually import a contact.
The contact will be displayed in the list, but in the DB, the contact_ldap_dn will have two slashes.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
