### PR TITLE
fix(remote-export): hostgroup and servicegroup not exported

### DIFF
--- a/www/class/config-generate-remote/HostGroup.php
+++ b/www/class/config-generate-remote/HostGroup.php
@@ -145,12 +145,8 @@ class HostGroup extends AbstractObject
      */
     public function reset($createfile = false): void
     {
+        $this->hg = [];
         parent::reset($createfile);
-        foreach ($this->hg as &$value) {
-            if (!is_null($value)) {
-                $value['members'] = [];
-            }
-        }
     }
 
     /**

--- a/www/class/config-generate-remote/ServiceGroup.php
+++ b/www/class/config-generate-remote/ServiceGroup.php
@@ -262,12 +262,8 @@ class ServiceGroup extends AbstractObject
      */
     public function reset($createfile = false): void
     {
+        $this->sg = [];
         parent::reset($createfile);
-        foreach ($this->sg as &$value) {
-            if (!is_null($value)) {
-                $value['members_cache'] = [];
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
# Pull Request Template

## Description

If you export more than one remote server configuration at once, you won't have hostgroups/servicegroups files (if you same hostgroups/servicegroups between remote servers).

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Add one hostgroup only
- Export one poller attached to 2 remote servers
- Second remote server won't get data imported (no hostgroups.infile created)

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
