### PR TITLE
fix(remote-server): Host and service templates not properly imported

### DIFF
--- a/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
+++ b/src/CentreonRemote/Domain/Exporter/ConfigurationExporter.php
@@ -75,13 +75,17 @@ class ConfigurationExporter extends ExporterServiceAbstract
         $db->beginTransaction();
 
         try {
+            $truncated = [];
             // allow insert records without foreign key checks
             $db->query('SET FOREIGN_KEY_CHECKS=0;');
 
             $import = $manifest->get("import");
             foreach ($import['data'] as $data) {
-                // truncate table
-                $db->query("TRUNCATE TABLE `" . $data['table'] . "`;");
+                if (!isset($truncated[$data['table']])) {
+                    // truncate table
+                    $db->query("TRUNCATE TABLE `" . $data['table'] . "`;");
+                    $truncated[$data['table']] = 1;
+                }
 
                 // insert data
                 $exportPathFile = $this->getFile($data['filename']);


### PR DESCRIPTION
# Pull Request Template

## Description

Host and service templates not properly imported on the remote-server. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- export a remote-server
- there are no service templates and host templates

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
