### PR TITLE
fix(UI): revert popin z-index value from #8088

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -1915,7 +1915,7 @@ span.state_badge {
 /* Style for popin */
 .centreon-popin {
     position: absolute;
-    z-index: 5050;
+    z-index: 1065;
     background-color: white;
     padding: 1em 3em 1em 1em;
     border-radius: 4px;


### PR DESCRIPTION
# Pull Request Template

## Description

Revert the https://github.com/centreon/centreon/pull/8088

As the CSS classes of the widgets are not properly used, the centreon style.css z-index fix impact the host monitoring, service monitoring and metric select2 widgets.
The z-index correction need to be reverted to remove the side effects, until a more consistent fix is developed.

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Add one of the 3 listed (above) widget, open the configuration popin, check that the select2 work properly

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
