### PR TITLE
fix(widget): fix double quote in widget title

### DIFF
--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -143,7 +143,7 @@ class CentreonWidget
             throw new \Exception("An error occured");
         }
         while ($row = $stmt->fetch()) {
-            return $row['title'];
+            return htmlentities($row['title'], ENT_QUOTES);
         }
         return null;
     }
@@ -400,11 +400,11 @@ class CentreonWidget
     }
 
     /**
-     * @param $viewId
-     * @return mixed
+     * @param int $viewId
+     * @return array
      * @throws Exception
      */
-    public function getWidgetsFromViewId($viewId)
+    public function getWidgetsFromViewId(int $viewId) : array
     {
         if (!isset($this->widgets[$viewId])) {
             $this->widgets[$viewId] = array();
@@ -423,7 +423,7 @@ class CentreonWidget
                 throw new \Exception("An error occured");
             }
             while ($row = $stmt->fetch()) {
-                $this->widgets[$viewId][$row['widget_id']]['title'] = $row['title'];
+                $this->widgets[$viewId][$row['widget_id']]['title'] = htmlentities($row['title'], ENT_QUOTES);
                 $this->widgets[$viewId][$row['widget_id']]['url'] = $row['url'];
                 $this->widgets[$viewId][$row['widget_id']]['widget_order'] = $row['widget_order'];
                 $this->widgets[$viewId][$row['widget_id']]['widget_id'] = $row['widget_id'];


### PR DESCRIPTION
# Pull Request Template

## Description

When double quotes (") are defined in a widget title, the custom view won't load.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

edit widget title
add double quote
refresh

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
