### PR TITLE
fix(traps) Can't save a trap configuration

### DIFF
--- a/www/class/centreonTraps.class.php
+++ b/www/class/centreonTraps.class.php
@@ -406,8 +406,8 @@ class CentreonTraps
             : $rq .= "NULL, ";
 
         $rq .= "`traps_mode` = ";
-        isset($ret['traps_mode']) && $ret['traps_mode'] != null
-            ? $rq .= "'" . $ret['traps_mode'] . "' "
+        isset($ret['traps_mode']['traps_mode']) && $ret['traps_mode']['traps_mode'] != null
+            ? $rq .= "'" . $ret['traps_mode']['traps_mode'] . "' "
             : $rq .= "NULL ";
 
         $rq .= 'WHERE `traps_id` = ' . (int)$traps_id ;

--- a/www/class/centreonTraps.class.php
+++ b/www/class/centreonTraps.class.php
@@ -403,11 +403,11 @@ class CentreonTraps
         $rq .= "`traps_customcode` = ";
         isset($ret["traps_customcode"]) && $ret["traps_customcode"] != null
             ? $rq .= "'" . $ret["traps_customcode"] . "', "
-            : $rq .= "NULL ";
+            : $rq .= "NULL, ";
 
         $rq .= "`traps_mode` = ";
-        isset($ret['traps_mode']['traps_mode']) && $ret['traps_mode']['traps_mode'] != null
-            ? $rq .= "'" . $ret['traps_mode']['traps_mode'] . "' "
+        isset($ret['traps_mode']) && $ret['traps_mode'] != null
+            ? $rq .= "'" . $ret['traps_mode'] . "' "
             : $rq .= "NULL ";
 
         $rq .= 'WHERE `traps_id` = ' . (int)$traps_id ;


### PR DESCRIPTION
# Pull Request Template

## Description

We can't save a trap configuration because it missed a comma and "trap_mode" was in double.
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Edit a trap and do a modification. Click on save

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
