### PR TITLE
fix(install): remove 2 notice from the logs

### DIFF
--- a/www/install/steps/process/createDbUser.php
+++ b/www/install/steps/process/createDbUser.php
@@ -97,11 +97,12 @@ try {
 
     // checking mysql version before trying to alter the password plugin
     $prepareCheckVersion = $link->query($checkMysqlVersion);
+    $versionName = $versionNumber = "";
     while ($row = $prepareCheckVersion->fetch()) {
-        if (!isset($versionNumber) && $row['Variable_name'] === "version") {
-            $versionNumber = $row['version'];
-        } elseif (!isset($versionName) && $row['Variable_name'] === "version_comment") {
-            $versionName = $row['version_comment'];
+        if ($row['Variable_name'] === "version") {
+            $versionNumber = $row['Variable_name'];
+        } elseif ($row['Variable_name'] === "version_comment") {
+            $versionName = $row['Variable_name'];
         }
     }
     if ((strpos($versionName, "MariaDB") !== false && version_compare($versionNumber, '10.2.0') >= 0)


### PR DESCRIPTION
# Pull Request Template

## Description

Remove two notices in the php logs when installating Centreon
`[02-Dec-2019 11:57:01 Europe/Paris] PHP Notice:  Undefined index: version in /usr/share/centreon/www/install/steps/process/createDbUser.php on line 102
[02-Dec-2019 11:57:01 Europe/Paris] PHP Notice:  Undefined index: version_comment in /usr/share/centreon/www/install/steps/process/createDbUser.php on line 104
`
**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Install a Centreon from scratch, before the step 8, these two logs should be displayed in the php logs

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
