### PR TITLE
enh(smarty/tpl): simplify the initSmartyTplForPopup function & compatibility

### DIFF
--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -161,36 +161,37 @@ function tidySearchKey($search, $advanced_search)
 
 #
 
+/**
+ * Allows to load Smarty's configuration in relation to a path
+ *
+ * @param {string} [$path=null] Path to the default template directory
+ * @param {object} [$tpl=null] A Smarty instance
+ * @param {string} [$subDir=null] A subdirectory of path
+ *
+ * @return {empty|object} A Smarty instance with configuration parameters
+ */
 function initSmartyTpl($path = null, $tpl = null, $subDir = null)
 {
     if (!$tpl) {
         return;
     }
     $tpl->template_dir = $path . $subDir;
-    $tpl->compile_dir = "../GPL_LIB/SmartyCache/compile";
-    $tpl->config_dir = "../GPL_LIB/SmartyCache/config";
-    $tpl->cache_dir = "../GPL_LIB/SmartyCache/cache";
-    $tpl->plugins_dir[] = "../GPL_LIB/smarty-plugins";
+    $tpl->compile_dir = __DIR__ . "/../../../GPL_LIB/SmartyCache/compile";
+    $tpl->config_dir = __DIR__ . "/../../../GPL_LIB/SmartyCache/config";
+    $tpl->cache_dir = __DIR__ . "/../../../GPL_LIB/SmartyCache/cache";
+    $tpl->plugins_dir[] = __DIR__ . "/../../../GPL_LIB/smarty-plugins";
     $tpl->caching = 0;
     $tpl->compile_check = true;
     $tpl->force_compile = true;
     return $tpl;
 }
 
-function initSmartyTplForPopup($path = null, $tpl = null, $subDir = null, $centreon_path = null)
+/**
+ * This function is mainly used in widgets
+ */
+function initSmartyTplForPopup($path = null, $tpl = null, $subDir = null, $centreonPath = null)
 {
-    if (!$tpl) {
-        return;
-    }
-    $tpl->template_dir = $path . $subDir;
-    $tpl->compile_dir = _CENTREON_PATH_ . "/GPL_LIB/SmartyCache/compile";
-    $tpl->config_dir = _CENTREON_PATH_ . "/GPL_LIB/SmartyCache/config";
-    $tpl->cache_dir = _CENTREON_PATH_ . "/GPL_LIB/SmartyCache/cache";
-    $tpl->plugins_dir[] = _CENTREON_PATH_ . "/GPL_LIB/smarty-plugins";
-    $tpl->caching = 0;
-    $tpl->compile_check = true;
-    $tpl->force_compile = true;
-    return $tpl;
+    return initSmartyTpl($path, $tpl, $subDir);
 }
 
 /*


### PR DESCRIPTION
# Pull Request Template

## Description

The initialization of Smarty templates for "popins" & "custom view widgets" was on a different function.
To keep the compatibility with all consumers of this function, it is not destroyed but it uses the "main" function with the same arguments. 
Also, the path to the folders was not very aligned with the standards (__DIR__) so I changed that too so that it would be consistent and compatible everywhere.

Refs: STUDIO-2228

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check if the display and operation of the widgets of the different modules is still ok

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
