### PR TITLE
fix(CenWeb): copy container file into the final destination folder

### DIFF
--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -147,6 +147,7 @@ mkdir -p $TMP_DIR/final/config
 cp -Rf $TMP_DIR/src/config/partition.d $TMP_DIR/final/config/partition.d
 mv $TMP_DIR/src/config/centreon.config.php.template $TMP_DIR/src/config/centreon.config.php
 cp -f $TMP_DIR/src/bootstrap.php $TMP_DIR/final
+cp -f $TMP_DIR/src/container.php $TMP_DIR/final
 cp -f $TMP_DIR/src/composer.json $TMP_DIR/final
 cp -f $TMP_DIR/src/package.json $TMP_DIR/final
 cp -f $TMP_DIR/src/package-lock.json $TMP_DIR/final

--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -384,6 +384,9 @@ check_result $? "$(gettext "Change right for install directory")"
 cp -f $TMP_DIR/final/bootstrap.php $INSTALL_DIR_CENTREON/bootstrap.php >> "$LOG_FILE" 2>&1
 $CHOWN $WEB_USER:$WEB_GROUP $INSTALL_DIR_CENTREON/bootstrap.php
 
+cp -f $TMP_DIR/final/container.php $INSTALL_DIR_CENTREON/container.php >> "$LOG_FILE" 2>&1
+$CHOWN $WEB_USER:$WEB_GROUP $INSTALL_DIR_CENTREON/container.php
+
 cp -Rf $TMP_DIR/final/vendor $INSTALL_DIR_CENTREON/ >> "$LOG_FILE" 2>&1
 $CHOWN -R $WEB_USER:$WEB_GROUP $INSTALL_DIR_CENTREON/vendor
 

--- a/libinstall/functions
+++ b/libinstall/functions
@@ -218,7 +218,7 @@ yes_no_default() {
 	done
 	if [ "$res" = "$yes" ] ; then
 		return 0
-	else 
+	else
 		return 1
 	fi
 }
@@ -2074,7 +2074,7 @@ check_broker_user()
 #----
 copyInTempFile()
 {
-	local srclistcp="bin cron config logrotate GPL_LIB lang lib snmptrapd src vendor www libinstall bootstrap.php composer.json package.json package-lock.json"
+	local srclistcp="bin cron config logrotate GPL_LIB lang lib snmptrapd src vendor www libinstall bootstrap.php container.php composer.json package.json package-lock.json"
 	# Prepare centreon Plugins
 	echo "$(gettext "Preparing Centreon temporary files")"
 	if [ -d $TMP_DIR ] ; then


### PR DESCRIPTION
## Description

The `container.php` file is not copied to the final destination. The final setup is crashing with the following error.

```
[05-Dec-2019 11:42:45 Europe/Paris] PHP Fatal error:  require_once(): Failed opening required '/usr/local/centreon/container.php' (include_path='/usr/local/centreon/vendor/pear/pear_exception:/usr/local/centreon/vendor/pear/console_getopt:/usr/local/centreon/vendor/pear/pear-core-minimal/src:/usr/local/centreon/www/class:/usr/local/centreon/www/lib:.:/usr/share/php') in /usr/local/centreon/bootstrap.php on line 65
```

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Launch the `install.sh` script and try to navigate to `http://domain.tld/centreon/install`.

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
