### PR TITLE
fix(install): update libinstall scripts for Centreon 19.10.x

### DIFF
--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -143,13 +143,14 @@ check_result $? "$(gettext "Change right on") $CENTREON_ETC"
 log "INFO" "$(gettext "Copy CentWeb and GPL_LIB in temporary final directory")"
 cp -Rf $TMP_DIR/src/www $TMP_DIR/final
 cp -Rf $TMP_DIR/src/GPL_LIB $TMP_DIR/final
-mkdir -p $TMP_DIR/final/config
-cp -Rf $TMP_DIR/src/config/partition.d $TMP_DIR/final/config/partition.d
+cp -Rf $TMP_DIR/src/config $TMP_DIR/final
 mv $TMP_DIR/src/config/centreon.config.php.template $TMP_DIR/src/config/centreon.config.php
+cp -f $TMP_DIR/src/container.php $TMP_DIR/final
 cp -f $TMP_DIR/src/bootstrap.php $TMP_DIR/final
 cp -f $TMP_DIR/src/composer.json $TMP_DIR/final
 cp -f $TMP_DIR/src/package.json $TMP_DIR/final
 cp -f $TMP_DIR/src/package-lock.json $TMP_DIR/final
+cp -f $TMP_DIR/src/.env $TMP_DIR/final
 cp -Rf $TMP_DIR/src/src $TMP_DIR/final
 
 ## Prepare and copy composer module
@@ -383,6 +384,12 @@ check_result $? "$(gettext "Change right for install directory")"
 cp -f $TMP_DIR/final/bootstrap.php $INSTALL_DIR_CENTREON/bootstrap.php >> "$LOG_FILE" 2>&1
 $CHOWN $WEB_USER:$WEB_GROUP $INSTALL_DIR_CENTREON/bootstrap.php
 
+cp -f $TMP_DIR/final/.env $INSTALL_DIR_CENTREON/.env >> "$LOG_FILE" 2>&1
+$CHOWN $WEB_USER:$WEB_GROUP $INSTALL_DIR_CENTREON/.env
+
+cp -f $TMP_DIR/final/container.php $INSTALL_DIR_CENTREON/container.php >> "$LOG_FILE" 2>&1
+$CHOWN $WEB_USER:$WEB_GROUP $INSTALL_DIR_CENTREON/container.php
+
 cp -Rf $TMP_DIR/final/vendor $INSTALL_DIR_CENTREON/ >> "$LOG_FILE" 2>&1
 $CHOWN -R $WEB_USER:$WEB_GROUP $INSTALL_DIR_CENTREON/vendor
 
@@ -413,6 +420,9 @@ $INSTALL_DIR/cinstall $cinstall_opts \
 $INSTALL_DIR/cinstall $cinstall_opts \
     -u "$CENTREON_USER" -g "$CENTREON_GROUP" -d 775 \
     $CENTREON_CACHEDIR/config/export >> "$LOG_FILE" 2>&1
+$INSTALL_DIR/cinstall $cinstall_opts \
+    -u "$CENTREON_USER" -g "$CENTREON_GROUP" -d 775 \
+    $CENTREON_CACHEDIR/symfony >> "$LOG_FILE" 2>&1
 
 log "INFO" "$(gettext "Copying GPL_LIB")"
 $INSTALL_DIR/cinstall $cinstall_opts \

--- a/libinstall/functions
+++ b/libinstall/functions
@@ -218,7 +218,7 @@ yes_no_default() {
 	done
 	if [ "$res" = "$yes" ] ; then
 		return 0
-	else 
+	else
 		return 1
 	fi
 }
@@ -2074,7 +2074,7 @@ check_broker_user()
 #----
 copyInTempFile()
 {
-	local srclistcp="bin cron config logrotate GPL_LIB lang lib snmptrapd src vendor www libinstall bootstrap.php composer.json package.json package-lock.json"
+	local srclistcp="bin cron config logrotate GPL_LIB lang lib snmptrapd src vendor www libinstall .env bootstrap.php container.php composer.json package.json package-lock.json"
 	# Prepare centreon Plugins
 	echo "$(gettext "Preparing Centreon temporary files")"
 	if [ -d $TMP_DIR ] ; then


### PR DESCRIPTION
## Description

Some files are not copied from the binary to the final destination with the changes in Centreon 19.10.

- New `.env` file and `container.php` in the root directory.
- All files in the `config` directory are also absent.

Also, the Symfony cache folder is not created during the setup and the install dashboard will fail in this step (also because `.env` is not here).

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Try to install Centreon on Ubuntu/Debian with the `install.sh -i` script and to run the HTTP dashboard. Both will fail at several steps.

## Checklist

#### Community contributors & Centreon team

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).