### PR TITLE
Host severity filter

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -8756,7 +8756,6 @@ msgstr "Hosts desactivados"
 #: centreon-web/www/include/configuration/configObject/traps/formTraps.php:283
 #: centreon-web/www/include/configuration/configObject/service_categories/listServiceCategories.php:132
 #: centreon-web/www/include/monitoring/status/Hosts/host.php:301
-#: centreon-web/www/include/monitoring/status/Services/service.php:383
 msgid "Severity"
 msgstr "criticidad"
 
@@ -11829,9 +11828,24 @@ msgid "Tries"
 msgstr "intentos"
 
 #: centreon-web/www/include/monitoring/status/Hosts/hostJS.php:130
-#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:143
 msgid "Sort by severity"
 msgstr "Ordenar por criticidad"
+
+#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:160
+msgid "Sort by service severity"
+msgstr "Ordenar por criticidad de servicio"
+
+#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:171
+msgid "Sort by host severity"
+msgstr "Ordenar por criticidad de anfitrión"
+
+#: centreon-web/www/include/monitoring/status/Services/service.php:455
+msgid "Service Severity"
+msgstr "Criticidad de servicio"
+
+#: centreon-web/www/include/monitoring/status/Services/service.php:471
+msgid "Host Severity"
+msgstr "Criticidad de anfitrión"
 
 #: centreon-web/www/include/monitoring/status/Hosts/hostJS.php:136
 #: centreon-web/www/include/monitoring/status/Hosts/host.php:161

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -9178,7 +9178,6 @@ msgstr "Hôtes désactivés"
 #: centreon-web/www/include/configuration/configObject/traps/formTraps.php:283
 #: centreon-web/www/include/configuration/configObject/service_categories/listServiceCategories.php:132
 #: centreon-web/www/include/monitoring/status/Hosts/host.php:301
-#: centreon-web/www/include/monitoring/status/Services/service.php:383
 msgid "Severity"
 msgstr "Criticité"
 
@@ -11977,6 +11976,14 @@ msgstr "Modèle de service"
 msgid "Servicegroup"
 msgstr "Groupes de services"
 
+#: centreon-web/www/include/monitoring/status/Services/service.php:455
+msgid "Service Severity"
+msgstr "Criticité de service"
+
+#: centreon-web/www/include/monitoring/status/Services/service.php:471
+msgid "Host Severity"
+msgstr "Criticité d'hôte"
+
 #: centreon-web/www/include/configuration/configKnowledge/search.php:58
 msgid "Show wiki pageless only"
 msgstr "Voir les objets sans base de connaissance"
@@ -12304,9 +12311,16 @@ msgid "Tries"
 msgstr "Tentatives"
 
 #: centreon-web/www/include/monitoring/status/Hosts/hostJS.php:130
-#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:143
 msgid "Sort by severity"
 msgstr "Trier par criticité"
+
+#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:160
+msgid "Sort by service severity"
+msgstr "Trier par criticité de service"
+
+#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:171
+msgid "Sort by host severity"
+msgstr "Trier par criticité d'hôte"
 
 #: centreon-web/www/include/monitoring/status/Hosts/hostJS.php:136
 #: centreon-web/www/include/monitoring/status/Hosts/host.php:161

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -4327,7 +4327,7 @@ msgstr "Ordenar por severidade"
 
 #: centreon-web/www/include/monitoring/status/Services/serviceJS.php:160
 msgid "Sort by service severity"
-msgstr "Ordenar pr severidade do Serviço"
+msgstr "Ordenar por severidade do Serviço"
 
 #: centreon-web/www/include/monitoring/status/Services/serviceJS.php:171
 msgid "Sort by host severity"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -4307,7 +4307,6 @@ msgid "Pending"
 msgstr "Pendente"
 
 #: centreon-web/www/include/monitoring/status/Hosts/host.php:372
-#: centreon-web/www/include/monitoring/status/Services/service.php:449
 #: centreon-web/www/include/configuration/configObject/service_categories/listServiceCategories.php:146
 #: centreon-web/www/include/configuration/configObject/traps/formTraps.php:289
 #: centreon-web/www/include/configuration/configObject/host_categories/listHostCategories.php:169
@@ -4323,9 +4322,24 @@ msgid "Hard State Duration"
 msgstr "Duração do Estado Válido"
 
 #: centreon-web/www/include/monitoring/status/Hosts/hostJS.php:148
-#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:159
 msgid "Sort by severity"
 msgstr "Ordenar por severidade"
+
+#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:160
+msgid "Sort by service severity"
+msgstr "Ordenar pr severidade do Serviço"
+
+#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:171
+msgid "Sort by host severity"
+msgstr "Ordenar por severidade do host"
+
+#: centreon-web/www/include/monitoring/status/Services/service.php:455
+msgid "Service Severity"
+msgstr "Severidade do Serviços"
+
+#: centreon-web/www/include/monitoring/status/Services/service.php:471
+msgid "Host Severity"
+msgstr "Severidade do host"
 
 #: centreon-web/www/include/monitoring/status/Hosts/xml/hostXML.php:268
 msgid "Top Priority Hosts"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -4329,7 +4329,7 @@ msgstr "Ordenar por severidade"
 
 #: centreon-web/www/include/monitoring/status/Services/serviceJS.php:160
 msgid "Sort by service severity"
-msgstr "Ordenar pr severidade do Serviço"
+msgstr "Ordenar por severidade do Serviço"
 
 #: centreon-web/www/include/monitoring/status/Services/serviceJS.php:171
 msgid "Sort by host severity"

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -4308,7 +4308,6 @@ msgid "Pending"
 msgstr "Pendente"
 
 #: centreon-web/www/include/monitoring/status/Hosts/host.php:372
-#: centreon-web/www/include/monitoring/status/Services/service.php:449
 #: centreon-web/www/include/configuration/configObject/service_categories/listServiceCategories.php:146
 #: centreon-web/www/include/configuration/configObject/traps/formTraps.php:289
 #: centreon-web/www/include/configuration/configObject/host_categories/listHostCategories.php:169
@@ -4327,6 +4326,22 @@ msgstr "Duração do Estado Válido"
 #: centreon-web/www/include/monitoring/status/Services/serviceJS.php:159
 msgid "Sort by severity"
 msgstr "Ordenar por severidade"
+
+#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:160
+msgid "Sort by service severity"
+msgstr "Ordenar pr severidade do Serviço"
+
+#: centreon-web/www/include/monitoring/status/Services/serviceJS.php:171
+msgid "Sort by host severity"
+msgstr "Ordenar por severidade do host"
+
+#: centreon-web/www/include/monitoring/status/Services/service.php:455
+msgid "Service Severity"
+msgstr "Severidade do Serviços"
+
+#: centreon-web/www/include/monitoring/status/Services/service.php:471
+msgid "Host Severity"
+msgstr "Severidade do host"
 
 #: centreon-web/www/include/monitoring/status/Hosts/xml/hostXML.php:268
 msgid "Top Priority Hosts"

--- a/www/class/centreonXMLBGRequest.class.php
+++ b/www/class/centreonXMLBGRequest.class.php
@@ -346,9 +346,18 @@ class CentreonXMLBGRequest
         $_SESSION['monitoring_default_servicegroups'] = sg;
     }
 
-    public function setCriticality($criticality)
+    /**
+     * Set criticality in Session
+     * @param int $criticalityId
+     * @param bool $service
+     */
+    public function setCriticality($criticality, $service = false)
     {
-        $_SESSION['criticality_id'] = $criticality;
+        if ($service === false) {
+            $_SESSION['host_criticality_id'] = $criticality;
+        } else {
+            $_SESSION['service_criticality_id'] = $criticality;
+        }
     }
 
     public function checkArgument($name, $tab, $defaultValue)

--- a/www/include/monitoring/status/Hosts/host.php
+++ b/www/include/monitoring/status/Hosts/host.php
@@ -62,7 +62,7 @@ if ($resetFilter) {
     $_SESSION['monitoring_default_poller'] = '';
     $_SESSION['monitoring_host_status'] = '';
     $_SESSION['monitoring_host_status_filter'] = '';
-    $_SESSION['criticality_id'] = '';
+    $_SESSION['host_criticality_id'] = '';
 }
 
 foreach ($myinputsGet as $key => $value) {
@@ -110,7 +110,7 @@ if (!empty($filters['hostgroups'])) {
 }
 
 if (!empty($filters['criticality_id'])) {
-    $_SESSION['criticality_id'] = $filters['criticality_id'];
+    $_SESSION['host_criticality_id'] = $filters['criticality_id'];
 }
 
 $problem_sort_type = 'host_name';
@@ -363,7 +363,7 @@ $form->addElement(
     $critArray,
     array('id' => 'critFilter', 'onChange' => "filterCrit(this.value);")
 );
-$form->setDefaults(array('criticality' => isset($_SESSION['criticality_id']) ? $_SESSION['criticality_id'] : "0"));
+$form->setDefaults(array('criticality' => isset($_SESSION['host_criticality_id']) ? $_SESSION['host_criticality_id'] : "0"));
 
 $tpl->assign('limit', $limit);
 $tpl->assign('hostStr', _('Host'));

--- a/www/include/monitoring/status/Services/serviceJS.php
+++ b/www/include/monitoring/status/Services/serviceJS.php
@@ -57,7 +57,8 @@ if (isset($_GET["acknowledge"])) {
 
     var _addrXML = "./include/monitoring/status/Services/xml/serviceXML.php";
     var _addrXSL = "./include/monitoring/status/Services/xsl/service.xsl";
-    var _criticality_id = 0;
+    var _host_criticality_id = 0;
+    var _service_criticality_id = 0;
 
     <?php include_once "./include/monitoring/status/Common/commonJS.php"; ?>
 
@@ -152,15 +153,26 @@ if (isset($_GET["acknowledge"])) {
             };
             h.style.cursor = "pointer";
 
-            var h = document.getElementById('criticality_id');
+            var h = document.getElementById('service_criticality_id');
             if (h) {
-                h.innerHTML = '<?php echo addslashes("S"); ?>';
-                h.indice = 'criticality_id';
-                h.title = "<?php echo _("Sort by severity"); ?>";
+                h.innerHTML = '<?php echo addslashes("SC"); ?>';
+                h.indice = 'service_criticality_id';
+                h.title = "<?php echo _("Sort by service severity"); ?>";
                 h.onclick = function () {
                     change_type_order(this.indice)
                 };
                 h.style.cursor = "pointer";
+            }
+
+            var h = document.getElementById('host_criticality_id');
+            if (h) {
+                h.innerHTML = '<?php echo addslashes("HC"); ?>';
+                h.indice = 'host_criticality_id';
+                h.title = "<?php echo _("Sort by host severity"); ?>";
+                h.onclick = function () {
+                    change_type_order(this.indice)
+                };
+                h.style.cursor = 'pointer';
             }
 
             var h = document.getElementById('plugin_output');
@@ -219,9 +231,14 @@ if (isset($_GET["acknowledge"])) {
             _search = "";
         }
 
-        if (document.getElementById("critFilter") && document.getElementById("critFilter").value) {
-            _criticality_id = document.getElementById("critFilter").value;
-            viewDebugInfo('service criticality: ' + document.getElementById("critFilter").value);
+        if (document.getElementById("serviceCritFilter") && document.getElementById("serviceCritFilter").value) {
+            _service_criticality_id = document.getElementById("serviceCritFilter").value;
+            viewDebugInfo('service criticality: ' + document.getElementById("serviceCritFilter").value);
+        }
+
+        if (document.getElementById('hostCritFilter') && document.getElementById('hostCritFilter').value) {
+            _host_criticality_id = document.getElementById('hostCritFilter').value;
+            viewDebugInfo('host criticality: ' + document.getElementById('hostCritFilter').value);
         }
 
         if (_first) {
@@ -257,9 +274,9 @@ if (isset($_GET["acknowledge"])) {
             _addrXML + "?" + '&search=' + _search + '&search_host=' + _host_search +
             '&search_output=' + _output_search + '&num=' + _num + '&limit=' + _limit + '&sort_type=' + _sort_type +
             '&order=' + _order + '&date_time_format_status=' + _date_time_format_status + '&o=' + _o + '&p=' + _p +
-            '&host_name=<?php echo $host_name; ?>' + '&nc=' + _nc + '&criticality=' + _criticality_id +
-            '&statusService=' + statusService + '&statusFilter=' + statusFilter +
-            "&sSetOrderInMemory=" + sSetOrderInMemory
+            '&host_name=<?php echo $host_name; ?>' + '&nc=' + _nc + '&service_criticality=' + _service_criticality_id +
+            '&host_criticality=' + _host_criticality_id + '&statusService=' + statusService +
+            '&statusFilter=' + statusFilter + '&sSetOrderInMemory=' + sSetOrderInMemory
         );
         proc.setXslt(_addrXSL);
         if (handleVisibilityChange()) {

--- a/www/include/monitoring/status/Services/templates/service.ihtml
+++ b/www/include/monitoring/status/Services/templates/service.ihtml
@@ -8,8 +8,11 @@
     <tr>
         <td><h4>{$statusService}</h4></td>
         <td><h4>{$form.statusFilter.label}</h4></td>
-        {if $criticalityUsed}
-        <td><h4>{$form.criticality.label}</h4></td>
+        {if $hostCriticalityUsed}
+          <td><h4>{$form.host_criticality.label}</h4></td>
+        {/if}
+        {if $serviceCriticalityUsed}
+          <td><h4>{$form.service_criticality.label}</h4></td>
         {/if}
         {if $poller_listing}
         <td><h4>{$pollerStr}</h4></td>
@@ -18,8 +21,11 @@
     <tr>
       <td>{$form.statusService.html}</td>
       <td>{$form.statusFilter.html}</td>
-      {if $criticalityUsed}
-      <td>{$form.criticality.html}</td>
+      {if $hostCriticalityUsed}
+        <td>{$form.host_criticality.html}</td>
+      {/if}
+      {if $serviceCriticalityUsed}
+        <td>{$form.service_criticality.html}</td>
       {/if}
       {if $poller_listing}
       <td><span id="instance_selected"></span></td>
@@ -87,7 +93,7 @@
 {/if}
 <input name='cmd' id='cmd' value='42' type='hidden'>
 <input name='o' value='{$o}' type='hidden'>
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
+<input type='hidden' id='limit' name='limit' value='{$limit}'>
 {$form.hidden}
 </form>
 <script src="./include/common/javascript/moment-with-locales.js"></script>

--- a/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -170,12 +170,11 @@ $request = "SELECT SQL_CALC_FOUND_ROWS DISTINCT h.name, h.alias, h.address, h.ho
     h.icon_image AS h_icon_images, h.display_name AS h_display_name, h.action_url AS h_action_url,
     h.notes_url AS h_notes_url, h.notes AS h_notes, h.address,
     h.passive_checks AS h_passive_checks, h.active_checks AS h_active_checks,
-    i.name as instance_name, cv.value as service_criticality, cv.value IS NULL as sc_isnull";
+    i.name as instance_name, cv.value as service_criticality, cv.value IS NULL as sc_isnull,
+    cv2.value as host_criticality, cv2.value IS NULL as hc_isnull";
 
-// if ($hostCriticalityId) {
-    $request .= ", cv2.value as host_criticality, cv2.value IS NULL as hc_isnull";
-// }
 $request .= " FROM hosts h, instances i ";
+
 if (isset($hostgroups) && $hostgroups != 0) {
     $request .= ", hosts_hostgroups hg, hostgroups hg2";
 }
@@ -190,22 +189,22 @@ if (!$obj->is_admin) {
 }
 $request .= ", services s LEFT JOIN customvariables cv ON (s.service_id = cv.service_id
     AND cv.host_id = s.host_id AND cv.name = 'CRITICALITY_LEVEL')";
-// if ($hostCriticalityId) {
-    $request .= " LEFT JOIN customvariables cv2
-        ON (cv2.service_id IS NULL
-        AND cv2.host_id = s.host_id
-        AND cv2.name = 'CRITICALITY_LEVEL')
-        LEFT JOIN customvariables cv3
+$request .= " LEFT JOIN customvariables cv2
+    ON (cv2.service_id IS NULL
+    AND cv2.host_id = s.host_id
+    AND cv2.name = 'CRITICALITY_LEVEL')";
+if ($hostCriticalityId) {
+    $request .= " LEFT JOIN customvariables cv3
         ON (cv3.service_id IS NULL
         AND cv3.host_id = s.host_id
         AND cv3.name = 'CRITICALITY_ID')";
-// }
+}
 $request .= " WHERE h.host_id = s.host_id
     AND s.enabled = 1
     AND h.enabled = 1
     AND h.instance_id = i.instance_id ";
 if ($serviceCriticalityId) {
-    $request .= " AND s.service_id = cvs. service_id
+    $request .= " AND s.service_id = cvs.service_id
         AND cvs.host_id = h.host_id
         AND cvs.name = 'CRITICALITY_ID'
         AND cvs.value = :serviceCriticalityValue";

--- a/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -145,7 +145,6 @@ if ($outputToSearch) {
     $queryValues['outputToSearch'] = [\PDO::PARAM_STR => '%' . $outputToSearch . '%'];
 }
 
-// TODO: fix order for criticalities
 $tabOrder = [];
 $tabOrder["service_criticality_id"] = " ORDER BY sc_isnull " . $order . ", service_criticality " . $order . ", h.name, s.description ";
 $tabOrder["host_criticality_id"] = " ORDER BY hc_isnull " . $order . ", host_criticality " . $order . ", h.name, s.description ";

--- a/www/include/monitoring/status/Services/xsl/service.xsl
+++ b/www/include/monitoring/status/Services/xsl/service.xsl
@@ -10,10 +10,13 @@
                 <label class="empty-label" for="checkall"></label>
             </div>
         </td>
-        <xsl:if test = "//i/use_criticality = 1">
-            <td class="ListColHeaderCenter" style="white-space:nowrap;width:17px;" id="criticality_id"></td>
+        <xsl:if test = "//i/use_host_criticality = 1">
+            <td class="ListColHeaderCenter" style="white-space:nowrap;width:17px;" id="host_criticality_id"></td>
         </xsl:if>
         <td colspan="2" class="ListColHeaderCenter" style="white-space:nowrap;" id="host_name"></td>
+        <xsl:if test = "//i/use_service_criticality = 1">
+            <td class="ListColHeaderCenter" style="white-space:nowrap;width:17px;" id="service_criticality_id"></td>
+        </xsl:if>
         <td colspan="3" class="ListColHeaderCenter" style="white-space:nowrap;" id="service_description"></td>
         <td class="ListColHeaderCenter" style="white-space:nowrap;" id="current_state"></td>
         <td class="ListColHeaderCenter" style="white-space:nowrap;" id="last_state_change"></td>
@@ -25,7 +28,7 @@
             </xsl:if>
         </xsl:for-each>
         <td class="ListColHeaderCenter" style="white-space:nowrap;" id="last_check"></td>
-        <td class="ListColHeaderCenter" style="white-space:nowrap;" id="current_attempt"></td>                
+        <td class="ListColHeaderCenter" style="white-space:nowrap;" id="current_attempt"></td>
         <td class="ListColHeaderCenter" style="white-space:nowrap;" id="plugin_output"></td>
         <xsl:for-each select="//i">
             <xsl:if test="nc = 1">
@@ -58,16 +61,16 @@
                 </xsl:element>
             </div>
         </td>
-        <xsl:if test = "//i/use_criticality = 1">
+        <xsl:if test = "//i/use_host_criticality = 1">
             <td class="ListColCenter">
-            <xsl:if test = "hci = 1">
+            <xsl:if test = "hhci = 1">
                 <xsl:element name="img">
-                    <xsl:attribute name="src">img/media/<xsl:value-of select="ci"/></xsl:attribute>
+                    <xsl:attribute name="src">img/media/<xsl:value-of select="hci"/></xsl:attribute>
                     <xsl:attribute name="width">16</xsl:attribute>
                     <xsl:attribute name="height">16</xsl:attribute>
-                    <xsl:attribute name="title"><xsl:value-of select='cih'/></xsl:attribute>
+                    <xsl:attribute name="title"><xsl:value-of select='hcih'/></xsl:attribute>
                 </xsl:element>
-            </xsl:if>                
+            </xsl:if>
             </td>
         </xsl:if>
         <td class="ListColLeft" style="white-space:nowrap;">
@@ -185,6 +188,18 @@
                 </xsl:choose>
             </xsl:if>
         </td>
+        <xsl:if test = "//i/use_service_criticality = 1">
+            <td class="ListColCenter">
+            <xsl:if test = "hsci = 1">
+                <xsl:element name="img">
+                    <xsl:attribute name="src">img/media/<xsl:value-of select="sci"/></xsl:attribute>
+                    <xsl:attribute name="width">16</xsl:attribute>
+                    <xsl:attribute name="height">16</xsl:attribute>
+                    <xsl:attribute name="title"><xsl:value-of select='scih'/></xsl:attribute>
+                </xsl:element>
+            </xsl:if>
+            </td>
+        </xsl:if>
         <td class="ListColLeft" style="white-space:nowrap;">
             <xsl:if test="sico != ''">
                 <xsl:element name="img">
@@ -235,14 +250,14 @@
                         </xsl:element>
                 </xsl:element>
             </xsl:if>
-            <xsl:if test="dtm != 0">                    
+            <xsl:if test="dtm != 0">
                 <xsl:element name="a">
                     <xsl:attribute name="class">infobulle</xsl:attribute>
                     <xsl:element name="img">
                         <xsl:attribute name="src">./img/icons/warning.png</xsl:attribute>
                         <xsl:attribute name="class">link_generic_info_volante ico-18</xsl:attribute>
                         <xsl:attribute name="id">dtmspan_<xsl:value-of select="hid"/>_<xsl:value-of select="svc_id"/></xsl:attribute>
-                        <xsl:attribute name="name"><xsl:value-of select="dtmXml"/>|<xsl:value-of select="dtmXsl"/></xsl:attribute>              
+                        <xsl:attribute name="name"><xsl:value-of select="dtmXml"/>|<xsl:value-of select="dtmXsl"/></xsl:attribute>
                     </xsl:element>
                 </xsl:element>
             </xsl:if>
@@ -261,7 +276,7 @@
                     <xsl:element name="img">
                         <xsl:attribute name="src">./img/icons/passive_check.png</xsl:attribute>
                         <xsl:attribute name="class">ico-16</xsl:attribute>
-                        <xsl:attribute name="title">                        
+                        <xsl:attribute name="title">
                             <xsl:value-of select='//i/service_passive_mode'/>
                         </xsl:attribute>
                     </xsl:element>
@@ -270,7 +285,7 @@
                     <xsl:element name="img">
                         <xsl:attribute name="src">./img/icons/never_checked.png</xsl:attribute>
                         <xsl:attribute name="class">ico-16</xsl:attribute>
-                        <xsl:attribute name="title">                            
+                        <xsl:attribute name="title">
                             <xsl:value-of select='//i/service_not_active_not_passive'/>
                         </xsl:attribute>
                     </xsl:element>
@@ -278,7 +293,7 @@
             <xsl:if test="is = 1">
                     <xsl:element name="img">
                         <xsl:attribute name="src">./img/icones/16x16/flapping.gif</xsl:attribute>
-                        <xsl:attribute name="title">                            
+                        <xsl:attribute name="title">
                             <xsl:value-of select='//i/service_flapping'/>
                         </xsl:attribute>
                     </xsl:element>
@@ -287,7 +302,7 @@
                     <xsl:element name="img">
                         <xsl:attribute name="class">ico-18</xsl:attribute>
                         <xsl:attribute name="src">./img/icons/notifications_off.png</xsl:attribute>
-                        <xsl:attribute name="title">                            
+                        <xsl:attribute name="title">
                             <xsl:value-of select='//i/notif_disabled'/>
                         </xsl:attribute>
                     </xsl:element>
@@ -296,12 +311,12 @@
         <td class="ListColRight">
             <xsl:if test="svc_index &gt; 0">
                 <xsl:element name="a">
-                    <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/>;<xsl:value-of select="sdl"/></xsl:attribute>                   
+                    <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/>;<xsl:value-of select="sdl"/></xsl:attribute>
                         <xsl:element name="img">
                             <xsl:attribute name="id"><xsl:value-of select="hid"/>_<xsl:value-of select="svc_id"/></xsl:attribute>
                             <xsl:attribute name="class">graph-volant ico-18</xsl:attribute>
                             <xsl:attribute name="src">./img/icons/chart.png</xsl:attribute>
-                        </xsl:element>                  
+                        </xsl:element>
                 </xsl:element>
             </xsl:if>
         </td>


### PR DESCRIPTION
# Pull Request Template

## Description
this PR is here to add a new feature which is having the possibility to filter on the host severity when you're in the monitoring page of the services. 

This is a breaking change because i've changed the way you can use your filter in the url. For now you can use s=1 to filter on the severity that has 1 as an ID. With this PR it is going to be service_criticality=1. Before releasing this feature, I need to adapt every widget that is using the url with such filters.

![host-severity-PR](https://user-images.githubusercontent.com/7352865/70261179-303a1b80-1792-11ea-9013-2fedb11ca1f0.gif)

I've notice a few discrepancies between the host monitoring menu and the service one
- in service monitoring I am now using host_criticality and service_criticality filters in the url, it was only "s" before, and in the host monitoring we use criticality in the url
- in service monitoring i've changed the table to display HC and SC that stands for host criticality and service critilicaty, before it was S for the service severity and it is still S in the host monitoring page

let me know if I should normalize everything. 

I forgot to translate the new menu elements. Will do that later. And I'll make the PR for the widget that need to be adapted to this change. 

the one thing that i'm not able to tell is the impact on the performances of the two LEFT JOIN that i've added 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- create at least two host categories each one have a severity with a dedicated icon so it is easier to see the filter in action.
- create at least two service categories each one have a severity with a dedicated icon so it is easier to see the filter in action.
- play with the filters in the service monitoring menu and also the host monitoring menu (don't forget to order the results by host name and various severities)


## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
