### PR TITLE
fix(centcore): fix restart/reload of centengine on localhost

### DIFF
--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -827,10 +827,13 @@ sub initEngine($$$){
                 'using remote server "' . $remote_server->{name} . '" (' . $remote_server->{id} . ')'
             );
         } else {
-            $cmd = "$self->{ssh} -p $port " . $conf->{ns_ip_address} . " $self->{sudo} $self->{service} "
-                . $conf->{init_script} . " " . $options;
+            $cmd = '';
+            if ($conf->{localhost} == 0) {
+                $cmd = "$self->{ssh} -p $port $conf->{ns_ip_address} ";
+            }
+            $cmd .= "$self->{sudo} $self->{service} " . $conf->{init_script} . " " . $options;
             $self->{logger}->writeLogInfo(
-                'Init Script : "' . $self->{sudo} . ' ' . $self->{service} . ' ' . $conf->{init_script} . ' ' . $options . '" ' .
+                'Init Script : "' . $cmd . '" ' .
                 'on poller "' . $conf->{name} . '" (' . $id . ')'
             );
         }

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -828,10 +828,13 @@ sub initEngine($$$){
             );
         } else {
             $cmd = '';
+
+            # if the target is the central server, we don't need to use ssh
             if ($conf->{localhost} == 0) {
                 $cmd = "$self->{ssh} -p $port $conf->{ns_ip_address} ";
             }
-            $cmd .= "$self->{sudo} $self->{service} " . $conf->{init_script} . " " . $options;
+
+            $cmd .= "$self->{sudo} $self->{service} $conf->{init_script} $options;
             $self->{logger}->writeLogInfo(
                 'Init Script : "' . $cmd . '" ' .
                 'on poller "' . $conf->{name} . '" (' . $id . ')'

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -834,7 +834,7 @@ sub initEngine($$$){
                 $cmd = "$self->{ssh} -p $port $conf->{ns_ip_address} ";
             }
 
-            $cmd .= "$self->{sudo} $self->{service} $conf->{init_script} $options;
+            $cmd .= "$self->{sudo} $self->{service} $conf->{init_script} $options";
             $self->{logger}->writeLogInfo(
                 'Init Script : "' . $cmd . '" ' .
                 'on poller "' . $conf->{name} . '" (' . $id . ')'


### PR DESCRIPTION
## Description

centcore always try to use ssh to restart/reload centengine
This PR allows centcore to restart/reload centengine on localhost without using ssh

**Fixes** MON-4195 MON-4152

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

restart centengine using CLAPI