### PR TITLE
fix(ui): check format of top counter's endpoints return data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4949,6 +4949,11 @@
         }
       }
     },
+    "fn-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fn-name/-/fn-name-2.0.1.tgz",
+      "integrity": "sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc="
+    },
     "follow-redirects": {
       "version": "1.5.8",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.8.tgz",
@@ -5099,7 +5104,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5117,11 +5123,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5134,15 +5142,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5245,7 +5256,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5255,6 +5267,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5267,17 +5280,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5294,6 +5310,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5366,7 +5383,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5376,6 +5394,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5451,7 +5470,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5481,6 +5501,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5498,6 +5519,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5536,11 +5558,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -11709,6 +11733,11 @@
         "object-assign": "^4.1.1"
       }
     },
+    "property-expr": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-1.5.1.tgz",
+      "integrity": "sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g=="
+    },
     "proxy-addr": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
@@ -12051,11 +12080,6 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-5.0.3.tgz",
       "integrity": "sha512-TLMcjJcNy7BalEHN1iNuIK0E6ODYgExcrdaKraT4kzKVztkrBHI1THTAn3qx7GVvtP4TbCqi+mBjsZqoWtuiEQ=="
-    },
-    "react-favicon": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/react-favicon/-/react-favicon-0.0.14.tgz",
-      "integrity": "sha512-dE1Q13jgc5/Z49G3O3LSdJ87XGK6I4sIYmx3+ROYOEkt0wcrdP9J5wf2oDLtq7D9bOm0j62HAWP+DoofjsHNJQ=="
     },
     "react-full-screen": {
       "version": "0.2.3",
@@ -14516,6 +14540,11 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY="
     },
+    "synchronous-promise": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.10.tgz",
+      "integrity": "sha512-6PC+JRGmNjiG3kJ56ZMNWDPL8hjyghF5cMXIFOKg+NiwwEZZIvxTWd0pinWKyD227odg9ygF8xVhhz7gb8Uq7A=="
+    },
     "table": {
       "version": "4.0.3",
       "resolved": "http://registry.npmjs.org/table/-/table-4.0.3.tgz",
@@ -16551,6 +16580,26 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+        }
+      }
+    },
+    "yup": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-0.27.0.tgz",
+      "integrity": "sha512-v1yFnE4+u9za42gG/b/081E7uNW9mUj3qtkmelLbW5YPROZzSH/KUUyJu9Wt8vxFJcT9otL/eZopS0YK1L5yPQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "fn-name": "~2.0.1",
+        "lodash": "^4.17.11",
+        "property-expr": "^1.5.0",
+        "synchronous-promise": "^2.0.6",
+        "toposort": "^2.0.2"
+      },
+      "dependencies": {
+        "toposort": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+          "integrity": "sha1-riF2gXXRVZ1IvvNUILL0li8JwzA="
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "redux": "^4.0.0",
     "redux-form": "^7.4.2",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.3.0"
+    "redux-thunk": "^2.3.0",
+    "yup": "^0.27.0"
   },
   "jest": {
     "testResultsProcessor": "jest-junit",

--- a/www/front_src/src/App.js
+++ b/www/front_src/src/App.js
@@ -76,7 +76,7 @@ class App extends Component {
         .get()
         .then(() => this.keepAlive())
         .catch(error => {
-          if (error.response.status == 401) {
+          if (error.response && error.response.status === 401) {
             // redirect to login page
             window.location.href = config.urlBase + 'index.php?disconnect=1'
           } else {

--- a/www/front_src/src/components/hostMenu/index.js
+++ b/www/front_src/src/components/hostMenu/index.js
@@ -57,9 +57,7 @@ class HostMenu extends Component {
   getData = () => {
     this.hostsService.get().then(({ data }) => {
       statusSchema.validate(data).then(() => {
-        this.setState({
-          data
-        });
+        this.setState({ data });
       });
     }).catch((error) => {
       if (error.response && error.response.status === 401) {

--- a/www/front_src/src/components/hostMenu/index.js
+++ b/www/front_src/src/components/hostMenu/index.js
@@ -12,7 +12,6 @@ import { connect } from "react-redux";
 const numberFormat = yup
   .number()
   .required()
-  .positive()
   .integer();
 
 const statusSchema = yup.object().shape({

--- a/www/front_src/src/components/hostMenu/index.js
+++ b/www/front_src/src/components/hostMenu/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import * as yup from 'yup';
 import numeral from "numeral";
 import {Link} from 'react-router-dom';
 import PropTypes from 'prop-types';
@@ -7,6 +8,27 @@ import {Translate} from 'react-redux-i18n';
 import axios from "../../axios";
 
 import { connect } from "react-redux";
+
+const numberFormat = yup
+  .number()
+  .required()
+  .positive()
+  .integer();
+
+const statusSchema = yup.object().shape({
+  down: yup.object().shape({
+    total: numberFormat,
+    unhandled: numberFormat,
+  }),
+  unreachable: yup.object().shape({
+    total: numberFormat,
+    unhandled: numberFormat,
+  }),
+  ok: numberFormat,
+  pending: numberFormat,
+  total: numberFormat,
+  refreshTime: numberFormat,
+});
 
 class HostMenu extends Component {
 
@@ -33,12 +55,14 @@ class HostMenu extends Component {
 
   // fetch api to get host data
   getData = () => {
-    this.hostsService.get().then(({data}) => {
-      this.setState({
-        data
+    this.hostsService.get().then(({ data }) => {
+      statusSchema.validate(data).then(() => {
+        this.setState({
+          data
+        });
       });
     }).catch((error) => {
-      if (error.response.status == 401){
+      if (error.response && error.response.status === 401) {
         this.setState({
           data: null
         });

--- a/www/front_src/src/components/pollerMenu/index.js
+++ b/www/front_src/src/components/pollerMenu/index.js
@@ -82,7 +82,7 @@ class PollerMenu extends Component {
         data
       });
     }).catch((error) => {
-      if (error.response.status == 401){
+      if (error.response && error.response.status === 401) {
         this.setState({
           data: null
         });

--- a/www/front_src/src/components/serviceStatusMenu/index.js
+++ b/www/front_src/src/components/serviceStatusMenu/index.js
@@ -61,9 +61,7 @@ class ServiceStatusMenu extends Component {
   getData = () => {
     this.servicesStatusService.get().then(({ data }) => {
       statusSchema.validate(data).then(() => {
-        this.setState({
-          data
-        });
+        this.setState({ data });
       });
     }).catch((error) => {
       if (error.response && error.response.status === 401) {

--- a/www/front_src/src/components/serviceStatusMenu/index.js
+++ b/www/front_src/src/components/serviceStatusMenu/index.js
@@ -12,7 +12,6 @@ import { connect } from "react-redux";
 const numberFormat = yup
   .number()
   .required()
-  .positive()
   .integer();
 
 const statusSchema = yup.object().shape({

--- a/www/front_src/src/components/serviceStatusMenu/index.js
+++ b/www/front_src/src/components/serviceStatusMenu/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import * as yup from 'yup';
 import PropTypes from 'prop-types';
 import numeral from "numeral";
 import { Link } from "react-router-dom";
@@ -7,6 +8,31 @@ import {Translate} from 'react-redux-i18n';
 import axios from "../../axios";
 
 import { connect } from "react-redux";
+
+const numberFormat = yup
+  .number()
+  .required()
+  .positive()
+  .integer();
+
+const statusSchema = yup.object().shape({
+  critical: yup.object().shape({
+    total: numberFormat,
+    unhandled: numberFormat,
+  }),
+  warning: yup.object().shape({
+    total: numberFormat,
+    unhandled: numberFormat,
+  }),
+  unknown: yup.object().shape({
+    total: numberFormat,
+    unhandled: numberFormat,
+  }),
+  ok: numberFormat,
+  pending: numberFormat,
+  total: numberFormat,
+  refreshTime: numberFormat,
+});
 
 class ServiceStatusMenu extends Component {
 
@@ -33,12 +59,14 @@ class ServiceStatusMenu extends Component {
 
   // fetch api to get service data
   getData = () => {
-    this.servicesStatusService.get().then(({data}) => {
-      this.setState({
-        data
+    this.servicesStatusService.get().then(({ data }) => {
+      statusSchema.validate(data).then(() => {
+        this.setState({
+          data
+        });
       });
     }).catch((error) => {
-      if (error.response.status == 401){
+      if (error.response && error.response.status === 401) {
         this.setState({
           data: null
         });

--- a/www/front_src/src/components/userMenu/index.js
+++ b/www/front_src/src/components/userMenu/index.js
@@ -37,7 +37,7 @@ class UserMenu extends Component {
         data
       }, this.refreshData);
     }).catch((error) => {
-      if (error.response.status == 401){
+      if (error.response && error.response.status === 401) {
         this.setState({
           data: null
         });

--- a/www/front_src/src/translations/index.js
+++ b/www/front_src/src/translations/index.js
@@ -20,7 +20,7 @@ export default function setTranslations(store, callback) {
       callback();
     })
     .catch((error) => {
-      if (error.response.status === 401) {
+      if (error.response && error.response.status === 401) {
         // redirect to login page
         window.location.href = 'index.php?disconnect=1';
       }


### PR DESCRIPTION
## Description

Cannot reproduce
But it seems that if the top counter endpoint return 200 status and bad formatted date, it breaks the page
==> blank screen

**Fixes** MON-4590

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Mainly check that the top counter is working properly