### PR TITLE
fix(ui): display top counter even if monitoring is off

### DIFF
--- a/www/api/class/centreon_topcounter.class.php
+++ b/www/api/class/centreon_topcounter.class.php
@@ -554,14 +554,14 @@ class CentreonTopCounter extends CentreonWebService
         }
 
         $query = 'SELECT
-            SUM(CASE WHEN h.state = 0 THEN 1 ELSE 0 END) AS up_total,
-            SUM(CASE WHEN h.state = 1 THEN 1 ELSE 0 END) AS down_total,
-            SUM(CASE WHEN h.state = 2 THEN 1 ELSE 0 END) AS unreachable_total,
-            SUM(CASE WHEN h.state = 4 THEN 1 ELSE 0 END) AS pending_total,
-            SUM(CASE WHEN h.state = 1 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0)
-                THEN 1 ELSE 0 END) AS down_unhandled,
-            SUM(CASE WHEN h.state = 2 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0)
-                THEN 1 ELSE 0 END) AS unreachable_unhandled
+            COALESCE(SUM(CASE WHEN h.state = 0 THEN 1 ELSE 0 END), 0) AS up_total,
+            COALESCE(SUM(CASE WHEN h.state = 1 THEN 1 ELSE 0 END), 0) AS down_total,
+            COALESCE(SUM(CASE WHEN h.state = 2 THEN 1 ELSE 0 END), 0) AS unreachable_total,
+            COALESCE(SUM(CASE WHEN h.state = 4 THEN 1 ELSE 0 END), 0) AS pending_total,
+            COALESCE(SUM(CASE WHEN h.state = 1 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0)
+                THEN 1 ELSE 0 END), 0) AS down_unhandled,
+            COALESCE(SUM(CASE WHEN h.state = 2 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0)
+                THEN 1 ELSE 0 END), 0) AS unreachable_unhandled
             FROM hosts h, instances i';
         $query .= ' WHERE i.deleted = 0
             AND h.instance_id = i.instance_id
@@ -613,17 +613,17 @@ class CentreonTopCounter extends CentreonWebService
         }
 
         $query = 'SELECT
-            SUM(CASE WHEN s.state = 0 THEN 1 ELSE 0 END) AS ok_total,
-            SUM(CASE WHEN s.state = 1 THEN 1 ELSE 0 END) AS warning_total,
-            SUM(CASE WHEN s.state = 2 THEN 1 ELSE 0 END) AS critical_total,
-            SUM(CASE WHEN s.state = 3 THEN 1 ELSE 0 END) AS unknown_total,
-            SUM(CASE WHEN s.state = 4 THEN 1 ELSE 0 END) AS pending_total,
-            SUM(CASE WHEN s.state = 1 AND (s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
-                THEN 1 ELSE 0 END) AS warning_unhandled,
-            SUM(CASE WHEN s.state = 2 AND (s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
-                THEN 1 ELSE 0 END) AS critical_unhandled,
-            SUM(CASE WHEN s.state = 3 AND (s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
-                THEN 1 ELSE 0 END) AS unknown_unhandled
+            COALESCE(SUM(CASE WHEN s.state = 0 THEN 1 ELSE 0 END), 0) AS ok_total,
+            COALESCE(SUM(CASE WHEN s.state = 1 THEN 1 ELSE 0 END), 0) AS warning_total,
+            COALESCE(SUM(CASE WHEN s.state = 2 THEN 1 ELSE 0 END), 0) AS critical_total,
+            COALESCE(SUM(CASE WHEN s.state = 3 THEN 1 ELSE 0 END), 0) AS unknown_total,
+            COALESCE(SUM(CASE WHEN s.state = 4 THEN 1 ELSE 0 END), 0) AS pending_total,
+            COALESCE(SUM(CASE WHEN s.state = 1 AND (s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
+                THEN 1 ELSE 0 END), 0) AS warning_unhandled,
+            COALESCE(SUM(CASE WHEN s.state = 2 AND (s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
+                THEN 1 ELSE 0 END), 0) AS critical_unhandled,
+            COALESCE(SUM(CASE WHEN s.state = 3 AND (s.acknowledged = 0 AND s.scheduled_downtime_depth = 0)
+                THEN 1 ELSE 0 END), 0) AS unknown_unhandled
             FROM hosts h, services s, instances i';
         $query .= ' WHERE i.deleted = 0
             AND h.instance_id = i.instance_id


### PR DESCRIPTION
### Description

On a fresh install, top counter was not display cause monitoring was never set.
This fix allows to display 0 values instead

Mysql COALESCE function allows to return 0 if the first result return NULL

**Fixes** MON-4590

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Install Centreon Web
* Check top counter without generate configuration