### PR TITLE
fix(chart): Re allow to use wildcard in curve definition

### DIFF
--- a/www/class/centreonGraph.class.php
+++ b/www/class/centreonGraph.class.php
@@ -565,7 +565,7 @@ class CentreonGraph
                     $ds_data_regular = null;
                     foreach ($components_ds_cache as $ds_val) {
                         /* Prepare pattern for metrics */
-                        $metricPattern = '/^' . preg_quote($ds_val['ds_name'], '/') . '$/i';
+                        $metricPattern = '/^' . str_replace('/', '\/', $dsVal['ds_name']).'$/i';
                         $metricPattern = str_replace('\\*', '.*', $metricPattern);
 
                         # Check associated

--- a/www/class/centreonGraph.class.php
+++ b/www/class/centreonGraph.class.php
@@ -563,7 +563,7 @@ class CentreonGraph
                     }
                     $ds_data_associated = null;
                     $ds_data_regular = null;
-                    foreach ($components_ds_cache as $ds_val) {
+                    foreach ($components_ds_cache as $dsVal) {
                         /* Prepare pattern for metrics */
                         $metricPattern = '/^' . str_replace('/', '\/', $dsVal['ds_name']).'$/i';
                         $metricPattern = str_replace('\\*', '.*', $metricPattern);

--- a/www/class/centreonGraphNg.class.php
+++ b/www/class/centreonGraphNg.class.php
@@ -335,7 +335,7 @@ class CentreonGraphNg
         $dsDataAssociated = null;
         $dsDataRegular = null;
         foreach ($this->componentsDsCache as $dsVal) {
-            $metricPattern = '/^' .  preg_quote($dsVal['ds_name'], '/') . '$/i';
+            $metricPattern = '/^' . str_replace('/', '\/', $dsVal['ds_name']).'$/i';
             $metricPattern = str_replace('*', '.*', $metricPattern);
 
             if (isset($metric['host_id']) && isset($metric['service_id']) &&

--- a/www/class/centreonGraphNg.class.php
+++ b/www/class/centreonGraphNg.class.php
@@ -1147,7 +1147,7 @@ class CentreonGraphNg
         $stmt->bindParam(':index_id', $indexId, PDO::PARAM_INT);
         $stmt->bindParam(':metric_id', $metricId, PDO::PARAM_INT);
         $stmt->execute();
-        return $l_rndcolor;
+        return $lRndcolor;
     }
 
     /**


### PR DESCRIPTION
# Pull Request Template

## Description

- Re allow to use wildcard in curve definition
- Fix variable name to prevent PHP warning

**Fixes** #8131 

## Type of change

- [] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Edit/create a curve definition
2. Use PRCE in curve name
3. Display a chart that one of the metrics can be validated by the definition
4. Check the curve definition is used (legend name, color of curve, ...)

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
