### PR TITLE
fix(filter) apply second filter whatever the first

### DIFF
--- a/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
@@ -87,17 +87,14 @@ $obj->setInstanceHistory($instance);
  */
 $s_search = "";
 // Display service problems
-if ($o == "svcgridSG_pb" || $o == "svcOVSG_pb") {
+if (substr($o, -3) === '_pb') {
     $s_search .= " AND s.state != 0 AND s.state != 4 ";
 }
-
 // Display acknowledged services
-if ($o == "svcgridSG_ack_1" || $o == "svcOVSG_ack_1") {
+if (substr($o, -6) === '_ack_1') {
     $s_search .= " AND s.acknowledged = '1' ";
-}
-
+} elseif (substr($o, -6) === '_ack_0') {
 // Display not acknowledged services
-if ($o == "svcgridSG_ack_0" || $o == "svcOVSG_ack_0") {
     $s_search .= " AND s.state != 0 AND s.state != 4 AND s.acknowledged = 0 ";
 }
 


### PR DESCRIPTION
## Description

On "Monitoring > Status Details > Services by Servicegroup" page, we can't apply the two filters Display and Display details

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

    Go to the "Monitoring > Status Details > Services by Servicegroup" page,
    Select "Summary" in "Display" drop-down list,
    Select all the options in "Display details" drop-down list,
    Result is not filtered accordingly.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
