### PR TITLE
fix(code) fix search image

### DIFF
--- a/www/include/options/media/images/listImg.php
+++ b/www/include/options/media/images/listImg.php
@@ -46,11 +46,13 @@ if (isset($_POST['searchM'])) {
         $_POST['searchM'],
         CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
     );
+    $search = $centreon->historySearch[$url];
 } elseif (isset($_GET['searchM'])) {
     $centreon->historySearch[$url] = CentreonUtils::escapeSecure(
         $_GET['searchM'],
         CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
     );
+    $search = $centreon->historySearch[$url];
 } elseif (isset($centreon->historySearch[$url])) {
     $search = $centreon->historySearch[$url];
 }


### PR DESCRIPTION
# Pull Request Template

## Description
when you search for image in administration -> parameters -> images, it doesn't work at all

let say you enter "dazdzadazdazd" in the search bar, and hit the enter key you'll still see all your images. After that, you can hit the f5 key, and now the filter is going to be applied.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- go in your administration->parameters->images menu
- write the name of an image you're looking for
- click the search button
- it should display only your image
- hit the F5 key, and your filter should still be applied
- remove what you wrote in the search field, hit the search button, it should display every images.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
