### PR TITLE
fix(UI): do not display gorgone options on central's form

### DIFF
--- a/www/include/configuration/configServers/formServers.ihtml
+++ b/www/include/configuration/configServers/formServers.ihtml
@@ -25,7 +25,7 @@
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="is_default"> {$form.is_default.label}</td><td class="FormRowValue">{$form.is_default.html}</td></tr>
         {if $form.remote_id.label}
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="remote_id"> {$form.remote_id.label}</td><td class="FormRowValue">{$form.remote_id.html}</td></tr>
-        <tr class="list_tow">
+        <tr class="list_two">
             <td class="FormRowField"><img class="helpTooltip" name="remote_additional_id"> {$form.remote_additional_id.label}</td>
             <td class="FormRowValue">{$form.remote_additional_id.html}</td>
         </tr>
@@ -36,40 +36,44 @@
                 <h4>{$form.header.Remote_Configuration}</h4>
             </td>
             <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="http_method">{$form.http_method.label}</td><td class="FormRowValue">{$form.http_method.html}</td></tr>
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="http_port">{$form.http_port.label}</td><td class="FormRowValue">{$form.http_port.html}</td></tr>
+            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="http_port">{$form.http_port
+                .label}</td><td class="FormRowValue">{$form.http_port.html}</td></tr>
             <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="no_check_certificate">{$form.no_check_certificate.label}</td><td class="FormRowValue">{$form.no_check_certificate.html}</td></tr>
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="no_proxy">{$form.no_proxy.label}</td><td class="FormRowValue">{$form.no_proxy.html}</td></tr>
+            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="no_proxy">{$form.no_proxy.label}</td><td class="FormRowValue">{$form.no_proxy.html}</td></tr>
         </tr>
         {/if}
-        {if $form.header.gorgone_Informations.lable}
-        <tr class="list_lvl_1">
-            <td class="ListColLvl1_name" colspan="2"><h4>{$form.header.gorgone_Informations}</h4></td>
-        </tr>
-        <tr class="list_one">
-            <td class="FormRowField"><img class="helpTooltip" name="gorgone_communication_type"> {$form.gorgone_communication_type.label}</td>
-            <td class="FormRowValue">{$form.gorgone_communication_type.html}</td>
-        </tr>
-        <tr class="list_two">
-            <td class="FormRowField"><img class="helpTooltip" name="gorgone_port"> {$form.gorgone_port.label}</td>
-            <td class="FormRowValue">{$form.gorgone_port.html}</td>
-        </tr>
-        {/if}
-        {if $form.remote_server_use_as_proxy.label}
-        <tr class="list_two">
-            <td class="FormRowField"><img class="helpTooltip" name="remote_server_use_as_proxy"> {$form.remote_server_use_as_proxy.label}</td>
-            <td class="FormRowValue">{$form.remote_server_use_as_proxy.html}</td>
-        </tr>
-        {/if}
+        <!-- specific gorgone fields for remote or poller -->
+        <tbody id="gorgoneData">
+            <tr class="list_lvl_1">
+                <td class="ListColLvl1_name" colspan="2"><h4>{$form.header.gorgone_Informations}</h4></td>
+            </tr>
+            <tr class="list_one">
+                <td class="FormRowField"><img class="helpTooltip" name="gorgone_communication_type"> {$form.gorgone_communication_type.label}</td>
+                <td class="FormRowValue">{$form.gorgone_communication_type.html}</td>
+            </tr>
+            <tr class="list_two">
+                <td class="FormRowField"><img class="helpTooltip" name="gorgone_port"> {$form.gorgone_port.label}</td>
+                <td class="FormRowValue">{$form.gorgone_port.html}</td>
+            </tr>
+
+            {if $form.remote_server_use_as_proxy.label}
+            <tr class="list_one">
+                <td class="FormRowField"><img class="helpTooltip" name="remote_server_use_as_proxy"> {$form.remote_server_use_as_proxy.label}</td>
+                <td class="FormRowValue">{$form.remote_server_use_as_proxy.html}</td>
+            </tr>
+            {/if}
+        </tbody>
+
         <tr class="list_lvl_1">
             <td class="ListColLvl1_name" colspan="2"><h4>{$form.header.Nagios_Informations}</h4></td>
         </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_start_command"> {$form.engine_start_command.label}</td><td class="FormRowValue">{$form.engine_start_command.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="engine_start_command"> {$form.engine_start_command.label}</td><td class="FormRowValue">{$form.engine_start_command.html}</td></tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_stop_command"> {$form.engine_stop_command.label}</td><td class="FormRowValue">{$form.engine_stop_command.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_restart_command"> {$form.engine_restart_command.label}</td><td class="FormRowValue">{$form.engine_restart_command.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="engine_reload_command"> {$form.engine_reload_command.label}</td><td class="FormRowValue">{$form.engine_reload_command.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="nagios_bin"> {$form.nagios_bin.label}</td><td class="FormRowValue">{$form.nagios_bin.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="nagiostats_bin"> {$form.nagiostats_bin.label}</td><td class="FormRowValue">{$form.nagiostats_bin.html}</td></tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="nagios_perfdata"> {$form.nagios_perfdata.label}</td><td class="FormRowValue">{$form.nagios_perfdata.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="engine_restart_command"> {$form.engine_restart_command.label}</td><td class="FormRowValue">{$form.engine_restart_command.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_reload_command"> {$form.engine_reload_command.label}</td><td class="FormRowValue">{$form.engine_reload_command.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="nagios_bin"> {$form.nagios_bin.label}</td><td class="FormRowValue">{$form.nagios_bin.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="nagiostats_bin"> {$form.nagiostats_bin.label}</td><td class="FormRowValue">{$form.nagiostats_bin.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="nagios_perfdata"> {$form.nagios_perfdata.label}</td><td class="FormRowValue">{$form.nagios_perfdata.html}</td></tr>
         <tr class="list_lvl_1">
             <td class="ListColLvl1_name" colspan="2">
                 <h4>{$form.header.CentreonBroker}</h4>
@@ -90,14 +94,14 @@
                 <h4>{$form.header.Centreontrapd}</h4>
             </td>
         </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreontrapd_init_script"> {$form.init_script_centreontrapd.label}</td><td class="FormRowValue">{$form.init_script_centreontrapd.html}</td></tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="snmp_trapd_path_conf"> {$form.snmp_trapd_path_conf.label}</td><td class="FormRowValue">{$form.snmp_trapd_path_conf.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="centreontrapd_init_script"> {$form.init_script_centreontrapd.label}</td><td class="FormRowValue">{$form.init_script_centreontrapd.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="snmp_trapd_path_conf"> {$form.snmp_trapd_path_conf.label}</td><td class="FormRowValue">{$form.snmp_trapd_path_conf.html}</td></tr>
             <tr class="list_lvl_1">
                 <td class="ListColLvl1_name" colspan="2">
                     <h4>{$form.header.Misc}</h4>
                 </td>
             </tr>
-		<tr class="list_one">
+		<tr class="list_two">
             <td class="FormRowField">
                 <img class="helpTooltip" name="pollercmd"> {t}Post-Restart command{/t}
             </td>
@@ -105,7 +109,7 @@
                 {include file="file:$centreon_path/www/include/common/templates/clone.ihtml" cloneId="pollercmd" cloneSet=$cloneSetCmd}
             </td>
         </tr>
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ns_activate"> {$form.ns_activate.label}</td><td class="FormRowValue">{$form.ns_activate.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="ns_activate"> {$form.ns_activate.label}</td><td class="FormRowValue">{$form.ns_activate.html}</td></tr>
 		{if $o == "a" || $o == "c"}
 		    <tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">{$form.required_note}</td></tr>
 		{/if}

--- a/www/include/configuration/configServers/formServers.ihtml
+++ b/www/include/configuration/configServers/formServers.ihtml
@@ -1,136 +1,131 @@
 {$form.javascript}
 <form {$form.attributes}>
-	<div id="validFormTop">
-	{if $o == "a" || $o == "c"}
-		<p class="oreonbutton">{$form.submitC.html}{$form.submitA.html}&nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
-	{else if $o == "w"}
-		<p class="oreonbutton">{$form.change.html}</p>
-	{/if}
-	</div>
-	<div id='tab1' class='tab'>
-	 <table class="formTable table">
-	 	<tr class="ListHeader">
-      <td class="FormHeader" colspan="2">
-        <h3>| {$form.header.title}</h3>
-      </td>
-    </tr>
+    <div id="validFormTop">
+    {if $o == "a" || $o == "c"}
+        <p class="oreonbutton">{$form.submitC.html}{$form.submitA.html}&nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
+    {else if $o == "w"}
+        <p class="oreonbutton">{$form.change.html}</p>
+    {/if}
+    </div>
+    <div id='tab1' class='tab'>
+    <table class="formTable table">
+        <tr class="ListHeader">
+            <td class="FormHeader" colspan="2">
+                <h3>| {$form.header.title}</h3>
+            </td>
+        </tr>
 	 	<tr class="list_lvl_1">
-      <td class="ListColLvl1_name" colspan="2">
-        <h4>{$form.header.Server_Informations}</h4>
-      </td>
-    </tr>
-		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="name"> {$form.name.label}</td><td class="FormRowValue">{$form.name.html}</td></tr>
-		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ns_ip_address"> {$form.ns_ip_address.label}</td><td class="FormRowValue">{$form.ns_ip_address.html}</td></tr>
-		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="localhost"> {$form.localhost.label}</td><td class="FormRowValue">{$form.localhost.html}</td></tr>
-		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="is_default"> {$form.is_default.label}</td><td class="FormRowValue">{$form.is_default.html}</td></tr>
-		{if $form.remote_id.label}
-		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="remote_id"> {$form.remote_id.label}</td><td class="FormRowValue">{$form.remote_id.html}</td></tr>
+            <td class="ListColLvl1_name" colspan="2">
+                <h4>{$form.header.Server_Informations}</h4>
+            </td>
+        </tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="name"> {$form.name.label}</td><td class="FormRowValue">{$form.name.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ns_ip_address"> {$form.ns_ip_address.label}</td><td class="FormRowValue">{$form.ns_ip_address.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="localhost"> {$form.localhost.label}</td><td class="FormRowValue">{$form.localhost.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="is_default"> {$form.is_default.label}</td><td class="FormRowValue">{$form.is_default.html}</td></tr>
+        {if $form.remote_id.label}
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="remote_id"> {$form.remote_id.label}</td><td class="FormRowValue">{$form.remote_id.html}</td></tr>
         <tr class="list_tow">
             <td class="FormRowField"><img class="helpTooltip" name="remote_additional_id"> {$form.remote_additional_id.label}</td>
             <td class="FormRowValue">{$form.remote_additional_id.html}</td>
         </tr>
-		{/if}
-    {if $form.header.Remote_Configuration.label}
-    <tr class="list_lvl_1">
-      <td class="ListColLvl1_name" colspan="2">
-          <h4>{$form.header.Remote_Configuration}</h4>
-      </td>
-      <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="http_method">{$form.http_method.label}</td><td class="FormRowValue">{$form.http_method.html}</td></tr>
-      <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="http_port">{$form.http_port.label}</td><td class="FormRowValue">{$form.http_port.html}</td></tr>
-      <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="no_check_certificate">{$form.no_check_certificate.label}</td><td class="FormRowValue">{$form.no_check_certificate.html}</td></tr>
-      <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="no_proxy">{$form.no_proxy.label}</td><td class="FormRowValue">{$form.no_proxy.html}</td></tr>
-    </tr>
-    {/if}
-		<tr class="list_lvl_1">
-      <td class="ListColLvl1_name" colspan="2">
-        <h4>{$form.header.gorgone_Informations}</h4>
-      </td>
-    </tr>
-		<tr class="list_one">
+        {/if}
+        {if $form.header.Remote_Configuration.label}
+        <tr class="list_lvl_1">
+            <td class="ListColLvl1_name" colspan="2">
+                <h4>{$form.header.Remote_Configuration}</h4>
+            </td>
+            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="http_method">{$form.http_method.label}</td><td class="FormRowValue">{$form.http_method.html}</td></tr>
+            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="http_port">{$form.http_port.label}</td><td class="FormRowValue">{$form.http_port.html}</td></tr>
+            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="no_check_certificate">{$form.no_check_certificate.label}</td><td class="FormRowValue">{$form.no_check_certificate.html}</td></tr>
+            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="no_proxy">{$form.no_proxy.label}</td><td class="FormRowValue">{$form.no_proxy.html}</td></tr>
+        </tr>
+        {/if}
+        <tr class="list_lvl_1">
+            <td class="ListColLvl1_name" colspan="2"><h4>{$form.header.gorgone_Informations}</h4></td>
+        </tr>
+        <tr class="list_one">
             <td class="FormRowField"><img class="helpTooltip" name="gorgone_communication_type"> {$form.gorgone_communication_type.label}</td>
             <td class="FormRowValue">{$form.gorgone_communication_type.html}</td>
         </tr>
-		<tr class="list_two">
+        <tr class="list_two">
             <td class="FormRowField"><img class="helpTooltip" name="gorgone_port"> {$form.gorgone_port.label}</td>
             <td class="FormRowValue">{$form.gorgone_port.html}</td>
         </tr>
-		{if $form.remote_server_use_as_proxy.label}
-		<tr class="list_two">
-		  <td class="FormRowField"><img class="helpTooltip" name="remote_server_use_as_proxy"> {$form.remote_server_use_as_proxy.label}</td>
-		  <td class="FormRowValue">{$form.remote_server_use_as_proxy.html}</td>
-		</tr>
-		{/if}
-		<tr class="list_lvl_1">
-      <td class="ListColLvl1_name" colspan="2">
-        <h4>{$form.header.Nagios_Informations}</h4>
-      </td>
-    </tr>
-    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_start_command"> {$form.engine_start_command.label}</td><td class="FormRowValue">{$form.engine_start_command.html}</td></tr>
-    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_stop_command"> {$form.engine_stop_command.label}</td><td class="FormRowValue">{$form.engine_stop_command.html}</td></tr>
-    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_restart_command"> {$form.engine_restart_command.label}</td><td class="FormRowValue">{$form.engine_restart_command.html}</td></tr>
-    <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="engine_reload_command"> {$form.engine_reload_command.label}</td><td class="FormRowValue">{$form.engine_reload_command.html}</td></tr>
-    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="nagios_bin"> {$form.nagios_bin.label}</td><td class="FormRowValue">{$form.nagios_bin.html}</td></tr>
-    <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="nagiostats_bin"> {$form.nagiostats_bin.label}</td><td class="FormRowValue">{$form.nagiostats_bin.html}</td></tr>
-    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="nagios_perfdata"> {$form.nagios_perfdata.label}</td><td class="FormRowValue">{$form.nagios_perfdata.html}</td></tr>
-    <tr class="list_lvl_1">
-      <td class="ListColLvl1_name" colspan="2">
-        <h4>{$form.header.CentreonBroker}</h4>
-      </td>
-    </tr>
-    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="broker_reload_command"> {$form.broker_reload_command.label}</td><td class="FormRowValue">{$form.broker_reload_command.html}</td></tr>
-    <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="centreonbroker_cfg_path"> {$form.centreonbroker_cfg_path.label}</td><td class="FormRowValue">{$form.centreonbroker_cfg_path.html}</td></tr>
-    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreonbroker_module_path"> {$form.centreonbroker_module_path.label}</td><td class="FormRowValue">{$form.centreonbroker_module_path.html}</td></tr>
-    <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="centreonbroker_logs_path"> {$form.centreonbroker_logs_path.label}</td><td class="FormRowValue">{$form.centreonbroker_logs_path.html}</td></tr>
-    <tr class="list_lvl_1">
-      <td class="ListColLvl1_name" colspan="2">
-        <h4>{$form.header.CentreonConnector}</h4>
-      </td>
-    </tr>
-		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreonconnector_path"> {$form.centreonconnector_path.label}</td><td class="FormRowValue">{$form.centreonconnector_path.html}</td></tr>
-		<tr class="list_lvl_1">
-      <td class="ListColLvl1_name" colspan="2">
-        <h4>{$form.header.Centreontrapd}</h4>
-      </td>
-    </tr>
-		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreontrapd_init_script"> {$form.init_script_centreontrapd.label}</td><td class="FormRowValue">{$form.init_script_centreontrapd.html}</td></tr>
-    <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="snmp_trapd_path_conf"> {$form.snmp_trapd_path_conf.label}</td><td class="FormRowValue">{$form.snmp_trapd_path_conf.html}</td></tr>
-		<tr class="list_lvl_1">
-      <td class="ListColLvl1_name" colspan="2">
-        <h4>{$form.header.Misc}</h4>
-      </td>
-    </tr>
+        {if $form.remote_server_use_as_proxy.label}
+        <tr class="list_two">
+            <td class="FormRowField"><img class="helpTooltip" name="remote_server_use_as_proxy"> {$form.remote_server_use_as_proxy.label}</td>
+            <td class="FormRowValue">{$form.remote_server_use_as_proxy.html}</td>
+        </tr>
+        {/if}
+        <tr class="list_lvl_1">
+            <td class="ListColLvl1_name" colspan="2"><h4>{$form.header.Nagios_Informations}</h4></td>
+        </tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_start_command"> {$form.engine_start_command.label}</td><td class="FormRowValue">{$form.engine_start_command.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_stop_command"> {$form.engine_stop_command.label}</td><td class="FormRowValue">{$form.engine_stop_command.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="engine_restart_command"> {$form.engine_restart_command.label}</td><td class="FormRowValue">{$form.engine_restart_command.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="engine_reload_command"> {$form.engine_reload_command.label}</td><td class="FormRowValue">{$form.engine_reload_command.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="nagios_bin"> {$form.nagios_bin.label}</td><td class="FormRowValue">{$form.nagios_bin.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="nagiostats_bin"> {$form.nagiostats_bin.label}</td><td class="FormRowValue">{$form.nagiostats_bin.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="nagios_perfdata"> {$form.nagios_perfdata.label}</td><td class="FormRowValue">{$form.nagios_perfdata.html}</td></tr>
+        <tr class="list_lvl_1">
+            <td class="ListColLvl1_name" colspan="2">
+                <h4>{$form.header.CentreonBroker}</h4>
+            </td>
+        </tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="broker_reload_command"> {$form.broker_reload_command.label}</td><td class="FormRowValue">{$form.broker_reload_command.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="centreonbroker_cfg_path"> {$form.centreonbroker_cfg_path.label}</td><td class="FormRowValue">{$form.centreonbroker_cfg_path.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreonbroker_module_path"> {$form.centreonbroker_module_path.label}</td><td class="FormRowValue">{$form.centreonbroker_module_path.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="centreonbroker_logs_path"> {$form.centreonbroker_logs_path.label}</td><td class="FormRowValue">{$form.centreonbroker_logs_path.html}</td></tr>
+        <tr class="list_lvl_1">
+            <td class="ListColLvl1_name" colspan="2">
+                <h4>{$form.header.CentreonConnector}</h4>
+            </td>
+        </tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreonconnector_path"> {$form.centreonconnector_path.label}</td><td class="FormRowValue">{$form.centreonconnector_path.html}</td></tr>
+        <tr class="list_lvl_1">
+            <td class="ListColLvl1_name" colspan="2">
+                <h4>{$form.header.Centreontrapd}</h4>
+            </td>
+        </tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreontrapd_init_script"> {$form.init_script_centreontrapd.label}</td><td class="FormRowValue">{$form.init_script_centreontrapd.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="snmp_trapd_path_conf"> {$form.snmp_trapd_path_conf.label}</td><td class="FormRowValue">{$form.snmp_trapd_path_conf.html}</td></tr>
+            <tr class="list_lvl_1">
+                <td class="ListColLvl1_name" colspan="2">
+                    <h4>{$form.header.Misc}</h4>
+                </td>
+            </tr>
 		<tr class="list_one">
-      <td class="FormRowField">
-          <img class="helpTooltip" name="pollercmd"> {t}Post-Restart command{/t}
-      </td>
-      <td class="FormRowValue">
-          {include file="file:$centreon_path/www/include/common/templates/clone.ihtml" cloneId="pollercmd" cloneSet=$cloneSetCmd}
-      </td>
-    </tr>
-    <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ns_activate"> {$form.ns_activate.label}</td><td class="FormRowValue">{$form.ns_activate.html}</td></tr>
+            <td class="FormRowField">
+                <img class="helpTooltip" name="pollercmd"> {t}Post-Restart command{/t}
+            </td>
+            <td class="FormRowValue">
+                {include file="file:$centreon_path/www/include/common/templates/clone.ihtml" cloneId="pollercmd" cloneSet=$cloneSetCmd}
+            </td>
+        </tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ns_activate"> {$form.ns_activate.label}</td><td class="FormRowValue">{$form.ns_activate.html}</td></tr>
 		{if $o == "a" || $o == "c"}
-			<tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">{$form.required_note}</td></tr>
+		    <tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">{$form.required_note}</td></tr>
 		{/if}
-	</table>
-	</div>
-	<div id="validForm">
-	{if $o == "a" || $o == "c"}
-		<p class="oreonbutton">{$form.submitC.html}{$form.submitA.html}&nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
-	{else if $o == "w"}
-		<p class="oreonbutton">{$form.change.html}</p>
-	{/if}
-	</div>
-	{$form.hidden}
+    </table>
+    </div>
+    <div id="validForm">
+    {if $o == "a" || $o == "c"}
+        <p class="oreonbutton">{$form.submitC.html}{$form.submitA.html}&nbsp;&nbsp;&nbsp;{$form.reset.html}</p>
+    {else if $o == "w"}
+        <p class="oreonbutton">{$form.change.html}</p>
+    {/if}
+    </div>
+    {$form.hidden}
 </form>
 <script type="text/javascript">
-var engines = {literal}{{/literal}
-{foreach name=engines from=$engines key=ename item=engine}
-  "{$ename}": {literal}{{/literal}
-{foreach name=engine from=$engine key=k item=v}
-    "{$k}": "{$v}"{if not $smarty.foreach.engine.last},{/if}
-{/foreach}
-  {literal}}{/literal}{if not $smarty.foreach.engines.last},{/if}
-
-{/foreach}
+    var engines = {literal}{{/literal}
+    {foreach name=engines from=$engines key=ename item=engine}
+        "{$ename}": {literal}{{/literal}
+        {foreach name=engine from=$engine key=k item=v}
+            "{$k}": "{$v}"{if not $smarty.foreach.engine.last},{/if}
+        {/foreach}
+        {literal}}{/literal}{if not $smarty.foreach.engines.last},{/if}
+    {/foreach}
 </script>
 {$helptext}

--- a/www/include/configuration/configServers/formServers.ihtml
+++ b/www/include/configuration/configServers/formServers.ihtml
@@ -41,6 +41,7 @@
             <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="no_proxy">{$form.no_proxy.label}</td><td class="FormRowValue">{$form.no_proxy.html}</td></tr>
         </tr>
         {/if}
+        {if $form.header.gorgone_Informations.lable}
         <tr class="list_lvl_1">
             <td class="ListColLvl1_name" colspan="2"><h4>{$form.header.gorgone_Informations}</h4></td>
         </tr>
@@ -52,6 +53,7 @@
             <td class="FormRowField"><img class="helpTooltip" name="gorgone_port"> {$form.gorgone_port.label}</td>
             <td class="FormRowValue">{$form.gorgone_port.html}</td>
         </tr>
+        {/if}
         {if $form.remote_server_use_as_proxy.label}
         <tr class="list_two">
             <td class="FormRowField"><img class="helpTooltip" name="remote_server_use_as_proxy"> {$form.remote_server_use_as_proxy.label}</td>
@@ -127,5 +129,6 @@
         {/foreach}
         {literal}}{/literal}{if not $smarty.foreach.engines.last},{/if}
     {/foreach}
+    {literal}}{/literal}
 </script>
 {$helptext}

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -62,14 +62,14 @@ $nagios = array();
 $selectedAdditionnalRS = null;
 $serverType = "poller";
 if (($o == SERVER_MODIFY || $o == SERVER_WATCH) && $server_id) {
-    $DBRESULT = $pearDB->query("SELECT * FROM `nagios_server` WHERE `id` = '$server_id' LIMIT 1");
-    $cfg_server = array_map("myDecode", $DBRESULT->fetchRow());
-    $DBRESULT->closeCursor();
+    $dbResult = $pearDB->query("SELECT * FROM `nagios_server` WHERE `id` = '$server_id' LIMIT 1");
+    $cfg_server = array_map("myDecode", $dbResult->fetch());
+    $dbResult->closeCursor();
 
     $query = 'SELECT ip FROM remote_servers';
-    $DBRESULT = $pearDB->query($query);
-    $remotesServerIPs = $DBRESULT->fetchAll(PDO::FETCH_COLUMN);
-    $DBRESULT->closeCursor();
+    $dbResult = $pearDB->query($query);
+    $remotesServerIPs = $dbResult->fetchAll(PDO::FETCH_COLUMN);
+    $dbResult->closeCursor();
 
     if ($cfg_server['localhost']) {
         $serverType = "central";
@@ -78,9 +78,11 @@ if (($o == SERVER_MODIFY || $o == SERVER_WATCH) && $server_id) {
     }
 
     if ($serverType === "remote") {
-        $statement = $pearDB->prepare("SELECT http_method, http_port, no_check_certificate, no_proxy
+        $statement = $pearDB->prepare(
+            "SELECT http_method, http_port, no_check_certificate, no_proxy
             FROM `remote_servers`
-            WHERE `ip` = :ns_ip_address LIMIT 1");
+            WHERE `ip` = :ns_ip_address LIMIT 1"
+        );
         $statement->bindParam(':ns_ip_address', $cfg_server['ns_ip_address'], \PDO::PARAM_STR);
         $statement->execute();
 
@@ -124,11 +126,11 @@ $cdata->addJsData('clone-count-pollercmd', count($cmdArray));
  * nagios servers comes from DB
  */
 $nagios_servers = array();
-$DBRESULT = $pearDB->query("SELECT * FROM `nagios_server` ORDER BY name");
-while ($nagios_server = $DBRESULT->fetchRow()) {
+$dbResult = $pearDB->query("SELECT * FROM `nagios_server` ORDER BY name");
+while ($nagios_server = $dbResult->fetch()) {
     $nagios_servers[$nagios_server["id"]] = $nagios_server["name"];
 }
-$DBRESULT->closeCursor();
+$dbResult->closeCursor();
 
 $attrsText = array("size" => "30");
 $attrsText2 = array("size" => "50");

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -452,9 +452,8 @@ if ($valid) {
             jQuery('#gorgoneData').fadeOut({duration: 0});
         }
     }
-    // check current gorgone fields visibility
+    // init current gorgone fields visibility
     displayGorgoneParam(<?= !$cfg_server['localhost'] ? "true" : "false" ?>)
-
 
     jQuery("#remote_additional_id").centreonSelect2({
         select2: {
@@ -523,6 +522,4 @@ if ($valid) {
             jQuery('#remote_additional_id').trigger('change');
         }
     });
-
-
 </script>

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -234,14 +234,11 @@ $form->addElement('text', 'nagios_bin', _("Monitoring Engine Binary"), $attrsTex
 $form->addElement('text', 'nagiostats_bin', _("Monitoring Engine Statistics Binary"), $attrsText2);
 $form->addElement('text', 'nagios_perfdata', _("Perfdata file"), $attrsText2);
 
-// display gorgone fields only if not a central
-if (!$cfg_server['localhost']) {
-    $tab = array();
-    $tab[] = $form->createElement('radio', 'gorgone_communication_type', null, _("ZMQ"), ZMQ);
-    $tab[] = $form->createElement('radio', 'gorgone_communication_type', null, _("SSH"), SSH);
-    $form->addGroup($tab, 'gorgone_communication_type', _("Gorgone connection protocol"), '&nbsp;');
-    $form->addElement('text', 'gorgone_port', _("Gorgone connection port"), $attrsText3);
-}
+$tab = array();
+$tab[] = $form->createElement('radio', 'gorgone_communication_type', null, _("ZMQ"), ZMQ);
+$tab[] = $form->createElement('radio', 'gorgone_communication_type', null, _("SSH"), SSH);
+$form->addGroup($tab, 'gorgone_communication_type', _("Gorgone connection protocol"), '&nbsp;');
+$form->addElement('text', 'gorgone_port', _("Gorgone connection port"), $attrsText3);
 
 $tab = array();
 $tab[] = $form->createElement('radio', 'localhost', null, _("Yes"), '1');

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -177,10 +177,7 @@ if ($o == SERVER_ADD) {
  * Headers
  */
 $form->addElement('header', 'Server_Informations', _("Server Information"));
-// display gorgone fields only if not a central
-if (!$cfg_server['localhost']) {
-    $form->addElement('header', 'gorgone_Informations', _("Gorgone Information"));
-}
+$form->addElement('header', 'gorgone_Informations', _("Gorgone Information"));
 $form->addElement('header', 'Nagios_Informations', _("Monitoring Engine Information"));
 $form->addElement('header', 'Misc', _("Miscelleneous"));
 $form->addElement('header', 'Centreontrapd', _("Centreon Trap Collector"));
@@ -241,8 +238,22 @@ $form->addGroup($tab, 'gorgone_communication_type', _("Gorgone connection protoc
 $form->addElement('text', 'gorgone_port', _("Gorgone connection port"), $attrsText3);
 
 $tab = array();
-$tab[] = $form->createElement('radio', 'localhost', null, _("Yes"), '1');
-$tab[] = $form->createElement('radio', 'localhost', null, _("No"), '0');
+$tab[] = $form->createElement(
+    'radio',
+    'localhost',
+    null,
+    _("Yes"),
+    '1',
+    array('onclick' => "displayGorgoneParam(false);")
+);
+$tab[] = $form->createElement(
+    'radio',
+    'localhost',
+    null,
+    _("No"),
+    '0',
+    array('onclick' => "displayGorgoneParam(true);")
+);
 $form->addGroup($tab, 'localhost', _("Localhost ?"), '&nbsp;');
 
 $tab = array();
@@ -433,6 +444,18 @@ if ($valid) {
 
 ?>
 <script type='text/javascript'>
+    // toggle gorgone port and communication mode fields
+    function displayGorgoneParam(checkValue) {
+        if (checkValue === true) {
+            jQuery('#gorgoneData').fadeIn({duration: 0});
+        } else {
+            jQuery('#gorgoneData').fadeOut({duration: 0});
+        }
+    }
+    // check current gorgone fields visibility
+    displayGorgoneParam(<?= !$cfg_server['localhost'] ? "true" : "false" ?>)
+
+
     jQuery("#remote_additional_id").centreonSelect2({
         select2: {
             ajax: {
@@ -500,4 +523,6 @@ if ($valid) {
             jQuery('#remote_additional_id').trigger('change');
         }
     });
+
+
 </script>

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -91,11 +91,13 @@ if (($o == SERVER_MODIFY || $o == SERVER_WATCH) && $server_id) {
     }
 
     if ($serverType === "poller") {
-        // Select additionnal Remote Servers
-        $statement = $pearDB->prepare("SELECT remote_server_id, name 
+        // Select additional Remote Servers
+        $statement = $pearDB->prepare(
+            "SELECT remote_server_id, name
             FROM rs_poller_relation AS rspr
             LEFT JOIN nagios_server AS ns ON (rspr.remote_server_id = ns.id)
-            WHERE poller_server_id = :poller_server_id");
+            WHERE poller_server_id = :poller_server_id"
+        );
         $statement->bindParam(':poller_server_id', $cfg_server['id'], \PDO::PARAM_INT);
         $statement->execute();
 
@@ -115,7 +117,7 @@ if (($o == SERVER_MODIFY || $o == SERVER_WATCH) && $server_id) {
  * Preset values of misc commands
  */
 $cdata = CentreonData::getInstance();
-$cmdArray = $instanceObj->getCommandsFromPollerId(isset($server_id) ? $server_id : null);
+$cmdArray = $instanceObj->getCommandsFromPollerId($server_id ?? null);
 $cdata->addJsData('clone-values-pollercmd', htmlspecialchars(
     json_encode($cmdArray),
     ENT_QUOTES
@@ -175,7 +177,10 @@ if ($o == SERVER_ADD) {
  * Headers
  */
 $form->addElement('header', 'Server_Informations', _("Server Information"));
-$form->addElement('header', 'gorgone_Informations', _("Gorgone Information"));
+// display gorgone fields only if not a central
+if (!$cfg_server['localhost']) {
+    $form->addElement('header', 'gorgone_Informations', _("Gorgone Information"));
+}
 $form->addElement('header', 'Nagios_Informations', _("Monitoring Engine Information"));
 $form->addElement('header', 'Misc', _("Miscelleneous"));
 $form->addElement('header', 'Centreontrapd', _("Centreon Trap Collector"));
@@ -229,11 +234,14 @@ $form->addElement('text', 'nagios_bin', _("Monitoring Engine Binary"), $attrsTex
 $form->addElement('text', 'nagiostats_bin', _("Monitoring Engine Statistics Binary"), $attrsText2);
 $form->addElement('text', 'nagios_perfdata', _("Perfdata file"), $attrsText2);
 
-$tab = array();
-$tab[] = $form->createElement('radio', 'gorgone_communication_type', null, _("ZMQ"), ZMQ);
-$tab[] = $form->createElement('radio', 'gorgone_communication_type', null, _("SSH"), SSH);
-$form->addGroup($tab, 'gorgone_communication_type', _("Gorgone connection protocol"), '&nbsp;');
-$form->addElement('text', 'gorgone_port', _("Gorgone connection port"), $attrsText3);
+// display gorgone fields only if not a central
+if (!$cfg_server['localhost']) {
+    $tab = array();
+    $tab[] = $form->createElement('radio', 'gorgone_communication_type', null, _("ZMQ"), ZMQ);
+    $tab[] = $form->createElement('radio', 'gorgone_communication_type', null, _("SSH"), SSH);
+    $form->addGroup($tab, 'gorgone_communication_type', _("Gorgone connection protocol"), '&nbsp;');
+    $form->addElement('text', 'gorgone_port', _("Gorgone connection port"), $attrsText3);
+}
 
 $tab = array();
 $tab[] = $form->createElement('radio', 'localhost', null, _("Yes"), '1');

--- a/www/include/configuration/configServers/servers.php
+++ b/www/include/configuration/configServers/servers.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2019 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under


### PR DESCRIPTION
# Pull Request Template

## Description

1- 
gorgone data shouldn't be displayed on the central poller configuration form.
This PR is intended to hide these options when the localhost parameter has been set.

Before :
![image](https://user-images.githubusercontent.com/34628915/71355085-38f66400-257e-11ea-891d-84d916106d46.png)

After : 
![image](https://user-images.githubusercontent.com/34628915/71355096-427fcc00-257e-11ea-8775-41255fda28bc.png)


2- 
Correct the error in the browser console (legacy)
![image](https://user-images.githubusercontent.com/34628915/71355057-2a0fb180-257e-11ea-8d38-3288576242a2.png)

**Fixes** # (VF MON-4509)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

check the sreenshots above

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
