### PR TITLE
fix(clapi): use downtime_id to show and cancel rtdowntimes (master)

### DIFF
--- a/lib/Centreon/Object/Downtime/RtDowntime.php
+++ b/lib/Centreon/Object/Downtime/RtDowntime.php
@@ -59,7 +59,7 @@ class Centreon_Object_RtDowntime extends Centreon_ObjectRt
             $hostFilter = "AND h.name IN ('" . implode("','", $hostList) . "') ";
         }
 
-        $query = "SELECT internal_id, name, author, actual_start_time , actual_end_time, " .
+        $query = "SELECT downtime_id, name, author, actual_start_time , actual_end_time, " .
             "start_time, end_time, comment_data, duration, fixed " .
             "FROM downtimes d, hosts h " .
             "WHERE d.host_id = h.host_id " .
@@ -91,7 +91,7 @@ class Centreon_Object_RtDowntime extends Centreon_ObjectRt
             $serviceFilter .= implode(' AND ', $filterTab) . ') ';
         }
 
-        $query = "SELECT d.internal_id, h.name, s.description, author, actual_start_time, actual_end_time, " .
+        $query = "SELECT d.downtime_id, h.name, s.description, author, actual_start_time, actual_end_time, " .
             "start_time, end_time, comment_data, duration, fixed " .
             "FROM downtimes d, hosts h, services s " .
             "WHERE d.service_id = s.service_id " .
@@ -113,7 +113,7 @@ class Centreon_Object_RtDowntime extends Centreon_ObjectRt
     public function getCurrentDowntime($id)
     {
         $query = "SELECT * FROM downtimes WHERE ISNULL(actual_end_time) " .
-            " AND end_time > " . time() . " AND internal_id = " . $id;
+            " AND end_time > " . time() . " AND downtime_id = " . $id;
         return $this->getResult($query, array(), 'fetch');
     }
 }

--- a/www/class/centreon-clapi/centreonRtDowntime.class.php
+++ b/www/class/centreon-clapi/centreonRtDowntime.class.php
@@ -227,7 +227,7 @@ class CentreonRtDowntime extends CentreonObject
      */
     public function showHost($hostList)
     {
-        $unknownHost = array();
+        $unknownHost = [];
 
         $fields = array(
             'id',

--- a/www/class/centreon-clapi/centreonRtDowntime.class.php
+++ b/www/class/centreon-clapi/centreonRtDowntime.class.php
@@ -227,6 +227,8 @@ class CentreonRtDowntime extends CentreonObject
      */
     public function showHost($hostList)
     {
+        $unknownHost = array();
+
         $fields = array(
             'id',
             'host_name',
@@ -252,7 +254,6 @@ class CentreonRtDowntime extends CentreonObject
             );
 
             // check if host exist
-            $unknownHost = array();
             $existingHost = array();
             foreach ($hostList as $host) {
                 if ($this->hostObject->getHostID($host) == 0) {
@@ -750,10 +751,16 @@ class CentreonRtDowntime extends CentreonObject
                 $infoDowntime = $this->object->getCurrentDowntime($downtime);
                 if ($infoDowntime) {
                     $hostName = $this->hostObject->getHostName($infoDowntime['host_id']);
-                    if (is_null($infoDowntime['service_id'])) {
-                        $this->externalCmdObj->deleteDowntime('HOST', array($hostName . ';' . $downtime => 'on'));
+                    if ($infoDowntime['type'] == 2) {
+                        $this->externalCmdObj->deleteDowntime(
+                            'HOST',
+                            array($hostName . ';' . $infoDowntime['internal_id'] => 'on')
+                        );
                     } else {
-                        $this->externalCmdObj->deleteDowntime('SVC', array($hostName . ';' . $downtime => 'on'));
+                        $this->externalCmdObj->deleteDowntime(
+                            'SVC',
+                            array($hostName . ';' . $infoDowntime['internal_id'] => 'on')
+                        );
                     }
                 } else {
                     $unknownDowntime[] = $downtime;


### PR DESCRIPTION
## Description 

The CLAPI commands "-o RTDOWNTIME -a show -v "HOST"" and "-o RTDOWNTIME -a show -v "SVC"" use the internal_id for the downtimes, instead of the downtime_id which is unique.
Same for "-o RTDOWNTIME -a cancel".

This way, you cannot cancel the exact downtimes you want.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Add several downtimes on several hosts and services of several pollers
* Use CLAPI to list real-time downtimes
* Try to delete some of those downtimes using listed IDs
* You will delete the downtimes you want (The external commands in engine will use the internal_id)

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
