### PR TITLE
enh(admin): adapt broker stats page to new folder tree

### DIFF
--- a/www/include/Administration/brokerPerformance/brokerPerformance.php
+++ b/www/include/Administration/brokerPerformance/brokerPerformance.php
@@ -180,7 +180,7 @@ function parseStatsFile($statfile)
         }
 
         /* Create list of loaded modules */
-        if (preg_match('/module \/.*\/\d+\-(.*)\.so/', $key, $matches)) {
+        if (preg_match('/module\s*\/.*\/\d+\-(.*)\.so/', $key, $matches)) {
             $result['modules'][$matches[1]] = $json_stats[$key]['state'];
         }
     }
@@ -265,7 +265,7 @@ try {
     while ($row = $stmt->fetch()) {
         $statsfile = $row['cache_directory'] . '/' . $row['config_name'] . '-stats.json';
         if ($defaultPoller != $selectedPoller) {
-            $statsfile = _CENTREON_VARLIB_ . '/broker-stats/broker-stats-' . $selectedPoller . '.dat';
+            $statsfile = _CENTREON_CACHEDIR_ . '/broker-stats/' . $selectedPoller . '/' . $row['config_name'] . '.json';
         }
         if (!file_exists($statsfile) || !is_readable($statsfile)) {
             $perf_err[$row['config_name']] = _('Cannot open statistics file');


### PR DESCRIPTION
## Description

Adapt Broker statistics parsing to match new folder tree caused by Gorgone.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Go to 'Administration > Platform Status > Broker Statistics'
* Select any monitoring instance
* Broker statistics are displayed (if enabled)

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
