### PR TITLE
Convert LDAP attributes names to lowercase, fixes #8219

### DIFF
--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -1138,6 +1138,13 @@ class CentreonLdapAdmin
             if (is_array($value)) { //radio buttons
                 $value = $value[$key];
             }
+            // Make all attributes lowercase since ldap_get_entries
+            // converts them to lowercase.
+            if (in_array($key, array("alias", "user_name", "user_email", "user_pager",
+                "user_firstname", "user_lastname", "group_name", "group_member"))
+            ) {
+                $value = strtolower($value);
+            }
             if (isset($gopt[$key])) {
                 $query = "UPDATE `auth_ressource_info` 
                          SET `ari_value` = '" . $this->db->escape($value, false) . "' 


### PR DESCRIPTION
## Description
This makes all attribute names lowercase so that they will always match results returned by `ldap_get_entries`.

**Fixes** #8219

## Type of change
Patch fixing an issue (non-breaking change)


## Target serie
20.04.x (master)

<h2> How this pull request can be tested ? </h2>
Save a LDAP configuration with attributes containing uppercase attribute names.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**. (_not necessary here IMO_)
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Additional info
I don't think that this will break anything but I might be wrong, please let me know if I need to amend the code.

I didn't touch `user_group` because it is used within a filter and not after a call to `ldap_get_entries`:
https://github.com/centreon/centreon/blob/35c17fbf3eaa97e6fdae9c87d218eeb012e4e0f2/www/class/centreonLDAP.class.php#L485-L486