### PR TITLE
fix(doc): Remove Extended Settings paragraph for TP

### DIFF
--- a/doc/en/configuration_guide/timeperiod.rst
+++ b/doc/en/configuration_guide/timeperiod.rst
@@ -76,16 +76,4 @@ For each exceptional day, you will need to define a time period. The table below
 |     monday -2         |       00:00-24:00       |   All day every second to the last Monday of the month          |
 +-----------------------+-------------------------+-----------------------------------------------------------------+
 
-Extended Settings
-=================
-
-In the extended settings, it is possible to **include** or to **exclude** periods in the definition of the object. 
-
-Example of application: Let us take two time periods:
-
-* One period is defined as 24 hours a day / 7 days a week, called **24x7**
-* Another which covers the office opening hours, called **working_hours**
-
-To obtain the office closing hours, we simply have to create a time period in which we include the period **24x7** and from which we exclude the **working_hours** period.
-
 .. |navigate_plus|      image:: /images/navigate_plus.png

--- a/doc/fr/configuration_guide/timeperiod.rst
+++ b/doc/fr/configuration_guide/timeperiod.rst
@@ -78,15 +78,4 @@ Par journée exceptionnelle, vous devez définir une plage horaire. Le tableau c
 |     monday -2         |       00:00-24:00       |   Tous les avant derniers lundi du mois toute la journée        |
 +-----------------------+-------------------------+-----------------------------------------------------------------+
 
-Options avancées
-================
-
-Au sein des options avancées, il est possible d'**inclure** ou d'**exclure** des périodes à la définition de l'objet.
-Exemple d'application. Prenons deux périodes temporelles :
-
-* Une période est définie 24 heures sur 24 / 7 jours sur 7 appelée **24x7**
-* Une autre qui regroupe les horaires d'ouvertures du bureau appelée **working_hours**
-
-Pour obtenir les horaires de fermeture du bureau, je n'ai qu'à créer une période temporelle dans laquelle j'inclus la plage **24x7** et pour laquelle j'exclus la plage **working_hours**.
-
 .. |navigate_plus|	image:: /images/navigate_plus.png


### PR DESCRIPTION
## Description

This tab doesn't exist anymore in "Configuration > Users > Time Periods" menu

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)
