### PR TITLE
enh(ui): Add nowrap style to badge class to avoid wrap in dense typeface environments like chinese.

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -548,6 +548,7 @@ p.description a, p.description a:visited {
     font-size: 10px;
     font-weight: bold;
     text-transform: uppercase;
+    white-space: nowrap;
 }
 
 .badge a            {

--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -1580,7 +1580,7 @@ div.update_readme,div.update_output {background-color:#FFF;border:1px #AEAEAE so
 
 .ListColFooterRight,.ListColFooterLeft,.ListColFooterCenter {border-top-style:solid;border-top-width:0.1px;}
 
-.ListColNoWrap                          {white-space:normal;}
+.ListColNoWrap                          {white-space:nowrap;}
 .ListColFooter1                         {padding:1px 3px;}
 .ListColFooterLeft, .ListColLeft                {text-align:left;}
 .ListColCenter,.ListColLeft,.ListColRight,.ListColNoWrap    {padding:1px 3px;}


### PR DESCRIPTION
## Description
Before add nowrap style: 
The status column text (chinese word) wrapped undesired.
![image](https://user-images.githubusercontent.com/33437974/71546153-d9a9b100-29ce-11ea-806a-d6b5eef3a27e.png)

After:
The status column text unwrapped.
![image](https://user-images.githubusercontent.com/33437974/71546114-820b4580-29ce-11ea-8c87-264f0f208d41.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
