### PR TITLE
fix(doc): remove obsolete paragraph - #8176

### DIFF
--- a/doc/en/faq/performance.rst
+++ b/doc/en/faq/performance.rst
@@ -187,12 +187,6 @@ Enable process and set unix socket path:
 .. image:: /images/faq/rrd_file_generator.png
     :align: center
 
-Centreon web interface
-**********************
-
-RRDCacheD don't update performances graphs in real time. If a blank range appears on right of performances graphs it
-means that cache are not yet written to disk.
-
 .. warning::
     If the **RRDCacheD process crash** (in theory because it's a stable process) data will be lost! It is not possible
     to get data unless rebuild all graphs from Centreon web.

--- a/doc/fr/faq/performance.rst
+++ b/doc/fr/faq/performance.rst
@@ -189,13 +189,6 @@ les fichiers RRD, sans l'onglet "Output" renseigner les données suivantes :
 .. image:: /images/faq/rrd_file_generator.png
     :align: center
 
-Interface web Centreon
-======================
-
-La mise en place de rrdcached fait que les graphiques ne sont plus mis à jours en temps réel.
-Il est donc possible de voir un petit blanc sur la droite de certains graphiques.
-Cela veut dire que les données sont encore dans le cache du processus, cela est normal !
-
 .. warning::
     Attention, si le **processus crash** pour une raison quelconque (aucune en théorie c'est plutôt stable), les
     **données** sont **perdues**, donc aucun moyen de les rejouer sauf en reconstruisant les graphiques via centreon-broker.


### PR DESCRIPTION
## Description

A paragraph in Centreon FAQ for RRDCacheD is obsolete because we implement a FLUSH command in order to display chart in UI.

**Fixes** #8176 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)
