### PR TITLE
fix(eventlogs): allow to filter on disabled objects

### DIFF
--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -1521,7 +1521,7 @@ class CentreonACL
         return $tab;
     }
 
-    public function getHostServices($pearDBMonitoring, $host_id, $withServiceDescription = null)
+    public function getHostServices($pearDBMonitoring, $host_id)
     {
         $tab = array();
         if ($this->admin) {

--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -1461,11 +1461,11 @@ class CentreonACL
      *
      * @return array
      */
-    public function getHostsServices($pearDBMonitoring, $withServiceDescription = null)
+    public function getHostsServices($pearDBMonitoring, $withServiceDescription = false)
     {
         $tab = [];
         if ($this->admin) {
-            $req = (!is_null($withServiceDescription)) ? ", s.service_description " : "";
+            $req = $withServiceDescription ? ", s.service_description " : "";
             $query = "SELECT h.host_id, s.service_id " . $req
                 . "FROM host h "
                 . "LEFT JOIN host_service_relation hsr on hsr.host_host_id = h.host_id "
@@ -1473,7 +1473,7 @@ class CentreonACL
                 . "WHERE h.host_register = '1' ";
             $result = \CentreonDBInstance::getConfInstance()->query($query);
             while ($row = $result->fetchRow()) {
-                if (!is_null($withServiceDescription)) {
+                if ($withServiceDescription) {
                     $tab[$row['host_id']][$row['service_id']] = $row['service_description'];
                 } else {
                     $tab[$row['host_id']][$row['service_id']] = 1;
@@ -1481,7 +1481,7 @@ class CentreonACL
             }
             $result->closeCursor();
             // Used By EventLogs page Only
-            if (!is_null($withServiceDescription)) {
+            if ($withServiceDescription) {
                 // Get Services attached to hostgroups
                 $query = "SELECT hgr.host_host_id, s.service_id, s.service_description "
                     . "FROM hostgroup_relation hgr, service s, host_service_relation hsr "
@@ -1494,7 +1494,7 @@ class CentreonACL
                 $result->closeCursor();
             }
         } else {
-            if (!is_null($withServiceDescription)) {
+            if ($withServiceDescription) {
                 $query = "SELECT acl.host_id, acl.service_id, s.description "
                     . "FROM centreon_acl acl "
                     . "LEFT JOIN services s on acl.service_id = s.service_id "
@@ -1509,7 +1509,7 @@ class CentreonACL
 
             $result = $pearDBMonitoring->query($query);
             while ($row = $result->fetchRow()) {
-                if (!is_null($withServiceDescription)) {
+                if ($withServiceDescription) {
                     $tab[$row['host_id']][$row['service_id']] = $row['description'];
                 } else {
                     $tab[$row['host_id']][$row['service_id']] = 1;

--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -1470,8 +1470,7 @@ class CentreonACL
                 . "FROM host h "
                 . "LEFT JOIN host_service_relation hsr on hsr.host_host_id = h.host_id "
                 . "LEFT JOIN service s on hsr.service_service_id = s.service_id "
-                . "WHERE h.host_activate = '1' "
-                . "AND (s.service_activate = '1' OR s.service_id is null) ";
+                . "WHERE h.host_register = '1' ";
             $result = \CentreonDBInstance::getConfInstance()->query($query);
             while ($row = $result->fetchRow()) {
                 if (!is_null($withServiceDescription)) {

--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -1455,42 +1455,47 @@ class CentreonACL
     /**
      * Function that returns the pair host/service by ID if $host_id is NULL
      *  Otherwise, it returns all the services of a specific host
+     *
+     * @param CentreonDB $pearDBMonitoring access to centreon_storage database
+     * @param Boolean $withServiceDescription to retrieve description of services
+     *
+     * @return array
      */
-    public function getHostsServices($pearDBMonitoring, $get_service_description = null)
+    public function getHostsServices($pearDBMonitoring, $withServiceDescription = null)
     {
-        $tab = array();
+        $tab = [];
         if ($this->admin) {
-            $req = (!is_null($get_service_description)) ? ", s.service_description " : "";
+            $req = (!is_null($withServiceDescription)) ? ", s.service_description " : "";
             $query = "SELECT h.host_id, s.service_id " . $req
                 . "FROM host h "
                 . "LEFT JOIN host_service_relation hsr on hsr.host_host_id = h.host_id "
                 . "LEFT JOIN service s on hsr.service_service_id = s.service_id "
                 . "WHERE h.host_activate = '1' "
                 . "AND (s.service_activate = '1' OR s.service_id is null) ";
-            $DBRESULT = \CentreonDBInstance::getConfInstance()->query($query);
-            while ($row = $DBRESULT->fetchRow()) {
-                if (!is_null($get_service_description)) {
+            $result = \CentreonDBInstance::getConfInstance()->query($query);
+            while ($row = $result->fetchRow()) {
+                if (!is_null($withServiceDescription)) {
                     $tab[$row['host_id']][$row['service_id']] = $row['service_description'];
                 } else {
                     $tab[$row['host_id']][$row['service_id']] = 1;
                 }
             }
-            $DBRESULT->closeCursor();
+            $result->closeCursor();
             // Used By EventLogs page Only
-            if (!is_null($get_service_description)) {
+            if (!is_null($withServiceDescription)) {
                 // Get Services attached to hostgroups
                 $query = "SELECT hgr.host_host_id, s.service_id, s.service_description "
                     . "FROM hostgroup_relation hgr, service s, host_service_relation hsr "
                     . "WHERE hsr.hostgroup_hg_id = hgr.hostgroup_hg_id "
                     . "AND s.service_id = hsr.service_service_id ";
-                $DBRESULT = \CentreonDBInstance::getConfInstance()->query($query);
-                while ($elem = $DBRESULT->fetchRow()) {
+                $result = \CentreonDBInstance::getConfInstance()->query($query);
+                while ($elem = $result->fetchRow()) {
                     $tab[$elem['host_host_id']][$elem["service_id"]] = $elem["service_description"];
                 }
-                $DBRESULT->closeCursor();
+                $result->closeCursor();
             }
         } else {
-            if (!is_null($get_service_description)) {
+            if (!is_null($withServiceDescription)) {
                 $query = "SELECT acl.host_id, acl.service_id, s.description "
                     . "FROM centreon_acl acl "
                     . "LEFT JOIN services s on acl.service_id = s.service_id "
@@ -1503,21 +1508,21 @@ class CentreonACL
                     . "GROUP BY host_id, service_id ";
             }
 
-            $DBRESULT = $pearDBMonitoring->query($query);
-            while ($row = $DBRESULT->fetchRow()) {
-                if (!is_null($get_service_description)) {
+            $result = $pearDBMonitoring->query($query);
+            while ($row = $result->fetchRow()) {
+                if (!is_null($withServiceDescription)) {
                     $tab[$row['host_id']][$row['service_id']] = $row['description'];
                 } else {
                     $tab[$row['host_id']][$row['service_id']] = 1;
                 }
             }
-            $DBRESULT->closeCursor();
+            $result->closeCursor();
         }
 
         return $tab;
     }
 
-    public function getHostServices($pearDBMonitoring, $host_id, $get_service_description = null)
+    public function getHostServices($pearDBMonitoring, $host_id, $withServiceDescription = null)
     {
         $tab = array();
         if ($this->admin) {


### PR DESCRIPTION
## Description

If you disable a service and you try to filter on it in "Monitoring > Event Logs > Event Logs", this filter is not used

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

On a platform with event
Disable a service
Go to "Monitoring > Event Logs > Event Logs" menu
Select this service in "Services" filter
Select a period
Click on "Apply period"
You must see event regarding your filter

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
