### PR TITLE
fix: servicegroup details displayed status

### DIFF
--- a/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2020 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -206,7 +206,7 @@ if ($numRows > 0) {
     $query2 = "SELECT SQL_CALC_FOUND_ROWS DISTINCT sg.name AS sg_name,
         sg.name AS alias,
         h.name AS host_name,
-        h.state as host_state,
+        h.state AS host_state,
         h.icon_image, h.host_id, s.state, s.description, s.service_id,
         (CASE s.state WHEN 0 THEN 3 WHEN 2 THEN 0 WHEN 3 THEN 2 ELSE s.state END) AS tri
         FROM servicegroups sg, services_servicegroups sgm, services s, hosts h ";
@@ -217,6 +217,7 @@ if ($numRows > 0) {
 
     $query2 .= "WHERE sgm.servicegroup_id = sg.servicegroup_id
         AND sgm.host_id = h.host_id
+        AND h.host_id = s.host_id
         AND sgm.service_id = s.service_id ";
 
     // filter elements with acl (host, service, servicegroup)

--- a/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
+++ b/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
@@ -76,7 +76,7 @@ $obj->setInstanceHistory($instance);
 
 $_SESSION['monitoring_service_groups'] = $sgSearch;
 
-// Prepare pagination
+// Filter on state
 $s_search = "";
 
 // Display service problems
@@ -104,6 +104,7 @@ if (!$obj->is_admin) {
 
 $query .= "WHERE sgm.servicegroup_id = sg.servicegroup_id
     AND sgm.host_id = h.host_id
+    AND h.host_id = s.host_id
     AND sgm.service_id = s.service_id ";
 
 // filter elements with acl (host, service, servicegroup)
@@ -133,10 +134,7 @@ if ($hSearch != "") {
         \PDO::PARAM_STR => "%" . $hSearch . "%"
     ];
 }
-$query .= $h_search;
-
-// Service search
-$query .= $s_search;
+$query .= $h_search . $s_search;
 
 // Poller search
 if ($instance != -1) {


### PR DESCRIPTION
# Pull Request Template

## Description

- Correct displayed services status
When multiples host are linked to a same service in the servicegroup and only one host is still enabled, the status displayed in the detail view of the servicegroup is false.

![image](https://user-images.githubusercontent.com/34628915/72163273-d1387980-33c3-11ea-8d5c-87f9be6ae70f.png)



- Correct pagination
The pagination displays unconsistent number of services. 

![image](https://user-images.githubusercontent.com/34628915/72163132-8880c080-33c3-11ea-8878-4bf28e59c601.png)


**Fixes** # (support)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
