### PR TITLE
fix(helper) fix path of the check command

### DIFF
--- a/www/include/configuration/configObject/command/minHelpCommand.php
+++ b/www/include/configuration/configObject/command/minHelpCommand.php
@@ -67,7 +67,7 @@ if ($commandId != null) {
     $prepare->execute();
     $resource = $prepare->fetch();
     //Match if the first part of the path is a MACRO
-    if ($prepare->rowCount()) {
+    if ($resource = $prepare->fetch()) {
         $resourcePath = $resource["resource_line"];
         unset($aCmd[0]);
         $command = rtrim($resourcePath, "/") . "#S#" . implode("#S#", $aCmd);

--- a/www/include/configuration/configObject/command/minHelpCommand.php
+++ b/www/include/configuration/configObject/command/minHelpCommand.php
@@ -48,10 +48,8 @@ $commandName = filter_var(
 );
 
 if ($commandId != null) {
-    /*
-     * Get command information
-     */
-    $sth = $pearDB->prepare("SELECT * FROM `command` WHERE `command_id` = :command_id LIMIT 1");
+    //Get command information
+    $sth = $pearDB->prepare('SELECT * FROM `command` WHERE `command_id` = :command_id LIMIT 1');
     $sth->bindParam(':command_id', $commandId, PDO::PARAM_INT);
     $sth->execute();
     $cmd = $sth->fetch();
@@ -61,22 +59,15 @@ if ($commandId != null) {
     $fullLine = $aCmd[0];
     $aCmd = explode("/", $fullLine);
     $resourceInfo = $aCmd[0];
-    $resourceDef = str_replace('$', '@DOLLAR@', $resourceInfo);
 
-    /*
-     * Match if the first part of the path is a MACRO
-     */
-    if (preg_match("/@DOLLAR@USER([0-9]+)@DOLLAR@/", $resourceDef, $matches)) {
-        /*
-         * Select Resource line
-         */
-        $query = "SELECT `resource_line` FROM `cfg_resource` " .
-            "WHERE `resource_name` = '\$USER" . $matches[1] . "\$' LIMIT 1";
-        $sth = $pearDB->query($query);
-
-        $resource = $sth->fetch();
-        unset($sth);
-
+    $prepare = $pearDB->prepare(
+        'SELECT `resource_line` FROM `cfg_resource` WHERE `resource_name` = :resource LIMIT 1'
+    );
+    $prepare->bindValue(':resource', $resourceInfo, \PDO::PARAM_STR);
+    $prepare->execute();
+    $resource = $prepare->fetch();
+    //Match if the first part of the path is a MACRO
+    if ($prepare->rowCount()) {
         $resourcePath = $resource["resource_line"];
         unset($aCmd[0]);
         $command = rtrim($resourcePath, "/") . "#S#" . implode("#S#", $aCmd);
@@ -90,26 +81,10 @@ if ($commandId != null) {
 $command = str_replace("#S#", "/", $command);
 $command = str_replace("#BS#", "\\", $command);
 
-if (strncmp($command, "/usr/lib/nagios/", strlen("/usr/lib/nagios/"))) {
-    if (is_dir("/usr/lib64/nagios/")) {
-        $command = str_replace("/usr/lib/nagios/plugins/", "/usr/lib64/nagios/plugins/", $command);
-        $oreon->optGen["nagios_path_plugins"] = str_replace(
-            "/usr/lib/nagios/plugins/",
-            "/usr/lib64/nagios/plugins/",
-            $oreon->optGen["nagios_path_plugins"]
-        );
-    }
-}
-
 $tab = explode(' ', $command);
-if (strncmp(realpath($tab[0]), $oreon->optGen["nagios_path_plugins"], strlen($oreon->optGen["nagios_path_plugins"]))) {
-    $msg = _('Error: Cannot Execute this command due to a path security problem.');
-    $command = realpath($tab[0]);
-} else {
-    $command = realpath($tab[0]);
-    $stdout = shell_exec(realpath($tab[0]) . " --help");
-    $msg = str_replace("\n", "<br />", $stdout);
-}
+$command = realpath($tab[0]);
+$stdout = shell_exec($command . " --help 2>&1");
+$msg = str_replace("\n", "<br />", $stdout);
 
 $attrsText = array("size" => "25");
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);

--- a/www/include/configuration/configObject/command/minHelpCommand.php
+++ b/www/include/configuration/configObject/command/minHelpCommand.php
@@ -65,7 +65,6 @@ if ($commandId != null) {
     );
     $prepare->bindValue(':resource', $resourceInfo, \PDO::PARAM_STR);
     $prepare->execute();
-    $resource = $prepare->fetch();
     //Match if the first part of the path is a MACRO
     if ($resource = $prepare->fetch()) {
         $resourcePath = $resource["resource_line"];


### PR DESCRIPTION

## Description

Macro problem, replace only $USERx$
Path problem, execute only plugins in /usr/lib64/nagios/plugins/

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

    Go to 'Configuration > Services > Templates'
    Select a command in 'Check Command' field
    Click on the :info: icon
    Popup will always display "Error: Cannot Execute this command due to a path security problem."

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
