### PR TITLE
fix(filters): save service state filters to get consistent data on refresh

### DIFF
--- a/www/include/monitoring/status/Common/setHistory.php
+++ b/www/include/monitoring/status/Common/setHistory.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -33,7 +33,7 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . "/../../../../../config/centreon.config.php");
+require_once realpath(__DIR__ . "/../../../../../config/centreon.config.php");
 
 $path = _CENTREON_PATH_ . "/www";
 require_once("$path/class/centreon.class.php");

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -422,7 +422,7 @@ if (isset($myinputsGet['o'])) {
     $defaultStatusService = $myinputsGet['o'];
 
     // data sent from topcounter using the URI
-    if ($myinputsGet['o'] === 'svc_ok' && isset($myinputsGet['statusService'])) {
+    if (defaultStatusService === 'svc_ok' && isset($myinputsGet['statusService'])) {
         $defaultStatusFilter = $myinputsGet['statusService'];
     } else {
         $defaultStatusFilter = '';

--- a/www/include/monitoring/status/Services/service.php
+++ b/www/include/monitoring/status/Services/service.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -54,7 +54,9 @@ $filterParameters = array(
     'monitoring_service_status_filter' => FILTER_SANITIZE_STRING,
     'monitoring_service_status' => FILTER_SANITIZE_STRING,
     'criticality_id' => FILTER_SANITIZE_NUMBER_INT,
-    'reset_filter' => FILTER_SANITIZE_NUMBER_INT
+    'reset_filter' => FILTER_SANITIZE_NUMBER_INT,
+    'o' => FILTER_SANITIZE_STRING,
+    'statusService' => FILTER_SANITIZE_STRING
 );
 
 $myinputsGet = filter_input_array(INPUT_GET, $filterParameters);
@@ -129,16 +131,12 @@ $GroupListofUser = array();
 $GroupListofUser = $centreon->user->access->getAccessGroups();
 
 $allActions = false;
-/*
- * Get list of actions allowed for user
- */
+// Get list of actions allowed for user
 if (count($GroupListofUser) > 0 && $is_admin == 0) {
     $authorized_actions = array();
     $authorized_actions = $centreon->user->access->getActions();
 } else {
-    /*
-     * if user is admin, or without ACL, he cans perform all actions
-     */
+    // if user is admin, or without ACL, he cans perform all actions
     $allActions = true;
 }
 
@@ -227,14 +225,6 @@ $tpl->assign("mon_status_information", _("Status information"));
 
 $tab_class = array("0" => "list_one", "1" => "list_two");
 $rows = 10;
-
-$sDefaultOrder = "0";
-
-if (!isset($_GET['o'])) {
-    $sSetOrderInMemory = "1";
-} else {
-    $sSetOrderInMemory = "0";
-}
 
 $form = new HTML_QuickFormCustom('select_form', 'GET', "?p=" . $p);
 
@@ -414,12 +404,6 @@ $form->addElement(
     $statusList,
     array('id' => 'statusFilter', 'onChange' => "filterStatus(this.value);")
 );
-if ((!isset($_GET['o']) || empty($_GET['o'])) && isset($_SESSION['monitoring_service_status_filter'])) {
-    $form->setDefaults(array('statusFilter' => $_SESSION['monitoring_service_status_filter']));
-    $sDefaultOrder = "1";
-}
-$defaultStatusFilter = $_GET['statusFilter'] ?? '';
-$defaultStatusService = $_GET['statusService'] ?? 'svc_unhandled';
 
 $form->addElement(
     'select',
@@ -429,15 +413,45 @@ $form->addElement(
     array('id' => 'statusService', 'onChange' => "statusServices(this.value);")
 );
 
-/* Get default service status by GET */
-if (isset($_GET['o']) && in_array($_GET['o'], array_keys($statusService))) {
-    $form->setDefaults(array('statusService' => $_GET['o']));
-    /* Get default service status in SESSION */
-} elseif ((!isset($_GET['o']) || empty($_GET['o'])) && isset($_SESSION['monitoring_service_status'])) {
-    $o = $_SESSION['monitoring_service_status'];
-    $form->setDefaults(array('statusService' => $_SESSION['monitoring_service_status']));
-    $sDefaultOrder = "1";
+$sDefaultOrder = "0";
+
+// Get default service status from REQUEST
+if (isset($myinputsGet['o'])) {
+    $sSetOrderInMemory = "0";
+
+    $defaultStatusService = $myinputsGet['o'];
+
+    // data sent from topcounter using the URI
+    if ($myinputsGet['o'] === 'svc_ok' && isset($myinputsGet['statusService'])) {
+        $defaultStatusFilter = $myinputsGet['statusService'];
+    } else {
+        $defaultStatusFilter = '';
+    }
+} else {
+    $sSetOrderInMemory = "1";
+
+    // service status filter
+    $defaultStatusService = $myinputsGet['statusService']
+        ?? $myinputsPost['statusService']
+        ?? $_SESSION['monitoring_service_status']
+        ?? 'svc_unhandled';
+
+    // chosen state filter
+    $defaultStatusFilter = $myinputsGet['statusFilter']
+        ?? $myinputsPost['statusFilter']
+        ?? $_SESSION['monitoring_service_status_filter']
+        ?? '';
+
+    if ($defaultStatusFilter === $_SESSION['monitoring_service_status_filter']) {
+        $sDefaultOrder = "1";
+    }
 }
+
+// saving chosen status
+$_SESSION['monitoring_service_status'] = $defaultStatusService;
+
+$form->setDefaults(array('statusService' => $defaultStatusService));
+$form->setDefaults(array('statusFilter' => $defaultStatusFilter));
 
 $criticality = new CentreonCriticality($pearDB);
 $crits = $criticality->getList(null, "level", 'ASC', null, null, true);

--- a/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2020 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -90,7 +90,12 @@ $hostToSearch = filter_input(INPUT_GET, 'search_host', FILTER_SANITIZE_STRING, [
 $outputToSearch = filter_input(INPUT_GET, 'search_output', FILTER_SANITIZE_STRING, ['options' => ['default' => '']]);
 $sortType = filter_input(INPUT_GET, 'sort_type', FILTER_SANITIZE_STRING, ['options' => ['default' => 'host_name']]);
 $order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
-$statusService = filter_input(INPUT_GET, 'statusService', FILTER_SANITIZE_STRING, ['options' => ['default' => '']]);
+$statusService = filter_input(
+    INPUT_GET,
+    'statusService',
+    FILTER_SANITIZE_STRING,
+    ['options' => ['default' => 'svc_unhandled']]
+);
 $statusFilter = filter_input(INPUT_GET, 'statusFilter', FILTER_SANITIZE_STRING, ['options' => ['default' => '']]);
 $dateFormat = "Y/m/d H:i:s";
 //if instance, hostgroup or servicegroup values are not set, displaying each active linked resources


### PR DESCRIPTION
# Pull Request Template

## Description

Save user's chosen serviceState and status filters to be able to keep current data when refreshing the page

![image](https://user-images.githubusercontent.com/34628915/72349357-ab211b00-36dc-11ea-9a69-28a7d8591e57.png)


**Fixes** # (support)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

On page "Monitoring  >  Status Details  >  Services"
The chosen service state and status should be saved and restored on a refresh of the page.

This PR isn't intended to override the slug of the URL.
ie : When you click on the topCounter, the URI is modified accordingly. So on a refresh, the user will lost the chosen service state and status overriden by the params in the slug.
eg : click on the topcounter "services OK" button -> the slug will override the state as "ALL" and the status as "OK".
![image](https://user-images.githubusercontent.com/34628915/72349845-93966200-36dd-11ea-8dd3-b6b818e68b7d.png)


## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
