### PR TITLE
Mon 4634 check command helper option

### DIFF
--- a/www/include/configuration/configObject/command/minHelpCommand.php
+++ b/www/include/configuration/configObject/command/minHelpCommand.php
@@ -67,9 +67,8 @@ if ($commandId != null) {
     );
     $prepare->bindValue(':resource', $resourceInfo, \PDO::PARAM_STR);
     $prepare->execute();
-    $resource = $prepare->fetch();
     //Match if the first part of the path is a MACRO
-    if ($prepare->rowCount()) {
+    if ($resource = $prepare->fetch()) {
         $resourcePath = $resource["resource_line"];
         unset($aCmd[0]);
         $command = rtrim($resourcePath, "/") . "#S#" . implode("#S#", $aCmd);

--- a/www/include/configuration/configObject/command/minHelpCommand.php
+++ b/www/include/configuration/configObject/command/minHelpCommand.php
@@ -57,6 +57,8 @@ if ($commandId != null) {
 
     $aCmd = explode(" ", $cmd["command_line"]);
     $fullLine = $aCmd[0];
+    $plugin = array_values(preg_grep('/^\-\-plugin\=(\w+)/i', $aCmd))[0];
+    $mode = array_values(preg_grep('/^\-\-mode\=(\w+)/i', $aCmd))[0];
     $aCmd = explode("/", $fullLine);
     $resourceInfo = $aCmd[0];
 
@@ -65,8 +67,9 @@ if ($commandId != null) {
     );
     $prepare->bindValue(':resource', $resourceInfo, \PDO::PARAM_STR);
     $prepare->execute();
+    $resource = $prepare->fetch();
     //Match if the first part of the path is a MACRO
-    if ($resource = $prepare->fetch()) {
+    if ($prepare->rowCount()) {
         $resourcePath = $resource["resource_line"];
         unset($aCmd[0]);
         $command = rtrim($resourcePath, "/") . "#S#" . implode("#S#", $aCmd);
@@ -81,8 +84,13 @@ $command = str_replace("#S#", "/", $command);
 $command = str_replace("#BS#", "\\", $command);
 
 $tab = explode(' ', $command);
-$command = realpath($tab[0]);
-$stdout = shell_exec($command . " --help 2>&1");
+if (realpath($tab[0])) {
+    $command = realpath($tab[0]) . ' ' . $plugin . ' ' . $mode . ' --help';
+} else {
+    $command = $tab[0] . ' ' . $plugin . ' ' . $mode . ' --help';
+}
+
+$stdout = shell_exec($command . " 2>&1");
 $msg = str_replace("\n", "<br />", $stdout);
 
 $attrsText = array("size" => "25");
@@ -109,7 +117,7 @@ $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $form->accept($renderer);
 $tpl->assign('form', $renderer->toArray());
 $tpl->assign('o', $o);
-$tpl->assign('command_line', $command . " --help");
+$tpl->assign('command_line', $command);
 if (isset($msg) && $msg) {
     $tpl->assign('msg', $msg);
 }


### PR DESCRIPTION
## Description

Following of #8255

    If command is a Centreon Plugins it will lead to “/usr/lib/centreon/plugins/centreon_linux_snmp.pl --help” that is not enough,
    We should have --plugin=… and --mode=… to have the actual helper of the plugin’s mode,
    I know its Centreon Plugins specific but as we want users to use those plugins, we should provide a way to make this feature match.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

My command checking disk I/O on linux here in the conf:
$CENTREONPLUGINS$/centreon_linux_snmp.pl --plugin=os::linux::snmp::plugin --mode=diskio --hostname=$HOSTADDRESS$ --snmp-version='$_HOSTSNMPVERSION$' --snmp-community='$_HOSTSNMPCOMMUNITY$' $_HOSTSNMPEXTRAOPTIONS$ --device '$_SERVICEDISKNAME$' --name --warning-read='$_SERVICEWARNINGREAD$' --critical-read='$_SERVICECRITICALREAD$' --warning-write='$_SERVICEWARNINGWRITE$' --critical-write='$_SERVICECRITICALWRITE$' $_SERVICEEXTRAOPTIONS$

Should become this when testing through UI:
/usr/lib/centreon/plugins/centreon_linux_snmp.pl --plugin=os::linux::snmp::plugin --mode=diskio --help

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
