### PR TITLE
[Pagination] BA: the pagination doesn't work

### DIFF
--- a/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
+++ b/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
@@ -274,13 +274,12 @@ class CentreonPaginationService
      */
     public function getListing(): DataRepresenter\Listing
     {
-        $entities = $this->db
-            ->getRepository($this->repository)
+        $repository = $this->db->getRepository($this->repository);
+
+        $entities = $repository
             ->getPaginationList($this->filters, $this->limit, $this->offset, $this->ordering, $this->extras);
 
-        $total = $this->db
-            ->getRepository($this->repository)
-            ->getPaginationListTotal();
+        $total = $repository->getPaginationListTotal();
 
         // Serialize list of entities
         if ($this->context !== null) {


### PR DESCRIPTION
## Description

improve CentreonPaginationService::getListing to keep the same object of the repository.
Every time when we call `$this->db->getRepository(Repo::class)` we will receive a new object of the Repo class, to fix the problem described in the issue we need to keep the same object of the repository class

**Fixes** BAM-927

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

the CentreonPaginationService::getListing  has been using in API `/centreon/api/internal.php?object=centreon_command&action=list` with GET method and active session has to return JSON result

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
