### PR TITLE
To fix issue #8306 Can't delete comment

### DIFF
--- a/www/include/monitoring/comments/comments.php
+++ b/www/include/monitoring/comments/comments.php
@@ -69,8 +69,8 @@ switch ($o) {
         require_once($path . "AddSvcComment.php");
         break;
     case "ds":
-        if (isset($_GET["select"])) {
-            foreach ($_GET["select"] as $key => $value) {
+        if (isset($_POST["select"])) {
+            foreach ($_POST["select"] as $key => $value) {
                 $res = explode(';', urldecode($key));
                 DeleteComment($res[0], array($res[1] . ';' . $res[2] => 'on'));
             }


### PR DESCRIPTION
# Pull Request Template

## Description

We can't delete comment in Monitoring, Downtimes, Comments

**Fixes** # #8306

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Go to downtime > comment  and  delete a comment

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
