### PR TITLE
fix(ui): Fix icons not loading and live reload (19.10.x)

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,7 +1,7 @@
 const merge = require('webpack-merge');
-const baseConfig = require('./webpack.config');
 const LiveReloadPlugin = require('webpack-livereload-plugin');
 const HtmlWebpackTagsPlugin = require('html-webpack-tags-plugin');
+const baseConfig = require('./webpack.config');
 
 module.exports = merge(baseConfig, {
   devtool: 'inline-source-map',
@@ -10,7 +10,8 @@ module.exports = merge(baseConfig, {
     new LiveReloadPlugin(),
     new HtmlWebpackTagsPlugin({
       tags: ['http://localhost:35729/livereload.js'],
-      append: true
+      append: true,
+      usePublicPath: false,
     }),
   ],
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,7 +124,7 @@ module.exports = {
           {
             loader: 'file-loader',
             options: {
-              name: '[name].[ext]',
+              name: '[name].[hash:8].[ext]',
               outputPath: './static/fonts/',
               publicPath: '../../static/fonts/',
             },


### PR DESCRIPTION
# Pull Request Template

## Description

This fixes the squares displayed instead of fonticons (like in the extension page). 

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to the extension page
- all icons should be displayed (no blank squares)

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
