### PR TITLE
enh(UI): Add nowrap style to badge class - from aladdinchan

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -548,6 +548,7 @@ p.description a, p.description a:visited {
     font-size: 10px;
     font-weight: bold;
     text-transform: uppercase;
+    white-space: nowrap;
 }
 
 .badge a            {


### PR DESCRIPTION
## Description

Community Pull Request from @aladdinchan -> https://github.com/centreon/centreon/pull/8223

Fix the badge splitted on multiple lines on dense environments

![image](https://user-images.githubusercontent.com/34628915/73865447-8cc5bf80-4843-11ea-8d79-49ade09e6986.png)

**Fixes** # (8223)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

From a listing page using text badges, like on the monitoring > status > services.
Check that the badge stay on a unique line no matter the density or the lenght of the displayed page

If you want to test in chinese, you can use the translation made by @zheddiewen -> here : https://github.com/zheddiewen/centreon-translation/tree/master/zh_CN/LC_MESSAGES

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
