### PR TITLE
Mon 4834 educate user menus access

### DIFF
--- a/doc/en/administration_guide/acl.rst
+++ b/doc/en/administration_guide/acl.rst
@@ -136,7 +136,7 @@ The menus are ranked as follows:
 .. note::
     To access an ‘n-1’ menu level, the user must have access to the ‘n’ menu level, otherwise he will not be able
     to view the menu via the interface. If this is not the case, the user will have to directly access the page
-    concerned via a direct link (autologin, etc.).
+     via a direct link (autologin, etc.).
 
 .. warning::
     Accessing the command editing menu, as well as accessing the SNMP trap editing menu can be very dangerous. Indeed,

--- a/doc/en/administration_guide/acl.rst
+++ b/doc/en/administration_guide/acl.rst
@@ -135,7 +135,7 @@ The menus are ranked as follows:
 
 .. note::
     To access an ‘n-1’ menu level, the user must have access to the ‘n’ menu level, otherwise he will not be able
-    to view the menu via the interface. If this is not the case the user will have to access directly to the page
+    to view the menu via the interface. If this is not the case, the user will have to directly access the page
     concerned via a direct link (autologin, etc.).
 
 .. warning::

--- a/doc/en/administration_guide/acl.rst
+++ b/doc/en/administration_guide/acl.rst
@@ -130,7 +130,18 @@ The menus are ranked as follows:
 * Level 4  context menus (Monitoring > Services > By Hosts / Details > Problems)
 
 .. note::
-   To access to a level of menu ‘n-1’, the user must have access to the menu of level ‘n’ otherwise he will not be able to view the menu via the interface. If this is not the case the user will have to access directly to the page concerned via a direct link (autologin, etc.).
+    By default, access is **Read Only**. If you want to allow your users to modify the configuration, you will need to
+    select the **Read / Write** option for each submenu.
+
+.. note::
+    To access to a level of menu ‘n-1’, the user must have access to the menu of level ‘n’ otherwise he will not be able
+    to view the menu via the interface. If this is not the case the user will have to access directly to the page
+    concerned via a direct link (autologin, etc.).
+
+.. warning::
+    Accessing the command editing menu, as well as accessing the SNMP trap editing menu can be very dangerous. Indeed,
+    the user can create commands that can allow the creation of security breaches (RCE). Only give this access to
+    people you can trust.
 
 To add an access filter to the menus:
 

--- a/doc/en/administration_guide/acl.rst
+++ b/doc/en/administration_guide/acl.rst
@@ -134,7 +134,7 @@ The menus are ranked as follows:
     select the **Read / Write** option for each submenu.
 
 .. note::
-    To access to a level of menu ‘n-1’, the user must have access to the menu of level ‘n’ otherwise he will not be able
+    To access an ‘n-1’ menu level, the user must have access to the ‘n’ menu level, otherwise he will not be able
     to view the menu via the interface. If this is not the case the user will have to access directly to the page
     concerned via a direct link (autologin, etc.).
 

--- a/doc/en/administration_guide/acl.rst
+++ b/doc/en/administration_guide/acl.rst
@@ -140,7 +140,7 @@ The menus are ranked as follows:
 
 .. warning::
     Accessing the command editing menu, as well as accessing the SNMP trap editing menu can be very dangerous. Indeed,
-    the privileged user can create commands that can allow the creation of security breaches (RCE). Only give this
+    the privileged user can create commands, which may lead to the creation of security breaches (RCE). Only give this
     access to people you can trust.
 
 To add an access filter to the menus:

--- a/doc/en/administration_guide/acl.rst
+++ b/doc/en/administration_guide/acl.rst
@@ -140,8 +140,8 @@ The menus are ranked as follows:
 
 .. warning::
     Accessing the command editing menu, as well as accessing the SNMP trap editing menu can be very dangerous. Indeed,
-    the user can create commands that can allow the creation of security breaches (RCE). Only give this access to
-    people you can trust.
+    the privileged user can create commands that can allow the creation of security breaches (RCE). Only give this
+    access to people you can trust.
 
 To add an access filter to the menus:
 

--- a/doc/fr/administration_guide/acl.rst
+++ b/doc/fr/administration_guide/acl.rst
@@ -139,8 +139,8 @@ Les menus sont hiérarchisés de la manière suivante :
 
 .. warning::
     L’accès au menu d’édition des commandes, ainsi que l’accès au menu d’édition des traps SNMP peut être très dangereux.
-    En effet, l’utilisateur peut créer des commandes pouvant favoriser la création de failles de sécurité (RCE). Ne
-    donnez cet accès qu’à des personnes dignes de confiance.
+    En effet, l’utilisateur privilégié peut créer des commandes pouvant favoriser la création de failles de sécurité (RCE).
+    Ne donnez cet accès qu’à des personnes dignes de confiance.
 
 Pour ajouter un filtre d'accès aux menus :
 

--- a/doc/fr/administration_guide/acl.rst
+++ b/doc/fr/administration_guide/acl.rst
@@ -129,7 +129,18 @@ Les menus sont hiérarchisés de la manière suivante :
 * Les menus contextuels de niveau 4 (Supervision > Services > Par hôtes / détails > Problems)
 
 .. note::
-    Pour accéder à un niveau de menu 'n-1', l'utilisateur doit avoir accès au menu de niveau 'n' sinon ce dernier ne pourra pas visualiser le menu au travers de l'interface. Dans le cas contraire, l'utilisateur devra accéder directement à la page concernée via un lien direct (autologin, ...).
+    Par défaut, l’accès est donné en lecture seule (**Read Only**). Si vous souhaitez autoriser vos utilisateurs à
+    modifier la configuration, il faudra sélectionner l’option **Read/Write** pour chaque sous menu.
+
+.. note::
+    Pour accéder à un niveau de menu 'n-1', l'utilisateur doit avoir accès au menu de niveau 'n' sinon ce dernier ne
+    pourra pas visualiser le menu au travers de l'interface. Dans le cas contraire, l'utilisateur devra accéder
+    directement à la page concernée via un lien direct (autologin, ...).
+
+.. warning::
+    L’accès au menu d’édition des commandes, ainsi que l’accès au menu d’édition des traps SNMP peut être très dangereux.
+    En effet, l’utilisateur peut créer des commandes pouvant favoriser la création de failles de sécurité (RCE). Ne
+    donnez cet accès qu’à des personnes dignes de confiance.
 
 Pour ajouter un filtre d'accès aux menus :
 

--- a/doc/fr/administration_guide/acl.rst
+++ b/doc/fr/administration_guide/acl.rst
@@ -139,7 +139,7 @@ Les menus sont hiérarchisés de la manière suivante :
 
 .. warning::
     L’accès au menu d’édition des commandes, ainsi que l’accès au menu d’édition des traps SNMP peut être très dangereux.
-    En effet, l’utilisateur privilégié peut créer des commandes pouvant favoriser la création de failles de sécurité (RCE).
+    En effet, un utilisateur privilégié peut créer des commandes pouvant permettre la création de failles de sécurité (RCE).
     Ne donnez cet accès qu’à des personnes dignes de confiance.
 
 Pour ajouter un filtre d'accès aux menus :

--- a/www/include/common/javascript/tool.js
+++ b/www/include/common/javascript/tool.js
@@ -44,7 +44,7 @@ function checkItem(element, toCheck)
 		var element = document.Form[element.name];
 		var value = 0;
 		if (toCheck) {
-			value = 1;
+			value = 2;
 		}
 		for (var j = 0; j < element.length; j++) {
 			if (element[j].value == value) {


### PR DESCRIPTION
## Description

Educate user about giving access to configuration menus in "Read/Write" mode.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Check in Centreon documentation for "Administration > Access control list" chapter that special note and warning appear for "Menus Access" sub chapter
- Check in "Administration > ACL > Menus Access" menu in Centreon that when you check a main box for "Configuration" menus that all radio boxes are in "Read Only" mode

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
