### PR TITLE
enh(mobile): add third level menu in mobile

### DIFF
--- a/www/include/common/mobile_menu.php
+++ b/www/include/common/mobile_menu.php
@@ -12,11 +12,30 @@
             <?php if (!empty($subMenu['children'])) : ?>
                 <ul class="nav-items nav-expand-content">
                 <?php foreach ($subMenu['children'] as $index2 => $subMenu2) : ?>
-                    <li class="nav-item">
-                        <a class="nav-link" href="main.php?p=<?= substr($index2, 1) ?>">
-                            <?= $subMenu2['label'] ?>
-                        </a>
-                    </li>
+                    <?php if (!empty($subMenu2['children'])) : ?>
+                        <li class="nav-item nav-expand">
+                            <a class="nav-link nav-expand-link" href="#">
+                                <?= $subMenu2['label'] ?>
+                            </a>
+                            <ul class="nav-items nav-expand-content">
+                            <?php foreach ($subMenu2['children'] as $childrens) : ?>
+                                <?php foreach ($childrens as $index3 => $subMenu3) : ?>
+                                    <li class="nav-item">
+                                        <a class="nav-link" href="main.php?p=<?= substr($index3, 1) . $subMenu3['options'] ?>">
+                                            <?= $subMenu3['label'] ?>
+                                        </a>
+                                    </li>
+                                <?php endforeach; ?>
+                            <?php endforeach; ?>
+                            </ul>
+                        </li>
+                    <?php else : ?>
+                        <li class="nav-item">
+                            <a class="nav-link" href="main.php?p=<?= substr($index2, 1) ?>">
+                                <?= $subMenu2['label'] ?>
+                            </a>
+                        </li>
+                    <?php endif; ?>
                 <?php endforeach; ?>
                 </ul>
             <?php endif; ?>


### PR DESCRIPTION
## Description

Add third level menus with mobile access

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Connect to Centreon using mobile
Go to a third level menu and click to acces

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
