### PR TITLE
enh(UI): Hide empty graphs from service details

### DIFF
--- a/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/www/include/monitoring/objectDetails/serviceDetails.php
@@ -533,8 +533,8 @@ if (!is_null($host_id)) {
 
         $optionsURL = "host_name=" . urlencode($host_name) . "&service_description=" . urlencode($svc_description);
 
-        $query = "SELECT id FROM `index_data` WHERE host_name = '" . $pearDBO->escape($host_name) .
-            "' AND service_description = '" . $pearDBO->escape($svc_description) . "' LIMIT 1";
+        $query = "SELECT id FROM `index_data`,`metrics` WHERE host_name = '" . $pearDBO->escape($host_name) .
+            "' AND service_description = '" . $pearDBO->escape($svc_description) . "' AND id=index_id LIMIT 1";
         $DBRES = $pearDBO->query($query);
         $index_data = 0;
         if ($DBRES->rowCount()) {

--- a/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/www/include/monitoring/objectDetails/serviceDetails.php
@@ -533,8 +533,8 @@ if (!is_null($host_id)) {
 
         $optionsURL = "host_name=" . urlencode($host_name) . "&service_description=" . urlencode($svc_description);
 
-        $query = "SELECT id FROM `index_data`,`metrics` WHERE host_name = '" . $pearDBO->escape($host_name) .
-            "' AND service_description = '" . $pearDBO->escape($svc_description) . "' AND id=index_id LIMIT 1";
+        $query = "SELECT id FROM `index_data`, `metrics` WHERE host_name = '" . $pearDBO->escape($host_name) .
+            "' AND service_description = '" . $pearDBO->escape($svc_description) . "' AND id = index_id LIMIT 1";
         $DBRES = $pearDBO->query($query);
         $index_data = 0;
         if ($DBRES->rowCount()) {


### PR DESCRIPTION
Hi,

## Description

One may intentionally disable graphs for one or more services, or for its whole installation, switching of RRDs processing.
This then leads to an empty "_There's no data_" graphs in the _Services Status Details_ pages, which is useless and can (well does) confuse users.
Let's then get rid of these empty graphs when there's no data (from `data_bin`) to plot.

Fixes : N/A (no issue has been opened for this, I directly submitted the corresponding PR)

## Type of change

Well, hard to tell, between the 2 followings :
- [x] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Disable RRD processing (be sure then your `data_bin` table is empty), or at least remove graphs / empty `data_bin` table for a service, and verify, in the _Services Status Details_ pages, that the following empty graph does not show up :

![image](https://user-images.githubusercontent.com/40244829/74419149-bf764600-4e49-11ea-9b41-e4b934ca7f0d.png)

Thank you 👍

Edit : issue still present in 19.10.10.