### PR TITLE
fix(UI): correct blank CSS page

### DIFF
--- a/www/include/Administration/parameters/css/form.php
+++ b/www/include/Administration/parameters/css/form.php
@@ -97,10 +97,13 @@ while ($DBRESULT->rowCount() && $elem = $DBRESULT->fetchRow()) {
  */
 $tab_create_menu = array();
 foreach ($tab_menu as $key => $val) {
-    if (!isset($tab_css[$tab_menu[$key]["topology_page"]])) {
-        $rq = "INSERT INTO `css_color_menu` ( `id_css_color_menu` , `menu_nb` , `css_name` )" .
-                "VALUES ( NULL , ".$tab_menu[$key]["topology_page"].", '".$css_default."' )";
-        $DBRESULT = $pearDB->query($rq);
+    if (!isset($tab_css[$tab_menu[$key]["topology_page"]]) && (int)$tab_menu[$key]["topology_page"]) {
+        $css_default = filter_var($css_default, FILTER_SANITIZE_STRING);
+        $rq = "INSERT INTO `css_color_menu` ( `id_css_color_menu` , `menu_nb` , `css_name` 
+            VALUES ( NULL , " . (int)$tab_menu[$key]["topology_page"] . ", '" . $css_default . "' )";
+        $dbResult = $pearDB->prepare($rq);
+        $dbResult->bindValue(':cssDefault', $css_default, \PDO::PARAM_STR);
+        $dbResult->execute();
     }
 }
 

--- a/www/include/Administration/parameters/css/form.php
+++ b/www/include/Administration/parameters/css/form.php
@@ -97,7 +97,7 @@ while ($DBRESULT->rowCount() && $elem = $DBRESULT->fetchRow()) {
  */
 $tab_create_menu = array();
 foreach ($tab_menu as $key => $val) {
-    if (!isset($tab_css[$tab_menu[$key]["topology_page"]]) && (int)$tab_menu[$key]["topology_page"]) {
+    if ((int)$tab_menu[$key]["topology_page"] && !isset($tab_css[$tab_menu[$key]["topology_page"]]))) {
         $css_default = filter_var($css_default, FILTER_SANITIZE_STRING);
         $rq = "INSERT INTO `css_color_menu` ( `id_css_color_menu` , `menu_nb` , `css_name` 
             VALUES ( NULL , " . (int)$tab_menu[$key]["topology_page"] . ", '" . $css_default . "' )";


### PR DESCRIPTION
# Pull Request Template

## Description

The introduction of react has disabled the CSS customization. But the page is broken and insert an error in the PHP and SQL logs.
Issue still not fixed on the latest 18.10.x
PR made only for the 18.10.x

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Go to adminsitration > CSS and check that the form is displayed without errors in the specified logs

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
