### PR TITLE
fix(UI): redirect user to his default page

### DIFF
--- a/www/index.php
+++ b/www/index.php
@@ -126,7 +126,7 @@ if (isset($_GET["disconnect"])) {
 if (isset($_SESSION["centreon"])) {
     $centreon = &$_SESSION["centreon"];
     $headerRedirection = "main.php";
-    if (isset($centreon->user->default_page) && $centreon->user->default_page != '') {
+    if (!empty($centreon->user->default_page)) {
         $headerRedirection .= "?p=" . $centreon->user->default_page;
     }
     header('Location: ' . $headerRedirection);

--- a/www/index.php
+++ b/www/index.php
@@ -125,7 +125,11 @@ if (isset($_GET["disconnect"])) {
  */
 if (isset($_SESSION["centreon"])) {
     $centreon = &$_SESSION["centreon"];
-    header('Location: main.php');
+    $headerRedirection = "main.php";
+    if (isset($centreon->user->default_page) && $centreon->user->default_page != '') {
+        $headerRedirection .= "?p=" . $centreon->user->default_page;
+    }
+    header('Location: ' . $headerRedirection);
 }
 
 /*


### PR DESCRIPTION
Hi,

## Description

When a user is already logged-in, he will not be redirected to his default page in new tabs / windows.
This PR then redirects the user to his default page reaching Centreon portal, when already logged-in.

It then closes #6548

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Login to Centreon.
Open a new tab or window to your Centreon portal, and be sure to reach your own default page.

Edit : issue still present in 19.10.10.