### PR TITLE
fix(install): replace macro in cron files

### DIFF
--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -496,23 +496,6 @@ check_result $? "$(gettext "Install Centreon cron.d file")"
 ## cron binary
 cp -R $TMP_DIR/src/cron/ $TMP_DIR/final/
 
-log "INFO" "$(gettext "Change macros for centAcl.php")"
-${SED} -e 's|@CENTREON_ETC@|'"$CENTREON_ETC"'|g' \
-    $TMP_DIR/src/cron/centAcl.php > $TMP_DIR/work/cron/centAcl.php
-check_result $? "$(gettext "Change macros for centAcl.php")"
-
-cp -f $TMP_DIR/work/cron/centAcl.php \
-    $TMP_DIR/final/cron/centAcl.php >> "$LOG_FILE" 2>&1
-
-log "INFO" "$(gettext "Change macros for downtimeManager.php")"
-${SED} -e 's|@CENTREON_ETC@|'"$CENTREON_ETC"'|g' \
-    -e 's|@CENTREON_VARLIB@|'"$CENTREON_VARLIB"'|g' \
-    $TMP_DIR/src/cron/downtimeManager.php > $TMP_DIR/work/cron/downtimeManager.php
-check_result $? "$(gettext "Change macros for downtimeManager.php")"
-
-cp -f $TMP_DIR/work/cron/downtimeManager.php \
-    $TMP_DIR/final/cron/downtimeManager.php >> "$LOG_FILE" 2>&1
-
 log "INFO" "$(gettext "Change macros for centreon-backup.pl")"
 ${SED} -e 's|@CENTREON_ETC@|'"$CENTREON_ETC"'|g' \
     $TMP_DIR/src/cron/centreon-backup.pl > $TMP_DIR/work/cron/centreon-backup.pl
@@ -524,7 +507,7 @@ cp -f $TMP_DIR/work/cron/centreon-backup.pl \
 log "INFO" "$(gettext "Install cron directory")"
 $INSTALL_DIR/cinstall $cinstall_opts \
     -u "$CENTREON_USER" -g "$CENTREON_GROUP" -d 755 -m 644 \
-    $TMP_DIR/final/cron/* $INSTALL_DIR_CENTREON/cron/ >> "$LOG_FILE" 2>&1
+    $TMP_DIR/work/cron/* $INSTALL_DIR_CENTREON/cron/ >> "$LOG_FILE" 2>&1
 check_result $? "$(gettext "Install cron directory")"
 
 log "INFO" "$(gettext "Modify rights for eventReportBuilder")"

--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -261,10 +261,11 @@ log "INFO" "$(gettext "Generated a random key") : $HEX_KEY"
 macros="@CENTREON_ETC@,@CENTREON_CACHEDIR@,@CENTPLUGINSTRAPS_BINDIR@,@CENTREON_LOG@,@CENTREON_VARLIB@,@CENTREONTRAPD_BINDIR@,@PHP_BIN@"
 find_macros_in_dir "$macros" "$TMP_DIR/src/" "www" "*.php" "file_php_temp"
 find_macros_in_dir "$macros" "$TMP_DIR/src/" "bin" "*" "file_bin_temp"
+find_macros_in_dir "$macros" "$TMP_DIR/src/" "cron" "*" "file_cron_temp"
 log "INFO" "$(gettext "Apply macros on php files")"
 
 flg_error=0
-${CAT} "$file_php_temp" "$file_bin_temp" | while read file ; do
+${CAT} "$file_php_temp" "$file_bin_temp" "$file_cron_temp" | while read file ; do
     log "MACRO" "$(gettext "Change macro for") : $file"
     [ ! -d $(dirname $TMP_DIR/work/$file) ] && \
         mkdir -p  $(dirname $TMP_DIR/work/$file) >> $LOG_FILE 2>&1


### PR DESCRIPTION
## Description

replace the PHP_BIN macro in the files of the cron folder in the source installation script

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)
