### PR TITLE
enh(doc): remove useless checks

### DIFF
--- a/doc/en/installation/from_sources.rst
+++ b/doc/en/installation/from_sources.rst
@@ -747,17 +747,6 @@ Once composer is installed, go to the centreon directory
 
     composer install --no-dev --optimize-autoloader
 
-Macro modifications
--------------------
-
-> **Notice**: Macros may not have been properly replaced. Run the following commands to correct their values: ::
-
-    $ sed -i -e 's/_CENTREON_PATH_PLACEHOLDER_/centreon/g' /usr/share/centreon/www/index.html
-    $ sed -i -e 's/@PHP_BIN@/\/usr\/bin\/php/g' /usr/share/centreon/bin/centreon
-    $ sed -i -e 's/@PHP_BIN@/\/usr\/bin\/php/g' /usr/share/centreon/bin/export-mysql-indexes
-    $ sed -i -e 's/@PHP_BIN@/\/usr\/bin\/php/g' /usr/share/centreon/bin/generateSqlLite
-    $ sed -i -e 's/@PHP_BIN@/\/usr\/bin\/php/g' /usr/share/centreon/bin/import-mysql-indexes
-
 Javascript dependencies installation
 ------------------------------------
 

--- a/doc/fr/installation/from_sources.rst
+++ b/doc/fr/installation/from_sources.rst
@@ -756,17 +756,6 @@ Une fois que composer est installé, rendez-vous dans les répertoires Centreon
 
     $ composer install --no-dev --optimize-autoloader
 
-Modification des macro
-----------------------
-
-> **Notice**: Il se peut que des macros n'aient pas été remplacées. Exécutez les commandes suivantes pour corriger leurs valeurs : ::
-
-    $ sed -i -e 's/_CENTREON_PATH_PLACEHOLDER_/centreon/g' /usr/share/centreon/www/index.html
-    $ sed -i -e 's/@PHP_BIN@/\/usr\/bin\/php/g' /usr/share/centreon/bin/centreon
-    $ sed -i -e 's/@PHP_BIN@/\/usr\/bin\/php/g' /usr/share/centreon/bin/export-mysql-indexes
-    $ sed -i -e 's/@PHP_BIN@/\/usr\/bin\/php/g' /usr/share/centreon/bin/generateSqlLite
-    $ sed -i -e 's/@PHP_BIN@/\/usr\/bin\/php/g' /usr/share/centreon/bin/import-mysql-indexes
-
 Installation des dépendances Javascript
 ---------------------------------------
 


### PR DESCRIPTION
## Description

Remove from documentation the useless "sed" replacement steps
**Fixes** # (none)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)
