### PR TITLE
fix(api): retrieve service state in service listing

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Service.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Service.yml
@@ -142,6 +142,7 @@ Centreon\Domain\Monitoring\Service:
         state:
             type: int
             groups:
+                - 'service_main'
                 - 'service_full'
         stateType:
             type: int


### PR DESCRIPTION
## Description

retrieve service status in API service listing, which was removed since a few days

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

get list of services using APIv2
check that state is returned