### PR TITLE
fix(trapd): correct export on poller behind RS

### DIFF
--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -1,6 +1,6 @@
 ################################################################################
-# Copyright 2005-2017 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Copyright 2005-2020 Centreon
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 # 
 # This program is free software; you can redistribute it and/or modify it under 
@@ -950,7 +950,7 @@ sub syncTraps($) {
                 if (defined($ns_server->{remote_id}) && $ns_server->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
                     $remote_server = $self->getServerConfig($ns_server->{remote_id});
                     $port = checkSSHPort($remote_server->{ssh_port});
-                    $cmd = "$self->{scp} -r -P $port /etc/snmp/centreon_traps/$id/centreontrapd.sdb $remote_server->{'ns_ip_address'}:/etc/snmp/centreon_traps/";
+                    $cmd = "$self->{scp} -r -P $port /etc/snmp/centreon_traps/$id $remote_server->{'ns_ip_address'}:/etc/snmp/centreon_traps/";
                 } else {
                     $cmd = "$self->{scp} -P $port /etc/snmp/centreon_traps/$id/centreontrapd.sdb $ns_server->{ns_ip_address}:$ns_server->{snmp_trapd_path_conf} 2>&1";
                 }

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -908,7 +908,7 @@ sub syncTraps($) {
             if (defined($ns_server->{remote_id}) && $ns_server->{remote_id} != 0 && $self->{instance_mode} ne "remote") {
                 $remote_server = $self->getServerConfig($ns_server->{remote_id});
                 $port = checkSSHPort($remote_server->{ssh_port});
-                $cmd = "$self->{scp} -r -P $port /etc/snmp/centreon_traps/$id/centreontrapd.sdb $remote_server->{'ns_ip_address'}:/etc/snmp/centreon_traps/";
+                $cmd = "$self->{scp} -r -P $port /etc/snmp/centreon_traps/$id $remote_server->{'ns_ip_address'}:/etc/snmp/centreon_traps/";
             } else {
                 $cmd = "$self->{scp} -P $port /etc/snmp/centreon_traps/$id/centreontrapd.sdb $ns_server->{ns_ip_address}:$ns_server->{snmp_trapd_path_conf} 2>&1";
             }


### PR DESCRIPTION
## Description

Correct the export 

**Fixes** # (7741) from @tanguyvda 

when you have a poller linked to a remote server, if you export the trap configuration on it, it will fail because the central server doesn't create the trap directory related to the poller on the remote server.

this could have been handled using rsync instead of scp (rsync allows you to create parent directories when sending file. Since we use scp, we're better copying the whole directory instead of the sdb file.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

have a poller linked to a remote server. export the snmp trap configuration from the central to the poller on the central server, you should have at least 3 objects inside the /etc/snmp/centreon_traps directory: one centreontrapd.sdb file one directory named after the ID of your remote server one directory named after the ID of your poller each directory having a centreontrapd.sdb file inside
on the remote server you should have
one centreontrapd.sdb file
one directory named after the ID of your poller

on the poller you should have
one centreontrapd.sdb file

each time you export your snmp trap configuration every centreontrapd.sdb file should be updated.

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
