### PR TITLE
fix(web): delete comments

### DIFF
--- a/www/include/monitoring/comments/commentHost.php
+++ b/www/include/monitoring/comments/commentHost.php
@@ -59,17 +59,17 @@ require_once "./include/monitoring/comments/common-Func.php";
 require_once "./include/monitoring/external_cmd/functions.php";
 
 switch ($o) {
-case "ah":
-    require_once($path . "AddHostComment.php");
-    break;
-case "dh":
-    DeleteComment("HOST", $select);
-    require_once($path . "viewHostComment.php");
-    break;
-case "vh":
-    require_once($path . "viewHostComment.php");
-    break;
-default:
-    require_once($path . "viewHostComment.php");
-    break;
+    case "ah":
+        require_once($path . "AddHostComment.php");
+        break;
+    case "dh":
+        DeleteComment("HOST", $select);
+        require_once($path . "viewHostComment.php");
+        break;
+    case "vh":
+        require_once($path . "viewHostComment.php");
+        break;
+    default:
+        require_once($path . "viewHostComment.php");
+        break;
 }

--- a/www/include/monitoring/comments/commentHost.php
+++ b/www/include/monitoring/comments/commentHost.php
@@ -39,37 +39,34 @@
 if (!isset($oreon)) {
     exit();
 }
+$contactId = $_GET["contact_id"] ?? $_POST["contact_id"] ?? null;
 
-    isset($_GET["contact_id"]) ? $cG = $_GET["contact_id"] : $cG = null;
-    isset($_POST["contact_id"]) ? $cP = $_POST["contact_id"] : $cP = null;
-    $cG ? $contact_id = $cG : $contact_id = $cP;
+$form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
 
-    $form = new HTML_QuickFormCustom('Form', 'post', "?p=".$p);
+/*
+ * Path to the configuration folder
+ */
+$path = "./include/monitoring/comments/";
 
-    /*
-	 * Path to the configuration dir
-	 */
-    $path = "./include/monitoring/comments/";
-
-    /*
-	 * PHP functions
-	 */
-    require_once "./include/common/common-Func.php";
-    require_once "./include/monitoring/comments/common-Func.php";
-    require_once "./include/monitoring/external_cmd/functions.php";
+/*
+ * PHP functions
+ */
+require_once "./include/common/common-Func.php";
+require_once "./include/monitoring/comments/common-Func.php";
+require_once "./include/monitoring/external_cmd/functions.php";
 
 switch ($o) {
-    case "ah":
-        require_once($path."AddHostComment.php");
-        break;
-    case "dh":
-        DeleteComment("HOST", isset($_GET["select"]) ? $_GET["select"] : array());
-        require_once($path."viewHostComment.php");
-        break;
-    case "vh":
-        require_once($path."viewHostComment.php");
-        break;
-    default:
-        require_once($path."viewHostComment.php");
-        break;
+case "ah":
+    require_once($path . "AddHostComment.php");
+    break;
+case "dh":
+    DeleteComment("HOST", $_GET["select"] ?? array());
+    require_once($path . "viewHostComment.php");
+    break;
+case "vh":
+    require_once($path . "viewHostComment.php");
+    break;
+default:
+    require_once($path . "viewHostComment.php");
+    break;
 }

--- a/www/include/monitoring/comments/commentHost.php
+++ b/www/include/monitoring/comments/commentHost.php
@@ -39,8 +39,11 @@
 if (!isset($oreon)) {
     exit();
 }
-$contactId = $_GET["contact_id"] ?? $_POST["contact_id"] ?? null;
-
+$contactId = filter_var(
+    $_GET["contact_id"] ?? $_POST["contact_id"] ?? 0,
+    FILTER_VALIDATE_INT
+);
+$select = $_GET["select"] ?? $_POST["select"] ?? [];
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
 
 /*
@@ -60,7 +63,7 @@ case "ah":
     require_once($path . "AddHostComment.php");
     break;
 case "dh":
-    DeleteComment("HOST", $_GET["select"] ?? array());
+    DeleteComment("HOST", $select);
     require_once($path . "viewHostComment.php");
     break;
 case "vh":

--- a/www/include/monitoring/comments/comments.php
+++ b/www/include/monitoring/comments/comments.php
@@ -74,7 +74,7 @@ switch ($o) {
         if (!empty($select)) {
             foreach ($select as $key => $value) {
                 $res = explode(';', urldecode($key));
-                DeleteComment($res[0], array((int)$res[1] . ';' . (int)$res[2] => 'on'));
+                DeleteComment($res[0], [(int)$res[1] . ';' . (int)$res[2] => 'on']);
             }
         }
         require_once($path . "listComment.php");

--- a/www/include/monitoring/comments/comments.php
+++ b/www/include/monitoring/comments/comments.php
@@ -41,7 +41,7 @@ $contactId = filter_var(
     $_GET["contact_id"] ?? $_POST["contact_id"] ?? 0,
     FILTER_VALIDATE_INT
 );
-$select = $_GET["select"] ?? $_POST["select"] ?? '';
+$select = $_GET["select"] ?? $_POST["select"] ?? [];
 
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
 

--- a/www/include/monitoring/comments/comments.php
+++ b/www/include/monitoring/comments/comments.php
@@ -37,9 +37,11 @@ if (!isset($centreon)) {
     exit();
 }
 
-isset($_GET["contact_id"]) ? $cG = $_GET["contact_id"] : $cG = null;
-isset($_POST["contact_id"]) ? $cP = $_POST["contact_id"] : $cP = null;
-$cG ? $contact_id = $cG : $contact_id = $cP;
+$contactId = filter_var(
+    $_GET["contact_id"] ?? $_POST["contact_id"] ?? 0,
+    FILTER_VALIDATE_INT
+);
+$select = $_GET["select"] ?? $_POST["select"] ?? '';
 
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
 
@@ -69,10 +71,10 @@ switch ($o) {
         require_once($path . "AddSvcComment.php");
         break;
     case "ds":
-        if (isset($_GET["select"])) {
-            foreach ($_GET["select"] as $key => $value) {
+        if (!empty($select)) {
+            foreach ($select as $key => $value) {
                 $res = explode(';', urldecode($key));
-                DeleteComment($res[0], array($res[1] . ';' . $res[2] => 'on'));
+                DeleteComment($res[0], array((int)$res[1] . ';' . (int)$res[2] => 'on'));
             }
         }
         require_once($path . "listComment.php");

--- a/www/include/monitoring/comments/common-Func.php
+++ b/www/include/monitoring/comments/common-Func.php
@@ -37,7 +37,7 @@ if (!isset($centreon)) {
     exit();
 }
 
-function DeleteComment($type = null, $hosts = array())
+function DeleteComment($type = null, $hosts = [])
 {
     if (!isset($type) || !is_array($hosts)) {
         return;

--- a/www/include/monitoring/comments/common-Func.php
+++ b/www/include/monitoring/comments/common-Func.php
@@ -1,7 +1,7 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -37,12 +37,18 @@ if (!isset($centreon)) {
     exit();
 }
 
-function DeleteComment($type, $hosts = array())
+function DeleteComment($type = null, $hosts = array())
 {
+    if (!isset($type)) {
+        return;
+    }
     global $pearDB;
+    $type = filter_var($type ?? '', FILTER_SANITIZE_STRING);
 
     foreach ($hosts as $key => $value) {
         $res = preg_split("/\;/", $key);
+        $res[0] = filter_var($key[0] ?? 0, FILTER_VALIDATE_INT);
+        $res[1] = filter_var($key[1] ?? 0, FILTER_VALIDATE_INT);
         write_command(" DEL_" . $type . "_COMMENT;" . $res[1], GetMyHostPoller($pearDB, $res[0]));
     }
 }

--- a/www/include/monitoring/comments/common-Func.php
+++ b/www/include/monitoring/comments/common-Func.php
@@ -39,7 +39,7 @@ if (!isset($centreon)) {
 
 function DeleteComment($type = null, $hosts = array())
 {
-    if (!isset($type)) {
+    if (!isset($type) || !is_array($hosts)) {
         return;
     }
     global $pearDB;
@@ -47,8 +47,8 @@ function DeleteComment($type = null, $hosts = array())
 
     foreach ($hosts as $key => $value) {
         $res = preg_split("/\;/", $key);
-        $res[0] = filter_var($key[0] ?? 0, FILTER_VALIDATE_INT);
-        $res[1] = filter_var($key[1] ?? 0, FILTER_VALIDATE_INT);
+        $res[0] = filter_var($res[0] ?? 0, FILTER_VALIDATE_INT);
+        $res[1] = filter_var($res[1] ?? 0, FILTER_VALIDATE_INT);
         write_command(" DEL_" . $type . "_COMMENT;" . $res[1], GetMyHostPoller($pearDB, $res[0]));
     }
 }


### PR DESCRIPTION
## Description

- fix comments deletion for services and hosts
- sanitize data

**Fixes** # (#8308, #8306) - from rk4an

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

create a comment from the monitoring > status > downtime > comment page, then try to delete it

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).