### PR TITLE
fix(api): improve linking a remote server to a BA

### DIFF
--- a/src/Centreon/Domain/Entity/NagiosServer.php
+++ b/src/Centreon/Domain/Entity/NagiosServer.php
@@ -27,16 +27,23 @@ use PDO;
 
 class NagiosServer implements Mapping\MetadataInterface
 {
+    public const SERIALIZER_GROUP_REMOTE_LIST = 'nagios-server-remote-list';
     public const SERIALIZER_GROUP_LIST = 'nagios-server-list';
 
     /**
-     * @Serializer\Groups({NagiosServer::SERIALIZER_GROUP_LIST})
+     * @Serializer\Groups({
+     *     NagiosServer::SERIALIZER_GROUP_REMOTE_LIST,
+     *     NagiosServer::SERIALIZER_GROUP_LIST
+     * })
      * @var int
      */
     private $id;
 
     /**
-     * @Serializer\Groups({NagiosServer::SERIALIZER_GROUP_LIST})
+     * @Serializer\Groups({
+     *     NagiosServer::SERIALIZER_GROUP_REMOTE_LIST,
+     *     NagiosServer::SERIALIZER_GROUP_LIST
+     * })
      * @var string
      */
     private $name;
@@ -60,6 +67,8 @@ class NagiosServer implements Mapping\MetadataInterface
     private $lastRestart;
 
     /**
+     * @Serializer\SerializedName("ip")
+     * @Serializer\Groups({NagiosServer::SERIALIZER_GROUP_REMOTE_LIST})
      * @var string
      */
     private $nsIpAddress;

--- a/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -117,7 +117,13 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
      */
     public function getList(): array
     {
-        return $this->postGetRemotesList();
+        $list = [];
+        foreach ($this->postGetRemotesList() as $row) {
+            $row['id'] = (int)$row['id'];
+            $list[] = $row;
+        }
+
+        return $list;
     }
 
     /**


### PR DESCRIPTION
## Description

when the BA is creating the selected value in `Display on remote server` is not stored

**Fixes**  BAM-944

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

create BA with selected `Display on remote server` and after that open it again for editing, the drop-down has to be with a pre-selected value

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
