### PR TITLE
feat(api): set in Resource some properties as vritual and skip executing of the query if the filters are in conflict

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Resource.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Resource.yml
@@ -1,4 +1,23 @@
 Centreon\Domain\Monitoring\Resource:
+    virtual_properties:
+        getDuration:
+            name: getDuration
+            serialized_name: duration
+            type: string
+            groups:
+                - 'resource_main'
+        getLastCheckAsString:
+            name: getLastCheckAsString
+            serialized_name: last_check
+            type: string
+            groups:
+                - 'resource_main'
+        getShortType:
+            name: getShortType
+            serialized_name: short_type
+            type: string
+            groups:
+                - 'resource_main'
     properties:
         id:
             type: string
@@ -6,10 +25,6 @@ Centreon\Domain\Monitoring\Resource:
                 - 'resource_main'
                 - 'resource_parent'
         type:
-            type: string
-            groups:
-                - 'resource_main'
-        shortType:
             type: string
             groups:
                 - 'resource_main'
@@ -73,16 +88,8 @@ Centreon\Domain\Monitoring\Resource:
             type: DateTime<'Y-m-d\TH:i:sP'>
             groups:
                 - 'resource_main'
-        duration:
-            type: string
-            groups:
-                - 'resource_main'
         tries:
             type: string
-            groups:
-                - 'resource_main'
-        lastCheck:
-            type: DateTime<'Y-m-d\TH:i:sP'>
             groups:
                 - 'resource_main'
         information:

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -2513,7 +2513,7 @@ components:
           example: "3/3 (H)"
         last_check:
           type: string
-          description: "Date of the last check (ISO8601)"
+          description: "Duration since last check"
           example: "1h 45m"
         information:
           type: string

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -2513,8 +2513,8 @@ components:
           example: "3/3 (H)"
         last_check:
           type: string
-          format: date-time
           description: "Date of the last check (ISO8601)"
+          example: "1h 45m"
         information:
           type: string
           description: "Output of the resource"

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -26,6 +26,7 @@ use Centreon\Domain\Monitoring\Icon;
 use Centreon\Domain\Monitoring\ResourceStatus;
 use Centreon\Domain\Monitoring\ResourceSeverity;
 use DateTime;
+use CentreonDuration;
 
 /**
  * Class representing a record of a resource in the repository.
@@ -51,11 +52,6 @@ class Resource
      * @var string|null
      */
     private $type;
-
-    /**
-     * @var string|null
-     */
-    private $shortType;
 
     /**
      * @var string|null
@@ -130,11 +126,6 @@ class Resource
     /**
      * @var string|null
      */
-    private $duration;
-
-    /**
-     * @var string|null
-     */
     private $tries;
 
     /**
@@ -166,6 +157,42 @@ class Resource
     /**
      * @return string|null
      */
+    public function getShortType(): ?string
+    {
+        return $this->type ? $this->type{0} : null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDuration(): ?string
+    {
+        $result = null;
+
+        if ($this->getLastCheck()) {
+            $result = CentreonDuration::toString(time() - $this->getLastStatusChange()->getTimestamp());
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLastCheckAsString(): ?string
+    {
+        $result = null;
+
+        if ($this->getLastCheck()) {
+            $result = CentreonDuration::toString(time() - $this->getLastCheck()->getTimestamp());
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return string|null
+     */
     public function getId(): ?string
     {
         return $this->id;
@@ -178,25 +205,6 @@ class Resource
     public function setId(?string $id): self
     {
         $this->id = $id;
-
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getShortType(): ?string
-    {
-        return $this->shortType;
-    }
-
-    /**
-     * @param string|null $shortType
-     * @return \Centreon\Domain\Monitoring\Resource
-     */
-    public function setShortType(?string $shortType): self
-    {
-        $this->shortType = $shortType;
 
         return $this;
     }
@@ -482,25 +490,6 @@ class Resource
     public function setLastStatusChange(?DateTime $lastStatusChange): self
     {
         $this->lastStatusChange = $lastStatusChange;
-
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getDuration(): ?string
-    {
-        return $this->duration;
-    }
-
-    /**
-     * @param string|null $duration
-     * @return \Centreon\Domain\Monitoring\Resource
-     */
-    public function setDuration(?string $duration): self
-    {
-        $this->duration = $duration;
 
         return $this;
     }


### PR DESCRIPTION
## Description

improvements and feedback related to #8388

- skip executing of the SQL query for the Resource list if the filters are in conflict
- change the type of `last_check` to be like duration
- replace some properties to be virtual as short_type, duration, last_check (with type string)

**Fixes** MON-4887

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
