### PR TITLE
enh(centcore): move external command processing loop

### DIFF
--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -1753,14 +1753,15 @@ sub run {
                 while (<FILE>){
                     $self->parseRequest($_);
                 }
+                close(FILE);                
+                $self->{logger}->writeLogError("Error When removing ".$self->{cmdFile}."_read file : $!") if (!unlink($self->{cmdFile}."_read"));
+
                 foreach my $poller (keys(%{$self->{commandBuffer}})) {
                     if (length($self->{commandBuffer}{$poller}) != 0) {
                         $self->sendExternalCommand($poller, $self->{commandBuffer}{$poller});
                         $self->{commandBuffer}{$poller} = "";
                     }
                 }
-                close(FILE);
-                $self->{logger}->writeLogError("Error When removing ".$self->{cmdFile}."_read file : $!") if (!unlink($self->{cmdFile}."_read"));
             }
         }
 
@@ -1773,18 +1774,19 @@ sub run {
                         while (<FILE>){
                             $self->parseRequest($_);
                         }
-                        foreach my $poller (keys(%{$self->{commandBuffer}})) {
-                            if (length($self->{commandBuffer}{$poller}) != 0) {
-                                $self->sendExternalCommand($poller, $self->{commandBuffer}{$poller});
-                                $self->{commandBuffer}{$poller} = "";
-                            }
-                        }
                         close(FILE);
                         $self->{logger}->writeLogError("Error When removing ".$self->{cmdDir}.$file."_read file : $!") if (!unlink($self->{cmdDir}.$file."_read"));
                     }
                 }
             }
             closedir $dh;
+
+            foreach my $poller (keys(%{$self->{commandBuffer}})) {
+                if (length($self->{commandBuffer}{$poller}) != 0) {
+                    $self->sendExternalCommand($poller, $self->{commandBuffer}{$poller});
+                    $self->{commandBuffer}{$poller} = "";
+                }
+            }
         }
 
         if (defined($self->{timeSyncPerf}) && $self->{timeSyncPerf}) {

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -1754,7 +1754,7 @@ sub run {
                     $self->parseRequest($_);
                 }
                 close(FILE);
-                if (!unlink($self->{cmdFile}."_read")) {
+                if (!unlink($self->{cmdFile} . "_read")) {
                     $self->{logger}->writeLogError("Error When removing " . $self->{cmdFile} . "_read file : $!");
                 }
 

--- a/lib/perl/centreon/script/centcore.pm
+++ b/lib/perl/centreon/script/centcore.pm
@@ -1753,8 +1753,10 @@ sub run {
                 while (<FILE>){
                     $self->parseRequest($_);
                 }
-                close(FILE);                
-                $self->{logger}->writeLogError("Error When removing ".$self->{cmdFile}."_read file : $!") if (!unlink($self->{cmdFile}."_read"));
+                close(FILE);
+                if (!unlink($self->{cmdFile}."_read")) {
+                    $self->{logger}->writeLogError("Error When removing " . $self->{cmdFile} . "_read file : $!");
+                }
 
                 foreach my $poller (keys(%{$self->{commandBuffer}})) {
                     if (length($self->{commandBuffer}{$poller}) != 0) {


### PR DESCRIPTION
## Description

Depending on the external command, web UI writes one file per external command in the centcore directory (ie /var/lib/centreon/centcore/) or multiple in the centcore file (ie /var/lib/centreon/centcore.cmd).

For downtimes, we are in the first case.

So when we schedule lots of downtimes, in can take several seconds to schedule all downtimes.

This is because the loop in charge of processing files does it one at a time and call the function in charge to process the external command, often only one, that multliply the number of ssh connection opening/closing.

This cause a useless hanging of external commands.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

In internal ticket.

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
