### PR TITLE
enh(api): update service graph endpoints

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Resource.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Resource.yml
@@ -68,6 +68,14 @@ Centreon\Domain\Monitoring\Resource:
             type: string
             groups:
                 - 'resource_main'
+        statusGraphEndpoint:
+            type: string
+            groups:
+                - 'resource_main'
+        performanceGraphEndpoint:
+            type: string
+            groups:
+                - 'resource_main'
         severity:
             type: Centreon\Domain\Monitoring\ResourceSeverity
             groups:

--- a/config/routes/Centreon/monitoring/metric.yaml
+++ b/config/routes/Centreon/monitoring/metric.yaml
@@ -19,3 +19,21 @@ monitoring.metric.getServiceStatus:
         end: '\S+'
     controller: 'Centreon\Application\Controller\Monitoring\MetricController::getServiceStatus'
     condition: "request.attributes.get('version') >= 2.0"
+
+monitoring.metric.getServicePerformanceMetrics:
+    methods: GET
+    path: /monitoring/hosts/{hostId}/services/{serviceId}/metrics/performance
+    requirements:
+        hostId: '\d+'
+        serviceId: '\d+'
+    controller: 'Centreon\Application\Controller\Monitoring\MetricController::getServicePerformanceMetrics'
+    condition: "request.attributes.get('version') >= 2.0"
+
+monitoring.metric.getServiceStatusMetrics:
+    methods: GET
+    path: /monitoring/hosts/{hostId}/services/{serviceId}/metrics/status
+    requirements:
+        hostId: '\d+'
+        serviceId: '\d+'
+    controller: 'Centreon\Application\Controller\Monitoring\MetricController::getServiceStatusMetrics'
+    condition: "request.attributes.get('version') >= 2.0"

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -2489,9 +2489,9 @@ components:
           type: string
           description: "URL of the status chart linked to the resource"
           example: "/monitoring/hosts/1/services/2/metrics/status"
-        metrics_graph_endpoint:
+        performance_graph_endpoint:
           type: string
-          description: "URL of the metrics chart linked to the resource"
+          description: "URL of the performance chart linked to the resource"
           example: "/monitoring/hosts/1/services/2/metrics/performance"
         duration:
           type: string

--- a/src/Centreon/Application/Controller/Monitoring/MetricController.php
+++ b/src/Centreon/Application/Controller/Monitoring/MetricController.php
@@ -26,7 +26,9 @@ use Centreon\Application\Controller\AbstractController;
 use Centreon\Domain\Monitoring\Metric\Interfaces\MetricServiceInterface;
 use Centreon\Domain\Monitoring\Interfaces\MonitoringServiceInterface;
 use Centreon\Domain\Monitoring\Service;
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
 use Centreon\Domain\Exception\EntityNotFoundException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use FOS\RestBundle\View\View;
 
 /**
@@ -89,6 +91,36 @@ class MetricController extends AbstractController
     }
 
     /**
+     * Validate and extract start/end dates from request parameters
+     *
+     * @param RequestParametersInterface $requestParameters
+     * @return array
+     * @example [new \Datetime('yesterday'), new \Datetime('today')]
+     * @throws NotFoundHttpException
+     * @throws \LogicException
+     */
+    private function extractDatesFromRequestParameters(RequestParametersInterface $requestParameters): array
+    {
+        $start = $requestParameters->getExtraParameter('start') ?: '1 day ago';
+        $end = $requestParameters->getExtraParameter('end') ?: 'now';
+
+        foreach (['start' => $start, 'end' => $end] as $param => $value) {
+            if (false === strtotime($value)) {
+                throw new NotFoundHttpException(sprintf('Invalid date given for parameter "%s".', $param));
+            }
+        }
+
+        $start = new \DateTime($start);
+        $end = new \DateTime($end);
+
+        if ($start >= $end) {
+            throw new \RangeException('End date must be greater than start date.');
+        }
+
+        return [$start, $end];
+    }
+
+    /**
      * Entry point to get service metrics
      *
      * @param int $hostId
@@ -137,6 +169,68 @@ class MetricController extends AbstractController
         \DateTime $end
     ): View {
         $this->denyAccessUnlessGrantedForApiRealtime();
+
+        /**
+         * @var $contact Contact
+         */
+        $contact = $this->getUser();
+
+        $service = $this->findService($hostId, $serviceId);
+
+        $status = $this->metricService
+            ->filterByContact($contact)
+            ->findStatusByService($service, $start, $end);
+
+        return $this->view($status);
+    }
+
+    /**
+     * Entry point to get service performance metrics
+     *
+     * @param int $hostId
+     * @param int $serviceId
+     * @return View
+     * @throws \Exception
+     */
+    public function getServicePerformanceMetrics(
+        RequestParametersInterface $requestParameters,
+        int $hostId,
+        int $serviceId
+    ): View {
+        $this->denyAccessUnlessGrantedForApiRealtime();
+
+        list($start, $end) = $this->extractDatesFromRequestParameters($requestParameters);
+
+        /**
+         * @var $contact Contact
+         */
+        $contact = $this->getUser();
+
+        $service = $this->findService($hostId, $serviceId);
+
+        $metrics = $this->metricService
+            ->filterByContact($contact)
+            ->findMetricsByService($service, $start, $end);
+
+        return $this->view($metrics);
+    }
+
+    /**
+     * Entry point to get service status metrics
+     *
+     * @param int $hostId
+     * @param int $serviceId
+     * @return View
+     * @throws \Exception
+     */
+    public function getServiceStatusMetrics(
+        RequestParametersInterface $requestParameters,
+        int $hostId,
+        int $serviceId
+    ): View {
+        $this->denyAccessUnlessGrantedForApiRealtime();
+
+        list($start, $end) = $this->extractDatesFromRequestParameters($requestParameters);
 
         /**
          * @var $contact Contact

--- a/src/Centreon/Domain/Monitoring/Resource.php
+++ b/src/Centreon/Domain/Monitoring/Resource.php
@@ -99,6 +99,16 @@ class Resource
     private $acknowledgementEndpoint;
 
     /**
+     * @var string|null
+     */
+    private $statusGraphEndpoint;
+
+    /**
+     * @var string|null
+     */
+    private $performanceGraphEndpoint;
+
+    /**
      * @var \Centreon\Domain\Monitoring\ResourceSeverity|null
      */
     private $severity;
@@ -395,6 +405,44 @@ class Resource
     public function setAcknowledgementEndpoint(string $acknowledgementEndpoint): self
     {
         $this->acknowledgementEndpoint = $acknowledgementEndpoint;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getStatusGraphEndpoint(): ?string
+    {
+        return $this->statusGraphEndpoint;
+    }
+
+    /**
+     * @param string $statusGraphEndpoint
+     * @return \Centreon\Domain\Monitoring\Resource
+     */
+    public function setStatusGraphEndpoint(string $statusGraphEndpoint): self
+    {
+        $this->statusGraphEndpoint = $statusGraphEndpoint;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPerformanceGraphEndpoint(): ?string
+    {
+        return $this->performanceGraphEndpoint;
+    }
+
+    /**
+     * @param string $performanceGraphEndpoint
+     * @return \Centreon\Domain\Monitoring\Resource
+     */
+    public function setPerformanceGraphEndpoint(string $performanceGraphEndpoint): self
+    {
+        $this->performanceGraphEndpoint = $performanceGraphEndpoint;
 
         return $this;
     }


### PR DESCRIPTION
## Description

new endpoints : 
- /monitoring/hosts/{hostId}/services/{serviceId}/metrics/performance
- /monitoring/hosts/{hostId}/services/{serviceId}/metrics/status

new properties of resource endpoint : 
- performance_graph_endpoint
- status_graph_endpoint

**Fixes** MON-4792

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check API documentation and validate new endpoints : 
- /monitoring/hosts/{hostId}/services/{serviceId}/metrics/performance
- /monitoring/hosts/{hostId}/services/{serviceId}/metrics/status

new properties of resource endpoint : 
- performance_graph_endpoint
- status_graph_endpoint