### PR TITLE
enh(events): move resources to events view

### DIFF
--- a/www/front_src/src/route-maps/route-map.js
+++ b/www/front_src/src/route-maps/route-map.js
@@ -9,7 +9,7 @@ const routeMap = {
   pollerList: '/main.php?p=60901',
   extensionsManagerPage: '/administration/extensions/manager',
   notAllowedPage: '/not-allowed',
-  resources: '/monitoring/resources',
+  resources: '/monitoring/events',
 };
 
 export default routeMap;

--- a/www/install/insertTopology.sql
+++ b/www/install/insertTopology.sql
@@ -185,7 +185,7 @@ INSERT INTO `topology` (topology_name, topology_url, topology_parent, topology_p
 INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_group`) VALUES ('Manager', '/administration/extensions/manager', '1', '1', 507, 50709, 1);
 
 -- Add unified view page entry
-INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_group`, `topology_order`) VALUES ('Resources (beta)', '/monitoring/resources', '1', '1', 2, 201, 1, 1);
+INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_group`, `topology_order`) VALUES ('Events view (beta)', '/monitoring/events', '1', '1', 1, 104, 1, 2);
 
 /*!40000 ALTER TABLE `topology` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/www/install/sql/centreon/Update-DB-20.04.0-beta.1.sql
+++ b/www/install/sql/centreon/Update-DB-20.04.0-beta.1.sql
@@ -12,7 +12,7 @@ UPDATE topology SET topology_url_opt = '&o=svcOVHG_pb' WHERE topology_page = 202
 UPDATE topology SET topology_url_opt = '&o=svcOVSG_pb' WHERE topology_page = 20212;
 
 -- Add unified view page entry
-INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_group`, `topology_order`) VALUES ('Resources (beta)', '/monitoring/resources', '1', '1', 2, 201, 1, 1);
+INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_group`, `topology_order`) VALUES ('Events view (beta)', '/monitoring/events', '1', '1', 1, 104, 1, 2);
 
 -- Delete legacy engine parameters
 ALTER TABLE `cfg_nagios` DROP COLUMN `check_result_path`;


### PR DESCRIPTION
## Description

Move `monitoring > resources (beta)` to `home > events view (beta)`

**Fixes** MON-4984

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)