### PR TITLE
enh(install): add dependency mechanism to fresh installation

### DIFF
--- a/www/install/steps/process/process_step8.php
+++ b/www/install/steps/process/process_step8.php
@@ -49,7 +49,8 @@ if (isset($parameters['modules'])) {
         /* If the selected module is already installed (as dependency for example)
          * then we can skip the installation process
          */
-        if (isset($result['modules'][$module]['install']) &&
+        if (
+            isset($result['modules'][$module]['install'])
             && $result['modules'][$module]['install'] === true
         ) {
             continue;

--- a/www/install/steps/process/process_step8.php
+++ b/www/install/steps/process/process_step8.php
@@ -50,7 +50,8 @@ if (isset($parameters['modules'])) {
          * then we can skip the installation process
          */
         if (isset($result['modules'][$module]['install']) &&
-            $result['modules'][$module]['install'] === true) {
+            && $result['modules'][$module]['install'] === true
+        ) {
             continue;
         }
         /* retrieving the module's information stored in the conf.php

--- a/www/install/steps/process/process_step8.php
+++ b/www/install/steps/process/process_step8.php
@@ -69,21 +69,21 @@ if (isset($parameters['modules'])) {
                 }
                 $installer = $moduleFactory->newInstaller($dependency);
                 $id = $installer->install();
-                $install = ($id) ? true : false;
-                $result['modules'][] = array(
+                $install = $id ? true : false;
+                $result['modules'][$dependency] = [
                     'module' => $dependency,
-                    'install' => $install
-                );
+                    'install' => $install,
+                ];
             }
         }
         // installing the selected module
         $installer = $moduleFactory->newInstaller($module);
         $id = $installer->install();
-        $install = ($id) ? true : false;
-        $result['modules'][] = array(
+        $install = $id ? true : false;
+        $result['modules'][$module] = [
             'module' => $module,
-            'install' => $install
-        );
+            'install' => $install,
+        ];
     }
 }
 
@@ -95,7 +95,7 @@ if (isset($parameters['widgets'])) {
         $installer = $widgetFactory->newInstaller($widget);
         $id = $installer->install();
         $install = ($id) ? true : false;
-        $result['widgets'][] = array(
+        $result['widgets'][$widget] = array(
             'widget' => $widget,
             'install' => $install
         );

--- a/www/install/steps/process/process_step8.php
+++ b/www/install/steps/process/process_step8.php
@@ -69,7 +69,8 @@ if (isset($parameters['modules'])) {
                 // If the dependency is already installed skip install
                 if (
                     isset($result['modules'][$dependency]['install'])
-                    $result['modules'][$dependency]['install'] === true) {
+                    && $result['modules'][$dependency]['install'] === true
+                ) {
                     continue;
                 }
                 $installer = $moduleFactory->newInstaller($dependency);

--- a/www/install/steps/process/process_step8.php
+++ b/www/install/steps/process/process_step8.php
@@ -49,7 +49,8 @@ if (isset($parameters['modules'])) {
         /* If the selected module is already installed (as dependency for example)
          * then we can skip the installation process
          */
-        if ($result['modules'][$module]['install']) {
+        if (isset($result['modules'][$module]['install']) &&
+            $result['modules'][$module]['install'] === true) {
             continue;
         }
         /* retrieving the module's information stored in the conf.php
@@ -64,7 +65,8 @@ if (isset($parameters['modules'])) {
         if (isset($moduleInformation['dependencies'])) {
             foreach ($moduleInformation['dependencies'] as $dependency) {
                 // If the dependency is already installed skip install
-                if ($result['modules'][$dependency]['install']) {
+                if (isset($result['modules'][$dependency]['install']) &&
+                    $result['modules'][$dependency]['install'] === true) {
                     continue;
                 }
                 $installer = $moduleFactory->newInstaller($dependency);

--- a/www/install/steps/process/process_step8.php
+++ b/www/install/steps/process/process_step8.php
@@ -67,7 +67,8 @@ if (isset($parameters['modules'])) {
         if (isset($moduleInformation['dependencies'])) {
             foreach ($moduleInformation['dependencies'] as $dependency) {
                 // If the dependency is already installed skip install
-                if (isset($result['modules'][$dependency]['install']) &&
+                if (
+                    isset($result['modules'][$dependency]['install'])
                     $result['modules'][$dependency]['install'] === true) {
                     continue;
                 }

--- a/www/install/steps/templates/step8.tpl
+++ b/www/install/steps/templates/step8.tpl
@@ -133,6 +133,7 @@
                         if (module.install) {
                             jQuery('label[for="module_' + module.module + '"]').addClass('md-label-green');
                             jQuery("input[type=checkbox]#module_" + module.module).attr('disabled', 'disabled');
+                            jQuery("input[type=checkbox]#module_" + module.module).prop('checked', 'checked');
                         }
                     });
                 }

--- a/www/install/steps/templates/step8.tpl
+++ b/www/install/steps/templates/step8.tpl
@@ -128,20 +128,25 @@
                 }
             }).success(function(data) {
                 var data = JSON.parse(data);
-                if (data['modules'] && data['modules'].length > 0) {
-                    data['modules'].forEach(function(module) {
+                var modules = Object.values(data['modules']);
+                if (modules && modules.length > 0) {
+                    modules.forEach(function(module) {
                         if (module.install) {
-                            jQuery('label[for="module_' + module.module + '"]').addClass('md-label-green');
-                            jQuery("input[type=checkbox]#module_" + module.module).attr('disabled', 'disabled');
-                            jQuery("input[type=checkbox]#module_" + module.module).prop('checked', 'checked');
+                            jQuery('label[for="module_' + module.name + '"]').addClass('md-label-green');
+                            jQuery("input[type=checkbox]#module_" + module.name)
+                                .attr('disabled', 'disabled')
+                                .prop('checked', 'checked');
                         }
                     });
                 }
-                if (data['widgets'] && data['widgets'].length > 0) {
-                    data['widgets'].forEach(function(widget) {
+                var widgets = Object.values(data['widgets']);
+                if (widgets && widgets.length > 0) {
+                    widgets.forEach(function(widget) {
                         if (widget.install) {
-                            jQuery('label[for="widget_' + widget.widget + '"]').addClass('md-label-green');
-                            jQuery("input[type=checkbox]#widget_" + widget.widget).attr('disabled', 'disabled');
+                            jQuery('label[for="widget_' + widget.name + '"]').addClass('md-label-green');
+                            jQuery("input[type=checkbox]#widget_" + widget.name)
+                                .attr('disabled', 'disabled')
+                                .prop('checked', 'checked');
                         }
                     });
                 }


### PR DESCRIPTION
## Description

Several issues occured during fresh installations of Centreon.
In fact sometimes the installation order is not correct (installing auto-discovery without license-manager and/or pp-manager).

This should not occur to prevent broken installations of modules.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Do a fresh installation of Centreon.
- On Step 8 if you only select auto-discovery to install, license-manager and pp-manager should also be installed.

**Important**

There is no message clearly indicating the dependencies. This will be handled later on the Extension -> Manager and in the long term when redoing the installation wizard. This is a **simple quickfix**

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
