### PR TITLE
fix(core): duplicate SSH key on source upgrade

### DIFF
--- a/doc/en/installation/from_sources.rst
+++ b/doc/en/installation/from_sources.rst
@@ -271,7 +271,6 @@ License agreement
 -----------------
 
 ::
-
     This General Public License does not permit incorporating your program into
     proprietary programs.  If your program is a subroutine library, you may
     consider it more useful to permit linking proprietary applications with the
@@ -310,8 +309,7 @@ Answer [y] to all the questions: ::
 Definition of installation paths
 --------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
             Start CentWeb Installation
     ------------------------------------------------------------------------
@@ -330,7 +328,7 @@ Definition of installation paths
     > y
     Path /var/log/centreon                                     OK
 
-    ::
+::
 
     Where is your Centreon etc directory ?
     default to [/etc/centreon]
@@ -407,8 +405,7 @@ the user will likely be *centreon-broker*. ::
 Monitoring logs directory
 -------------------------
 
-    ::
-
+::
     What is the Monitoring engine log directory ?[/var/log/centreon-engine]
     default to [/var/log/centreon-engine]
     >
@@ -423,8 +420,7 @@ Monitoring logs directory
 Sudo configuration
 ------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     	  Configure Sudo
     ------------------------------------------------------------------------
@@ -463,8 +459,7 @@ Sudo configuration
 Apache configuration
 --------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
       	  Configure Apache server
     ------------------------------------------------------------------------
@@ -484,8 +479,7 @@ Apache configuration
 PHP FPM configuration
 ---------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
       	  Configure PHP FPM service
     ------------------------------------------------------------------------
@@ -553,8 +547,7 @@ PHP FPM configuration
 Pear module installation
 ------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     Pear Modules
     ------------------------------------------------------------------------
@@ -569,8 +562,7 @@ Pear module installation
 Configuration file installation
 -------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     		  Centreon Post Install
     ------------------------------------------------------------------------
@@ -580,8 +572,7 @@ Configuration file installation
 Performance data component (CentStorage) installation
 -----------------------------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     	  Starting CentStorage Installation
     ------------------------------------------------------------------------
@@ -619,8 +610,7 @@ Performance data component (CentStorage) installation
 Poller communication subsystem (CentCore) installation
 ------------------------------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     	  Starting CentCore Installation
     ------------------------------------------------------------------------
@@ -647,8 +637,7 @@ Poller communication subsystem (CentCore) installation
 Plugin installation
 -------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     	  Starting Centreon Plugins Installation
     ------------------------------------------------------------------------
@@ -668,8 +657,7 @@ Plugin installation
 Centreon SNMP trap management installation
 ------------------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
      	  Starting CentreonTrapD Installation
     ------------------------------------------------------------------------

--- a/doc/fr/installation/from_sources.rst
+++ b/doc/fr/installation/from_sources.rst
@@ -274,7 +274,6 @@ Approbation de la licence
 -------------------------
 
 ::
-
     This General Public License does not permit incorporating your program into
     proprietary programs.  If your program is a subroutine library, you may
     consider it more useful to permit linking proprietary applications with the
@@ -315,8 +314,7 @@ Répondez [y] à toutes les questions ::
 Définition des chemins d'installation
 -------------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
             Start CentWeb Installation
     ------------------------------------------------------------------------
@@ -335,7 +333,7 @@ Définition des chemins d'installation
     > y
     Path /var/log/centreon                                     OK
 
-    ::
+::
 
     Where is your Centreon etc directory ?
     default to [/etc/centreon]
@@ -412,8 +410,7 @@ l'utilisateur sera vraisemblablement *centreon-broker*.  ::
 Répertoire des journaux d'évènements
 ------------------------------------
 
-    ::
-
+::
     What is the Monitoring engine log directory ?[/var/log/centreon-engine]
     default to [/var/log/centreon-engine]
     >
@@ -428,8 +425,7 @@ Répertoire des journaux d'évènements
 Configuration des droits sudo
 -----------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     	  Configure Sudo
     ------------------------------------------------------------------------
@@ -470,8 +466,7 @@ Configuration des droits sudo
 Configuration du serveur Apache
 -------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
       	  Configure Apache server
     ------------------------------------------------------------------------
@@ -490,8 +485,7 @@ Configuration du serveur Apache
 Configuration de PHP FPM
 ------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
       	  Configure PHP FPM service
     ------------------------------------------------------------------------
@@ -561,8 +555,7 @@ Configuration de PHP FPM
 Installation des modules pear
 -----------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     Pear Modules
     ------------------------------------------------------------------------
@@ -577,8 +570,7 @@ Installation des modules pear
 Installation du fichier de configuration
 ----------------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     		  Centreon Post Install
     ------------------------------------------------------------------------
@@ -588,8 +580,7 @@ Installation du fichier de configuration
 Installation du composant CentStorage
 -------------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     	  Starting CentStorage Installation
     ------------------------------------------------------------------------
@@ -627,8 +618,7 @@ Installation du composant CentStorage
 Installation du composant CentCore
 ----------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     	  Starting CentCore Installation
     ------------------------------------------------------------------------
@@ -655,8 +645,7 @@ Installation du composant CentCore
 Installation des plugins
 ------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
     	  Starting Centreon Plugins Installation
     ------------------------------------------------------------------------
@@ -676,8 +665,7 @@ Installation des plugins
 Installation du système de gestion des traps SNMP (CentreonTrapD)
 -----------------------------------------------------------------
 
-    ::
-
+::
     ------------------------------------------------------------------------
      	  Starting CentreonTrapD Installation
     ------------------------------------------------------------------------

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ BASE_DIR=$(dirname $0)
 BASE_DIR=$( cd $BASE_DIR; pwd )
 export BASE_DIR
 if [ -z "${BASE_DIR#/}" ] ; then
-	echo -e "I think it is not right to have Centreon source on slash"
+	echo -e "You cannot select the filesystem root folder"
 	exit 1
 fi
 INSTALL_DIR="$BASE_DIR/libinstall"

--- a/install.sh
+++ b/install.sh
@@ -157,7 +157,7 @@ if [ "$_tmp_install_opts" -eq 0 ] ; then
 fi
 
 #Export variable for all programs
-export silent_install user_install_vars CENTREON_CONF cinstall_opts inst_upgrade_dir
+export silent_install user_install_vars CENTREON_CONF cinstall_opts inst_upgrade_dir upgrade
 
 ## init LOG_FILE
 # backup old log file...
@@ -240,10 +240,11 @@ if [ "$silent_install" -ne 1 ] ; then
 
 	yes_no_default "$(gettext "Do you accept GPL license ?")" 
 	if [ "$?" -ne 0 ] ; then 
-		echo_info "$(gettext "You do not agree to GPL license ? Okay... have a nice day.")"
+		echo_info "As you did not accept the license, we cannot continue."
+		log "INFO" "Installation aborted - License not accepted"
 		exit 1
 	else
-		log "INFO" "$(gettext "You accepted GPL license")"
+		log "INFO" "Accepted the license"
 	fi
 else 
 	if [ "$upgrade" -eq 0 ] ; then
@@ -263,7 +264,7 @@ if [ "$upgrade" -eq 1 ] ; then
 		echo_info "$(gettext "You seem to have an existing Centreon.")\n"
 		yes_no_default "$(gettext "Do you want to use the last Centreon install parameters ?")" "$yes"
 		if [ "$?" -eq 0 ] ; then
-			echo_passed "\n$(gettext "Using: ") $(ls $inst_upgrade_dir/instCent*)"
+			echo_passed "\n$(gettext "Using: ") $(ls $inst_upgrade_dir/instCent*)" "$ok"
 			use_upgrade_files="1"
 		fi
 	fi
@@ -274,8 +275,6 @@ if [ "$silent_install" -ne 1 ] ; then
 	echo -e "\t$(gettext "Please choose what you want to install")"
 	echo "$line"
 fi
-
-export upgrade
 
 ## init install process
 # I prefer split install script.

--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,7 @@ LOG_FILE=${LOG_FILE:=log\/install_centreon.log}
 if [ "${FORCE_NO_ROOT:-0}" -ne 0 ]; then
 	USERID=$(id -u)
 	if [ "$USERID" != "0" ]; then
-	    echo -e "$(gettext "You must exec with root user")"
+	    echo -e "$(gettext "You must launch this script using a root user")"
 	    exit 1
 	fi
 fi
@@ -240,7 +240,7 @@ if [ "$silent_install" -ne 1 ] ; then
 
 	yes_no_default "$(gettext "Do you accept GPL license ?")" 
 	if [ "$?" -ne 0 ] ; then 
-		echo_info "As you did not accept the license, we cannot continue."
+		echo_info "$(gettext "As you did not accept the license, we cannot continue.")"
 		log "INFO" "Installation aborted - License not accepted"
 		exit 1
 	else

--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -243,8 +243,6 @@ cp -Rf $TMP_DIR/src/libinstall/{functions,cinstall,gettext} \
   $TMP_DIR/final/libinstall/ >> "$LOG_FILE" 2>&1
 
 ## Prepare insertBaseConf.sql
-#echo -e "$(gettext "In process")"
-### Step 1:
 ## Change Macro on sql file
 log "INFO" "$(gettext "Change macros for insertBaseConf.sql")"
 ${SED} -e 's|@INSTALL_DIR_CENTREON@|'"$INSTALL_DIR_CENTREON"'|g' \

--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -79,15 +79,41 @@ locate_perl
 
 ## Check PHP version
 check_php_version
-[ "$?" -eq 1 ] && purge_centreon_tmp_dir && exit 1
+if [ "$?" -eq 1 ] ; then
+    echo_info "\n\t$(gettext "Your php version does not meet the requirements")"
+
+    echo -e "\t$(gettext "Please read the documentation available here") : documentation.centreon.com"
+    echo -e "\n\t$(gettext "Installation aborted")"
+
+    purge_centreon_tmp_dir
+    exit 1
+fi
 
 ## Check composer dependencies (if vendor directory exists)
 check_composer_dependencies
-[ "$?" -eq 1 ] && purge_centreon_tmp_dir && exit 1
+if [ "$?" -eq 1 ] ; then
+    echo_info "\n\t$(gettext "You must first install the composer dependencies")"
+
+    echo -e "\n\t$(gettext "composer install --no-dev --optimize-autoloader")"
+    echo -e "\t$(gettext "Please read the documentation available here") : documentation.centreon.com"
+
+    echo -e "\n\t$(gettext "Installation aborted")"
+    purge_centreon_tmp_dir
+    exit 1
+fi
 
 ## Check frontend application (if www/static directory exists)
 check_frontend_application
-[ "$?" -eq 1 ] && purge_centreon_tmp_dir && exit 1
+if [ "$?" -eq 1 ] ; then
+    echo_info "\n\t$(gettext "You must first build the frontend application")"
+
+    echo -e "\n\t$(gettext "Using npm install and then npm build")"
+    echo -e "\t$(gettext "Please read the documentation available here") : documentation.centreon.com"
+
+    echo -e "\n\t$(gettext "Installation aborted")"
+    purge_centreon_tmp_dir
+    exit 1
+fi
 
 ## Config apache
 check_httpd_directory
@@ -717,7 +743,7 @@ $INSTALL_DIR/cinstall $cinstall_opts -m 755 \
 ## Prepare to install all pear modules needed.
 # use check_pear.php script
 echo -e "\n$line"
-echo -e "$(gettext "Pear Modules")"
+echo -e "\t$(gettext "Pear Modules")"
 echo -e "$line"
 pear_module="0"
 first=1
@@ -748,14 +774,20 @@ done
 #----
 ## Gorgone specific tasks
 #----
+echo "$line"
+echo -e "\t$(gettext "Achieve gorgone's module integration")"
+echo "$line"
 ## Copy pollers SSH keys (in case of upgrade) to the new "user" gorgone
 if [ "$upgrade" = "1" ]; then
+
     copy_ssh_keys_to_gorgone
 fi
 ## Create gorgone's configuration structure
 create_gorgone_configuration_structure
 
-
+echo "$line"
+echo -e "\t$(gettext "Create configuration and installation files")"
+echo "$line"
 ## Create configfile for web install
 createConfFile
 

--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -92,7 +92,7 @@ fi
 ## Check composer dependencies (if vendor directory exists)
 check_composer_dependencies
 if [ "$?" -eq 1 ] ; then
-    echo_info "\n\t$(gettext "You must first install the composer dependencies")"
+    echo_info "\n\t$(gettext "You must first install the composer's dependencies")"
 
     echo -e "\n\t$(gettext "composer install --no-dev --optimize-autoloader")"
     echo -e "\t$(gettext "Please read the documentation available here") : documentation.centreon.com"

--- a/libinstall/functions
+++ b/libinstall/functions
@@ -226,7 +226,7 @@ yes_no_default() {
     local default=${2:-$no}
     local res="not_define"
     while [ "$res" != "$yes" ] && [ "$res" != "$no" ] && [ ! -z "$res" ] ; do
-        echo -e "\n$message\n$(gettext "[y/n], default to [$default]:")"
+        echo -e "\n$message\n$(gettext "[y/n], default to") [$default]:"
         echo -en "> "
         read res
         [ -z "$res" ] && res="$default"
@@ -249,7 +249,7 @@ answer() {
     local first=0
     while [ '!' -z "$res" ] ; do
         echo -e "\n$message"
-        [ "$default" != "NO_DEFAULT" ] && echo -e "$(gettext "default to [$default]")"
+        [ "$default" != "NO_DEFAULT" ] && echo -e "$(gettext "default to") [$default]"
         echo -en "> "
         read res
         if [ -z "$res" ] ; then
@@ -275,16 +275,16 @@ answer_with_testdir() {
     local res="not_define"
     local first=0
     while [ ! -d "$res" ] ; do
-        [ $first -eq 1 ] && echo_passed "$(gettext "$res is not a directory or does not exist.")" "$critical"
+        [ $first -eq 1 ] && echo_passed "$res $(gettext "is not a directory or does not exist.")" "$critical"
         echo -e "\n$message"
-        [ "$default" != "NO_DEFAULT" ] && echo -e "$(gettext "default to [$default]")"
+        [ "$default" != "NO_DEFAULT" ] && echo -e "$(gettext "default to") [$default]"
         echo -en "> "
         read res
         if [ -z "$res" ] ; then
             [ "$default" != "NO_DEFAULT" ] && res=$default
         fi
         if [ -z ${res#/} ] ; then
-            echo_passed  "$(gettext "You select slash...")"
+            echo_passed  "$(gettext "You cannot select slash")"
             res="not_define"
         else
             first=1
@@ -318,7 +318,7 @@ answer_with_createdir() {
             [ "$default" != "NO_DEFAULT" ] && res=$default
         fi
         if [ -z "${res#/}" -o "$yes" = "$res" -o "$no" = "$res" ] ; then
-            echo_passed  "$(gettext "You select slash...")"
+            echo_passed  "$(gettext "You cannot select slash")"
             res="not_define"
         else
             first=1
@@ -362,7 +362,7 @@ answer_with_createfile() {
             [ "$default" != "NO_DEFAULT" ] && res=$default
         fi
         if [ -z "${res#/}" -o "$yes" = "$res" -o "$no" = "$res" ] ; then
-            echo_passed  "$(gettext "You select slash...")"
+            echo_passed  "$(gettext "You cannot select slash")"
             res="not_define"
         else
             first=1
@@ -371,7 +371,7 @@ answer_with_createfile() {
             if [ $? -eq 0 ] ; then
                 touch $res
                 if [ $? -ne 0 ] ; then
-                    echo_passed "$(gettext "Could not create file.")" "$critical"
+                    echo_passed "$(gettext "Could not create the file.")" "$critical"
                     #continue
                 fi
                 log "INFO" "$(gettext "Creating") : $res"
@@ -576,7 +576,6 @@ dir_test_create() {
             return 1
         fi
         echo_success "$(gettext "Creating directory") $dirname" "$ok"
-        log "INFO" "$(gettext "Creating directory") $dirname"
     fi
     return 0
 }
@@ -597,7 +596,6 @@ user_create() {
         return 1
     fi
     echo_success "$(gettext "Creating user") $username ($description)" "$ok"
-    log "INFO" "$(gettext "Creating user") $username"
     return 0
 }
 
@@ -614,7 +612,6 @@ group_create() {
         return 1
     fi
     echo_success "$(gettext "Creating group") $groupname" "$ok"
-    log "INFO" "$(gettext "Creating group") $groupname"
     return 0
 }
 
@@ -1367,7 +1364,6 @@ reload_service_apache() {
         service="apache2"
     else
         echo_warning "$(gettext "Unable to reload Apache server")" "$warning"
-        log "WARN" "$(gettext "Unable to reload Apache server")"
     fi
 
     log "DEBUG" "$(gettext "use") : $service"
@@ -1444,7 +1440,7 @@ __EOT__
     if [ -e $directory/centreon.apache.conf ] ; then
         return 0
     else
-        log "INFO" "$(gettext "Problem when I generate an apache configuration")"
+        log "INFO" "$(gettext "Problem when generating apache configuration")"
         return 1
     fi
 }
@@ -1561,7 +1557,7 @@ __EOT__
     if [ -e $directory/centreon.php-fpm.conf ] ; then
         return 0
     else
-        log "INFO" "$(gettext "Problem when I generate an PHP FPM configuration")"
+        log "INFO" "$(gettext "Problem when generating PHP FPM configuration")"
         return 1
     fi
 }
@@ -1587,7 +1583,6 @@ reload_service_php_fpm() {
 
     if [ "$service_reloaded" -eq 0 ] ; then
         echo_warning "$(gettext "Unable to reload PHP FPM service")" "$warning"
-        log "WARN" "$(gettext "Unable to reload PHP FPM service")"
     fi
 }
 
@@ -1644,7 +1639,7 @@ __EOT__
     if [ -e $directory/centreon.sudo ] ; then
         return 0
     else
-        log "INFO" "$(gettext "Problem when I generate a sudo configuration")"
+        log "INFO" "$(gettext "Problem when generating sudo configuration")"
         return 1
     fi
 }
@@ -1718,7 +1713,7 @@ configureSUDO() {
             echo_passed "$(gettext "Please configure your sudo with this example"):\n\t $dir_conf/centreon.sudo" "$passed"
         fi
     fi
-    log "INFO" "$(gettext "Please configure your sudo with this example"): $dir_conf/centreon.sudo"
+    log "INFO" "$(gettext "Please configure your sudo using this example"): $dir_conf/centreon.sudo"
     return 0
 }
 
@@ -1801,7 +1796,7 @@ createConfFile() {
 __EOT__
 
     echo "?>" >> $INSTALL_DIR_CENTREON_CONF
-    log "INFO" "$(gettext "Change right on") : $INSTALL_DIR_CENTREON_CONF"
+    log "INFO" "$(gettext "Change rights on") : $INSTALL_DIR_CENTREON_CONF"
     ${CHOWN} $WEB_USER:$WEB_GROUP $INSTALL_DIR_CENTREON_CONF >> $LOG_FILE 2>&1
     echo_success "Create $INSTALL_DIR_CENTREON_CONF" "OK"
 }
@@ -2245,7 +2240,7 @@ copyInTempFile() {
     mkdir -p "$TMP_DIR/final"
 
     for folder in $srclistcp ; do
-        log "INFO" "$(gettext "Copy") $BASE_DIR/$folder $TMP_DIR/src/"
+        log "INFO" "$(gettext "Copy") $BASE_DIR/$folder $(gettext "to") $TMP_DIR/src/"
         cp -Rf $BASE_DIR/$folder $TMP_DIR/src/
     done
 }
@@ -2396,18 +2391,18 @@ find_OS() {
 ##      - ...
 #----
 clean_and_exit() {
-  local trap_sig=${1:-0}
-  if [ $trap_sig -eq 0 ] ; then
-    echo -e "$(gettext "\nTrap interrupt, Centreon'll exit now and clean install")"
-    yes_no_default "$(gettext "Do you really want to quit Centreon install process ? ")" "$no"
-    if [ $? -eq 1 ] ; then
-      echo "$(gettext "Continue...")"
-      return 1
+    local trap_sig=${1:-0}
+    if [ $trap_sig -eq 0 ] ; then
+        echo -e "$(gettext "\nTrap interrupt, Centreon'll exit now and clean install")"
+        yes_no_default "$(gettext "Do you really want to quit Centreon install process ? ")" "$no"
+        if [ $? -eq 1 ] ; then
+            echo "$(gettext "Continue...")"
+            return 1
+        fi
     fi
-  fi
     log "EXIT" "$(gettext "Exit Centreon install")"
-  [ -n "$SUDO_FILE" -a $upgrade -eq 0 ] && clean_sudo "$SUDO_FILE" 0
-  purge_centreon_tmp_dir "silent"
+    [ -n "$SUDO_FILE" -a $upgrade -eq 0 ] && clean_sudo "$SUDO_FILE" 0
+    purge_centreon_tmp_dir "silent"
     exit 1
 }
 

--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1242,7 +1242,7 @@ configureApache() {
 ## Copy ssh keys to gorgone and add proper rights
 #----
 copy_ssh_keys_to_gorgone() {
-    if [ ! -d $GORGONE_VARLIB ] ; then
+    if [ ! -d "$GORGONE_VARLIB/.ssh" ] ; then
         mkdir -p "$GORGONE_VARLIB/.ssh"
         if [ $? -ne 0 ] ; then
             echo_failure "$(gettext "Cannot create the subfolder $GORGONE_VARLIB/.ssh")" "$fail"

--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1258,7 +1258,7 @@ copy_ssh_keys_to_gorgone() {
         return 1
     fi
 
-    cp -Rf "$CENTREON_SPOOL_SSH" "$GORGONE_VARLIB/.ssh"
+    cp -Rf "$CENTREON_SPOOL_SSH/.ssh" "$GORGONE_VARLIB"
     if [ $? -ne 0 ] ; then
         echo_failure "$(gettext "Cannot move the SSH keys to $GORGONE_VARLIB/.ssh")" "$fail"
         return 1


### PR DESCRIPTION
## Description

Manage gorgone integration on update using sources
Duplicate ssh keys in /var/lib/centreon-gorgone to be able to communicate with pollers and remote (using the legacy mode and without modifications)

**Fixes** # (none)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
