### PR TITLE
fix(api): prevent smart grouping of the services related to host with status down

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -383,7 +383,6 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             FROM `:dbstg`.`services` AS s
             INNER JOIN `:dbstg`.`hosts` sh
                 ON sh.host_id = s.host_id
-                AND sh.state = 0
                 AND sh.name NOT LIKE :serviceModule
                 AND sh.enabled = 1";
         $collector->addValue(':serviceModule', '_Module_%');


### PR DESCRIPTION
## Description

the services attached to the down host are not visible, the host is visible

**Fixes** MON-5019

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
