### PR TITLE
fix(web): undefined variable in ldap form

### DIFF
--- a/www/include/Administration/parameters/ldap/form.ihtml
+++ b/www/include/Administration/parameters/ldap/form.ihtml
@@ -33,7 +33,7 @@
 		</td>
 		<td class="FormRowValue">{$form.ldap_auto_sync.html}</td>
 	</tr>
-	{if hideSyncInterval != 1}
+	{if $hideSyncInterval != 1}
 		<tr class="list_one" id="ldap_sync_interval">
 			<td class="FormRowField">
 				<img class="helpTooltip" name="ldap_sync_interval" />


### PR DESCRIPTION
## Description

correct the "undefined variable assumed to be ..." in the 
**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

go to the LDAP form and check that the undefined warning log is not displayed anymore

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
