### PR TITLE
fix(api): Removing host type AND having the cursor in the search bar sends an error 500

### DIFF
--- a/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+++ b/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
@@ -201,7 +201,7 @@ class SqlRequestParametersTranslator
             $searchOperator = (string) key($valueOrArray);
             $mixedValue = $valueOrArray[$searchOperator];
 
-            // replace REGEXP operator with LIKE if it's not vaild
+            // replace REGEXP operator with LIKE if it's not valid
             if (
                 $mixedValue
                 && $searchOperator === RequestParameters::OPERATOR_REGEXP

--- a/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+++ b/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
@@ -200,6 +200,15 @@ class SqlRequestParametersTranslator
         if (is_array($valueOrArray)) {
             $searchOperator = (string) key($valueOrArray);
             $mixedValue = $valueOrArray[$searchOperator];
+
+            // replace REGEXP operator with LIKE if it's not vaild
+            if (
+                $mixedValue
+                && $searchOperator === RequestParameters::OPERATOR_REGEXP
+                && @preg_match("/{$mixedValue}/", '') === false
+            ) {
+                $searchOperator = RequestParameters::OPERATOR_LIKE;
+            }
         } else {
             $searchOperator = RequestParameters::DEFAULT_SEARCH_OPERATOR;
             $mixedValue = $valueOrArray;


### PR DESCRIPTION
## Description

when the user sends invalid regexp to with operator $rg server will throw an exception from the DB,
the idea is to change the REGEXP with LIKE when the syntax is not valid

**Fixes** MON-5034

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

send GET request to [http://localhost/centreon/api/beta/monitoring/resources?page=1&limit=100&search={%22$or%22:[{%22name%22:{%22$rg%22:%22*a*%22}}]}](http://localhost/centreon/api/beta/monitoring/resources?page=1&limit=100&search={%22$or%22:[{%22name%22:{%22$rg%22:%22*a*%22}}]})

## Checklist

#### Community contributors & Centreon team

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [x] I have made sure that the **unit tests** related to the story are successful.
- [x] I have made sure that **unit tests cover 80%** of the code written for the story.
- [x] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
