### PR TITLE
enh(api): add new method to list only metrics name from a selected svc

### DIFF
--- a/www/api/class/centreon_metric.class.php
+++ b/www/api/class/centreon_metric.class.php
@@ -198,12 +198,12 @@ class CentreonMetric extends CentreonWebService
             $queryValues['limit'] = (int)$this->arguments['page_limit'];
         }
         $stmt = $this->pearDBMonitoring->prepare($query);
-        $stmt->bindParam(':name', $queryValues['name'], PDO::PARAM_STR);
-        $stmt->bindParam(':host_id', $queryValues['host_id'], PDO::PARAM_INT);
-        $stmt->bindParam(':service_id', $queryValues['service_id'], PDO::PARAM_INT);
+        $stmt->bindParam(':name', $queryValues['name'], \PDO::PARAM_STR);
+        $stmt->bindParam(':host_id', $queryValues['host_id'], \PDO::PARAM_INT);
+        $stmt->bindParam(':service_id', $queryValues['service_id'], \PDO::PARAM_INT);
         if (isset($queryValues['offset'])) {
-            $stmt->bindParam(':offset', $queryValues["offset"], PDO::PARAM_INT);
-            $stmt->bindParam(':limit', $queryValues["limit"], PDO::PARAM_INT);
+            $stmt->bindParam(':offset', $queryValues["offset"], \PDO::PARAM_INT);
+            $stmt->bindParam(':limit', $queryValues["limit"], \PDO::PARAM_INT);
         }
         $stmt->execute();
         $metrics = array();

--- a/www/api/class/centreon_metric.class.php
+++ b/www/api/class/centreon_metric.class.php
@@ -156,6 +156,70 @@ class CentreonMetric extends CentreonWebService
     }
 
     /**
+     * @return array
+     *
+     * @throws RestBadRequestException
+     */
+    protected function getListOfMetricsByService()
+    {
+        $queryValues = array();
+        if (isset($this->arguments['id'])) {
+            $tmp = explode ('-', $this->arguments['id']);
+            $queryValues['host_id'] = (int)$tmp[0];
+            $queryValues['service_id'] = (int)$tmp[1];
+        } else {
+            throw new \RestBadRequestException('400 Bad Request, invalid service id');
+        }
+        if (isset($this->arguments['q'])) {
+            $queryValues['name'] = '%' . (string)$this->arguments['q'] . '%';
+        } else {
+            $queryValues['name'] = '%%';
+        }
+
+        $query = 'SELECT SQL_CALC_FOUND_ROWS m.metric_id, ' .
+            'm.metric_name AS name ' .
+            'FROM metrics m, hosts h, services s, index_data i ' .
+            'WHERE m.index_id = i.id ' .
+            'AND h.host_id = i.host_id ' .
+            'AND s.service_id = i.service_id ' .
+            'AND h.enabled = 1 ' .
+            'AND s.enabled = 1 ' .
+            'AND m.metric_name LIKE :name ' .
+            'AND h.host_id = :host_id AND s.service_id = :service_id ' .
+            'ORDER BY m.metric_name ';
+
+        if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
+            if (!is_numeric($this->arguments['page']) || !is_numeric($this->arguments['page_limit'])) {
+                throw new \RestBadRequestException('400 Bad Request, limit error');
+            }
+            $offset = ($this->arguments['page'] - 1) * $this->arguments['page_limit'];
+            $query .= 'LIMIT :offset,:limit';
+            $queryValues['offset'] = (int)$offset;
+            $queryValues['limit'] = (int)$this->arguments['page_limit'];
+        }
+        $stmt = $this->pearDBMonitoring->prepare($query);
+        $stmt->bindParam(':name', $queryValues['name'], PDO::PARAM_STR);
+        $stmt->bindParam(':host_id', $queryValues['host_id'], PDO::PARAM_INT);
+        $stmt->bindParam(':service_id', $queryValues['service_id'], PDO::PARAM_INT);
+        if (isset($queryValues['offset'])) {
+            $stmt->bindParam(':offset', $queryValues["offset"], PDO::PARAM_INT);
+            $stmt->bindParam(':limit', $queryValues["limit"], PDO::PARAM_INT);
+        }
+        $stmt->execute();
+        $metrics = array();
+        while ($row = $stmt->fetch()) {
+            $metrics[] = array(
+                'id' => $row['metric_id'],
+                'text' => $row['name']
+            );
+        }
+        return array(
+            'items' => $metrics,
+            'total' => (int) $this->pearDBMonitoring->numberRows()
+        );
+    }
+
+    /**
      * Get last metrics value by services or/and metrics
      *
      * @return array | null if arguments are not set

--- a/www/api/class/centreon_metric.class.php
+++ b/www/api/class/centreon_metric.class.php
@@ -170,8 +170,9 @@ class CentreonMetric extends CentreonWebService
         } else {
             throw new \RestBadRequestException('400 Bad Request, invalid service id');
         }
-        if (isset($this->arguments['q'])) {
-            $queryValues['name'] = '%' . (string)$this->arguments['q'] . '%';
+        $nameArg = filter_var($this->arguments['q'] ?? false, FILTER_SANITIZE_STRING);
+        if ($nameArg !== false) {
+            $queryValues['name'] = '%' . $nameArg . '%';
         } else {
             $queryValues['name'] = '%%';
         }


### PR DESCRIPTION
## Description 

Add new method to list only metrics name from a selected hostId-serviceId couple.
Needed for Anomaly Detection

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
