### PR TITLE
Add missing index on ods_view_details.index_id

### DIFF
--- a/www/install/createTables.sql
+++ b/www/install/createTables.sql
@@ -1659,6 +1659,7 @@ CREATE TABLE `ods_view_details` (
   `contact_id` int(11) DEFAULT NULL,
   `all_user` enum('0','1') DEFAULT NULL,
   PRIMARY KEY (`dv_id`),
+  KEY `index_id` (`index_id`),
   KEY `contact_index` (`contact_id`, `index_id`) USING BTREE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/www/install/sql/centreon/Update-DB-20.04.0-beta.1.sql
+++ b/www/install/sql/centreon/Update-DB-20.04.0-beta.1.sql
@@ -37,3 +37,6 @@ INSERT INTO `options` (`key`, `value`) VALUES ('gorgone_api_address', '127.0.0.1
 INSERT INTO `options` (`key`, `value`) VALUES ('gorgone_api_port', '8085');
 INSERT INTO `options` (`key`, `value`) VALUES ('gorgone_api_ssl', '0');
 INSERT INTO `options` (`key`, `value`) VALUES ('gorgone_api_allow_self_signed', '1');
+
+-- Add missing index on ods_view_details
+ALTER TABLE `ods_view_details`ADD KEY `index_id` (`index_id`);


### PR DESCRIPTION
## Description

There are a lot of requests ( UPDATE `ods_view_details` SET `rnd_color` = '#99ff00' WHERE `index_id` = '1005229' for instance) that consume a lot of database CPU. 

Indeed, it's because there is no index on this column. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)