### PR TITLE
fix(api): Sanitize arguments in API request

### DIFF
--- a/www/api/class/centreon_home_customview.class.php
+++ b/www/api/class/centreon_home_customview.class.php
@@ -171,8 +171,11 @@ class CentreonHomeCustomview extends CentreonWebService
      */
     public function getPreferences()
     {
-        if (!isset($this->arguments['widgetId']) || !isset($this->arguments['viewId'])) {
-            throw new \Exception('Missing argument');
+        if (
+            filter_var(($widgetId = $this->arguments['widgetId'] ?? false), FILTER_VALIDATE_INT) === false
+            || filter_var(($viewId = $this->arguments['viewId'] ?? false), FILTER_VALIDATE_INT) === false
+        ) {
+            throw new \InvalidArgumentException('Bad argument format');
         }
 
         require_once _CENTREON_PATH_ . "www/class/centreonWidget.class.php";
@@ -190,8 +193,6 @@ class CentreonHomeCustomview extends CentreonWebService
 
         global $centreon;
 
-        $viewId = $this->arguments['viewId'];
-        $widgetId = $this->arguments['widgetId'];
         $action = "setPreferences";
 
         $viewObj = new CentreonCustomView($centreon, $this->pearDB);


### PR DESCRIPTION
## Description

Sanitize widgetId and viewId arguments in API request
**Fixes**  MON-4964

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)