### PR TITLE
fix(config): fix gorgone config generation for poller not using remote as proxy

### DIFF
--- a/www/include/configuration/configServers/popup/popup.php
+++ b/www/include/configuration/configServers/popup/popup.php
@@ -39,17 +39,12 @@ $dbResult->closeCursor();
 
 //get poller informations
 $query = "
-SELECT ns.`id`, ns.`name`, ns.`gorgone_port`, ns.`ns_ip_address`, ns.`localhost`,ns.remote_id, 
-cn.`command_file`, GROUP_CONCAT( pr.`remote_server_id` ) AS list_remote_server_id , 
-CASE
-    WHEN (ns.localhost = '1') THEN 'central'
-    WHEN (rs.id > '0') THEN 'remote'
-    ELSE 'poller' 
-END  AS poller_type 
+SELECT ns.`id`, ns.`name`, ns.`gorgone_port`, ns.`ns_ip_address`, ns.`localhost`, ns.remote_id, 
+remote_server_use_as_proxy, cn.`command_file`, GROUP_CONCAT( pr.`remote_server_id` ) AS list_remote_server_id 
 FROM nagios_server AS ns 
 LEFT JOIN remote_servers AS rs ON (rs.ip = ns.ns_ip_address) 
-LEFT JOIN cfg_nagios AS cn ON (cn.`nagios_id` = ns.`id` ) 
-LEFT JOIN rs_poller_relation AS pr ON (pr.`poller_server_id` = ns.`id` ) 
+LEFT JOIN cfg_nagios AS cn ON (cn.`nagios_id` = ns.`id`) 
+LEFT JOIN rs_poller_relation AS pr ON (pr.`poller_server_id` = ns.`id`) 
 WHERE ns.ns_activate = '1' 
 AND ns.`id` =" . (int)$_GET['id'];
 
@@ -64,7 +59,8 @@ while ($row = $dbResult->fetch()) {
 }
 
 $tpl->assign('serverIp', $server['ns_ip_address']);
-if (empty($server['remote_id']) && empty($server['list_remote_server_id'])) {
+if ((empty($server['remote_id']) && empty($server['list_remote_server_id'])) ||
+    $server['remote_server_use_as_proxy'] == 0) {
     //parent is the central
     $query = "SELECT `id` FROM nagios_server WHERE ns_activate = '1' AND localhost = '1'";
     $dbResult = $pearDB->query($query);

--- a/www/include/configuration/configServers/popup/popup.php
+++ b/www/include/configuration/configServers/popup/popup.php
@@ -62,7 +62,7 @@ $tpl->assign('serverIp', $server['ns_ip_address']);
 if (
     (empty($server['remote_id']) && empty($server['list_remote_server_id'])) ||
     $server['remote_server_use_as_proxy'] == 0
-    ) {
+) {
     //parent is the central
     $query = "SELECT `id` FROM nagios_server WHERE ns_activate = '1' AND localhost = '1'";
     $dbResult = $pearDB->query($query);

--- a/www/include/configuration/configServers/popup/popup.php
+++ b/www/include/configuration/configServers/popup/popup.php
@@ -59,8 +59,10 @@ while ($row = $dbResult->fetch()) {
 }
 
 $tpl->assign('serverIp', $server['ns_ip_address']);
-if ((empty($server['remote_id']) && empty($server['list_remote_server_id'])) ||
-    $server['remote_server_use_as_proxy'] == 0) {
+if (
+    (empty($server['remote_id']) && empty($server['list_remote_server_id'])) ||
+    $server['remote_server_use_as_proxy'] == 0
+    ) {
     //parent is the central
     $query = "SELECT `id` FROM nagios_server WHERE ns_activate = '1' AND localhost = '1'";
     $dbResult = $pearDB->query($query);


### PR DESCRIPTION
## Description

Use the `remote_server_use_as_proxy` option to determine wether Central or Remote is the "parent" of the Poller.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Have a Central > Remote > Poller kinf of setup,
* Use ZMQ communication type for Poller,
* Set "Use the Remote Server as a proxy" to "Yes",
* Generate Gorgone configuration, authorized_clients key should be Remote thumbprint,
* Set "Use the Remote Server as a proxy" to "No",
* Generate Gorgone configuration, authorized_clients key should be Central thumbprint,

## Checklist

#### Community contributors & Centreon team

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

#### Centreon team only

- [ ] I have made sure that the **unit tests** related to the story are successful.
- [ ] I have made sure that **unit tests cover 80%** of the code written for the story.
- [ ] I have made sure that **acceptance tests** related to the story are successful (**local and CI**)
