### PR TITLE
fix(install): wrong value used for checkboxes refresh

### DIFF
--- a/www/install/steps/templates/step8.tpl
+++ b/www/install/steps/templates/step8.tpl
@@ -132,8 +132,8 @@
                 if (modules && modules.length > 0) {
                     modules.forEach(function(module) {
                         if (module.install) {
-                            jQuery('label[for="module_' + module.name + '"]').addClass('md-label-green');
-                            jQuery("input[type=checkbox]#module_" + module.name)
+                            jQuery('label[for="module_' + module.module + '"]').addClass('md-label-green');
+                            jQuery("input[type=checkbox]#module_" + module.module)
                                 .attr('disabled', 'disabled')
                                 .prop('checked', 'checked');
                         }
@@ -143,8 +143,8 @@
                 if (widgets && widgets.length > 0) {
                     widgets.forEach(function(widget) {
                         if (widget.install) {
-                            jQuery('label[for="widget_' + widget.name + '"]').addClass('md-label-green');
-                            jQuery("input[type=checkbox]#widget_" + widget.name)
+                            jQuery('label[for="widget_' + widget.widget + '"]').addClass('md-label-green');
+                            jQuery("input[type=checkbox]#widget_" + widget.widget)
                                 .attr('disabled', 'disabled')
                                 .prop('checked', 'checked');
                         }


### PR DESCRIPTION
## Description

When the install was done of the modules/widgets in the step 7 of a fresh installation, the checkboxes were not correctly refreshed


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Prepare a fresh install of Centreon (with rpm installed modules like autodisco, bam, map, mbi)
- On step 7 of fresh installation when the selected modules are installed (click on the button)
     - Dependencies of the modules should be automatically installed
     - The checkboxes are turned into a green tick and disabled.

## Checklist

#### Requirements

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
