### PR TITLE
fix(web): correctly compute localized downtime's datepickers

### DIFF
--- a/www/class/centreonUser.class.php
+++ b/www/class/centreonUser.class.php
@@ -238,6 +238,9 @@ class CentreonUser
         // Get locale from browser
         if ($lang === 'browser') {
             $lang = \Locale::acceptFromHttp($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+
+            // check that the variable value end with .UTF-8 or add it
+            $lang = (strpos($lang, '.UTF-8') !== false) ?: $lang . '.UTF-8';
         }
 
         return $lang;

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -41,7 +42,7 @@ require_once "./include/common/common-Func.php";
 
 require_once './class/centreonFeature.class.php';
 
-$form = new HTML_QuickFormCustom('Form', 'post', "?p=".$p);
+$form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
 
 /*
  * Path to the configuration dir
@@ -60,24 +61,30 @@ if (!isset($centreonFeature)) {
  */
 $cct = array();
 if ($o == "c") {
-    $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager, " .
-        "contact_js_effects, contact_autologin_key, default_page, contact_auth_type " .
-        "FROM contact WHERE contact_id = '" . $centreon->user->get_id() . "'";
-    $DBRESULT = $pearDB->query($query);
+    $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager,
+        contact_js_effects, contact_autologin_key, default_page, contact_auth_type
+        FROM contact WHERE contact_id = :id";
+    $DBRESULT = $pearDB->prepare($query);
+    $DBRESULT->bindValue(':id', $centreon->user->get_id(), \PDO::PARAM_INT);
+    $DBRESULT->execute();
+
     // Set base value
     $cct = array_map("myDecode", $DBRESULT->fetch());
-    $res = $pearDB->query(
-        "SELECT cp_key, cp_value " .
-        "FROM contact_param " .
-        "WHERE cp_contact_id = '" . $pearDB->escape($centreon->user->get_id()) . "'"
+    $res = $pearDB->prepare(
+        "SELECT cp_key, cp_value
+        FROM contact_param
+        WHERE cp_contact_id = :id"
     );
+    $res->bindValue(':id', $centreon->user->get_id(), \PDO::PARAM_INT);
+    $res->execute();
+
     while ($row = $res->fetch()) {
         $cct[$row['cp_key']] = $row['cp_value'];
     }
 }
 
 /*
- * Database retrieve information for differents elements list we need on the page
+ * Database retrieve information for different elements list we need on the page
  *
  * Langs -> $langs Array
  */
@@ -87,7 +94,6 @@ $attrsText = array("size" => "35");
 
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
 $form->addElement('header', 'title', _("Change my settings"));
-
 $form->addElement('header', 'information', _("General Information"));
 $form->addElement('text', 'contact_name', _("Name"), $attrsText);
 if ($cct["contact_auth_type"] != 'ldap') {

--- a/www/include/common/javascript/centreon/dateMoment.js
+++ b/www/include/common/javascript/centreon/dateMoment.js
@@ -55,7 +55,7 @@ function formatDateMoment() {
                 myElement.text(moment(currentDate).tz(userTimezone).format('LT'));
             } else if (myElement.hasClass("isDate")) {
                 myElement.text(moment(currentDate).tz(userTimezone).format('LL'));
-            }else if (myElement.hasClass("isShortDate")) {
+            } else if (myElement.hasClass("isShortDate")) {
                 myElement.text(moment(currentDate).tz(userTimezone).format('LLL'));
             } else {
                 myElement.text(moment(currentDate).tz(userTimezone).format('LL LTS'));

--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -66,7 +66,7 @@ function initDatepicker(className, altFormat, defaultDate, idName, timestampToSe
             if (typeof(altName) != "undefined") {
                 var alternativeField = "input[name=alternativeDate" + altName[0].toUpperCase() + altName.slice(1) + "]";
                 // $(this).val(), if exists, is a GMT YYYY-MM-DDTHH:mm:ss timestamp, for example with PHP : gmdate("Y-m-d\TH:i:s")
-                var value = $(this) && $(this).val() ? moment($(this).val()).tz(timezone) : defaultDate;
+                var value = $(this) && $(this).val() ? moment($(this).val(),"DD-MM-YYYY").tz(timezone) : defaultDate;
                 jQuery(this).datepicker({
                     //formatting the hidden fields using a specific format
                     altField: alternativeField,

--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -1,5 +1,5 @@
 /*
-* Copyright 2005-2019 Centreon
+* Copyright 2005-2020 Centreon
 * Centreon is developed by : Julien Mathis and Romain Le Merlus under
 * GPL Licence 2.0.
 *
@@ -37,8 +37,7 @@
  *
  * @param className string : tag class name
  * @param altFormat string : format of the alternative field
- * @param defaultDate string : GMT YYYY-MM-DDTHH:mm:ss timestamp
- * @todo following 2 parameters seem to never be used, to remove ?
+ * @param defaultDate string : datepicker parameter of the setDate - GMT YYYY-MM-DDTHH:mm:ss timestamp
  * @param idName string : tag id of the displayed field
  * @param timestampToSet int : timestamp used to make a new date using the user localization and format
  */
@@ -80,9 +79,9 @@ function initDatepicker(className, altFormat, defaultDate, idName, timestampToSe
                 jQuery(this).datepicker();
             }
         });
-    // @todo section then seems to never be used, to remove ?
     } else {
         // setting the displayed and hidden fields with a timestamp value sent from the backend
+        // used for MBI pages
         var alternativeField = "input[name=alternativeDate" + idName + "]";
         var dateToSet = new Date(timestampToSet);
         jQuery("#" + idName).datepicker({
@@ -99,7 +98,8 @@ function initDatepicker(className, altFormat, defaultDate, idName, timestampToSe
  */
 function setUserFormat() {
     // Getting the local storage attribute
-    var userLanguage = localStorage.getItem('locale') ? localStorage.getItem('locale').substring(0, 5) : "en_US";
+    let userLanguage = localStorage.getItem('locale') ? localStorage.getItem('locale').substring(0, 5) : "en_US";
+
     if ("en_US" != userLanguage) {
         //calling the webservice to check if the file exists
         $.ajax({
@@ -114,8 +114,8 @@ function setUserFormat() {
                         .attr('src', './include/common/javascript/datepicker/' + data)
                         .appendTo('body');
                 } else {
-                    console.log ('WARNING : datepicker localized library not found for : "' + userLanguage + '"');
-                    console.log ('Initializing the datepicker for "en_US"');
+                    console.log('WARNING : datepicker localized library not found for : "' + userLanguage + '"');
+                    console.log('Initializing the datepicker for "en_US"');
                 }
             }
         });
@@ -145,6 +145,7 @@ function turnOffEvents() {
 function updateEndTime() {
     var start = moment($('[name="alternativeDateStart"]').val() + ' ' +  $(".timepicker").first().val(), "MM/DD/YYYY HH:mm");
     var end = moment($('[name="alternativeDateEnd"]').val() + ' ' +  $(".timepicker").last().val(), "MM/DD/YYYY HH:mm");
+
     if (start.isAfter(end) || start.isSame(end)) {
         turnOffEvents();
         start.add($('#duration').val(), $('#duration_scale').val());
@@ -157,6 +158,7 @@ function updateEndTime() {
 function updateStartTime() {
     var start = moment($('[name="alternativeDateStart"]').val() + ' ' +  $(".timepicker").first().val(), "MM/DD/YYYY HH:mm");
     var end = moment($('[name="alternativeDateEnd"]').val() + ' ' +  $(".timepicker").last().val(), "MM/DD/YYYY HH:mm");
+
     if (start.isAfter(end) || start.isSame(end)) {
         turnOffEvents();
         end.subtract($('#duration').val(), $('#duration_scale').val());

--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -66,7 +66,7 @@ function initDatepicker(className, altFormat, defaultDate, idName, timestampToSe
             if (typeof(altName) != "undefined") {
                 var alternativeField = "input[name=alternativeDate" + altName[0].toUpperCase() + altName.slice(1) + "]";
                 // $(this).val(), if exists, is a GMT YYYY-MM-DDTHH:mm:ss timestamp, for example with PHP : gmdate("Y-m-d\TH:i:s")
-                var value = $(this) && $(this).val() ? moment($(this).val(),"DD-MM-YYYY").tz(timezone) : defaultDate;
+                var value = $(this) && $(this).val() ? moment($(this).val(), "DD-MM-YYYY").tz(timezone) : defaultDate;
                 jQuery(this).datepicker({
                     //formatting the hidden fields using a specific format
                     altField: alternativeField,

--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -48,10 +48,9 @@ function initDatepicker(className, altFormat, defaultDate, idName, timestampToSe
 
     setUserFormat();
 
-    var timezone = localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess();
+    var timezone = localStorage.getItem('realTimezone') || moment.tz.guess();
 
     if (typeof(idName) == "undefined" || typeof(timestampToSet) == "undefined") {
-
         // generate default date in proper timezone
         if (defaultDate == "0") {
             defaultDate = moment().tz(timezone);

--- a/www/include/monitoring/downtime/AddDowntime.php
+++ b/www/include/monitoring/downtime/AddDowntime.php
@@ -393,8 +393,14 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
         }
 
         /* concatenating the chosen dates before sending them to ext_cmd */
-        $concatenatedStart = $_POST["alternativeDateStart"] . ' ' . $_POST['start_time'];
-        $concatenatedEnd = $_POST["alternativeDateEnd"] . ' ' . $_POST['end_time'];
+        $concatenatedStart = filter_var(
+            $_POST["alternativeDateStart"] . ' ' . $_POST['start_time'],
+            FILTER_SANITIZE_STRING
+        );
+        $concatenatedEnd = filter_var(
+            $_POST["alternativeDateEnd"] . ' ' . $_POST['end_time'],
+            FILTER_SANITIZE_STRING
+        );
 
         if (
             isset($values['downtimeType'])

--- a/www/include/monitoring/downtime/AddDowntime.php
+++ b/www/include/monitoring/downtime/AddDowntime.php
@@ -279,8 +279,9 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
 
     $defaultDuration = 7200;
     $defaultScale = 's';
-    if (isset($centreon->optGen['monitoring_dwt_duration']) &&
-        $centreon->optGen['monitoring_dwt_duration']
+    if (
+        isset($centreon->optGen['monitoring_dwt_duration'])
+        && $centreon->optGen['monitoring_dwt_duration']
     ) {
         $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
         if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&

--- a/www/include/monitoring/downtime/AddDowntime.php
+++ b/www/include/monitoring/downtime/AddDowntime.php
@@ -37,16 +37,10 @@ if (!isset($centreon)) {
     exit();
 }
 
-include_once _CENTREON_PATH_ . "www/class/centreonGMT.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonDB.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonService.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonHost.class.php";
 
-/*
- * Init GMT class
- */
-$centreonGMT = new CentreonGMT($pearDB);
-$centreonGMT->getMyGMTFromSession(session_id(), $pearDB);
 $hostStr = $centreon->user->access->getHostsString("ID", $pearDBO);
 $hostAclId = preg_split('/,/', str_replace("'", "", $hostStr));
 
@@ -287,6 +281,17 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
     );
 
     $defaultDuration = 7200;
+    $defaultScale = 's';
+    if (isset($centreon->optGen['monitoring_dwt_duration']) &&
+        $centreon->optGen['monitoring_dwt_duration']
+    ) {
+        $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
+        if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
+            $centreon->optGen['monitoring_dwt_duration_scale']
+        ) {
+            $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
+        }
+    }
     $form->setDefaults(array('duration' => $defaultDuration));
 
     $form->addElement(
@@ -296,11 +301,6 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
         array("s" => _("seconds"), "m" => _("minutes"), "h" => _("hours"), "d" => _("days")),
         array('id' => 'duration_scale')
     );
-    $defaultScale = 's';
-    if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
-        $centreon->optGen['monitoring_dwt_duration_scale']) {
-        $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
-    }
     $form->setDefaults(array('duration_scale' => $defaultScale));
 
     $withServices[] = $form->createElement('radio', 'with_services', null, _("Yes"), '1');
@@ -316,13 +316,7 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
     $form->addRule('comment', _("Required Field"), 'required');
 
     $data = array();
-    $gmt = $centreonGMT->getMyGMT();
-    if (!$gmt) {
-        $gmt = date_default_timezone_get();
-    }
 
-    $data["start_time"] = $centreonGMT->getDate("G:i", time(), $gmt);
-    $data["end_time"] = $centreonGMT->getDate("G:i", time() + $defaultDuration, $gmt);
     $data["host_or_hg"] = 1;
     $data["with_services"] = $centreon->optGen['monitoring_dwt_svc'];
 
@@ -578,12 +572,15 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
 
     function setDurationField() {
         var durationField = jQuery('#duration');
+        var durationScaleField = jQuery('#duration_scale');
         var fixedCb = jQuery('#fixed');
 
         if (fixedCb.prop("checked") == true) {
-            durationField.disabled = true;
+            durationField.attr('disabled', true);
+            durationScaleField.attr('disabled', true);
         } else {
-            durationField.disabled = false;
+            durationField.removeAttr('disabled');
+            durationScaleField.removeAttr('disabled');
         }
     }
 </script>

--- a/www/include/monitoring/downtime/AddDowntime.php
+++ b/www/include/monitoring/downtime/AddDowntime.php
@@ -284,8 +284,9 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
         && $centreon->optGen['monitoring_dwt_duration']
     ) {
         $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
-        if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
-            $centreon->optGen['monitoring_dwt_duration_scale']
+        if (
+            isset($centreon->optGen['monitoring_dwt_duration_scale'])
+            && $centreon->optGen['monitoring_dwt_duration_scale']
         ) {
             $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
         }

--- a/www/include/monitoring/downtime/AddDowntime.php
+++ b/www/include/monitoring/downtime/AddDowntime.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2019 Centreon
+ * Copyright 2005-2020 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -69,14 +70,10 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
     $redirect = $form->addElement('hidden', 'o');
     $redirect->setValue($o);
 
-    if (isset($_GET["host_id"])
-        && !isset($_GET["service_id"])
-    ) {
+    if (isset($_GET["host_id"]) && !isset($_GET["service_id"])) {
         $disabled = "disabled";
         $hostName = $hObj->getHostName($_GET['host_id']);
-    } elseif (isset($_GET["host_id"])
-        && isset($_GET["service_id"])
-    ) {
+    } elseif (isset($_GET["host_id"]) && isset($_GET["service_id"])) {
         $disabled = "disabled";
         $serviceParameters = $serviceObj->getParameters($_GET['service_id'], array('service_description'));
         $serviceDisplayName = $serviceParameters['service_description'];
@@ -378,7 +375,8 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
             }
         }
 
-        if (isset($_POST['host_or_centreon_time']['host_or_centreon_time'])
+        if (
+            isset($_POST['host_or_centreon_time']['host_or_centreon_time'])
             && $_POST['host_or_centreon_time']['host_or_centreon_time']
         ) {
             $hostOrCentreonTime = $_POST['host_or_centreon_time']['host_or_centreon_time'];
@@ -387,8 +385,9 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
         }
 
         $applyDtOnServices = false;
-        if (isset($values['with_services']) &&
-            $values['with_services']['with_services'] == 1
+        if (
+            isset($values['with_services'])
+            && $values['with_services']['with_services'] == 1
         ) {
             $applyDtOnServices = true;
         }
@@ -397,8 +396,9 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
         $concatenatedStart = $_POST["alternativeDateStart"] . ' ' . $_POST['start_time'];
         $concatenatedEnd = $_POST["alternativeDateEnd"] . ' ' . $_POST['end_time'];
 
-        if (isset($values['downtimeType']) &&
-            $values['downtimeType']['downtimeType'] == 1
+        if (
+            isset($values['downtimeType'])
+            && $values['downtimeType']['downtimeType'] == 1
         ) {
             /*
              * Set a downtime for host only
@@ -421,7 +421,8 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
                     $hostOrCentreonTime
                 );
             }
-        } elseif ($values['downtimeType']['downtimeType'] == 0
+        } elseif (
+            $values['downtimeType']['downtimeType'] == 0
             && isset($_POST['hostgroup_id'])
             && is_array($_POST['hostgroup_id'])
         ) {
@@ -458,9 +459,7 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
 
             foreach ($_POST["service_id"] as $value) {
                 $info = explode('-', $value);
-                if ($centreon->user->access->admin ||
-                    in_array($info[0], $hostAclId)
-                ) {
+                if ($centreon->user->access->admin || in_array($info[0], $hostAclId)) {
                     $ecObj->addSvcDowntime(
                         $info[0],
                         $info[1],
@@ -481,7 +480,7 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
                 $stmt = $pearDBO->prepare(
                     "SELECT host_id, service_id FROM services_servicegroups WHERE servicegroup_id = :sgId"
                 );
-                $stmt->bindValue(':sgId', $sgId, PDO::PARAM_INT);
+                $stmt->bindValue(':sgId', $sgId, \PDO::PARAM_INT);
                 $stmt->execute();
 
                 while ($row = $stmt->fetch()) {
@@ -505,12 +504,10 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
                 $stmt = $pearDBO->prepare(
                     "SELECT host_id FROM hosts WHERE instance_id = :poller_id AND enabled = 1"
                 );
-                $stmt->bindValue(':poller_id', $pollerId, PDO::PARAM_INT);
+                $stmt->bindValue(':poller_id', $pollerId, \PDO::PARAM_INT);
                 $stmt->execute();
                 while ($row = $stmt->fetch()) {
-                    if ($centreon->user->access->admin ||
-                        in_array($row['host_id'], $hostAclId)
-                    ) {
+                    if ($centreon->user->access->admin || in_array($row['host_id'], $hostAclId)) {
                         $ecObj->addHostDowntime(
                             $row['host_id'],
                             $_POST["comment"],
@@ -542,9 +539,7 @@ if (!$centreon->user->access->checkAction("host_schedule_downtime")
         $form->accept($renderer);
         $tpl->assign('form', $renderer->toArray());
 
-        if (isset($_GET['service_id']) &&
-            isset($_GET['host_id'])
-        ) {
+        if (isset($_GET['service_id']) && isset($_GET['host_id'])) {
             $tpl->assign('host_name', $hostName);
             $tpl->assign('service_description', $serviceDisplayName);
         } elseif (isset($_GET['host_id'])) {

--- a/www/include/monitoring/downtime/common-Func.php
+++ b/www/include/monitoring/downtime/common-Func.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under

--- a/www/include/monitoring/downtime/downtime.php
+++ b/www/include/monitoring/downtime/downtime.php
@@ -1,8 +1,8 @@
 <?php
 
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -54,25 +54,28 @@ $path = "./include/monitoring/downtime/";
  * PHP functions
  */
 require_once "./include/common/common-Func.php";
-require_once $path."common-Func.php";
+require_once $path . "common-Func.php";
 require_once "./include/monitoring/external_cmd/functions.php";
 
 switch ($o) {
+    case "a":
+        require_once($path . "AddDowntime.php");
+        break;
     case "ds":
         if (isset($_POST["select"])) {
             foreach ($_POST["select"] as $key => $value) {
                 $res = explode(';', urldecode($key));
                 $ishost = isDownTimeHost($res[2]);
-                if ($oreon->user->access->admin ||
-                    ($ishost && $oreon->user->access->checkAction("host_schedule_downtime")) ||
-                    (!$ishost && $oreon->user->access->checkAction("service_schedule_downtime"))
+                if (
+                    $oreon->user->access->admin
+                    || ($ishost && $oreon->user->access->checkAction("host_schedule_downtime"))
+                    || (!$ishost && $oreon->user->access->checkAction("service_schedule_downtime"))
                 ) {
                     $ecObj->deleteDowntime($res[0], array($res[1] . ';' . $res[2] => 'on'));
                     deleteDowntimeFromDb($oreon, array($res[1] . ';' . $res[2] => 'on'));
                 }
             }
         }
-        
         require_once($path . "listDowntime.php");
         break;
     case "cs":
@@ -80,26 +83,19 @@ switch ($o) {
             foreach ($_POST["select"] as $key => $value) {
                 $res = explode(';', urldecode($key));
                 $ishost = isDownTimeHost($res[2]);
-                if ($oreon->user->access->admin ||
-                    ($ishost && $oreon->user->access->checkAction("host_schedule_downtime")) ||
-                    (!$ishost && $oreon->user->access->checkAction("service_schedule_downtime"))
+                if (
+                    $oreon->user->access->admin
+                    || ($ishost && $oreon->user->access->checkAction("host_schedule_downtime"))
+                    || (!$ishost && $oreon->user->access->checkAction("service_schedule_downtime"))
                 ) {
                     $ecObj->deleteDowntime($res[0], array($res[1] . ';' . $res[2] => 'on'));
                 }
             }
         }
-        require_once($path . "listDowntime.php");
-        break;
+        // then, as all the next cases, requiring the listDowntime.php
     case "vs":
-        require_once($path . "listDowntime.php");
-        break;
-    case "a":
-        require_once($path."AddDowntime.php");
-        break;
     case "vh":
-        require_once($path."listDowntime.php");
-        break;
     default:
-        require_once($path."listDowntime.php");
+        require_once($path . "listDowntime.php");
         break;
 }

--- a/www/include/monitoring/downtime/template/AddDowntime.ihtml
+++ b/www/include/monitoring/downtime/template/AddDowntime.ihtml
@@ -151,12 +151,12 @@
 {literal}
 
 <script type="text/javascript">
-
-    initDatepicker("datepicker", "mm/dd/yy", "0");
-
-    $(document).ready(function() {
-        turnOnEvents();
+    jQuery(".timepicker").each(function () {
+        $(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
     });
-
+    jQuery(".timepicker").timepicker();
+    initDatepicker();
+    turnOnEvents();
+    updateEndTime();
 </script>
 {/literal}

--- a/www/include/monitoring/downtime/template/AddDowntime.ihtml
+++ b/www/include/monitoring/downtime/template/AddDowntime.ihtml
@@ -152,7 +152,10 @@
 
 <script type="text/javascript">
     jQuery(".timepicker").each(function () {
-        $(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
+        $(this).val(moment().tz(localStorage.getItem('realTimezone')
+            ? localStorage.getItem('realTimezone')
+            : moment.tz.guess()).format("HH:mm")
+        );
     });
     jQuery(".timepicker").timepicker();
     initDatepicker();

--- a/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+++ b/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -33,7 +34,7 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . "/../../../../../../config/centreon.config.php");
+require_once realpath(__DIR__ . "/../../../../../../config/centreon.config.php");
 include_once _CENTREON_PATH_ . "www/class/centreonDuration.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonGMT.class.php";
 include_once _CENTREON_PATH_ . "www/class/centreonXML.class.php";
@@ -54,19 +55,20 @@ $dbb = new CentreonDB("centstorage");
 
 $centreonlang = new CentreonLang(_CENTREON_PATH_, $oreon);
 $centreonlang->bindLang();
-$sid = session_id();
 if (isset($sid)) {
     //$sid = $_GET["sid"];
-    $res = $db->query("SELECT * FROM session WHERE session_id = '".CentreonDB::escape($sid)."'");
-    if (!$session = $res->fetchRow()) {
+    $res = $db->prepare("SELECT * FROM session WHERE session_id = :id");
+    $res->bindValue(':id', session_id(), \PDO::PARAM_STR);
+    $res->execute();
+    if (!$session = $res->fetch()) {
         get_error('bad session id');
     }
 } else {
     get_error('need session id !');
 }
 
-(isset($_GET["hid"])) ? $host_id = CentreonDB::escape($_GET["hid"]) : $host_id = 0;
-(isset($_GET["svc_id"])) ? $service_id = CentreonDB::escape($_GET["svc_id"]) : $service_id = 0;
+$host_id = (int)($_GET['hid'] ?? 0);
+$service_id = (int)($_GET["svc_id"] ?? 0);
 
 /*
  * Init GMT class
@@ -92,24 +94,24 @@ $xml->endElement();
  * Retrieve info
  */
 if (!$service_id) {
-    $query = "SELECT author, actual_start_time , end_time, comment_data, duration, fixed " .
-        "FROM downtimes " .
-        "WHERE host_id = ? " .
-        "AND type = 2 " .
-        "AND cancelled = 0 " .
-        "AND end_time > UNIX_TIMESTAMP(NOW()) " .
-        "ORDER BY actual_start_time";
+    $query = "SELECT author, actual_start_time , end_time, comment_data, duration, fixed
+        FROM downtimes
+        WHERE host_id = ?
+        AND type = 2
+        AND cancelled = 0
+        AND end_time > UNIX_TIMESTAMP(NOW())
+        ORDER BY actual_start_time";
     $stmt = $dbb->prepare($query);
     $dbb->execute($stmt, array($dbb->escape($host_id)));
 } else {
-    $query = "SELECT author, actual_start_time, end_time, comment_data, duration, fixed " .
-        "FROM downtimes " .
-        "WHERE host_id = ? " .
-        "AND service_id = ? " .
-        "AND type = 1 " .
-        "AND cancelled = 0 " .
-        "AND end_time > UNIX_TIMESTAMP(NOW()) " .
-        "ORDER BY actual_start_time";
+    $query = "SELECT author, actual_start_time, end_time, comment_data, duration, fixed
+        FROM downtimes
+        WHERE host_id = ?
+        AND service_id = ?
+        AND type = 1
+        AND cancelled = 0
+        AND end_time > UNIX_TIMESTAMP(NOW())
+        ORDER BY actual_start_time";
     $stmt = $dbb->prepare($query);
     $dbb->execute($stmt, array($dbb->escape($host_id), $dbb->escape($service_id)));
 }

--- a/www/include/monitoring/external_cmd/cmd.php
+++ b/www/include/monitoring/external_cmd/cmd.php
@@ -1,36 +1,37 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
- * 
- * This program is free software; you can redistribute it and/or modify it under 
- * the terms of the GNU General Public License as published by the Free Software 
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
  * Foundation ; either version 2 of the License.
- * 
+ *
  * This program is distributed in the hope that it will be useful, but WITHOUT ANY
- * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
  * PARTICULAR PURPOSE. See the GNU General Public License for more details.
- * 
- * You should have received a copy of the GNU General Public License along with 
+ *
+ * You should have received a copy of the GNU General Public License along with
  * this program; if not, see <http://www.gnu.org/licenses>.
- * 
- * Linking this program statically or dynamically with other modules is making a 
- * combined work based on this program. Thus, the terms and conditions of the GNU 
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
  * General Public License cover the whole combination.
- * 
- * As a special exception, the copyright holders of this program give Centreon 
- * permission to link this program with independent modules to produce an executable, 
- * regardless of the license terms of these independent modules, and to copy and 
- * distribute the resulting executable under terms of Centreon choice, provided that 
- * Centreon also meet, for each linked independent module, the terms  and conditions 
- * of the license of that module. An independent module is a module which is not 
- * derived from this program. If you modify this program, you may extend this 
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
  * exception to your version of the program, but you are not obliged to do so. If you
  * do not wish to do so, delete this exception statement from your version.
- * 
+ *
  * For more information : contact@centreon.com
- * 
+ *
  */
 
 if (!isset($centreon)) {
@@ -66,7 +67,7 @@ if ($serverIsRemote && in_array($param['cmd'], $disabledCommandsForRemote)) {
 
 foreach ($param['select'] as $key => $value) {
     switch ($param['cmd']) {
-        /* Re-Schedulde SVC Checks */
+        /* Re-Schedule SVC Checks */
         case 1:
             schedule_host_svc_checks($key, 0);
             break;
@@ -163,7 +164,7 @@ foreach ($param['select'] as $key => $value) {
             send_cmd('SHUTDOWN_PROGRAM', time());
             break;
         case 25:
-            send_cmd(' RESTART_PROGRAM', time());
+            send_cmd('RESTART_PROGRAM', time());
             break;
         case 26:
             send_cmd('PROCESS_SERVICE_CHECK_RESULT', '');
@@ -232,9 +233,11 @@ foreach ($param['select'] as $key => $value) {
             break;
 
         case 49:
+            // @TODO : seems like dead code - to check in other repo
             host_flap_detection($key, 1);
             break;
         case 50:
+            // @TODO : seems like dead code - to check in other repo
             host_flap_detection($key, 0);
             break;
         case 51:
@@ -245,21 +248,27 @@ foreach ($param['select'] as $key => $value) {
             break;
 
         case 59:
+            // @TODO : seems like dead code - to check in other repo
             add_hostgroup_downtime($param['dtm']);
             break;
         case 60:
+            // @TODO : seems like dead code - to check in other repo
             add_svc_hostgroup_downtime($param['dtm']);
             break;
         case 61:
+            // @TODO : seems like dead code - to check in other repo
             notifi_host_hostgroup($key, 1);
             break;
         case 62:
+            // @TODO : seems like dead code - to check in other repo
             notifi_host_hostgroup($key, 0);
             break;
         case 63:
+            // @TODO : seems like dead code - to check in other repo
             notifi_svc_host_hostgroup($key, 1);
             break;
         case 64:
+            // @TODO : seems like dead code - to check in other repo
             notifi_svc_host_hostgroup($key, 0);
             break;
         case 65:
@@ -269,7 +278,7 @@ foreach ($param['select'] as $key => $value) {
             checks_svc_host_hostgroup($key, 0);
             break;
         case 67:
-            schedule_svc_check($key, 1, 1);
+            schedule_svc_checks($key, 1);
             break;
 
         /* Auto Aknowledge */

--- a/www/include/monitoring/external_cmd/cmd.php
+++ b/www/include/monitoring/external_cmd/cmd.php
@@ -164,7 +164,7 @@ foreach ($param['select'] as $key => $value) {
             send_cmd('SHUTDOWN_PROGRAM', time());
             break;
         case 25:
-            send_cmd('RESTART_PROGRAM', time());
+            send_cmd(' RESTART_PROGRAM', time());
             break;
         case 26:
             send_cmd('PROCESS_SERVICE_CHECK_RESULT', '');
@@ -278,7 +278,7 @@ foreach ($param['select'] as $key => $value) {
             checks_svc_host_hostgroup($key, 0);
             break;
         case 67:
-            schedule_svc_checks($key, 1);
+            schedule_svc_check($key, 1, 1);
             break;
 
         /* Auto Aknowledge */

--- a/www/include/monitoring/external_cmd/cmdPopup.php
+++ b/www/include/monitoring/external_cmd/cmdPopup.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -33,7 +34,7 @@
  *
  */
 
-require_once realpath(dirname(__FILE__) . "/../../../../bootstrap.php");
+require_once realpath(__DIR__ . "/../../../../bootstrap.php");
 
 require_once _CENTREON_PATH_ . "www/class/centreonSession.class.php";
 require_once _CENTREON_PATH_ . "www/class/centreon.class.php";

--- a/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -154,8 +154,9 @@ if (
     && $centreon->optGen['monitoring_dwt_duration']
 ) {
     $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
-    if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
-        $centreon->optGen['monitoring_dwt_duration_scale']
+    if (
+        isset($centreon->optGen['monitoring_dwt_duration_scale'])
+        && $centreon->optGen['monitoring_dwt_duration_scale']
     ) {
         $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
     }

--- a/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -102,8 +102,9 @@ $form->addElement(
     )
 );
 
+$userDownTimeDuration = $_SESSION['centreon']->optGen['monitoring_dwt_duration'];
 $defaultStartTime = date('G:i');
-$defaultEndTime = date('G:i', strtotime('+2 hours'));
+$defaultEndTime = date('G:i', time() + $userDownTimeDuration);
 
 $form->addElement(
     'text',

--- a/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -138,8 +139,10 @@ $form->addElement(
         'disabled' => 'true'
     )
 );
+//setting default values
 $defaultDuration = 7200;
 $defaultScale = 's';
+//overriding the default duration and scale by the user's value from the administration fields
 if (isset($centreon->optGen['monitoring_dwt_duration']) &&
     $centreon->optGen['monitoring_dwt_duration']
 ) {
@@ -229,6 +232,7 @@ $form->addElement(
 );
 
 // adding hidden fields to get the result of datepicker in an unlocalized format
+// required for the external command to be send to centreon-engine
 $form->addElement(
     'hidden',
     'alternativeDateStart',

--- a/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -102,6 +102,9 @@ $form->addElement(
     )
 );
 
+$defaultStartTime = date('G:i');
+$defaultEndTime = date('G:i', strtotime('+2 hours'));
+
 $form->addElement(
     'text',
     'start_time',
@@ -109,7 +112,8 @@ $form->addElement(
     array(
         'id' => 'start_time',
         'size' => 5,
-        'class' => 'timepicker'
+        'class' => 'timepicker',
+        'value' => $defaultStartTime
     )
 );
 $form->addElement(
@@ -119,7 +123,8 @@ $form->addElement(
     array(
         'id' => 'end_time',
         'size' => 5,
-        'class' => 'timepicker'
+        'class' => 'timepicker',
+        'value' => $defaultEndTime
     )
 );
 

--- a/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -52,12 +52,6 @@ if (isset($_GET['select'])) {
 $path = _CENTREON_PATH_ . "/www/include/monitoring/external_cmd/popup/";
 
 /*
- * Init GMT
- */
-$centreonGMT = new CentreonGMT($pearDB);
-$centreonGMT->getMyGMTFromSession(session_id(), $pearDB);
-
-/*
  * Smarty template Init
  */
 $tpl = new Smarty();
@@ -134,11 +128,6 @@ $form->addElement(
     _("*The timezone used is configured on your user settings")
 );
 
-$gmt = $centreonGMT->getMyGMT();
-if (!$gmt) {
-    $gmt = date_default_timezone_get();
-}
-
 $form->addElement(
     'text',
     'duration',
@@ -150,6 +139,17 @@ $form->addElement(
     )
 );
 $defaultDuration = 7200;
+$defaultScale = 's';
+if (isset($centreon->optGen['monitoring_dwt_duration']) &&
+    $centreon->optGen['monitoring_dwt_duration']
+) {
+    $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
+    if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&
+        $centreon->optGen['monitoring_dwt_duration_scale']
+    ) {
+        $defaultScale = $centreon->optGen['monitoring_dwt_duration_scale'];
+    }
+}
 $form->setDefaults(array('duration' => $defaultDuration));
 
 $scaleChoices = array(
@@ -164,16 +164,11 @@ $form->addElement(
     _("Scale of time"),
     $scaleChoices,
     array(
-        'id' => 'duration_scale'
+        'id' => 'duration_scale',
+        'disabled' => 'true'
     )
 );
-$form->setDefaults(array('duration_scale' => 's'));
-$form->setDefaults(
-    array(
-        "start_time" => $centreonGMT->getDate("G:i", time(), $gmt),
-        "end_time" => $centreonGMT->getDate("G:i", time() + $defaultDuration, $gmt)
-    )
-);
+$form->setDefaults(array('duration_scale' => $defaultScale));
 
 $chckbox[] = $form->addElement(
     'checkbox',
@@ -252,7 +247,6 @@ $form->addElement(
         'class' => 'alternativeDate'
     )
 );
-
 
 $renderer = new HTML_QuickForm_Renderer_ArraySmarty($tpl);
 $renderer->setRequiredTemplate('{$label}&nbsp;<font color="red" size="1">*</font>');

--- a/www/include/monitoring/external_cmd/popup/massive_downtime.php
+++ b/www/include/monitoring/external_cmd/popup/massive_downtime.php
@@ -149,8 +149,9 @@ $form->addElement(
 $defaultDuration = 7200;
 $defaultScale = 's';
 //overriding the default duration and scale by the user's value from the administration fields
-if (isset($centreon->optGen['monitoring_dwt_duration']) &&
-    $centreon->optGen['monitoring_dwt_duration']
+if (
+    isset($centreon->optGen['monitoring_dwt_duration'])
+    && $centreon->optGen['monitoring_dwt_duration']
 ) {
     $defaultDuration = $centreon->optGen['monitoring_dwt_duration'];
     if (isset($centreon->optGen['monitoring_dwt_duration_scale']) &&

--- a/www/include/monitoring/external_cmd/popup/popup.php
+++ b/www/include/monitoring/external_cmd/popup/popup.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2018 Centreon
+ * Copyright 2005-2020 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -51,16 +52,17 @@ $centreon = $_SESSION['centreon'];
 $centreonLang = new CentreonLang(_CENTREON_PATH_, $centreon);
 $centreonLang->bindLang();
 
-if (!isset($centreon) ||
-    !isset($_GET['o']) ||
-    !isset($_GET['cmd']) ||
-    !isset($_GET['p'])
+if (
+    !isset($centreon)
+    || !isset($_GET['o'])
+    || !isset($_GET['cmd'])
+    || !isset($_GET['p'])
 ) {
     exit();
 }
 if (session_id()) {
     $res = $pearDB->prepare("SELECT * FROM `session` WHERE `session_id` = :sid");
-    $res->bindValue(':sid', session_id(), PDO::PARAM_STR);
+    $res->bindValue(':sid', session_id(), \PDO::PARAM_STR);
     $res->execute();
     if (!$session = $res->fetch()) {
         exit();

--- a/www/include/monitoring/external_cmd/popup/templates/massive_downtime.ihtml
+++ b/www/include/monitoring/external_cmd/popup/templates/massive_downtime.ihtml
@@ -62,7 +62,10 @@
 {literal}
 <script type="text/javascript">
     jQuery(".timepicker").each(function () {
-        $(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
+        $(this).val(moment().tz(localStorage.getItem('realTimezone')
+            ? localStorage.getItem('realTimezone')
+            : moment.tz.guess()).format("HH:mm")
+        );
     });
     jQuery(".timepicker").timepicker();
     initDatepicker();

--- a/www/include/monitoring/external_cmd/popup/templates/massive_downtime.ihtml
+++ b/www/include/monitoring/external_cmd/popup/templates/massive_downtime.ihtml
@@ -61,10 +61,12 @@
 </form>
 {literal}
 <script type="text/javascript">
-    /* initializing datepicker and the alternative format field */
-    initDatepicker("datepicker", "mm/dd/yy", "0");
-
+    jQuery(".timepicker").each(function () {
+        $(this).val(moment().tz(localStorage.getItem('realTimezone') ? localStorage.getItem('realTimezone') : moment.tz.guess()).format("HH:mm"));
+    });
     jQuery(".timepicker").timepicker();
+    initDatepicker();
     turnOnEvents();
+    updateEndTime();
 </script>
 {/literal}

--- a/www/include/monitoring/recurrentDowntime/templates/specific_date.html
+++ b/www/include/monitoring/recurrentDowntime/templates/specific_date.html
@@ -57,27 +57,27 @@ jQuery(function() {
 			}
 		});
 
-        jQuery('select[name="periods[{/literal}{$period_tab}{literal}][days]"]  > option').each(function (index, item) {
+        jQuery('select[name="periods[{/literal}{$period_tab}{literal}][days]"] > option').each(function (index, item) {
 			if (item.value == infos_{/literal}{$period_info}{literal}.day_of_week) {
 				item.selected = true;
 			}
 		});
 
-        jQuery('select[name="periods[{/literal}{$period_tab}{literal}][month_cycle]"]  > option').each(function (index, item){
+        jQuery('select[name="periods[{/literal}{$period_tab}{literal}][month_cycle]"] > option').each(function (index, item){
 	        if (item.value == infos_{/literal}{$period_info}{literal}.month_cycle) {
 		        item.selected = true;
 		    }
 		});
 	}
 
-        jQuery(".timepicker").timepicker();
+	jQuery(".timepicker").timepicker();
 });
 
-    $(document).ready(function () {
-        var validButton = $('#validForm');
-        if (!validButton.length) {
-            $("#tabs_periods :input").prop("disabled", true);
-        }
-    });
+$(document).ready(function () {
+	var validButton = $('#validForm');
+	if (!validButton.length) {
+		$("#tabs_periods :input").prop("disabled", true);
+	}
+});
 </script>
 {/literal}

--- a/www/include/monitoring/status/Hosts/hostJS.php
+++ b/www/include/monitoring/status/Hosts/hostJS.php
@@ -407,13 +407,15 @@ if (isset($_GET["acknowledge"])) {
     }
 
     function toggleFields(fixed) {
-        var dur;
-        dur = document.getElementById('duration');
+        var durationField = jQuery('#duration');
+        var durationScaleField = jQuery('#duration_scale');
+
         if (fixed.checked) {
-            dur.disabled = true;
-        }
-        else {
-            dur.disabled = false;
+            durationField.attr('disabled', true);
+            durationScaleField.attr('disabled', true);
+        } else {
+            durationField.removeAttr('disabled');
+            durationScaleField.removeAttr('disabled');
         }
     }
 </script>

--- a/www/include/monitoring/status/Services/serviceJS.php
+++ b/www/include/monitoring/status/Services/serviceJS.php
@@ -419,13 +419,15 @@ if (isset($_GET["acknowledge"])) {
     }
 
     function toggleFields(fixed) {
-        var dur;
-        dur = document.getElementById('duration');
+        var durationField = jQuery('#duration');
+        var durationScaleField = jQuery('#duration_scale');
+
         if (fixed.checked) {
-            dur.disabled = true;
-        }
-        else {
-            dur.disabled = false;
+            durationField.attr('disabled', true);
+            durationScaleField.attr('disabled', true);
+        } else {
+            durationField.removeAttr('disabled');
+            durationScaleField.removeAttr('disabled');
         }
     }
 </script>

--- a/www/include/views/graphs/graphs.php
+++ b/www/include/views/graphs/graphs.php
@@ -284,9 +284,7 @@ $form->addElement(
     )
 );
 
-if ($period_start != 'undefined' &&
-    $period_end != 'undefined'
-) {
+if ($period_start != 'undefined' && $period_end != 'undefined') {
     $startDay = date('Y-m-d', $period_start);
     $startTime = date('H:i', $period_start);
     $endDay = date('Y-m-d', $period_end);

--- a/www/main.get.php
+++ b/www/main.get.php
@@ -271,19 +271,19 @@ $inputPost = filter_input_array(
 if (isset($url) && $url) {
     foreach ($inputArguments as $argumentName => $argumentFlag) {
         switch ($argumentName) {
-        case 'limit':
-            if (!is_null($inputGet[$argumentName])) {
-                $centreon->historyLimit[$url] = $inputGet[$argumentName];
-            } elseif (!is_null($inputPost[$argumentName])) {
-                $centreon->historyLimit[$url] = $inputPost[$argumentName];
-            } else {
-                $centreon->historyLimit[$url] = 30;
-            }
-            break;
+            case 'limit':
+                if (!is_null($inputGet[$argumentName])) {
+                    $centreon->historyLimit[$url] = $inputGet[$argumentName];
+                } elseif (!is_null($inputPost[$argumentName])) {
+                    $centreon->historyLimit[$url] = $inputPost[$argumentName];
+                } else {
+                    $centreon->historyLimit[$url] = 30;
+                }
+                break;
 
-        default:
-            continue;
-            break;
+            default:
+                continue;
+                break;
         }
     }
 }


### PR DESCRIPTION
## Description

Fix an issue where datetime of downtimes weren't correctly computed, when not using the english localization :
- the ending datepicker was not set properly and displayed unconsistent date
- adding a downtime on two days, did not actualize the starting date of the datepicker
- setting an end time before the start date was possible and resulted on useless downtime (not processed by centengine)

**Fixes** MON-3935 & https://github.com/centreon/centreon/pull/7606 from @UrBnW  + https://github.com/centreon/centreon/issues/5963 + https://github.com/centreon/centreon/issues/7337 + https://github.com/centreon/centreon/issues/8266

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Choose for example the french language.
- Select a default duration on the Administration > parameters > monitoring + duration
- Set a downtime from the monitoring > status > downtime + add downtime
    check that the start and end date and time are set properly.
    check that consistent values are displayed when changing the datepicker and timepicker values.
    check that the datepicker and timepicker are still consistent with the choosen language.

- Do the same from all the other available downtime form in the UI eg :
    status > monitoring > services + choose a resource + set a downtime from the toolbar
    status > monitoring > host + choose a resource + set a downtime from the toolbar
    ...

- Check that no errors are displayed in the logs and that the moment deprecated notice is corrected :
![image](https://user-images.githubusercontent.com/34628915/77638821-0e8abd00-6f58-11ea-87af-511297694645.png)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
