### PR TITLE
fix(listing): set events view listing to empty on api error

### DIFF
--- a/www/front_src/src/Resources/index.tsx
+++ b/www/front_src/src/Resources/index.tsx
@@ -98,7 +98,7 @@ const Resources = (): JSX.Element => {
       })
       .catch((error) => {
         setListing(undefined);
-        showError(error?.response?.data?.message || error.message);
+        showError(error.response?.data?.message || error.message);
       })
       .finally(() => setLoading(false));
   };

--- a/www/front_src/src/Resources/index.tsx
+++ b/www/front_src/src/Resources/index.tsx
@@ -97,7 +97,8 @@ const Resources = (): JSX.Element => {
         setListing(retrievedListing);
       })
       .catch((error) => {
-        showError(error.message);
+        setListing(undefined);
+        showError(error?.response?.data?.message || error.message);
       })
       .finally(() => setLoading(false));
   };


### PR DESCRIPTION
## Description

when http code 500 is returned from resources endpoint, listing is reset to empty.
Furthermore, the snackbar error message is now more clearer

**Fixes** MON-5034

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

set search filter to `*test`
==> the listing should be empty