### PR TITLE
enh(generation): add grpc port in generation for engine & broker

### DIFF
--- a/www/class/config-generate/broker.class.php
+++ b/www/class/config-generate/broker.class.php
@@ -269,9 +269,7 @@ class Broker extends AbstractObjectJSON
 
             // gRPC parameters
             $object['grpc'] = [
-                [
-                    'port' => 51000 + (int) $row['config_id']
-                ],
+                'port' => 51000 + (int) $row['config_id']
             ];
 
             // Generate file

--- a/www/class/config-generate/broker.class.php
+++ b/www/class/config-generate/broker.class.php
@@ -267,6 +267,13 @@ class Broker extends AbstractObjectJSON
                 ];
             }
 
+            // gRPC parameters
+            $object['grpc'] = [
+                [
+                    'port' => 51000 + (int) $row['config_id']
+                ],
+            ];
+
             // Generate file
             $this->generateFile($object);
             $this->writeFile($this->backend_instance->getPath());

--- a/www/class/config-generate/engine.class.php
+++ b/www/class/config-generate/engine.class.php
@@ -225,7 +225,8 @@ class Engine extends AbstractObject
         'host_perfdata_file_processing_command',
         'service_perfdata_file_processing_command',
         'macros_filter',
-        'enable_macros_filter'
+        'enable_macros_filter',
+        'grpc_port'
     );
     protected $attributes_default = array(
         'enable_notifications',
@@ -400,6 +401,7 @@ class Engine extends AbstractObject
         $object['service_perfdata_file_processing_command']
             = $command_instance->generateFromCommandId($object['service_perfdata_file_processing_command_id']);
 
+        $object['grpc_port'] = 50000 + $poller_id;
         $this->generate_filename = 'centengine.DEBUG';
         $object['cfg_file'] = $this->cfg_file['debug']['cfg_file'];
         $object['resource_file'] = $this->cfg_file['debug']['resource_file'];


### PR DESCRIPTION
## Description

Add a gRPC port for Centreon Engine & Centreon Broker during generation of configuration

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Generate configuration
2. Must see in centengine.cfg

`grpc_port=(50000 + <engine_configuration_id>)`

3. Must see in <broker_conf_name>.json:

```
"grpc": {
    "port": 51002
}
```

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
