### PR TITLE
fix(poller): Fix PHP errors on edit poller configuration form

### DIFF
--- a/www/include/configuration/configServers/formServers.ihtml
+++ b/www/include/configuration/configServers/formServers.ihtml
@@ -30,7 +30,7 @@
             <td class="FormRowValue">{$form.remote_additional_id.html}</td>
         </tr>
         {/if}
-        {if $form.header.Remote_Configuration.label}
+        {if $form.header.Remote_Configuration}
         <tr class="list_lvl_1">
             <td class="ListColLvl1_name" colspan="2">
                 <h4>{$form.header.Remote_Configuration}</h4>

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -360,11 +360,13 @@ $form->registerRule('testAdditionalRemoteServer', 'callback', 'testAdditionalRem
 $form->registerRule('isValidIpAddress', 'callback', 'isValidIpAddress');
 $form->addRule('name', _("Name is already in use"), 'exist');
 $form->addRule('name', _("The name of the poller is mandatory"), 'required');
-$form->addRule(
-    array('remote_additional_id', 'remote_id'),
-    _('To use additional Remote Servers a Master Remote Server must be selected.'),
-    'testAdditionalRemoteServer'
-);
+if ($serverType === 'poller') {
+    $form->addRule(
+        array('remote_additional_id', 'remote_id'),
+        _('To use additional Remote Servers a Master Remote Server must be selected.'),
+        'testAdditionalRemoteServer'
+    );
+}
 $form->addRule('ns_ip_address', _("The IP address is incorrect"), 'isValidIpAddress');
 
 $form->setRequiredNote("<font style='color: red;'>*</font>&nbsp;" . _("Required fields"));


### PR DESCRIPTION
## Description

This PR fix an issue where when accessing the form to modify a Central or Remote poller configuration a PHP Notice was reported. 

This PR also fix a PHP Warning where an illegal offset was use in a template condition.

**Fixes** MON-5088

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

When opening the form for editing a poller configuration (Configuration -> Pollers) you shouldn't see any error in PHP logs

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
