### PR TITLE
fix(api): fix search parameter s.description in Resource list

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -102,9 +102,9 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
         'h.name' => 'sh.name',
         'h.alias' => 'sh.alias',
         'h.address' => 'sh.address',
-        'service.description' => 's.description',
-        'service.group' => 'sg.name',
-        'service.group.id' => 'ssg.servicegroup_id',
+        's.description' => 's.description',
+        's.group' => 'sg.name',
+        's.group.id' => 'ssg.servicegroup_id',
     ];
 
     /**


### PR DESCRIPTION
## Description

fix the problem with searching by parameter s.description in Resource list

example of the request
```http://localhost/centreon/api/beta/monitoring/resources?page=1&limit=10&search={%22s.description%22:{%22$rg%22:%22Ping%22}}```

**Fixes** MON-4882

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
