### PR TITLE
enh(ui): search resources when pressing enter key

### DIFF
--- a/www/front_src/src/Resources/Filter/index.tsx
+++ b/www/front_src/src/Resources/Filter/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-wrap-multilines */
-import React, { useState } from 'react';
+import React, { useState, KeyboardEvent } from 'react';
 
 import {
   Grid,
@@ -152,6 +152,13 @@ const Filter = ({
     onSearchRequest(searchFieldValue);
   };
 
+  const requestSearchOnEnterKey = (event: KeyboardEvent): void => {
+    // "Enter" key
+    if (event.keyCode === 13) {
+      requestSearch();
+    }
+  }
+
   const getHostGroupSearchEndpoint = (searchValue): string => {
     return buildHostGroupsEndpoint({
       limit: 10,
@@ -213,6 +220,7 @@ const Filter = ({
               value={searchFieldValue || ''}
               onChange={changeSearchFieldValue}
               placeholder={labelResourceName}
+              onKeyDown={requestSearchOnEnterKey}
             />
           </Grid>
           <Grid item>

--- a/www/front_src/src/Resources/Filter/index.tsx
+++ b/www/front_src/src/Resources/Filter/index.tsx
@@ -157,7 +157,7 @@ const Filter = ({
     if (event.keyCode === 13) {
       requestSearch();
     }
-  }
+  };
 
   const getHostGroupSearchEndpoint = (searchValue): string => {
     return buildHostGroupsEndpoint({

--- a/www/front_src/src/Resources/index.test.tsx
+++ b/www/front_src/src/Resources/index.test.tsx
@@ -224,8 +224,8 @@ describe(Resources, () => {
     );
   });
 
-  it.only('executes a listing request when a search is typed and enter key is pressed', async () => {
-    const { container, getByPlaceholderText } = render(<Resources />);
+  it('executes a listing request when a search is typed and enter key is pressed', async () => {
+    const { getByPlaceholderText } = render(<Resources />);
 
     const fieldSearchValue = 'foobar';
 

--- a/www/front_src/src/Resources/index.test.tsx
+++ b/www/front_src/src/Resources/index.test.tsx
@@ -5,6 +5,7 @@ import formatISO from 'date-fns/formatISO';
 import { render, waitFor, within, fireEvent } from '@testing-library/react';
 import UserEvent from '@testing-library/user-event';
 import last from 'lodash/last';
+import { Simulate } from 'react-dom/test-utils';
 
 import Resources from '.';
 import {
@@ -220,6 +221,35 @@ describe(Resources, () => {
         getEndpoint({}),
         cancelTokenRequestParam,
       ),
+    );
+  });
+
+  it.only('executes a listing request when a search is typed and enter key is pressed', async () => {
+    const { container, getByPlaceholderText } = render(<Resources />);
+
+    const fieldSearchValue = 'foobar';
+
+    const searchInput = getByPlaceholderText(labelResourceName);
+
+    fireEvent.change(searchInput, {
+      target: { value: fieldSearchValue },
+    });
+
+    mockedAxios.get.mockResolvedValueOnce({ data: retrievedListing });
+
+    Simulate.keyDown(searchInput, { key: 'Enter', keyCode: 13, which: 13 });
+
+    expect(mockedAxios.get).toHaveBeenCalledWith(
+      getEndpoint({
+        search: {
+          mode: '$or',
+          fieldPatterns: searchableFields.map((searchableField) => ({
+            field: searchableField,
+            value: fieldSearchValue,
+          })),
+        },
+      }),
+      cancelTokenRequestParam,
     );
   });
 


### PR DESCRIPTION
## Description

Search resources when search field is focused and enter is pressed

**Fixes** MON-5095

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Type search in search field and press enter
==> check search is applied, without need of clicking on search button