### PR TITLE
feat(api): Add missing information to host and service endpoints

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Host.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Host.yml
@@ -6,221 +6,268 @@ Centreon\Domain\Monitoring\Host:
                 - 'host_min'
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         pollerId:
             type: int
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         name:
             type: string
             groups:
                 - 'host_min'
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         acknowledged:
             type: bool
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         activeChecks:
             type: bool
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         addressIp:
             type: string
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         alias:
             type: string
             groups:
                 - 'host_min'
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         checkAttempt:
             type: int
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         checkCommand:
             type: string
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         checkInterval:
             type: double
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         checkPeriod:
             type: string
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         checkType:
             type: int
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         checked:
             type: bool
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         displayName:
             type: string
             groups:
                 - 'host_min'
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         executionTime:
             type: double
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         iconImage:
             type: string
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         iconImageAlt:
             type: string
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         lastCheck:
             type: DateTime
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         lastHardState:
             type: int
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         lastHardStateChange:
             type: DateTime
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         lastNotification:
             type: DateTime
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         lastStateChange:
             type: DateTime
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         lastTimeDown:
             type: DateTime
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         lastTimeUnreachable:
             type: DateTime
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         lastTimeUp:
             type: DateTime
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         lastUpdate:
             type: DateTime
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         latency:
             type: double
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         maxCheckAttempts:
             type: int
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         nextCheck:
             type: DateTime
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         nextHostNotification:
             type: int
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         notificationInterval:
             type: double
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         notificationNumber:
             type: int
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         notificationPeriod:
             type: string
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         notify:
             type: bool
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         notifyOnDown:
             type: bool
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         notifyOnDowntime:
             type: bool
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         notifyOnFlapping:
             type: bool
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         notifyOnRecovery:
             type: bool
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         notifyOnUnreachable:
             type: bool
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         output:
             type: string
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         passiveChecks:
             type: bool
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         services:
             type: array<Centreon\Domain\Monitoring\Service>
             groups:
                 - 'host_full'
                 - 'host_with_services'
+                - 'resource_details_host'
         state:
             type: int
             groups:
                 - 'host_min'
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         stateType:
             type: int
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         timezone:
             type: string
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         scheduledDowntimeDepth:
             type: int
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         criticality:
             type: string
             groups:
                 - 'host_main'
                 - 'host_full'
+                - 'resource_details_host'
         downtimes:
             type: array<Centreon\Domain\Downtime\Downtime>
             groups:
@@ -233,7 +280,9 @@ Centreon\Domain\Monitoring\Host:
             type: bool
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         percentStateChange:
             type: double
             groups:
                 - 'host_full'
+                - 'resource_details_host'

--- a/config/packages/serializer/Centreon/Monitoring.Host.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Host.yml
@@ -272,10 +272,12 @@ Centreon\Domain\Monitoring\Host:
             type: array<Centreon\Domain\Downtime\Downtime>
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         acknowledgement:
             type: Centreon\Domain\Acknowledgement\Acknowledgement
             groups:
                 - 'host_full'
+                - 'resource_details_host'
         flapping:
             type: bool
             groups:

--- a/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsHost.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsHost.yml
@@ -1,0 +1,40 @@
+Centreon\Domain\Monitoring\Model\ResourceDetailsHost:
+    exclusion_policy: none
+    virtual_properties:
+        getDuration:
+            name: getDuration
+            serialized_name: duration
+            type: string
+            groups:
+                - 'resource_details_host'
+        getDowntimesAuthor:
+            name: getDowntimesAuthor
+            serialized_name: downtimes
+            type: string
+            groups:
+                - 'resource_details_host'
+        getAcknowledgementAuthor:
+            name: getAcknowledgementAuthor
+            serialized_name: acknowledgement
+            type: string
+            groups:
+                - 'resource_details_host'
+    properties:
+        tries:
+            type: string
+            accessor:
+                getter: getTriesTranslatable
+            groups:
+                - 'resource_details_host'
+        parent:
+            type: Centreon\Domain\Monitoring\ResourceStatus
+            groups:
+                - 'resource_details_host'
+        status:
+            type: Centreon\Domain\Monitoring\ResourceStatus
+            groups:
+                - 'resource_details_host'
+        poller_name:
+            type: string
+            groups:
+                - 'resource_details_host'

--- a/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsHost.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsHost.yml
@@ -7,18 +7,6 @@ Centreon\Domain\Monitoring\Model\ResourceDetailsHost:
             type: string
             groups:
                 - 'resource_details_host'
-        getDowntimesAuthor:
-            name: getDowntimesAuthor
-            serialized_name: downtimes
-            type: string
-            groups:
-                - 'resource_details_host'
-        getAcknowledgementAuthor:
-            name: getAcknowledgementAuthor
-            serialized_name: acknowledgement
-            type: string
-            groups:
-                - 'resource_details_host'
     properties:
         tries:
             type: string

--- a/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsService.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsService.yml
@@ -1,0 +1,40 @@
+Centreon\Domain\Monitoring\Model\ResourceDetailsService:
+    exclusion_policy: none
+    virtual_properties:
+        getDuration:
+            name: getDuration
+            serialized_name: duration
+            type: string
+            groups:
+                - 'resource_details_service'
+        getDowntimesAuthor:
+            name: getDowntimesAuthor
+            serialized_name: downtimes
+            type: string
+            groups:
+                - 'resource_details_service'
+        getAcknowledgementAuthor:
+            name: getAcknowledgementAuthor
+            serialized_name: acknowledgement
+            type: string
+            groups:
+                - 'resource_details_service'
+    properties:
+        tries:
+            type: string
+            accessor:
+                getter: getTriesTranslatable
+            groups:
+                - 'resource_details_service'
+        parent:
+            type: Centreon\Domain\Monitoring\ResourceStatus
+            groups:
+                - 'resource_details_service'
+        status:
+            type: Centreon\Domain\Monitoring\ResourceStatus
+            groups:
+                - 'resource_details_service'
+        poller_name:
+            type: string
+            groups:
+                - 'resource_details_service'

--- a/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsService.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsService.yml
@@ -7,18 +7,6 @@ Centreon\Domain\Monitoring\Model\ResourceDetailsService:
             type: string
             groups:
                 - 'resource_details_service'
-        getDowntimesAuthor:
-            name: getDowntimesAuthor
-            serialized_name: downtimes
-            type: string
-            groups:
-                - 'resource_details_service'
-        getAcknowledgementAuthor:
-            name: getAcknowledgementAuthor
-            serialized_name: acknowledgement
-            type: string
-            groups:
-                - 'resource_details_service'
     properties:
         tries:
             type: string

--- a/config/packages/serializer/Centreon/Monitoring.Service.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Service.yml
@@ -6,47 +6,57 @@ Centreon\Domain\Monitoring\Service:
                 - 'service_min'
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         checkAttempt:
             type: string
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         checkCommand:
             type: string
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         checkInterval:
             type: float
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         checkPeriod:
             type: string
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         checkType:
             type: int
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         commandLine:
             type: string
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         description:
             type: string
             groups:
                 - 'service_min'
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         displayName:
             type: string
             groups:
                 - 'service_min'
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         executionTime:
             type: float
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         host:
             type: "Centreon\\Domain\\Monitoring\\Host"
             groups:
@@ -56,109 +66,134 @@ Centreon\Domain\Monitoring\Service:
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         iconImageAlt:
             type: string
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         isAcknowledged:
             type: bool
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         isActiveCheck:
             type: bool
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         isChecked:
             type: bool
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         scheduledDowntimeDepth:
             type: int
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         lastCheck:
             type: DateTime
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         lastHardStateChange:
             type: DateTime
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         lastNotification:
             type: DateTime
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         lastTimeCritical:
             type: DateTime
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         lastTimeOk:
             type: DateTime
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         lastTimeUnknown:
             type: DateTime
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         lastTimeWarning:
             type: DateTime
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         lastUpdate:
             type: DateTime
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         lastStateChange:
             type: DateTime
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         latency:
             type: float
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         maxCheckAttempts:
             type: int
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         nextCheck:
             type: DateTime
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         output:
             type: string
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         performanceData:
             type: string
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         state:
             type: int
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         stateType:
             type: int
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         criticality:
             type: int
             groups:
                 - 'service_main'
                 - 'service_full'
+                - 'resource_details_service'
         downtimes:
             type: array<Centreon\Domain\Downtime\Downtime>
             groups:
                 - 'service_full'
+                - 'resource_details_service'
         acknowledgement:
             type: Centreon\Domain\Acknowledgement\Acknowledgement
             groups:
                 - 'service_full'
+                - 'resource_details_service'

--- a/config/routes/Centreon/monitoring_resource.yaml
+++ b/config/routes/Centreon/monitoring_resource.yaml
@@ -3,3 +3,20 @@ centreon_application_monitoring_resource_list:
     path: /monitoring/resources
     controller: 'Centreon\Application\Controller\MonitoringResourceController::list'
     condition: "request.attributes.get('version.is_beta') == true"
+
+centreon_application_monitoring_resource_details_host:
+    methods: GET
+    path: /monitoring/resources/hosts/{hostId}
+    controller: 'Centreon\Application\Controller\MonitoringResourceController::detailsHost'
+    requirements:
+        hostId: '\d+'
+    condition: "request.attributes.get('version.is_beta') == true"
+
+centreon_application_monitoring_resource_details_service:
+    methods: GET
+    path: /monitoring/resources/hosts/{hostId}/services/{serviceId}
+    controller: 'Centreon\Application\Controller\MonitoringResourceController::detailsService'
+    requirements:
+        hostId: '\d+'
+        serviceId: '\d+'
+    condition: "request.attributes.get('version.is_beta') == true"

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -25,14 +25,20 @@ namespace Centreon\Application\Controller;
 use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\View\View;
+use Symfony\Component\HttpFoundation\Response;
 use JMS\Serializer\SerializerInterface;
 use JMS\Serializer\Exception\ValidationFailedException;
 use Symfony\Component\HttpFoundation\Request;
 use Centreon\Domain\Entity\EntityValidator;
+use Centreon\Domain\Monitoring\Interfaces\MonitoringServiceInterface;
 use Centreon\Domain\Monitoring\Interfaces\ResourceServiceInterface;
 use Centreon\Domain\Monitoring\Serializer\ResourceExclusionStrategy;
+use Centreon\Domain\Monitoring\Service;
 use Centreon\Domain\Monitoring\Resource;
 use Centreon\Domain\Monitoring\ResourceFilter;
+use Centreon\Domain\Monitoring\ResourceStatus;
+use Centreon\Domain\Monitoring\Model\ResourceDetailsHost;
+use Centreon\Domain\Monitoring\Model\ResourceDetailsService;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -62,6 +68,11 @@ class MonitoringResourceController extends AbstractController
     public const VALIDATION_GROUP_MAIN = 'resource_id_main';
 
     /**
+     * @var MonitoringServiceInterface
+     */
+    private $monitoring;
+
+    /**
      * @var ResourceServiceInterface
      */
     protected $resource;
@@ -72,11 +83,16 @@ class MonitoringResourceController extends AbstractController
     protected $router;
 
     /**
+     * @param MonitoringServiceInterface $monitoringService
      * @param ResourceServiceInterface $resource
      * @param UrlGeneratorInterface $router
      */
-    public function __construct(ResourceServiceInterface $resource, UrlGeneratorInterface $router)
-    {
+    public function __construct(
+        MonitoringServiceInterface $monitoringService,
+        ResourceServiceInterface $resource,
+        UrlGeneratorInterface $router
+    ) {
+        $this->monitoring = $monitoringService;
         $this->resource = $resource;
         $this->router = $router;
     }
@@ -172,5 +188,64 @@ class MonitoringResourceController extends AbstractController
             'result' => $resources,
             'meta' => $requestParameters->toArray(),
         ])->setContext($context);
+    }
+
+    /**
+     * Get resource details related to the host
+     *
+     * @return View
+     */
+    public function detailsHost(int $hostId): View {
+        // ACL check
+        $this->denyAccessUnlessGrantedForApiRealtime();
+
+        $host = $this->monitoring
+            ->filterByContact($this->getUser())
+            ->findOneHost($hostId);
+
+        if ($host === null) {
+            return View::create(null, Response::HTTP_NOT_FOUND, []);
+        }
+
+        $context = (new Context())
+            ->setGroups([
+                ResourceDetailsHost::SERIALIZER_GROUP_DETAILS,
+                ResourceStatus::SERIALIZER_GROUP_MAIN,
+                Service::SERIALIZER_GROUP_MIN,
+            ])
+            ->enableMaxDepth();
+
+        return $this
+            ->view($this->resource->enrichHostWithDetails($host))
+            ->setContext($context);
+    }
+
+    /**
+     * Get resource details related to the service
+     *
+     * @return View
+     */
+    public function detailsService(int $hostId, int $serviceId): View {
+        // ACL check
+        $this->denyAccessUnlessGrantedForApiRealtime();
+
+        $service = $this->monitoring
+            ->filterByContact($this->getUser())
+            ->findOneService($hostId, $serviceId);
+
+        if ($service === null) {
+            return View::create(null, Response::HTTP_NOT_FOUND, []);
+        }
+
+        $context = (new Context())
+            ->setGroups([
+                ResourceDetailsService::SERIALIZER_GROUP_DETAILS,
+                ResourceStatus::SERIALIZER_GROUP_MAIN,
+            ])
+            ->enableMaxDepth();
+
+        return $this
+            ->view($this->resource->enrichServiceWithDetails($service))
+            ->setContext($context);
     }
 }

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -40,6 +40,8 @@ use Centreon\Domain\Monitoring\ResourceStatus;
 use Centreon\Domain\Monitoring\Model\ResourceDetailsHost;
 use Centreon\Domain\Monitoring\Model\ResourceDetailsService;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Centreon\Domain\Downtime\Downtime;
+use Centreon\Domain\Acknowledgement\Acknowledgement;
 
 /**
  * Resource APIs for the Unified View page
@@ -209,11 +211,12 @@ class MonitoringResourceController extends AbstractController
         }
 
         $context = (new Context())
-            ->setGroups([
+            ->setGroups(array_merge([
                 ResourceDetailsHost::SERIALIZER_GROUP_DETAILS,
                 ResourceStatus::SERIALIZER_GROUP_MAIN,
                 Service::SERIALIZER_GROUP_MIN,
-            ])
+                Acknowledgement::SERIALIZER_GROUP_FULL,
+            ], Downtime::SERIALIZER_GROUPS_SERVICE))
             ->enableMaxDepth();
 
         return $this
@@ -240,10 +243,11 @@ class MonitoringResourceController extends AbstractController
         }
 
         $context = (new Context())
-            ->setGroups([
+            ->setGroups(array_merge([
                 ResourceDetailsService::SERIALIZER_GROUP_DETAILS,
                 ResourceStatus::SERIALIZER_GROUP_MAIN,
-            ])
+                Acknowledgement::SERIALIZER_GROUP_FULL,
+            ], Downtime::SERIALIZER_GROUPS_SERVICE))
             ->enableMaxDepth();
 
         return $this

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -195,7 +195,8 @@ class MonitoringResourceController extends AbstractController
      *
      * @return View
      */
-    public function detailsHost(int $hostId): View {
+    public function detailsHost(int $hostId): View
+    {
         // ACL check
         $this->denyAccessUnlessGrantedForApiRealtime();
 
@@ -225,7 +226,8 @@ class MonitoringResourceController extends AbstractController
      *
      * @return View
      */
-    public function detailsService(int $hostId, int $serviceId): View {
+    public function detailsService(int $hostId, int $serviceId): View
+    {
         // ACL check
         $this->denyAccessUnlessGrantedForApiRealtime();
 

--- a/src/Centreon/Domain/Monitoring/Host.php
+++ b/src/Centreon/Domain/Monitoring/Host.php
@@ -33,6 +33,8 @@ use Centreon\Domain\Service\EntityDescriptorMetadataInterface;
  */
 class Host implements EntityDescriptorMetadataInterface
 {
+    use Model\ImportTrait;
+
     // Groups for serilizing
     public const SERIALIZER_GROUP_MIN = 'host_min';
     public const SERIALIZER_GROUP_MAIN = 'host_main';
@@ -47,262 +49,262 @@ class Host implements EntityDescriptorMetadataInterface
     /**
      * @var int Id of host
      */
-    private $id;
+    protected $id;
 
     /**
      * @var int Poller id
      */
-    private $pollerId;
+    protected $pollerId;
 
     /**
      * @var string Name of host
      */
-    private $name;
+    protected $name;
 
     /**
      * @var bool|null
      */
-    private $acknowledged;
+    protected $acknowledged;
 
     /**
      * @var bool|null
      */
-    private $activeChecks;
+    protected $activeChecks;
 
     /**
      * @var string|null Ip address or domain name
      */
-    private $addressIp;
+    protected $addressIp;
 
     /**
      * @var string|null Alias of host
      */
-    private $alias;
+    protected $alias;
 
     /**
      * @var int|null
      */
-    private $checkAttempt;
+    protected $checkAttempt;
 
     /**
      * @var string|null
      */
-    private $checkCommand;
+    protected $checkCommand;
 
     /**
      * @var double|null
      */
-    private $checkInterval;
+    protected $checkInterval;
 
     /**
      * @var string|null
      */
-    private $checkPeriod;
+    protected $checkPeriod;
 
     /**
      * @var int|null
      */
-    private $checkType;
+    protected $checkType;
 
     /**
      * @var bool|null
      */
-    private $checked;
+    protected $checked;
 
     /**
      * @var string|null
      */
-    private $displayName;
+    protected $displayName;
 
     /**
      * @var bool
      */
-    private $enabled;
+    protected $enabled;
 
     /**
      * @var double|null
      */
-    private $executionTime;
+    protected $executionTime;
 
     /**
      * @var string|null
      */
-    private $iconImage;
+    protected $iconImage;
 
     /**
      * @var string|null
      */
-    private $iconImageAlt;
+    protected $iconImageAlt;
 
     /**
      * @var \DateTime|null
      */
-    private $lastCheck;
+    protected $lastCheck;
 
     /**
      * @var int|null
      */
-    private $lastHardState;
+    protected $lastHardState;
 
     /**
      * @var \DateTime|null
      */
-    private $lastHardStateChange;
+    protected $lastHardStateChange;
 
     /**
      * @var \DateTime|null
      */
-    private $lastNotification;
+    protected $lastNotification;
 
     /**
      * @var \DateTime|null
      */
-    private $lastStateChange;
+    protected $lastStateChange;
 
     /**
      * @var \DateTime|null
      */
-    private $lastTimeDown;
+    protected $lastTimeDown;
 
     /**
      * @var \DateTime|null
      */
-    private $lastTimeUnreachable;
+    protected $lastTimeUnreachable;
 
     /**
      * @var \DateTime|null
      */
-    private $lastTimeUp;
+    protected $lastTimeUp;
 
     /**
      * @var \DateTime|null
      */
-    private $lastUpdate;
+    protected $lastUpdate;
 
     /**
      * @var double|null
      */
-    private $latency;
+    protected $latency;
 
     /**
      * @var int|null
      */
-    private $maxCheckAttempts;
+    protected $maxCheckAttempts;
 
     /**
      * @var \DateTime|null
      */
-    private $nextCheck;
+    protected $nextCheck;
 
     /**
      * @var int|null
      */
-    private $nextHostNotification;
+    protected $nextHostNotification;
 
     /**
      * @var double|null
      */
-    private $notificationInterval;
+    protected $notificationInterval;
 
     /**
      * @var int|null
      */
-    private $notificationNumber;
+    protected $notificationNumber;
 
     /**
      * @var string|null
      */
-    private $notificationPeriod;
+    protected $notificationPeriod;
 
     /**
      * @var bool|null
      */
-    private $notify;
+    protected $notify;
 
     /**
      * @var bool|null
      */
-    private $notifyOnDown;
+    protected $notifyOnDown;
 
     /**
      * @var bool|null
      */
-    private $notifyOnDowntime;
+    protected $notifyOnDowntime;
 
     /**
      * @var bool|null
      */
-    private $notifyOnFlapping;
+    protected $notifyOnFlapping;
 
     /**
      * @var bool|null
      */
-    private $notifyOnRecovery;
+    protected $notifyOnRecovery;
 
     /**
      * @var bool|null
      */
-    private $notifyOnUnreachable;
+    protected $notifyOnUnreachable;
 
     /**
      * @var string|null
      */
-    private $output;
+    protected $output;
 
     /**
      * @var bool|null
      */
-    private $passiveChecks;
+    protected $passiveChecks;
 
     /**
      * @var Service[]
      */
-    private $services = [];
+    protected $services = [];
 
     /**
      * @var int|null ['0' => 'UP', '1' => 'DOWN', '2' => 'UNREACHABLE', '4' => 'PENDING']
      */
-    private $state;
+    protected $state;
 
     /**
      * @var int|null
      */
-    private $stateType;
+    protected $stateType;
 
     /**
      * @var string|null
      */
-    private $timezone;
+    protected $timezone;
 
     /**
      * @var int|null
      */
-    private $scheduledDowntimeDepth;
+    protected $scheduledDowntimeDepth;
 
     /**
      * @var int|null
      */
-    private $criticality;
+    protected $criticality;
 
     /**
      * @var bool|null
      */
-    private $flapping;
+    protected $flapping;
 
     /**
      * @var double|null
      */
-    private $percentStateChange;
+    protected $percentStateChange;
 
     /**
      * @var Downtime[]
      */
-    private $downtimes = [];
+    protected $downtimes = [];
 
     /**
      * @var Acknowledgement|null
      */
-    private $acknowledgement;
+    protected $acknowledgement;
 
     /**
      * {@inheritdoc}

--- a/src/Centreon/Domain/Monitoring/Interfaces/ResourceRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/ResourceRepositoryInterface.php
@@ -24,6 +24,8 @@ namespace Centreon\Domain\Monitoring\Interfaces;
 
 use Centreon\Domain\Monitoring\ResourceFilter;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Monitoring\Model\ResourceDetailsHost;
+use Centreon\Domain\Monitoring\Model\ResourceDetailsService;
 
 interface ResourceRepositoryInterface
 {
@@ -48,4 +50,20 @@ interface ResourceRepositoryInterface
      * @return ResourceRepositoryInterface
      */
     public function filterByAccessGroups(?array $accessGroups): ResourceRepositoryInterface;
+
+    /**
+     * Find the missing information about the host
+     *
+     * @param ResourceDetailsHost $host
+     * @return void
+     */
+    public function findMissingInformationAboutHost(ResourceDetailsHost $host): void;
+
+    /**
+     * Find the missing information about the service
+     *
+     * @param ResourceDetailsService $service
+     * @return void
+     */
+    public function findMissingInformationAboutService(ResourceDetailsService $service): void;
 }

--- a/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
@@ -23,6 +23,9 @@ declare(strict_types=1);
 namespace Centreon\Domain\Monitoring\Interfaces;
 
 use Centreon\Domain\Monitoring\ResourceFilter;
+use Centreon\Domain\Monitoring\Model;
+use Centreon\Domain\Monitoring\Host;
+use Centreon\Domain\Monitoring\Service;
 
 interface ResourceServiceInterface
 {
@@ -104,6 +107,22 @@ interface ResourceServiceInterface
      * @throws \Exception
      */
     public function findResources(ResourceFilter $filter): array;
+
+    /**
+     * Create a new object with details but with data from the parent
+     *
+     * @param Host $host
+     * @return Model\ResourceDetailsHost
+     */
+    public function enrichHostWithDetails(Host $host): Model\ResourceDetailsHost;
+
+    /**
+     * Create a new object with details but with data from the parent
+     *
+     * @param Service $service
+     * @return Model\ResourceDetailsService
+     */
+    public function enrichServiceWithDetails(Service $service): Model\ResourceDetailsService;
 
     /**
      * Used to filter requests according to a contact.

--- a/src/Centreon/Domain/Monitoring/Model/ImportTrait.php
+++ b/src/Centreon/Domain/Monitoring/Model/ImportTrait.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\Monitoring\Model;
+
+/**
+ * Trait with import method for loading of source object properties
+ */
+trait ImportTrait
+{
+
+    /**
+     * Import the source object to load the model with data
+     *
+     * @param self $model
+     * @return self
+     */
+    public function import(self $model): self
+    {
+        foreach (get_object_vars($model) as $key => $value) {
+            $this->$key = $value;
+        }
+
+        return $this;
+    }
+}

--- a/src/Centreon/Domain/Monitoring/Model/ResourceDetailsHost.php
+++ b/src/Centreon/Domain/Monitoring/Model/ResourceDetailsHost.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\Monitoring\Model;
+
+use Centreon\Domain\Monitoring\Host;
+
+/**
+ * The model enrich the Host model
+ */
+class ResourceDetailsHost extends Host
+{
+    use ResourceDetailsTrait;
+
+    public const SERIALIZER_GROUP_DETAILS = 'resource_details_host';
+
+    /**
+     * @var string|null
+     */
+    private $pollerName;
+
+    /**
+     * @return string|null
+     */
+    public function getPollerName(): ?string
+    {
+        return $this->pollerName;
+    }
+
+    /**
+     * @param string|null $pollerName
+     * @return self
+     */
+    public function setPollerName(?string $pollerName): self
+    {
+        $this->pollerName = $pollerName;
+
+        return $this;
+    }
+}

--- a/src/Centreon/Domain/Monitoring/Model/ResourceDetailsService.php
+++ b/src/Centreon/Domain/Monitoring/Model/ResourceDetailsService.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\Monitoring\Model;
+
+use Centreon\Domain\Monitoring\Service;
+use Centreon\Domain\Monitoring\ResourceStatus;
+
+/**
+ * The model enrich the Service model
+ */
+class ResourceDetailsService extends Service
+{
+    use ResourceDetailsTrait;
+
+    public const SERIALIZER_GROUP_DETAILS = 'resource_details_service';
+
+    /**
+     * @return self|null
+     */
+    public function getParent(): ?ResourceStatus
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @param ResourceStatus|null $parent
+     * @return self
+     */
+    public function setParent(?ResourceStatus $parent): self
+    {
+        $this->parent = $parent;
+
+        return $this;
+    }
+}

--- a/src/Centreon/Domain/Monitoring/Model/ResourceDetailsTrait.php
+++ b/src/Centreon/Domain/Monitoring/Model/ResourceDetailsTrait.php
@@ -1,0 +1,148 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Domain\Monitoring\Model;
+
+use Centreon\Domain\Monitoring\Resource;
+use Centreon\Domain\Monitoring\ResourceStatus;
+use Centreon\Domain\Acknowledgement\Acknowledgement;
+use CentreonDuration;
+
+/**
+ * The model enrich the Host model
+ */
+trait ResourceDetailsTrait
+{
+    /**
+     * @var Resource|null
+     */
+    protected $parent;
+
+    /**
+     * @var ResourceStatus|null
+     */
+    protected $status;
+
+    /**
+     * @var string|null
+     */
+    protected $tries;
+
+    /**
+     * @return \Centreon\Domain\Downtime\Downtime[]
+     */
+    abstract public function getDowntimes(): array;
+
+    /**
+     * @param Acknowledgement|null $acknowledgement
+     * @return Host
+     */
+    abstract public function getAcknowledgement(): ?Acknowledgement;
+
+    /**
+     * @return string|null
+     */
+    public function getDowntimesAuthor(): ?string
+    {
+        $downtimes = $this->getDowntimes();
+        return $downtimes
+            ? (end($downtimes))->getAuthorName()
+            : null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAcknowledgementAuthor(): ?string
+    {
+        return $this->getAcknowledgement()
+            ? $this->getAcknowledgement()->getAuthorName()
+            : null;
+    }
+
+    /**
+     * @return selfStatus|null
+     */
+    public function getStatus(): ?ResourceStatus
+    {
+        return $this->status;
+    }
+
+    /**
+     * @param ResourceStatus|null $status
+     * @return self
+     */
+    public function setStatus(?ResourceStatus $status): self
+    {
+        $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDuration(): ?string
+    {
+        $result = null;
+
+        if ($this->getLastStateChange()) {
+            $result = CentreonDuration::toString(time() - $this->getLastStateChange()->getTimestamp());
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTries(): ?string
+    {
+        return $this->tries;
+    }
+
+    /**
+     * Get the tries property with translation
+     *
+     * @return string|null
+     */
+    public function getTriesTranslatable(): ?string
+    {
+        $search = $replace = ['Hard', 'Soft'];
+        array_walk($replace, function(&$value){
+            $value = _($value);
+        });
+
+        return str_replace($search, $replace, $this->tries);
+    }
+
+    /**
+     * @param string|null $tries
+     * @return self
+     */
+    public function setTries(?string $tries): self
+    {
+        $this->tries = $tries;
+
+        return $this;
+    }
+}

--- a/src/Centreon/Domain/Monitoring/Model/ResourceDetailsTrait.php
+++ b/src/Centreon/Domain/Monitoring/Model/ResourceDetailsTrait.php
@@ -128,7 +128,7 @@ trait ResourceDetailsTrait
     public function getTriesTranslatable(): ?string
     {
         $search = $replace = ['Hard', 'Soft'];
-        array_walk($replace, function(&$value){
+        array_walk($replace, function (&$value) {
             $value = _($value);
         });
 

--- a/src/Centreon/Domain/Monitoring/Model/ResourceDetailsTrait.php
+++ b/src/Centreon/Domain/Monitoring/Model/ResourceDetailsTrait.php
@@ -48,38 +48,6 @@ trait ResourceDetailsTrait
     protected $tries;
 
     /**
-     * @return \Centreon\Domain\Downtime\Downtime[]
-     */
-    abstract public function getDowntimes(): array;
-
-    /**
-     * @param Acknowledgement|null $acknowledgement
-     * @return Host
-     */
-    abstract public function getAcknowledgement(): ?Acknowledgement;
-
-    /**
-     * @return string|null
-     */
-    public function getDowntimesAuthor(): ?string
-    {
-        $downtimes = $this->getDowntimes();
-        return $downtimes
-            ? (end($downtimes))->getAuthorName()
-            : null;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getAcknowledgementAuthor(): ?string
-    {
-        return $this->getAcknowledgement()
-            ? $this->getAcknowledgement()->getAuthorName()
-            : null;
-    }
-
-    /**
      * @return selfStatus|null
      */
     public function getStatus(): ?ResourceStatus

--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -33,6 +33,9 @@ use Centreon\Domain\Monitoring\Resource as ResourceEntity;
 use Centreon\Domain\Entity\EntityValidator;
 use Symfony\Component\Validator\ConstraintViolationList;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
+use Centreon\Domain\Monitoring\Model;
+use Centreon\Domain\Monitoring\Host;
+use Centreon\Domain\Monitoring\Service;
 
 /**
  * Service manage the resources in real-time monitoring : hosts and services.
@@ -42,7 +45,7 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
 class ResourceService extends AbstractCentreonService implements ResourceServiceInterface
 {
     /**
-     * @var \Centreon\Domain\Monitoring\Interfaces\ResourceRepositoryInterface
+     * @var ResourceRepositoryInterface
      */
     private $resourceRepository;
 
@@ -120,6 +123,26 @@ class ResourceService extends AbstractCentreonService implements ResourceService
         }
 
         return $list;
+    }
+
+    public function enrichHostWithDetails(Host $host): Model\ResourceDetailsHost
+    {
+        $enrichedHost = (new Model\ResourceDetailsHost())
+            ->import($host);
+
+        $this->resourceRepository->findMissingInformationAboutHost($enrichedHost);
+
+        return $enrichedHost;
+    }
+
+    public function enrichServiceWithDetails(Service $service): Model\ResourceDetailsService
+    {
+        $enrichedService = (new Model\ResourceDetailsService())
+            ->import($service);
+
+        $this->resourceRepository->findMissingInformationAboutService($enrichedService);
+
+        return $enrichedService;
     }
 
     /**

--- a/src/Centreon/Domain/Monitoring/Service.php
+++ b/src/Centreon/Domain/Monitoring/Service.php
@@ -33,6 +33,8 @@ use Centreon\Domain\Service\EntityDescriptorMetadataInterface;
  */
 class Service implements EntityDescriptorMetadataInterface
 {
+    use Model\ImportTrait;
+
     // Groups for serilizing
     public const SERIALIZER_GROUP_MIN = 'service_min';
     public const SERIALIZER_GROUP_MAIN = 'service_main';
@@ -42,182 +44,182 @@ class Service implements EntityDescriptorMetadataInterface
     /**
      * @var int Unique index
      */
-    private $id;
+    protected $id;
 
     /**
      * @var int
      */
-    private $checkAttempt;
+    protected $checkAttempt;
 
     /**
      * @var string|null
      */
-    private $checkCommand;
+    protected $checkCommand;
 
     /**
      * @var float|null
      */
-    private $checkInterval;
+    protected $checkInterval;
 
     /**
      * @var string|null
      */
-    private $checkPeriod;
+    protected $checkPeriod;
 
     /**
      * @var int|null
      */
-    private $checkType;
+    protected $checkType;
 
     /**
      * @var string|null
      */
-    private $commandLine;
+    protected $commandLine;
 
     /**
      * @var string
      */
-    private $description;
+    protected $description;
 
     /**
      * @var string
      */
-    private $displayName;
+    protected $displayName;
 
     /**
      * @var float|null
      */
-    private $executionTime;
+    protected $executionTime;
 
     /**
      * @var Host|null
      */
-    private $host;
+    protected $host;
 
     /**
      * @var string|null
      */
-    private $iconImage;
+    protected $iconImage;
 
     /**
      * @var string|null
      */
-    private $iconImageAlt;
+    protected $iconImageAlt;
 
     /**
      * @var bool
      */
-    private $isAcknowledged;
+    protected $isAcknowledged;
 
     /**
      * @var bool
      */
-    private $isActiveCheck;
+    protected $isActiveCheck;
 
     /**
      * @var bool
      */
-    private $isChecked;
+    protected $isChecked;
 
     /**
      * @var int|null
      */
-    private $scheduledDowntimeDepth;
+    protected $scheduledDowntimeDepth;
 
     /**
      * @var \DateTime|null
      */
-    private $lastCheck;
+    protected $lastCheck;
 
     /**
      * @var \DateTime|null
      */
-    private $lastHardStateChange;
+    protected $lastHardStateChange;
 
     /**
      * @var \DateTime|null
      */
-    private $lastNotification;
+    protected $lastNotification;
 
     /**
      * @var \DateTime|null
      */
-    private $lastTimeCritical;
+    protected $lastTimeCritical;
 
     /**
      * @var \DateTime|null
      */
-    private $lastTimeOk;
+    protected $lastTimeOk;
 
     /**
      * @var \DateTime|null
      */
-    private $lastTimeUnknown;
+    protected $lastTimeUnknown;
 
     /**
      * @var \DateTime|null
      */
-    private $lastTimeWarning;
+    protected $lastTimeWarning;
 
     /**
      * @var \DateTime|null
      */
-    private $lastUpdate;
+    protected $lastUpdate;
 
     /**
      * @var \DateTime|null
      */
-    private $lastStateChange;
+    protected $lastStateChange;
 
     /**
      * @var float|null
      */
-    private $latency;
+    protected $latency;
 
     /**
      * @var int
      */
-    private $maxCheckAttempts;
+    protected $maxCheckAttempts;
 
     /**
      * @var \DateTime
      */
-    private $nextCheck;
+    protected $nextCheck;
 
     /**
      * @var string
      */
-    private $output;
+    protected $output;
 
     /**
      * @var string
      */
-    private $performanceData;
+    protected $performanceData;
 
     /**
      * @var int ['0' => 'OK', '1' => 'WARNING', '2' => 'CRITICAL', '3' => 'UNKNOWN', '4' => 'PENDING']
      */
-    private $state;
+    protected $state;
 
     /**
      * @var int ('1' => 'HARD', '0' => 'SOFT')
      */
-    private $stateType;
+    protected $stateType;
 
     /**
      * @var int
      */
-    private $criticality;
+    protected $criticality;
 
     /**
      * @var Downtime[]
      */
-    private $downtimes = [];
+    protected $downtimes = [];
 
     /**
      * @var Acknowledgement|null
      */
-    private $acknowledgement;
+    protected $acknowledgement;
 
     /**
      * {@inheritdoc}

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -556,7 +556,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                   AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
 
         $request =
-            'SELECT DISTINCT srv.*
+            'SELECT DISTINCT srv.*, h.host_id AS `host_host_id`
             FROM `:dbstg`.services srv
             LEFT JOIN `:dbstg`.hosts h 
               ON h.host_id = srv.host_id'
@@ -578,6 +578,10 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 $service = EntityCreator::createEntityByArray(
                     Service::class,
                     $row
+                );
+
+                $service->setHost(
+                    EntityCreator::createEntityByArray(Host::class, $row, 'host_')
                 );
             } else {
                 return null;


### PR DESCRIPTION
## Description

add new APIs of detail of host and services as part of the resources. The host\service objects are extended with the missing information

**Fixes** MON-5071

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

GET `/centreon/api/beta/monitoring/resources/hosts/14`
GET `/centreon/api/beta/monitoring/resources/hosts/14/services/24`

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
