### PR TITLE
fix(conf): add broker stat to remote conf

### DIFF
--- a/www/include/configuration/configServers/popup/remote.yaml
+++ b/www/include/configuration/configServers/popup/remote.yaml
@@ -33,3 +33,19 @@ gorgone:
       package: gorgone::modules::centreon::engine::hooks
       enable: true
       command_file: "__COMMAND__"
+
+    - name: statistics
+      package: "gorgone::modules::centreon::statistics::hooks"
+      enable: true
+      broker_cache_dir: "/var/cache/centreon/broker-stats/"
+      cron:
+        - id: broker_stats
+          timespec: "*/5 * * * *"
+          action: BROKERSTATS
+          parameters:
+            timeout: 10
+        - id: engine_stats
+          timespec: "*/5 * * * *"
+          action: ENGINESTATS
+          parameters:
+            timeout: 10


### PR DESCRIPTION
## Description

Add to the remote template the broker statisctic module and enable it.
In the export configuration popup

**Fixes** # (MON-5121)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Export the configuration on a remote server and check that the broker statistics are retrieved

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
