### PR TITLE
fix(update): generate remote conf file on update

### DIFF
--- a/www/install/php/Update-20.04.0-beta.1.php
+++ b/www/install/php/Update-20.04.0-beta.1.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
  *
@@ -77,8 +78,8 @@ try {
         $line = fgets($file);
         if (strpos($line, "CENTREON_CACHEDIR") !== false) {
             //remove superfluous carriage return
-            $line = preg_replace("/\r|\n/", "", $line);
-            $line = explode("=", $line);
+            $line = preg_replace("/\r|\n/", '', $line);
+            $line = explode('=', $line);
             $pattern[] = '/--CENTREON_CACHEDIR--/';
             // if no value is found, a default value is required
             $userValues[] = $line[1] ?? '/var/cache/centreon';
@@ -104,13 +105,15 @@ try {
         if (strpos($line, '$centreon_config = {') !== false) {
             $start = true;
             continue;
-        } elseif ($start === true
+        } elseif (
+            $start === true
             && strpos($line, '$instance_mode =') !== false
         ) {
             $stop = true;
             $isACentral = strpos($line, 'central') ? true : false;
             continue;
-        } elseif ($start === true
+        } elseif (
+            $start === true
             && strlen($line) > 5
             && substr($line, 0, 1) !== "#"
             && strpos($line, ' => ') !== false
@@ -301,12 +304,5 @@ try {
         " - Code : " . (int)$e->getCode() .
         " - Error : " . $e->getMessage() .
         " - Trace : " . $e->getTraceAsString()
-    );
-}
-
-if (empty($errorMessage)) {
-    $centreonLog->insertLog(
-        4,
-        $versionOfTheUpgrade . " - Successful Update"
     );
 }

--- a/www/install/php/Update-20.04.0-beta.1.php
+++ b/www/install/php/Update-20.04.0-beta.1.php
@@ -65,6 +65,7 @@ try {
     ];
 
     $isACentral = false;
+    $isARemote = false;
 
     // get user's centreon cache folder path
     $fileToOpen = _CENTREON_ETC_ . '/instCentWeb.conf';
@@ -111,6 +112,7 @@ try {
         ) {
             $stop = true;
             $isACentral = strpos($line, 'central') ? true : false;
+            $isARemote = strpos($line, 'remote') ? true : false;
             continue;
         } elseif (
             $start === true
@@ -156,9 +158,13 @@ try {
             $errorMessage = 'Database configuration file is not created properly';
             throw new \InvalidArgumentException($errorMessage);
         }
+    }
 
+    if (true === $isACentral || true === $isARemote) {
+        // central and remote have different template
+        $tplName = $isACentral ? 'gorgoneCoreTemplate.yaml' : 'gorgoneRemoteTemplate.yaml';
         // gorgone configuration file for centreon. Created in the centreon-gorgone folder
-        $fileTpl = __DIR__ . '/../var/gorgone/gorgoneCoreTemplate.yaml';
+        $fileTpl = __DIR__ . '/../var/gorgone/' . $tplName;
         if (!file_exists($fileTpl) || 0 === filesize($fileTpl)) {
             $errorMessage = 'Gorgone configuration template is empty or missing';
             throw new \InvalidArgumentException($errorMessage);

--- a/www/install/var/gorgone/gorgoneCoreTemplate.yaml
+++ b/www/install/var/gorgone/gorgoneCoreTemplate.yaml
@@ -47,13 +47,18 @@ gorgone:
       enable: true
       command_file: "--CENTREON_VARLIB---engine/rw/centengine.cmd"
 
-    - name: broker
-      package: "gorgone::modules::centreon::broker::hooks"
+    - name: statistics
+      package: "gorgone::modules::centreon::statistics::hooks"
       enable: true
-      cache_dir: "--CENTREON_CACHEDIR--/broker-stats/"
+      broker_cache_dir: "--CENTREON_CACHEDIR--/broker-stats/"
       cron:
         - id: broker_stats
-          timespec: "*/2 * * * *"
+          timespec: "*/5 * * * *"
           action: BROKERSTATS
+          parameters:
+            timeout: 10
+        - id: engine_stats
+          timespec: "*/5 * * * *"
+          action: ENGINESTATS
           parameters:
             timeout: 10

--- a/www/install/var/gorgone/gorgoneRemoteTemplate.yaml
+++ b/www/install/var/gorgone/gorgoneRemoteTemplate.yaml
@@ -1,0 +1,51 @@
+gorgone:
+  gorgonecore:
+    privkey: "--CENTREON_VARLIB---gorgone/.keys/rsakey.priv.pem"
+    pubkey: "--CENTREON_VARLIB---gorgone/.keys/rsakey.pub.pem"
+
+  modules:
+    - name: action
+      package: "gorgone::modules::core::action::hooks"
+      enable: true
+
+    - name: cron
+      package: "gorgone::modules::core::cron::hooks"
+      enable: true
+      cron: !include cron.d/*.yaml
+
+    - name: nodes
+      package: "gorgone::modules::centreon::nodes::hooks"
+      enable: true
+
+    - name: proxy
+      package: "gorgone::modules::core::proxy::hooks"
+      enable: true
+
+    - name: legacycmd
+      package: "gorgone::modules::centreon::legacycmd::hooks"
+      enable: true
+      cmd_file: "--CENTREON_VARLIB--/centcore.cmd"
+      cache_dir: "--CENTREON_CACHEDIR--"
+      cache_dir_trap: "--CENTREON_TRAPDIR--"
+      remote_dir: "--CENTREON_CACHEDIR--/config/remote-data/"
+
+    - name: engine
+      package: "gorgone::modules::centreon::engine::hooks"
+      enable: true
+      command_file: "--CENTREON_VARLIB---engine/rw/centengine.cmd"
+
+    - name: statistics
+      package: "gorgone::modules::centreon::statistics::hooks"
+      enable: true
+      broker_cache_dir: "--CENTREON_CACHEDIR--/broker-stats/"
+      cron:
+        - id: broker_stats
+          timespec: "*/5 * * * *"
+          action: BROKERSTATS
+          parameters:
+            timeout: 10
+        - id: engine_stats
+          timespec: "*/5 * * * *"
+          action: ENGINESTATS
+          parameters:
+            timeout: 10


### PR DESCRIPTION
## Description

Manage the creation of remote configuration file on update for legacy mode
Add broker statistics on remote
Rename and improve broker statistics on central
Remove success message displayed in the logs after the update

**Fixes** # (MON-5119)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

When updating to the 20.04, the remote should have a default configuration to be able to use the legacy mode in SSH

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
