### PR TITLE
fix(ui): Breadcrumb on "Legacy" BAM conf pages leads to wrong link

### DIFF
--- a/www/include/core/footer/footerPart.php
+++ b/www/include/core/footer/footerPart.php
@@ -298,7 +298,7 @@ function validateFeature(name, version, enabled) {
         ;
 
         // if it's a relative path, we can use the default redirection
-        if (!href.match(/^\.\/(?!main(?:\.get)?\.php)/) && isHandled === false) {
+        if (!href.match(/^\.\/(?!main(?:\.get)?\.php)/) && isHandled === false && !isReact) {
           e.preventDefault();
 
           // Manage centreon links

--- a/www/include/core/pathway/pathway.php
+++ b/www/include/core/pathway/pathway.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
+ * Copyright 2005-2020 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  * 
@@ -75,7 +76,7 @@ if (isset($url)) {
  */
 $pdoStatement = $pearDB->prepare(
     'SELECT `topology_url`, `topology_url_opt`, `topology_parent`,
-    `topology_name`, `topology_page`
+    `topology_name`, `topology_page`, `is_react`
     FROM topology where topology_page IN
         (SELECT :topology_page
         UNION
@@ -94,6 +95,10 @@ $pdoStatement = $pearDB->prepare(
 $pdoStatement->bindValue(':topology_page', (int) $p, \PDO::PARAM_INT);
 
 $breadcrumbData = [];
+$basePath = '/' . trim(explode('main.get.php', $_SERVER['REQUEST_URI'])[0], "/");
+/*
+ * <a href="<?= $details['is_react'] ? "{$basePath}{$details['url']}" : "main.php?p={$page}{$details["opt"]}" ?>" class="pathWay"><?= _($details["name"]); ?></a>
+ */
 
 if ($pdoStatement->execute()) {
     while ($result = $pdoStatement->fetch(\PDO::FETCH_ASSOC)) {
@@ -116,6 +121,7 @@ if ($pdoStatement->execute()) {
         }
 
         $breadcrumbData[$result['topology_page']] = [
+            'is_react' => $result['is_react'],
             'name' => $result['topology_name'],
             'url' => $result['topology_url'],
             'opt' => $result['topology_url_opt'],
@@ -131,7 +137,7 @@ if ($centreon->user->access->page($p)) {
     foreach ($breadcrumbData as $page => $details) {
         echo $flag;
         ?>
-        <a href="main.php?p=<?= $page . $details["opt"]; ?>" class="pathWay"><?= _($details["name"]); ?></a>
+        <a href="<?= $details['is_react'] ? "{$basePath}{$details['url']}" : "main.php?p={$page}{$details["opt"]}" ?>"<?= $details['is_react'] ? ' isreact="isreact"' : '' ?> class="pathWay"><?= _($details["name"]); ?></a>
         <?php
         $flag = '<span class="pathWayBracket" >  &nbsp;&#62;&nbsp; </span>';
     }


### PR DESCRIPTION
## Description

when we have a page with the parent page that on react the breadcrumb doesn't cover this case and the user is redirected to the page as `/centreon/main.php?p=626`

example of a page with react parent is `/centreon/main.php?p=62606` (Configuration  >  Business Activity  >  Indicators)

**Fixes** BAM-950

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).