### PR TITLE
fix(api): author_id not filled in timeline endpoint

### DIFF
--- a/src/Centreon/Domain/Monitoring/Entity/AckEventObject.php
+++ b/src/Centreon/Domain/Monitoring/Entity/AckEventObject.php
@@ -100,6 +100,7 @@ class AckEventObject extends Acknowledgement implements EventObjectInterface
             'sticky' => 'setSticky',
             'timestamp' => 'setEntryTime',
             'contact' => 'setAuthor',
+            'contact_id' => 'setAuthorId',
             'service_id' => 'setServiceId'
         ];
     }

--- a/src/Centreon/Domain/Monitoring/Entity/DowntimeEventObject.php
+++ b/src/Centreon/Domain/Monitoring/Entity/DowntimeEventObject.php
@@ -112,6 +112,7 @@ class DowntimeEventObject extends Downtime implements EventObjectInterface, Enti
             'timestamp' => 'setEntryTime',
             'type' => 'setType',
             'contact' => 'setAuthor',
+            'contact_id' => 'setAuthorId',
             'start_time' => 'setStartTime',
             'end_time' => 'setEndTime',
             'actual_start_time' => 'setActualStartTime',

--- a/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Acknowledgement/AcknowledgementRepositoryRDB.php
@@ -172,7 +172,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
         $request =
             'SELECT ack.*, contact.contact_id AS author_id
             FROM `:dbstg`.acknowledgements ack
-            INNER JOIN `:db`.contact
+            LEFT JOIN `:db`.contact
               ON contact.contact_alias = ack.author'
             . $accessGroupFilter
             . 'WHERE ack.host_id = :host_id
@@ -208,7 +208,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
         $request =
             'SELECT ack.*, contact.contact_id AS author_id
             FROM `:dbstg`.acknowledgements ack
-            INNER JOIN `:db`.contact
+            LEFT JOIN `:db`.contact
               ON contact.contact_alias = ack.author'
             . $accessGroupFilter
             . 'WHERE ack.host_id = :host_id
@@ -242,7 +242,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
         $request =
             'SELECT ack.*, contact.contact_id AS author_id
             FROM `:dbstg`.acknowledgements ack
-            INNER JOIN `:db`.contact
+            LEFT JOIN `:db`.contact
             ON contact.contact_alias = ack.author
             WHERE ack.acknowledgement_id = (
             SELECT MAX(ack2.acknowledgement_id)
@@ -290,7 +290,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
         $request =
             'SELECT ack.*, contact.contact_id AS author_id
         FROM `:dbstg`.acknowledgements ack
-        INNER JOIN `:db`.contact
+        LEFT JOIN `:db`.contact
           ON contact.contact_alias = ack.author
         WHERE ack.acknowledgement_id = (
           SELECT MAX(ack2.acknowledgement_id)
@@ -351,7 +351,7 @@ final class AcknowledgementRepositoryRDB extends AbstractRepositoryDRB implement
 
         $request = 'SELECT ack.*, contact.contact_id AS author_id
             FROM `:dbstg`.acknowledgements ack
-            INNER JOIN `:db`.contact
+            LEFT JOIN `:db`.contact
                 ON contact.contact_alias = ack.author '
             . $accessGroupFilter
             . 'WHERE ack.service_id ' . (($type === self::TYPE_HOST_ACKNOWLEDGEMENT) ? ' = 0' : ' != 0');

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1260,10 +1260,13 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return $downtimes;
         }
 
-        $sql = 'SELECT * FROM `:dbstg`.`downtimes` WHERE host_id = :hostId AND service_id = :serviceId ' .
-                'AND deletion_time IS NULL AND ((NOW() BETWEEN FROM_UNIXTIME(actual_start_time) ' .
-                'AND FROM_UNIXTIME(actual_end_time)) OR ((NOW() > FROM_UNIXTIME(actual_start_time) ' .
-                'AND actual_end_time IS NULL))) ORDER BY entry_time DESC';
+        $sql = 'SELECT d.*, c.contact_id AS `author_id` FROM `:dbstg`.`downtimes`  AS `d` '
+            . 'INNER JOIN `:db`.contact AS `c` ON c.contact_alias = d.author '
+            . 'WHERE d.host_id = :hostId AND d.service_id = :serviceId '
+            . 'AND d.deletion_time IS NULL AND ((NOW() BETWEEN FROM_UNIXTIME(d.actual_start_time) '
+            . 'AND FROM_UNIXTIME(d.actual_end_time)) OR ((NOW() > FROM_UNIXTIME(d.actual_start_time) '
+            . 'AND d.actual_end_time IS NULL))) '
+            . 'ORDER BY d.entry_time DESC';
 
         $request = $this->translateDbName($sql);
         $statement = $this->db->prepare($request);
@@ -1295,8 +1298,10 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             return $acks;
         }
 
-        $sql = 'SELECT * FROM `:dbstg`.`acknowledgements` WHERE host_id = :hostId AND service_id = :serviceId ' .
-                'AND deletion_time IS NULL ORDER BY entry_time DESC';
+        $sql = 'SELECT a.*, c.contact_id AS `author_id` FROM `:dbstg`.`acknowledgements` AS `a` '
+            . 'INNER JOIN `:db`.contact AS `c` ON c.contact_alias = a.author '
+            . 'WHERE a.host_id = :hostId AND a.service_id = :serviceId AND a.deletion_time IS NULL '
+            . 'ORDER BY a.entry_time DESC';
 
         $request = $this->translateDbName($sql);
         $statement = $this->db->prepare($request);

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1261,7 +1261,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
 
         $sql = 'SELECT d.*, c.contact_id AS `author_id` FROM `:dbstg`.`downtimes`  AS `d` '
-            . 'INNER JOIN `:db`.contact AS `c` ON c.contact_alias = d.author '
+            . 'LEFT JOIN `:db`.contact AS `c` ON c.contact_alias = d.author '
             . 'WHERE d.host_id = :hostId AND d.service_id = :serviceId '
             . 'AND d.deletion_time IS NULL AND ((NOW() BETWEEN FROM_UNIXTIME(d.actual_start_time) '
             . 'AND FROM_UNIXTIME(d.actual_end_time)) OR ((NOW() > FROM_UNIXTIME(d.actual_start_time) '
@@ -1299,7 +1299,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
 
         $sql = 'SELECT a.*, c.contact_id AS `author_id` FROM `:dbstg`.`acknowledgements` AS `a` '
-            . 'INNER JOIN `:db`.contact AS `c` ON c.contact_alias = a.author '
+            . 'LEFT JOIN `:db`.contact AS `c` ON c.contact_alias = a.author '
             . 'WHERE a.host_id = :hostId AND a.service_id = :serviceId AND a.deletion_time IS NULL '
             . 'ORDER BY a.entry_time DESC';
 

--- a/src/Centreon/Infrastructure/Monitoring/TimelineRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/TimelineRepositoryRDB.php
@@ -207,6 +207,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
         l.type AS `type`,
         l.retry AS `retry`,
         l.notification_contact AS `contact`,
+        null AS `contact_id`,
         l.notification_cmd AS `command`,
         NULL AS `persistent`,    
         NULL as `deletion_time`,
@@ -262,6 +263,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
         c.type AS `type`,
         NULL AS `retry`,
         c.author AS `contact`,
+        null AS `contact_id`,
         NULL AS `command`,
         c.persistent AS `persistent`,
         NULL as `deletion_time`,
@@ -318,6 +320,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
         d.type AS `type`,
         NULL AS `retry`,
         d.author AS `contact`,
+        contact_d.contact_id AS `contact_id`,
         NULL AS `command`,
         NULL AS `persistent`,
         d.deletion_time as `deletion_time`,
@@ -332,6 +335,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
         NULL AS `sticky`,
         NULL AS `notify_contacts`
         FROM `:dbstg`.`downtimes` d
+        INNER JOIN `:db`.contact AS `contact_d` ON contact_d.contact_alias = d.author
         ";
 
         $collector->addValue(":hostId", $hostId);
@@ -377,6 +381,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
         a.type AS `type`,
         NULL AS `retry`,
         a.author AS `contact`,
+        contact_a.contact_id AS `contact_id`,
         NULL AS `command`,
         a.persistent_comment AS `persistent`,
         a.deletion_time as `deletion_time`,
@@ -391,6 +396,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
         a.sticky AS `sticky`,
         a.notify_contacts AS `notify_contacts`
         FROM `:dbstg`.`acknowledgements` a
+        INNER JOIN `:db`.contact AS `contact_a` ON contact_a.contact_alias = a.author
         ";
 
         $collector->addValue(":hostId", $hostId);

--- a/src/Centreon/Infrastructure/Monitoring/TimelineRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/TimelineRepositoryRDB.php
@@ -335,7 +335,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
         NULL AS `sticky`,
         NULL AS `notify_contacts`
         FROM `:dbstg`.`downtimes` d
-        INNER JOIN `:db`.contact AS `contact_d` ON contact_d.contact_alias = d.author
+        LEFT JOIN `:db`.contact AS `contact_d` ON contact_d.contact_alias = d.author
         ";
 
         $collector->addValue(":hostId", $hostId);
@@ -396,7 +396,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
         a.sticky AS `sticky`,
         a.notify_contacts AS `notify_contacts`
         FROM `:dbstg`.`acknowledgements` a
-        INNER JOIN `:db`.contact AS `contact_a` ON contact_a.contact_alias = a.author
+        LEFT JOIN `:db`.contact AS `contact_a` ON contact_a.contact_alias = a.author
         ";
 
         $collector->addValue(":hostId", $hostId);


### PR DESCRIPTION
## Description

the property author_id is empty in the following APIs:
- `/centreon/api/beta/monitoring/hosts/14`
- `/centreon/api/beta/monitoring/hosts/14/timeline`
- `/centreon/api/beta/monitoring/hosts/14/services/19`
- `/centreon/api/beta/monitoring/hosts/14/services/19/timeline`

**Fixes** MON-5105

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
