### PR TITLE
feat(api): do not define status_graph_endpoint and performance_graph_endpoint whenever graph data are empty

### DIFF
--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -170,7 +170,6 @@ class MonitoringResourceController extends AbstractController
                     'service_id' => $resource->getId(),
                 ], $resourcesGraphData)
             ) {
-
                 $parameters = [
                     'hostId' => $resource->getParent()->getId(),
                     'serviceId' => $resource->getId(),

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -161,8 +161,16 @@ class MonitoringResourceController extends AbstractController
         $resources = $this->resource->filterByContact($this->getUser())
             ->findResources($filter);
 
+        $resourcesGraphData = $this->resource->getListOfResourcesWithGraphData($resources);
+
         foreach ($resources as $resource) {
-            if ($resource->getParent() != null) {
+            if (
+                $resource->getParent() != null && in_array([
+                    'host_id' => $resource->getParent()->getId(),
+                    'service_id' => $resource->getId(),
+                ], $resourcesGraphData)
+            ) {
+
                 $parameters = [
                     'hostId' => $resource->getParent()->getId(),
                     'serviceId' => $resource->getId(),

--- a/src/Centreon/Domain/Monitoring/Interfaces/ResourceRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/ResourceRepositoryInterface.php
@@ -66,4 +66,12 @@ interface ResourceRepositoryInterface
      * @return void
      */
     public function findMissingInformationAboutService(ResourceDetailsService $service): void;
+
+    /**
+     * Get list of resources with graph data.
+     *
+     * @param Resource[] $resources
+     * @return int[]
+     */
+    public function getListOfResourcesWithGraphData(array $resources): array;
 }

--- a/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/ResourceServiceInterface.php
@@ -109,6 +109,14 @@ interface ResourceServiceInterface
     public function findResources(ResourceFilter $filter): array;
 
     /**
+     * Get list of resources with graph data.
+     *
+     * @param Resource[] $resources
+     * @return int[]
+     */
+    public function getListOfResourcesWithGraphData(array $resources): array;
+
+    /**
      * Create a new object with details but with data from the parent
      *
      * @param Host $host

--- a/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -93,6 +93,14 @@ class ResourceService extends AbstractCentreonService implements ResourceService
     /**
      * {@inheritDoc}
      */
+    public function getListOfResourcesWithGraphData(array $resources): array
+    {
+        return $this->resourceRepository->getListOfResourcesWithGraphData($resources);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function findResources(ResourceFilter $filter): array
     {
         // try to avoid exception from the regexp bad syntax in search criteria

--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -261,7 +261,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             $collector->addValue(":host_id_{$key}", $resources->getId(), PDO::PARAM_INT);
             $collector->addValue(":service_id_{$key}", $resources->getParent()->getId(), PDO::PARAM_INT);
         }
-        
+
         if (!$where) {
             return [];
         }
@@ -269,7 +269,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
         $statement = $this->db->prepare(
             $this->translateDbName(
                 'SELECT host_id, service_id FROM `:dbstg`.metrics AS m, `:dbstg`.index_data AS i '
-                . 'WHERE (' . implode(' OR ', $where ) . ') AND i.id = m.index_id AND m.hidden = :hidden '
+                . 'WHERE (' . implode(' OR ', $where) . ') AND i.id = m.index_id AND m.hidden = :hidden '
                 . 'GROUP BY m.metric_id '
                 . 'LIMIT 0, 1'
             )


### PR DESCRIPTION
## Description

performance_graph_endpoint and status_graph_endpoint are always defined, even when no graph data are available. 

The User should not be able to display a graph when no data is there to be displayed. Since the Frontend only has the endpoint at first and needs to query the data before checking its content, it’s more efficient to prevent from getting any endpoint from the backend instead. 

**Fixes** MON-5128

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
