### PR TITLE
fix(monitoring): change SQL Request to get ServiceGroups as non-admin user

### DIFF
--- a/www/include/monitoring/status/Common/commonJS.php
+++ b/www/include/monitoring/status/Common/commonJS.php
@@ -427,7 +427,7 @@ if (!$centreon->user->access->admin) {
     $query = "SELECT DISTINCT sg.sg_alias, sg.sg_name AS name
                 FROM servicegroup sg, acl_resources_sg_relations arsr
                 WHERE sg.sg_id = arsr.sg_id
-                    AND arsr.acl_res_id IN (".$centreon->user->access->getResourceGroupsString().")
+                    AND arsr.acl_res_id IN (" . $centreon->user->access->getResourceGroupsString() . ")
                     AND sg.sg_activate = '1'";
     $DBRESULT = $pearDB->query($query);
     while ($data = $DBRESULT->fetchRow()) {

--- a/www/include/monitoring/status/Common/commonJS.php
+++ b/www/include/monitoring/status/Common/commonJS.php
@@ -428,10 +428,7 @@ if (!$centreon->user->access->admin) {
                 FROM servicegroup sg, acl_resources_sg_relations arsr
                 WHERE sg.sg_id = arsr.sg_id
                     AND arsr.acl_res_id IN (".$centreon->user->access->getResourceGroupsString().")
-                    AND sg.sg_activate = '1'
-                    AND sg.sg_id in (SELECT servicegroup_sg_id
-                FROM servicegroup_relation
-                WHERE service_service_id IN (".$centreon->user->access->getServicesString("ID", $acldb)."))";
+                    AND sg.sg_activate = '1'";
     $DBRESULT = $pearDB->query($query);
     while ($data = $DBRESULT->fetchRow()) {
         $sgBrk[$data["name"]] = 1;


### PR DESCRIPTION
## Description

When adding service templates in service groups, and not service directly, non-admin user will not be able to see them in Status Details > Service page.

**Fixes** # MON-5118

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a service template,
- Create a host template,
- Link the service template with the host template,
- Create a service group,
- Link the host/service templates couple to the service group,
- Create a user,
- Create ACL for this user allowing it to see all service groups and everything else,
- Create a host/service couple that uses the service template,
- Push config,
- Logging with user,
- You will not see the service group even though you can see them all and it is pushed to Engine

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
