### PR TITLE
fix(sql) resolve broker form radio button dependencies

### DIFF
--- a/www/install/sql/centreon/Update-DB-20.04.0-beta.1.sql
+++ b/www/install/sql/centreon/Update-DB-20.04.0-beta.1.sql
@@ -5,6 +5,10 @@ DELETE FROM `cb_field` WHERE
   OR `description` LIKE 'File where correlation%'
   OR `displayname` = 'Correlation passive';
 DELETE FROM `cb_type` WHERE `type_shortname` = 'correlation';
+-- Resolve radio button broker form
+INSERT INTO cb_list_values (cb_list_id, value_name, value_value) VALUES
+((SELECT cb_list_id FROM cb_list WHERE cb_field_id = (SELECT cb_field_id FROM cb_field WHERE fieldtype ='radio' AND fieldname ='error') LIMIT 1),'No','no'),
+((SELECT cb_list_id FROM cb_list WHERE cb_field_id = (SELECT cb_field_id FROM cb_field WHERE fieldtype ='radio' AND fieldname ='error') LIMIT 1),'Yes','yes')
 
 -- Update topology of service grid / by host group / by service group
 UPDATE topology SET topology_url_opt = '&o=svcOV_pb' WHERE topology_page = 20204;


### PR DESCRIPTION
## Description

radio button in broker form disappears

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

 check logger in borker configuration : Configuration  >  Pollers  >  Broker configuration

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
