### PR TITLE
fix(api): the SQL parameter of are switched

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -257,8 +257,8 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             }
 
             $where[] = "(i.host_id = :host_id_{$key} AND i.service_id = :service_id_{$key})";
-            $collector->addValue(":host_id_{$key}", $resources->getId(), PDO::PARAM_INT);
-            $collector->addValue(":service_id_{$key}", $resources->getParent()->getId(), PDO::PARAM_INT);
+            $collector->addValue(":service_id_{$key}", $resources->getId(), PDO::PARAM_INT);
+            $collector->addValue(":host_id_{$key}", $resources->getParent()->getId(), PDO::PARAM_INT);
         }
 
         if (!$where) {


### PR DESCRIPTION
## Description

the parameters that are passed in SQL query are switched in ResourceRepositoryRDB::getListOfResourcesWithGraphData

**Fixes** MON-5128

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
