### PR TITLE
fix(ResourceFilter): pending mapping code incorrect for host object

### DIFF
--- a/src/Centreon/Domain/Monitoring/ResourceFilter.php
+++ b/src/Centreon/Domain/Monitoring/ResourceFilter.php
@@ -78,7 +78,7 @@ class ResourceFilter
         self::STATUS_UP => 0,
         self::STATUS_DOWN => 1,
         self::STATUS_UNREACHABLE => 2,
-        self::STATUS_PENDING => 3,
+        self::STATUS_PENDING => 4,
     ];
 
     /**


### PR DESCRIPTION
## Description

Pending status filter was not working for hosts in pending status.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Get a host in pending status
- Display the Event View page and filter on pending status
- Services and hosts in pending statuses should be listed

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
