### PR TITLE
fix(api): improve the parent object of Resource details endpoints and add data for severity_code

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsHost.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsHost.yml
@@ -15,7 +15,7 @@ Centreon\Domain\Monitoring\Model\ResourceDetailsHost:
             groups:
                 - 'resource_details_host'
         parent:
-            type: Centreon\Domain\Monitoring\ResourceStatus
+            type: Centreon\Domain\Monitoring\Resource
             groups:
                 - 'resource_details_host'
         status:

--- a/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsService.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Model.ResourceDetailsService.yml
@@ -15,7 +15,7 @@ Centreon\Domain\Monitoring\Model\ResourceDetailsService:
             groups:
                 - 'resource_details_service'
         parent:
-            type: Centreon\Domain\Monitoring\ResourceStatus
+            type: Centreon\Domain\Monitoring\Resource
             groups:
                 - 'resource_details_service'
         status:

--- a/config/packages/serializer/Centreon/Monitoring.Resource.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Resource.yml
@@ -24,6 +24,7 @@ Centreon\Domain\Monitoring\Resource:
             groups:
                 - 'resource_main'
                 - 'resource_parent'
+                - 'resource_details_service'
         type:
             type: string
             groups:
@@ -33,6 +34,7 @@ Centreon\Domain\Monitoring\Resource:
             groups:
                 - 'resource_main'
                 - 'resource_parent'
+                - 'resource_details_service'
         icon:
             type: Centreon\Domain\Monitoring\Icon
             groups:
@@ -47,6 +49,7 @@ Centreon\Domain\Monitoring\Resource:
             groups:
                 - 'resource_main'
                 - 'resource_parent'
+                - 'resource_details_service'
         inDowntime:
             type: bool
             groups:

--- a/src/Centreon/Domain/Monitoring/Model/ResourceDetailsService.php
+++ b/src/Centreon/Domain/Monitoring/Model/ResourceDetailsService.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 namespace Centreon\Domain\Monitoring\Model;
 
 use Centreon\Domain\Monitoring\Service;
-use Centreon\Domain\Monitoring\ResourceStatus;
 
 /**
  * The model enrich the Service model
@@ -33,23 +32,4 @@ class ResourceDetailsService extends Service
     use ResourceDetailsTrait;
 
     public const SERIALIZER_GROUP_DETAILS = 'resource_details_service';
-
-    /**
-     * @return self|null
-     */
-    public function getParent(): ?ResourceStatus
-    {
-        return $this->parent;
-    }
-
-    /**
-     * @param ResourceStatus|null $parent
-     * @return self
-     */
-    public function setParent(?ResourceStatus $parent): self
-    {
-        $this->parent = $parent;
-
-        return $this;
-    }
 }

--- a/src/Centreon/Domain/Monitoring/Model/ResourceDetailsTrait.php
+++ b/src/Centreon/Domain/Monitoring/Model/ResourceDetailsTrait.php
@@ -24,7 +24,6 @@ namespace Centreon\Domain\Monitoring\Model;
 
 use Centreon\Domain\Monitoring\Resource;
 use Centreon\Domain\Monitoring\ResourceStatus;
-use Centreon\Domain\Acknowledgement\Acknowledgement;
 use CentreonDuration;
 
 /**
@@ -78,6 +77,25 @@ trait ResourceDetailsTrait
         }
 
         return $result;
+    }
+
+    /**
+     * @return self|null
+     */
+    public function getParent(): ?Resource
+    {
+        return $this->parent;
+    }
+
+    /**
+     * @param ResourceStatus|null $parent
+     * @return self
+     */
+    public function setParent(?Resource $parent): self
+    {
+        $this->parent = $parent;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
## Description

the properties parent and severity_code are not loaded correctly in Resource details endpoints (http://localhost/centreon/api/beta/monitoring/resources/hosts/14/services/19)
**Fixes** MON-5071

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
