### PR TITLE
fix(servicegroups): Get the correct Service Template related to a servicegroup

### DIFF
--- a/www/class/centreonService.class.php
+++ b/www/class/centreonService.class.php
@@ -1120,9 +1120,10 @@ class CentreonService
                     $serviceList[] = array('id' => $serviceCompleteId, 'text' => $serviceCompleteName);
                 }
             } else {
-                $queryService = "SELECT DISTINCT s.service_description, s.service_id, h.host_name, h.host_id "
-                    . "FROM host h, service s, host_service_relation hsr "
+                $queryService = "SELECT DISTINCT s.service_description, s.service_id, h.host_name, h.host_id, sgr.host_host_id "
+                    . "FROM host h, service s, host_service_relation hsr, servicegroup_relation sgr "
                     . 'WHERE hsr.host_host_id = h.host_id '
+                    . "AND sgr.host_host_id = h.host_id "
                     . "AND hsr.service_service_id = s.service_id "
                     . "AND h.host_register = '$register' AND s.service_register = '$register' "
                     . $selectedHosts


### PR DESCRIPTION
## Description

When we add a service template with multiple host templates in a service group the other service template link with other host templates is added automatically in service group.

This PR change the request made by the form to display only the real relations

**Fixes** MON-5112

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

-Create 2 host templates,
-Create 1 service template,
-Link the service template with the 2 host templates,
-Create a service group and link it with one host/service templates couple,
-Save and return in service group.
-You will see both host/service templates couples.

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
