### PR TITLE
Mon 5102 fix acl for apiv2

### DIFF
--- a/src/Security/ContactBySession.php
+++ b/src/Security/ContactBySession.php
@@ -26,8 +26,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 
 /**
  * This class has been defined to differentiate between contacts that have
- * identified by session and those by token. By session, all calls to the
- * **hasRole()** method will return TRUE.
+ * identified by session and those by token.
  *
  * @package Security
  */
@@ -51,11 +50,6 @@ class ContactBySession extends Contact
             Contact::ROLE_API_REALTIME,
             Contact::ROLE_API_CONFIGURATION
         ];
-    }
-
-    public function hasRole(string $role): bool
-    {
-        return true;
     }
 
     public function getId(): int
@@ -126,15 +120,5 @@ class ContactBySession extends Contact
     public function getUsername()
     {
         return $this->contact->getUsername();
-    }
-
-    public function hasAccessToApiConfiguration(): bool
-    {
-        return true;
-    }
-
-    public function hasAccessToApiRealTime(): bool
-    {
-        return true;
     }
 }

--- a/src/Security/ContactBySession.php
+++ b/src/Security/ContactBySession.php
@@ -26,7 +26,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 
 /**
  * This class has been defined to differentiate between contacts that have
- * identified by session and those by token.
+ * identified by session and those by token. 
  *
  * @package Security
  */
@@ -120,5 +120,15 @@ class ContactBySession extends Contact
     public function getUsername()
     {
         return $this->contact->getUsername();
+    }
+
+    public function hasAccessToApiConfiguration(): bool
+    {
+        return true;
+    }
+
+    public function hasAccessToApiRealTime(): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
## Description

When client connects via session (api request through react), they always got all roles, no matter if user was admin or not. This PR enables acl role check.

**Fixes** # MON 5102

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Try to acknowledge a resource without having the needed role.

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
