### PR TITLE
fix(base): Can't use the new event view as my default page (ACL manageable?)

### DIFF
--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -48,7 +48,7 @@ class AutologinOptionsContext extends CentreonContext
     {
         $this->spin(
             function ($context) {
-                $element = $this->currentPage->find('css', 'div.toggleEdit');
+                $element = $this->currentPage->find('css', '*[aria-label="Breadcrumb"]  a[href="/centreon/monitoring/events"]');
                 return !is_null($element);
             },
             'The current page is not valid.',

--- a/www/class/centreonAuth.class.php
+++ b/www/class/centreonAuth.class.php
@@ -36,6 +36,11 @@
 
 class CentreonAuth
 {
+    /**
+     * The default page has to be Events view
+     */
+    public const DEFAULT_PAGE = 104;
+
     // Declare Values
     public $userInfos;
     protected $login;
@@ -101,7 +106,7 @@ class CentreonAuth
         $this->debug = $this->getLogFlag();
         $this->ldap_auto_import = array();
         $this->ldap_store_password = array();
-        $this->default_page = 1;
+        $this->default_page = self::DEFAULT_PAGE;
         $this->source = $source;
 
         $res = $pearDB->query(

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -82,7 +82,8 @@ if ($o == "c") {
         $cct[$row['cp_key']] = $row['cp_value'];
     }
 
-    $cct['default_page'] = $cct['default_page'] ?: 104; // selected by default is Events view page
+    // selected by default is Events view page
+    $cct['default_page'] = $cct['default_page'] ?: CentreonAuth::DEFAULT_PAGE;
 }
 
 /*

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -82,7 +82,7 @@ if ($o == "c") {
         $cct[$row['cp_key']] = $row['cp_value'];
     }
 
-    $cct['default_page'] = $cct['default_page'] ?: 104; // selected bu default is Events view page
+    $cct['default_page'] = $cct['default_page'] ?: 104; // selected by default is Events view page
 }
 
 /*

--- a/www/include/Administration/myAccount/formMyAccount.php
+++ b/www/include/Administration/myAccount/formMyAccount.php
@@ -81,6 +81,8 @@ if ($o == "c") {
     while ($row = $res->fetch()) {
         $cct[$row['cp_key']] = $row['cp_value'];
     }
+
+    $cct['default_page'] = $cct['default_page'] ?: 104; // selected bu default is Events view page
 }
 
 /*
@@ -231,6 +233,9 @@ if (!empty($aclUser)) {
         $parentNameLvl1 = $translatedPages[$parentLvl1]['i18n'];
         foreach ($childrenLvl2 as $parentLvl2 => $childrenLvl3) {
             $parentNameLvl2 = $translatedPages[$parentLvl2]['i18n'];
+            $isThirdLevelMenu = false;
+            $parentLvl3 = null;
+
             if ($oneChildCanBeShown()) {
                 /**
                  * There is at least one child that can be shown then we can
@@ -254,11 +259,18 @@ if (!empty($aclUser)) {
                         }
                     }
                 }
-            } else {
+
+                $isThirdLevelMenu = true;
+            }
+
+            // select parent from level 2 if level 3 is missing
+            $pageId = $parentLvl3 ?: $parentLvl2;
+
+            if (!$isThirdLevelMenu && $translatedPages[$pageId]['show']) {
                 /**
                  * We show only first and second level
                  */
-                $pages[$parentLvl3] =
+                $pages[$pageId] =
                     $parentNameLvl1 . ' > ' . $parentNameLvl2;
             }
         }

--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -142,7 +142,8 @@ function tidySearchKey($search, $advanced_search)
     if ($advanced_search == 1) {
         if (isset($search) && !strstr($search, "*") && !strstr($search, "%")) {
             $search = "'" . $search . "'";
-        } elseif (isset($search) &&
+        } elseif (
+            isset($search) &&
             isset($search[0]) &&
             isset($search[strlen($search) - 1]) &&
             $search[0] == "%" &&
@@ -365,7 +366,7 @@ function getMyHostGroups($host_id = null)
     return $hgs;
 }
 
-function getMyHostField($host_id = null, $field)
+function getMyHostField($host_id, $field)
 {
     if (!$host_id) {
         return;
@@ -389,7 +390,7 @@ function getMyHostField($host_id = null, $field)
     return null;
 }
 
-function getMyHostFieldOnHost($host_id = null, $field)
+function getMyHostFieldOnHost($host_id, $field)
 {
     global $pearDB;
 
@@ -502,7 +503,7 @@ function getMyHostMacroFromMultiTemplates($host_id, $field)
     return null;
 }
 
-function getMyHostMacro($host_id = null, $field)
+function getMyHostMacro($host_id, $field)
 {
     if (!$host_id) {
         return;
@@ -575,7 +576,7 @@ function getMyCategorieName($sc_id = null)
     return $row["sc_name"];
 }
 
-function getMyServiceMacro($service_id = null, $field)
+function getMyServiceMacro($service_id, $field)
 {
     if (!$service_id) {
         return;
@@ -598,7 +599,7 @@ function getMyServiceMacro($service_id = null, $field)
     }
 }
 
-function getMyHostExtendedInfoField($host_id = null, $field)
+function getMyHostExtendedInfoField($host_id, $field)
 {
     if (!$host_id) {
         return;
@@ -617,7 +618,7 @@ function getMyHostExtendedInfoField($host_id = null, $field)
     }
 }
 
-function getMyHostExtendedInfoImage($host_id = null, $field, $flag1stLevel = null, $antiLoop = null)
+function getMyHostExtendedInfoImage($host_id, $field, $flag1stLevel = null, $antiLoop = null)
 {
     global $pearDB, $oreon;
 
@@ -675,12 +676,13 @@ function getMyHostExtendedInfoImage($host_id = null, $field, $flag1stLevel = nul
                         }
                     }
                 } else {
-                    if ($result_field = getMyHostExtendedInfoImage(
-                        $row['host_tpl_id'],
-                        $field,
-                        null,
-                        $row['host_tpl_id']
-                    )
+                    if (
+                        $result_field = getMyHostExtendedInfoImage(
+                            $row['host_tpl_id'],
+                            $field,
+                            null,
+                            $row['host_tpl_id']
+                        )
                     ) {
                         return $result_field;
                     }
@@ -974,7 +976,7 @@ function getMyServiceGroupActivateServices($sg_id = null, $access = null)
 
 #
 
-function getMyServiceField($service_id = null, $field)
+function getMyServiceField($service_id, $field)
 {
     if (!$service_id) {
         return;
@@ -1002,7 +1004,7 @@ function getMyServiceField($service_id = null, $field)
     }
 }
 
-function getMyServiceExtendedInfoField($service_id = null, $field)
+function getMyServiceExtendedInfoField($service_id, $field)
 {
     if (!$service_id) {
         return;
@@ -1032,7 +1034,7 @@ function getMyServiceExtendedInfoField($service_id = null, $field)
     }
 }
 
-function getMyServiceExtendedInfoImage($service_id = null, $field)
+function getMyServiceExtendedInfoImage($service_id, $field)
 {
     if (!$service_id) {
         return;
@@ -1859,7 +1861,8 @@ function host_has_one_or_more_GraphService($host_id, $search = 0)
     $services = getMyHostServices($host_id, $search);
 
     foreach ($services as $svc_id => $svc_name) {
-        if (service_has_graph($host_id, $svc_id) &&
+        if (
+            service_has_graph($host_id, $svc_id) &&
             ($is_admin || (!$is_admin && isset($lca["LcaHost"][$host_id][$svc_id])))
         ) {
             return true;
@@ -2207,30 +2210,33 @@ function cleanString($str)
     return $str;
 }
 
-// Global Function 
+// Global Function
 
 function get_my_first_allowed_root_menu($lcaTStr)
 {
     global $pearDB;
 
     if (trim($lcaTStr) != "") {
-        $rq = " SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt 
-                FROM topology 
-                WHERE topology_page IN ($lcaTStr) 
-                AND topology_parent IS NULL AND topology_page IS NOT NULL AND topology_show = '1' 
-                LIMIT 1";
+        $rq = "SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt, is_react
+               FROM topology 
+               WHERE topology_page IN ($lcaTStr) 
+               AND (topology_parent IS NULL OR topology_page = 104) AND topology_page IS NOT NULL AND topology_show = '1' 
+               ORDER BY CASE topology_page WHEN 104 THEN 1 ELSE 0 END DESC, topology_id ASC
+               LIMIT 1";
     } else {
-        $rq = " SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt 
-                FROM topology 
-                WHERE topology_parent IS NULL AND topology_page IS NOT NULL AND topology_show = '1' 
-                LIMIT 1";
+        $rq = "SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt, is_react
+               FROM topology 
+               WHERE topology_parent IS NULL AND topology_page IS NOT NULL AND topology_show = '1' 
+               LIMIT 1";
     }
-    $DBRESULT = $pearDB->query($rq);
-    $root_menu = array();
-    if ($DBRESULT->rowCount()) {
-        $root_menu = $DBRESULT->fetchRow();
+
+    $dbResult = $pearDB->query($rq);
+
+    if (!$dbResult->rowCount()) {
+        return [];
     }
-    return $root_menu;
+
+    return $dbResult->fetchRow();
 }
 
 function reset_search_page($url)
@@ -2240,7 +2246,8 @@ function reset_search_page($url)
     if (!isset($url)) {
         return;
     }
-    if (isset($_GET['search'])
+    if (
+        isset($_GET['search'])
         && isset($centreon->historySearch[$url])
         && $_GET['search'] != $centreon->historySearch[$url]
         && !isset($_GET['num'])
@@ -2248,7 +2255,8 @@ function reset_search_page($url)
     ) {
         $_POST['num'] = 0;
         $_GET['num'] = 0;
-    } elseif (isset($_GET["search"])
+    } elseif (
+        isset($_GET["search"])
         && isset($_POST["search"])
         && $_GET["search"] === $_POST["search"]
     ) {

--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -2217,17 +2217,17 @@ function get_my_first_allowed_root_menu($lcaTStr)
     global $pearDB;
 
     if (trim($lcaTStr) != "") {
-        $rq = "SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt, is_react
-               FROM topology 
-               WHERE topology_page IN ($lcaTStr) 
-               AND (topology_parent IS NULL OR topology_page = 104) AND topology_page IS NOT NULL AND topology_show = '1' 
-               ORDER BY CASE topology_page WHEN 104 THEN 1 ELSE 0 END DESC, topology_id ASC
-               LIMIT 1";
+        $rq = "SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt, is_react "
+            . "FROM topology WHERE topology_page IN ({$lcaTStr}) "
+            . "AND (topology_parent IS NULL OR topology_page = 104) "
+            . "AND topology_page IS NOT NULL AND topology_show = '1' "
+            . "ORDER BY CASE topology_page WHEN 104 THEN 1 ELSE 0 END DESC, topology_id ASC "
+            . "LIMIT 1";
     } else {
-        $rq = "SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt, is_react
-               FROM topology 
-               WHERE topology_parent IS NULL AND topology_page IS NOT NULL AND topology_show = '1' 
-               LIMIT 1";
+        $rq = "SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt, is_react "
+            . "FROM topology "
+            . "WHERE topology_parent IS NULL AND topology_page IS NOT NULL AND topology_show = '1' "
+            . "LIMIT 1";
     }
 
     $dbResult = $pearDB->query($rq);

--- a/www/include/core/header/header.php
+++ b/www/include/core/header/header.php
@@ -1,7 +1,8 @@
 <?php
+
 /*
- * Copyright 2005-2015 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Copyright 2005-2020 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under
@@ -147,14 +148,14 @@ unset($centreon->optGen);
 $centreon->initOptGen($pearDB);
 
 if (!$p) {
-    $root_menu = get_my_first_allowed_root_menu($centreon->user->access->topologyStr);
-    if (isset($root_menu["topology_page"])) {
-        $p = $root_menu["topology_page"];
-    } else {
-        $p = null;
-    }
-    if (isset($root_menu["topology_url_opt"])) {
-        $tab = preg_split("/\=/", $root_menu["topology_url_opt"]);
+    $rootMenu = get_my_first_allowed_root_menu($centreon->user->access->topologyStr);
+
+    if ($rootMenu && $rootMenu['topology_url'] && $rootMenu['is_react']) {
+        header("Location: .{$rootMenu['topology_url']}");
+    } elseif ($root_menu) {
+        $p = $rootMenu["topology_page"];
+        $tab = preg_split("/\=/", $rootMenu["topology_url_opt"]);
+
         if (isset($tab[1])) {
             $o = $tab[1];
         }


### PR DESCRIPTION
## Description

in this PR are fixed two issues
- after the login redirect to react page if selected as the default page
- fix the default page drop-down

**Fixes** MON-5149

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
