### PR TITLE
fix(api): update graph endpoints to be returned at resource listing

### DIFF
--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -24,6 +24,7 @@ namespace Centreon\Application\Controller;
 
 use Centreon\Application\Normalizer\IconUrlNormalizer;
 use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+use Doctrine\Instantiator\Exception\ExceptionInterface;
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\View\View;
 use Symfony\Component\HttpFoundation\Response;
@@ -115,6 +116,9 @@ class MonitoringResourceController extends AbstractController
      * @param Request $request
      * @param SerializerInterface $serializer
      * @param EntityValidator $entityValidator
+     * @throws ValidationFailedException
+     * @throws \Symfony\Component\Serializer\Exception\ExceptionInterface
+     * @throws \Exception
      * @return View
      */
     public function list(
@@ -170,8 +174,6 @@ class MonitoringResourceController extends AbstractController
         $resources = $this->resource->filterByContact($this->getUser())
             ->findResources($filter);
 
-        $resourcesGraphData = $this->resource->getListOfResourcesWithGraphData($resources);
-
         foreach ($resources as $resource) {
             $this->iconUrlNormalizer->normalize($resource);
 
@@ -198,10 +200,7 @@ class MonitoringResourceController extends AbstractController
             $resource->setDetailsEndpoint($this->router->generate($routeNameDetails, $parameters));
 
             if (
-                $resource->getParent() != null && in_array([
-                    'host_id' => $resource->getParent()->getId(),
-                    'service_id' => $resource->getId(),
-                ], $resourcesGraphData)
+                $resource->getParent() != null
             ) {
                 $parameters = [
                     'hostId' => $resource->getParent()->getId(),
@@ -242,7 +241,7 @@ class MonitoringResourceController extends AbstractController
 
     /**
      * Get resource details related to the host
-     *
+     * @throws \Exception
      * @return View
      */
     public function detailsHost(int $hostId): View
@@ -274,7 +273,7 @@ class MonitoringResourceController extends AbstractController
 
     /**
      * Get resource details related to the service
-     *
+     * @throws \Exception
      * @return View
      */
     public function detailsService(int $hostId, int $serviceId): View

--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -24,7 +24,6 @@ namespace Centreon\Application\Controller;
 
 use Centreon\Application\Normalizer\IconUrlNormalizer;
 use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
-use Doctrine\Instantiator\Exception\ExceptionInterface;
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\View\View;
 use Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
## Description

In resource listing endpoint, always return graph URLs, regardless if service has data to it or not.

**Fixes** # MON-5146

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Make a get request for: http://localhost:5567/centreon/api/beta/monitoring/resources and make sure graph endpoints are returned for all services.

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
