### PR TITLE
Use 19.10 unattended in doc

### DIFF
--- a/doc/en/installation/index.rst
+++ b/doc/en/installation/index.rst
@@ -33,4 +33,4 @@ Finally, you can install the platform.
 
 To quickly test Centreon from a CentOS or Red Hat 7.x, you can run the following command as **root**: ::
 
-    # curl -L https://raw.githubusercontent.com/centreon/centreon/master/unattended.sh | sh
+    # curl -L https://raw.githubusercontent.com/centreon/centreon/19.10.x/unattended.sh | sh

--- a/doc/fr/installation/index.rst
+++ b/doc/fr/installation/index.rst
@@ -38,4 +38,4 @@ Enfin, vous pourrez procéder à l'installation de la plate-forme.
 Pour tester rapidement Centreon à partir d'un serveur CentOS ou Red Hat en version 7.x, vous pouvez
 exécuter la commande suivante en **root** : ::
 
-    # curl -L https://raw.githubusercontent.com/centreon/centreon/master/unattended.sh | sh
+    # curl -L https://raw.githubusercontent.com/centreon/centreon/19.10.x/unattended.sh | sh

--- a/unattended.sh
+++ b/unattended.sh
@@ -128,14 +128,19 @@ print_step_end "OK, timezone set to $timezone"
 print_step_begin "Firewall configuration"
 command -v firewall-cmd > /dev/null 2>&1
 if [ "x$?" '=' x0 ] ; then
-  for svc in http snmp snmptrap ; do
-    firewall-cmd --zone=public --add-service=$svc --permanent > /dev/null 2>&1
-    if [ "x$?" '!=' x0 ] ; then
-      error_and_exit "Could not configure firewall. You might need to run this script as root."
-    fi
-  done
-  firewall-cmd --reload
-  print_step_end
+  firewall-cmd --state > /dev/null 2>&1
+  if [ "x$?" '=' x0 ] ; then
+    for svc in http snmp snmptrap ; do
+      firewall-cmd --zone=public --add-service=$svc --permanent > /dev/null 2>&1
+      if [ "x$?" '!=' x0 ] ; then
+        error_and_exit "Could not configure firewall. You might need to run this script as root."
+      fi
+    done
+    firewall-cmd --reload
+    print_step_end
+  else
+    print_step_end "OK, not active"
+  fi
 else
   print_step_end "OK, not detected"
 fi


### PR DESCRIPTION
## Description

Use 19.10.x unattended.sh in 19.10.x documentation.

This PR also backports a fix from the master in a separate commit.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [X] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [ ] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Use unattended installation instruction from the documentation. Install should go smoothly.

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
