### PR TITLE
fix(ui/api): manage every kind of centreon base URI

### DIFF
--- a/config/routes/centreon.yaml
+++ b/config/routes/centreon.yaml
@@ -1,5 +1,8 @@
 centreon:
     resource: "./Centreon/**/*.yaml"
-    prefix: /centreon/api/{version}
+    prefix: "/{base_uri}api/{version}"
     defaults:
+        base_uri: "centreon"
         version: "beta"
+    requirements:
+        base_uri: "(.+/)|.{0}"

--- a/config/routes/centreon.yaml
+++ b/config/routes/centreon.yaml
@@ -2,7 +2,7 @@ centreon:
     resource: "./Centreon/**/*.yaml"
     prefix: "/{base_uri}api/{version}"
     defaults:
-        base_uri: "centreon"
+        base_uri: "centreon/"
         version: "beta"
     requirements:
         base_uri: "(.+/)|.{0}"

--- a/doc/en/administration_guide/ui_access.rst
+++ b/doc/en/administration_guide/ui_access.rst
@@ -15,10 +15,7 @@ To update the Centreon URI, you need to follow those steps:
 .. image:: /_static/images/adminstration/custom_uri.png
     :align: center
 
-2. On the centreon central server:
-
-* Replace **/centreon** occurences by **/your_custom_uri** in **centreon/www/.htaccess**.
-* Navigate to your Centreon URL.
+2. Edit Apache configuration file for Centreon Web : **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**
 
 ************
 HTTPS access
@@ -73,6 +70,12 @@ To access to the UI using HTTPS, follow those steps:
         <IfModule mod_php5.c>
           php_admin_value engine Off
         </IfModule>
+
+        RewriteRule ^index\.html$ - [L]
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteCond %{REQUEST_FILENAME} !-d
+        RewriteRule . /index.html [L]
+        ErrorDocument 404 /centreon/index.html
 
         AddType text/plain hbs
       </Directory>

--- a/doc/fr/administration_guide/ui_access.rst
+++ b/doc/fr/administration_guide/ui_access.rst
@@ -15,10 +15,7 @@ Pour mettre à jour l'URI Centreon, vous devez suivre les étapes suivantes:
 .. image:: /_static/images/adminstration/custom_uri.png
     :align: center
 
-2. Sur le serveur Centreon :
-
-* Remplacez les occurences **/centreon** par **/votre_uri_personnalise** dans **centreon/www/.htaccess**
-* Naviguez vers l'URL Centreon
+2. Modifiez le fichier de configuration Apache pour Centreon Web : **/opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf**
 
 *******************
 Accès en mode HTTPS
@@ -74,6 +71,12 @@ suivantes :
         <IfModule mod_php5.c>
           php_admin_value engine Off
         </IfModule>
+
+        RewriteRule ^index\.html$ - [L]
+        RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteCond %{REQUEST_FILENAME} !-d
+        RewriteRule . /index.html [L]
+        ErrorDocument 404 /centreon/index.html
 
         AddType text/plain hbs
       </Directory>

--- a/libinstall/CentWeb.sh
+++ b/libinstall/CentWeb.sh
@@ -225,7 +225,7 @@ cd "${OLDPATH}"
 OLDPATH=$(pwd)
 cd $TMP_DIR/src/
 log "INFO" "$(gettext "Copying frontend application...")"
-cp -Rf www/index.html www/static www/.htaccess $TMP_DIR/final/www/
+cp -Rf www/index.html www/static $TMP_DIR/final/www/
 cd "${OLDPATH}"
 
 ## Create temporary directory
@@ -433,10 +433,6 @@ $INSTALL_DIR/cinstall $cinstall_opts \
     -p $TMP_DIR/final/www \
     $TMP_DIR/final/www/* $INSTALL_DIR_CENTREON/www/ >> "$LOG_FILE" 2>&1
 check_result $? "$(gettext "Install CentWeb (web front of centreon)")"
-
-cp -f $TMP_DIR/final/www/.htaccess $INSTALL_DIR_CENTREON/www/ >> "$LOG_FILE" 2>&1
-$CHOWN $WEB_USER:$WEB_GROUP $INSTALL_DIR_CENTREON/www/.htaccess
-$CHMOD 644 $INSTALL_DIR_CENTREON/www/.htaccess
 
 cp -Rf $TMP_DIR/final/src $INSTALL_DIR_CENTREON/ >> "$LOG_FILE" 2>&1
 $CHOWN -R $WEB_USER:$WEB_GROUP $INSTALL_DIR_CENTREON/src

--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1417,6 +1417,12 @@ ProxyTimeout 300
         php_admin_value engine Off
     </IfModule>
 
+    RewriteRule ^index\.html$ - [L]
+    RewriteCond %{REQUEST_FILENAME} !-f
+    RewriteCond %{REQUEST_FILENAME} !-d
+    RewriteRule . /index.html [L]
+    ErrorDocument 404 /centreon/index.html
+
     AddType text/plain hbs
 </Directory>
 

--- a/src/EventSubscriber/CentreonEventSubscriber.php
+++ b/src/EventSubscriber/CentreonEventSubscriber.php
@@ -252,10 +252,8 @@ class CentreonEventSubscriber implements EventSubscriberInterface
         $event->getRequest()->attributes->set('version.not_beta', true);
 
         $uri = $event->getRequest()->getRequestUri();
-        $paths = explode('/', $uri);
-        array_shift($paths);
-        if (count($paths) >= 3) {
-            $requestApiVersion = $paths[2];
+        if (preg_match('/\/api\/([^\/]+)/', $uri, $matches)) {
+            $requestApiVersion = $matches[1];
             if ($requestApiVersion[0] == 'v') {
                 $requestApiVersion = substr($requestApiVersion, 1);
                 $requestApiVersion = VersionHelper::regularizeDepthVersion(

--- a/www/front_src/src/Resources/ApiNotFoundMessage.tsx
+++ b/www/front_src/src/Resources/ApiNotFoundMessage.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+
+import { Link } from '@material-ui/core';
+
+import {
+  labelApiNotFoundNotUpToDate,
+  labelApiNotFoundContactAdmin,
+  labelApiNotFoundDocumentation,
+} from './translatedLabels';
+
+const ApiNotFoundMessage = (): JSX.Element => {
+  return (
+    <>
+      <p style={{ margin: 0 }}>{`${labelApiNotFoundNotUpToDate}.`}</p>
+      <p style={{ margin: 0 }}>
+        {`${labelApiNotFoundContactAdmin} : /opt/rh/httpd24/root/etc/httpd/conf.d/10-centreon.conf`}
+      </p>
+      <p style={{ margin: 0 }}>
+        <Link
+          href="https://docs.centreon.com/20.04/en/upgrade/upgrade-from-19-10.html#configure-apache-api-access"
+          target="_blank"
+          color="inherit"
+        >
+          {`( ${labelApiNotFoundDocumentation} )`}
+        </Link>
+      </p>
+    </>
+  );
+};
+
+export default ApiNotFoundMessage;

--- a/www/front_src/src/Resources/index.tsx
+++ b/www/front_src/src/Resources/index.tsx
@@ -17,9 +17,11 @@ import { filterById, FilterGroup, allFilter } from './Filter/models';
 import ResourceActions from './Actions/Resource';
 import GlobalActions from './Actions/Refresh';
 import Details from './Details';
+import ApiNotFoundMessage from './ApiNotFoundMessage';
 import { rowColorConditions } from './colors';
 import { detailsTabId, graphTabId } from './Details/Body/tabs';
 import useFilter from './Filter/useFilter';
+import { labelSomethingWentWrong } from './translatedLabels';
 
 const useStyles = makeStyles((theme) => ({
   page: {
@@ -135,7 +137,13 @@ const Resources = (): JSX.Element => {
       })
       .catch((error) => {
         setListing(undefined);
-        showError(error.response?.data?.message || error.message);
+
+        // if 404 is returned, it is probably an issue in apache configuration file
+        if (error.response?.status === 404) {
+          showError(ApiNotFoundMessage);
+        } else {
+          showError(error.response?.data?.message || labelSomethingWentWrong);
+        }
       })
       .finally(() => setLoading(false));
   };

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -138,3 +138,10 @@ export const labelUp = I18n.t('Up');
 export const labelYes = I18n.t('Yes');
 export const labelSomethingWentWrong = I18n.t('Oops, something went wrong');
 export const labelWarning = I18n.t('Warning');
+export const labelApiNotFoundNotUpToDate = I18n.t(
+  'Seems that your Apache configuration is not up-to-date',
+);
+export const labelApiNotFoundContactAdmin = I18n.t(
+  'Contact your Centreon administrator or update the following file',
+);
+export const labelApiNotFoundDocumentation = I18n.t('See Documentation');

--- a/www/front_src/src/store/index.js
+++ b/www/front_src/src/store/index.js
@@ -11,9 +11,8 @@ import createRootReducer from '../redux/reducers';
 
 const sagaMiddleware = createSagaMiddleware();
 
-const paths = window.location.pathname.split('/');
 export const history = createBrowserHistory({
-  basename: `/${paths[1] ? paths[1] : ''}`,
+  basename: document.baseURI.replace(window.location.origin, ''),
 });
 
 const createAppStore = (initialState = {}) => {

--- a/www/index.php
+++ b/www/index.php
@@ -89,16 +89,18 @@ if (file_exists("./install/setup.php")) {
  * Install frontend assets if needed
  */
 $basePath = '/' . trim(explode('index.php', $_SERVER['REQUEST_URI'])[0], "/") . '/';
+$basePath = str_replace('//', '/', $basePath);
 $indexHtmlPath = './index.html';
 $indexHtmlContent = file_get_contents($indexHtmlPath);
 
 // update base path only if it has changed
 if (!preg_match('/.*<base\shref="' . preg_quote($basePath, '/') . '">/', $indexHtmlContent)) {
     $indexHtmlContent = preg_replace(
-        '/(.*<base\shref=").*(">)/',
+        '/(^.*<base\shref=")\S+(">.*$)/s',
         '${1}' . $basePath . '${2}',
         $indexHtmlContent
     );
+
     file_put_contents($indexHtmlPath, $indexHtmlContent);
 }
 


### PR DESCRIPTION
## Description

- Manage every kind of base URI (/centreon, /monitoring, /, /monitoring/centreon ...)
- Display error message with documentation link when apache API configuration is not good

**Fixes** MON-4844

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Remove API configuration section in apache configuration
- Check events view error message (snackbar)

- Update centreon base URI and check centreon web is working properly