### PR TITLE
fix(install): issue when only modules or widgets selected

### DIFF
--- a/www/install/steps/templates/step8.tpl
+++ b/www/install/steps/templates/step8.tpl
@@ -128,27 +128,31 @@
                 }
             }).success(function(data) {
                 var data = JSON.parse(data);
-                var modules = Object.values(data['modules']);
-                if (modules && modules.length > 0) {
-                    modules.forEach(function(module) {
-                        if (module.install) {
-                            jQuery('label[for="module_' + module.module + '"]').addClass('md-label-green');
-                            jQuery("input[type=checkbox]#module_" + module.module)
-                                .attr('disabled', 'disabled')
-                                .prop('checked', 'checked');
-                        }
-                    });
+                if (data['modules']) {
+                    var modules = Object.values(data['modules']);
+                    if (modules && modules.length > 0) {
+                        modules.forEach(function(module) {
+                            if (module.install) {
+                                jQuery('label[for="module_' + module.module + '"]').addClass('md-label-green');
+                                jQuery("input[type=checkbox]#module_" + module.module)
+                                    .attr('disabled', 'disabled')
+                                    .prop('checked', 'checked');
+                            }
+                        });
+                    }
                 }
-                var widgets = Object.values(data['widgets']);
-                if (widgets && widgets.length > 0) {
-                    widgets.forEach(function(widget) {
-                        if (widget.install) {
-                            jQuery('label[for="widget_' + widget.widget + '"]').addClass('md-label-green');
-                            jQuery("input[type=checkbox]#widget_" + widget.widget)
-                                .attr('disabled', 'disabled')
-                                .prop('checked', 'checked');
-                        }
-                    });
+                if(data['widgets']) {
+                    var widgets = Object.values(data['widgets']);
+                    if (widgets && widgets.length > 0) {
+                        widgets.forEach(function(widget) {
+                            if (widget.install) {
+                                jQuery('label[for="widget_' + widget.widget + '"]').addClass('md-label-green');
+                                jQuery("input[type=checkbox]#widget_" + widget.widget)
+                                    .attr('disabled', 'disabled')
+                                    .prop('checked', 'checked');
+                            }
+                        });
+                    }
                 }
                 manageButtons();
             }).complete(function() {

--- a/www/install/steps/templates/step8.tpl
+++ b/www/install/steps/templates/step8.tpl
@@ -128,31 +128,27 @@
                 }
             }).success(function(data) {
                 var data = JSON.parse(data);
-                if (data['modules']) {
-                    var modules = Object.values(data['modules']);
-                    if (modules && modules.length > 0) {
-                        modules.forEach(function(module) {
-                            if (module.install) {
-                                jQuery('label[for="module_' + module.module + '"]').addClass('md-label-green');
-                                jQuery("input[type=checkbox]#module_" + module.module)
-                                    .attr('disabled', 'disabled')
-                                    .prop('checked', 'checked');
-                            }
-                        });
-                    }
+                const modules = data['modules'] ? Object.values(data['modules']) : [];
+                if (modules && modules.length > 0) {
+                    modules.forEach(function(module) {
+                        if (module.install) {
+                            jQuery('label[for="module_' + module.module + '"]').addClass('md-label-green');
+                            jQuery("input[type=checkbox]#module_" + module.module)
+                                .attr('disabled', 'disabled')
+                                .prop('checked', 'checked');
+                        }
+                    });
                 }
-                if(data['widgets']) {
-                    var widgets = Object.values(data['widgets']);
-                    if (widgets && widgets.length > 0) {
-                        widgets.forEach(function(widget) {
-                            if (widget.install) {
-                                jQuery('label[for="widget_' + widget.widget + '"]').addClass('md-label-green');
-                                jQuery("input[type=checkbox]#widget_" + widget.widget)
-                                    .attr('disabled', 'disabled')
-                                    .prop('checked', 'checked');
-                            }
-                        });
-                    }
+                const widgets = data['widgets'] ? Object.values(data['widgets']) : [];
+                if (widgets && widgets.length > 0) {
+                    widgets.forEach(function(widget) {
+                        if (widget.install) {
+                            jQuery('label[for="widget_' + widget.widget + '"]').addClass('md-label-green');
+                            jQuery("input[type=checkbox]#widget_" + widget.widget)
+                                .attr('disabled', 'disabled')
+                                .prop('checked', 'checked');
+                        }
+                    });
                 }
                 manageButtons();
             }).complete(function() {


### PR DESCRIPTION
## Description

The issue here was that when only modules or widgets were selected the `Object.values` function threw an exeption. We need to check that the data['modules'] and data['widgets'] aren't undefined before processing the code.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Install first a module only -> Should work and others checkboxes can be clickable
- Install then a widget only -> Should work and others checkboxes can be clickable
- Install everything -> should work and next button should appear

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
