### PR TITLE
fix(ui): use timezone in downtime popin

### DIFF
--- a/www/api/class/centreon_topcounter.class.php
+++ b/www/api/class/centreon_topcounter.class.php
@@ -263,7 +263,7 @@ class CentreonTopCounter extends CentreonWebService
             'fullname' => $this->centreon->user->name,
             'username' => $this->centreon->user->alias,
             'locale' => $locale,
-            'timezone' => $this->centreon->user->gmt,
+            'timezone' => $this->centreon->CentreonGMT->getActiveTimezone($this->centreon->user->gmt),
             'hasAccessToProfile' => $this->hasAccessToProfile,
             'autologinkey' => $autoLoginKey,
             'soundNotificationsEnabled' => $this->soundNotificationsEnabled

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 
+import moment from 'moment-timezone/builds/moment-timezone-with-data-10-year-range';
 import MomentUtils from '@date-io/moment';
 
 import { Typography, Checkbox, FormHelperText, Grid } from '@material-ui/core';
@@ -39,6 +40,7 @@ import { Resource } from '../../../models';
 
 interface Props {
   locale: string | null;
+  timezone: string | null;
   resources: Array<Resource>;
   canConfirm: boolean;
   onCancel;
@@ -75,6 +77,7 @@ const timePickerProps = {
 
 const DialogDowntime = ({
   locale,
+  timezone,
   resources,
   canConfirm,
   onCancel,
@@ -94,6 +97,14 @@ const DialogDowntime = ({
     setFieldValue(field, value);
   };
 
+  React.useEffect(() => {
+    moment.locale(locale);
+  }, [locale]);
+
+  React.useEffect(() => {
+    moment.tz.setDefault(timezone);
+  }, [timezone]);
+
   return (
     <Dialog
       labelCancel={labelCancel}
@@ -107,7 +118,11 @@ const DialogDowntime = ({
       submitting={submitting}
     >
       {loading && <Loader fullContent />}
-      <MuiPickersUtilsProvider utils={MomentUtils} locale={locale}>
+      <MuiPickersUtilsProvider
+        libInstance={moment}
+        utils={MomentUtils}
+        locale={locale}
+      >
         <Grid direction="column" container spacing={1}>
           <Grid item>
             <FormHelperText>{labelFrom}</FormHelperText>

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
@@ -39,8 +39,8 @@ import {
 import { Resource } from '../../../models';
 
 interface Props {
-  locale?: string | null;
-  timezone?: string | null;
+  locale: string | null;
+  timezone: string | null;
   resources: Array<Resource>;
   canConfirm: boolean;
   onCancel;
@@ -90,7 +90,6 @@ const DialogDowntime = ({
   loading,
 }: Props): JSX.Element => {
   const open = resources.length > 0;
-  const localizationLoaded = locale !== undefined && timezone !== undefined;
 
   const hasHosts = resources.find((resource) => resource.type === 'host');
 
@@ -99,15 +98,11 @@ const DialogDowntime = ({
   };
 
   React.useEffect(() => {
-    if (locale !== undefined) {
-      moment.locale(locale);
-    }
+    moment.locale(locale);
   }, [locale]);
 
   React.useEffect(() => {
-    if (timezone !== undefined) {
-      moment.tz.setDefault(timezone);
-    }
+    moment.tz.setDefault(timezone);
   }, [timezone]);
 
   return (
@@ -123,158 +118,156 @@ const DialogDowntime = ({
       submitting={submitting}
     >
       {loading && <Loader fullContent />}
-      {localizationLoaded && (
-        <MuiPickersUtilsProvider
-          libInstance={moment}
-          utils={MomentUtils}
-          locale={locale}
-        >
-          <Grid direction="column" container spacing={1}>
-            <Grid item>
-              <FormHelperText>{labelFrom}</FormHelperText>
-              <Grid direction="row" container spacing={1}>
-                <Grid item style={{ width: 240 }}>
-                  <KeyboardDatePicker
-                    aria-label={labelStartDate}
-                    value={values.dateStart}
-                    onChange={changeDate('dateStart')}
-                    KeyboardButtonProps={{
-                      'aria-label': labelChangeStartDate,
-                    }}
-                    error={errors?.dateStart !== undefined}
-                    helperText={errors?.dateStart}
-                    {...datePickerProps}
-                  />
-                </Grid>
-                <Grid item style={{ width: 200 }}>
-                  <KeyboardTimePicker
-                    aria-label={labelStartTime}
-                    value={values.timeStart}
-                    onChange={changeDate('timeStart')}
-                    KeyboardButtonProps={{
-                      'aria-label': labelChangeStartTime,
-                    }}
-                    error={errors?.timeStart !== undefined}
-                    helperText={errors?.timeStart}
-                    {...timePickerProps}
-                  />
-                </Grid>
+      <MuiPickersUtilsProvider
+        libInstance={moment}
+        utils={MomentUtils}
+        locale={locale}
+      >
+        <Grid direction="column" container spacing={1}>
+          <Grid item>
+            <FormHelperText>{labelFrom}</FormHelperText>
+            <Grid direction="row" container spacing={1}>
+              <Grid item style={{ width: 240 }}>
+                <KeyboardDatePicker
+                  aria-label={labelStartDate}
+                  value={values.dateStart}
+                  onChange={changeDate('dateStart')}
+                  KeyboardButtonProps={{
+                    'aria-label': labelChangeStartDate,
+                  }}
+                  error={errors?.dateStart !== undefined}
+                  helperText={errors?.dateStart}
+                  {...datePickerProps}
+                />
+              </Grid>
+              <Grid item style={{ width: 200 }}>
+                <KeyboardTimePicker
+                  aria-label={labelStartTime}
+                  value={values.timeStart}
+                  onChange={changeDate('timeStart')}
+                  KeyboardButtonProps={{
+                    'aria-label': labelChangeStartTime,
+                  }}
+                  error={errors?.timeStart !== undefined}
+                  helperText={errors?.timeStart}
+                  {...timePickerProps}
+                />
               </Grid>
             </Grid>
-            <Grid item>
-              <FormHelperText>{labelTo}</FormHelperText>
-              <Grid direction="row" container spacing={1}>
-                <Grid item style={{ width: 240 }}>
-                  <KeyboardDatePicker
-                    aria-label={labelEndDate}
-                    value={values.dateEnd}
-                    onChange={changeDate('dateEnd')}
-                    KeyboardButtonProps={{
-                      'aria-label': labelChangeEndDate,
-                    }}
-                    error={errors?.dateEnd !== undefined}
-                    helperText={errors?.dateEnd}
-                    {...datePickerProps}
-                  />
-                </Grid>
-                <Grid item style={{ width: 200 }}>
-                  <KeyboardTimePicker
-                    aria-label={labelEndTime}
-                    value={values.timeEnd}
-                    onChange={changeDate('timeEnd')}
-                    KeyboardButtonProps={{
-                      'aria-label': labelChangeEndTime,
-                    }}
-                    error={errors?.timeEnd !== undefined}
-                    helperText={errors?.timeEnd}
-                    {...timePickerProps}
-                  />
-                </Grid>
+          </Grid>
+          <Grid item>
+            <FormHelperText>{labelTo}</FormHelperText>
+            <Grid direction="row" container spacing={1}>
+              <Grid item style={{ width: 240 }}>
+                <KeyboardDatePicker
+                  aria-label={labelEndDate}
+                  value={values.dateEnd}
+                  onChange={changeDate('dateEnd')}
+                  KeyboardButtonProps={{
+                    'aria-label': labelChangeEndDate,
+                  }}
+                  error={errors?.dateEnd !== undefined}
+                  helperText={errors?.dateEnd}
+                  {...datePickerProps}
+                />
+              </Grid>
+              <Grid item style={{ width: 200 }}>
+                <KeyboardTimePicker
+                  aria-label={labelEndTime}
+                  value={values.timeEnd}
+                  onChange={changeDate('timeEnd')}
+                  KeyboardButtonProps={{
+                    'aria-label': labelChangeEndTime,
+                  }}
+                  error={errors?.timeEnd !== undefined}
+                  helperText={errors?.timeEnd}
+                  {...timePickerProps}
+                />
               </Grid>
             </Grid>
+          </Grid>
+          <Grid container item direction="column">
+            <Grid item container xs alignItems="center">
+              <Grid item xs={1}>
+                <Checkbox
+                  checked={values.fixed}
+                  inputProps={{ 'aria-label': labelFixed }}
+                  color="primary"
+                  onChange={handleChange('fixed')}
+                />
+              </Grid>
+              <Grid item xs>
+                <Typography>{labelFixed}</Typography>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            <FormHelperText>{labelDuration}</FormHelperText>
+            <Grid direction="row" container spacing={1}>
+              <Grid item style={{ width: 150 }}>
+                <TextField
+                  disabled={values.fixed}
+                  type="number"
+                  onChange={handleChange('duration.value')}
+                  value={values.duration.value}
+                  error={errors?.duration?.value !== undefined}
+                  helperText={errors?.duration?.value}
+                />
+              </Grid>
+              <Grid item style={{ width: 150 }}>
+                <SelectField
+                  disabled={values.fixed}
+                  options={[
+                    {
+                      id: 'seconds',
+                      name: labelSeconds,
+                    },
+                    {
+                      id: 'minutes',
+                      name: labelMinutes,
+                    },
+                    {
+                      id: 'hours',
+                      name: labelHours,
+                    },
+                  ]}
+                  selectedOptionId={values.duration.unit}
+                  onChange={handleChange('duration.unit')}
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item>
+            <TextField
+              value={values.comment}
+              onChange={handleChange('comment')}
+              multiline
+              label={labelComment}
+              fullWidth
+              rows={3}
+              error={errors?.comment !== undefined}
+              helperText={errors?.comment}
+            />
+          </Grid>
+          {hasHosts && (
             <Grid container item direction="column">
               <Grid item container xs alignItems="center">
                 <Grid item xs={1}>
                   <Checkbox
-                    checked={values.fixed}
-                    inputProps={{ 'aria-label': labelFixed }}
+                    checked={values.downtimeAttachedResources}
+                    inputProps={{ 'aria-label': labelSetDowntimeOnServices }}
                     color="primary"
-                    onChange={handleChange('fixed')}
+                    onChange={handleChange('downtimeAttachedResources')}
                   />
                 </Grid>
                 <Grid item xs>
-                  <Typography>{labelFixed}</Typography>
+                  <Typography>{labelSetDowntimeOnServices}</Typography>
                 </Grid>
               </Grid>
             </Grid>
-            <Grid item>
-              <FormHelperText>{labelDuration}</FormHelperText>
-              <Grid direction="row" container spacing={1}>
-                <Grid item style={{ width: 150 }}>
-                  <TextField
-                    disabled={values.fixed}
-                    type="number"
-                    onChange={handleChange('duration.value')}
-                    value={values.duration.value}
-                    error={errors?.duration?.value !== undefined}
-                    helperText={errors?.duration?.value}
-                  />
-                </Grid>
-                <Grid item style={{ width: 150 }}>
-                  <SelectField
-                    disabled={values.fixed}
-                    options={[
-                      {
-                        id: 'seconds',
-                        name: labelSeconds,
-                      },
-                      {
-                        id: 'minutes',
-                        name: labelMinutes,
-                      },
-                      {
-                        id: 'hours',
-                        name: labelHours,
-                      },
-                    ]}
-                    selectedOptionId={values.duration.unit}
-                    onChange={handleChange('duration.unit')}
-                  />
-                </Grid>
-              </Grid>
-            </Grid>
-            <Grid item>
-              <TextField
-                value={values.comment}
-                onChange={handleChange('comment')}
-                multiline
-                label={labelComment}
-                fullWidth
-                rows={3}
-                error={errors?.comment !== undefined}
-                helperText={errors?.comment}
-              />
-            </Grid>
-            {hasHosts && (
-              <Grid container item direction="column">
-                <Grid item container xs alignItems="center">
-                  <Grid item xs={1}>
-                    <Checkbox
-                      checked={values.downtimeAttachedResources}
-                      inputProps={{ 'aria-label': labelSetDowntimeOnServices }}
-                      color="primary"
-                      onChange={handleChange('downtimeAttachedResources')}
-                    />
-                  </Grid>
-                  <Grid item xs>
-                    <Typography>{labelSetDowntimeOnServices}</Typography>
-                  </Grid>
-                </Grid>
-              </Grid>
-            )}
-          </Grid>
-        </MuiPickersUtilsProvider>
-      )}
+          )}
+        </Grid>
+      </MuiPickersUtilsProvider>
     </Dialog>
   );
 };

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
@@ -39,8 +39,8 @@ import {
 import { Resource } from '../../../models';
 
 interface Props {
-  locale: string | null;
-  timezone: string | null;
+  locale?: string | null;
+  timezone?: string | null;
   resources: Array<Resource>;
   canConfirm: boolean;
   onCancel;
@@ -90,6 +90,7 @@ const DialogDowntime = ({
   loading,
 }: Props): JSX.Element => {
   const open = resources.length > 0;
+  const localizationLoaded = locale !== undefined && timezone !== undefined;
 
   const hasHosts = resources.find((resource) => resource.type === 'host');
 
@@ -98,11 +99,15 @@ const DialogDowntime = ({
   };
 
   React.useEffect(() => {
-    moment.locale(locale);
+    if (locale !== undefined) {
+      moment.locale(locale);
+    }
   }, [locale]);
 
   React.useEffect(() => {
-    moment.tz.setDefault(timezone);
+    if (timezone !== undefined) {
+      moment.tz.setDefault(timezone);
+    }
   }, [timezone]);
 
   return (
@@ -118,156 +123,158 @@ const DialogDowntime = ({
       submitting={submitting}
     >
       {loading && <Loader fullContent />}
-      <MuiPickersUtilsProvider
-        libInstance={moment}
-        utils={MomentUtils}
-        locale={locale}
-      >
-        <Grid direction="column" container spacing={1}>
-          <Grid item>
-            <FormHelperText>{labelFrom}</FormHelperText>
-            <Grid direction="row" container spacing={1}>
-              <Grid item style={{ width: 240 }}>
-                <KeyboardDatePicker
-                  aria-label={labelStartDate}
-                  value={values.dateStart}
-                  onChange={changeDate('dateStart')}
-                  KeyboardButtonProps={{
-                    'aria-label': labelChangeStartDate,
-                  }}
-                  error={errors?.dateStart !== undefined}
-                  helperText={errors?.dateStart}
-                  {...datePickerProps}
-                />
-              </Grid>
-              <Grid item style={{ width: 200 }}>
-                <KeyboardTimePicker
-                  aria-label={labelStartTime}
-                  value={values.timeStart}
-                  onChange={changeDate('timeStart')}
-                  KeyboardButtonProps={{
-                    'aria-label': labelChangeStartTime,
-                  }}
-                  error={errors?.timeStart !== undefined}
-                  helperText={errors?.timeStart}
-                  {...timePickerProps}
-                />
-              </Grid>
-            </Grid>
-          </Grid>
-          <Grid item>
-            <FormHelperText>{labelTo}</FormHelperText>
-            <Grid direction="row" container spacing={1}>
-              <Grid item style={{ width: 240 }}>
-                <KeyboardDatePicker
-                  aria-label={labelEndDate}
-                  value={values.dateEnd}
-                  onChange={changeDate('dateEnd')}
-                  KeyboardButtonProps={{
-                    'aria-label': labelChangeEndDate,
-                  }}
-                  error={errors?.dateEnd !== undefined}
-                  helperText={errors?.dateEnd}
-                  {...datePickerProps}
-                />
-              </Grid>
-              <Grid item style={{ width: 200 }}>
-                <KeyboardTimePicker
-                  aria-label={labelEndTime}
-                  value={values.timeEnd}
-                  onChange={changeDate('timeEnd')}
-                  KeyboardButtonProps={{
-                    'aria-label': labelChangeEndTime,
-                  }}
-                  error={errors?.timeEnd !== undefined}
-                  helperText={errors?.timeEnd}
-                  {...timePickerProps}
-                />
+      {localizationLoaded && (
+        <MuiPickersUtilsProvider
+          libInstance={moment}
+          utils={MomentUtils}
+          locale={locale}
+        >
+          <Grid direction="column" container spacing={1}>
+            <Grid item>
+              <FormHelperText>{labelFrom}</FormHelperText>
+              <Grid direction="row" container spacing={1}>
+                <Grid item style={{ width: 240 }}>
+                  <KeyboardDatePicker
+                    aria-label={labelStartDate}
+                    value={values.dateStart}
+                    onChange={changeDate('dateStart')}
+                    KeyboardButtonProps={{
+                      'aria-label': labelChangeStartDate,
+                    }}
+                    error={errors?.dateStart !== undefined}
+                    helperText={errors?.dateStart}
+                    {...datePickerProps}
+                  />
+                </Grid>
+                <Grid item style={{ width: 200 }}>
+                  <KeyboardTimePicker
+                    aria-label={labelStartTime}
+                    value={values.timeStart}
+                    onChange={changeDate('timeStart')}
+                    KeyboardButtonProps={{
+                      'aria-label': labelChangeStartTime,
+                    }}
+                    error={errors?.timeStart !== undefined}
+                    helperText={errors?.timeStart}
+                    {...timePickerProps}
+                  />
+                </Grid>
               </Grid>
             </Grid>
-          </Grid>
-          <Grid container item direction="column">
-            <Grid item container xs alignItems="center">
-              <Grid item xs={1}>
-                <Checkbox
-                  checked={values.fixed}
-                  inputProps={{ 'aria-label': labelFixed }}
-                  color="primary"
-                  onChange={handleChange('fixed')}
-                />
-              </Grid>
-              <Grid item xs>
-                <Typography>{labelFixed}</Typography>
-              </Grid>
-            </Grid>
-          </Grid>
-          <Grid item>
-            <FormHelperText>{labelDuration}</FormHelperText>
-            <Grid direction="row" container spacing={1}>
-              <Grid item style={{ width: 150 }}>
-                <TextField
-                  disabled={values.fixed}
-                  type="number"
-                  onChange={handleChange('duration.value')}
-                  value={values.duration.value}
-                  error={errors?.duration?.value !== undefined}
-                  helperText={errors?.duration?.value}
-                />
-              </Grid>
-              <Grid item style={{ width: 150 }}>
-                <SelectField
-                  disabled={values.fixed}
-                  options={[
-                    {
-                      id: 'seconds',
-                      name: labelSeconds,
-                    },
-                    {
-                      id: 'minutes',
-                      name: labelMinutes,
-                    },
-                    {
-                      id: 'hours',
-                      name: labelHours,
-                    },
-                  ]}
-                  selectedOptionId={values.duration.unit}
-                  onChange={handleChange('duration.unit')}
-                />
+            <Grid item>
+              <FormHelperText>{labelTo}</FormHelperText>
+              <Grid direction="row" container spacing={1}>
+                <Grid item style={{ width: 240 }}>
+                  <KeyboardDatePicker
+                    aria-label={labelEndDate}
+                    value={values.dateEnd}
+                    onChange={changeDate('dateEnd')}
+                    KeyboardButtonProps={{
+                      'aria-label': labelChangeEndDate,
+                    }}
+                    error={errors?.dateEnd !== undefined}
+                    helperText={errors?.dateEnd}
+                    {...datePickerProps}
+                  />
+                </Grid>
+                <Grid item style={{ width: 200 }}>
+                  <KeyboardTimePicker
+                    aria-label={labelEndTime}
+                    value={values.timeEnd}
+                    onChange={changeDate('timeEnd')}
+                    KeyboardButtonProps={{
+                      'aria-label': labelChangeEndTime,
+                    }}
+                    error={errors?.timeEnd !== undefined}
+                    helperText={errors?.timeEnd}
+                    {...timePickerProps}
+                  />
+                </Grid>
               </Grid>
             </Grid>
-          </Grid>
-          <Grid item>
-            <TextField
-              value={values.comment}
-              onChange={handleChange('comment')}
-              multiline
-              label={labelComment}
-              fullWidth
-              rows={3}
-              error={errors?.comment !== undefined}
-              helperText={errors?.comment}
-            />
-          </Grid>
-          {hasHosts && (
             <Grid container item direction="column">
               <Grid item container xs alignItems="center">
                 <Grid item xs={1}>
                   <Checkbox
-                    checked={values.downtimeAttachedResources}
-                    inputProps={{ 'aria-label': labelSetDowntimeOnServices }}
+                    checked={values.fixed}
+                    inputProps={{ 'aria-label': labelFixed }}
                     color="primary"
-                    onChange={handleChange('downtimeAttachedResources')}
+                    onChange={handleChange('fixed')}
                   />
                 </Grid>
                 <Grid item xs>
-                  <Typography>{labelSetDowntimeOnServices}</Typography>
+                  <Typography>{labelFixed}</Typography>
                 </Grid>
               </Grid>
             </Grid>
-          )}
-        </Grid>
-      </MuiPickersUtilsProvider>
+            <Grid item>
+              <FormHelperText>{labelDuration}</FormHelperText>
+              <Grid direction="row" container spacing={1}>
+                <Grid item style={{ width: 150 }}>
+                  <TextField
+                    disabled={values.fixed}
+                    type="number"
+                    onChange={handleChange('duration.value')}
+                    value={values.duration.value}
+                    error={errors?.duration?.value !== undefined}
+                    helperText={errors?.duration?.value}
+                  />
+                </Grid>
+                <Grid item style={{ width: 150 }}>
+                  <SelectField
+                    disabled={values.fixed}
+                    options={[
+                      {
+                        id: 'seconds',
+                        name: labelSeconds,
+                      },
+                      {
+                        id: 'minutes',
+                        name: labelMinutes,
+                      },
+                      {
+                        id: 'hours',
+                        name: labelHours,
+                      },
+                    ]}
+                    selectedOptionId={values.duration.unit}
+                    onChange={handleChange('duration.unit')}
+                  />
+                </Grid>
+              </Grid>
+            </Grid>
+            <Grid item>
+              <TextField
+                value={values.comment}
+                onChange={handleChange('comment')}
+                multiline
+                label={labelComment}
+                fullWidth
+                rows={3}
+                error={errors?.comment !== undefined}
+                helperText={errors?.comment}
+              />
+            </Grid>
+            {hasHosts && (
+              <Grid container item direction="column">
+                <Grid item container xs alignItems="center">
+                  <Grid item xs={1}>
+                    <Checkbox
+                      checked={values.downtimeAttachedResources}
+                      inputProps={{ 'aria-label': labelSetDowntimeOnServices }}
+                      color="primary"
+                      onChange={handleChange('downtimeAttachedResources')}
+                    />
+                  </Grid>
+                  <Grid item xs>
+                    <Typography>{labelSetDowntimeOnServices}</Typography>
+                  </Grid>
+                </Grid>
+              </Grid>
+            )}
+          </Grid>
+        </MuiPickersUtilsProvider>
+      )}
     </Dialog>
   );
 };

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/index.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/index.tsx
@@ -95,8 +95,8 @@ const DowntimeForm = ({
     showMessage({ message, severity: Severity.success });
 
   const [loaded, setLoaded] = React.useState(false);
-  const [locale, setLocale] = React.useState<string | null>();
-  const [timezone, setTimezone] = React.useState<string | null>();
+  const [locale, setLocale] = React.useState<string | null>('en');
+  const [timezone, setTimezone] = React.useState<string | null>(null);
 
   const currentDate = new Date();
   const twoHoursMs = 2 * 60 * 60 * 1000;

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/index.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/index.tsx
@@ -95,8 +95,8 @@ const DowntimeForm = ({
     showMessage({ message, severity: Severity.success });
 
   const [loaded, setLoaded] = React.useState(false);
-  const [locale, setLocale] = React.useState<string | null>('en');
-  const [timezone, setTimezone] = React.useState<string | null>(null);
+  const [locale, setLocale] = React.useState<string | null>();
+  const [timezone, setTimezone] = React.useState<string | null>();
 
   const currentDate = new Date();
   const twoHoursMs = 2 * 60 * 60 * 1000;

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/index.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/index.tsx
@@ -96,6 +96,7 @@ const DowntimeForm = ({
 
   const [loaded, setLoaded] = React.useState(false);
   const [locale, setLocale] = React.useState<string | null>('en');
+  const [timezone, setTimezone] = React.useState<string | null>(null);
 
   const currentDate = new Date();
   const twoHoursMs = 2 * 60 * 60 * 1000;
@@ -155,6 +156,7 @@ const DowntimeForm = ({
       .then((user) => {
         form.setFieldValue('comment', `${labelDowntimeBy} ${user.username}`);
         setLocale(user.locale);
+        setTimezone(user.timezone);
       })
       .catch(() => showError(labelSomethingWentWrong))
       .finally(() => setLoaded(true));
@@ -169,6 +171,7 @@ const DowntimeForm = ({
   return (
     <DialogDowntime
       locale={locale}
+      timezone={timezone}
       resources={resources}
       onConfirm={form.submitForm}
       onCancel={onClose}

--- a/www/front_src/src/Resources/models.ts
+++ b/www/front_src/src/Resources/models.ts
@@ -58,6 +58,7 @@ export type ResourceListing = Listing<Resource>;
 export interface User {
   username: string;
   locale: string | null;
+  timezone: string | null;
 }
 
 export interface Downtime {

--- a/www/front_src/src/components/clock/index.js
+++ b/www/front_src/src/components/clock/index.js
@@ -3,15 +3,14 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
 import React, { Component } from 'react';
-import Moment from 'moment';
-import 'moment-timezone/builds/moment-timezone-with-data-10-year-range'; // minimize bundle size (905KB -> 33KB)
+import moment from 'moment-timezone/builds/moment-timezone-with-data-10-year-range'; // minimize bundle size (905KB -> 33KB)
 import axios from '../../axios';
 
 import styles from '../header/header.scss';
 
 const instantiateDate = (tz, locale, timestamp) => {
   const currentTime =
-    tz !== '' ? Moment.unix(timestamp).tz(tz) : Moment.unix(timestamp);
+    tz !== '' ? moment.unix(timestamp).tz(tz) : moment.unix(timestamp);
   locale = locale !== null ? currentTime.locale(locale) : currentTime;
 
   return {


### PR DESCRIPTION
## Description

Take into account user timezone in downtime popin

/!\ this does not fix the table columns which do not use timezone

note : did not find a way to unit test timezone in popin

**Fixes** MON-5122

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Set a timezone to the user
- Add a downtime to a resource and check that dates and times take into account user timezone