### PR TITLE
fix(config): add missing fields of engine conf in remote export

### DIFF
--- a/www/class/config-generate-remote/Engine.php
+++ b/www/class/config-generate-remote/Engine.php
@@ -37,7 +37,7 @@ class Engine extends AbstractObject
         nagios_id,
         use_timezone,
         cfg_dir,
-        cfg_file as cfg_filename,
+        cfg_file,
         log_file,
         status_file,
         status_update_interval,
@@ -141,6 +141,7 @@ class Engine extends AbstractObject
     ';
     protected $attributesWrite = [
         'nagios_server_id',
+        'nagios_id',
         'use_timezone',
         'log_file',
         'status_file',
@@ -205,7 +206,8 @@ class Engine extends AbstractObject
         'macros_filter',
         'enable_macros_filter',
         'nagios_activate',
-        'cfg_dir'
+        'cfg_dir',
+        'cfg_file'
     ];
     protected $stmtEngine = null;
 


### PR DESCRIPTION
## Description

_nagios_id_ was missing from _cfg_nagios_ causing inconsistency between _nagios_server_ and _cfg_nagios_ tables, impacting Engine statistics collection.
Add _cfg_file_ for consistency.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

On a Remote Server after config export, following query should give a result:
`SELECT id, nagiostats_bin, cfg_dir, cfg_file FROM cfg_nagios JOIN nagios_server WHERE ns_activate = '1' AND nagios_id = id;`

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
