### PR TITLE
fix(ui): allow to order events view by duration

### DIFF
--- a/www/front_src/src/Resources/columns/index.tsx
+++ b/www/front_src/src/Resources/columns/index.tsx
@@ -246,6 +246,7 @@ export const getColumns = (actions): Array<Column> => [
     label: labelDuration,
     type: TABLE_COLUMN_TYPES.string,
     getFormattedString: ({ duration }): string => duration,
+    sortField: 'last_status_change',
     width: 125,
   },
   {


### PR DESCRIPTION
## Description

Fix order by duration in events view

**Fixes** MON-5199

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Try to order events view by duration