### PR TITLE
enh(ui): Fixes to details panel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3249,6 +3249,12 @@
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
     },
+    "arch": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
+      "dev": true
+    },
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
@@ -4320,6 +4326,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -5029,6 +5044,25 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+    },
+    "clipboardy": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-2.3.0.tgz",
+      "integrity": "sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==",
+      "dev": true,
+      "requires": {
+        "arch": "^2.1.1",
+        "execa": "^1.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "dependencies": {
+        "is-wsl": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.1.1.tgz",
+          "integrity": "sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==",
+          "dev": true
+        }
+      }
     },
     "cliui": {
       "version": "5.0.0",
@@ -7437,6 +7471,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -11081,6 +11121,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -19122,6 +19163,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -20296,6 +20338,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-merge": "^3.0.0",
     "cache-loader": "^4.1.0",
     "clean-webpack-plugin": "^3.0.0",
+    "clipboardy": "^2.3.0",
     "css-loader": "^3.4.2",
     "eslint-config-airbnb": "^18.1.0",
     "eslint-config-prettier": "^6.10.1",

--- a/www/front_src/src/Resources/Details/Body/tabs/Details/DetailsCard/cards.tsx
+++ b/www/front_src/src/Resources/Details/Body/tabs/Details/DetailsCard/cards.tsx
@@ -18,6 +18,7 @@ import {
   labelPercentStateChange,
   labelLastNotification,
   labelCurrentNotificationNumber,
+  labelNo,
 } from '../../../../../translatedLabels';
 import { getFormattedDate, getFormattedTime } from '../../../../../dateTime';
 import { ResourceDetails } from '../../../../models';
@@ -154,7 +155,7 @@ const getDetailCardLines = (
       getLines: (): Lines => [
         {
           key: 'flapping',
-          line: <DetailsLine line={details.flapping ? labelYes : 'N/A'} />,
+          line: <DetailsLine line={details.flapping ? labelYes : labelNo} />,
         },
       ],
     },

--- a/www/front_src/src/Resources/Details/Body/tabs/Details/DetailsCard/cards.tsx
+++ b/www/front_src/src/Resources/Details/Body/tabs/Details/DetailsCard/cards.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Typography, Grid, makeStyles } from '@material-ui/core';
+import { Typography, Grid, makeStyles, Box } from '@material-ui/core';
 import IconCheck from '@material-ui/icons/Check';
 
 import {
@@ -31,7 +31,13 @@ interface DetailCardLines {
 }
 
 const DetailsLine = ({ line }: { line?: string }): JSX.Element => {
-  return <Typography variant="h5">{line}</Typography>;
+  return (
+    <Typography component="div">
+      <Box fontWeight={500} lineHeight={1}>
+        {line}
+      </Box>
+    </Typography>
+  );
 };
 
 const useStyles = makeStyles((theme) => ({

--- a/www/front_src/src/Resources/Details/Body/tabs/Details/DetailsCard/cards.tsx
+++ b/www/front_src/src/Resources/Details/Body/tabs/Details/DetailsCard/cards.tsx
@@ -154,7 +154,7 @@ const getDetailCardLines = (
       getLines: (): Lines => [
         {
           key: 'flapping',
-          line: <DetailsLine line={details.flapping ? 'N/A' : labelYes} />,
+          line: <DetailsLine line={details.flapping ? labelYes : 'N/A'} />,
         },
       ],
     },

--- a/www/front_src/src/Resources/Details/Body/tabs/Details/DetailsCard/index.tsx
+++ b/www/front_src/src/Resources/Details/Body/tabs/Details/DetailsCard/index.tsx
@@ -11,19 +11,15 @@ const DetailsCard = ({ title, lines }: Props): JSX.Element => {
   return (
     <Card style={{ height: '100%' }}>
       <CardContent>
-        <Grid container direction="column" spacing={1}>
-          <Grid item>
-            <Typography variant="subtitle2" color="textSecondary">
-              {title}
-            </Typography>
-          </Grid>
-          <Grid item direction="column" container>
-            {lines.map(({ key, line }) => (
-              <Grid item key={key}>
-                {line}
-              </Grid>
-            ))}
-          </Grid>
+        <Typography variant="subtitle2" color="textSecondary" gutterBottom>
+          {title}
+        </Typography>
+        <Grid direction="column" container spacing={1}>
+          {lines.map(({ key, line }) => (
+            <Grid item key={key}>
+              {line}
+            </Grid>
+          ))}
         </Grid>
       </CardContent>
     </Card>

--- a/www/front_src/src/Resources/Details/Body/tabs/Details/ExpandableCard.tsx
+++ b/www/front_src/src/Resources/Details/Body/tabs/Details/ExpandableCard.tsx
@@ -32,7 +32,6 @@ const useStyles = makeStyles<Theme, { severityCode?: number }>((theme) => {
       }),
     }),
     title: ({ severityCode }): CreateCSSProperties => ({
-      marginBottom: 5,
       ...(severityCode && { color: getStatusBackgroundColor(severityCode) }),
     }),
   };
@@ -74,6 +73,7 @@ const ExpandableCard = ({
           className={classes.title}
           variant="subtitle2"
           color="textSecondary"
+          gutterBottom
         >
           {title}
         </Typography>

--- a/www/front_src/src/Resources/Details/Body/tabs/Details/ExpandableCard.tsx
+++ b/www/front_src/src/Resources/Details/Body/tabs/Details/ExpandableCard.tsx
@@ -52,7 +52,7 @@ const ExpandableCard = ({
 
   const [outputExpanded, setOutputExpanded] = React.useState(false);
 
-  const lines = content.split('\n');
+  const lines = content.split(/\n|\\n/);
   const threeFirstlines = lines.slice(0, 3);
   const lastlines = lines.slice(2, lines.length);
 

--- a/www/front_src/src/Resources/Details/Body/tabs/Details/index.tsx
+++ b/www/front_src/src/Resources/Details/Body/tabs/Details/index.tsx
@@ -2,11 +2,24 @@ import * as React from 'react';
 
 import { isNil } from 'ramda';
 
-import { Grid, Card, CardContent, Typography, styled } from '@material-ui/core';
+import {
+  Grid,
+  Card,
+  CardContent,
+  Typography,
+  styled,
+  Tooltip,
+  IconButton,
+} from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
+import IconCopyFile from '@material-ui/icons/FileCopy';
+
+import { useSnackbar, Severity } from '@centreon/ui';
 
 import ExpandableCard from './ExpandableCard';
 import {
+  labelCopy,
+  labelCommand,
   labelStatusInformation,
   labelDowntimeDuration,
   labelFrom,
@@ -14,6 +27,8 @@ import {
   labelAcknowledgedBy,
   labelAt,
   labelPerformanceData,
+  labelCommandCopied,
+  labelSomethingWentWrong,
 } from '../../../../translatedLabels';
 import StateCard from './StateCard';
 import { getFormattedDateTime } from '../../../../dateTime';
@@ -46,9 +61,29 @@ interface Props {
 }
 
 const DetailsTab = ({ details }: Props): JSX.Element => {
+  const { showMessage } = useSnackbar();
+
   if (details === undefined) {
     return <LoadingSkeleton />;
   }
+
+  const copyCommandLine = (): void => {
+    try {
+      const textArea = document.createElement('textarea');
+      document.body.appendChild(textArea);
+      textArea.value = details.command_line;
+      textArea.select();
+      document.execCommand('copy');
+      document.body.removeChild(textArea);
+
+      showMessage({ message: labelCommandCopied, severity: Severity.success });
+    } catch (_) {
+      showMessage({
+        message: labelSomethingWentWrong,
+        severity: Severity.error,
+      });
+    }
+  };
 
   return (
     <Grid container direction="column" spacing={2}>
@@ -111,7 +146,19 @@ const DetailsTab = ({ details }: Props): JSX.Element => {
       <Grid item>
         <Card>
           <CardContent>
-            <Typography variant="body2">{details.check_command}</Typography>
+            <Typography variant="subtitle2" color="textSecondary" gutterBottom>
+              <Grid container alignItems="center" spacing={1}>
+                <Grid item>{labelCommand}</Grid>
+                <Grid item>
+                  <Tooltip onClick={copyCommandLine} title={labelCopy}>
+                    <IconButton size="small">
+                      <IconCopyFile color="primary" fontSize="small" />
+                    </IconButton>
+                  </Tooltip>
+                </Grid>
+              </Grid>
+            </Typography>
+            <Typography variant="body2">{details.command_line}</Typography>
           </CardContent>
         </Card>
       </Grid>

--- a/www/front_src/src/Resources/Details/Body/tabs/Details/index.tsx
+++ b/www/front_src/src/Resources/Details/Body/tabs/Details/index.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 
 import { isNil } from 'ramda';
+import { write as writeToClipboard } from 'clipboardy';
 
 import {
   Grid,
@@ -68,21 +69,19 @@ const DetailsTab = ({ details }: Props): JSX.Element => {
   }
 
   const copyCommandLine = (): void => {
-    try {
-      const textArea = document.createElement('textarea');
-      document.body.appendChild(textArea);
-      textArea.value = details.command_line;
-      textArea.select();
-      document.execCommand('copy');
-      document.body.removeChild(textArea);
-
-      showMessage({ message: labelCommandCopied, severity: Severity.success });
-    } catch (_) {
-      showMessage({
-        message: labelSomethingWentWrong,
-        severity: Severity.error,
+    writeToClipboard(details.command_line)
+      .then(() => {
+        showMessage({
+          message: labelCommandCopied,
+          severity: Severity.success,
+        });
+      })
+      .catch(() => {
+        showMessage({
+          message: labelSomethingWentWrong,
+          severity: Severity.error,
+        });
       });
-    }
   };
 
   return (

--- a/www/front_src/src/Resources/Details/Body/tabs/Details/index.tsx
+++ b/www/front_src/src/Resources/Details/Body/tabs/Details/index.tsx
@@ -69,7 +69,7 @@ const DetailsTab = ({ details }: Props): JSX.Element => {
   }
 
   const copyCommandLine = (): void => {
-    writeToClipboard(details.command_line)
+    writeToClipboard(details.command_line as string)
       .then(() => {
         showMessage({
           message: labelCommandCopied,
@@ -142,25 +142,31 @@ const DetailsTab = ({ details }: Props): JSX.Element => {
           />
         </Grid>
       )}
-      <Grid item>
-        <Card>
-          <CardContent>
-            <Typography variant="subtitle2" color="textSecondary" gutterBottom>
-              <Grid container alignItems="center" spacing={1}>
-                <Grid item>{labelCommand}</Grid>
-                <Grid item>
-                  <Tooltip onClick={copyCommandLine} title={labelCopy}>
-                    <IconButton size="small">
-                      <IconCopyFile color="primary" fontSize="small" />
-                    </IconButton>
-                  </Tooltip>
+      {details.command_line && (
+        <Grid item>
+          <Card>
+            <CardContent>
+              <Typography
+                variant="subtitle2"
+                color="textSecondary"
+                gutterBottom
+              >
+                <Grid container alignItems="center" spacing={1}>
+                  <Grid item>{labelCommand}</Grid>
+                  <Grid item>
+                    <Tooltip onClick={copyCommandLine} title={labelCopy}>
+                      <IconButton size="small">
+                        <IconCopyFile color="primary" fontSize="small" />
+                      </IconButton>
+                    </Tooltip>
+                  </Grid>
                 </Grid>
-              </Grid>
-            </Typography>
-            <Typography variant="body2">{details.command_line}</Typography>
-          </CardContent>
-        </Card>
-      </Grid>
+              </Typography>
+              <Typography variant="body2">{details.command_line}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      )}
     </Grid>
   );
 };

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import axios from 'axios';
-import { readSync } from 'clipboardy';
+import clipboardy from 'clipboardy';
 
 import {
   render,
@@ -44,6 +44,10 @@ import { selectOption } from '../test';
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 jest.mock('../icons/Downtime');
+
+jest.mock('clipboardy');
+
+const mockedClipboardy = clipboardy as jest.Mocked<typeof clipboardy>;
 
 const onClose = jest.fn();
 
@@ -248,12 +252,16 @@ describe(Details, () => {
   it('copies the command line to clipboard when the copy button is clicked', async () => {
     const { getByTitle } = renderDetails();
 
+    mockedClipboardy.write.mockResolvedValue();
+
     await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
 
     fireEvent.click(getByTitle(labelCopy));
 
     await waitFor(() =>
-      expect(readSync()).toEqual(retrievedDetails.command_line),
+      expect(mockedClipboardy.write).toHaveBeenCalledWith(
+        retrievedDetails.command_line,
+      ),
     );
   });
 });

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 
 import axios from 'axios';
+import { readSync } from 'clipboardy';
 
-import { render, waitFor, fireEvent } from '@testing-library/react';
+import {
+  render,
+  waitFor,
+  fireEvent,
+  RenderResult,
+} from '@testing-library/react';
+
 import Details from '.';
 import {
   labelMore,
@@ -28,6 +35,8 @@ import {
   labelLast7Days,
   labelLast24h,
   labelLast31Days,
+  labelCopy,
+  labelCommand,
 } from '../translatedLabels';
 import { selectOption } from '../test';
 
@@ -59,7 +68,7 @@ const retrievedDetails = {
   timezone: 'Europe/Paris',
   criticality: 10,
   active_checks: true,
-  check_command: 'base_host_alive',
+  command_line: 'base_host_alive',
   last_notification: '2020-07-18T19:30',
   latency: 0.005,
   next_check: '2020-06-18T19:15',
@@ -95,6 +104,19 @@ const statusGraphData = { warning: [], ok: [], critical: [], unknown: [] };
 const RealDate = Date;
 const currentDateIsoString = '2020-06-20T20:00:00.000Z';
 
+const renderDetails = (): RenderResult =>
+  render(
+    <Details
+      endpoints={{
+        details: detailsEndpoint,
+        performanceGraph: performanceGraphEndpoint,
+        statusGraph: statusGraphEndpoint,
+      }}
+      onClose={onClose}
+      openTabId={defaultTabIdOpen}
+    />,
+  );
+
 describe(Details, () => {
   beforeEach(() => {
     global.Date.now = jest.fn(() => Date.parse(currentDateIsoString));
@@ -113,15 +135,9 @@ describe(Details, () => {
   it('displays resource details information', async () => {
     mockedAxios.get.mockResolvedValueOnce({ data: retrievedDetails });
 
-    const { getByText, queryByText, getAllByText } = render(
-      <Details
-        endpoints={{ details: detailsEndpoint }}
-        onClose={onClose}
-        openTabId={defaultTabIdOpen}
-      />,
-    );
+    const { getByText, queryByText, getAllByText } = renderDetails();
 
-    await waitFor(() => expect(getByText('Central')).toBeInTheDocument());
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
 
     expect(getByText('10')).toBeInTheDocument();
     expect(getByText('CRITICAL')).toBeInTheDocument();
@@ -192,6 +208,7 @@ describe(Details, () => {
       ),
     ).toBeInTheDocument();
 
+    expect(getByText(labelCommand)).toBeInTheDocument();
     expect(getByText('base_host_alive')).toBeInTheDocument();
   });
 
@@ -205,19 +222,9 @@ describe(Details, () => {
         .mockResolvedValueOnce({ data: performanceGraphData })
         .mockResolvedValueOnce({ data: statusGraphData });
 
-      const { getByText } = render(
-        <Details
-          endpoints={{
-            details: detailsEndpoint,
-            statusGraph: statusGraphEndpoint,
-            performanceGraph: performanceGraphEndpoint,
-          }}
-          onClose={onClose}
-          openTabId={defaultTabIdOpen}
-        />,
-      );
+      const { getByText } = renderDetails();
 
-      await waitFor(() => expect(getByText('Central')).toBeInTheDocument());
+      await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
 
       fireEvent.click(getByText(labelGraph));
 
@@ -233,4 +240,16 @@ describe(Details, () => {
       );
     }),
   );
+
+  it('copies the command line to clipboard when the copy button is clicked', async () => {
+    const { getByTitle } = renderDetails();
+
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
+
+    fireEvent.click(getByTitle(labelCopy));
+
+    await waitFor(() =>
+      expect(readSync()).toEqual(retrievedDetails.command_line),
+    );
+  });
 });

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -37,6 +37,7 @@ import {
   labelLast31Days,
   labelCopy,
   labelCommand,
+  labelResourceFlapping,
 } from '../translatedLabels';
 import { selectOption } from '../test';
 
@@ -190,6 +191,9 @@ describe(Details, () => {
 
     expect(getByText(labelLatency)).toBeInTheDocument();
     expect(getByText('0.005 s')).toBeInTheDocument();
+
+    expect(getByText(labelResourceFlapping)).toBeInTheDocument();
+    expect(getByText('N/A')).toBeInTheDocument();
 
     expect(getByText(labelPercentStateChange)).toBeInTheDocument();
     expect(getByText('3.5%')).toBeInTheDocument();

--- a/www/front_src/src/Resources/Details/index.tsx
+++ b/www/front_src/src/Resources/Details/index.tsx
@@ -65,7 +65,7 @@ const Details = ({
   }, [detailsEndpoint]);
 
   return (
-    <Paper variant="outlined" elevation={2} className={classes.details}>
+    <Paper elevation={4} className={classes.details}>
       <div className={classes.header}>
         <Header details={details} onClickClose={onClose} />
       </div>

--- a/www/front_src/src/Resources/Details/index.tsx
+++ b/www/front_src/src/Resources/Details/index.tsx
@@ -65,7 +65,7 @@ const Details = ({
   }, [detailsEndpoint]);
 
   return (
-    <Paper elevation={4} className={classes.details}>
+    <Paper elevation={5} className={classes.details}>
       <div className={classes.header}>
         <Header details={details} onClickClose={onClose} />
       </div>

--- a/www/front_src/src/Resources/Details/models.ts
+++ b/www/front_src/src/Resources/Details/models.ts
@@ -18,10 +18,10 @@ export interface ResourceDetails {
   active_checks: boolean;
   execution_time: number;
   latency: number;
-  flapping: boolean;
+  flapping?: boolean;
   percent_state_change: number;
   last_notification: string;
   notification_number: number;
   performance_data?: string;
-  command_line: string;
+  command_line?: string;
 }

--- a/www/front_src/src/Resources/Details/models.ts
+++ b/www/front_src/src/Resources/Details/models.ts
@@ -23,5 +23,5 @@ export interface ResourceDetails {
   last_notification: string;
   notification_number: number;
   performance_data?: string;
-  check_command: string;
+  command_line: string;
 }

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -16,6 +16,9 @@ export const labelClearAll = I18n.t('Clear all');
 export const labelCriterias = I18n.t('Criterias');
 export const labelCritical = I18n.t('Critical');
 export const labelCheckDuration = I18n.t('Check duration');
+export const labelCommand = I18n.t('Command');
+export const labelCopy = I18n.t('Copy');
+export const labelCommandCopied = I18n.t('Command copied to clipboard');
 export const labelCurrentNotificationNumber = I18n.t(
   'Current notification number',
 );


### PR DESCRIPTION
## Description

This PR makes the following fixes:
-  Show flapping card only when flapping is defined / show 'Yes' label when value is true, 'N/A' otherwise
- Fix command line not showing the correct value, and add a copy button. The card is not shown if command line value is not defined
- Reduce the font sizes of cards content

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)
