### PR TITLE
fix(api): update resources listing to filter out hosts when searching…

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -413,8 +413,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
      */
     private function hasServiceSearch(): bool
     {
-        return $this->extractSpecificSearchCriteria('/^s\./')
-            && !$this->extractSpecificSearchCriteria('/^h\./');
+        return $this->extractSpecificSearchCriteria('/^s\./');
     }
 
     /**


### PR DESCRIPTION
… for service parameters

## Description

Previously, when searching for h.name and s.description you would get the host too, now you get only service if you define service parameters.

**Fixes** bug reported by Etienne

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Create regex search in filter for host and service similar to:
h.name:^Ce s.description:^moo

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
