### PR TITLE
fix(symfony): Configure the service HostConfigurationService in public

### DIFF
--- a/config/Modules/Centreon.yaml
+++ b/config/Modules/Centreon.yaml
@@ -147,3 +147,7 @@ services:
         calls:
             - method: setSqlRequestTranslator
               arguments: ['@sqlRequestTranslator']
+
+    Centreon\Domain\HostConfiguration\Interfaces\HostConfigurationServiceInterface:
+        class: Centreon\Domain\HostConfiguration\HostConfigurationService
+        public: true


### PR DESCRIPTION
## Description

The HostConfigurationService must be defined on public.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
