### PR TITLE
fix(api): improve the filtering in subqueries of Resource list endpoint

### DIFF
--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -415,7 +415,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
     {
         $search = $this->sqlRequestTranslator->getRequestParameters()->getSearch();
 
-        if (!$search) {
+        if (empty($search)) {
             return false;
         }
 

--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -413,6 +413,18 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
      */
     private function hasServiceSearch(): bool
     {
+        $search = $this->sqlRequestTranslator->getRequestParameters()->getSearch();
+
+        if (!$search) {
+            return false;
+        }
+
+        $operator = array_keys($search)[0];
+
+        if ($operator === RequestParameters::AGGREGATE_OPERATOR_OR) {
+            return !$this->extractSpecificSearchCriteria('/^h\./');
+        }
+
         return $this->extractSpecificSearchCriteria('/^s\./');
     }
 


### PR DESCRIPTION
## Description

fit in the cases when in the search criteria are joined by OR/AND operator from different subqueries in the Resource list endpoint

**Fixes**  MON-5207

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
