### PR TITLE
fix(api): update hosts to return sanitized timezone string

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.Host.yml
+++ b/config/packages/serializer/Centreon/Monitoring.Host.yml
@@ -252,6 +252,10 @@ Centreon\Domain\Monitoring\Host:
                 - 'resource_details_host'
         timezone:
             type: string
+            access_type: public_method
+            accessor:
+              getter: getSanitizedTimezone
+              setter: setTimezone
             groups:
                 - 'host_main'
                 - 'host_full'

--- a/src/Centreon/Domain/Monitoring/Host.php
+++ b/src/Centreon/Domain/Monitoring/Host.php
@@ -1147,7 +1147,9 @@ class Host implements EntityDescriptorMetadataInterface
 
     public function getSanitizedTimezone(): ?string
     {
-        return preg_replace('/^:/', '', $this->timezone);
+        return (null !== $this->timezone) ?
+            preg_replace('/^:/', '', $this->timezone) :
+            $this->timezone;
     }
 
     /**

--- a/src/Centreon/Domain/Monitoring/Host.php
+++ b/src/Centreon/Domain/Monitoring/Host.php
@@ -1145,6 +1145,11 @@ class Host implements EntityDescriptorMetadataInterface
         return $this->timezone;
     }
 
+    public function getSanitizedTimezone(): ?string
+    {
+        return preg_replace('/^:/', '', $this->timezone);
+    }
+
     /**
      * @param string|null $timezone
      * @return Host

--- a/src/Centreon/Domain/Monitoring/Host.php
+++ b/src/Centreon/Domain/Monitoring/Host.php
@@ -1145,6 +1145,9 @@ class Host implements EntityDescriptorMetadataInterface
         return $this->timezone;
     }
 
+    /**
+     * @return null|string
+     */
     public function getSanitizedTimezone(): ?string
     {
         return (null !== $this->timezone) ?


### PR DESCRIPTION
## Description

In centreon_storage timezone is listed as ":Europe/Paris". The semicolon is required for Engine to work properly, so I added a new method to return the cleaned string, because React FE needs it without the symbol.

**Fixes** # MON-5205

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check host detail API to see the returned string for 'timezone' property.

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
