### PR TITLE
enh(ui): move filter collapse icon to the left

### DIFF
--- a/www/front_src/src/Resources/Filter/index.tsx
+++ b/www/front_src/src/Resources/Filter/index.tsx
@@ -59,12 +59,14 @@ const ExpansionPanelSummary = withStyles((theme) => ({
     '&$expanded': {
       minHeight: 'auto',
     },
+    justifyContent: 'flex-start',
   },
   content: {
     margin: theme.spacing(1, 0),
     '&$expanded': {
       margin: theme.spacing(1, 0),
     },
+    flexGrow: 0,
   },
   expanded: {},
 }))(MuiExpansionPanelSummary);
@@ -162,12 +164,23 @@ const Filter = ({
 
   const getOptionsFromResult = ({ result }): Array<SelectEntry> => result;
 
+  const avoidToggleExpansionPanel = (
+    event: React.MouseEvent<HTMLElement>,
+  ): void => {
+    event.stopPropagation();
+  };
+
   const requestSearchOnEnterKey = (event: KeyboardEvent): void => {
     const enterKeyPressed = event.keyCode === 13;
 
     if (enterKeyPressed) {
       onSearchRequest();
     }
+  };
+
+  const requestSearch = (event: React.MouseEvent<HTMLElement>): void => {
+    avoidToggleExpansionPanel(event);
+    onSearchRequest();
   };
 
   return (
@@ -180,15 +193,7 @@ const Filter = ({
           />
         }
       >
-        <Grid
-          spacing={1}
-          container
-          alignItems="center"
-          onClick={(e): void => {
-            e.stopPropagation();
-          }}
-          style={{ cursor: 'default' }}
-        >
+        <Grid spacing={1} container alignItems="center">
           <Grid item>
             <Typography className={classes.filterLineLabel} variant="h6">
               {labelFilter}
@@ -203,6 +208,7 @@ const Filter = ({
                 allFilter,
               ]}
               selectedOptionId={filter.id}
+              onClick={avoidToggleExpansionPanel}
               onChange={onFilterGroupChange}
               aria-label={labelStateFilter}
             />
@@ -212,6 +218,7 @@ const Filter = ({
               className={classes.searchField}
               EndAdornment={(): JSX.Element => <SearchHelpTooltip />}
               value={nextSearch || ''}
+              onClick={avoidToggleExpansionPanel}
               onChange={onSearchPrepare}
               placeholder={labelResourceName}
               onKeyDown={requestSearchOnEnterKey}
@@ -222,7 +229,7 @@ const Filter = ({
               variant="contained"
               color="primary"
               disabled={!currentSearch && !nextSearch}
-              onClick={onSearchRequest}
+              onClick={requestSearch}
             >
               {labelSearch}
             </Button>


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/11978823/78910357-20567f00-7a85-11ea-958b-ba622111273b.png)

**Fixes** MON-5212

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check filter collapse in events view