### PR TITLE
enh(ui): improve search help tooltip in events view

### DIFF
--- a/www/front_src/src/Resources/Filter/index.tsx
+++ b/www/front_src/src/Resources/Filter/index.tsx
@@ -215,7 +215,7 @@ const Filter = ({
           <Grid item>
             <SearchField
               className={classes.searchField}
-              EndAdornment={(): JSX.Element => <SearchHelpTooltip />}
+              EndAdornment={SearchHelpTooltip}
               value={nextSearch || ''}
               onClick={avoidToggleExpansionPanel}
               onChange={onSearchPrepare}

--- a/www/front_src/src/Resources/SearchHelpTooltip.tsx
+++ b/www/front_src/src/Resources/SearchHelpTooltip.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
+import * as React from 'react';
 
-import { Tooltip, makeStyles } from '@material-ui/core';
+import { Tooltip, IconButton, Box, makeStyles } from '@material-ui/core';
 import IconHelp from '@material-ui/icons/HelpOutline';
+import IconClose from '@material-ui/icons/HighlightOff';
 
 import {
+  labelSearchHelp,
   labelSearchOnFields,
   labelSearchByRegexp,
   labelSearchSyntax,
@@ -17,56 +19,95 @@ import {
 
 const useStyles = makeStyles((theme) => ({
   tooltip: {
+    backgroundColor: theme.palette.common.white,
+    color: theme.palette.text.primary,
+    boxShadow: theme.shadows[3],
     fontSize: theme.typography.pxToRem(12),
     maxWidth: 500,
+    padding: theme.spacing(1, 2, 1, 1),
   },
-  icon: {
-    cursor: 'auto',
+  buttonClose: {
+    position: 'absolute',
+    right: theme.spacing(0.5),
   },
 }));
 
 const searchFields = ['h.name', 'h.alias', 'h.address', 's.description'];
 
-const Content = (): JSX.Element => (
-  <>
-    <p>{`${labelSearchOnFields}. ${labelSearchByRegexp}.`}</p>
-    <p>{`${labelSearchSyntax} ${searchFields.join(':, ')}:.`}</p>
-    <p>{labelSearchSomeExamples}</p>
-    <ul>
-      <li>
-        <b>h.name:^FR20</b>
-        {` ${labelSearchByHostNameStartingWith} "FR20"`}
-      </li>
-      <li>
-        <b>s.description:ens192$</b>
-        {` ${labelSearchByServiceDescEndingWith} "ens192"`}
-      </li>
-      <li>
-        <b>h.alias:prod</b>
-        {` ${labelSearchByHostAliasContaining} "prod"`}
-      </li>
-      <li>
-        <b>h.address:^((?!production).)*$</b>
-        {` ${labelSearchByHostAddressNotContaining} "production"`}
-      </li>
-      <li>
-        <b>h.name:^FR20 h.alias:prod</b>
-        {` ${labelSearchByHostNameStartingWith} "FR20" ${labelSearchAndHostAliasContaining} "prod"`}
-      </li>
-    </ul>
-  </>
-);
+interface ContentProps {
+  onClose: (event) => void;
+}
+
+const Content = ({ onClose }: ContentProps): JSX.Element => {
+  const classes = useStyles();
+
+  return (
+    <>
+      <IconButton
+        size="small"
+        onClick={onClose}
+        className={classes.buttonClose}
+      >
+        <IconClose fontSize="small" />
+      </IconButton>
+      <Box padding={1}>
+        <p>{`${labelSearchOnFields}. ${labelSearchByRegexp}.`}</p>
+        <p>{`${labelSearchSyntax} ${searchFields.join(':, ')}:.`}</p>
+        <p>{labelSearchSomeExamples}</p>
+        <ul>
+          <li>
+            <b>h.name:^FR20</b>
+            {` ${labelSearchByHostNameStartingWith} "FR20"`}
+          </li>
+          <li>
+            <b>s.description:ens192$</b>
+            {` ${labelSearchByServiceDescEndingWith} "ens192"`}
+          </li>
+          <li>
+            <b>h.alias:prod</b>
+            {` ${labelSearchByHostAliasContaining} "prod"`}
+          </li>
+          <li>
+            <b>h.address:^((?!production).)*$</b>
+            {` ${labelSearchByHostAddressNotContaining} "production"`}
+          </li>
+          <li>
+            <b>h.name:^FR20 h.alias:prod</b>
+            {` ${labelSearchByHostNameStartingWith} "FR20" ${labelSearchAndHostAliasContaining} "prod"`}
+          </li>
+        </ul>
+      </Box>
+    </>
+  );
+};
 
 const SearchHelpTooltip = (): JSX.Element => {
   const classes = useStyles();
 
+  const [open, setOpen] = React.useState(false);
+
+  const toggleTooltip = (): void => {
+    setOpen(!open);
+  };
+
+  const closeTooltip = (): void => {
+    setOpen(false);
+  };
+
   return (
     <Tooltip
-      title={<Content />}
+      open={open}
+      title={<Content onClose={closeTooltip} />}
       classes={{ tooltip: classes.tooltip }}
       interactive
     >
-      <IconHelp className={classes.icon} />
+      <IconButton
+        aria-label={labelSearchHelp}
+        size="small"
+        onClick={toggleTooltip}
+      >
+        <IconHelp />
+      </IconButton>
     </Tooltip>
   );
 };

--- a/www/front_src/src/Resources/columns/State/index.tsx
+++ b/www/front_src/src/Resources/columns/State/index.tsx
@@ -41,7 +41,7 @@ const DowntimeHoverChip = ({
       endpoint={resource.downtime_endpoint as string}
       label={`${resource.name} ${labelInDowntime}`}
       DetailsTable={DowntimeDetailsTable}
-      Chip={(): JSX.Element => <DowntimeChip />}
+      Chip={DowntimeChip}
     />
   );
 };
@@ -56,7 +56,7 @@ const AcknowledgeHoverChip = ({
       endpoint={resource.acknowledgement_endpoint as string}
       label={`${resource.name} ${labelAcknowledged}`}
       DetailsTable={AcknowledgementDetailsTable}
-      Chip={(): JSX.Element => <AcknowledgeChip />}
+      Chip={AcknowledgeChip}
     />
   );
 };

--- a/www/front_src/src/Resources/index.test.tsx
+++ b/www/front_src/src/Resources/index.test.tsx
@@ -28,6 +28,8 @@ import { ThemeProvider } from '@centreon/ui';
 import {
   labelResourceName,
   labelSearch,
+  labelSearchHelp,
+  labelSearchOnFields,
   labelInDowntime,
   labelAcknowledged,
   labelTypeOfResource,
@@ -321,17 +323,19 @@ describe(Resources, () => {
 
     Simulate.keyDown(searchInput, { key: 'Enter', keyCode: 13, which: 13 });
 
-    expect(mockedAxios.get).toHaveBeenCalledWith(
-      getEndpoint({
-        search: {
-          mode: '$or',
-          fieldPatterns: searchableFields.map((searchableField) => ({
-            field: searchableField,
-            value: fieldSearchValue,
-          })),
-        },
-      }),
-      cancelTokenRequestParam,
+    await waitFor(() =>
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        getEndpoint({
+          search: {
+            mode: '$or',
+            fieldPatterns: searchableFields.map((searchableField) => ({
+              field: searchableField,
+              value: fieldSearchValue,
+            })),
+          },
+        }),
+        cancelTokenRequestParam,
+      ),
     );
   });
 
@@ -1053,5 +1057,29 @@ describe(Resources, () => {
         search: 'searching...',
       }),
     );
+  });
+
+  it('leaves search help tooltip when the search input filled ', async () => {
+    const {
+      getByLabelText,
+      getByText,
+      getByPlaceholderText,
+    } = renderResources();
+
+    fireEvent.click(getByLabelText(labelSearchHelp));
+
+    expect(
+      getByText(labelSearchOnFields, { exact: false }),
+    ).toBeInTheDocument();
+
+    const searchInput = getByPlaceholderText(labelResourceName);
+
+    fireEvent.change(searchInput, {
+      target: { value: 'foobar' },
+    });
+
+    expect(
+      getByText(labelSearchOnFields, { exact: false }),
+    ).toBeInTheDocument();
   });
 });

--- a/www/front_src/src/Resources/index.test.tsx
+++ b/www/front_src/src/Resources/index.test.tsx
@@ -1059,7 +1059,7 @@ describe(Resources, () => {
     );
   });
 
-  it('leaves search help tooltip when the search input filled ', async () => {
+  it('leaves search help tooltip visible when the search input is filled', async () => {
     const {
       getByLabelText,
       getByText,

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -93,6 +93,7 @@ export const labelMore = I18n.t('More');
 export const labelRefresh = I18n.t('Refresh');
 export const labelDisableAutorefresh = I18n.t('Disable autorefresh');
 export const labelEnableAutorefresh = I18n.t('Enable autorefresh');
+export const labelSearchHelp = I18n.t('Search help');
 export const labelSearchOnFields = I18n.t(
   'This search bar will search matching occurences you type contained in: host name or alias or address or service description',
 );


### PR DESCRIPTION
## Description

Improve search help tooltip in events view : 
- stay persistent, until the close button is clicked
- add close icon button
- set background to white
- some minor improvements to avoid unneccessary rendering (remove arrow functions)

![image](https://user-images.githubusercontent.com/11978823/78968893-f7c29980-7b05-11ea-85be-1afd6b15fc76.png)

**Fixes** MON-5211

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check help tooltip in events view