### PR TITLE
fix(ui): use last value of search field when a filter triggers a listing search

### DIFF
--- a/www/front_src/src/Resources/index.test.tsx
+++ b/www/front_src/src/Resources/index.test.tsx
@@ -221,6 +221,52 @@ const webAccessServiceGroup = {
 const hostResources = entities.filter(({ type }) => type === 'host');
 const serviceResources = entities.filter(({ type }) => type === 'service');
 
+const filterParams = [
+  {
+    filterName: labelTypeOfResource,
+    optionToSelect: labelHost,
+    endpointParamChanged: { resourceTypes: ['host'] },
+  },
+  {
+    filterName: labelState,
+    optionToSelect: labelAcknowledged,
+    endpointParamChanged: {
+      states: [...defaultStates, 'acknowledged'],
+    },
+  },
+  {
+    filterName: labelStatus,
+    optionToSelect: labelOk,
+    endpointParamChanged: {
+      statuses: [...defaultStatuses, 'OK'],
+    },
+  },
+  {
+    filterName: labelHostGroup,
+    optionToSelect: linuxServersHostGroup.name,
+    selectEndpointMockAction: (): void => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { result: [linuxServersHostGroup] },
+      });
+    },
+    endpointParamChanged: {
+      hostGroupsIds: [linuxServersHostGroup.id],
+    },
+  },
+  {
+    filterName: labelServiceGroup,
+    optionToSelect: webAccessServiceGroup.name,
+    selectEndpointMockAction: (): void => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { result: [webAccessServiceGroup] },
+      });
+    },
+    endpointParamChanged: {
+      serviceGroupIds: [webAccessServiceGroup.id],
+    },
+  },
+];
+
 const mockedLocalStorageGetItem = jest.fn();
 const mockedLocalStorageSetItem = jest.fn();
 
@@ -380,51 +426,7 @@ describe(Resources, () => {
     });
   });
 
-  [
-    {
-      filterName: labelTypeOfResource,
-      optionToSelect: labelHost,
-      endpointParamChanged: { resourceTypes: ['host'] },
-    },
-    {
-      filterName: labelState,
-      optionToSelect: labelAcknowledged,
-      endpointParamChanged: {
-        states: [...defaultStates, 'acknowledged'],
-      },
-    },
-    {
-      filterName: labelStatus,
-      optionToSelect: labelOk,
-      endpointParamChanged: {
-        statuses: [...defaultStatuses, 'OK'],
-      },
-    },
-    {
-      filterName: labelHostGroup,
-      optionToSelect: linuxServersHostGroup.name,
-      selectEndpointMockAction: (): void => {
-        mockedAxios.get.mockResolvedValueOnce({
-          data: { result: [linuxServersHostGroup] },
-        });
-      },
-      endpointParamChanged: {
-        hostGroupsIds: [linuxServersHostGroup.id],
-      },
-    },
-    {
-      filterName: labelServiceGroup,
-      optionToSelect: webAccessServiceGroup.name,
-      selectEndpointMockAction: (): void => {
-        mockedAxios.get.mockResolvedValueOnce({
-          data: { result: [webAccessServiceGroup] },
-        });
-      },
-      endpointParamChanged: {
-        serviceGroupIds: [webAccessServiceGroup.id],
-      },
-    },
-  ].forEach(
+  filterParams.forEach(
     ({
       filterName,
       optionToSelect,
@@ -621,6 +623,57 @@ describe(Resources, () => {
       cancelTokenRequestParam,
     );
   });
+
+  filterParams.forEach(
+    ({
+      filterName,
+      optionToSelect,
+      endpointParamChanged,
+      selectEndpointMockAction,
+    }) => {
+      it(`executes a listing request with the last typed search when "${filterName}" filter options are changed`, async () => {
+        const {
+          getAllByText,
+          getByTitle,
+          getByPlaceholderText,
+        } = renderResources();
+
+        await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
+
+        selectEndpointMockAction?.();
+        mockedAxios.get.mockResolvedValueOnce({ data: retrievedListing });
+
+        const searchValue = 'foobar';
+
+        fireEvent.change(getByPlaceholderText(labelResourceName), {
+          target: { value: searchValue },
+        });
+
+        const filterToChange = getByTitle(`${labelOpen} ${filterName}`);
+        fireEvent.click(filterToChange);
+
+        await waitFor(() => {
+          const [selectedOption] = getAllByText(optionToSelect);
+
+          return fireEvent.click(selectedOption);
+        });
+
+        expect(mockedAxios.get).toHaveBeenCalledWith(
+          getEndpoint({
+            search: {
+              mode: '$or',
+              fieldPatterns: searchableFields.map((searchableField) => ({
+                field: searchableField,
+                value: searchValue,
+              })),
+            },
+            ...endpointParamChanged,
+          }),
+          cancelTokenRequestParam,
+        );
+      });
+    },
+  );
 
   it('displays downtime details when the downtime state chip is hovered', async () => {
     const { getByLabelText, getByText } = renderResources();

--- a/www/front_src/src/Resources/index.test.tsx
+++ b/www/front_src/src/Resources/index.test.tsx
@@ -221,7 +221,7 @@ const webAccessServiceGroup = {
 const hostResources = entities.filter(({ type }) => type === 'host');
 const serviceResources = entities.filter(({ type }) => type === 'service');
 
-const filterParams = [
+const filtersParams = [
   {
     filterName: labelTypeOfResource,
     optionToSelect: labelHost,
@@ -426,7 +426,7 @@ describe(Resources, () => {
     });
   });
 
-  filterParams.forEach(
+  filtersParams.forEach(
     ({
       filterName,
       optionToSelect,
@@ -624,7 +624,7 @@ describe(Resources, () => {
     );
   });
 
-  filterParams.forEach(
+  filtersParams.forEach(
     ({
       filterName,
       optionToSelect,

--- a/www/front_src/src/Resources/index.tsx
+++ b/www/front_src/src/Resources/index.tsx
@@ -163,6 +163,17 @@ const Resources = (): JSX.Element => {
     load();
   };
 
+  const prepareSearch = (event): void => {
+    setNextSearch(event.target.value);
+  };
+
+  const requestSearch = (): void => {
+    if (currentSearch === nextSearch) {
+      initAutorefreshAndLoad();
+    }
+    setCurrentSearch(nextSearch);
+  };
+
   React.useEffect(() => {
     return (): void => {
       tokenSource.cancel();
@@ -172,33 +183,15 @@ const Resources = (): JSX.Element => {
 
   React.useEffect(() => {
     initAutorefreshAndLoad();
-  }, [
-    sortf,
-    sorto,
-    page,
-    limit,
-    currentSearch,
-    states,
-    statuses,
-    resourceTypes,
-    hostGroups,
-    serviceGroups,
-  ]);
+  }, [sortf, sorto, page, limit, currentSearch]);
+
+  React.useEffect(() => {
+    requestSearch();
+  }, [states, statuses, resourceTypes, hostGroups, serviceGroups]);
 
   React.useEffect(() => {
     initAutorefresh();
   }, [enabledAutorefresh]);
-
-  const prepareSearch = (event): void => {
-    setNextSearch(event.target.value);
-  };
-
-  const requestSearch = (): void => {
-    if (currentSearch === nextSearch) {
-      load();
-    }
-    setCurrentSearch(nextSearch);
-  };
 
   const changeSort = ({ order, orderBy }): void => {
     setSortf(orderBy);

--- a/www/front_src/src/Resources/index.tsx
+++ b/www/front_src/src/Resources/index.tsx
@@ -185,7 +185,12 @@ const Resources = (): JSX.Element => {
     initAutorefreshAndLoad();
   }, [sortf, sorto, page, limit, currentSearch]);
 
+  const firstUpdate = React.useRef(true);
   React.useEffect(() => {
+    if (firstUpdate.current) {
+      firstUpdate.current = false;
+      return;
+    }
     requestSearch();
   }, [states, statuses, resourceTypes, hostGroups, serviceGroups]);
 

--- a/www/front_src/src/Resources/index.tsx
+++ b/www/front_src/src/Resources/index.tsx
@@ -188,6 +188,7 @@ const Resources = (): JSX.Element => {
   const firstUpdate = React.useRef(true);
   React.useEffect(() => {
     if (firstUpdate.current) {
+      // to avoid duplicate rendering on mount
       firstUpdate.current = false;
       return;
     }


### PR DESCRIPTION
## Description

Use last value of search field when a filter triggers a listing search

**Fixes** MON-5228

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Type something in events view search field without clicking on search button (and without pressing enter key)
- Change another filter (eg: "All" instead of "Unhandled Problems"
- Check the listing take into account search field