### PR TITLE
enh(ui): toggle events view panel only on icon click

### DIFF
--- a/www/front_src/src/Resources/Filter/index.tsx
+++ b/www/front_src/src/Resources/Filter/index.tsx
@@ -149,7 +149,7 @@ const Filter = ({
 
   const [expanded, setExpanded] = React.useState(false);
 
-  const toggleExpanded = () => {
+  const toggleExpanded = (): void => {
     setExpanded(!expanded);
   };
 

--- a/www/front_src/src/Resources/Filter/index.tsx
+++ b/www/front_src/src/Resources/Filter/index.tsx
@@ -147,6 +147,12 @@ const Filter = ({
 }: Props): JSX.Element => {
   const classes = useStyles();
 
+  const [expanded, setExpanded] = React.useState(false);
+
+  const toggleExpanded = () => {
+    setExpanded(!expanded);
+  };
+
   const getHostGroupSearchEndpoint = (searchValue): string => {
     return buildHostGroupsEndpoint({
       limit: 10,
@@ -163,12 +169,6 @@ const Filter = ({
 
   const getOptionsFromResult = ({ result }): Array<SelectEntry> => result;
 
-  const avoidToggleExpansionPanel = (
-    event: React.MouseEvent<HTMLElement>,
-  ): void => {
-    event.stopPropagation();
-  };
-
   const requestSearchOnEnterKey = (event: KeyboardEvent): void => {
     const enterKeyPressed = event.keyCode === 13;
 
@@ -177,13 +177,8 @@ const Filter = ({
     }
   };
 
-  const requestSearch = (event: React.MouseEvent<HTMLElement>): void => {
-    avoidToggleExpansionPanel(event);
-    onSearchRequest();
-  };
-
   return (
-    <ExpansionPanel square>
+    <ExpansionPanel square expanded={expanded}>
       <ExpansionPanelSummary
         expandIcon={
           <ExpandMoreIcon
@@ -191,6 +186,8 @@ const Filter = ({
             aria-label={labelShowCriteriasFilters}
           />
         }
+        IconButtonProps={{ onClick: toggleExpanded }}
+        style={{ cursor: 'default' }}
       >
         <Grid spacing={1} container alignItems="center">
           <Grid item>
@@ -207,7 +204,6 @@ const Filter = ({
                 allFilter,
               ]}
               selectedOptionId={filter.id}
-              onClick={avoidToggleExpansionPanel}
               onChange={onFilterGroupChange}
               aria-label={labelStateFilter}
             />
@@ -217,14 +213,17 @@ const Filter = ({
               className={classes.searchField}
               EndAdornment={SearchHelpTooltip}
               value={nextSearch || ''}
-              onClick={avoidToggleExpansionPanel}
               onChange={onSearchPrepare}
               placeholder={labelResourceName}
               onKeyDown={requestSearchOnEnterKey}
             />
           </Grid>
           <Grid item>
-            <Button variant="contained" color="primary" onClick={requestSearch}>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={onSearchRequest}
+            >
               {labelSearch}
             </Button>
           </Grid>


### PR DESCRIPTION
## Description

toggle events view panel only on icon click

**Fixes** MON-5243

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check that event views filter is toggled only when you click on expand icon