### PR TITLE
MON-5112: fix select2 service templates linked to a servicegroup

### DIFF
--- a/www/class/centreonServicegroups.class.php
+++ b/www/class/centreonServicegroups.class.php
@@ -152,7 +152,8 @@ class CentreonServicegroups
                 $parameters['externalObject']['object'] = 'centreonServicetemplates';
                 $parameters['externalObject']['objectOptions'] = array('withHosttemplate' => true);
                 $parameters['relationObject']['table'] = 'servicegroup_relation';
-                $parameters['relationObject']['field'] = 'service_service_id';
+                $parameters['relationObject']['field'] = 'host_host_id';
+                $parameters['relationObject']['additionalField'] = 'service_service_id';
                 $parameters['relationObject']['comparator'] = 'servicegroup_sg_id';
                 break;
             case 'sg_hgServices':


### PR DESCRIPTION
## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
