### PR TITLE
fix(header): Add missing translations for hosts and services

### DIFF
--- a/www/front_src/src/components/hostMenu/index.js
+++ b/www/front_src/src/components/hostMenu/index.js
@@ -134,7 +134,11 @@ class HostMenu extends Component {
         ref={(host) => (this.host = host)}
       >
         <SubmenuHeader submenuType="top" active={toggled}>
-          <IconHeader iconType="hosts" iconName="Hosts" onClick={this.toggle} />
+          <IconHeader
+            iconType="hosts"
+            iconName={I18n.t('Hosts')}
+            onClick={this.toggle}
+          />
           <Link
             className={classnames(styles.link, styles['wrap-middle-icon'])}
             to="/main.php?p=20202&o=h_down&search="

--- a/www/front_src/src/components/serviceStatusMenu/index.js
+++ b/www/front_src/src/components/serviceStatusMenu/index.js
@@ -140,7 +140,7 @@ class ServiceStatusMenu extends Component {
         <SubmenuHeader submenuType="top" active={toggled}>
           <IconHeader
             iconType="services"
-            iconName="services"
+            iconName={I18n.t('Services')}
             onClick={this.toggle}
           />
           <Link


### PR DESCRIPTION
## Description

Add missing translations for "hosts" and "services"

![image](https://user-images.githubusercontent.com/31647811/79213306-3da29900-7e49-11ea-840b-a7c2aa0a59f9.png)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Change lang of Centreon and check that translations are done for those 2 strings

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
