### PR TITLE
fix(poller): correctly bindValue and define local poller as default

### DIFF
--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -904,7 +904,7 @@ function updateServer(int $id, array $data): void
     $rq .= "`is_default` = ";
     if (isset($data["is_default"]['is_default']) && $data["is_default"]['is_default'] != null) {
         $rq .= ':is_default, ';
-        $retValue[':is_default'] = (int)$data["is_default"]['is_default'];
+        $retValue[':isDefault'] = (int)$data["is_default"]['is_default'];
     } else {
         $rq .= "0, ";
     }

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -1088,7 +1088,7 @@ function defineLocalPollerToDefault()
     $query = "SELECT `is_default` FROM `nagios_server`";
     $result = $pearDB->query($query);
 
-    for ($i = 0; $config = $result->fetch(); $i++) {
+    while ($config = $result->fetch()) {
         $defaultPoller[] = $config['is_default'];
     }
 

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -1092,8 +1092,8 @@ function defineLocalPollerToDefault()
         $defaultPoller[] = $config['is_default'];
     }
 
-    if (!in_array("1",$defaultPoller)) {
-        $query = "UPDATE `nagios_server` SET `is_default` = \"1\" WHERE `localhost` = \"1\"";
+    if (!in_array("1", $defaultPoller)) {
+        $query = "UPDATE `nagios_server` SET `is_default` = '1' WHERE `localhost` = '1'";
         $pearDB->query($query);
     }
 }

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -903,7 +903,7 @@ function updateServer(int $id, array $data): void
     }
     $rq .= "`is_default` = ";
     if (isset($data["is_default"]['is_default']) && $data["is_default"]['is_default'] != null) {
-        $rq .= ':is_default, ';
+        $rq .= ':isDefault, ';
         $retValue[':isDefault'] = (int)$data["is_default"]['is_default'];
     } else {
         $rq .= "0, ";

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -1084,15 +1084,11 @@ REQUEST;
 function defineLocalPollerToDefault() 
 {
     global $pearDB;
-    $defaultPoller = [];
-    $query = "SELECT `is_default` FROM `nagios_server`";
-    $result = $pearDB->query($query);
+    $query = "SELECT COUNT(*) AS `nb_of_default_poller` FROM `nagios_server` WHERE `is_default` = '1'";
+    $statement = $pearDB->query($query);
+    $result = $statement->fetch(\PDO::FETCH_ASSOC);
 
-    while ($config = $result->fetch()) {
-        $defaultPoller[] = $config['is_default'];
-    }
-
-    if (!in_array("1", $defaultPoller)) {
+    if ($result !== false && ((int) $result['nb_of_default_poller'] === 0)) {
         $query = "UPDATE `nagios_server` SET `is_default` = '1' WHERE `localhost` = '1'";
         $pearDB->query($query);
     }

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -902,9 +902,9 @@ function updateServer(int $id, array $data): void
         $rq .= "NULL, ";
     }
     $rq .= "`is_default` = ";
-    if (isset($data["is_default"]) && $data["is_default"] != null) {
+    if (isset($data["is_default"]['is_default']) && $data["is_default"]['is_default'] != null) {
         $rq .= ':is_default, ';
-        $retValue[':is_default'] = (int)$data["is_default"];
+        $retValue[':is_default'] = (int)$data["is_default"]['is_default'];
     } else {
         $rq .= "0, ";
     }
@@ -1074,4 +1074,26 @@ REQUEST;
     }
 
     return false;
+}
+
+/**
+ * Define LocalPoller as Default Poller if there is no Default Poller
+ *
+ * @return void
+ */
+function defineLocalPollerToDefault() 
+{
+    global $pearDB;
+    $defaultPoller = [];
+    $query = "SELECT `is_default` FROM `nagios_server`";
+    $result = $pearDB->query($query);
+
+    for ($i = 0; $config = $result->fetch(); $i++) {
+        $defaultPoller[] = $config['is_default'];
+    }
+
+    if (!in_array("1",$defaultPoller)) {
+        $query = "UPDATE `nagios_server` SET `is_default` = \"1\" WHERE `localhost` = \"1\"";
+        $pearDB->query($query);
+    }
 }

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -427,6 +427,7 @@ if ($form->validate()) {
 }
 
 if ($valid) {
+    defineLocalPollerToDefault();
     require_once($path . "listServers.php");
 } else {
     /*


### PR DESCRIPTION
## Description

This PR fix a bug where multiples Poller could be define as Default Poller.
1 - the value binded while updating has been corrected.
2 - create a new function to handle case where no Pollers was set to Default.

**Fixes** # MON-5260

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Set a configuration with multiples Remote Servers, Distant Pollers. 
- Only one poller should be by default. 
- Set another poller as default , it should be the only as default.
- Set this same poller to Default Poller  "No"
-  Your local poller should be the Default Poller.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
