### PR TITLE
fix(generation): correct broker empty lua parameters generation

### DIFF
--- a/www/class/config-generate/broker.class.php
+++ b/www/class/config-generate/broker.class.php
@@ -281,10 +281,13 @@ class Broker extends AbstractObjectJSON
             }
 
             if ($anomalyDetectionLuaOutputGroupID >= 0) {
-                $object["output"][$anomalyDetectionLuaOutputGroupID]['lua_parameter'] = array_merge_recursive(
-                    $object["output"][$anomalyDetectionLuaOutputGroupID]['lua_parameter'],
-                    $this->generateAnomalyDetectionLuaParameters()
-                );
+                $luaParameters = $this->generateAnomalyDetectionLuaParameters();
+                if (!empty($luaParameters)) {
+                    $object["output"][$anomalyDetectionLuaOutputGroupID]['lua_parameter'] = array_merge_recursive(
+                        $object["output"][$anomalyDetectionLuaOutputGroupID]['lua_parameter'],
+                        $luaParameters
+                    );
+                }
                 $anomalyDetectionLuaOutputGroupID = -1;
             }
 


### PR DESCRIPTION
## Description

Fix Centreon Broker null lua_parameters generation
```
(...)
            {
                "name": "forward-to-anomaly-detection",
                "path": "/usr/share/centreon-broker/lua/centreon-anomaly-detection.lua",
                "type": "lua",
                "lua_parameter": [
                    {
                        "type": "number",
                        "name": "max_queue_size",
                        "value": "100"
                    }
                ]
            },
            {
                "lua_parameter": null
            }
(...)
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
