### PR TITLE
fix(ui): restore pending blue light for host and service

### DIFF
--- a/www/front_src/src/components/hostMenu/index.js
+++ b/www/front_src/src/components/hostMenu/index.js
@@ -138,7 +138,9 @@ class HostMenu extends Component {
             iconType="hosts"
             iconName={I18n.t('Hosts')}
             onClick={this.toggle}
-          />
+          >
+            {data.pending > 0 && <span className={styles['custom-icon']} />}
+          </IconHeader>
           <Link
             className={classnames(styles.link, styles['wrap-middle-icon'])}
             to="/main.php?p=20202&o=h_down&search="

--- a/www/front_src/src/components/serviceStatusMenu/index.js
+++ b/www/front_src/src/components/serviceStatusMenu/index.js
@@ -142,7 +142,9 @@ class ServiceStatusMenu extends Component {
             iconType="services"
             iconName={I18n.t('Services')}
             onClick={this.toggle}
-          />
+          >
+            {data.pending > 0 && <span className={styles['custom-icon']} />}
+          </IconHeader>
           <Link
             className={classnames(styles.link, styles['wrap-middle-icon'])}
             to="/main.php?p=20201&o=svc_unhandled&statusFilter=critical&search="


### PR DESCRIPTION
## Description

The indicator had disappeared from the top counter in the latest version.
This PR is here to restore it.

![image](https://user-images.githubusercontent.com/31647811/79243038-62ad0100-7e75-11ea-8954-778ffe88bb46.png)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Add a passive service/host
- Do not check it yet so that its status stays pending
- The blue lights should be displayed in the top counter next the host/service icon

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
