### PR TITLE
MON-5234: fix unitialized values

### DIFF
--- a/www/api/class/centreon_topcounter.class.php
+++ b/www/api/class/centreon_topcounter.class.php
@@ -474,14 +474,14 @@ class CentreonTopCounter extends CentreonWebService
                 $result['issues']['latency']['warning']['poller'][] = array(
                     'id' => $poller['id'],
                     'name' => $poller['name'],
-                    'since' => $poller['warning']['time']
+                    'since' => $poller['latency']['time']
                 );
                 $latWar++;
             } elseif ($poller['latency']['state'] === 2) {
                 $result['issues']['latency']['critical']['poller'][] = array(
                     'id' => $poller['id'],
                     'name' => $poller['name'],
-                    'since' => $poller['warning']['time']
+                    'since' => $poller['latency']['time']
                 );
                 $latCri++;
             }
@@ -810,7 +810,7 @@ class CentreonTopCounter extends CentreonWebService
         while ($row = $res->fetch()) {
             if ($row['stat_value'] >= 120) {
                 $listPoller[$row['instance_id']]['latency']['state'] = 2;
-                $listPoller[$row['instance_id']]['database']['time'] = $row['stat_value'];
+                $listPoller[$row['instance_id']]['latency']['time'] = $row['stat_value'];
             } elseif ($row['stat_value'] >= 60) {
                 $listPoller[$row['instance_id']]['latency']['state'] = 1;
                 $listPoller[$row['instance_id']]['latency']['time'] = $row['stat_value'];


### PR DESCRIPTION
## Description

Get notice error in centreon-error.log (and also a wrong information in poller top counters)

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

You need to get latency on your pollers and if you connect with an admin, you'll get notices.

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
