### PR TITLE
enh(install): start gorgoned at the end of unattended.sh.

### DIFF
--- a/unattended.sh
+++ b/unattended.sh
@@ -152,7 +152,7 @@ fi
 print_step_begin "Services configuration"
 if [ "x$has_systemd" '=' x1 ] ; then
   systemctl enable httpd24-httpd mariadb rh-php72-php-fpm snmpd snmptrapd gorgoned centreontrapd cbd centengine centreon
-  systemctl restart httpd24-httpd mariadb rh-php72-php-fpm snmpd snmptrapd
+  systemctl restart gorgoned httpd24-httpd mariadb rh-php72-php-fpm snmpd snmptrapd
   print_step_end
 else
   print_step_end "OK, systemd not detected, skipping"


### PR DESCRIPTION
## Description

gorgoned is not started at the end of unattended.sh.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Run unattended.sh. gorgoned should be started at the end of install.

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
