### PR TITLE
MON-3082: cannot generate trap or configuration for non allowed users

### DIFF
--- a/www/include/configuration/configGenerate/formGenerateFiles.php
+++ b/www/include/configuration/configGenerate/formGenerateFiles.php
@@ -37,6 +37,11 @@ if (!isset($centreon)) {
     exit();
 }
 
+if (!$centreon->user->admin && $centreon->user->access->checkAction('generate_cfg') === 0) {
+    require_once _CENTREON_PATH_ . 'www/include/core/errors/alt_error.php';
+    return null;
+}
+
 /*
  *  Get Poller List
  */

--- a/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+++ b/www/include/configuration/configGenerateTraps/formGenerateTraps.php
@@ -37,6 +37,11 @@ if (!isset($centreon)) {
     exit();
 }
 
+if (!$centreon->user->admin && $centreon->user->access->checkAction('generate_trap') === 0) {
+    require_once _CENTREON_PATH_ . 'www/include/core/errors/alt_error.php';
+    return null;
+}
+
 /*
  * Init Centcore Pipe
  */


### PR DESCRIPTION
## Description

Cannot generate trap or configuration for non allowed users.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Use a non admin users and doesn't provide actions to generate traps and config. It cannot generate anymore.

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
