### PR TITLE
fix(ui): Fix column widths for ACK and DT Details tables

### DIFF
--- a/www/front_src/src/Resources/columns/State/DetailsTable/Acknowledgement.tsx
+++ b/www/front_src/src/Resources/columns/State/DetailsTable/Acknowledgement.tsx
@@ -20,7 +20,6 @@ import { getFormattedDateTime } from '../../../dateTime';
 const useStyles = makeStyles({
   comment: {
     display: 'block',
-    maxWidth: 500,
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
@@ -46,12 +45,14 @@ const AcknowledgementDetailsTable = ({ endpoint }: Props): JSX.Element => {
       label: labelAuthor,
       type: TABLE_COLUMN_TYPES.string,
       getContent: ({ author_name }): string => author_name,
+      width: 100,
     },
     {
       id: 'entry_time',
       label: labelEntryTime,
       type: TABLE_COLUMN_TYPES.string,
       getContent: ({ entry_time }): string => getFormattedDateTime(entry_time),
+      width: 150,
     },
     {
       id: 'is_persistent',
@@ -59,18 +60,21 @@ const AcknowledgementDetailsTable = ({ endpoint }: Props): JSX.Element => {
       type: TABLE_COLUMN_TYPES.string,
       getContent: ({ is_persistent_comment }): string =>
         getYesNoLabel(is_persistent_comment),
+      width: 100,
     },
     {
       id: 'is_sticky',
       label: labelSticky,
       type: TABLE_COLUMN_TYPES.string,
       getContent: ({ is_sticky }): string => getYesNoLabel(is_sticky),
+      width: 100,
     },
 
     {
       id: 'comment',
       label: labelComment,
       type: TABLE_COLUMN_TYPES.string,
+      width: 250,
       getContent: ({ comment }: AcknowledgementDetails): JSX.Element => {
         return (
           <span className={classes.comment}>

--- a/www/front_src/src/Resources/columns/State/DetailsTable/Downtime.tsx
+++ b/www/front_src/src/Resources/columns/State/DetailsTable/Downtime.tsx
@@ -22,7 +22,6 @@ import { getFormattedDateTime } from '../../../dateTime';
 const useStyles = makeStyles({
   comment: {
     display: 'block',
-    maxWidth: 500,
     whiteSpace: 'nowrap',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
@@ -48,30 +47,35 @@ const DowntimeDetailsTable = ({ endpoint }: Props): JSX.Element => {
       label: labelAuthor,
       type: TABLE_COLUMN_TYPES.string,
       getContent: ({ author_name }): string => author_name,
+      width: 100,
     },
     {
       id: 'is_fixed',
       label: labelFixed,
       type: TABLE_COLUMN_TYPES.string,
       getContent: ({ is_fixed }): string => (is_fixed ? labelYes : labelNo),
+      width: 100,
     },
     {
       id: 'start_time',
       label: labelStartTime,
       type: TABLE_COLUMN_TYPES.string,
       getContent: ({ start_time }): string => getFormattedDateTime(start_time),
+      width: 150,
     },
     {
       id: 'end_time',
       label: labelEndTime,
       type: TABLE_COLUMN_TYPES.string,
       getContent: ({ end_time }): string => getFormattedDateTime(end_time),
+      width: 150,
     },
 
     {
       id: 'comment',
       label: labelComment,
       type: TABLE_COLUMN_TYPES.string,
+      width: 250,
       getContent: ({ comment }: DowntimeDetails): JSX.Element => {
         return (
           <span className={classes.comment}>

--- a/www/front_src/src/Resources/columns/State/DetailsTable/index.tsx
+++ b/www/front_src/src/Resources/columns/State/DetailsTable/index.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect } from 'react';
 
+import { map, prop, sum, pipe } from 'ramda';
+
 import {
   TableContainer,
   TableRow,
@@ -24,8 +26,6 @@ import { Listing } from '../../../models';
 import { Column } from '../..';
 
 const getYesNoLabel = (value): string => (value ? labelYes : labelNo);
-
-const columnMaxWidth = 150;
 
 interface DetailsTableColumn extends Column {
   getContent: (details) => string | JSX.Element;
@@ -60,7 +60,7 @@ const DetailsTable = <TDetails extends unknown>({
   const error = details === null;
   const success = !loading && !error;
 
-  const tableMaxWidth = columns.length * columnMaxWidth;
+  const tableMaxWidth = pipe(map(prop('width')), sum)(columns);
 
   return (
     <TableContainer component={Paper}>
@@ -83,8 +83,8 @@ const DetailsTable = <TDetails extends unknown>({
           {success &&
             details?.map((detail, index) => (
               <TableRow key={index}>
-                {columns.map(({ label, getContent }) => (
-                  <TableCell key={label}>
+                {columns.map(({ label, getContent, width }) => (
+                  <TableCell key={label} style={{ maxWidth: width }}>
                     <span>{getContent?.(detail)}</span>
                   </TableCell>
                 ))}


### PR DESCRIPTION

![Screenshot from 2020-04-15 15-17-41](https://user-images.githubusercontent.com/8367233/79342526-8b90cd00-7f2d-11ea-9aa3-056b793c3f93.png)
![Screenshot from 2020-04-15 15-17-48](https://user-images.githubusercontent.com/8367233/79342533-8c296380-7f2d-11ea-9cff-7f46f04a7909.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)
