### PR TITLE
chore(npm): Update package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6482,9 +6482,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.407",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.407.tgz",
-      "integrity": "sha512-ayDQgkwCLHq0AVmsU10t2H/8X9lq3nb1CRV9rWYsc2nTTbFMvh4Aaau48Ao0iW/L+Q8Y9bgbJ5iHyPse7DGMJw=="
+      "version": "1.3.408",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.408.tgz",
+      "integrity": "sha512-vn1zWIxIdyl0MR72lr81/7kHYTRlDRjJT4ocp8dtb85VhH46J3lNqDMEBljAKPKgguqjK0+WAbf3IL6ZKw72kQ=="
     },
     "elliptic": {
       "version": "6.5.2",


### PR DESCRIPTION
## Description
This updates centreon-ui, in order to remove the TopFilter white background. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)