### PR TITLE
enh(upgrade): externalize release note documentation during upgrade

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3269,6 +3269,19 @@ msgstr "Se recomienda encarecidamente realizar una copia de seguridad de sus bas
 msgid "Release notes"
 msgstr "Notas de lanzamiento"
 
+#: centreon-web/www/install/step_upgrade/step3.php:46
+msgid "Everything is ready !"
+msgstr "Todo está listo !"
+
+#: centreon-web/www/install/step_upgrade/step3.php:46
+msgid "Your Centreon Platform is about to be upgraded from version "
+msgstr "Su plataforma Centreon está a punto de ser actualizada de la versión "
+
+#: centreon-web/www/install/step_upgrade/step3.php:46
+msgid "For further details on changes, please find the complete changelog on "
+msgstr "Para más detalles sobre los cambios, por favor encuentre el registro completo de cambios en "
+
+
 #: centreon-web/www/install/step_upgrade/step5.php:44
 msgid "Upgrade finished"
 msgstr "Actualización completada"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3532,6 +3532,18 @@ msgstr ""
 msgid "Release notes"
 msgstr "Notes de version"
 
+#: centreon-web/www/install/step_upgrade/step3.php:46
+msgid "Everything is ready !"
+msgstr "Tout est prêts !"
+
+#: centreon-web/www/install/step_upgrade/step3.php:46
+msgid "Your Centreon Platform is about to be upgraded from version "
+msgstr "Votre plateforme Centreon va être mise à jour de la version "
+
+#: centreon-web/www/install/step_upgrade/step3.php:46
+msgid "For further details on changes, please find the complete changelog on "
+msgstr "Pour plus d'informations, consultez les notes de version sur "
+
 #: centreon-web/www/install/step_upgrade/step5.php:44
 msgid "Upgrade finished"
 msgstr "Mise à jour terminée"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3534,7 +3534,7 @@ msgstr "Notes de version"
 
 #: centreon-web/www/install/step_upgrade/step3.php:46
 msgid "Everything is ready !"
-msgstr "Tout est prêts !"
+msgstr "Tout est prêt !"
 
 #: centreon-web/www/install/step_upgrade/step3.php:46
 msgid "Your Centreon Platform is about to be upgraded from version "

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -11970,6 +11970,18 @@ msgstr "Ficheiro de configuração não encontrado."
 msgid "Release notes"
 msgstr "Notas de lançamento"
 
+#: centreon-web/www/install/step_upgrade/step3.php:46
+msgid "Everything is ready !"
+msgstr "Está tudo pronto !"
+
+#: centreon-web/www/install/step_upgrade/step3.php:46
+msgid "Your Centreon Platform is about to be upgraded from version "
+msgstr "A sua plataforma Centreon está prestes a ser atualizada a partir da versão "
+
+#: centreon-web/www/install/step_upgrade/step3.php:46
+msgid "For further details on changes, please find the complete changelog on "
+msgstr "Para mais informações sobre as alterações, consulte o changelog completo sobre "
+
 #: centreon-web/www/install/step_upgrade/step4.php:56
 #: centreon-web/src/CentreonLegacy/Core/Install/Step/Step7.php:48
 msgid "Installation"

--- a/www/install/step_upgrade/step3.php
+++ b/www/install/step_upgrade/step3.php
@@ -43,17 +43,47 @@ $_SESSION['step'] = STEP_NUMBER;
 require_once '../steps/functions.php';
 $template = getTemplate('templates');
 
+require_once realpath(dirname(__FILE__) . "/../../../config/centreon.config.php");
+include_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
+
 $title = _('Release notes');
 
-if (is_file('../RELEASENOTES.html')) {
-    $contents = "<div id='releasenotes'></div>";
-} else {
-    $releasenotesContent = '';
-    if (file_exists('../RELEASENOTES')) {
-        $releasenotesContent = file_get_contents('../RELEASENOTES');
+$db = new CentreonDB();
+$res = $db->query("SELECT `value` FROM `informations` WHERE `key` = 'version'");
+$row = $res->fetchRow();
+$current = $row['value'];
+
+$_SESSION['CURRENT_VERSION'] = $current;
+
+/*
+** To find the final version that we should update to, we will look in
+** the www/install/php directory where all PHP update scripts are
+** stored. We will extract the target version from the filename and find
+** the farthest version to the current version.
+*/
+$next = '';
+if ($handle = opendir('../php')) {
+    while (false !== ($file = readdir($handle))) {
+        if (preg_match('/Update-([a-zA-Z0-9\-\.]+)\.php/', $file, $matches)) {
+            if ((version_compare($current, $matches[1]) < 0) &&
+                (empty($next) || (version_compare($next, $matches[1]) < 0))) {
+                $next = $matches[1];
+            }
+        }
     }
-    $contents = "<textarea cols='100' rows='30' readonly>" . $releasenotesContent . "</textarea>";
+    closedir($handle);
 }
+
+$majors = explode('.', $next);
+
+$releaseNoteLink = "https://documentation.centreon.com/" . $majors[0] . '.' . $majors[1] . '/en/releases/centreon-core.md';
+
+$title = _('Release notes');
+
+$contents = '<p><b>' . _('Everything is ready !') . '</b></p>';
+$contents .= '<p>' . _('Your Centreon Platform is about to be upgraded from version') . $current . _(' to ') . $next . '</p>';
+$contents .= '<p>' . _('For further details on changes, please find the complete changelog on ');
+$contents .= '<a href="' . $releaseNoteLink . '"target="_blank" style="text-decoration:underline;font-size:11px">documentation.centreon.com</a></p>';
 
 $template->assign('step', STEP_NUMBER);
 $template->assign('title', $title);
@@ -62,36 +92,10 @@ $template->assign('blockPreview', 1);
 $template->display('content.tpl');
 ?>
 <script type='text/javascript'>
-    var step3_s = 10;
+    var step3_s = 3;
     var step3_t;
 
     jQuery(function () {
-        jQuery('#releasenotes').load('RELEASENOTES.html', function() {
-            /* add accordion class to all div matching centreon-web-* id */
-            jQuery('div[id^="centreon-web-"]').addClass('accordion');
-
-            var acc = document.getElementsByClassName("accordion");
-            var i;
-
-            for (i = 0; i < acc.length; i++) {
-              acc[i].addEventListener("click", function() {
-                /* Toggle between adding and removing the "active" class,
-                to highlight the button that controls the panel */
-                this.classList.toggle("active");
-
-                /* Toggle between hiding and showing the active panel */
-                var panels = this.getElementsByClassName("section");
-                var j;
-                for (j = 0; j < panels.length; j++) {
-                    if (panels[j].style.display === "block") {
-                        panels[j].style.display = "none";
-                    } else {
-                        panels[j].style.display = "block";
-                    }
-                }
-              });
-            }
-        });
         jQuery('#next').attr('disabled', 'disabled');
         timeout_button();
     });

--- a/www/install/step_upgrade/step3.php
+++ b/www/install/step_upgrade/step3.php
@@ -44,7 +44,7 @@ require_once '../steps/functions.php';
 $template = getTemplate('templates');
 
 require_once __DIR__ . "/../../../config/centreon.config.php";
-include_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
+require_once __DIR__ . "/../../class/centreonDB.class.php";
 
 $title = _('Release notes');
 

--- a/www/install/step_upgrade/step3.php
+++ b/www/install/step_upgrade/step3.php
@@ -74,14 +74,14 @@ if ($handle = opendir('../php')) {
     closedir($handle);
 }
 
-$majors = explode('.', $next);
+$majors = preg_match('/^(\d+\.\d+)/', $next, $matches);
 
-$releaseNoteLink = "https://documentation.centreon.com/" . $majors[0] . '.' . $majors[1] . '/en/releases/centreon-core.md';
+$releaseNoteLink = "https://documentation.centreon.com/" . $matches[1] . '/en/releases/centreon-core.md';
 
 $title = _('Release notes');
 
 $contents = '<p><b>' . _('Everything is ready !') . '</b></p>';
-$contents .= '<p>' . _('Your Centreon Platform is about to be upgraded from version') . $current . _(' to ') . $next . '</p>';
+$contents .= '<p>' . _('Your Centreon Platform is about to be upgraded from version ') . $current . _(' to ') . $next . '</p>';
 $contents .= '<p>' . _('For further details on changes, please find the complete changelog on ');
 $contents .= '<a href="' . $releaseNoteLink . '"target="_blank" style="text-decoration:underline;font-size:11px">documentation.centreon.com</a></p>';
 

--- a/www/install/step_upgrade/step3.php
+++ b/www/install/step_upgrade/step3.php
@@ -43,7 +43,7 @@ $_SESSION['step'] = STEP_NUMBER;
 require_once '../steps/functions.php';
 $template = getTemplate('templates');
 
-require_once realpath(dirname(__FILE__) . "/../../../config/centreon.config.php");
+require_once __DIR__ . "/../../../config/centreon.config.php";
 include_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
 
 $title = _('Release notes');

--- a/www/install/step_upgrade/step4.php
+++ b/www/install/step_upgrade/step4.php
@@ -40,21 +40,14 @@ session_start();
 define('STEP_NUMBER', 4);
 
 $_SESSION['step'] = STEP_NUMBER;
-require_once realpath(dirname(__FILE__) . "/../../../config/centreon.config.php");
 require_once '../steps/functions.php';
 $template = getTemplate('templates');
-
-include_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
 
 /*
 ** Get and check initial Centreon version.
 ** Should be >= 2.8.0-beta1.
 */
-$db = new CentreonDB();
-$res = $db->query("SELECT `value` FROM `informations` WHERE `key` = 'version'");
-$row = $res->fetchRow();
-$current = $row['value'];
-$_SESSION['CURRENT_VERSION'] = $current;
+$current = $_SESSION['CURRENT_VERSION'];
 if (version_compare($current, '2.8.0-beta1') < 0) {
     $troubleshootTxt1 = _('Upgrade to this release requires Centreon >= 2.8.0-beta1.');
     $troubleshootTxt2 = sprintf(_('Your current version is %s.'), $current);


### PR DESCRIPTION
## Description

During the upgrade process we will now use the release notes that will be written in the new documentation.

The timeout on the button has been also dicreased from 10s to 3s

**Before**
![from](https://user-images.githubusercontent.com/31647811/79451110-4c728280-7fe6-11ea-9e0e-786e84d7f951.png)

**After**
![to](https://user-images.githubusercontent.com/31647811/79451111-4d0b1900-7fe6-11ea-9361-fe03be1ca8d8.png)


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Upgrade to latest 20.04.x from 19.10.x for example
* New step 3 should be displayed
