### PR TITLE
fix(ui): Remove legacy pages bottom margin

### DIFF
--- a/www/front_src/src/route-components/legacyRoute/index.js
+++ b/www/front_src/src/route-components/legacyRoute/index.js
@@ -32,7 +32,7 @@ class LegacyRoute extends Component {
         if (clientHeight !== contentHeight) {
           this.setState({
             loading: false,
-            contentHeight: clientHeight - 30,
+            contentHeight: clientHeight,
           });
         }
       }, 200);


### PR DESCRIPTION
## Description
Since the footer has not a fixed position anymore, the manual margin added to the legacy page creates a gap at the bottom and needs to be removed. 

**Before the change**:
![Screenshot from 2020-04-16 14-19-16](https://user-images.githubusercontent.com/8367233/79455663-8430f880-7fed-11ea-9179-e01b19e35cb5.png)

**After the change**
![Screenshot from 2020-04-16 14-19-33](https://user-images.githubusercontent.com/8367233/79455694-8a26d980-7fed-11ea-87c0-1f26830c1c6d.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)
