### PR TITLE
fix(topcounter): remove warning from the top counter api

### DIFF
--- a/www/api/class/centreon_topcounter.class.php
+++ b/www/api/class/centreon_topcounter.class.php
@@ -474,14 +474,14 @@ class CentreonTopCounter extends CentreonWebService
                 $result['issues']['latency']['warning']['poller'][] = array(
                     'id' => $poller['id'],
                     'name' => $poller['name'],
-                    'since' => $poller['warning']['time']
+                    'since' => $poller['latency']['time']
                 );
                 $latWar++;
             } elseif ($poller['latency']['state'] === 2) {
                 $result['issues']['latency']['critical']['poller'][] = array(
                     'id' => $poller['id'],
                     'name' => $poller['name'],
-                    'since' => $poller['warning']['time']
+                    'since' => $poller['latency']['time']
                 );
                 $latCri++;
             }


### PR DESCRIPTION
## Description

When latency is detected on a poller the RED icon appears in the top counter. But one information relies on a field that does not exist which prints out a lot of logs (1 / refresh time data)

```
[16-Apr-2020 18:17:32 Europe/Paris] PHP Notice:  Undefined index: warning in /usr/share/centreon/www/api/class/centreon_topcounter.class.php on line 484
[16-Apr-2020 18:17:47 Europe/Paris] PHP Notice:  Undefined index: warning in /usr/share/centreon/www/api/class/centreon_topcounter.class.php on line 484
[16-Apr-2020 18:18:02 Europe/Paris] PHP Notice:  Undefined index: warning in /usr/share/centreon/www/api/class/centreon_topcounter.class.php on line 484
[16-Apr-2020 18:18:17 Europe/Paris] PHP Notice:  Undefined index: warning in /usr/share/centreon/www/api/class/centreon_topcounter.class.php on line 484
[16-Apr-2020 18:18:32 Europe/Paris] PHP Notice:  Undefined index: warning in /usr/share/centreon/www/api/class/centreon_topcounter.class.php on line 484
[16-Apr-2020 18:18:47 Europe/Paris] PHP Notice:  Undefined index: warning in /usr/share/centreon/www/api/class/centreon_topcounter.class.php on line 484
[16-Apr-2020 18:19:02 Europe/Paris] PHP Notice:  Undefined index: warning in /usr/share/centreon/www/api/class/centreon_topcounter.class.php on line 484
[16-Apr-2020 18:19:17 Europe/Paris] PHP Notice:  Undefined index: warning in /usr/share/centreon/www/api/class/centreon_topcounter.class.php on line 484
[16-Apr-2020 18:19:32 Europe/Paris] PHP Notice:  Undefined index: warning in /usr/share/centreon/www/api/class/centreon_topcounter.class.php on line 484
[16-Apr-2020 18:19:47 Europe/Paris] PHP Notice:  Undefined index: warning in /usr/share/centreon/www/api/class/centreon_topcounter.class.php on line 484
```

Here is what the poller object looks like

```
(
    [id] => 1
    [name] => Central
    [stability] => 0
    [database] => Array
        (
            [state] => 0
            [time] => 128679741.258
        )

    [latency] => Array
        (
            [state] => 2
            [time] => 
        )

)

```

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create some latency on the Central server to get the red icon
- Check that there is no more warning printed in the php logs

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
