### PR TITLE
fix(upgrade): fix PHP warning on step4

### DIFF
--- a/www/install/step_upgrade/step4.php
+++ b/www/install/step_upgrade/step4.php
@@ -41,6 +41,7 @@ define('STEP_NUMBER', 4);
 
 $_SESSION['step'] = STEP_NUMBER;
 require_once '../steps/functions.php';
+require_once __DIR__ . "/../../../config/centreon.config.php";
 $template = getTemplate('templates');
 
 /*


### PR DESCRIPTION
## Description

Fix PHP warning on step4 upgrade

```
[16-Apr-2020 23:41:10 Europe/Paris] PHP Warning: Use of undefined constant _CENTREON_PATH_ - assumed '_CENTREON_PATH_' (this will throw an Error in a future version of PHP) in /usr/share/centreon/www/install/step_upgrade/step4.php on line 84
```

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Upgrade from version x to 20.04.0
- No PHP warning should be printed for step4 in the logs

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
