### PR TITLE
fix(upgrade): use the final URL for the release notes

### DIFF
--- a/www/install/step_upgrade/step3.php
+++ b/www/install/step_upgrade/step3.php
@@ -76,7 +76,7 @@ if ($handle = opendir('../php')) {
 
 $majors = preg_match('/^(\d+\.\d+)/', $next, $matches);
 
-$releaseNoteLink = "https://documentation.centreon.com/" . $matches[1] . '/en/releases/centreon-core.md';
+$releaseNoteLink = "https://documentation.centreon.com/" . $matches[1] . '/en/releases/centreon-core.html';
 
 $title = _('Release notes');
 


### PR DESCRIPTION
## Description

Final URL to release note updated

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Upgrade from 19.10.x to 20.04.0
- Step 3 of the upgrade should display a new message with a link to the release note on the new documentation

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
