### PR TITLE
enh(poller): Adding a notification method in case of configuration change

### DIFF
--- a/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
+++ b/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
@@ -52,4 +52,12 @@ interface MonitoringServerRepositoryInterface
      * @throws \Exception
      */
     public function findLocalServer(): ?MonitoringServer;
+
+    /**
+     * We notify that the configuration has changed.
+     *
+     * @param MonitoringServer $monitoringServer Monitoring server to notify
+     * @throws \Exception
+     */
+    public function notifyConfigurationChanged(MonitoringServer $monitoringServer): void;
 }

--- a/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerServiceInterface.php
+++ b/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerServiceInterface.php
@@ -55,4 +55,12 @@ interface MonitoringServerServiceInterface
      * @throws MonitoringServerException
      */
     public function findLocalServer(): ?MonitoringServer;
+
+    /**
+     * We notify that the configuration has changed.
+     *
+     * @param MonitoringServer $monitoringServer Monitoring server to notify
+     * @throws MonitoringServerException
+     */
+    public function notifyConfigurationChanged(MonitoringServer $monitoringServer): void;
 }

--- a/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
+++ b/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
@@ -81,4 +81,21 @@ class MonitoringServerService implements MonitoringServerServiceInterface
             throw new MonitoringServerException('Error when searching for the local monitoring servers', 0, $ex);
         }
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function notifyConfigurationChanged(MonitoringServer $monitoringServer): void
+    {
+        if ($monitoringServer->getId() === null && $monitoringServer->getName() === null) {
+            throw new MonitoringServerException(
+                'The id or name of the monitoring server must be defined and not null'
+            );
+        }
+        try {
+            $this->monitoringServerRepository->notifyConfigurationChanged($monitoringServer);
+        } catch (\Exception $ex) {
+            throw new MonitoringServerException('Error when notifying a configuration change', 0, $ex);
+        }
+    }
 }

--- a/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
@@ -173,4 +173,26 @@ class MonitoringServerRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
         return null;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function notifyConfigurationChanged(MonitoringServer $monitoringServer): void
+    {
+        if ($monitoringServer->getId() !== null) {
+            $request = $this->translateDbName(
+                'UPDATE `:db`.nagios_server SET updated = "1" WHERE id = :server_id'
+            );
+            $statement = $this->db->prepare($request);
+            $statement->bindValue(':server_id', $monitoringServer->getId(), \PDO::PARAM_INT);
+            $statement->execute();
+        } elseif ($monitoringServer->getName() !== null) {
+            $request = $this->translateDbName(
+                'UPDATE `:db`.nagios_server SET updated = "1" WHERE name = :server_name'
+            );
+            $statement = $this->db->prepare($request);
+            $statement->bindValue(':server_name', $monitoringServer->getName(), \PDO::PARAM_STR);
+            $statement->execute();
+        }
+    }
 }


### PR DESCRIPTION
## Description

Adding a notification method in case of configuration change

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)


## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
