### PR TITLE
fix(acl): fix default page when user cannot access to it

### DIFF
--- a/www/include/core/header/header.php
+++ b/www/include/core/header/header.php
@@ -152,7 +152,7 @@ if (!$p) {
 
     if ($rootMenu && $rootMenu['topology_url'] && $rootMenu['is_react']) {
         header("Location: .{$rootMenu['topology_url']}");
-    } elseif ($root_menu) {
+    } elseif ($rootMenu) {
         $p = $rootMenu["topology_page"];
         $tab = preg_split("/\=/", $rootMenu["topology_url_opt"]);
 


### PR DESCRIPTION
## Description

fix default page after login when non admin user is not allowed to access to it

**Fixes** MON-5329

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)