### PR TITLE
chore(dev): Setup webpack-dev-server with HMR

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   extends: '@centreon/frontend-core/babel/typescript',
+  plugins: ['react-hot-loader/babel'],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1324,6 +1324,28 @@
         "@hapi/hoek": "^8.3.0"
       }
     },
+    "@hot-loader/react-dom": {
+      "version": "16.13.0",
+      "resolved": "https://registry.npmjs.org/@hot-loader/react-dom/-/react-dom-16.13.0.tgz",
+      "integrity": "sha512-lJZrmkucz2MrQJTQtJobx5MICXcfQvKihszqv655p557HPi0hMOWxrNpiHv3DWD8ugNWjtWcVWqRnFvwsHq1mQ==",
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.0"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -6323,6 +6345,12 @@
         "entities": "^2.0.0"
       }
     },
+    "dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
+      "dev": true
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
@@ -6482,9 +6510,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.410",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.410.tgz",
-      "integrity": "sha512-DbCBdwtARI0l3e3m6ZIxVaTNahb6dSsmGjuag/twiVcWuM4MSpL5IfsJsJSyqLqxosE/m0CXlZaBmxegQW/dAg=="
+      "version": "1.3.411",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.411.tgz",
+      "integrity": "sha512-TDDfkuSYEbknN0kRPSAD8WzB452pJ6EmIxGbI9yQHkDxUNbD6Educ10DxyA9r/DuLL4z255IO1OZIw+eFK6XUw=="
     },
     "elliptic": {
       "version": "6.5.2",
@@ -7131,11 +7159,11 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
     },
     "esquery": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.0.tgz",
-      "integrity": "sha512-/5qB+Mb0m2bh86tjGbA8pB0qBfdmCIK6ZNPjcw4/TtEH0+tTf0wLA5HK4KMTweSMwLGHwBDWCBV+6+2+EuHmgg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
       "requires": {
-        "estraverse": "^5.0.0"
+        "estraverse": "^5.1.0"
       },
       "dependencies": {
         "estraverse": {
@@ -8100,6 +8128,16 @@
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
       "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
     },
+    "global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "dev": true,
+      "requires": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
     "global-modules": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
@@ -8487,6 +8525,14 @@
         "html-dom-parser": "0.2.3",
         "react-property": "1.0.1",
         "style-to-object": "0.3.0"
+      }
+    },
+    "html-webpack-harddisk-plugin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/html-webpack-harddisk-plugin/-/html-webpack-harddisk-plugin-1.0.1.tgz",
+      "integrity": "sha512-GWfutTqfxOe53qEKocqAFrrLVP/EJbmJZDAS5jBBmALkfyc2aakoQkSgo3fitYJORWcN0Fi8ekuySxfffhhRYw==",
+      "requires": {
+        "mkdirp": "^0.5.1"
       }
     },
     "html-webpack-plugin": {
@@ -10585,9 +10631,9 @@
           }
         },
         "yargs-parser": {
-          "version": "18.1.2",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
-          "integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
             "camelcase": "^5.0.0",
@@ -12905,6 +12951,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
+      "dev": true,
+      "requires": {
+        "dom-walk": "^0.1.0"
+      }
     },
     "min-indent": {
       "version": "1.0.0",
@@ -15750,6 +15805,30 @@
       "resolved": "https://registry.npmjs.org/react-fullscreen-crossbrowser/-/react-fullscreen-crossbrowser-1.0.9.tgz",
       "integrity": "sha512-O8OqVca/i3pZWlBT5bnNJ55SYhTOsdwlXu0ZUi514ZrzbQKhUpz0ux1sh++1caEd2rtGP2OXCTwjj/0DfNi1+w=="
     },
+    "react-hot-loader": {
+      "version": "4.12.20",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.12.20.tgz",
+      "integrity": "sha512-lPlv1HVizi0lsi+UFACBJaydtRYILWkfHAC/lyCs6ZlAxlOZRQIfYHDqiGaRvL/GF7zyti+Qn9XpnDAUvdFA4A==",
+      "dev": true,
+      "requires": {
+        "fast-levenshtein": "^2.0.6",
+        "global": "^4.3.0",
+        "hoist-non-react-statics": "^3.3.0",
+        "loader-utils": "^1.1.0",
+        "prop-types": "^15.6.1",
+        "react-lifecycles-compat": "^3.0.4",
+        "shallowequal": "^1.1.0",
+        "source-map": "^0.7.3"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.7.3",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
+          "dev": true
+        }
+      }
+    },
     "react-i18nify": {
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/react-i18nify/-/react-i18nify-1.11.18.tgz",
@@ -17457,6 +17536,12 @@
           "integrity": "sha1-f+3fLctu23fRHvHRF6tf/fCrG2U="
         }
       }
+    },
+    "shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -19300,494 +19385,491 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
+          }
+        },
+        "fsevents": {
+          "version": "1.2.12",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+          "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1",
+            "node-pre-gyp": "*"
           },
           "dependencies": {
-            "fsevents": {
-              "version": "1.2.12",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
-              "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
               "optional": true,
               "requires": {
-                "nan": "^2.12.1",
-                "node-pre-gyp": "*"
-              },
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "aproba": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "are-we-there-yet": {
-                  "version": "1.1.5",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "delegates": "^1.0.0",
-                    "readable-stream": "^2.0.6"
-                  }
-                },
-                "balanced-match": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  }
-                },
-                "chownr": {
-                  "version": "1.1.4",
-                  "bundled": true,
-                  "optional": true
-                },
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "debug": {
-                  "version": "3.2.6",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "ms": "^2.1.1"
-                  }
-                },
-                "deep-extend": {
-                  "version": "0.6.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "delegates": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "detect-libc": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "optional": true
-                },
-                "fs-minipass": {
-                  "version": "1.2.7",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "minipass": "^2.6.0"
-                  }
-                },
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "gauge": {
-                  "version": "2.7.4",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "aproba": "^1.0.3",
-                    "console-control-strings": "^1.0.0",
-                    "has-unicode": "^2.0.0",
-                    "object-assign": "^4.1.0",
-                    "signal-exit": "^3.0.0",
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "wide-align": "^1.1.0"
-                  }
-                },
-                "glob": {
-                  "version": "7.1.6",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "fs.realpath": "^1.0.0",
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "^3.0.4",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
-                  }
-                },
-                "has-unicode": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "iconv-lite": {
-                  "version": "0.4.24",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "safer-buffer": ">= 2.1.2 < 3"
-                  }
-                },
-                "ignore-walk": {
-                  "version": "3.0.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "minimatch": "^3.0.4"
-                  }
-                },
-                "inflight": {
-                  "version": "1.0.6",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "once": "^1.3.0",
-                    "wrappy": "1"
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.4",
-                  "bundled": true,
-                  "optional": true
-                },
-                "ini": {
-                  "version": "1.3.5",
-                  "bundled": true,
-                  "optional": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  }
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  }
-                },
-                "minimist": {
-                  "version": "1.2.5",
-                  "bundled": true,
-                  "optional": true
-                },
-                "minipass": {
-                  "version": "2.9.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "safe-buffer": "^5.1.2",
-                    "yallist": "^3.0.0"
-                  }
-                },
-                "minizlib": {
-                  "version": "1.3.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "minipass": "^2.9.0"
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "minimist": "^1.2.5"
-                  }
-                },
-                "ms": {
-                  "version": "2.1.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "needle": {
-                  "version": "2.3.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "debug": "^3.2.6",
-                    "iconv-lite": "^0.4.4",
-                    "sax": "^1.2.4"
-                  }
-                },
-                "node-pre-gyp": {
-                  "version": "0.14.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "detect-libc": "^1.0.2",
-                    "mkdirp": "^0.5.1",
-                    "needle": "^2.2.1",
-                    "nopt": "^4.0.1",
-                    "npm-packlist": "^1.1.6",
-                    "npmlog": "^4.0.2",
-                    "rc": "^1.2.7",
-                    "rimraf": "^2.6.1",
-                    "semver": "^5.3.0",
-                    "tar": "^4.4.2"
-                  }
-                },
-                "nopt": {
-                  "version": "4.0.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "abbrev": "1",
-                    "osenv": "^0.1.4"
-                  }
-                },
-                "npm-bundled": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "npm-normalize-package-bin": "^1.0.1"
-                  }
-                },
-                "npm-normalize-package-bin": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "npm-packlist": {
-                  "version": "1.4.8",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "ignore-walk": "^3.0.1",
-                    "npm-bundled": "^1.0.1",
-                    "npm-normalize-package-bin": "^1.0.1"
-                  }
-                },
-                "npmlog": {
-                  "version": "4.1.2",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "are-we-there-yet": "~1.1.2",
-                    "console-control-strings": "~1.1.0",
-                    "gauge": "~2.7.3",
-                    "set-blocking": "~2.0.0"
-                  }
-                },
-                "number-is-nan": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "wrappy": "1"
-                  }
-                },
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "osenv": {
-                  "version": "0.1.5",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "os-homedir": "^1.0.0",
-                    "os-tmpdir": "^1.0.0"
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "process-nextick-args": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "rc": {
-                  "version": "1.2.8",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "deep-extend": "^0.6.0",
-                    "ini": "~1.3.0",
-                    "minimist": "^1.2.0",
-                    "strip-json-comments": "~2.0.1"
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.3.7",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "rimraf": {
-                  "version": "2.7.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "glob": "^7.1.3"
-                  }
-                },
-                "safe-buffer": {
-                  "version": "5.1.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "safer-buffer": {
-                  "version": "2.1.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "sax": {
-                  "version": "1.2.4",
-                  "bundled": true,
-                  "optional": true
-                },
-                "semver": {
-                  "version": "5.7.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  }
-                },
-                "strip-json-comments": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "tar": {
-                  "version": "4.4.13",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "chownr": "^1.1.1",
-                    "fs-minipass": "^1.2.5",
-                    "minipass": "^2.8.6",
-                    "minizlib": "^1.2.1",
-                    "mkdirp": "^0.5.0",
-                    "safe-buffer": "^5.1.2",
-                    "yallist": "^3.0.3"
-                  }
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "wide-align": {
-                  "version": "1.1.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "string-width": "^1.0.2 || 2"
-                  }
-                },
-                "wrappy": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "yallist": {
-                  "version": "3.1.1",
-                  "bundled": true,
-                  "optional": true
-                }
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
               }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "3.2.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.6.0"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.3.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.9.0"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.3.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^3.2.6",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.14.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4.4.2"
+              }
+            },
+            "nopt": {
+              "version": "4.0.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npm-normalize-package-bin": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1",
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.7.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.1",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.13",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.8.6",
+                "minizlib": "^1.2.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.3"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "bundled": true,
+              "optional": true
             }
           }
         },
-        "fsevents": {},
         "glob-parent": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
@@ -20436,491 +20518,6 @@
             "path-is-absolute": "^1.0.0",
             "readdirp": "^2.2.1",
             "upath": "^1.1.1"
-          },
-          "dependencies": {
-            "fsevents": {
-              "version": "1.2.12",
-              "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
-              "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
-              "optional": true,
-              "requires": {
-                "nan": "^2.12.1",
-                "node-pre-gyp": "*"
-              },
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "aproba": {
-                  "version": "1.2.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "are-we-there-yet": {
-                  "version": "1.1.5",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "delegates": "^1.0.0",
-                    "readable-stream": "^2.0.6"
-                  }
-                },
-                "balanced-match": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  }
-                },
-                "chownr": {
-                  "version": "1.1.4",
-                  "bundled": true,
-                  "optional": true
-                },
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "console-control-strings": {
-                  "version": "1.1.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "debug": {
-                  "version": "3.2.6",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "ms": "^2.1.1"
-                  }
-                },
-                "deep-extend": {
-                  "version": "0.6.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "delegates": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "detect-libc": {
-                  "version": "1.0.3",
-                  "bundled": true,
-                  "optional": true
-                },
-                "fs-minipass": {
-                  "version": "1.2.7",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "minipass": "^2.6.0"
-                  }
-                },
-                "fs.realpath": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "gauge": {
-                  "version": "2.7.4",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "aproba": "^1.0.3",
-                    "console-control-strings": "^1.0.0",
-                    "has-unicode": "^2.0.0",
-                    "object-assign": "^4.1.0",
-                    "signal-exit": "^3.0.0",
-                    "string-width": "^1.0.1",
-                    "strip-ansi": "^3.0.1",
-                    "wide-align": "^1.1.0"
-                  }
-                },
-                "glob": {
-                  "version": "7.1.6",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "fs.realpath": "^1.0.0",
-                    "inflight": "^1.0.4",
-                    "inherits": "2",
-                    "minimatch": "^3.0.4",
-                    "once": "^1.3.0",
-                    "path-is-absolute": "^1.0.0"
-                  }
-                },
-                "has-unicode": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "iconv-lite": {
-                  "version": "0.4.24",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "safer-buffer": ">= 2.1.2 < 3"
-                  }
-                },
-                "ignore-walk": {
-                  "version": "3.0.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "minimatch": "^3.0.4"
-                  }
-                },
-                "inflight": {
-                  "version": "1.0.6",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "once": "^1.3.0",
-                    "wrappy": "1"
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.4",
-                  "bundled": true,
-                  "optional": true
-                },
-                "ini": {
-                  "version": "1.3.5",
-                  "bundled": true,
-                  "optional": true
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "number-is-nan": "^1.0.0"
-                  }
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "minimatch": {
-                  "version": "3.0.4",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  }
-                },
-                "minimist": {
-                  "version": "1.2.5",
-                  "bundled": true,
-                  "optional": true
-                },
-                "minipass": {
-                  "version": "2.9.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "safe-buffer": "^5.1.2",
-                    "yallist": "^3.0.0"
-                  }
-                },
-                "minizlib": {
-                  "version": "1.3.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "minipass": "^2.9.0"
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "minimist": "^1.2.5"
-                  }
-                },
-                "ms": {
-                  "version": "2.1.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "needle": {
-                  "version": "2.3.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "debug": "^3.2.6",
-                    "iconv-lite": "^0.4.4",
-                    "sax": "^1.2.4"
-                  }
-                },
-                "node-pre-gyp": {
-                  "version": "0.14.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "detect-libc": "^1.0.2",
-                    "mkdirp": "^0.5.1",
-                    "needle": "^2.2.1",
-                    "nopt": "^4.0.1",
-                    "npm-packlist": "^1.1.6",
-                    "npmlog": "^4.0.2",
-                    "rc": "^1.2.7",
-                    "rimraf": "^2.6.1",
-                    "semver": "^5.3.0",
-                    "tar": "^4.4.2"
-                  }
-                },
-                "nopt": {
-                  "version": "4.0.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "abbrev": "1",
-                    "osenv": "^0.1.4"
-                  }
-                },
-                "npm-bundled": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "npm-normalize-package-bin": "^1.0.1"
-                  }
-                },
-                "npm-normalize-package-bin": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "npm-packlist": {
-                  "version": "1.4.8",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "ignore-walk": "^3.0.1",
-                    "npm-bundled": "^1.0.1",
-                    "npm-normalize-package-bin": "^1.0.1"
-                  }
-                },
-                "npmlog": {
-                  "version": "4.1.2",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "are-we-there-yet": "~1.1.2",
-                    "console-control-strings": "~1.1.0",
-                    "gauge": "~2.7.3",
-                    "set-blocking": "~2.0.0"
-                  }
-                },
-                "number-is-nan": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "once": {
-                  "version": "1.4.0",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "wrappy": "1"
-                  }
-                },
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "osenv": {
-                  "version": "0.1.5",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "os-homedir": "^1.0.0",
-                    "os-tmpdir": "^1.0.0"
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "process-nextick-args": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "rc": {
-                  "version": "1.2.8",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "deep-extend": "^0.6.0",
-                    "ini": "~1.3.0",
-                    "minimist": "^1.2.0",
-                    "strip-json-comments": "~2.0.1"
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.3.7",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "core-util-is": "~1.0.0",
-                    "inherits": "~2.0.3",
-                    "isarray": "~1.0.0",
-                    "process-nextick-args": "~2.0.0",
-                    "safe-buffer": "~5.1.1",
-                    "string_decoder": "~1.1.1",
-                    "util-deprecate": "~1.0.1"
-                  }
-                },
-                "rimraf": {
-                  "version": "2.7.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "glob": "^7.1.3"
-                  }
-                },
-                "safe-buffer": {
-                  "version": "5.1.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "safer-buffer": {
-                  "version": "2.1.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "sax": {
-                  "version": "1.2.4",
-                  "bundled": true,
-                  "optional": true
-                },
-                "semver": {
-                  "version": "5.7.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "bundled": true,
-                  "optional": true
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "code-point-at": "^1.0.0",
-                    "is-fullwidth-code-point": "^1.0.0",
-                    "strip-ansi": "^3.0.0"
-                  }
-                },
-                "string_decoder": {
-                  "version": "1.1.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "safe-buffer": "~5.1.0"
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "ansi-regex": "^2.0.0"
-                  }
-                },
-                "strip-json-comments": {
-                  "version": "2.0.1",
-                  "bundled": true,
-                  "optional": true
-                },
-                "tar": {
-                  "version": "4.4.13",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "chownr": "^1.1.1",
-                    "fs-minipass": "^1.2.5",
-                    "minipass": "^2.8.6",
-                    "minizlib": "^1.2.1",
-                    "mkdirp": "^0.5.0",
-                    "safe-buffer": "^5.1.2",
-                    "yallist": "^3.0.3"
-                  }
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "wide-align": {
-                  "version": "1.1.3",
-                  "bundled": true,
-                  "optional": true,
-                  "requires": {
-                    "string-width": "^1.0.2 || 2"
-                  }
-                },
-                "wrappy": {
-                  "version": "1.0.2",
-                  "bundled": true,
-                  "optional": true
-                },
-                "yallist": {
-                  "version": "3.1.1",
-                  "bundled": true,
-                  "optional": true
-                }
-              }
-            }
           }
         },
         "cliui": {
@@ -20964,7 +20561,489 @@
             "locate-path": "^3.0.0"
           }
         },
-        "fsevents": {},
+        "fsevents": {
+          "version": "1.2.12",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.12.tgz",
+          "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
+          "optional": true,
+          "requires": {
+            "nan": "^2.12.1",
+            "node-pre-gyp": "*"
+          },
+          "dependencies": {
+            "abbrev": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            },
+            "are-we-there-yet": {
+              "version": "1.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+              }
+            },
+            "balanced-match": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "brace-expansion": {
+              "version": "1.1.11",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+              }
+            },
+            "chownr": {
+              "version": "1.1.4",
+              "bundled": true,
+              "optional": true
+            },
+            "code-point-at": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "concat-map": {
+              "version": "0.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "bundled": true,
+              "optional": true
+            },
+            "core-util-is": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "debug": {
+              "version": "3.2.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ms": "^2.1.1"
+              }
+            },
+            "deep-extend": {
+              "version": "0.6.0",
+              "bundled": true,
+              "optional": true
+            },
+            "delegates": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "detect-libc": {
+              "version": "1.0.3",
+              "bundled": true,
+              "optional": true
+            },
+            "fs-minipass": {
+              "version": "1.2.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.6.0"
+              }
+            },
+            "fs.realpath": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "glob": {
+              "version": "7.1.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
+              }
+            },
+            "has-unicode": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "iconv-lite": {
+              "version": "0.4.24",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+              }
+            },
+            "ignore-walk": {
+              "version": "3.0.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimatch": "^3.0.4"
+              }
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "once": "^1.3.0",
+                "wrappy": "1"
+              }
+            },
+            "inherits": {
+              "version": "2.0.4",
+              "bundled": true,
+              "optional": true
+            },
+            "ini": {
+              "version": "1.3.5",
+              "bundled": true,
+              "optional": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            },
+            "minimist": {
+              "version": "1.2.5",
+              "bundled": true,
+              "optional": true
+            },
+            "minipass": {
+              "version": "2.9.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+              }
+            },
+            "minizlib": {
+              "version": "1.3.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minipass": "^2.9.0"
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "minimist": "^1.2.5"
+              }
+            },
+            "ms": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "needle": {
+              "version": "2.3.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "debug": "^3.2.6",
+                "iconv-lite": "^0.4.4",
+                "sax": "^1.2.4"
+              }
+            },
+            "node-pre-gyp": {
+              "version": "0.14.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "detect-libc": "^1.0.2",
+                "mkdirp": "^0.5.1",
+                "needle": "^2.2.1",
+                "nopt": "^4.0.1",
+                "npm-packlist": "^1.1.6",
+                "npmlog": "^4.0.2",
+                "rc": "^1.2.7",
+                "rimraf": "^2.6.1",
+                "semver": "^5.3.0",
+                "tar": "^4.4.2"
+              }
+            },
+            "nopt": {
+              "version": "4.0.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "abbrev": "1",
+                "osenv": "^0.1.4"
+              }
+            },
+            "npm-bundled": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npm-normalize-package-bin": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "npm-packlist": {
+              "version": "1.4.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ignore-walk": "^3.0.1",
+                "npm-bundled": "^1.0.1",
+                "npm-normalize-package-bin": "^1.0.1"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "number-is-nan": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "bundled": true,
+              "optional": true
+            },
+            "once": {
+              "version": "1.4.0",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "wrappy": "1"
+              }
+            },
+            "os-homedir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "os-tmpdir": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "osenv": {
+              "version": "0.1.5",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "process-nextick-args": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "rc": {
+              "version": "1.2.8",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.7",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+              }
+            },
+            "rimraf": {
+              "version": "2.7.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "glob": "^7.1.3"
+              }
+            },
+            "safe-buffer": {
+              "version": "5.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "safer-buffer": {
+              "version": "2.1.2",
+              "bundled": true,
+              "optional": true
+            },
+            "sax": {
+              "version": "1.2.4",
+              "bundled": true,
+              "optional": true
+            },
+            "semver": {
+              "version": "5.7.1",
+              "bundled": true,
+              "optional": true
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "bundled": true,
+              "optional": true
+            },
+            "signal-exit": {
+              "version": "3.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "string_decoder": {
+              "version": "1.1.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            },
+            "strip-json-comments": {
+              "version": "2.0.1",
+              "bundled": true,
+              "optional": true
+            },
+            "tar": {
+              "version": "4.4.13",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "fs-minipass": "^1.2.5",
+                "minipass": "^2.8.6",
+                "minizlib": "^1.2.1",
+                "mkdirp": "^0.5.0",
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.3"
+              }
+            },
+            "util-deprecate": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "wide-align": {
+              "version": "1.1.3",
+              "bundled": true,
+              "optional": true,
+              "requires": {
+                "string-width": "^1.0.2 || 2"
+              }
+            },
+            "wrappy": {
+              "version": "1.0.2",
+              "bundled": true,
+              "optional": true
+            },
+            "yallist": {
+              "version": "3.1.1",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
         "get-caller-file": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4480,42 +4480,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
     },
-    "body": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
-      "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
-      "dev": true,
-      "requires": {
-        "continuable-cache": "^0.3.1",
-        "error": "^7.0.0",
-        "raw-body": "~1.1.0",
-        "safe-json-parse": "~1.0.1"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-          "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
-          "dev": true
-        },
-        "raw-body": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
-          "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
-          "dev": true,
-          "requires": {
-            "bytes": "1",
-            "string_decoder": "0.10"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
-    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -5486,12 +5450,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "continuable-cache": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
-      "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
-      "dev": true
     },
     "convert-source-map": {
       "version": "1.7.0",
@@ -6615,15 +6573,6 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
         "prr": "~1.0.1"
-      }
-    },
-    "error": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/error/-/error-7.2.1.tgz",
-      "integrity": "sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==",
-      "dev": true,
-      "requires": {
-        "string-template": "~0.2.1"
       }
     },
     "error-ex": {
@@ -8531,6 +8480,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/html-webpack-harddisk-plugin/-/html-webpack-harddisk-plugin-1.0.1.tgz",
       "integrity": "sha512-GWfutTqfxOe53qEKocqAFrrLVP/EJbmJZDAS5jBBmALkfyc2aakoQkSgo3fitYJORWcN0Fi8ekuySxfffhhRYw==",
+      "dev": true,
       "requires": {
         "mkdirp": "^0.5.1"
       }
@@ -12366,12 +12316,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
-    },
-    "livereload-js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.4.0.tgz",
-      "integrity": "sha512-XPQH8Z2GDP/Hwz2PCDrh2mth4yFejwA1OZ/81Ti3LgKyhDcEjsSsqFWZojHG0va/duGd+WyosY7eXLDoOyqcPw==",
-      "dev": true
     },
     "load-json-file": {
       "version": "4.0.0",
@@ -16969,12 +16913,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
       "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
     },
-    "safe-json-parse": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
-      "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
-      "dev": true
-    },
     "safe-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
@@ -18160,12 +18098,6 @@
         }
       }
     },
-    "string-template": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
-      "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
-      "dev": true
-    },
     "string-width": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
@@ -18732,20 +18664,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-    },
-    "tiny-lr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
-      "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
-      "dev": true,
-      "requires": {
-        "body": "^5.1.0",
-        "debug": "^3.1.0",
-        "faye-websocket": "~0.10.0",
-        "livereload-js": "^2.3.0",
-        "object-assign": "^4.1.0",
-        "qs": "^6.4.0"
-      }
     },
     "tiny-warning": {
       "version": "1.0.3",
@@ -21287,35 +21205,6 @@
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
           }
-        }
-      }
-    },
-    "webpack-livereload-plugin": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/webpack-livereload-plugin/-/webpack-livereload-plugin-2.3.0.tgz",
-      "integrity": "sha512-vVBLQLlNpElt2sfsBG+XLDeVbQFS4RrniVU8Hi1/hX5ycSfx6mtW8MEEITr2g0Cvo36kuPWShFFDuy+DS7KFMA==",
-      "dev": true,
-      "requires": {
-        "anymatch": "^3.1.1",
-        "portfinder": "^1.0.17",
-        "tiny-lr": "^1.1.1"
-      },
-      "dependencies": {
-        "anymatch": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
-          "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
-          "dev": true,
-          "requires": {
-            "normalize-path": "^3.0.0",
-            "picomatch": "^2.0.4"
-          }
-        },
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint-plugin-prettier": "^3.1.2",
     "file-loader": "^6.0.0",
     "fork-ts-checker-webpack-plugin": "^4.1.2",
+    "html-webpack-harddisk-plugin": "^1.0.1",
     "html-webpack-plugin": "^4.0.2",
     "jest": "^25.2.3",
     "jest-environment-jsdom-sixteen": "^1.0.3",
@@ -71,7 +72,6 @@
     "webpack": "^4.42.1",
     "webpack-bundle-analyzer": "^3.6.1",
     "webpack-cli": "^3.3.11",
-    "webpack-livereload-plugin": "^2.3.0",
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {
@@ -92,7 +92,6 @@
     "filesize": "^6.1.0",
     "formik": "^2.1.4",
     "html-react-parser": "^0.10.3",
-    "html-webpack-harddisk-plugin": "^1.0.1",
     "install": "^0.13.0",
     "jsdom": "^16.2.1",
     "loaders.css": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "postcss-loader": "^3.0.0",
     "postcss-safe-parser": "^4.0.2",
     "prettier": "^2.0.2",
+    "react-hot-loader": "^4.12.20",
     "react-mock-router": "^1.0.15",
     "redux-mock-store": "^1.5.4",
     "resolve-url-loader": "^3.1.1",
@@ -76,6 +77,7 @@
   "dependencies": {
     "@centreon/ui": "github:centreon/centreon-ui",
     "@date-io/moment": "1.3.13",
+    "@hot-loader/react-dom": "^16.13.0",
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.46",
@@ -90,6 +92,7 @@
     "filesize": "^6.1.0",
     "formik": "^2.1.4",
     "html-react-parser": "^0.10.3",
+    "html-webpack-harddisk-plugin": "^1.0.1",
     "install": "^0.13.0",
     "jsdom": "^16.2.1",
     "loaders.css": "^0.1.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "eslint:fix": "npm run eslint -- --fix",
     "test": "jest",
     "test:watch": "npm test -- --watch",
-    "start:dev": "npm run build:dev -- --watch"
+    "start:dev": "webpack-dev-server --config ./webpack.config.dev.js"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,14 +1,28 @@
 const merge = require('webpack-merge');
 const path = require('path');
+const os = require('os');
 
 const devConfig = require('@centreon/frontend-core/webpack/patch/dev');
 const baseConfig = require('./webpack.config');
 
 const devServerPort = 9090;
 
+const interfaces = os.networkInterfaces();
+const externalInterface = Object.keys(interfaces).find((interfaceName) => {
+  return (
+    !interfaceName.includes('docker') &&
+    interfaces[interfaceName][0].family === 'IPv4' &&
+    interfaces[interfaceName][0].internal === false
+  );
+});
+
+const devServerAddress = externalInterface
+  ? interfaces[externalInterface][0].address
+  : 'localhost';
+
 module.exports = merge(baseConfig, devConfig, {
   output: {
-    publicPath: `http://localhost:${devServerPort}/static/`,
+    publicPath: `http://${devServerAddress}:${devServerPort}/static/`,
   },
   resolve: {
     alias: {
@@ -21,6 +35,7 @@ module.exports = merge(baseConfig, devConfig, {
   devServer: {
     contentBase: path.resolve(`${__dirname}/www/modules/`),
     compress: true,
+    host: '0.0.0.0',
     port: devServerPort,
     hot: true,
     watchContentBase: true,

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,17 +1,29 @@
 const merge = require('webpack-merge');
-const LiveReloadPlugin = require('webpack-livereload-plugin');
 const path = require('path');
 
 const devConfig = require('@centreon/frontend-core/webpack/patch/dev');
 const baseConfig = require('./webpack.config');
 
+const devServerPort = 9090;
+
 module.exports = merge(baseConfig, devConfig, {
+  output: {
+    publicPath: `http://localhost:${devServerPort}/static/`,
+  },
   resolve: {
     alias: {
       react: path.resolve('./node_modules/react'),
+      'react-dom': '@hot-loader/react-dom',
       'react-router-dom': path.resolve('./node_modules/react-router-dom'),
       '@material-ui/core': path.resolve('./node_modules/@material-ui/core'),
     },
   },
-  plugins: [new LiveReloadPlugin({ appendScriptTag: true })],
+  devServer: {
+    contentBase: path.resolve(`${__dirname}/www/modules/`),
+    compress: true,
+    port: devServerPort,
+    hot: true,
+    watchContentBase: true,
+    headers: { 'Access-Control-Allow-Origin': '*' },
+  },
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,13 +35,25 @@ module.exports = merge(baseConfig, extractCssConfig, {
     rules: [
       { parser: { system: false } },
       {
-        test: /fonts(\\|\/).+\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?|\.(bmp|png|jpg|jpeg|gif|svg)$/,
+        test: /fonts(\\|\/).+\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[name].[hash:8].[ext]',
+              publicPath: './',
+            },
+          },
+        ],
+      },
+      {
+        test: /\.(bmp|png|jpg|jpeg|gif|svg)$/,
         use: [
           {
             loader: 'url-loader',
             options: {
-              name: '[name].[hash:8].[ext]',
               limit: 10000,
+              name: '[name].[hash:8].[ext]',
             },
           },
         ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,4 +1,5 @@
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlWebpackHarddiskPlugin = require('html-webpack-harddisk-plugin');
 const merge = require('webpack-merge');
 const path = require('path');
 
@@ -6,7 +7,11 @@ const baseConfig = require('@centreon/frontend-core/webpack/base');
 const extractCssConfig = require('@centreon/frontend-core/webpack/patch/extractCss');
 
 module.exports = merge(baseConfig, extractCssConfig, {
-  entry: ['@babel/polyfill', './www/front_src/src/index.js'],
+  entry: [
+    'react-hot-loader/patch',
+    '@babel/polyfill',
+    './www/front_src/src/index.js',
+  ],
   output: {
     path: path.resolve(`${__dirname}/www/static`),
     publicPath: './static/',
@@ -20,21 +25,23 @@ module.exports = merge(baseConfig, extractCssConfig, {
   },
   plugins: [
     new HtmlWebpackPlugin({
+      alwaysWriteToDisk: true,
       template: './www/front_src/public/index.html',
       filename: '../index.html',
     }),
+    new HtmlWebpackHarddiskPlugin(),
   ],
   module: {
     rules: [
       { parser: { system: false } },
       {
-        test: /fonts(\\|\/).+\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?$/,
+        test: /fonts(\\|\/).+\.(woff(2)?|ttf|eot|svg)(\?v=\d+\.\d+\.\d+)?|\.(bmp|png|jpg|jpeg|gif|svg)$/,
         use: [
           {
-            loader: 'file-loader',
+            loader: 'url-loader',
             options: {
               name: '[name].[hash:8].[ext]',
-              publicPath: './',
+              limit: 10000,
             },
           },
         ],
@@ -42,18 +49,6 @@ module.exports = merge(baseConfig, extractCssConfig, {
       {
         test: /\.icon.svg$/,
         use: ['@svgr/webpack'],
-      },
-      {
-        test: /\.(bmp|png|jpg|jpeg|gif|svg)$/,
-        use: [
-          {
-            loader: 'url-loader',
-            options: {
-              limit: 10000,
-              name: '[name].[hash:8].[ext]',
-            },
-          },
-        ],
       },
     ],
   },

--- a/www/front_src/src/App.tsx
+++ b/www/front_src/src/App.tsx
@@ -7,6 +7,7 @@
 /* eslint-disable react/jsx-filename-extension */
 
 import React, { Component, ReactNode } from 'react';
+import { hot } from 'react-hot-loader/root';
 
 import { connect } from 'react-redux';
 import { ConnectedRouter } from 'connected-react-router';
@@ -160,4 +161,4 @@ const mapDispatchToProps = (dispatch: (any) => void): Props => {
   };
 };
 
-export default connect(null, mapDispatchToProps)(App);
+export default hot(connect(null, mapDispatchToProps)(App));


### PR DESCRIPTION
## Description
This PR introduces the webpack-dev-server with HMR and react-hot-loader. This improves greatly the development workflow by reloading modules on the fly when something changes instead of having to reload the whole page.

HMR is not supported for external modules yet as it's not compatible with System js at the moment. We might need to wait for webpack 5 to be able to build external ES modules or give https://github.com/alexisvincent/systemjs-hot-reloader a try

**This PR should be merged after final 20.04 build**

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x (master)
- [x] 20.10.x (next)