### PR TITLE
fix host duplication when strict mode is enabled

### DIFF
--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -2512,13 +2512,10 @@ class CentreonACL
      * @param array $hosts | hosts to duplicate
      * @return void
      */
-    public function duplicateHostAcl($hosts = array())
+    public function duplicateHostAcl($hosts = [])
     {
-        $sql = "INSERT INTO %s 
-                    (host_host_id, acl_res_id)
-                    (SELECT %d, acl_res_id 
-                    FROM %s 
-                    WHERE host_host_id = %d)";
+        $sql = "INSERT INTO %s (host_host_id, acl_res_id)
+            (SELECT %d, acl_res_id FROM %s WHERE host_host_id = %d)";
         $tbHost = "acl_resources_host_relations";
         $tbHostEx = "acl_resources_hostex_relations";
         foreach ($hosts as $copyId => $originalId) {

--- a/www/include/configuration/configObject/host/DB-Func.php
+++ b/www/include/configuration/configObject/host/DB-Func.php
@@ -356,18 +356,18 @@ function multipleHostInDB($hosts = array(), $nbrDup = array())
         for ($i = 1; $i <= $nbrDup[$key]; $i++) {
             $val = null;
             foreach ($row as $key2 => $value2) {
-                $key2 == "host_name" ? ($host_name = $value2 = $value2 . "_" . $i) : null;
+                $key2 == "host_name" ? ($hostName = $value2 = $value2 . "_" . $i) : null;
                 $val
                     ? $val .= ($value2 != null ? (", '" . CentreonDB::escape($value2) . "'") : ", NULL")
                     : $val .= ($value2 != null ? ("'" . CentreonDB::escape($value2) . "'") : "NULL");
                 if ($key2 != "host_id") {
                     $fields[$key2] = $value2;
                 }
-                if (isset($host_name)) {
-                    $fields["host_name"] = $host_name;
+                if (isset($hostName)) {
+                    $fields["host_name"] = $hostName;
                 }
             }
-            if (hasHostNameNeverUsed($host_name)) {
+            if (hasHostNameNeverUsed($hostName)) {
                 $val ? $rq = "INSERT INTO host VALUES (" . $val . ")" : $rq = null;
                 $dbResult = $pearDB->query($rq);
                 $dbResult = $pearDB->query("SELECT MAX(host_id) FROM host");
@@ -567,7 +567,7 @@ function multipleHostInDB($hosts = array(), $nbrDup = array())
                                 WHERE host_host_id = '" . (int)$key . "'";
                     $dbResult3 = $pearDB->query($request);
 
-                    $centreon->CentreonLogAction->insertLog("host", $maxId["MAX(host_id)"], $host_name, "a", $fields);
+                    $centreon->CentreonLogAction->insertLog("host", $maxId["MAX(host_id)"], $hostName, "a", $fields);
                 }
             }
             $centreon->user->access->updateACL(array(

--- a/www/include/configuration/configObject/host/DB-Func.php
+++ b/www/include/configuration/configObject/host/DB-Func.php
@@ -570,12 +570,15 @@ function multipleHostInDB($hosts = array(), $nbrDup = array())
                     $centreon->CentreonLogAction->insertLog("host", $maxId["MAX(host_id)"], $hostName, "a", $fields);
                 }
             }
-            $centreon->user->access->updateACL(array(
-                "type" => 'HOST',
-                'id' => $maxId["MAX(host_id)"],
-                "action" => "DUP",
-                "duplicate_host" => (int)$key
-            ));
+            // if all duplication names are already used, next value is never set
+            if (isset($maxId['MAX(host_id)'])) {
+                $centreon->user->access->updateACL([
+                    'type' => 'HOST',
+                    'id' => $maxId['MAX(host_id)'],
+                    'action' => 'DUP',
+                    'duplicate_host' => (int)$key,
+                ]);
+            }
         }
     }
     CentreonACL::duplicateHostAcl($hostAcl);


### PR DESCRIPTION
## Description

Correct the broken queries when all duplication names are already used.

**Fixes** # (MON-5324)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Duplicate a host. Then duplicate a second time the same host. No blank page should be displayed and the list of host should stay the same.
No stack trace should be thrown to the PHP log... nor the SQL

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
