### PR TITLE
fix(ui): Fix bottom gap in fullscreen mode

### DIFF
--- a/www/front_src/src/route-components/legacyRoute/index.js
+++ b/www/front_src/src/route-components/legacyRoute/index.js
@@ -16,28 +16,9 @@ class LegacyRoute extends Component {
     this.resizeTimeout = null;
 
     this.state = {
-      contentHeight: 0,
       loading: true,
     };
   }
-
-  handleResize = () => {
-    // wait size is the same during 200ms to handle it
-    clearTimeout(this.resizeTimeout);
-
-    if (this.mainContainer) {
-      this.resizeTimeout = setTimeout(() => {
-        const { clientHeight } = this.mainContainer;
-        const { contentHeight } = this.state;
-        if (clientHeight !== contentHeight) {
-          this.setState({
-            loading: false,
-            contentHeight: clientHeight,
-          });
-        }
-      }, 200);
-    }
-  };
 
   handleHref = (event) => {
     const { href } = event.detail;
@@ -54,9 +35,6 @@ class LegacyRoute extends Component {
 
   componentDidMount() {
     this.mainContainer = window.document.getElementById('fullscreen-wrapper');
-
-    // add a listener on global page size
-    window.addEventListener('resize', this.handleResize);
 
     // add event listener to update page url
     window.addEventListener('react.href.update', this.handleHref, false);
@@ -78,8 +56,12 @@ class LegacyRoute extends Component {
     window.removeEventListener('react.href.disconnect', this.handleDisconnect);
   }
 
+  load = () => {
+    this.setState({ loading: false });
+  };
+
   render() {
-    const { contentHeight, loading } = this.state;
+    const { loading } = this.state;
     const {
       history: {
         location: { search, hash },
@@ -104,10 +86,10 @@ class LegacyRoute extends Component {
           id="main-content"
           title="Main Content"
           frameBorder="0"
-          onLoad={this.handleResize}
+          onLoad={this.load}
           scrolling="yes"
           className={classnames({ [styles.hidden]: loading })}
-          style={{ width: '100%', height: `${contentHeight}px` }}
+          style={{ width: '100%', height: '100%' }}
           src={`./main.get.php${params}`}
         />
       </>


### PR DESCRIPTION
## Description
This removes the gap in legacy pages when displayed in fullscreen mode. It also removes the now deprecated resize handler.

![Screenshot from 2020-04-20 12-12-17](https://user-images.githubusercontent.com/8367233/79740754-7b4b6a00-8300-11ea-8cb4-5bf6521b2621.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)
