### PR TITLE
fix(api): do not get useless severity url

### DIFF
--- a/config/packages/serializer/Centreon/Monitoring.ResourceSeverity.yml
+++ b/config/packages/serializer/Centreon/Monitoring.ResourceSeverity.yml
@@ -8,7 +8,3 @@ Centreon\Domain\Monitoring\ResourceSeverity:
             type: string
             groups:
                 - 'resource_severity_main'
-        url:
-            type: string
-            groups:
-                - 'resource_severity_main'

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -2702,11 +2702,6 @@ components:
         severity:
           type: object
           properties:
-            id:
-              type: integer
-              format: int32
-              description: "ID of the severity"
-              example: 12
             level:
               type: integer
               description: "level of the severity"
@@ -2715,10 +2710,6 @@ components:
               type: string
               description: "Name of the severity"
               example: "severity 1"
-            url:
-              type: string
-              description: "Url of the severity icon"
-              example: "/img/media/severity1.png"
         impacted_resources_count:
           type: integer
           description: "count of impacted resources"

--- a/src/Centreon/Domain/Monitoring/ResourceSeverity.php
+++ b/src/Centreon/Domain/Monitoring/ResourceSeverity.php
@@ -43,11 +43,6 @@ class ResourceSeverity
     private $name;
 
     /**
-     * @var string|null
-     */
-    private $url;
-
-    /**
      * @return int|null
      */
     public function getLevel(): ?int
@@ -81,25 +76,6 @@ class ResourceSeverity
     public function setName(?string $name): self
     {
         $this->name = $name;
-
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getUrl(): ?string
-    {
-        return $this->url;
-    }
-
-    /**
-     * @param string|null $url
-     * @return \Centreon\Domain\Monitoring\ResourceSeverity
-     */
-    public function setUrl(?string $url): self
-    {
-        $this->url = $url;
 
         return $this;
     }

--- a/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/ResourceRepositoryRDB.php
@@ -324,7 +324,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             . 'resource.parent_icon_name, resource.parent_icon_url, ' // parent icon
             // parent status
             . 'resource.parent_status_code, resource.parent_status_name, resource.parent_status_severity_code, '
-            . 'resource.severity_level, resource.severity_url, resource.severity_name, ' // severity
+            . 'resource.severity_level, resource.severity_name, ' // severity
             . 'resource.in_downtime, resource.acknowledged, '
             . 'resource.impacted_resources_count, resource.last_status_change, '
             . 'resource.tries, resource.last_check, resource.information '
@@ -557,7 +557,6 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             s.acknowledged AS `acknowledged`,
             service_cvl.value AS `severity_level`,
             sc.sc_name AS `severity_name`,
-            CONCAT(service_vid.dir_alias, IF(service_vid.dir_alias, '/', NULL), service_vi.img_path) AS `severity_url`,
             0 AS `impacted_resources_count`,
             s.last_state_change AS `last_status_change`,
             CONCAT(s.check_attempt, '/', s.max_check_attempts, ' (', CASE
@@ -593,9 +592,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
         LEFT JOIN `:db`.`service_categories` AS sc ON sc.sc_id = scr.sc_id
             AND sc.level IS NOT NULL
             AND sc.icon_id IS NOT NULL
-        LEFT JOIN `:db`.`view_img` AS service_vi ON service_vi.img_id = sc.icon_id
-        LEFT JOIN `:db`.`view_img_dir_relation` AS service_vidr ON service_vidr.img_img_id = service_vi.img_id
-        LEFT JOIN `:db`.`view_img_dir` AS service_vid ON service_vid.dir_id = service_vidr.dir_dir_parent_id';
+        LEFT JOIN `:db`.`view_img` AS service_vi ON service_vi.img_id = sc.icon_id';
 
         $collector->addValue(':serviceCustomVariablesName', 'CRITICALITY_LEVEL');
 
@@ -709,7 +706,6 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             h.acknowledged AS `acknowledged`,
             host_cvl.value AS `severity_level`,
             hc.hc_comment AS `severity_name`,
-            CONCAT(host_vid.dir_alias, '/', host_vi.img_path) AS `severity_url`,
             (SELECT COUNT(DISTINCT host_s.service_id)
                 FROM `:dbstg`.`services` AS host_s
                 WHERE host_s.host_id = h.host_id AND host_s.enabled = 1
@@ -738,9 +734,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
         LEFT JOIN `:db`.`hostcategories` AS hc ON hc.hc_id = hcr.hostcategories_hc_id
             AND hc.level IS NOT NULL
             AND hc.icon_id IS NOT NULL
-        LEFT JOIN `:db`.`view_img` AS host_vi ON host_vi.img_id = hc.icon_id
-        LEFT JOIN `:db`.`view_img_dir_relation` AS host_vidr ON host_vidr.img_img_id = host_vi.img_id
-        LEFT JOIN `:db`.`view_img_dir` AS host_vid ON host_vid.dir_id = host_vidr.dir_dir_parent_id';
+        LEFT JOIN `:db`.`view_img` AS host_vi ON host_vi.img_id = hc.icon_id';
 
         $collector->addValue(':hostCustomVariablesName', 'CRITICALITY_LEVEL');
 
@@ -838,7 +832,7 @@ final class ResourceRepositoryRDB extends AbstractRepositoryDRB implements Resou
             'severity_'
         );
 
-        if ($severity->getLevel() || $severity->getName() || $severity->getUrl()) {
+        if ($severity->getLevel() && $severity->getName()) {
             $resource->setSeverity($severity);
         }
 


### PR DESCRIPTION
## Description

Avoid to get severity url, which is useless for events view page

**Fixes** MON-5365

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)