### PR TITLE
fix(ui): Mount Event view Acknowledge and Downtime components only when necessary 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ src/Centreon*
 www/modules/centreon-*
 www/widgets
 !www/widgets/require.php
+
+.vscode/

--- a/www/front_src/src/Resources/Actions/Resource/Acknowledge/index.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Acknowledge/index.tsx
@@ -68,10 +68,6 @@ const AcknowledgeForm = ({
   const hasResources = resources.length > 0;
 
   React.useEffect(() => {
-    if (!hasResources) {
-      return;
-    }
-
     getUser(token)
       .then((user) =>
         form.setFieldValue(
@@ -84,10 +80,6 @@ const AcknowledgeForm = ({
   }, [hasResources]);
 
   React.useEffect(() => (): void => cancel(), []);
-
-  if (resources.length === 0) {
-    return null;
-  }
 
   return (
     <DialogAcknowledge

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/index.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/index.tsx
@@ -145,13 +145,7 @@ const DowntimeForm = ({
     validate,
   });
 
-  const hasResources = resources.length > 0;
-
   React.useEffect(() => {
-    if (!hasResources) {
-      return;
-    }
-
     getUser(token)
       .then((user) => {
         form.setFieldValue('comment', `${labelDowntimeBy} ${user.username}`);
@@ -160,13 +154,9 @@ const DowntimeForm = ({
       })
       .catch(() => showError(labelSomethingWentWrong))
       .finally(() => setLoaded(true));
-  }, [hasResources]);
+  }, []);
 
   React.useEffect(() => (): void => cancel(), []);
-
-  if (resources.length === 0) {
-    return null;
-  }
 
   return (
     <DialogDowntime

--- a/www/front_src/src/Resources/Actions/Resource/index.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/index.tsx
@@ -105,16 +105,20 @@ const ResourceActions = ({
           {labelCheck}
         </ActionButton>
       </Grid>
-      <AcknowledgeForm
-        resources={resourcesToAcknowledge}
-        onClose={onCancelAcknowledge}
-        onSuccess={onSuccess}
-      />
-      <DowntimeForm
-        resources={resourcesToSetDowntime}
-        onClose={onCancelSetDowntime}
-        onSuccess={onSuccess}
-      />
+      {resourcesToAcknowledge.length > 0 && (
+        <AcknowledgeForm
+          resources={resourcesToAcknowledge}
+          onClose={onCancelAcknowledge}
+          onSuccess={onSuccess}
+        />
+      )}
+      {resourcesToSetDowntime.length > 0 && (
+        <DowntimeForm
+          resources={resourcesToSetDowntime}
+          onClose={onCancelSetDowntime}
+          onSuccess={onSuccess}
+        />
+      )}
     </Grid>
   );
 };


### PR DESCRIPTION
## Description

This PR makes sure that the Acknowledge and Downtime dialogs are mounted only when they show up, to avoid unnecessary renders, as well as outdated current date in the Downtime case.  

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>
In the event view page: Make sure the Downtime dialog always shows the current start date, even if the page haven't been refreshed for a while. Also make sure that the Acknowledge dialog work as before
