### PR TITLE
enh(ui): Improve resource name and parent resource name display in Event view page

### DIFF
--- a/www/front_src/src/Resources/columns/index.tsx
+++ b/www/front_src/src/Resources/columns/index.tsx
@@ -30,11 +30,13 @@ import ActionButton from '../ActionButton';
 const useStyles = makeStyles((theme) => ({
   resourceDetailsCell: {
     padding: theme.spacing(0, 0.5),
+    display: 'flex',
+    flexWrap: 'nowrap',
+    alignItems: 'center',
   },
   resourceNameItem: {
-    display: 'flex',
-    alignItems: 'center',
-    paddingLeft: theme.spacing(1),
+    marginLeft: theme.spacing(1),
+    whiteSpace: 'nowrap',
   },
   extraSmallChipContainer: {
     height: 16,
@@ -159,43 +161,40 @@ const ResourceColumn = ({ row }: ColumnProps): JSX.Element => {
   const classes = useStyles();
 
   return (
-    <Grid container spacing={0} className={classes.resourceDetailsCell}>
-      <Grid item>
-        {row.icon ? (
-          <img src={row.icon.url} alt={row.icon.name} width={16} height={16} />
-        ) : (
-          <StatusChip
-            label={row.short_type}
-            severityCode={SeverityCode.None}
-            classes={{
-              root: classes.extraSmallChipContainer,
-              label: classes.smallChipLabel,
-            }}
-          />
-        )}
-      </Grid>
-      <Grid item className={classes.resourceNameItem}>
+    <div className={classes.resourceDetailsCell}>
+      {row.icon ? (
+        <img src={row.icon.url} alt={row.icon.name} width={16} height={16} />
+      ) : (
+        <StatusChip
+          label={row.short_type}
+          severityCode={SeverityCode.None}
+          classes={{
+            root: classes.extraSmallChipContainer,
+            label: classes.smallChipLabel,
+          }}
+        />
+      )}
+      <div className={classes.resourceNameItem}>
         <Typography variant="body2">{row.name}</Typography>
-      </Grid>
-    </Grid>
+      </div>
+    </div>
   );
 };
 
 const ParentResourceColumn = ({ row }: ColumnProps): JSX.Element | null => {
+  const classes = useStyles();
+
   if (!row.parent) {
     return null;
   }
 
   return (
-    <Grid container spacing={1}>
-      <Grid item xs={1} />
-      <Grid item>
-        <StatusChip severityCode={row.parent?.status?.severity_code || 0} />
-      </Grid>
-      <Grid item>
+    <div className={classes.resourceDetailsCell}>
+      <StatusChip severityCode={row.parent?.status?.severity_code || 0} />
+      <div className={classes.resourceNameItem}>
         <Typography variant="body2">{row.parent.name}</Typography>
-      </Grid>
-    </Grid>
+      </div>
+    </div>
   );
 };
 


### PR DESCRIPTION
## Description

This PR prevents the resource name and parent resource name columns from wrapping into multiple lines.
This also means that the information column will now shrink in case of longer resource / parent names.

**Before the fix**
![Screenshot from 2020-04-24 11-30-59](https://user-images.githubusercontent.com/8367233/80197958-b363ed00-861f-11ea-894a-f90b67da78b2.png)

**After the fix**
![Screenshot from 2020-04-24 11-21-38](https://user-images.githubusercontent.com/8367233/80197966-b52db080-861f-11ea-903e-35f3935caaa5.png)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)
