### PR TITLE
fix(typo): incorrect tab name 'Host Informations'

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2183,7 +2183,7 @@ msgid "Performances"
 msgstr "Información de rendimiento"
 
 #: centreon-web/www/install/smarty_translate.php:831
-msgid "Host Informations"
+msgid "Host Information"
 msgstr "Información sobre el anfitrión"
 
 #: centreon-web/www/install/smarty_translate.php:834 centreon-web/www/install/smarty_translate.php:885

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2379,7 +2379,7 @@ msgid "Performances"
 msgstr "Informations de performance"
 
 #: centreon-web/www/install/smarty_translate.php:831
-msgid "Host Informations"
+msgid "Host Information"
 msgstr "Informations sur l'hôte"
 
 #: centreon-web/www/install/smarty_translate.php:834

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -11736,7 +11736,7 @@ msgid "Performances"
 msgstr "Informações de Performance"
 
 #: centreon-web/www/install/smarty_translate.php:210
-msgid "Host Informations"
+msgid "Host Information"
 msgstr "Informações de Host"
 
 #: centreon-web/www/install/smarty_translate.php:225

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -11737,7 +11737,7 @@ msgid "Performances"
 msgstr "Informações de Performance"
 
 #: centreon-web/www/install/smarty_translate.php:210
-msgid "Host Informations"
+msgid "Host Information"
 msgstr "Informações de Host"
 
 #: centreon-web/www/install/smarty_translate.php:225

--- a/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -24,7 +24,7 @@
                             <ul id="mainnav">
                                 <li class="a" id='c1'><a href="#" style='cursor:pointer' onclick="javascript:montre('1');">{t}Service Status{/t}</a></li>
                                 <li class="b" id='c2'><a href="#" style='cursor:pointer' onclick="javascript:montre('2');">{t}Performances{/t}</a></li>
-                                <li class="b" id='c3'><a href="#" style='cursor:pointer' onclick="javascript:montre('3');">{t}Host Informations{/t}</a></li>
+                                <li class="b" id='c3'><a href="#" style='cursor:pointer' onclick="javascript:montre('3');">{t}Host Information{/t}</a></li>
                                 <li class="b" id='c4'><a href="#" style='cursor:pointer' onclick="javascript:montre('4');">{t}Comments{/t}</a></li>
                             </ul>
                         </div>


### PR DESCRIPTION
## Description

Fix an incorrect usage of the english word "information" which is uncountable (can never be used as a plural form)


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>


## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
