### PR TITLE
enh: escape specific characters from database password

### DIFF
--- a/www/install/php/Update-20.04.1.php
+++ b/www/install/php/Update-20.04.1.php
@@ -45,6 +45,11 @@ try {
     );
     $engineCommand = $res->fetch()['command_file'];
 
+    // escape double quotes and backslashes
+    $pattern = ['\\', '"'];
+    $replacement = ['\\\\', '\"'];
+    $password = str_replace($pattern, $replacement, password);
+
     // set macro keys
     $pattern = [
         '/--ADDRESS--/',
@@ -70,7 +75,7 @@ try {
         hostCentreon,
         port,
         user,
-        password,
+        $password,
         db,
         dbcstg,
         _CENTREON_VARLIB_,

--- a/www/install/php/Update-20.04.1.php
+++ b/www/install/php/Update-20.04.1.php
@@ -46,9 +46,9 @@ try {
     $engineCommand = $res->fetch()['command_file'];
 
     // escape double quotes and backslashes
-    $pattern = ['\\', '"'];
+    $needle = ['\\', '"'];
     $replacement = ['\\\\', '\"'];
-    $password = str_replace($pattern, $replacement, password);
+    $password = str_replace($needle, $replacement, password);
 
     // set macro keys
     $pattern = [

--- a/www/install/php/Update-20.04.1.php
+++ b/www/install/php/Update-20.04.1.php
@@ -47,8 +47,8 @@ try {
 
     // escape double quotes and backslashes
     $needle = ['\\', '"'];
-    $replacement = ['\\\\', '\"'];
-    $password = str_replace($needle, $replacement, password);
+    $escape = ['\\\\', '\"'];
+    $password = str_replace($needle, $escape, password);
 
     // set macro keys
     $pattern = [

--- a/www/install/steps/process/configFileSetup.php
+++ b/www/install/steps/process/configFileSetup.php
@@ -69,10 +69,15 @@ $patterns = [
     '/--CENTREON_VARLIB--/',
 ];
 
+// escape double quotes and backslashes
+$pattern = ['\\', '"'];
+$replacement = ['\\\\', '\"'];
+$password = str_replace($pattern, $replacement, $parameters['db_password']);
+
 $replacements = [
     $host,
     $parameters['db_user'],
-    $parameters['db_password'],
+    $password,
     $parameters['db_configuration'],
     $parameters['db_storage'],
     $configuration['centreon_dir'],

--- a/www/install/steps/process/configFileSetup.php
+++ b/www/install/steps/process/configFileSetup.php
@@ -70,9 +70,9 @@ $patterns = [
 ];
 
 // escape double quotes and backslashes
-$pattern = ['\\', '"'];
+$needle = ['\\', '"'];
 $replacement = ['\\\\', '\"'];
-$password = str_replace($pattern, $replacement, $parameters['db_password']);
+$password = str_replace($needle, $replacement, $parameters['db_password']);
 
 $replacements = [
     $host,

--- a/www/install/steps/process/configFileSetup.php
+++ b/www/install/steps/process/configFileSetup.php
@@ -71,8 +71,9 @@ $patterns = [
 
 // escape double quotes and backslashes
 $needle = ['\\', '"'];
-$replacement = ['\\\\', '\"'];
-$password = str_replace($needle, $replacement, $parameters['db_password']);
+$escape = ['\\\\', '\"'];
+$password = str_replace($needle, $escape, $parameters['db_password']);
+
 
 $replacements = [
     $host,

--- a/www/install/var/databaseTemplate.yaml
+++ b/www/install/var/databaseTemplate.yaml
@@ -2,8 +2,8 @@ database:
   db_configuration:
     dsn: "mysql:host=--ADDRESS--:--DBPORT--;dbname=--CONFDB--"
     username: "--DBUSER--"
-    password: '--DBPASS--'
+    password: "--DBPASS--"
   db_realtime:
     dsn: "mysql:host=--ADDRESS--:--DBPORT--;dbname=--STORAGEDB--"
     username: "--DBUSER--"
-    password: '--DBPASS--'
+    password: "--DBPASS--"


### PR DESCRIPTION
## Description

Escape doubles quotes and backslashes to keep db password consistency.
For upgrade and new installations

**Fixes** # (MON-5391)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

On the DB :
Create a user using a password with special characters and at least one double quote.
Grant privileges to this user

On a terminal : 
Modify the /etc/centreon/centreon.conf.php file using this user data.
Upgrade your platform and check the /etc/centreon/config.d/10-database.yaml.new

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
