### PR TITLE
enh(api): Added the possibility to search for a monitoring server by its id

### DIFF
--- a/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
+++ b/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
@@ -22,8 +22,10 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\MonitoringServer\Interfaces;
 
+use Centreon\Domain\Entity\EntityCreator;
 use Centreon\Domain\MonitoringServer\MonitoringServer;
 use Centreon\Domain\MonitoringServer\MonitoringServerResource;
+use Centreon\Infrastructure\MonitoringServer\MonitoringServerRepositoryRDB;
 
 interface MonitoringServerRepositoryInterface
 {
@@ -60,4 +62,13 @@ interface MonitoringServerRepositoryInterface
      * @throws \Exception
      */
     public function notifyConfigurationChanged(MonitoringServer $monitoringServer): void;
+
+    /**
+     * Find a monitoring server.
+     *
+     * @param int $monitoringServerId Id of the monitoring server to be found
+     * @return MonitoringServer|null
+     * @throws \Exception
+     */
+    public function findServer(int $monitoringServerId): ?MonitoringServer;
 }

--- a/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerServiceInterface.php
+++ b/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerServiceInterface.php
@@ -63,4 +63,13 @@ interface MonitoringServerServiceInterface
      * @throws MonitoringServerException
      */
     public function notifyConfigurationChanged(MonitoringServer $monitoringServer): void;
+
+    /**
+     * Find a monitoring server.
+     *
+     * @param int $monitoringServerId Id of the monitoring server to be found.
+     * @return MonitoringServer|null
+     * @throws MonitoringServerException
+     */
+    public function findServer(int $monitoringServerId): ?MonitoringServer;
 }

--- a/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
+++ b/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
@@ -61,6 +61,22 @@ class MonitoringServerService implements MonitoringServerServiceInterface
     /**
      * @inheritDoc
      */
+    public function findServer(int $monitoringServerId): ?MonitoringServer
+    {
+        try {
+            return $this->monitoringServerRepository->findServer($monitoringServerId);
+        } catch (\Exception $ex) {
+            throw new MonitoringServerException(
+                'Error when searching for a monitoring server (' . $monitoringServerId . ')',
+                0,
+                $ex
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function findResource(int $monitoringServerId, string $resourceName): ?MonitoringServerResource
     {
         try {

--- a/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
@@ -149,6 +149,32 @@ class MonitoringServerRepositoryRDB extends AbstractRepositoryDRB implements Mon
     /**
      * @inheritDoc
      */
+    public function findServer(int $monitoringServerId): ?MonitoringServer
+    {
+        $request = $this->translateDbName('SELECT * FROM `:db`.nagios_server WHERE id = :server_id');
+        $statement = $this->db->prepare($request);
+        $statement->bindValue(':server_id', $monitoringServerId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        if (($record = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
+            /**
+             * @var MonitoringServer $server
+             */
+            $server = EntityCreator::createEntityByArray(
+                MonitoringServer::class,
+                $record
+            );
+            if ((int) $record['last_restart'] === 0) {
+                $server->setLastRestart(null);
+            }
+            return $server;
+        }
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function findResource(int $monitoringServerId, string $resourceName): ?MonitoringServerResource
     {
         $request = $this->translateDbName(


### PR DESCRIPTION
## Description

Added the possibility to search for a monitoring server by its id

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
