### PR TITLE
fix(ci): Increase temporarily jest timeout

### DIFF
--- a/setupTest.js
+++ b/setupTest.js
@@ -1,3 +1,5 @@
+jest.setTimeout(10000);
+
 document.createRange = () => ({
   setStart: () => {},
   setEnd: () => {},


### PR DESCRIPTION
## Description

This prevents the build from failing because of jest timeouts, preventing others from being blocked in their development. 
This fix will last until some further investigation has been done and fixes are made to improve test performance. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x (master)
