### PR TITLE
enh(ui): display link to regex101 in search tooltip

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14453,6 +14453,12 @@ msgstr ""
 msgid "and host alias containing"
 msgstr ""
 
+msgid "Tips"
+msgstr ""
+
+msgid "get some help while creating your regular expression query at"
+msgstr ""
+
 msgid "Service group"
 msgstr ""
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15309,6 +15309,12 @@ msgstr "affichera les ressources avec un FQDN ne contenant pas"
 msgid "and host alias containing"
 msgstr "et un alias d'hôte contenant"
 
+msgid "Tips"
+msgstr "Conseils"
+
+msgid "get some help while creating your regular expression query at"
+msgstr "obtenez de l'aide lors de la création de votre expression régulière sur"
+
 msgid "Service group"
 msgstr "Groupe de services"
 

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -14903,6 +14903,12 @@ msgstr ""
 msgid "and host alias containing"
 msgstr ""
 
+msgid "Tips"
+msgstr ""
+
+msgid "get some help while creating your regular expression query at"
+msgstr ""
+
 msgid "Service group"
 msgstr ""
 

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -14917,6 +14917,12 @@ msgstr ""
 msgid "and host alias containing"
 msgstr ""
 
+msgid "Tips"
+msgstr ""
+
+msgid "get some help while creating your regular expression query at"
+msgstr ""
+
 msgid "Service group"
 msgstr ""
 

--- a/www/front_src/src/Resources/SearchHelpTooltip.tsx
+++ b/www/front_src/src/Resources/SearchHelpTooltip.tsx
@@ -81,7 +81,7 @@ const Content = ({ onClose }: ContentProps): JSX.Element => {
         <i>
           <b>{`${labelTips}: `}</b>
           {`${labelGetRegexHelp} `}
-          <Link href="https://regex101.com" target="_blank" rel="noopener">
+          <Link href="https://regex101.com" target="_blank" rel="noopener noreferrer">
             regex101.com
           </Link>
         </i>

--- a/www/front_src/src/Resources/SearchHelpTooltip.tsx
+++ b/www/front_src/src/Resources/SearchHelpTooltip.tsx
@@ -15,6 +15,8 @@ import {
   labelSearchByHostAliasContaining,
   labelSearchByHostAddressNotContaining,
   labelSearchAndHostAliasContaining,
+  labelTips,
+  labelGetRegexHelp,
 } from './translatedLabels';
 
 const useStyles = makeStyles((theme) => ({
@@ -77,9 +79,8 @@ const Content = ({ onClose }: ContentProps): JSX.Element => {
           </li>
         </ul>
         <i>
-          <b>Tips: </b>
-          get some help while creating your regular expression query at
-          <span> </span>
+          <b>{`${labelTips}: `}</b>
+          {`${labelGetRegexHelp} `}
           <Link href="https://regex101.com" target="_blank">
             regex101.com
           </Link>

--- a/www/front_src/src/Resources/SearchHelpTooltip.tsx
+++ b/www/front_src/src/Resources/SearchHelpTooltip.tsx
@@ -81,7 +81,11 @@ const Content = ({ onClose }: ContentProps): JSX.Element => {
         <i>
           <b>{`${labelTips}: `}</b>
           {`${labelGetRegexHelp} `}
-          <Link href="https://regex101.com" target="_blank" rel="noopener noreferrer">
+          <Link
+            href="https://regex101.com"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             regex101.com
           </Link>
         </i>

--- a/www/front_src/src/Resources/SearchHelpTooltip.tsx
+++ b/www/front_src/src/Resources/SearchHelpTooltip.tsx
@@ -81,7 +81,7 @@ const Content = ({ onClose }: ContentProps): JSX.Element => {
         <i>
           <b>{`${labelTips}: `}</b>
           {`${labelGetRegexHelp} `}
-          <Link href="https://regex101.com" target="_blank">
+          <Link href="https://regex101.com" target="_blank" rel="noopener">
             regex101.com
           </Link>
         </i>

--- a/www/front_src/src/Resources/SearchHelpTooltip.tsx
+++ b/www/front_src/src/Resources/SearchHelpTooltip.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import { Tooltip, IconButton, Box, makeStyles } from '@material-ui/core';
+import { Tooltip, IconButton, Box, Link, makeStyles } from '@material-ui/core';
 import IconHelp from '@material-ui/icons/HelpOutline';
 import IconClose from '@material-ui/icons/HighlightOff';
 
@@ -76,6 +76,14 @@ const Content = ({ onClose }: ContentProps): JSX.Element => {
             {` ${labelSearchByHostNameStartingWith} "FR20" ${labelSearchAndHostAliasContaining} "prod"`}
           </li>
         </ul>
+        <i>
+          <b>Tips: </b>
+          get some help while creating your regular expression query at
+          <span> </span>
+          <Link href="https://regex101.com" target="_blank">
+            regex101.com
+          </Link>
+        </i>
       </Box>
     </>
   );

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -124,6 +124,10 @@ export const labelSearchByHostAddressNotContaining = I18n.t(
 export const labelSearchAndHostAliasContaining = I18n.t(
   'and host alias containing',
 );
+export const labelTips = I18n.t('Tips');
+export const labelGetRegexHelp = I18n.t(
+  'get some help while creating your regular expression query at',
+);
 export const labelService = I18n.t('Service');
 export const labelServiceGroup = I18n.t('Service group');
 export const labelStartTime = I18n.t('Start time');


### PR DESCRIPTION
## Description

![image](https://user-images.githubusercontent.com/11978823/80701605-f3274a80-8adf-11ea-920a-2899b66a43de.png)

**Fixes** MON-5328

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check search tooltip in events view page