### PR TITLE
fix(ui): do not display filter background when search field is focused

### DIFF
--- a/www/front_src/src/Resources/Filter/index.tsx
+++ b/www/front_src/src/Resources/Filter/index.tsx
@@ -59,6 +59,9 @@ const ExpansionPanelSummary = withStyles((theme) => ({
     '&$expanded': {
       minHeight: 'auto',
     },
+    '&$focused': {
+      backgroundColor: 'unset',
+    },
     justifyContent: 'flex-start',
   },
   content: {
@@ -68,6 +71,7 @@ const ExpansionPanelSummary = withStyles((theme) => ({
     },
     flexGrow: 0,
   },
+  focused: {},
   expanded: {},
 }))(MuiExpansionPanelSummary);
 
@@ -96,15 +100,6 @@ const useStyles = makeStyles((theme) => ({
     minWidth: 200,
     maxWidth: 400,
   },
-  collapseWrapper: {
-    margin: 0,
-    padding: theme.spacing(1),
-    '&$expanded': {
-      margin: 0,
-      padding: theme.spacing(1),
-    },
-  },
-  expanded: {},
 }));
 
 interface Props {


### PR DESCRIPTION
## Description

* Do not change background color of filter panel when search field is focused
* Remove useless styling (collapseWrapper)

**Fixes** MON-5154

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Click on search field in events view
* Check background of filter panel does not change