### PR TITLE
enh(ui): Use legend name in performance chart tooltip

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -205,7 +205,6 @@ const PerformanceGraph = ({
           <Tooltip
             labelFormatter={formatTooltipTime}
             formatter={formatTooltipValue}
-            contentStyle={{}}
           />
         </ComposedChart>
       </ResponsiveContainer>

--- a/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
+++ b/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
@@ -56,7 +56,7 @@ const getTimeSeries = (graphData: GraphData): Array<MetricData> => {
   )(graphData);
 };
 
-export interface LegendColor {
+interface LegendColor {
   name: string;
   color: string;
   metric: string;

--- a/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
+++ b/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
@@ -22,9 +22,9 @@ const toTimeWithMetrics = (
   timeIndex: number,
 ): MetricData => {
   const getMetricsForIndex = (): MetricData => {
-    const addMetricForTimeIndex = (acc, { legend, data }): MetricData => ({
+    const addMetricForTimeIndex = (acc, { metric, data }): MetricData => ({
       ...acc,
-      [legend]: data[timeIndex],
+      [metric]: data[timeIndex],
     });
 
     return reduce(addMetricForTimeIndex, {}, metrics);
@@ -56,13 +56,15 @@ const getTimeSeries = (graphData: GraphData): Array<MetricData> => {
   )(graphData);
 };
 
-interface LegendColor {
-  legend: string;
+export interface LegendColor {
+  name: string;
   color: string;
+  metric: string;
 }
 
-const toLegendColor = ({ ds_data, legend }: Metric): LegendColor => ({
-  legend,
+const toLegendColor = ({ ds_data, legend, metric }: Metric): LegendColor => ({
+  metric,
+  name: legend,
   color: ds_data.ds_color_line,
 });
 

--- a/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
+++ b/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
@@ -22,9 +22,9 @@ const toTimeWithMetrics = (
   timeIndex: number,
 ): MetricData => {
   const getMetricsForIndex = (): MetricData => {
-    const addMetricForTimeIndex = (acc, { metric, data }): MetricData => ({
+    const addMetricForTimeIndex = (acc, { legend, data }): MetricData => ({
       ...acc,
-      [metric]: data[timeIndex],
+      [legend]: data[timeIndex],
     });
 
     return reduce(addMetricForTimeIndex, {}, metrics);


### PR DESCRIPTION
## Description
This corrects the legend name in the chart tooltip:

![Screenshot from 2020-05-04 16-19-58](https://user-images.githubusercontent.com/8367233/80976048-3c023a80-8e23-11ea-98ba-6ac9013c97d9.png)

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Open a performance chart
- Hover the time series
- The tooltip should display the data using the same name as the legend
