### PR TITLE
fix(ui): fix default page when user is already logged in

### DIFF
--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -2216,25 +2216,24 @@ function cleanString($str)
  * get first menu entry allowed to a given user
  *
  * @param string $lcaTStr Allowed topology pages separated by comma
- * @param int $defautPage User default page
+ * @param int $defaultPage User default page
  * @return array The topology information (url, options, name...)
  */
-function getFirstAllowedMenu($lcaTStr, $defautPage = null)
+function getFirstAllowedMenu($lcaTStr, $defaultPage = null)
 {
     global $pearDB;
 
     $eventsViewPage = 104;
-    $orderedFields = [$eventsViewPage];
 
-    if ($defautPage !== null) {
-        array_unshift($orderedFields, $defautPage);
+    if ($defaultPage === null) {
+        $defaultPage = $eventsViewPage;
     }
 
     $query = "SELECT topology_parent,topology_name,topology_id,topology_url,topology_page,topology_url_opt, is_react "
         . "FROM topology "
         . "WHERE " . (trim($lcaTStr) != "" ? "topology_page IN ({$lcaTStr}) AND " : "")
         . "topology_page IS NOT NULL AND topology_show = '1' "
-        . "ORDER BY FIELD(topology_page, " . implode(',', $orderedFields) . ") DESC, topology_id ASC "
+        . "ORDER BY FIELD(topology_page, " . $defaultPage . ") DESC, topology_id ASC "
         . "LIMIT 1";
 
     $dbResult = $pearDB->query($query);


### PR DESCRIPTION
## Description

fix default page when user is already logged in

**Fixes** MON-5369

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Add a default page to a user
* Login with the user (==> check the user is properly redirected)
* Refresh centreon base uri (==> check the user is properly redirected)