### PR TITLE
fix: undefined variable and avoid PDO exception on altered requests

### DIFF
--- a/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+++ b/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
@@ -64,10 +64,14 @@ if (isset($sid)) {
     get_error('need session id !');
 }
 
-//check that $_GET['id'] is set, if not assign 0.
-// If a string is sent to host_id, return id 0 instead of false;
-$hostId = filter_var($_GET['hid'] ?? 0, FILTER_VALIDATE_INT) ?: 0;
-$svcId = filter_var($_GET['svc_id'] ?? 0, FILTER_VALIDATE_INT);
+// sanitize host and service id from request;
+$hostId = filter_var($_GET['hid'] ?? false, FILTER_VALIDATE_INT);
+$svcId = filter_var($_GET['svc_id'] ?? false, FILTER_VALIDATE_INT);
+
+// check if a mandatory valid hostId is given
+if (false === $hostId) {
+    get_error('bad host Id');
+}
 
 // Init GMT class
 $centreonGMT = new CentreonGMT($db);
@@ -85,7 +89,7 @@ $xml->writeElement('comment', _('Comment'));
 $xml->endElement();
 
 // Retrieve info
-if (!$service_id) {
+if (false === $svcId) {
     $res = $dbb->prepare(
         'SELECT author, entry_time, comment_data, persistent_comment, sticky
         FROM acknowledgements

--- a/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+++ b/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
@@ -66,10 +66,14 @@ if (isset($sid)) {
     get_error('need session id !');
 }
 
-//check that $_GET['id'] is set, if not assign 0.
-// If a string is sent to host_id, return id 0 instead of false;
-$hostId = filter_var($_GET['hid'] ?? 0, FILTER_VALIDATE_INT) ?: 0;
-$svcId = filter_var($_GET['svc_id'] ?? 0, FILTER_VALIDATE_INT);
+// sanitize host and service id from request;
+$hostId = filter_var($_GET['hid'] ?? false, FILTER_VALIDATE_INT);
+$svcId = filter_var($_GET['svc_id'] ?? false, FILTER_VALIDATE_INT);
+
+// check if a mandatory valid hostId is given
+if (false === $hostId) {
+    get_error('bad host Id');
+}
 
 // Init GMT class
 $centreonGMT = new CentreonGMT($db);
@@ -87,7 +91,7 @@ $xml->writeElement('comment', _('Comment'));
 $xml->endElement();
 
 // Retrieve info
-if (!$service_id) {
+if (false === $svcId) {
     $res = $dbb->prepare(
         'SELECT author, actual_start_time , end_time, comment_data, duration, fixed
         FROM downtimes


### PR DESCRIPTION
## Description

remove error in the logs when the user alter the http request with unconsistent data : 

```
==> /var/opt/rh/rh-php72/log/php-fpm/centreon-error.log <==
[06-May-2020 16:31:06 Europe/Paris] PHP Notice: Undefined variable: service_id in /usr/share/centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php on line 88
[06-May-2020 16:31:06 Europe/Paris] PHP Notice: Undefined variable: service_id in /usr/share/centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php on line 90
[06-May-2020 16:31:06 Europe/Paris] PHP Notice: Undefined variable: stmt in /usr/share/centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php on line 119
[06-May-2020 16:31:06 Europe/Paris] PHP Fatal error: Uncaught Error: Call to a member function fetch() on null in /usr/share/centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php:119
Stack trace:
#0 {main}
thrown in /usr/share/centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php on line 119
```

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
