### PR TITLE
enh(secu): sanitize and cast parameters to int

### DIFF
--- a/www/include/eventLogs/xml/data.php
+++ b/www/include/eventLogs/xml/data.php
@@ -170,13 +170,13 @@ if (isset($sid) && $sid) {
     );
 }
 
-$num = isset($inputs["num"]) ? intval($inputs["num"]) : "0";
-$limit = isset($inputs["limit"]) ? intval($inputs["limit"]) : "30";
+$num = isset($inputs["num"]) ? (int) $inputs["num"] : 0;
+$limit = isset($inputs["limit"]) ? (int) $inputs["limit"] : 30;
 $StartDate = isset($inputs["StartDate"]) ? htmlentities($inputs["StartDate"]) : "";
 $EndDate = isset($inputs["EndDate"]) ? $EndDate = htmlentities($inputs["EndDate"]) : "";
 $StartTime = isset($inputs["StartTime"]) ? $StartTime = htmlentities($inputs["StartTime"]) : "";
 $EndTime = isset($inputs["EndTime"]) ? $EndTime = htmlentities($inputs["EndTime"]) : "";
-$auto_period = isset($inputs["period"]) ? $auto_period = intval($inputs["period"]) : "-1";
+$auto_period = isset($inputs["period"]) ? $auto_period = (int) $inputs["period"] : -1;
 $engine = isset($inputs["engine"]) ? $engine = htmlentities($inputs["engine"]) : "false";
 $up = isset($inputs["up"]) ? htmlentities($inputs["up"]) : "true";
 $down = isset($inputs["down"]) ? htmlentities($inputs["down"]) : "true";

--- a/www/include/eventLogs/xml/data.php
+++ b/www/include/eventLogs/xml/data.php
@@ -87,13 +87,13 @@ include_once _CENTREON_PATH_ . "www/include/common/common-Func.php";
 $inputArguments = array(
     'lang' => FILTER_SANITIZE_STRING,
     'id' => FILTER_SANITIZE_STRING,
-    'num' => FILTER_SANITIZE_STRING,
-    'limit' => FILTER_SANITIZE_STRING,
+    'num' => FILTER_SANITIZE_NUMBER_INT,
+    'limit' => FILTER_SANITIZE_NUMBER_INT,
     'StartDate' => FILTER_SANITIZE_STRING,
     'EndDate' => FILTER_SANITIZE_STRING,
     'StartTime' => FILTER_SANITIZE_STRING,
     'EndTime' => FILTER_SANITIZE_STRING,
-    'period' => FILTER_SANITIZE_STRING,
+    'period' => FILTER_SANITIZE_NUMBER_INT,
     'engine' => FILTER_SANITIZE_STRING,
     'up' => FILTER_SANITIZE_STRING,
     'down' => FILTER_SANITIZE_STRING,
@@ -170,13 +170,13 @@ if (isset($sid) && $sid) {
     );
 }
 
-$num = isset($inputs["num"]) ? htmlentities($inputs["num"]) : "0";
-$limit = isset($inputs["limit"]) ? htmlentities($inputs["limit"]) : "30";
+$num = isset($inputs["num"]) ? intval($inputs["num"]) : "0";
+$limit = isset($inputs["limit"]) ? intval($inputs["limit"]) : "30";
 $StartDate = isset($inputs["StartDate"]) ? htmlentities($inputs["StartDate"]) : "";
 $EndDate = isset($inputs["EndDate"]) ? $EndDate = htmlentities($inputs["EndDate"]) : "";
 $StartTime = isset($inputs["StartTime"]) ? $StartTime = htmlentities($inputs["StartTime"]) : "";
 $EndTime = isset($inputs["EndTime"]) ? $EndTime = htmlentities($inputs["EndTime"]) : "";
-$auto_period = isset($inputs["period"]) ? $auto_period = htmlentities($inputs["period"]) : "-1";
+$auto_period = isset($inputs["period"]) ? $auto_period = intval($inputs["period"]) : "-1";
 $engine = isset($inputs["engine"]) ? $engine = htmlentities($inputs["engine"]) : "false";
 $up = isset($inputs["up"]) ? htmlentities($inputs["up"]) : "true";
 $down = isset($inputs["down"]) ? htmlentities($inputs["down"]) : "true";


### PR DESCRIPTION
Convert the num, limit, and period parameters to int. Sanitize them and call
intval on them, when performing the XML export on the event logs page.

These parameters are certainly meant to be numeric, since we do calculations
with them later on, such as this:

    $limitReq = " LIMIT " . $num * $limit . ", " . $limit;

Casting them to int prevents the possibility for SQL injection in the line
above. Additionally, on line 656 we loop over values derived from $num, and
that can lead to an infinite loop if $num is not numeric.

This change causes no functional changes to the event logs XML export. When
calling this page with non-numeric values for num, limit, or period, the
default options are used instead.

fixe (MON-5477)