### PR TITLE
enh(BE): add Asia/Yangon to the timezone list

### DIFF
--- a/doc/en/release_notes/centreon-19.04/centreon-19.04.15.rst
+++ b/doc/en/release_notes/centreon-19.04/centreon-19.04.15.rst
@@ -1,0 +1,9 @@
+#####################
+Centreon Web 19.04.15
+#####################
+
+Bug fixes
+---------
+enh(BE): add Asia/Yangon to the timezone list (#8711)
+
+

--- a/doc/fr/release_notes/centreon-19.04/centreon-19.04.15.rst
+++ b/doc/fr/release_notes/centreon-19.04/centreon-19.04.15.rst
@@ -1,0 +1,9 @@
+#####################
+Centreon Web 19.04.15
+#####################
+
+Bug fixes
+---------
+enh(BE): add Asia/Yangon to the timezone list (#8711)
+
+

--- a/www/install/insertBaseConf.sql
+++ b/www/install/insertBaseConf.sql
@@ -1168,6 +1168,7 @@ INSERT INTO timezone (`timezone_name`, `timezone_offset`, `timezone_dst_offset`)
                         ('Asia/Vientiane', '+07:00', '+07:00'),
                         ('Asia/Vladivostok', '+10:00', '+10:00'),
                         ('Asia/Yakutsk', '+09:00', '+09:00'),
+                        ('Asia/Yangon', '+6:30', '+6:30'),
                         ('Asia/Yekaterinburg', '+05:00', '+05:00'),
                         ('Asia/Yerevan', '+04:00', '+04:00'),
                         ('Atlantic/Azores', '-01:00', '-00:00'),

--- a/www/install/php/Update-19.04.15.php
+++ b/www/install/php/Update-19.04.15.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once __DIR__ . '/../../class/centreonLog.class.php';
+$centreonLog = new CentreonLog();
+
+// error specific content
+$versionOfTheUpgrade = 'UPGRADE - 19.04.15 : ';
+$errorMessage = '';
+
+/**
+ * Queries needing exception management BUT no rollback if failing
+ */
+try {
+    /*
+     * Get timezones and add "Asia/Yangon" if doesn't exist
+     */
+    $errorMessage = 'Cannot retrieve timezone list';
+    $res = $pearDB->query(
+        "SELECT timezone_name FROM timezone
+        WHERE timezone_name = 'Asia/Yangon'"
+    );
+    $timezone = $res->fetch();
+    if (false === $timezone) {
+        $errorMessage = 'Cannot add Asia/Yangon to timezone list';
+        $stmt = $pearDB->query(
+            'INSERT INTO timezone (timezone_name, timezone_offset, timezone_dst_offset, timezone_description)
+            VALUE ("Asia/Yangon", "+6:30", "+6:30", NULL)'
+        );
+    }
+} catch (\Exception $e) {
+    $centreonLog->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage .
+        " - Code : " . $e->getCode() .
+        " - Error : " . $e->getMessage() .
+        " - Trace : " . $e->getTraceAsString()
+    );
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, $e->getCode(), $e);
+}


### PR DESCRIPTION
## Description

Add to the timezone list the Yangon city from Myanmar
**Fixes** # (MON-5481)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
