### PR TITLE
 fix(ldap) fix authentication fallback to use local

### DIFF
--- a/www/class/centreonAuth.LDAP.class.php
+++ b/www/class/centreonAuth.LDAP.class.php
@@ -116,7 +116,13 @@ class CentreonAuthLDAP
             && $this->contactInfos['contact_ldap_dn'] != ''
             && $this->ldap->findUserDn($this->contactInfos['contact_alias']) !== $this->contactInfos['contact_ldap_dn']
         ) {
-            return 0;
+            if ($this->ldap->connect()) {
+                //User resource error
+                return 0;
+            } else {
+                //LDAP fallback
+                return 2;
+            }
         }
 
         /*


### PR DESCRIPTION
## Description

In a scenario where LDAP is configured and 'Store LDAP password' is set, Centreon should be able to authenticate an user if the connection with the LDAP server fails and the password has been previously stored. This fallback from the LDAP to local authentication should be automatic. Nowadays, the authentication fails instead.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

-Go to Administration  >  Parameters  >  LDAP
-Create your LDAP configuration and select ALL the following options:
    -Enable LDAP authentication: Yes
    -Store LDAP password: Yes
    -Auto import users: Yes
-Save the LDAP configuration
-Login to Centreon using an LDAP user that has not logged in before
-Logout
-Go to the database and confirm that the user account has been imported and password saved (probably, user and password are in the DB)
-Simulate a disruption in the connection with the LDAP. This can be achieved by manipulating the iptables on Centreon Central, for example

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
