### PR TITLE
fix(DT): replace end date when set in the past

### DIFF
--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -148,7 +148,7 @@ function turnOnEvents() {
 
     // End value of datepicker and timepicker selector
     $(".datepicker").last().on('change', function (e) {
-        // Check that the user do not set an end date lesser than the start date
+        // Check that the user do not set an end date lesser than the start date.
         checkEndDate();
         // Update the end time according to the chosen duration
         updateEndTime();

--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -220,10 +220,13 @@ function checkEndDate() {
     if (start.isSameOrAfter(end)) {
         turnOffEvents();
         start.add($('#duration').val(), $('#duration_scale').val());
-        $(".datepicker").last().datepicker("setDate", start.format($(".datepicker").last().datepicker(
-            "option",
-            "dateFormat"
-        ).toUpperCase().replace(/Y/g, 'YY')));
+        $(".datepicker").last()
+            .datepicker(
+                "setDate",
+                start.format(
+                    $(".datepicker").last().datepicker("option", "dateFormat").toUpperCase().replace(/Y/g, 'YY')
+                )
+            );
         turnOnEvents();
     }
 }

--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -209,7 +209,7 @@ function updateEndTime() {
 
 /**
  * Used for the end DATEPICKER, to avoid an end date value lesser than the start date
- * Update the end date according to the start values, and display a warning to the user.
+ * Updates the end date according to the start values.
  */
 function checkEndDate() {
     let start = moment($('[name="alternativeDateStart"]').val()

--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -180,10 +180,13 @@ function updateDateAndTime() {
     if (start.isSameOrAfter(end)) {
         turnOffEvents();
         start.add($('#duration').val(), $('#duration_scale').val());
-        $(".datepicker").last().datepicker("setDate", start.format($(".datepicker").last().datepicker(
-            "option",
-            "dateFormat"
-        ).toUpperCase().replace(/Y/g, 'YY')));
+        $(".datepicker").last()
+            .datepicker(
+                "setDate",
+                start.format(
+                    $(".datepicker").last().datepicker("option", "dateFormat").toUpperCase().replace(/Y/g, 'YY')
+                )
+            );
         $(".timepicker").last().timepicker("setTime", start.format("HH:mm"));
         turnOnEvents();
     }

--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -212,13 +212,10 @@ function updateEndTime() {
  * Update the end date according to the start values, and display a warning to the user.
  */
 function checkEndDate() {
-    let startDate = $('[name="alternativeDateStart"]').val();
-    let startTime = $(".timepicker").first().val();
-    let start = moment(startDate + ' ' + startTime, "MM/DD/YYYY HH:mm");
-
-    let endDate = $('[name="alternativeDateEnd"]').val();
-    let endTime = $(".timepicker").last().val();
-    let end = moment(endDate + ' ' + endTime, "MM/DD/YYYY HH:mm");
+    let start = moment($('[name="alternativeDateStart"]').val()
+        + ' ' + $(".timepicker").first().val(), "MM/DD/YYYY HH:mm");
+    let end = moment($('[name="alternativeDateEnd"]').val()
+        + ' ' + $(".timepicker").last().val(), "MM/DD/YYYY HH:mm");
 
     if (start.isSameOrAfter(end)) {
         turnOffEvents();
@@ -227,9 +224,6 @@ function checkEndDate() {
             "option",
             "dateFormat"
         ).toUpperCase().replace(/Y/g, 'YY')));
-        alert("The downtime end - " + endDate + " at " + endTime +
-            ",\nis not consistent with the start - " + startDate + " at " + startTime +
-            "\n\nThe downtime end will be modified according to the chosen duration");
         turnOnEvents();
     }
 }

--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -148,6 +148,9 @@ function turnOnEvents() {
 
     // End value of datepicker and timepicker selector
     $(".datepicker").last().on('change', function (e) {
+        // Check that the user do not set an end date lesser than the start date
+        checkEndDate();
+        // Update the end time according to the chosen duration
         updateEndTime();
     });
     $(".timepicker").last().on('change', function (e) {
@@ -200,6 +203,33 @@ function updateEndTime() {
         turnOffEvents();
         start.add($('#duration').val(), $('#duration_scale').val());
         $(".timepicker").last().timepicker("setTime", start.format("HH:mm"));
+        turnOnEvents();
+    }
+}
+
+/**
+ * Used for the end DATEPICKER, to avoid an end date value lesser than the start date
+ * Update the end date according to the start values, and display a warning to the user.
+ */
+function checkEndDate() {
+    let startDate = $('[name="alternativeDateStart"]').val();
+    let startTime = $(".timepicker").first().val();
+    let start = moment(startDate + ' ' + startTime, "MM/DD/YYYY HH:mm");
+
+    let endDate = $('[name="alternativeDateEnd"]').val();
+    let endTime = $(".timepicker").last().val();
+    let end = moment(endDate + ' ' + endTime, "MM/DD/YYYY HH:mm");
+
+    if (start.isSameOrAfter(end)) {
+        turnOffEvents();
+        start.add($('#duration').val(), $('#duration_scale').val());
+        $(".datepicker").last().datepicker("setDate", start.format($(".datepicker").last().datepicker(
+            "option",
+            "dateFormat"
+        ).toUpperCase().replace(/Y/g, 'YY')));
+        alert("The downtime end - " + endDate + " at " + endTime +
+            ",\nis not consistent with the start - " + startDate + " at " + startTime +
+            "\n\nThe downtime end will be modified according to the chosen duration");
         turnOnEvents();
     }
 }

--- a/www/include/common/javascript/datepicker/localizedDatepicker.js
+++ b/www/include/common/javascript/datepicker/localizedDatepicker.js
@@ -150,7 +150,7 @@ function turnOnEvents() {
     $(".datepicker").last().on('change', function (e) {
         // Check that the user do not set an end date lesser than the start date.
         checkEndDate();
-        // Update the end time according to the chosen duration
+        // Update the end time according to the chosen duration.
         updateEndTime();
     });
     $(".timepicker").last().on('change', function (e) {


### PR DESCRIPTION
## Description

With last modifications, a downtime end date can be set before the start date.
- check the end date consistency
- modify the end date and time,using the start date, time and the chosen duration

**Fixes** # (MON-3935)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
