### PR TITLE
fix(lib): use moment 2.21 instead of 2.9.0

### DIFF
--- a/www/include/Administration/corePerformance/nagiosStats.html
+++ b/www/include/Administration/corePerformance/nagiosStats.html
@@ -36,7 +36,7 @@
 </div>
 </form>
 
-<script src="./include/common/javascript/moment-with-locales.js"></script>
+<script src="./include/common/javascript/moment-with-locales.min.2.21.js"></script>
 <script src="./include/common/javascript/moment-timezone-with-data.min.js"></script>
 <script src="./include/common/javascript/handlebars-v4.0.5.js"></script>
 <script src="./include/common/javascript/centreon/centreon-select2.js"></script>

--- a/www/include/monitoring/objectDetails/template/hostDetails.ihtml
+++ b/www/include/monitoring/objectDetails/template/hostDetails.ihtml
@@ -489,7 +489,7 @@
     </tr>
 </table>
 <div id="div_img" class="img_volante"></div>
-<script src="./include/common/javascript/moment-with-locales.js"></script>
+<script src="./include/common/javascript/moment-with-locales.min.2.21.js"></script>
 <script src="./include/common/javascript/moment-timezone-with-data.min.js"></script>
 {literal}
 <script>

--- a/www/include/monitoring/status/Services/templates/service.ihtml
+++ b/www/include/monitoring/status/Services/templates/service.ihtml
@@ -90,5 +90,5 @@
 <input type='hidden' id='limit' name='limit' value='{$limit}'>	
 {$form.hidden}
 </form>
-<script src="./include/common/javascript/moment-with-locales.js"></script>
+<script src="./include/common/javascript/moment-with-locales.min.2.21.js"></script>
 <script src="./include/common/javascript/moment-timezone-with-data.min.js"></script>

--- a/www/include/views/graphs/graph-periods.html
+++ b/www/include/views/graphs/graph-periods.html
@@ -31,7 +31,7 @@
         </div>
     </div>
 </div>
-<script src="./include/common/javascript/moment-with-locales.js"></script>
+<script src="./include/common/javascript/moment-with-locales.min.2.21.js"></script>
 <script src="./include/common/javascript/moment-timezone-with-data.min.js"></script>
 <script src="./include/common/javascript/centreon/centreon-select2.js"></script>
 {literal}

--- a/www/include/views/graphs/graph-split.html
+++ b/www/include/views/graphs/graph-split.html
@@ -66,7 +66,7 @@
         </div>
     </div>
 </div>
-<script src="./include/common/javascript/moment-with-locales.js"></script>
+<script src="./include/common/javascript/moment-with-locales.min.2.21.js"></script>
 <script src="./include/common/javascript/moment-timezone-with-data.min.js"></script>
 <script src="./include/common/javascript/centreon/centreon-select2.js"></script>
 <script src="./include/common/javascript/datepicker/localizedDatepicker.js"></script>

--- a/www/include/views/graphs/graphs.html
+++ b/www/include/views/graphs/graphs.html
@@ -72,7 +72,7 @@
     </div>
 </div>
 
-<script src="./include/common/javascript/moment-with-locales.js"></script>
+<script src="./include/common/javascript/moment-with-locales.min.2.21.js"></script>
 <script src="./include/common/javascript/moment-timezone-with-data.min.js"></script>
 <script src="./include/common/javascript/handlebars-v4.0.5.js"></script>
 <script src="./include/common/javascript/centreon/centreon-select2.js"></script>


### PR DESCRIPTION
## Description

isSameOrAfter() method is not supported on momentJS 2.9.0. The host and services status pages do not support this method and need to use the latest momentJS library used in Centreon (2.21.0)

Notice : The lib 2.21.0 and 2.9.0 are already used and available in Centreon here : https://github.com/centreon/centreon/tree/master/www/include/common/javascript

Warning : Do not delete the momentJS 2.9.0 lib as it is still used by BAM

**Fixes** # (MON-3935)

![image](https://user-images.githubusercontent.com/34628915/81834792-c17f9c00-9541-11ea-807f-971ce87e9d7f.png)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
