### PR TITLE
fix(ui): fix user default page with options

### DIFF
--- a/features/AutologinOptions.feature
+++ b/features/AutologinOptions.feature
@@ -9,7 +9,6 @@ Feature: Autologin Options
         And the autologin option is enabled
 
     Scenario: Autologin with full screen option
-        Given user default page is a legacy page
         When I type the autologin url with the fullscreen option in my web browser
         Then Centreon default page is displayed without the menus and the header
 

--- a/features/AutologinOptions.feature
+++ b/features/AutologinOptions.feature
@@ -9,9 +9,10 @@ Feature: Autologin Options
         And the autologin option is enabled
 
     Scenario: Autologin with full screen option
+        Given user default page is a legacy page
         When I type the autologin url with the fullscreen option in my web browser
         Then Centreon default page is displayed without the menus and the header
-         
+
     Scenario: Autologin to Reporting Dashboards Hosts page
         When I type the autologin url with the option page 30701
         Then Reporting > Dashboards > Hosts page is displayed

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -2,7 +2,7 @@
 
 use Centreon\Test\Behat\Administration\ParametersCentreonUiPage;
 use Centreon\Test\Behat\Configuration\CurrentUserConfigurationPage;
-use Centreon\Test\Behat\Configuration\HostConfigurationPage;
+use Centreon\Test\Behat\Configuration\HostConfigurationListingPage;
 use Centreon\Test\Behat\CentreonContext;
 use Centreon\Test\Behat\External\LoginPage;
 
@@ -67,7 +67,7 @@ class AutologinOptionsContext extends CentreonContext
     {
         $this->spin(
             function ($context) {
-                new HostConfigurationPage($context, false);
+                new HostConfigurationListingPage($context, false);
                 return true;
             },
             'The current page is not valid.',

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -2,6 +2,7 @@
 
 use Centreon\Test\Behat\Administration\ParametersCentreonUiPage;
 use Centreon\Test\Behat\Configuration\CurrentUserConfigurationPage;
+use Centreon\Test\Behat\Configuration\HostConfigurationPage;
 use Centreon\Test\Behat\CentreonContext;
 use Centreon\Test\Behat\External\LoginPage;
 
@@ -16,7 +17,7 @@ class AutologinOptionsContext extends CentreonContext
     {
         $this->currentPage = new CurrentUserConfigurationPage($this);
         $this->currentPage->setProperties([
-            'default' => 'Administration > Sessions'
+            'default' => 'Configuration > Hosts'
         ]);
         $this->currentPage->save();
     }
@@ -66,11 +67,8 @@ class AutologinOptionsContext extends CentreonContext
     {
         $this->spin(
             function ($context) {
-                $element = $this->currentPage->find(
-                    'css',
-                    '*[aria-label="Breadcrumb"]  a[href="main.php?p=504"]'
-                );
-                return !is_null($element);
+                new HostConfigurationPage($context, false);
+                return true;
             },
             'The current page is not valid.',
             5

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -60,7 +60,10 @@ class AutologinOptionsContext extends CentreonContext
     {
         $this->spin(
             function ($context) {
-                $element = $this->currentPage->find('css', '*[aria-label="Breadcrumb"]  a[href="/centreon/monitoring/events"]');
+                $element = $this->currentPage->find(
+                    'css',
+                    '*[aria-label="Breadcrumb"]  a[href="main.php?p=50110&amp;o=general"]'
+                );
                 return !is_null($element);
             },
             'The current page is not valid.',

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -43,8 +43,9 @@ class AutologinOptionsContext extends CentreonContext
         $this->iAmLoggedOut();
 
         // log in with autologin
-        $this->visit('main.php?autologin=1&useralias=admin&token=autolog&min=1');
-        $this->currentPage = $this->getSession()->getPage();
+        $this->visit('main.php?autologin=1&useralias=admin&token=autolog&min=1', false);
+        self::$lastUri = 'p=60101';
+        $this->switchToIframe();
     }
 
     /**

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -62,7 +62,7 @@ class AutologinOptionsContext extends CentreonContext
             function ($context) {
                 $element = $this->currentPage->find(
                     'css',
-                    '*[aria-label="Breadcrumb"]  a[href="main.php?p=50110&o=general"]'
+                    '*[aria-label="Breadcrumb"]  a[href="main.php?p=504"]'
                 );
                 return !is_null($element);
             },

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -11,34 +11,16 @@ class AutologinOptionsContext extends CentreonContext
     private $currentPage;
 
     /**
-     * @Given user default page is a legacy page
-     */
-    public function userDefaultPageIsALegacyPage()
-    {
-        $this->currentPage = new CurrentUserConfigurationPage($this);
-        $this->currentPage->setProperties([
-            'default' => 'Configuration > Hosts'
-        ]);
-        $this->currentPage->save();
-    }
-
-    /**
      * @Given one autologin key has been generated
      */
     public function oneAutologinKeyHasBeenGenerated()
     {
         $this->currentPage = new CurrentUserConfigurationPage($this);
         $this->currentPage->setProperties(array(
+            'default' => 'Configuration > Hosts',
             'autologin_key' => 'autolog'
         ));
         $this->currentPage->save();
-
-        // Wait page is properly saved
-        $this->spin(
-            function ($context) {
-                return $context->getSession()->getPage()->has('css', 'input[name="change"]');
-            }
-        );
     }
 
     /**

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -62,7 +62,7 @@ class AutologinOptionsContext extends CentreonContext
             function ($context) {
                 $element = $this->currentPage->find(
                     'css',
-                    '*[aria-label="Breadcrumb"]  a[href="main.php?p=50110&amp;o=general"]'
+                    '*[aria-label="Breadcrumb"]  a[href="main.php?p=50110&o=general"]'
                 );
                 return !is_null($element);
             },

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -32,6 +32,13 @@ class AutologinOptionsContext extends CentreonContext
             'autologin_key' => 'autolog'
         ));
         $this->currentPage->save();
+
+        // Wait page is properly saved
+        $this->spin(
+            function ($context) {
+                return $context->getSession()->getPage()->has('css', 'input[type="button"][value="Modify"]');
+            }
+        );
     }
 
     /**

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -36,7 +36,7 @@ class AutologinOptionsContext extends CentreonContext
         // Wait page is properly saved
         $this->spin(
             function ($context) {
-                return $context->getSession()->getPage()->has('css', 'input[type="button"][value="Modify"]');
+                return $context->getSession()->getPage()->has('css', 'input[name="change"]');
             }
         );
     }

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -3,6 +3,7 @@
 use Centreon\Test\Behat\Administration\ParametersCentreonUiPage;
 use Centreon\Test\Behat\Configuration\CurrentUserConfigurationPage;
 use Centreon\Test\Behat\CentreonContext;
+use Centreon\Test\Behat\External\LoginPage;
 
 class AutologinOptionsContext extends CentreonContext
 {
@@ -49,6 +50,11 @@ class AutologinOptionsContext extends CentreonContext
      */
     public function iTypeTheAutologinUrlWithTheFullscreenOptionInMyWebBrowser()
     {
+        // log out
+        $this->visit('index.php?disconnect=1');
+        $this->currentPage = new LoginPage($this, false);
+
+        // log in with autologin
         $this->visit('main.php?autologin=1&useralias=admin&token=autolog&min=1');
         $this->currentPage = $this->getSession()->getPage();
     }

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -58,9 +58,7 @@ class AutologinOptionsContext extends CentreonContext
      */
     public function iTypeTheAutologinUrlWithTheFullscreenOptionInMyWebBrowser()
     {
-        // log out
-        $this->visit('index.php?disconnect=1');
-        $this->currentPage = new LoginPage($this, false);
+        $this->iAmLoggedOut();
 
         // log in with autologin
         $this->visit('main.php?autologin=1&useralias=admin&token=autolog&min=1');

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -15,7 +15,7 @@ class AutologinOptionsContext extends CentreonContext
     {
         $this->currentPage = new CurrentUserConfigurationPage($this);
         $this->currentPage->setProperties([
-            'default' => 'Administration > Parameters > Centreon UI'
+            'default' => 'Administration > Sessions'
         ]);
         $this->currentPage->save();
     }

--- a/features/bootstrap/AutologinOptionsContext.php
+++ b/features/bootstrap/AutologinOptionsContext.php
@@ -9,6 +9,18 @@ class AutologinOptionsContext extends CentreonContext
     private $currentPage;
 
     /**
+     * @Given user default page is a legacy page
+     */
+    public function userDefaultPageIsALegacyPage()
+    {
+        $this->currentPage = new CurrentUserConfigurationPage($this);
+        $this->currentPage->setProperties([
+            'default' => 'Administration > Parameters > Centreon UI'
+        ]);
+        $this->currentPage->save();
+    }
+
+    /**
      * @Given one autologin key has been generated
      */
     public function oneAutologinKeyHasBeenGenerated()


### PR DESCRIPTION
## Description

Fix user default page when default page use options

**Fixes** MON-5369

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check following user default page :
administration > parameters > centreon ui