### PR TITLE
fix(clapi) use same db connection instance

### DIFF
--- a/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -596,7 +596,7 @@ class CentreonConfigPoller
             throw new CentreonClapiException(self::MISSING_POLLER_ID);
         }
         $this->testPollerId($pollerId);
-        $centreonDir = CentreonUtils::getCentreonDir();
+        $centreonDir = realpath(__DIR__ . "/../../../");
         $pearDB = $this->dependencyInjector['configuration_db'];
         $res = $pearDB->query("SELECT snmp_trapd_path_conf FROM nagios_server WHERE id = '" . $pollerId . "'");
         $row = $res->fetchRow();

--- a/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -596,7 +596,7 @@ class CentreonConfigPoller
             throw new CentreonClapiException(self::MISSING_POLLER_ID);
         }
         $this->testPollerId($pollerId);
-        $centreonDir = realpath(__DIR__ . "/../../../");
+        $centreonDir = $this->centreon_path;
         $pearDB = $this->dependencyInjector['configuration_db'];
         $res = $pearDB->query("SELECT snmp_trapd_path_conf FROM nagios_server WHERE id = '" . $pollerId . "'");
         $row = $res->fetchRow();

--- a/www/class/centreon-clapi/centreonACL.class.php
+++ b/www/class/centreon-clapi/centreonACL.class.php
@@ -69,7 +69,8 @@ class CentreonACL
         $this->db->query("UPDATE acl_groups SET acl_group_changed = 1");
         $this->db->query("UPDATE acl_resources SET changed = 1");
         if ($flagOnly == false) {
-            passthru(CentreonUtils::getCentreonPath() . '/cron/centAcl.php');
+            $centreonDir = realpath(__DIR__ . "/../../../");
+            passthru($centreonDir . '/cron/centAcl.php');
         }
     }
 

--- a/www/class/centreon-clapi/centreonACL.class.php
+++ b/www/class/centreon-clapi/centreonACL.class.php
@@ -70,7 +70,7 @@ class CentreonACL
         $this->db->query("UPDATE acl_resources SET changed = 1");
         if ($flagOnly == false) {
             $centreonDir = realpath(__DIR__ . "/../../../");
-            passthru($this->centreon_path . '/cron/centAcl.php');
+            passthru($centreonDir . '/cron/centAcl.php');
         }
     }
 

--- a/www/class/centreon-clapi/centreonACL.class.php
+++ b/www/class/centreon-clapi/centreonACL.class.php
@@ -70,7 +70,7 @@ class CentreonACL
         $this->db->query("UPDATE acl_resources SET changed = 1");
         if ($flagOnly == false) {
             $centreonDir = realpath(__DIR__ . "/../../../");
-            passthru($centreonDir . '/cron/centAcl.php');
+            passthru($this->centreon_path . '/cron/centAcl.php');
         }
     }
 

--- a/www/class/centreon-clapi/centreonContact.class.php
+++ b/www/class/centreon-clapi/centreonContact.class.php
@@ -202,7 +202,8 @@ class CentreonContact extends CentreonObject
         if (strtolower($locale) == "en_us" || strtolower($locale) == "browser") {
             return true;
         }
-        $dir = CentreonUtils::getCentreonPath() . "/www/locale/$locale";
+        $centreonDir = realpath(__DIR__ . "/../../../");
+        $dir = $centreonDir . "/www/locale/$locale";
         if (is_dir($dir)) {
             return true;
         }

--- a/www/class/centreon-clapi/centreonHost.class.php
+++ b/www/class/centreon-clapi/centreonHost.class.php
@@ -668,7 +668,7 @@ class CentreonHost extends CentreonObject
                     || $params[1] == "ehi_statusmap_image"
                 ) {
                     if ($params[2]) {
-                        $id = CentreonUtils::getImageId($params[2]);
+                        $id = CentreonUtils::getImageId($params[2], $this->db);
                         if (is_null($id)) {
                             throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $params[2]);
                         }

--- a/www/class/centreon-clapi/centreonHostGroupService.class.php
+++ b/www/class/centreon-clapi/centreonHostGroupService.class.php
@@ -447,7 +447,7 @@ class CentreonHostGroupService extends CentreonObject
                 $params[2] = "esi_" . $params[2];
                 if ($params[2] == "esi_icon_image") {
                     if ($params[3]) {
-                        $id = CentreonUtils::getImageId($params[3]);
+                        $id = CentreonUtils::getImageId($params[3], $this->db);
                         if (is_null($id)) {
                             throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $params[3]);
                         }

--- a/www/class/centreon-clapi/centreonManufacturer.class.php
+++ b/www/class/centreon-clapi/centreonManufacturer.class.php
@@ -131,7 +131,7 @@ class CentreonManufacturer extends CentreonObject
             throw new CentreonClapiException(self::FILE_NOT_FOUND . ": " . $mibFile);
         }
         copy($mibFile, $tmpMibFile);
-        $centreonDir = CentreonUtils::getCentreonDir();
+        $centreonDir = realpath(__DIR__ . "/../../../");
         passthru("export MIBS=ALL && $centreonDir/bin/snmpttconvertmib --in=$tmpMibFile --out=$tmpMibFile.conf");
         passthru("$centreonDir/bin/centFillTrapDB -f $tmpMibFile.conf -m $vendorId");
         unlink($tmpMibFile);

--- a/www/class/centreon-clapi/centreonService.class.php
+++ b/www/class/centreon-clapi/centreonService.class.php
@@ -542,7 +542,7 @@ class CentreonService extends CentreonObject
                 $params[2] = "esi_" . $params[2];
                 if ($params[2] == "esi_icon_image") {
                     if ($params[3]) {
-                        $id = CentreonUtils::getImageId($params[3]);
+                        $id = CentreonUtils::getImageId($params[3], $this->db);
                         if (is_null($id)) {
                             throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $params[3]);
                         }

--- a/www/class/centreon-clapi/centreonServiceTemplate.class.php
+++ b/www/class/centreon-clapi/centreonServiceTemplate.class.php
@@ -410,7 +410,7 @@ class CentreonServiceTemplate extends CentreonObject
                 $params[1] = "esi_" . $params[1];
                 if ($params[1] == "esi_icon_image") {
                     if ($params[2]) {
-                        $id = CentreonUtils::getImageId($params[2]);
+                        $id = CentreonUtils::getImageId($params[2], $this->db);
                         if (is_null($id)) {
                             throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $params[2]);
                         }

--- a/www/class/centreon-clapi/centreonSeverityAbstract.class.php
+++ b/www/class/centreon-clapi/centreonSeverityAbstract.class.php
@@ -62,7 +62,7 @@ abstract class CentreonSeverityAbstract extends CentreonObject
                 throw new CentreonClapiException('Incorrect severity level parameters');
             }
             $level = (int)$params[1];
-            $iconId = CentreonUtils::getImageId($params[2]);
+            $iconId = CentreonUtils::getImageId($params[2], $this->db);
             if (is_null($iconId)) {
                 throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $params[2]);
             }

--- a/www/class/centreon-clapi/centreonUtils.class.php
+++ b/www/class/centreon-clapi/centreonUtils.class.php
@@ -1,6 +1,7 @@
 <?php
+
 /*
- * Copyright 2005-2015 CENTREON
+ * Copyright 2005-2020 CENTREON
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -35,6 +36,7 @@
 
 namespace CentreonClapi;
 
+
 class CentreonUtils
 {
     /**
@@ -53,39 +55,6 @@ class CentreonUtils
     private static $clapiUserId;
 
     /**
-     * Get centreon application path
-     *
-     * @return string
-     */
-    public static function getCentreonPath()
-    {
-        if (isset(self::$centreonPath)) {
-            return self::$centreonPath;
-        }
-        $db = new \CentreonDB('centreon');
-        $res = $db->query("SELECT `value` FROM options WHERE `key` = 'oreon_path'");
-        $row = $res->fetchRow();
-        self::$centreonPath = $row['value'];
-        return self::$centreonPath = $row['value'];
-    }
-
-    /**
-     * Get centreon directory
-     *
-     * @return string
-     */
-    public static function getCentreonDir()
-    {
-        $db = new \CentreonDB('centreon');
-        $res = $db->query("SELECT `value` FROM options WHERE `key` = 'oreon_path' LIMIT 1");
-        $row = $res->fetchRow();
-        if (isset($row['value'])) {
-            return $row['value'];
-        }
-        return "";
-    }
-
-    /**
      * Converts strings such as #S# #BS# #BR#
      *
      * @param string $pattern
@@ -101,10 +70,14 @@ class CentreonUtils
 
     /**
      * @param $imagename
-     * @return null
+     * @param null $db
+     * @return int|null
      */
-    public function getImageId($imagename)
+    public function getImageId($imagename, $db = null)
     {
+        if(is_null($db)){
+            $db = new \CentreonDB('centreon');
+        }
         $tab = preg_split("/\//", $imagename);
         isset($tab[0]) ? $dirname = $tab[0] : $dirname = null;
         isset($tab[1]) ? $imagename = $tab[1] : $imagename = null;
@@ -119,12 +92,11 @@ class CentreonUtils
             "AND img.img_path = '" . $imagename . "' " .
             "AND dir.dir_name = '" . $dirname . "' " .
             "LIMIT 1";
-        $db = new \CentreonDB('centreon');
         $res = $db->query($query);
         $img_id = null;
         $row = $res->fetchRow();
         if (isset($row['img_id']) && $row['img_id']) {
-            $img_id = $row['img_id'];
+            $img_id = (int)$row['img_id'];
         }
         return $img_id;
     }

--- a/www/class/centreon-clapi/centreonUtils.class.php
+++ b/www/class/centreon-clapi/centreonUtils.class.php
@@ -75,7 +75,7 @@ class CentreonUtils
      */
     public function getImageId($imagename, $db = null)
     {
-        if(is_null($db)){
+        if (is_null($db)) {
             $db = new \CentreonDB('centreon');
         }
         $tab = preg_split("/\//", $imagename);

--- a/www/class/centreon-clapi/centreonUtils.class.php
+++ b/www/class/centreon-clapi/centreonUtils.class.php
@@ -2,7 +2,7 @@
 
 /*
  * Copyright 2005-2020 CENTREON
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under


### PR DESCRIPTION
## Description

Line 21776 : Object already exists
PHP Fatal error: Uncaught Exception: SQLSTATE[HY000] [1040] Too many connections in /usr/share/centreon/www/class/centreonDB.class.php:163

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Import clapi  export (centreon -u user -p password -i ) with many lines

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
