### PR TITLE
fix(secu): avoid RCE using command helper

### DIFF
--- a/www/include/configuration/configObject/command/minHelpCommand.php
+++ b/www/include/configuration/configObject/command/minHelpCommand.php
@@ -80,7 +80,7 @@ if ($commandId != null) {
 }
 
 // Secure command
-$search  = array('#S#', '#BS#', '../');
+$search = array('#S#', '#BS#', '../');
 $replace = array('/', "\\", '/');
 $command = str_replace($search, $replace, $command);
 $command = escapeshellcmd($command);

--- a/www/include/configuration/configObject/command/minHelpCommand.php
+++ b/www/include/configuration/configObject/command/minHelpCommand.php
@@ -79,8 +79,11 @@ if ($commandId != null) {
     $command = $oreon->optGen["nagios_path_plugins"] . $commandName;
 }
 
-$command = str_replace("#S#", "/", $command);
-$command = str_replace("#BS#", "\\", $command);
+// Secure command
+$search  = array('#S#', '#BS#', '../');
+$replace = array('/', "\\", '/');
+$command = str_replace($search, $replace, $command);
+$command = escapeshellcmd($command);
 
 $tab = explode(' ', $command);
 if (realpath($tab[0])) {

--- a/www/include/configuration/configObject/command/minHelpCommand.php
+++ b/www/include/configuration/configObject/command/minHelpCommand.php
@@ -81,7 +81,7 @@ if ($commandId != null) {
 
 // Secure command
 $search = ['#S#', '#BS#', '../'];
-$replace = array('/', "\\", '/');
+$replace = ['/', "\\", '/'];
 $command = str_replace($search, $replace, $command);
 $command = escapeshellcmd($command);
 

--- a/www/include/configuration/configObject/command/minHelpCommand.php
+++ b/www/include/configuration/configObject/command/minHelpCommand.php
@@ -80,7 +80,7 @@ if ($commandId != null) {
 }
 
 // Secure command
-$search = array('#S#', '#BS#', '../');
+$search = ['#S#', '#BS#', '../'];
 $replace = array('/', "\\", '/');
 $command = str_replace($search, $replace, $command);
 $command = escapeshellcmd($command);


### PR DESCRIPTION
## Description

Sanitize command name from http request alterations.
Remove characters used to alter this feature, like bash "encoded" space

**Fixes** # (MON-5448) - reported by : TheCyberGeek


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please contact me

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
