### PR TITLE
fix: create media folder when inserting an old plugin

### DIFF
--- a/www/class/centreonMedia.class.php
+++ b/www/class/centreonMedia.class.php
@@ -182,9 +182,9 @@ class CentreonMedia
 
         $fullPath = $mediaDirectory . '/' . $dirname;
 
-        // Create directory
+        // Create directory and nested folder structure
         if (!is_dir($fullPath)) {
-            mkdir($fullPath);
+            mkdir($fullPath, 644, true);
         }
     }
 


### PR DESCRIPTION
## Description

As old plugin packs try to insert media in the "/usr/share/nagios/html/images/logo" while this folder isn't created anymore on fresh installs; we need to recusively create the path to the data to save

```
[20-May-2020 20:11:41 Europe/Paris] PHP Warning:  mkdir(): No such file or directory in /usr/share/centreon/www/class/centreonMedia.class.php on line 187
[20-May-2020 20:11:44 Europe/Paris] PHP Warning:  mkdir(): No such file or directory in /usr/share/centreon/www/class/centreonMedia.class.php on line 187
[20-May-2020 20:11:44 Europe/Paris] PHP Warning:  mkdir(): No such file or directory in /usr/share/centreon/www/class/centreonMedia.class.php on line 187
[20-May-2020 20:11:44 Europe/Paris] PHP Warning:  mkdir(): No such file or directory in /usr/share/centreon/www/class/centreonMedia.class.php on line 187
```
Debug shows : 
`path to insert = /usr/share/nagios/html/images/logos//ppm`

**Fixes** # (MON-5512)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)
