### PR TITLE
enh(install) disable default PHP pool

### DIFF
--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1491,6 +1491,11 @@ configure_php_fpm() {
     # Generate a apache config in directory
     prepare_php_fpm_config "$dir_conf"
 
+    # Disable the useless default pool to save resources
+    if [ -e $DIR_PHP_FPM_CONF/www.conf ] ; then
+        mv $DIR_PHP_FPM_CONF/www.conf $DIR_PHP_FPM_CONF/www.conf.orig
+    fi
+
     if [ "$silent_install" -ne 1 ] ; then
         if [ -e $DIR_PHP_FPM_CONF/centreon.conf ] ; then
             echo "$(gettext "Finding PHP FPM Centreon configuration file")"


### PR DESCRIPTION
Hi,

## Description

This PR disables the default PHP pool during installation.
This to save resources, as it is useless.

**Fixes** N/A

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

After Centreon installation, be sure only the `centreon` pool is enabled.

Before the PR :

```
# systemctl status rh-php72-php-fpm
● rh-php72-php-fpm.service - The PHP FastCGI Process Manager
   Loaded: loaded (/usr/lib/systemd/system/rh-php72-php-fpm.service; enabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/rh-php72-php-fpm.service.d
           └─centreon.conf
   Active: active (running) since Wed 2020-05-20 19:51:14 CEST; 1 day 21h ago
 Main PID: 803 (php-fpm)
   Status: "Processes active: 0, idle: 7, Requests: 161931, slow: 0, Traffic: 0.4req/sec"
   CGroup: /system.slice/rh-php72-php-fpm.service
           ├─  803 php-fpm: master process (/etc/opt/rh/rh-php72/php-fpm.conf)
           ├─  964 php-fpm: pool www
           ├─  965 php-fpm: pool www
           ├─  966 php-fpm: pool www
           ├─  967 php-fpm: pool www
           ├─  968 php-fpm: pool www
           ├─14598 php-fpm: pool centreon
           └─14613 php-fpm: pool centreon
```

After the PR :

```
# systemctl status rh-php72-php-fpm
● rh-php72-php-fpm.service - The PHP FastCGI Process Manager
   Loaded: loaded (/usr/lib/systemd/system/rh-php72-php-fpm.service; enabled; vendor preset: disabled)
  Drop-In: /etc/systemd/system/rh-php72-php-fpm.service.d
           └─centreon.conf
   Active: active (running) since Fri 2020-05-22 17:13:32 CEST; 2s ago
 Main PID: 14636 (php-fpm)
   Status: "Ready to handle connections"
   CGroup: /system.slice/rh-php72-php-fpm.service
           ├─14636 php-fpm: master process (/etc/opt/rh/rh-php72/php-fpm.conf)
           ├─14637 php-fpm: pool centreon
           └─14638 php-fpm: pool centreon
```

Thank you 👍