### PR TITLE
Do not use hardcoded tcp:// scheme when using proxy.

### DIFF
--- a/www/class/centreonRestHttp.class.php
+++ b/www/class/centreonRestHttp.class.php
@@ -202,8 +202,7 @@ class CentreonRestHttp
     public function setProxy($url, $port)
     {
         if (isset($url) && !empty($url)) {
-            $this->proxy = 'tcp://' . $url;
-            
+            $this->proxy = $url;
             if ($port) {
                 $this->proxy .= ':' . $port;
             }
@@ -228,8 +227,7 @@ class CentreonRestHttp
         }
 
         if (isset($dataProxy['proxy_url']) && !empty($dataProxy['proxy_url'])) {
-            $this->proxy = 'tcp://' . $dataProxy['proxy_url'];
-
+            $this->proxy = $dataProxy['proxy_url'];
             if ($dataProxy['proxy_port']) {
                 $this->proxy .= ':' . $dataProxy['proxy_port'];
             }


### PR DESCRIPTION
## Description

Do not use hardcoded tcp:// scheme before the proxy URL. Leave configuration of the scheme to the user.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

Specify a proxy in a distribution using an up-to-date (7.52+) version of curl (CentOS 8 for example). Without this fix, it should not work.

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
