### PR TITLE
fix(api): Avoid any exceptions by replacing command line with the error message

### DIFF
--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -308,10 +308,20 @@ class MonitoringResourceController extends AbstractController
         // ACL check
         $this->denyAccessUnlessGrantedForApiRealtime();
 
+        /**
+         * @var Service $service
+         */
         $service = $this->monitoring
             ->filterByContact($this->getUser())
             ->findOneService($hostId, $serviceId);
-        $this->monitoring->hidePasswordInCommandLine($service);
+        try {
+            $this->monitoring->hidePasswordInCommandLine($service);
+        } catch (\Throwable $ex) {
+            $service->setCommandLine(
+                sprintf('Unable to hide passwords in command (Reason: %s)', $ex->getMessage())
+            );
+        }
+
 
         if ($service === null) {
             return View::create(null, Response::HTTP_NOT_FOUND, []);

--- a/src/Centreon/Domain/Monitoring/MonitoringService.php
+++ b/src/Centreon/Domain/Monitoring/MonitoringService.php
@@ -395,7 +395,7 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
                     $macrosPasswordByName[$macro->getName()] = $macro;
                 }
                 $patternMacrosPassword = implode('|', $macroNames);
-                $patternMacrosPassword = str_replace(['$', '~'], ['\\$', '\~'], $patternMacrosPassword);
+                $patternMacrosPassword = str_replace(['$', '~'], ['\$', '\~'], $patternMacrosPassword);
                 foreach ($configurationToken as $index => $token) {
                     if (preg_match_all('~' . $patternMacrosPassword . '~', $token, $matches, PREG_SET_ORDER)) {
                         if (

--- a/src/Centreon/Domain/Monitoring/MonitoringService.php
+++ b/src/Centreon/Domain/Monitoring/MonitoringService.php
@@ -395,7 +395,7 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
                     $macrosPasswordByName[$macro->getName()] = $macro;
                 }
                 $patternMacrosPassword = implode('|', $macroNames);
-                $patternMacrosPassword = str_replace('$', '\\$', $patternMacrosPassword);
+                $patternMacrosPassword = str_replace(['$', '~'], ['\\$', '\~'], $patternMacrosPassword);
                 foreach ($configurationToken as $index => $token) {
                     if (preg_match_all('~' . $patternMacrosPassword . '~', $token, $matches, PREG_SET_ORDER)) {
                         if (


### PR DESCRIPTION
## Description

In the new event view, when we try to hide the password in the command line and an error occurs, a popup message appears with an error instead of displaying an error message in the Command section.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
