### PR TITLE
fix(ui): Prevent disabled actions resulting from limited ACL to be clickable

### DIFF
--- a/www/front_src/src/Resources/ActionButton.tsx
+++ b/www/front_src/src/Resources/ActionButton.tsx
@@ -21,7 +21,6 @@ type Props = {
 
 const ActionButton = ({
   title,
-  onClick,
   ariaLabel,
   disabled,
   ...props
@@ -34,7 +33,6 @@ const ActionButton = ({
         <IconButton
           className={classes.button}
           color="primary"
-          onClick={onClick}
           disabled={disabled}
           {...props}
         />

--- a/www/front_src/src/Resources/ActionButton.tsx
+++ b/www/front_src/src/Resources/ActionButton.tsx
@@ -19,23 +19,13 @@ type Props = {
   ariaLabel: string;
 } & IconButtonProps;
 
-const ActionButton = ({
-  title,
-  ariaLabel,
-  disabled,
-  ...props
-}: Props): JSX.Element => {
+const ActionButton = ({ title, ariaLabel, ...props }: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
     <Tooltip title={title} aria-label={ariaLabel}>
       <span>
-        <IconButton
-          className={classes.button}
-          color="primary"
-          disabled={disabled}
-          {...props}
-        />
+        <IconButton className={classes.button} color="primary" {...props} />
       </span>
     </Tooltip>
   );

--- a/www/front_src/src/Resources/ActionButton.tsx
+++ b/www/front_src/src/Resources/ActionButton.tsx
@@ -23,14 +23,21 @@ const ActionButton = ({
   title,
   onClick,
   ariaLabel,
+  disabled,
   ...props
 }: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
-    <Tooltip title={title} onClick={onClick} aria-label={ariaLabel}>
+    <Tooltip title={title} aria-label={ariaLabel}>
       <span>
-        <IconButton className={classes.button} color="primary" {...props} />
+        <IconButton
+          className={classes.button}
+          color="primary"
+          onClick={onClick}
+          disabled={disabled}
+          {...props}
+        />
       </span>
     </Tooltip>
   );

--- a/www/front_src/src/Resources/Actions/index.test.tsx
+++ b/www/front_src/src/Resources/Actions/index.test.tsx
@@ -145,7 +145,7 @@ describe(Actions, () => {
 
     await waitFor(() => expect(refreshButton).toBeEnabled());
 
-    fireEvent.click(refreshButton);
+    fireEvent.click(refreshButton.firstElementChild as HTMLElement);
 
     expect(onRefresh).toHaveBeenCalled();
   });
@@ -155,11 +155,15 @@ describe(Actions, () => {
 
     await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
 
-    fireEvent.click(getByLabelText(labelDisableAutorefresh));
+    fireEvent.click(
+      getByLabelText(labelDisableAutorefresh).firstElementChild as HTMLElement,
+    );
 
     expect(getByLabelText(labelEnableAutorefresh)).toBeTruthy();
 
-    fireEvent.click(getByLabelText(labelEnableAutorefresh));
+    fireEvent.click(
+      getByLabelText(labelEnableAutorefresh).firstElementChild as HTMLElement,
+    );
 
     expect(getByLabelText(labelDisableAutorefresh)).toBeTruthy();
   });


### PR DESCRIPTION
## Description
This prevents the User with limited ACL on an action to execute it even if the button is disabled. 

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Set a limited ACL for the current User on either acknowledge, downtime or check

- Go to the event view page

- try to click on a resource inline action (single Resource) corresponding to the limited ACL, that should be disabled (either acknowledge, downtime or check) 

Expected result: No action is triggered. 
