### PR TITLE
enh(ui): Use default font in Performance graph

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/Lines.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Lines.tsx
@@ -5,6 +5,8 @@ import { pipe, uniq, prop, map } from 'ramda';
 
 import { fade } from '@material-ui/core';
 
+import { fontFamily } from '.';
+
 const getGraphLines = ({ lines, formatValue }): Array<JSX.Element> => {
   const getUnits = (): Array<string> => {
     return pipe(map(prop('unit')), uniq)(lines);
@@ -22,6 +24,7 @@ const getGraphLines = ({ lines, formatValue }): Array<JSX.Element> => {
             yAxisId={unit}
             key={unit}
             orientation={index === 0 ? 'left' : 'right'}
+            tick={{ fontFamily }}
             tickFormatter={(tick): string => formatValue({ value: tick, unit })}
             {...props}
           />

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -33,6 +33,8 @@ import LoadingSkeleton from './LoadingSkeleton';
 import Legend from './Legend';
 import getGraphLines from './Lines';
 
+const fontFamily = 'Roboto, sans-serif';
+
 interface Props {
   endpoint: string;
   xAxisTickFormat?: string;
@@ -176,7 +178,7 @@ const PerformanceGraph = ({
           <XAxis
             dataKey="time"
             tickFormatter={formatXAxisTick}
-            tick={{ fontSize: 13 }}
+            tick={{ fontSize: 13, fontFamily }}
           />
 
           {getGraphLines({ lines: displayedLines, formatValue })}
@@ -184,6 +186,7 @@ const PerformanceGraph = ({
           <Tooltip
             labelFormatter={formatTooltipTime}
             formatter={formatTooltipValue}
+            contentStyle={{ fontFamily }}
           />
         </ComposedChart>
       </ResponsiveContainer>
@@ -201,3 +204,4 @@ const PerformanceGraph = ({
 };
 
 export default PerformanceGraph;
+export { fontFamily };


### PR DESCRIPTION
## Description

This PR makes the performance graph use Centreon default font (Roboto). It affects the X and Y axes, as well as the Tooltip legend (title and legend are formatted using mui's Typography, so they are already properly formatted).

![localhost_4000_centreon_monitoring_events](https://user-images.githubusercontent.com/8367233/83112903-251fd280-a0c7-11ea-8067-5d05c20eaed9.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>
- Go to the event views
- Open a performance graph details
- Check that Roboto is used consistently (compare with the demo platform if in doubt)
