### PR TITLE
enh(ui): Enhance graph unit formatting and Tooltip display in Event view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1156,7 +1156,7 @@
       "dev": true
     },
     "@centreon/ui": {
-      "version": "github:centreon/centreon-ui#889387f790a303416960142d8c89c64cc1ad22bf",
+      "version": "github:centreon/centreon-ui#c25f9f460f155aa55d89ea0d12f8343682a147c8",
       "from": "github:centreon/centreon-ui",
       "requires": {
         "@material-ui/core": "^4.9.11",
@@ -1175,6 +1175,8 @@
         "react-files": "^2.4.8",
         "react-router-dom": "^5.1.2",
         "resize-observer-polyfill": "^1.5.1",
+        "ts.data.json": "^1.1.0",
+        "ulog": "^2.0.0-beta.7",
         "use-debounce": "^3.4.1"
       }
     },
@@ -4812,6 +4814,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "block-stream": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
@@ -7961,10 +7972,11 @@
         }
       }
     },
-    "filesize": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
-      "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg=="
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "fill-range": {
       "version": "4.0.0",
@@ -11580,6 +11592,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }
@@ -18886,6 +18899,11 @@
       "integrity": "sha512-OgJPX0YOlhPD5fdFIoS50ZCWXDlmwBYbkXnlTs+TxOfsVzCvr+HoANzLLcTDLF9hkHO56DxtBTCm6XDPm7YEow==",
       "dev": true
     },
+    "ts.data.json": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ts.data.json/-/ts.data.json-1.1.0.tgz",
+      "integrity": "sha512-bdZJ19x6HVq7MTnCmSHDcOxipcVWhM8T86VaxScBd2awV/h1BW27iKL+DoFM4Nt5f9HUdp5V4IUGDHLrttLKyA=="
+    },
     "tslib": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
@@ -18990,6 +19008,11 @@
       "requires": {
         "typescript-compare": "^0.0.2"
       }
+    },
+    "ulog": {
+      "version": "2.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/ulog/-/ulog-2.0.0-beta.7.tgz",
+      "integrity": "sha512-LvQY6j+CcIilySof66EMr8spdCBmsklAUmvqvCqjWAGiyY2f44MgUbLgGyT27YM35pj0lLZlkCnNn1CcmDGbhQ=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -19370,6 +19393,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -20079,6 +20103,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "date-fns": "^2.14.0",
     "dom-serializer": "^1.0.1",
     "dompurify": "^2.0.11",
-    "filesize": "^6.1.0",
     "formik": "^2.1.4",
     "html-react-parser": "^0.10.3",
     "install": "^0.13.0",

--- a/www/front_src/src/Resources/Graph/Performance/Lines.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Lines.tsx
@@ -5,7 +5,9 @@ import { pipe, uniq, prop, map } from 'ramda';
 
 import { fade } from '@material-ui/core';
 
-const getGraphLines = ({ lines, formatValue }): Array<JSX.Element> => {
+import { fontFamily, formatValue } from '.';
+
+const getGraphLines = (lines): Array<JSX.Element> => {
   const getUnits = (): Array<string> => {
     return pipe(map(prop('unit')), uniq)(lines);
   };
@@ -22,6 +24,7 @@ const getGraphLines = ({ lines, formatValue }): Array<JSX.Element> => {
             yAxisId={unit}
             key={unit}
             orientation={index === 0 ? 'left' : 'right'}
+            tick={{ fontFamily }}
             tickFormatter={(tick): string => formatValue({ value: tick, unit })}
             {...props}
           />
@@ -29,7 +32,13 @@ const getGraphLines = ({ lines, formatValue }): Array<JSX.Element> => {
       });
     }
 
-    return [<YAxis key="single-y-axis" {...props} />];
+    return [
+      <YAxis
+        key="single-y-axis"
+        tickFormatter={(tick): string => formatValue({ value: tick, unit: '' })}
+        {...props}
+      />,
+    ];
   };
 
   return [

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -7,7 +7,7 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from 'recharts';
-import filesize from 'filesize';
+import * as numeral from 'numeral';
 import {
   pipe,
   map,
@@ -32,6 +32,26 @@ import { labelNoDataForThisPeriod } from '../../translatedLabels';
 import LoadingSkeleton from './LoadingSkeleton';
 import Legend from './Legend';
 import getGraphLines from './Lines';
+
+const fontFamily = 'Roboto, sans-serif';
+
+const formatValue = ({ value, unit }): string => {
+  const base2Units = [
+    'B',
+    'bytes',
+    'bytespersecond',
+    'B/s',
+    'B/sec',
+    'o',
+    'octets',
+  ];
+  const suffixFormat = base2Units.includes(unit) ? 'b' : 'a';
+
+  return numeral(value)
+    .format(`0.[00] ${suffixFormat}`)
+    .trim()
+    .replace('B', '');
+};
 
 interface Props {
   endpoint: string;
@@ -109,21 +129,6 @@ const PerformanceGraph = ({
   const sortedLines = sortBy(prop('name'), lineData);
   const displayedLines = reject(propEq('display', false), sortedLines);
 
-  const formatValue = ({ value, unit }): string => {
-    const base2Units = [
-      'B',
-      'bytes',
-      'bytespersecond',
-      'B/s',
-      'B/sec',
-      'o',
-      'octets',
-    ];
-    const base = base2Units.includes(unit) ? 2 : 10;
-
-    return filesize(value, { base }).replace('B', '');
-  };
-
   const formatTooltipValue = (value, metric, { unit }): Array<string> => {
     const legendName = pipe(
       find(propEq('metric', metric)),
@@ -179,11 +184,14 @@ const PerformanceGraph = ({
             tick={{ fontSize: 13 }}
           />
 
-          {getGraphLines({ lines: displayedLines, formatValue })}
+          {getGraphLines(displayedLines)}
 
           <Tooltip
             labelFormatter={formatTooltipTime}
             formatter={formatTooltipValue}
+            contentStyle={{ fontFamily }}
+            wrapperStyle={{ opacity: 0.7 }}
+            isAnimationActive={false}
           />
         </ComposedChart>
       </ResponsiveContainer>
@@ -201,3 +209,4 @@ const PerformanceGraph = ({
 };
 
 export default PerformanceGraph;
+export { fontFamily, formatValue };


### PR DESCRIPTION
## Description

This enhances the performance graph display by formatting the unit values (especially ones that are < 0) with more precision. It also adds some transparency to the legend tooltip in order to be able to have some visibility over the graph while looking at the detailed values.

Before:

![localhost_4000_centreon_monitoring_events](https://user-images.githubusercontent.com/8367233/83135947-eef24b00-a0e6-11ea-8340-d80b2e474d72.png)

After:

![localhost_4000_centreon_monitoring_events (4)](https://user-images.githubusercontent.com/8367233/83135986-fe719400-a0e6-11ea-98a4-6adeaf185b2b.png)

![localhost_4000_centreon_monitoring_events (3)](https://user-images.githubusercontent.com/8367233/83136003-04677500-a0e7-11ea-9409-41514484497c.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x (master)
