### PR TITLE
fix(sec): set Access-Control-Allow-Credentials response header to false

### DIFF
--- a/config/packages/nelmio_cors.yaml
+++ b/config/packages/nelmio_cors.yaml
@@ -1,6 +1,6 @@
 nelmio_cors:
     defaults:
-        allow_credentials: true
+        allow_credentials: false
         origin_regex: true
         allow_origin: ['*']
         allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']


### PR DESCRIPTION
## Description

Avoid security issue when using request.credentials with `include` value

**Fixes** MON-5496

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

* Login to centreon
* In an other tab, open a file with the following content (by replacing `<ip_address>`) : 
```html
<body>
  <script>
    fetch("http://<ip_address>/centreon/api/beta/monitoring/resources", {credentials: "include"}).then(response => response.json()).then(function (data) {
      document.body.textContent = JSON.stringify(data);
    });
  </script>
```
* Check resource listing is not returned