### PR TITLE
Remove initial state for AjaxTimeReloadMonitoring

### DIFF
--- a/www/front_src/src/redux/reducers/refreshReducer.js
+++ b/www/front_src/src/redux/reducers/refreshReducer.js
@@ -1,10 +1,6 @@
 import * as actions from '../actions/refreshActions';
 
-const initialState = {
-  AjaxTimeReloadMonitoring: 10,
-};
-
-const refreshReducer = (state = initialState, action) => {
+const refreshReducer = (state = {}, action) => {
   switch (action.type) {
     case actions.SET_REFRESH_INTERVALS:
       return { ...state, ...action.intervals };


### PR DESCRIPTION
## Description

This fixes the Host and Service top menus not being displayed. 

The issue was that the interval was being triggered within componentWillReceiveProps. The default value of 10 prevented the method from being called, whenever the received value from the parameter was 10 (including all the values below 10, enforced by the API to be 10).

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to Parameters -> Centreon UI
- Set the refresh interval for monitoring to a value of 10 or less than 10
- Save
- Refresh the page

Expected result:
- the Host and Service menus are displayed and the interval is correctly set to the value coming from the parameters. 
