### PR TITLE
fix(ui): Fix lower value display of Event view performance graph 

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
+++ b/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
@@ -35,7 +35,7 @@ const toTimeValue = (
 
 const getTimeSeries = (graphData: GraphData): Array<TimeValue> => {
   const isGreaterThanLowerLimit = (value): boolean =>
-    value > pathOr(value - 1, ['global', 'lower-limit'], graphData);
+    value >= pathOr(value - 1, ['global', 'lower-limit'], graphData);
 
   const rejectLowerThanLimit = ({ time, ...metrics }: TimeValue): TimeValue => {
     return {


### PR DESCRIPTION
## Description

This fixes the lower limit check so that even if the lower limit is set to 0, graph with only 0 values are displayed anyway:

![localhost_4000_centreon_monitoring_events (6)](https://user-images.githubusercontent.com/8367233/83431094-13c42680-a437-11ea-91d1-010b8c77ec7d.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie
- [x] 20.04.x (master)

<h2> How this pull request can be tested ? </h2>
- Open a performance graph (such as Centreon-ping)
- wait that enough values are available
- Check that a line (for instance Packet-loss for Centreon-ping) is displayed
