### PR TITLE
fix(trap): remove default value when options configured

### DIFF
--- a/lib/perl/centreon/script/centreon_trap_send.pm
+++ b/lib/perl/centreon/script/centreon_trap_send.pm
@@ -54,7 +54,7 @@ sub new {
     $self->{opt_snmpversion} = 'snmpv2c';
     $self->{opt_snmpport} = 162;
     $self->{opt_oidtrap} = '.1.3.6.1.4.1.12182.1';
-    @{$self->{opt_args}} = ('.1.3.6.1.4.1.12182.2.1:OCTET_STRING:Test "20"', '.1.3.6.1.4.1.12182.2.1:INTEGER:10', '.1.3.6.1.4.1.12182.2.1:COUNTER:100');
+    @{$self->{opt_args}} = ();
     $self->add_options(
         "d=s" => \$self->{opt_d}, "destination=s" => \$self->{opt_d},
         "c=s" => \$self->{opt_snmpcommunity}, "community=s" => \$self->{opt_snmpcommunity},


### PR DESCRIPTION
## Description

When the script was using, the default value from the help manual was used :

```
/usr/share/centreon/bin/centreon_trap_send -d 127.0.0.1 -c public -o 1.3.6.1.4.1.39009.1.2 -a '.1.3.6.1.4.1.39009.3:OCTET_STRING:HOST=$HOSTNAME$,IP=$HOSTADDRESS$,STATUS=$HOSTSTATE$,LOCATION=$HOSTALIAS$'
# IF I TAKE A LOOK ON MY TRAP : 
[root@archimede-central centreontrapd]# cat \#centreon-trap-1591279342617995
1591279342
localhost
UDP: [127.0.0.1]:55318->[127.0.0.1]:162
DISMAN-EVENT-MIB::sysUpTimeInstance 184:4:13:13.42
SNMPv2-MIB::snmpTrapOID.0 SNMPv2-SMI::enterprises.39009.1.2
SNMPv2-SMI::enterprises.12182.2.1 "Test \"20\""
SNMPv2-SMI::enterprises.12182.2.1 10
SNMPv2-SMI::enterprises.12182.2.1 100
SNMPv2-SMI::enterprises.39009.3 "HOST=$HOSTNAME$,IP=$HOSTADDRESS$,STATUS=$HOSTSTATE$,LOCATION=$HOSTALIAS$"
```
As you can seen I still have the default argument in my TRAP, and so my trap is not properly compute by my trap handler.

With the fixes :
```
[root@archimede-central centreontrapd]# /usr/share/centreon/bin/centreon_trap_send -d 127.0.0.1 -c public -o 1.3.6.1.4.1.39009.1.2 -a '.1.3.6.1.4.1.39009.3:OCTET_STRING:HOST=$HOSTNAME$,IP=$HOSTADDRESS$,STATUS=$HOSTSTATE$,LOCATION=$HOSTALIAS$'
[root@archimede-central centreontrapd]# cat \#centreon-trap-1591279690446843
1591279690
localhost
UDP: [127.0.0.1]:58939->[127.0.0.1]:162
DISMAN-EVENT-MIB::sysUpTimeInstance 184:4:13:16.90
SNMPv2-MIB::snmpTrapOID.0 SNMPv2-SMI::enterprises.39009.1.2
SNMPv2-SMI::enterprises.39009.3 "HOST=$HOSTNAME$,IP=$HOSTADDRESS$,STATUS=$HOSTSTATE$,LOCATION=$HOSTALIAS$"
```
Now my trap is correct.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x  (master)

<h2> How this pull request can be tested ? </h2>

You can test by using my commands above and start snmptrapd service (do not start centreontrapd) and take look into the traps stored /var/spool/centreontrapd/

Any **relevant details** of the configuration to perform the test should be added.

This patch is already in production on some customers plateforms.