### PR TITLE
[WEB][API] Correct sortType and order for host in realtime

### DIFF
--- a/www/api/class/centreon_realtime_hosts.class.php
+++ b/www/api/class/centreon_realtime_hosts.class.php
@@ -141,20 +141,20 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
         } else {
             $this->viewType = null;
         }
-        if (isset($this->arguments['sortType'])) {
-            if (strtolower($this->arguments['sortType']) === 'asc' ||
-                strtolower($this->arguments['sortType']) === 'desc') {
-                $this->sortType = $this->arguments['sortType'];
+        if (isset($this->arguments['order'])) {
+            if (strtolower($this->arguments['order']) === 'asc' ||
+                strtolower($this->arguments['order']) === 'desc') {
+                $this->order = $this->arguments['order'];
             } else {
-                throw new \RestBadRequestException('Bad sort type parameter');
+                throw new \RestBadRequestException('Bad order parameter');
             }
         } else {
-            $this->sortType = null;
-        }
-        if (isset($this->arguments['order'])) {
-            $this->order = $this->arguments['order'];
-        } else {
             $this->order = null;
+        }
+        if (isset($this->arguments['sortType'])) {
+            $this->sortType = $this->arguments['sortType'];
+        } else {
+            $this->sortType = null;
         }
     }
 


### PR DESCRIPTION
… realtime host

## Description

To make a sort type on host status with the API

**Fixes** # (MON-5668)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [ ] 18.10.x
- [ ] 19.04.x
- [X] 19.10.x
- [X] 20.04.x
- [X] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

With this modification, it is now possible to sort the realtime host by one field. Before, the sortType parameter could take only the values "desc" and "asc".