### PR TITLE
fix(backup): keep mount option only for xfs partition type

### DIFF
--- a/cron/centreon-backup-mysql.sh
+++ b/cron/centreon-backup-mysql.sh
@@ -243,10 +243,10 @@ mkdir -p "$SNAPSHOT_MOUNT"
 partition_type=$(df /dev/$vg_name/dbbackup --print-type | grep -i "xfs");
 if [ -z "$partition_type"]; then
     parameters = "/dev/$vg_name/dbbackup"
-else;
+else
     # the new partition is an 'xfs', adding the mount option 'nouuid'
     parameters = "$MNTOPTIONS /dev/$vg_name/dbbackup"
-    fi
+fi
 
 mount "$parameters" "$SNAPSHOT_MOUNT"
 

--- a/cron/centreon-backup-mysql.sh
+++ b/cron/centreon-backup-mysql.sh
@@ -242,10 +242,10 @@ mkdir -p "$SNAPSHOT_MOUNT"
 # check for ext4 type of the LVM partition.
 partition_type=$(df /dev/$vg_name/dbbackup --print-type | grep -i "xfs");
 if [ -z "$partition_type"]; then
-    parameters = "/dev/$vg_name/dbbackup"
+    parameters="/dev/$vg_name/dbbackup"
 else
     # the new partition is an 'xfs', adding the mount option 'nouuid'
-    parameters = "$MNTOPTIONS /dev/$vg_name/dbbackup"
+    parameters="$MNTOPTIONS /dev/$vg_name/dbbackup"
 fi
 
 mount "$parameters" "$SNAPSHOT_MOUNT"

--- a/cron/centreon-backup-mysql.sh
+++ b/cron/centreon-backup-mysql.sh
@@ -241,7 +241,7 @@ mkdir -p "$SNAPSHOT_MOUNT"
 
 # check for new partition type.
 patition_type=$(lsblk -n -o FSTYPE /dev/$vg_name/dbbackup)
-if [ $? = "xfs" ]; then
+if [ "$partition_type" = "xfs" ]; then
     # the new partition is an 'xfs', adding specific mount option 'nouuid'
     mount $MNT_OPTIONS_XFS "/dev/$vg_name/dbbackup" "$SNAPSHOT_MOUNT"
 else

--- a/cron/centreon-backup-mysql.sh
+++ b/cron/centreon-backup-mysql.sh
@@ -51,7 +51,7 @@ SAVE_LAST_FILE="backup.last"
 DO_ARCHIVE=1
 INIT_SCRIPT="" # try to find it
 PARTITION_NAME="centreon_storage/data_bin centreon_storage/logs"
-# warning this option will fail on partition type different than 'xfs'. The partition will be checked later
+# this option is required for 'xfs' partition type
 MNTOPTIONS="-o nouuid" 
 
 ###
@@ -242,11 +242,14 @@ mkdir -p "$SNAPSHOT_MOUNT"
 # check for ext4 type of the LVM partition.
 partition_type=$(df /dev/$vg_name/dbbackup --print-type | grep -i "xfs");
 if [ -z "$partition_type"]; then
-    # the new partition is not an 'xfs', removing the '-o nouuid' mount option
-    MNTOPTIONS="";
-fi
+    parameters = "/dev/$vg_name/dbbackup"
+else;
+    # the new partition is an 'xfs', adding the mount option 'nouuid'
+    parameters = "$MNTOPTIONS /dev/$vg_name/dbbackup"
+    fi
 
-mount $MNTOPTIONS /dev/$vg_name/dbbackup "$SNAPSHOT_MOUNT"
+mount "$parameters" "$SNAPSHOT_MOUNT"
+
 if [ $? -eq 0 ]; then
     output_log "Device mounted successfully"
 else

--- a/cron/centreon-backup-mysql.sh
+++ b/cron/centreon-backup-mysql.sh
@@ -51,7 +51,8 @@ SAVE_LAST_FILE="backup.last"
 DO_ARCHIVE=1
 INIT_SCRIPT="" # try to find it
 PARTITION_NAME="centreon_storage/data_bin centreon_storage/logs"
-MNTOPTIONS="-o nouuid"
+# warning this option will fail on partition type different than 'xfs'. The partition will be checked later
+MNTOPTIONS="-o nouuid" 
 
 ###
 # Check MySQL launch
@@ -237,6 +238,14 @@ $INIT_SCRIPT start
 ###
 output_log "Mount LVM snapshot"
 mkdir -p "$SNAPSHOT_MOUNT"
+
+# check for ext4 type of the LVM partition.
+partition_type=$(df /dev/$vg_name/dbbackup --print-type | grep -i "xfs");
+if [ -z "$partition_type"]; then
+    # the new partition is not an 'xfs', removing the '-o nouuid' mount option
+    MNTOPTIONS="";
+fi
+
 mount $MNTOPTIONS /dev/$vg_name/dbbackup "$SNAPSHOT_MOUNT"
 if [ $? -eq 0 ]; then
     output_log "Device mounted successfully"

--- a/cron/centreon-backup-mysql.sh
+++ b/cron/centreon-backup-mysql.sh
@@ -240,7 +240,7 @@ output_log "Mount LVM snapshot"
 mkdir -p "$SNAPSHOT_MOUNT"
 
 # check for new partition type.
-patition_type=$(lsblk -n -o FSTYPE /dev/$vg_name/dbbackup)
+partition_type=$(lsblk -n -o FSTYPE /dev/$vg_name/dbbackup)
 if [ "$partition_type" = "xfs" ]; then
     # the new partition is an 'xfs', adding specific mount option 'nouuid'
     mount $MNT_OPTIONS_XFS "/dev/$vg_name/dbbackup" "$SNAPSHOT_MOUNT"


### PR DESCRIPTION
## Description

The backup script fail when the new temporary partition is not an 'xfs' partition.

**Fixes** # (https://github.com/centreon/centreon/issues/8635)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 2.8.x
- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Launch manually the script located in /usr/share/centreon/cron/centreon-backup-mysql.sh
And check that the tables are correctly displayed and backuped
