### PR TITLE
Quiet SSH for nagiosPerfTrace.pm

### DIFF
--- a/lib/perl/centreon/script/nagiosPerfTrace.pm
+++ b/lib/perl/centreon/script/nagiosPerfTrace.pm
@@ -50,7 +50,7 @@ sub new {
     );
 
     bless $self, $class;
-    $self->{sshOptions} = "-o ConnectTimeout=5 -o StrictHostKeyChecking=yes -o PreferredAuthentications=publickey -o ServerAliveInterval=10 -o ServerAliveCountMax=3 -o Compression=yes ";
+    $self->{sshOptions} = "-o ConnectTimeout=5 -o StrictHostKeyChecking=yes -o PreferredAuthentications=publickey -o ServerAliveInterval=10 -o ServerAliveCountMax=3 -o Compression=yes -q ";
     $self->{interval} = 300;
     $self->{heartbeatFactor} = 10;
     $self->{heartbeat} = $self->{interval} * $self->{heartbeatFactor};


### PR DESCRIPTION
## Description

Add quiet option for SSH on the nagiosPerfTrace script in order to avoid to fill its log file with SSH banners.

## Target serie

- [ ] 19.04.x
- [x] 19.10.x

<h2> How this pull request can be tested ? </h2>

Add SSH banner on central and pollers.
Look the content of /var/log/centreon/nagiosPerfTrace.log on the central server (separately of the proper functioning of the script). You'll see all your banners in the log file.

Refs MON-5967