### PR TITLE
fix(ui): disable service checkbox when not allowed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "centreon",
-  "version": "20.04.0",
+  "version": "20.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1151,7 +1151,7 @@
       "dev": true
     },
     "@centreon/frontend-core": {
-      "version": "github:centreon/frontend-core#896e011ad5635eb85f1130f81e08dba9a1bbef91",
+      "version": "github:centreon/frontend-core#4c51ba99d805b1ee33970aaa23d3af9e0ef5fdec",
       "from": "github:centreon/frontend-core",
       "dev": true
     },
@@ -1159,12 +1159,12 @@
       "version": "github:centreon/centreon-ui#c25f9f460f155aa55d89ea0d12f8343682a147c8",
       "from": "github:centreon/centreon-ui",
       "requires": {
-        "@material-ui/core": "^4.9.11",
+        "@material-ui/core": "^4.10.0",
         "@material-ui/icons": "4.9.1",
-        "@material-ui/lab": "^4.0.0-alpha.50",
-        "@material-ui/styles": "^4.9.10",
+        "@material-ui/lab": "^4.0.0-alpha.54",
+        "@material-ui/styles": "^4.10.0",
         "axios": "^0.19.2",
-        "clsx": "^1.1.0",
+        "clsx": "^1.1.1",
         "formik": "^2.1.4",
         "loaders.css": "^0.1.2",
         "lodash": "^4.17.15",
@@ -1173,11 +1173,11 @@
         "react": "^16.11.0",
         "react-dom": "^16.11.0",
         "react-files": "^2.4.8",
-        "react-router-dom": "^5.1.2",
+        "react-router-dom": "^5.2.0",
         "resize-observer-polyfill": "^1.5.1",
         "ts.data.json": "^1.1.0",
         "ulog": "^2.0.0-beta.7",
-        "use-debounce": "^3.4.1"
+        "use-debounce": "^3.4.2"
       }
     },
     "@cnakazawa/watch": {

--- a/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
@@ -107,7 +107,7 @@ const DialogAcknowledge = ({
               control={
                 <Checkbox
                   checked={values.acknowledgeAttachedResources}
-                  disabled={!canAcknowledgeServices}
+                  disabled={!canAcknowledgeServices()}
                   inputProps={{ 'aria-label': labelAcknowledgeServices }}
                   color="primary"
                   onChange={handleChange('acknowledgeAttachedResources')}

--- a/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
@@ -106,7 +106,10 @@ const DialogAcknowledge = ({
             <FormControlLabel
               control={
                 <Checkbox
-                  checked={values.acknowledgeAttachedResources}
+                  checked={
+                    canAcknowledgeServices() &&
+                    values.acknowledgeAttachedResources
+                  }
                   disabled={!canAcknowledgeServices()}
                   inputProps={{ 'aria-label': labelAcknowledgeServices }}
                   color="primary"

--- a/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Acknowledge/Dialog.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
 
-import { Typography, Checkbox, FormHelperText, Grid } from '@material-ui/core';
+import {
+  Checkbox,
+  FormControlLabel,
+  FormHelperText,
+  Grid,
+} from '@material-ui/core';
 import { Alert } from '@material-ui/lab';
 
 import { Dialog, TextField, Loader } from '@centreon/ui';
@@ -39,7 +44,10 @@ const DialogAcknowledge = ({
   handleChange,
   loading,
 }: Props): JSX.Element => {
-  const { getAcknowledgementDeniedTypeAlert } = useAclQuery();
+  const {
+    getAcknowledgementDeniedTypeAlert,
+    canAcknowledgeServices,
+  } = useAclQuery();
 
   const deniedTypeAlert = getAcknowledgementDeniedTypeAlert(resources);
 
@@ -78,42 +86,36 @@ const DialogAcknowledge = ({
             helperText={errors?.comment}
           />
         </Grid>
-        <Grid container item direction="column">
-          <Grid item container xs alignItems="center">
-            <Grid item xs={1}>
+        <Grid item>
+          <FormControlLabel
+            control={
               <Checkbox
+                checked={values.notify}
                 inputProps={{ 'aria-label': labelNotify }}
                 color="primary"
-                value={values.notify}
                 onChange={handleChange('notify')}
+                size="small"
               />
-            </Grid>
-            <Grid item xs>
-              <Typography>{labelNotify}</Typography>
-            </Grid>
-          </Grid>
-          <Grid item container xs>
-            <Grid item xs={1} />
-            <Grid item xs>
-              <FormHelperText>{labelNotifyHelpCaption}</FormHelperText>
-            </Grid>
-          </Grid>
+            }
+            label={labelNotify}
+          />
+          <FormHelperText>{labelNotifyHelpCaption}</FormHelperText>
         </Grid>
         {hasHosts && (
-          <Grid container item direction="column">
-            <Grid item container xs alignItems="center">
-              <Grid item xs={1}>
+          <Grid item>
+            <FormControlLabel
+              control={
                 <Checkbox
                   checked={values.acknowledgeAttachedResources}
+                  disabled={!canAcknowledgeServices}
                   inputProps={{ 'aria-label': labelAcknowledgeServices }}
                   color="primary"
                   onChange={handleChange('acknowledgeAttachedResources')}
+                  size="small"
                 />
-              </Grid>
-              <Grid item xs>
-                <Typography>{labelAcknowledgeServices}</Typography>
-              </Grid>
-            </Grid>
+              }
+              label={labelAcknowledgeServices}
+            />
           </Grid>
         )}
       </Grid>

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
@@ -265,7 +265,9 @@ const DialogDowntime = ({
               <FormControlLabel
                 control={
                   <Checkbox
-                    checked={values.downtimeAttachedResources}
+                    checked={
+                      canDowntimeServices() && values.downtimeAttachedResources
+                    }
                     disabled={!canDowntimeServices()}
                     inputProps={{ 'aria-label': labelSetDowntimeOnServices }}
                     color="primary"

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
@@ -266,7 +266,7 @@ const DialogDowntime = ({
                 control={
                   <Checkbox
                     checked={values.downtimeAttachedResources}
-                    disabled={!canDowntimeServices}
+                    disabled={!canDowntimeServices()}
                     inputProps={{ 'aria-label': labelSetDowntimeOnServices }}
                     color="primary"
                     onChange={handleChange('downtimeAttachedResources')}

--- a/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Downtime/Dialog.tsx
@@ -3,7 +3,12 @@ import * as React from 'react';
 import moment from 'moment-timezone/builds/moment-timezone-with-data-10-year-range';
 import MomentUtils from '@date-io/moment';
 
-import { Typography, Checkbox, FormHelperText, Grid } from '@material-ui/core';
+import {
+  Checkbox,
+  FormControlLabel,
+  FormHelperText,
+  Grid,
+} from '@material-ui/core';
 import {
   MuiPickersUtilsProvider,
   KeyboardTimePicker,
@@ -91,7 +96,7 @@ const DialogDowntime = ({
   setFieldValue,
   loading,
 }: Props): JSX.Element => {
-  const { getDowntimeDeniedTypeAlert } = useAclQuery();
+  const { getDowntimeDeniedTypeAlert, canDowntimeServices } = useAclQuery();
 
   const open = resources.length > 0;
 
@@ -193,20 +198,19 @@ const DialogDowntime = ({
               </Grid>
             </Grid>
           </Grid>
-          <Grid container item direction="column">
-            <Grid item container xs alignItems="center">
-              <Grid item xs={1}>
+          <Grid item>
+            <FormControlLabel
+              control={
                 <Checkbox
                   checked={values.fixed}
                   inputProps={{ 'aria-label': labelFixed }}
                   color="primary"
                   onChange={handleChange('fixed')}
+                  size="small"
                 />
-              </Grid>
-              <Grid item xs>
-                <Typography>{labelFixed}</Typography>
-              </Grid>
-            </Grid>
+              }
+              label={labelFixed}
+            />
           </Grid>
           <Grid item>
             <FormHelperText>{labelDuration}</FormHelperText>
@@ -257,20 +261,20 @@ const DialogDowntime = ({
             />
           </Grid>
           {hasHosts && (
-            <Grid container item direction="column">
-              <Grid item container xs alignItems="center">
-                <Grid item xs={1}>
+            <Grid item>
+              <FormControlLabel
+                control={
                   <Checkbox
                     checked={values.downtimeAttachedResources}
+                    disabled={!canDowntimeServices}
                     inputProps={{ 'aria-label': labelSetDowntimeOnServices }}
                     color="primary"
                     onChange={handleChange('downtimeAttachedResources')}
+                    size="small"
                   />
-                </Grid>
-                <Grid item xs>
-                  <Typography>{labelSetDowntimeOnServices}</Typography>
-                </Grid>
-              </Grid>
+                }
+                label={labelSetDowntimeOnServices}
+              />
             </Grid>
           )}
         </Grid>

--- a/www/front_src/src/Resources/Actions/Resource/aclQuery.ts
+++ b/www/front_src/src/Resources/Actions/Resource/aclQuery.ts
@@ -22,8 +22,10 @@ import { labelServicesDenied, labelHostsDenied } from '../../translatedLabels';
 interface AclQuery {
   canDowntime: (resources) => boolean;
   getDowntimeDeniedTypeAlert: (resources) => string | undefined;
+  canDowntimeServices: () => boolean;
   canAcknowledge: (resources) => boolean;
   getAcknowledgementDeniedTypeAlert: (resources) => string | undefined;
+  canAcknowledgeServices: () => boolean;
   canCheck: (resources) => boolean;
 }
 
@@ -81,6 +83,9 @@ const useAclQuery = (): AclQuery => {
     return getDeniedTypeAlert({ resources, action: 'downtime' });
   };
 
+  const canDowntimeServices = (): boolean =>
+    pathEq(['actions', 'service', 'downtime'], true)(acl);
+
   const canAcknowledge = (resources: Array<Resource>): boolean => {
     return can({ resources, action: 'acknowledgement' });
   };
@@ -91,6 +96,9 @@ const useAclQuery = (): AclQuery => {
     return getDeniedTypeAlert({ resources, action: 'acknowledgement' });
   };
 
+  const canAcknowledgeServices = (): boolean =>
+    pathEq(['actions', 'service', 'acknowledgement'], true)(acl);
+
   const canCheck = (resources: Array<Resource>): boolean => {
     return can({ resources, action: 'check' });
   };
@@ -98,8 +106,10 @@ const useAclQuery = (): AclQuery => {
   return {
     canDowntime,
     getDowntimeDeniedTypeAlert,
+    canDowntimeServices,
     canAcknowledge,
     getAcknowledgementDeniedTypeAlert,
+    canAcknowledgeServices,
     canCheck,
   };
 };

--- a/www/front_src/src/Resources/Actions/index.test.tsx
+++ b/www/front_src/src/Resources/Actions/index.test.tsx
@@ -23,6 +23,7 @@ import {
   labelAcknowledge,
   labelDowntime,
   labelSetDowntime,
+  labelSetDowntimeOnServices,
   labelAcknowledgeServices,
   labelNotify,
   labelFixed,
@@ -554,6 +555,50 @@ describe(Actions, () => {
 
       await waitFor(() => {
         expect(getByText(labelWarning)).toBeInTheDocument();
+      });
+    },
+  );
+
+  it.each([
+    [
+      labelSetDowntime,
+      labelDowntime,
+      labelSetDowntimeOnServices,
+      cannotDowntimeServicesAcl,
+    ],
+    [
+      labelAcknowledge,
+      labelAcknowledge,
+      labelAcknowledgeServices,
+      cannotAcknowledgeServicesAcl,
+    ],
+  ])(
+    'disables services propagation option when trying to %p on hosts and not being able on services',
+    async (_, labelAction, labelAppliesOnServices, acl) => {
+      mockedUserContext.useUserContext.mockReset().mockReturnValue({
+        ...mockUserContext,
+        acl,
+      });
+
+      const { getByText } = renderActions();
+
+      const selectedHost = {
+        id: 0,
+        type: 'host',
+      } as Resource;
+
+      act(() => {
+        context.setSelectedResources([selectedHost]);
+      });
+
+      fireEvent.click(getByText(labelAction));
+
+      await waitFor(() => {
+        expect(
+          getByText(labelAppliesOnServices).parentElement?.querySelector(
+            'input[type="checkbox"]',
+          ),
+        ).toBeDisabled();
       });
     },
   );

--- a/www/front_src/src/Resources/Actions/index.test.tsx
+++ b/www/front_src/src/Resources/Actions/index.test.tsx
@@ -573,7 +573,7 @@ describe(Actions, () => {
       cannotAcknowledgeServicesAcl,
     ],
   ])(
-    'disables services propagation option when trying to %p on hosts when ACL on services are not sufficient,
+    'disables services propagation option when trying to %p on hosts when ACL on services are not sufficient',
     async (_, labelAction, labelAppliesOnServices, acl) => {
       mockedUserContext.useUserContext.mockReset().mockReturnValue({
         ...mockUserContext,

--- a/www/front_src/src/Resources/Actions/index.test.tsx
+++ b/www/front_src/src/Resources/Actions/index.test.tsx
@@ -573,7 +573,7 @@ describe(Actions, () => {
       cannotAcknowledgeServicesAcl,
     ],
   ])(
-    'disables services propagation option when trying to %p on hosts and not being able on services',
+    'disables services propagation option when trying to %p on hosts when ACL on services are not sufficient,
     async (_, labelAction, labelAppliesOnServices, acl) => {
       mockedUserContext.useUserContext.mockReset().mockReturnValue({
         ...mockUserContext,


### PR DESCRIPTION
## Description

Disable "applies to services checkbox when action is not allowed on services : 
- downtime dialog
- acknowledgement dialog

I've also reduced size of checkboxes (small)

![image](https://user-images.githubusercontent.com/11978823/84035956-d44c8b80-a99c-11ea-8287-88fd7ebbb2ec.png)

![image](https://user-images.githubusercontent.com/11978823/84036753-f2ff5200-a99d-11ea-80fa-1cd2d5db587c.png)


**Fixes** MON-5150

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

<h2> How this pull request can be tested ? </h2>

* log in with a user which cannot acknowledge and set downtime on services
* go to events view and check a host in listing
* try to acknowledge or set a downtime using top action buttons
* check that checkbox which apply action on services is not checked and disabled

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)