### PR TITLE
fix(config): change check_meta_host_alive command line to use dummy check

### DIFF
--- a/www/class/config-generate/meta_command.class.php
+++ b/www/class/config-generate/meta_command.class.php
@@ -57,7 +57,8 @@ class MetaCommand extends AbstractObject
         $this->generateObjectInFile($object, 0);
 
         $object['command_name'] = 'check_meta_host_alive';
-        $object['command_line'] = '$USER1$/check_ping -H $HOSTADDRESS$ -w 3000.0,80% -c 5000.0,100% -p 1';
+        $object['command_line'] = '$CENTREONPLUGINS$/centreon_centreon_central.pl ' .
+            '--plugin=apps::centreon::local::plugin --mode=dummy --status=\'0\' --output=\'This is a dummy check\'';
         $this->generateObjectInFile($object, 0);
     }
 }


### PR DESCRIPTION
## Description

Change embedded `check_meta_host_alive` command line to use centreon-plugins dummy check.
Current command line might prevent notifications to be sent if plugin is not present and host considered as down.

Fixes: #7728
Refs: MON-5446

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Add a meta service with configuration that can trigger notifications,
* Look at notifications in Engine's logs.

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
