### PR TITLE
fix(proxy): Fix bad serialization of proxy

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15392,3 +15392,9 @@ msgstr "Les services ne seront pas affectés car vous ne disposez pas de droits 
 
 msgid "Hosts will not be affected because you don't have sufficient permission"
 msgstr "Les hôtes ne seront pas affectés car vous ne disposez pas de droits suffisants"
+
+msgid "Protocol %s is not allowed"
+msgstr "Le protocole %s n'est pas autorisé"
+
+msgid "The port can only be between 0 and 65535 inclusive"
+msgstr "Le port ne peut être compris qu'entre 0 et 65535 inclus"

--- a/src/Centreon/Domain/Proxy/Proxy.php
+++ b/src/Centreon/Domain/Proxy/Proxy.php
@@ -81,12 +81,14 @@ class Proxy
     }
 
     /**
-     * @param string|null $url
+     * @param string|null $url An empty url will not be taken into account.
      * @return Proxy
      */
     public function setUrl(?string $url): Proxy
     {
-        $this->url = $url;
+        if (!empty($url)) {
+            $this->url = $url;
+        }
         return $this;
     }
 
@@ -99,12 +101,20 @@ class Proxy
     }
 
     /**
-     * @param int|null $port
+     * @param int|null $port Numerical value (0 >= PORT >= 65535)
      * @return Proxy
+     * @throws \InvalidArgumentException
      */
     public function setPort(?int $port): Proxy
     {
-        $this->port = $port;
+        if ($port >= 0 && $port <= 65535) {
+            $this->port = $port;
+        } else {
+            throw new \InvalidArgumentException(
+                sprintf(_('The port can only be between 0 and 65535 inclusive'))
+            );
+        }
+
         return $this;
     }
 
@@ -117,12 +127,14 @@ class Proxy
     }
 
     /**
-     * @param string|null $user
+     * @param string|null $user An empty user will not be taken into account.
      * @return Proxy
      */
     public function setUser(?string $user): Proxy
     {
-        $this->user = $user;
+        if (!empty($user)) {
+            $this->user = $user;
+        }
         return $this;
     }
 
@@ -184,12 +196,13 @@ class Proxy
      */
     public function __toString()
     {
-        $uri = $this->protocol;
-        if ($this->url !== null) {
-            if ($this->user !== null) {
+        $uri = '';
+        if (!empty($this->url)) {
+            $uri .= $this->protocol;
+            if (!empty($this->user)) {
                 $uri .= $this->user . ':' . $this->password . '@';
             }
-            if ($this->port !== null && $this->port >= 0) {
+            if (!empty($this->port) && $this->port >= 0) {
                 $uri .= $this->url . ':' . $this->port;
             } else {
                 $uri .= $this->url;

--- a/src/Centreon/Domain/Proxy/Proxy.php
+++ b/src/Centreon/Domain/Proxy/Proxy.php
@@ -101,7 +101,7 @@ class Proxy
     }
 
     /**
-     * @param int|null $port Numerical value (0 >= PORT >= 65535)
+     * @param int|null $port Numerical value (0 >= PORT <= 65535)
      * @return Proxy
      * @throws \InvalidArgumentException
      */

--- a/tests/php/Centreon/Domain/Proxy/ProxyTest.php
+++ b/tests/php/Centreon/Domain/Proxy/ProxyTest.php
@@ -1,0 +1,159 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Tests\Centreon\Domain\Proxy;
+
+use Centreon\Domain\Proxy\Proxy;
+use PHPUnit\Framework\TestCase;
+
+class ProxyTest extends TestCase
+{
+    public function testSettingProxyWithEmptyUrl(): void
+    {
+        $proxy = new Proxy();
+        $proxy->setUrl('');
+        $this->assertNull($proxy->getUrl());
+
+        $proxy->setUrl(null);
+        $this->assertNull($proxy->getUrl());
+    }
+
+    public function testSettingProxyWithNonEmptyUrl(): void
+    {
+        $proxy = new Proxy();
+        $proxy->setUrl('centreon.com');
+        $this->assertEquals('centreon.com', $proxy->getUrl());
+    }
+
+    public function testSettingProxyWithEmptyUser(): void
+    {
+        $proxy = new Proxy();
+        $proxy->setUser('');
+        $this->assertNull($proxy->getUser());
+
+        $proxy->setUser(null);
+        $this->assertNull($proxy->getUser());
+    }
+
+    public function testSettingProxyWithNonEmptyUser(): void
+    {
+        $proxy = new Proxy();
+        $proxy->setUser('admin');
+        $this->assertEquals('admin', $proxy->getUser());
+    }
+
+    public function testSettingProxyWithEmptyPassword(): void
+    {
+        $proxy = new Proxy();
+        $proxy->setPassword('');
+        $this->assertEmpty($proxy->getPassword());
+
+        $proxy->setPassword(null);
+        $this->assertNull($proxy->getPassword());
+    }
+
+    public function testSettingProxyWithNonEmptyPassword(): void
+    {
+        $proxy = new Proxy();
+        $proxy->setPassword('my password');
+        $this->assertEquals('my password', $proxy->getPassword());
+    }
+
+    public function testSettingProxyWithNotAllowedProtocol(): void
+    {
+        $protocol = 'http://badprotocol';
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(_('Protocol %s is not allowed'), $protocol));
+        $proxy = new Proxy();
+        $proxy->setProtocol($protocol);
+    }
+
+    public function testSettingProxyWithAllowedProtocol(): void
+    {
+        $proxy = new Proxy();
+        $proxy->setProtocol(Proxy::PROTOCOL_CONNECT);
+        $this->assertEquals(Proxy::PROTOCOL_CONNECT, $proxy->getProtocol());
+
+        $proxy = new Proxy();
+        $proxy->setProtocol(Proxy::PROTOCOL_HTTPS);
+        $this->assertEquals(Proxy::PROTOCOL_HTTPS, $proxy->getProtocol());
+
+        $proxy = new Proxy();
+        $proxy->setProtocol(Proxy::PROTOCOL_HTTP);
+        $this->assertEquals(Proxy::PROTOCOL_HTTP, $proxy->getProtocol());
+    }
+
+    public function testSettingProxyWithNegativePort(): void
+    {
+        $proxy = new Proxy();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The port can only be between 0 and 65535 inclusive');
+        $proxy->setPort(-1);
+    }
+
+    public function testSettingProxyWithOutOfRangePort(): void
+    {
+        $proxy = new Proxy();
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The port can only be between 0 and 65535 inclusive');
+        $proxy->setPort(65536);
+    }
+
+    public function testProxySerialization(): void
+    {
+        // Serialization to test: <<procotol>>://<<user>>:<<password>>@<<url>>:<<port>>
+        $proxy = new Proxy();
+        $proxy->setProtocol(Proxy::PROTOCOL_HTTPS);
+        $proxy->setUser('user');
+        $proxy->setPassword('password');
+        $proxy->setUrl('centreon.com');
+        $proxy->setPort(10);
+        $this->assertEquals('https://user:password@centreon.com:10', (string) $proxy);
+
+        // Serialization to test: <<procotol>>://<<user>>:<<password>>@<<url>>
+        $proxy = new Proxy();
+        $proxy->setProtocol(Proxy::PROTOCOL_HTTPS);
+        $proxy->setUser('user');
+        $proxy->setPassword('password');
+        $proxy->setUrl('centreon.com');
+        $this->assertEquals('https://user:password@centreon.com', (string) $proxy);
+
+        // Serialization to test: <<procotol>>://<<url>>:<<port>>
+        $proxy = new Proxy();
+        $proxy->setProtocol(Proxy::PROTOCOL_HTTPS);
+        $proxy->setPassword('password'); // Without user value the password should not be taken into account
+        $proxy->setUrl('centreon.com');
+        $proxy->setPort(10);
+        $this->assertEquals('https://centreon.com:10', (string) $proxy);
+
+        // Serialization to test: <<procotol>>://<<url>>
+        $proxy = new Proxy();
+        $proxy->setProtocol(Proxy::PROTOCOL_HTTPS);
+        $proxy->setUrl('centreon.com');
+        $this->assertEquals('https://centreon.com', (string) $proxy);
+
+        // Serialization when nothing is defined
+        $proxy = new Proxy();
+        $proxy->setProtocol(Proxy::PROTOCOL_HTTPS);
+        $this->assertEquals('', (string) $proxy);
+    }
+}


### PR DESCRIPTION
## Description

Fixed the bad serialization of proxy

**Fixes** # (issue)

When no properties have been defined for the proxy, serialization only returns the protocol instead of returning an empty value.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
