### PR TITLE
fix(api): acknowledge more than 10 first services

### DIFF
--- a/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+++ b/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
@@ -292,7 +292,7 @@ class AcknowledgementService extends AbstractCentreonService implements Acknowle
         if ($resource->getType() === ResourceEntity::TYPE_HOST) {
             $this->engineService->addHostAcknowledgement($ack, $host);
             if ($ack->isWithServices()) {
-                $services = $this->monitoringRepository->findServicesByHostWithoutParameters($host->getId());
+                $services = $this->monitoringRepository->findServicesByHostWithoutRequestParameters($host->getId());
                 foreach ($services as $service) {
                     $service->setHost($host);
                     $this->engineService->addServiceAcknowledgement($ack, $service);

--- a/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+++ b/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
@@ -164,7 +164,7 @@ class AcknowledgementService extends AbstractCentreonService implements Acknowle
         $this->engineService->addHostAcknowledgement($acknowledgement, $host);
 
         if ($acknowledgement->isWithServices()) {
-            $services = $this->monitoringRepository->findServicesByHost($host->getId());
+            $services = $this->monitoringRepository->findServicesByHostWithoutParameters($host->getId());
             foreach ($services as $service) {
                 $service->setHost($host);
                 $this->engineService->addServiceAcknowledgement($acknowledgement, $service);
@@ -292,7 +292,7 @@ class AcknowledgementService extends AbstractCentreonService implements Acknowle
         if ($resource->getType() === ResourceEntity::TYPE_HOST) {
             $this->engineService->addHostAcknowledgement($ack, $host);
             if ($ack->isWithServices()) {
-                $services = $this->monitoringRepository->findServicesByHost($host->getId());
+                $services = $this->monitoringRepository->findServicesByHostWithoutParameters($host->getId());
                 foreach ($services as $service) {
                     $service->setHost($host);
                     $this->engineService->addServiceAcknowledgement($ack, $service);

--- a/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
+++ b/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
@@ -164,7 +164,7 @@ class AcknowledgementService extends AbstractCentreonService implements Acknowle
         $this->engineService->addHostAcknowledgement($acknowledgement, $host);
 
         if ($acknowledgement->isWithServices()) {
-            $services = $this->monitoringRepository->findServicesByHostWithoutParameters($host->getId());
+            $services = $this->monitoringRepository->findServicesByHostWithoutRequestParameters($host->getId());
             foreach ($services as $service) {
                 $service->setHost($host);
                 $this->engineService->addServiceAcknowledgement($acknowledgement, $service);

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -112,12 +112,23 @@ interface MonitoringRepositoryInterface
 
     /**
      * Retrieve all real time services according to ACL of contact and host id
+     * using request parameters (search, sort, pagination)
      *
      * @param int $hostId Host ID for which we want to find services
      * @return Service[]
      * @throws \Exception
      */
-    public function findServicesByHost(int $hostId): array;
+    public function findServicesByHostWithParameters(int $hostId): array;
+
+    /**
+     * Retrieve all real time services according to ACL of contact and host id
+     * without request parameters (no search, no sort, no pagination)
+     *
+     * @param int $hostId Host ID for which we want to find services
+     * @return Service[]
+     * @throws \Exception
+     */
+    public function findServicesByHostWithoutParameters(int $hostId): array;
 
     /**
      * Find services according to the host id and service ids given

--- a/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
+++ b/src/Centreon/Domain/Monitoring/Interfaces/MonitoringRepositoryInterface.php
@@ -118,7 +118,7 @@ interface MonitoringRepositoryInterface
      * @return Service[]
      * @throws \Exception
      */
-    public function findServicesByHostWithParameters(int $hostId): array;
+    public function findServicesByHostWithRequestParameters(int $hostId): array;
 
     /**
      * Retrieve all real time services according to ACL of contact and host id
@@ -128,7 +128,7 @@ interface MonitoringRepositoryInterface
      * @return Service[]
      * @throws \Exception
      */
-    public function findServicesByHostWithoutParameters(int $hostId): array;
+    public function findServicesByHostWithoutRequestParameters(int $hostId): array;
 
     /**
      * Find services according to the host id and service ids given

--- a/src/Centreon/Domain/Monitoring/MonitoringService.php
+++ b/src/Centreon/Domain/Monitoring/MonitoringService.php
@@ -122,7 +122,7 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
      */
     public function findServicesByHost(int $hostId): array
     {
-        return $this->monitoringRepository->findServicesByHost($hostId);
+        return $this->monitoringRepository->findServicesByHostWithParameters($hostId);
     }
 
     /**

--- a/src/Centreon/Domain/Monitoring/MonitoringService.php
+++ b/src/Centreon/Domain/Monitoring/MonitoringService.php
@@ -122,7 +122,7 @@ class MonitoringService extends AbstractCentreonService implements MonitoringSer
      */
     public function findServicesByHost(int $hostId): array
     {
-        return $this->monitoringRepository->findServicesByHostWithParameters($hostId);
+        return $this->monitoringRepository->findServicesByHostWithRequestParameters($hostId);
     }
 
     /**

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -730,14 +730,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
     /**
      * @inheritDoc
      */
-    public function findServicesByHost(int $hostId): array
+    public function findServicesByHostWithParameters(int $hostId): array
     {
-        $services = [];
-
-        if ($this->hasNotEnoughRightsToContinue()) {
-            return $services;
-        }
-
         $this->sqlRequestTranslator->setConcordanceArray([
             'service.id' => 'srv.service_id',
             'service.description' => 'srv.description',
@@ -746,6 +740,48 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             'service.is_acknowledged' => 'srv.acknowledged',
             'service.state' => 'srv.state'
         ]);
+
+        // Search
+        $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
+
+        // Sort
+        $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();
+
+        // Pagination
+        $paginationRequest = $this->sqlRequestTranslator->translatePaginationToSql();
+
+        return $this->findServicesByHost($hostId, $searchRequest, $sortRequest, $paginationRequest);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findServicesByHostWithoutParameters(int $hostId): array
+    {
+        return $this->findServicesByHost($hostId, null, null, null);
+    }
+
+    /**
+     * Retrieve all real time services according to ACL of contact and host id
+     *
+     * @param int $hostId Host ID for which we want to find services
+     * @param string|null $searchRequest search request
+     * @param string|null $sortRequest sort request
+     * @param string|null $paginationRequest pagination request
+     * @return Service[]
+     * @throws \Exception
+     */
+    private function findServicesByHost(
+        int $hostId,
+        ?string $searchRequest = null,
+        ?string $sortRequest = null,
+        ?string $paginationRequest = null
+    ): array {
+        $services = [];
+
+        if ($this->hasNotEnoughRightsToContinue()) {
+            return $services;
+        }
 
         $accessGroupFilter = $this->isAdmin()
             ? ' '
@@ -776,18 +812,16 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $request = $this->translateDbName($request);
 
         // Search
-        $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
         $request .= !is_null($searchRequest) ? $searchRequest : '';
 
         // Group
         $request .= ' GROUP BY srv.service_id';
 
         // Sort
-        $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();
         $request .= !is_null($sortRequest) ? $sortRequest : '';
 
         // Pagination
-        $request .= $this->sqlRequestTranslator->translatePaginationToSql();
+        $request .= !is_null($paginationRequest) ? $paginationRequest : '';
 
         $statement = $this->db->prepare($request);
         $statement->bindValue(':host_id', $hostId, \PDO::PARAM_INT);
@@ -1042,10 +1076,10 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                   AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
 
         $request =
-            'SELECT DISTINCT 
-                srv.service_id, 
-                srv.display_name, 
-                srv.description, 
+            'SELECT DISTINCT
+                srv.service_id,
+                srv.display_name,
+                srv.description,
                 srv.host_id,
                 srv.state
             FROM :dbstg.services srv

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -730,7 +730,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
     /**
      * @inheritDoc
      */
-    public function findServicesByHostWithParameters(int $hostId): array
+    public function findServicesByHostWithRequestParameters(int $hostId): array
     {
         $this->sqlRequestTranslator->setConcordanceArray([
             'service.id' => 'srv.service_id',
@@ -756,7 +756,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
     /**
      * @inheritDoc
      */
-    public function findServicesByHostWithoutParameters(int $hostId): array
+    public function findServicesByHostWithoutRequestParameters(int $hostId): array
     {
         return $this->findServicesByHost($hostId, null, null, null);
     }


### PR DESCRIPTION
## Description

Fix acknowledgement from events view when "Acknowledge services attached to host" parameter is checked.
Previously only 10 first services linked to the host were acknowledged

**Fixes** MON-5596

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Monitoring a host with 11 non-ok services
* in events view page, acknowledge the host with "Acknowledge services attached to host" parameter
* ==> check all services linked to the host are acknowledged