### PR TITLE
fix(security) admin access

### DIFF
--- a/www/include/configuration/configServers/popup/popup.php
+++ b/www/include/configuration/configServers/popup/popup.php
@@ -41,7 +41,7 @@ if ($pollerId === false) {
     exit();
 }
 $userId = (int)$centreon->user->user_id;
-$isAdmin = (int)$centreon->user->admin;
+$isAdmin = (bool)$centreon->user->admin;
 
 if ($isAdmin !== 1) {
     $acl = new CentreonACL($userId, $isAdmin);

--- a/www/include/configuration/configServers/popup/popup.php
+++ b/www/include/configuration/configServers/popup/popup.php
@@ -36,15 +36,20 @@ if (!CentreonSession::checkSession(session_id(), $pearDB)) {
 }
 $centreon = $_SESSION['centreon'];
 $pollerId = filter_var($_GET['id'] ?? false, FILTER_VALIDATE_INT);
-$userId = $centreon->user->user_id;
-$isAdmin = $centreon->user->admin;
-
-$acl = new CentreonACL($userId, $isAdmin);
-$aclPollers = $acl->getPollers();
-
-if ($pollerId === false || !array_key_exists($pollerId, $aclPollers)) {
+if ($pollerId === false) {
     print "Bad Poller Id";
     exit();
+}
+$userId = (int)$centreon->user->user_id;
+$isAdmin = (int)$centreon->user->admin;
+
+if ($isAdmin !== 1) {
+    $acl = new CentreonACL($userId, $isAdmin);
+    $aclPollers = $acl->getPollers();
+    if (!array_key_exists($pollerId, $aclPollers)) {
+        print "No access rights to this Poller";
+        exit();
+    }
 }
 
 $tpl = new Smarty();

--- a/www/include/configuration/configServers/popup/popup.php
+++ b/www/include/configuration/configServers/popup/popup.php
@@ -43,7 +43,7 @@ if ($pollerId === false) {
 $userId = (int)$centreon->user->user_id;
 $isAdmin = (bool)$centreon->user->admin;
 
-if ($isAdmin !== 1) {
+if ($isAdmin === false) {
     $acl = new CentreonACL($userId, $isAdmin);
     $aclPollers = $acl->getPollers();
     if (!array_key_exists($pollerId, $aclPollers)) {


### PR DESCRIPTION
## Description

In menu Administration > Configuration > Pollers, clicking on the "View gorgone config for this poller " (little eye) button will display an almost empty popup with "Bad Poller ID" in it instead of the configuration.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>
in admin 
1 Go to Administration > Configuration > Pollers
2 Click on button "View gorgone config for this poller"
3 Popup is displayed, but without the configuration

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
