### PR TITLE
fix(reporting): fix reporting calculation when downtime end time is null

### DIFF
--- a/lib/perl/centreon/reporting/CentreonDownTime.pm
+++ b/lib/perl/centreon/reporting/CentreonDownTime.pm
@@ -90,7 +90,7 @@ sub getDownTime {
             if ($row->{"actual_start_time"} < $start) {
                 $row->{"actual_start_time"} = $start;
             }
-            if ($row->{"actual_end_time"} > $end || !defined $row->{"actual_end_time"}) {
+            if (!defined $row->{"actual_end_time"} || $row->{"actual_end_time"} > $end) {
                 $row->{"actual_end_time"} = $end;
             }
 


### PR DESCRIPTION
## Description

When a downtime is currently running, it breaks reporting calculation : 
Use of uninitialized value in numeric gt (>) at /usr/share/perl5/vendor_perl/centreon/reporting/CentreonDownTime.pm line 93.

**Fixes** MON-5551

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

* put a downtime which end next year
* rebuild reporting (eventReportBuilder)