### PR TITLE
fix(centreonCustomView): use class constant correctly

### DIFF
--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -214,15 +214,15 @@ class CentreonCustomView
             return true;
         }
         $associativeActions = [
-            'edit' => TOPOLOGY_PAGE_EDIT_VIEW,
-            'share' => TOPOLOGY_PAGE_SHARE_VIEW,
-            'setPreferences' => TOPOLOGY_PAGE_SET_WIDGET_PREFERENCES,
-            'addWidget' => TOPOLOGY_PAGE_ADD_WIDGET,
-            'deleteWidget' => TOPOLOGY_PAGE_DELETE_WIDGET,
-            'setRotate' => TOPOLOGY_PAGE_SET_ROTATE,
-            'deleteView' => TOPOLOGY_PAGE_DELETE_VIEW,
-            'add' => TOPOLOGY_PAGE_ADD_VIEW,
-            'setDefault' => TOPOLOGY_PAGE_SET_DEFAULT_VIEW
+            'edit' => self::TOPOLOGY_PAGE_EDIT_VIEW,
+            'share' => self::TOPOLOGY_PAGE_SHARE_VIEW,
+            'setPreferences' => self::TOPOLOGY_PAGE_SET_WIDGET_PREFERENCES,
+            'addWidget' => self::TOPOLOGY_PAGE_ADD_WIDGET,
+            'deleteWidget' => self::TOPOLOGY_PAGE_DELETE_WIDGET,
+            'setRotate' => self::TOPOLOGY_PAGE_SET_ROTATE,
+            'deleteView' => self::TOPOLOGY_PAGE_DELETE_VIEW,
+            'add' => self::TOPOLOGY_PAGE_ADD_VIEW,
+            'setDefault' => self::TOPOLOGY_PAGE_SET_DEFAULT_VIEW
         ];
 
         // retrieving menu access rights of the current user.


### PR DESCRIPTION
## Description

The class const variables were not used correctly which prevent actions to be done for a User under ACLS

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

See the ticket.

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
