### PR TITLE
fix(icon): change ppm folder creation rights

### DIFF
--- a/www/class/centreonMedia.class.php
+++ b/www/class/centreonMedia.class.php
@@ -184,7 +184,7 @@ class CentreonMedia
 
         // Create directory and nested folder structure
         if (!is_dir($fullPath)) {
-            mkdir($fullPath, 644, true);
+            mkdir($fullPath, 0755, true);
         }
     }
 


### PR DESCRIPTION
## Description

On PPM folder creation : 
- Add missing "0" on rights
- Change rights , to be able to create the imported icon files, as 0644 rights are not enough and still results in failures in the logs :

```
[26-Jun-2020 13:18:46 Europe/Paris] PHP Warning:  
file_put_contents(/usr/share/centreon//www/img/media//ppm//applications-monitoring-centreon-database-centreon-128-2.png): 
failed to open stream:
Permission denied in /usr/share/centreon/www/class/centreonMedia.class.php on line 44
```

**Fixes** # (MON-5686)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

