### PR TITLE
fix(sendCommand): centreonUtils class was not loaded

### DIFF
--- a/www/include/monitoring/objectDetails/xml/hostSendCommand.php
+++ b/www/include/monitoring/objectDetails/xml/hostSendCommand.php
@@ -40,6 +40,7 @@ require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonHost.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonACL.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonSession.class.php";
+require_once _CENTREON_PATH_ . "/www/class/centreonUtils.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreon.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonXML.class.php";
 

--- a/www/include/monitoring/objectDetails/xml/serviceSendCommand.php
+++ b/www/include/monitoring/objectDetails/xml/serviceSendCommand.php
@@ -44,6 +44,7 @@ require_once _CENTREON_PATH_ . "/www/class/centreonHost.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonService.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonACL.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonSession.class.php";
+require_once _CENTREON_PATH_ . "/www/class/centreonUtils.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreon.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonXML.class.php";
 


### PR DESCRIPTION
## Description

Issue found during the validation of "Secure host/service sendCommand" from object detail.
CentreonUtils class was not loaded which lead to a PHP fatal error

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Details for the tests are written down in the JIRA ticket

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
