### PR TITLE
fix(reporting): manage reporting calcuation on host/service rename

### DIFF
--- a/lib/perl/centreon/reporting/CentreonAck.pm
+++ b/lib/perl/centreon/reporting/CentreonAck.pm
@@ -48,7 +48,7 @@ sub new {
     $self->{centstatus} = shift;
     if (@_) {
         $self->{centstorage}  = shift;
-    }    
+    }
     bless $self, $class;
     return $self;
 }
@@ -59,21 +59,18 @@ sub getServiceAckTime {
     my $centreon = $self->{centstatus};
     my $start = shift;
     my $end = shift;
-    my $hostName = shift;
-    my $serviceDescription = shift;
+    my $hostId = shift;
+    my $serviceId = shift;
     my $query;
-    
+
     $query = "SELECT `entry_time` as ack_time, sticky ".
-    " FROM `acknowledgements` a, `services` s, `hosts` h ".
-    " WHERE h.`name` = '".$hostName. "'".
-    " AND h.`host_id` = s.`host_id`".   
-    " AND s.`description` = '".$serviceDescription. "'".
-    " AND s.`host_id` = a.`host_id`".
-    " AND s.`service_id` = a.`service_id`".
-    " AND `type` = 1".
-    " AND `entry_time` >= ".$start.
-    " AND `entry_time` <= ".$end. 
-    " ORDER BY `entry_time` asc";
+    " FROM `acknowledgements`".
+    " WHERE `host_id` = " . $hostId .
+    " AND `service_id` = ". $serviceId .
+    " AND `type` = 1" .
+    " AND `entry_time` >= " . $start .
+    " AND `entry_time` <= " . $end .
+    " ORDER BY `entry_time` ASC";
 
     my ($status, $sth) = $centreon->query($query);
     my $ackTime = "NULL";
@@ -92,17 +89,16 @@ sub getHostAckTime {
     my $centreon = $self->{centstatus};
     my $start = shift;
     my $end = shift;
-    my $hostName = shift;
+    my $hostId = shift;
     my $query;
-    
+
     $query = "SELECT entry_time as ack_time, sticky ".
-        " FROM `acknowledgements` a, `hosts` h".
-        " WHERE h.`host_id` = a.`host_id`".
-        " AND `type` = 0".
-        " AND `entry_time` >= ".$start.
-        " AND `entry_time` <= ".$end.
-        " AND h.`name` = '".$hostName. "'".
-        " ORDER BY `entry_time` asc";
+        " FROM `acknowledgements`".
+        " WHERE `type` = 0".
+        " AND `entry_time` >= " . $start .
+        " AND `entry_time` <= " . $end .
+        " AND `host_id` = " . $hostId .
+        " ORDER BY `entry_time` ASC";
 
     my ($status, $sth) = $centreon->query($query);
     my $ackTime = "NULL";

--- a/lib/perl/centreon/reporting/CentreonAck.pm
+++ b/lib/perl/centreon/reporting/CentreonAck.pm
@@ -1,33 +1,33 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 
@@ -64,7 +64,7 @@ sub getServiceAckTime {
     my $query;
 
     $query = "SELECT `entry_time` as ack_time, sticky ".
-    " FROM `acknowledgements`".
+    " FROM `acknowledgements`" .
     " WHERE `host_id` = " . $hostId .
     " AND `service_id` = ". $serviceId .
     " AND `type` = 1" .

--- a/lib/perl/centreon/reporting/CentreonAck.pm
+++ b/lib/perl/centreon/reporting/CentreonAck.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/perl/centreon/reporting/CentreonDashboard.pm
+++ b/lib/perl/centreon/reporting/CentreonDashboard.pm
@@ -1,33 +1,33 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 
@@ -54,7 +54,7 @@ sub new {
     return $self;
 }
 
-# returns two references to two hash tables => hosts indexed by id and hosts indexed by name
+# Insert data in log_archive_host
 sub insertHostStats {
     my $self = shift;
     my $centstorage = $self->{"centstorage"};
@@ -96,7 +96,7 @@ sub insertHostStats {
         }
         $count++;
         if ($count == 5000) {
-            ($status, $sth) = $centstorage->query($query_start.$query_end);        
+            ($status, $sth) = $centstorage->query($query_start.$query_end);
             $firstHost = 1;
             $query_end = "";
             $count = 0;
@@ -107,7 +107,7 @@ sub insertHostStats {
     }
 }
 
-# 
+# Insert data in log_archive_service
 sub insertServiceStats {
     my $self = shift;
     my $centstorage = $self->{"centstorage"};
@@ -160,7 +160,7 @@ sub insertServiceStats {
     }
     if ($count) {
         ($status, $sth) = $centstorage->query($query_start.$query_end);
-    }    
+    }
 }
 
 # Truncate service dashboard stats table
@@ -189,7 +189,7 @@ sub deleteServiceStats {
     my ($start, $end) = (shift, shift);
     my ($day, $month, $year) = (localtime($end))[3,4,5];
     $end = mktime(0, 0, 0, $day + 1, $month, $year);
-    my $query = "DELETE FROM `log_archive_service` WHERE `date_start`>= ".$start." AND `date_end` <= ".$end;
+    my $query = "DELETE FROM `log_archive_service` WHERE `date_start`>= " . $start . " AND `date_end` <= " . $end;
     $centstorage->query($query);
 }
 
@@ -201,7 +201,7 @@ sub deleteHostStats {
     my ($start, $end) = (shift, shift);
     my ($day, $month, $year) = (localtime($end))[3,4,5];
     $end = mktime(0, 0, 0, $day + 1, $month, $year);
-    my $query = "DELETE FROM `log_archive_host` WHERE `date_start`>= ".$start." AND `date_end` <= ".$end;
+    my $query = "DELETE FROM `log_archive_host` WHERE `date_start`>= " . $start . " AND `date_end` <= " . $end;
     $centstorage->query($query);
 }
 

--- a/lib/perl/centreon/reporting/CentreonDashboard.pm
+++ b/lib/perl/centreon/reporting/CentreonDashboard.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/perl/centreon/reporting/CentreonDownTime.pm
+++ b/lib/perl/centreon/reporting/CentreonDownTime.pm
@@ -1,33 +1,33 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 
@@ -184,7 +184,7 @@ sub splitUpdateEventDownTime {
          my $id = $tab->[0];
          my $downTimeStart = $tab->[1];
          my $downTimeEnd = $tab->[2];
- 
+
          if ($id eq $objectId) {
              if ($downTimeStart < $start) {
                  $downTimeStart = $start;
@@ -210,7 +210,7 @@ sub splitUpdateEventDownTime {
                         }else {
                             my @tab = ($downTimeStart, $downTimeEnd, 1);
                             $events[scalar(@events)] = \@tab;
-                        }            
+                        }
                     }
                 }else {
                     if ($downTimeStart > $start) {

--- a/lib/perl/centreon/reporting/CentreonDownTime.pm
+++ b/lib/perl/centreon/reporting/CentreonDownTime.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/perl/centreon/reporting/CentreonHost.pm
+++ b/lib/perl/centreon/reporting/CentreonHost.pm
@@ -2,32 +2,32 @@
 # Copyright 2005-2013 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 
@@ -53,17 +53,17 @@ sub new {
     return $self;
 }
 
-# returns two references to two hash tables => hosts indexed by id and hosts indexed by name
-sub getAllHosts {
+# returns two references to two hash tables => hosts indexed by id and hosts indexed by id
+sub getAllHostIds {
     my $self = shift;
     my $centreon = $self->{centreon};
     my $activated = 1;
     if (@_) {
         $activated  = 0;
     }
-    my (%host_ids, %host_names);
-    
-    my $query = "SELECT `host_id`, `host_name`".
+    my %hostIds;
+
+    my $query = "SELECT `host_id`" .
                 " FROM `host`".
                 " WHERE `host_register` = '1'";
     if ($activated == 1) {
@@ -71,25 +71,10 @@ sub getAllHosts {
     }
     my ($status, $sth) = $centreon->query($query);
     while (my $row = $sth->fetchrow_hashref()) {
-        $host_ids{$row->{host_name}} = $row->{host_id};
-        $host_names{$row->{host_id}} = $row->{host_name};
+        $hostIds{$row->{host_id}} = 1;
     }
     $sth->finish();
-    return (\%host_ids,\%host_names);
-}
-
-# Get all hosts, keys are IDs
-sub getAllHostsByID {
-    my $self = shift;
-    my ($host_ids, $host_names) = $self->getAllHosts();    
-    return ($host_ids);
-}
-
-# Get all hosts, keys are names
-sub getAllHostsByName {
-    my $self = shift;
-    my ($host_ids, $host_names) = $self->getAllHosts();    
-    return ($host_names);
+    return \%hostIds;
 }
 
 1;

--- a/lib/perl/centreon/reporting/CentreonHost.pm
+++ b/lib/perl/centreon/reporting/CentreonHost.pm
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #

--- a/lib/perl/centreon/reporting/CentreonHost.pm
+++ b/lib/perl/centreon/reporting/CentreonHost.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/perl/centreon/reporting/CentreonHostStateEvents.pm
+++ b/lib/perl/centreon/reporting/CentreonHostStateEvents.pm
@@ -1,33 +1,33 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 
@@ -79,13 +79,13 @@ sub getStateEventDurations {
             my @tab = (0, 0, 0, 0, 0, 0, 0, 0);
             # index 0: UP, index 1: DOWN, index 2: UNREACHABLE, index 3: DOWNTIME, index 4: UNDETERMINED
             # index 5: UP alerts, index 6: Down alerts, , index 7: Unreachable alerts
-            $hosts{$row->{host_id}} = \@tab;            
+            $hosts{$row->{host_id}} = \@tab;
         }
-        
+
         my $stats = $hosts{$row->{host_id}};
         if ($row->{in_downtime} == 0) {
             $stats->[$row->{state}] += $row->{end_time} - $row->{start_time};
-            
+
             # We count UP alert like a recovery (don't put it otherwise)
             if ($row->{state} != 0 || ($row->{state} == 0 && $row->{start_time} > $start)) {
                 $stats->[$row->{state} + 5] += 1;

--- a/lib/perl/centreon/reporting/CentreonHostStateEvents.pm
+++ b/lib/perl/centreon/reporting/CentreonHostStateEvents.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/perl/centreon/reporting/CentreonLog.pm
+++ b/lib/perl/centreon/reporting/CentreonLog.pm
@@ -1,33 +1,33 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 

--- a/lib/perl/centreon/reporting/CentreonLog.pm
+++ b/lib/perl/centreon/reporting/CentreonLog.pm
@@ -65,13 +65,13 @@ sub getLogOfServices {
         $start = shift;
         $end = shift;
     }
-    my $query = "SELECT `status`, `ctime`, `host_name`, `service_description`".
-        " FROM `logs`".
-        " WHERE `ctime` >= ".$start.
-        " AND `ctime` < ".$end.
-        " AND (`type` = 1 OR (`status` = 0 AND `type` = 0))".
-        " AND ((`service_id` != 0 AND `service_id` IS NOT NULL) OR `service_description` IS NOT NULL) ".
-        " AND `msg_type` IN ('0', '1', '6', '7', '8', '9')".
+    my $query = "SELECT `status`, `ctime`, `host_id`, `service_id`" .
+        " FROM `logs`" .
+        " WHERE `ctime` >= " . $start .
+        " AND `ctime` < " . $end .
+        " AND (`type` = 1 OR (`status` = 0 AND `type` = 0))" .
+        " AND ((`service_id` != 0 AND `service_id` IS NOT NULL) OR `service_description` IS NOT NULL) " .
+        " AND `msg_type` IN ('0', '1', '6', '7', '8', '9')" .
         " ORDER BY `ctime`";
     my ($status, $result) = $centstorage->query($query);
     return $result;
@@ -89,12 +89,12 @@ sub getLogOfHosts {
         $start = shift;
         $end = shift;
     }
-    my $query = "SELECT `status`, `ctime`, `host_name`".
-            " FROM `logs`".
+    my $query = "SELECT `status`, `ctime`, `host_id`" .
+            " FROM `logs`" .
             " WHERE `ctime` >= " . $start .
             " AND `ctime` < " . $end .
-            " AND (`type` = 1 OR (`status` = 0 AND `type` = 0))".
-            " AND `msg_type` IN ('0', '1', '6', '7', '8', '9')".
+            " AND (`type` = 1 OR (`status` = 0 AND `type` = 0))" .
+            " AND `msg_type` IN ('0', '1', '6', '7', '8', '9')" .
             " AND (`service_id` = 0 OR `service_id` IS NULL) AND (service_description = '' OR service_description IS NULL) ".
             " ORDER BY `ctime`";
     my ($status, $result) = $centstorage->query($query);

--- a/lib/perl/centreon/reporting/CentreonLog.pm
+++ b/lib/perl/centreon/reporting/CentreonLog.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/perl/centreon/reporting/CentreonProcessStateEvents.pm
+++ b/lib/perl/centreon/reporting/CentreonProcessStateEvents.pm
@@ -1,33 +1,33 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 
@@ -76,35 +76,56 @@ sub parseServiceLog {
         my $fullId  = $row->{host_id} . ";;" . $row->{service_id};
         if (defined($serviceIds->{$fullId})) {
             my $statusCode = $row->{status};
-            if (defined($currentEvents->{$fullId})) {
-                my $eventInfos =  $currentEvents->{$fullId};
-                # $eventInfos is a reference to a table containing : incident start time | status | state_event_id | in_downtime. The last one is optional
-                if ($statusCode ne "" && defined($eventInfos->[1]) && $eventInfos->[1] ne "" && $eventInfos->[1] != $statusCode) {
-                    my ($hostId, $serviceId) = split(";;", $fullId);
-                    my $result = {};
-                    if ($eventInfos->[2] != 0) {
-                        # If eventId of log is defined, update the last day event
-                        $result = $events->updateEventEndTime($hostId, $serviceId, $eventInfos->[0], $row->{ctime}, $eventInfos->[1], $eventInfos->[2], $eventInfos->[3], 0, $downtimes, $eventInfos->[4]);
-                    } else {
-                        if ($row->{ctime} > $eventInfos->[0]) {
-                            $result = $events->insertEvent($hostId, $serviceId, $eventInfos->[1], $eventInfos->[0], $row->{ctime}, 0, $downtimes, $eventInfos->[4]);
-                        }
-                    }
-                    $eventInfos->[0] = $row->{ctime};
-                    $eventInfos->[1] = $statusCode;
-                    $eventInfos->[2] = 0;
-                    $eventInfos->[3] = 0;
-                    $eventInfos->[4] = defined($result->{in_ack}) ? $result->{in_ack} : 0;
-                    $currentEvents->{$fullId} = $eventInfos;
-                }
-            } else {
-                my @tab;
-                @tab = ($row->{ctime}, $statusCode, 0, 0, 0);
+
+            # manage initial states (no entry in state events table)
+            if (!defined($currentEvents->{$fullId})) {
+                my @tab = ($row->{ctime}, $statusCode, 0, 0, 0);
                 $currentEvents->{$fullId} = \@tab;
+            }
+
+            my $eventInfos =  $currentEvents->{$fullId};
+            # $eventInfos is a reference to a table containing : incident start time | status | state_event_id | in_downtime. The last one is optional
+            if ($statusCode ne "" && defined($eventInfos->[1]) && $eventInfos->[1] ne "" && $eventInfos->[1] != $statusCode) {
+                my ($hostId, $serviceId) = split(";;", $fullId);
+                my $result = {};
+                if ($eventInfos->[2] != 0) {
+                    # If eventId of log is defined, update the last day event
+                    $result = $events->updateEventEndTime(
+                        $hostId,
+                        $serviceId,
+                        $eventInfos->[0],
+                        $row->{ctime},
+                        $eventInfos->[1],
+                        $eventInfos->[2],
+                        $eventInfos->[3],
+                        0,
+                        $downtimes,
+                        $eventInfos->[4]
+                    );
+                } else {
+                    if ($row->{ctime} > $eventInfos->[0]) {
+                        $result = $events->insertEvent(
+                            $hostId,
+                            $serviceId,
+                            $eventInfos->[1],
+                            $eventInfos->[0],
+                            $row->{ctime},
+                            0,
+                            $downtimes,
+                            $eventInfos->[4]
+                        );
+                    }
+                }
+                $eventInfos->[0] = $row->{ctime};
+                $eventInfos->[1] = $statusCode;
+                $eventInfos->[2] = 0;
+                $eventInfos->[3] = 0;
+                $eventInfos->[4] = defined($result->{in_ack}) ? $result->{in_ack} : 0;
+                $currentEvents->{$fullId} = $eventInfos;
             }
         }
     }
-    $self->insertLastServiceEvents($end, $currentEvents, $serviceIds, $downtimes);
+    $self->insertLastServiceEvents($end, $currentEvents, $downtimes);
 }
 
 # Parse host logs for given period
@@ -129,35 +150,55 @@ sub parseHostLog {
 
     while (my $row = $logs->fetchrow_hashref()) {
         my $hostId  = $row->{host_id};
+
         if (defined($hostIds->{$hostId})) {
             my $statusCode = $row->{status};
 
-            if (defined($currentEvents->{$hostId})) {
-                my $eventInfos =  $currentEvents->{$hostId}; # $eventInfos is a reference to a table containing : incident start time | status | state_event_id. The last one is optionnal
-                if ($statusCode ne "" && defined($eventInfos->[1]) && $eventInfos->[1] ne "" && $eventInfos->[1] != $statusCode) {
-                    my $result = {};
-                    if ($eventInfos->[2] != 0) {
-                        # If eventId of log is defined, update the last day event
-                        $result = $events->updateEventEndTime($hostId, $eventInfos->[0], $row->{'ctime'}, $eventInfos->[1], $eventInfos->[2],$eventInfos->[3], 0, $downtimes, $eventInfos->[4]);
-                    } else {
-                        if ($row->{ctime} > $eventInfos->[0]) {
-                            $result = $events->insertEvent($hostId, $eventInfos->[1], $eventInfos->[0], $row->{'ctime'}, 0, $downtimes, $eventInfos->[4]);
-                        }
-                    }
-                    $eventInfos->[0] = $row->{'ctime'};
-                    $eventInfos->[1] = $statusCode;
-                    $eventInfos->[2] = 0;
-                    $eventInfos->[3] = 0;
-                    $eventInfos->[4] = defined($result->{in_ack}) ? $result->{in_ack} : 0;
-                    $currentEvents->{$hostId} = $eventInfos;
-                }
-            } else {
+            # manage initial states (no entry in state events table)
+            if (!defined($currentEvents->{$hostId})) {
                 my @tab = ($row->{'ctime'}, $statusCode, 0, 0, 0);
                 $currentEvents->{$hostId} = \@tab;
             }
+
+            my $eventInfos =  $currentEvents->{$hostId}; # $eventInfos is a reference to a table containing : incident start time | status | state_event_id. The last one is optionnal
+            if ($statusCode ne "" && defined($eventInfos->[1]) && $eventInfos->[1] ne "" && $eventInfos->[1] != $statusCode) {
+                my $result = {};
+                if ($eventInfos->[2] != 0) {
+                    # If eventId of log is defined, update the last day event
+                    $result = $events->updateEventEndTime(
+                        $hostId,
+                        $eventInfos->[0],
+                        $row->{'ctime'},
+                        $eventInfos->[1],
+                        $eventInfos->[2],
+                        $eventInfos->[3],
+                        0,
+                        $downtimes,
+                        $eventInfos->[4]
+                    );
+                } else {
+                    if ($row->{ctime} > $eventInfos->[0]) {
+                        $result = $events->insertEvent(
+                            $hostId,
+                            $eventInfos->[1],
+                            $eventInfos->[0],
+                            $row->{'ctime'},
+                            0,
+                            $downtimes,
+                            $eventInfos->[4]
+                        );
+                    }
+                }
+                $eventInfos->[0] = $row->{'ctime'};
+                $eventInfos->[1] = $statusCode;
+                $eventInfos->[2] = 0;
+                $eventInfos->[3] = 0;
+                $eventInfos->[4] = defined($result->{in_ack}) ? $result->{in_ack} : 0;
+                $currentEvents->{$hostId} = $eventInfos;
+            }
         }
     }
-    $self->insertLastHostEvents($end, $currentEvents, $hostIds, $downtimes);
+    $self->insertLastHostEvents($end, $currentEvents, $downtimes);
 }
 
 
@@ -171,14 +212,34 @@ sub insertLastServiceEvents {
     my $events = $self->{"serviceEvents"};
 
     # parameters:
-    my ($end, $currentEvents, $serviceIds, $downTime)  = (shift, shift, shift, shift);
+    my ($end, $currentEvents, $downtimes)  = (shift, shift, shift, shift);
 
     while (my ($id, $eventInfos) = each (%$currentEvents)) {
-        my ($hostId, $serviceId) = split(";;", $serviceIds->{$id});
+        my ($hostId, $serviceId) = split(";;", $id);
         if ($eventInfos->[2] != 0) {
-            $events->updateEventEndTime($hostId, $serviceId, $eventInfos->[0], $end, $eventInfos->[1], $eventInfos->[2], $eventInfos->[3], 1, $downTime, $eventInfos->[4]);
+            $events->updateEventEndTime(
+                $hostId,
+                $serviceId,
+                $eventInfos->[0],
+                $end,
+                $eventInfos->[1],
+                $eventInfos->[2],
+                $eventInfos->[3],
+                1,
+                $downtimes,
+                $eventInfos->[4]
+            );
         } else {
-            $events->insertEvent($hostId, $serviceId, $eventInfos->[1], $eventInfos->[0], $end, 1, $downTime, $eventInfos->[4]);
+            $events->insertEvent(
+                $hostId,
+                $serviceId,
+                $eventInfos->[1],
+                $eventInfos->[0],
+                $end,
+                1,
+                $downtimes,
+                $eventInfos->[4]
+            );
         }
     }
 }
@@ -187,17 +248,26 @@ sub insertLastServiceEvents {
 # Parameters:
 # $end: period end
 # $currentEvents: reference to a hash table that contains last incident details
-# $hostIds: reference to a hash table that returns host ids
 sub insertLastHostEvents {
     my $self = shift;
     my $events = $self->{"hostEvents"};
 
     # parameters:
-    my ($end, $currentEvents, $hostIds, $downtimes)  = (shift, shift, shift, shift, shift);
+    my ($end, $currentEvents, $downtimes)  = (shift, shift, shift, shift, shift);
 
     while (my ($hostId, $eventInfos) = each (%$currentEvents)) {
         if ($eventInfos->[2] != 0) {
-            $events->updateEventEndTime($hostId, $eventInfos->[0], $end, $eventInfos->[1], $eventInfos->[2], $eventInfos->[3], 1, $downtimes, $eventInfos->[4]);
+            $events->updateEventEndTime(
+                $hostId,
+                $eventInfos->[0],
+                $end,
+                $eventInfos->[1],
+                $eventInfos->[2],
+                $eventInfos->[3],
+                1,
+                $downtimes,
+                $eventInfos->[4]
+            );
         } else {
             $events->insertEvent($hostId, $eventInfos->[1], $eventInfos->[0], $end, 1, $downtimes, $eventInfos->[4]);
         }

--- a/lib/perl/centreon/reporting/CentreonProcessStateEvents.pm
+++ b/lib/perl/centreon/reporting/CentreonProcessStateEvents.pm
@@ -253,7 +253,7 @@ sub insertLastHostEvents {
     my $events = $self->{"hostEvents"};
 
     # parameters:
-    my ($end, $currentEvents, $downtimes)  = (shift, shift, shift, shift, shift);
+    my ($end, $currentEvents, $downtimes)  = (shift, shift, shift);
 
     while (my ($hostId, $eventInfos) = each (%$currentEvents)) {
         if ($eventInfos->[2] != 0) {

--- a/lib/perl/centreon/reporting/CentreonProcessStateEvents.pm
+++ b/lib/perl/centreon/reporting/CentreonProcessStateEvents.pm
@@ -57,7 +57,7 @@ sub new {
 # Parse services logs for given period
 # Parameters:
 # $start: period start
-# $end: period end 
+# $end: period end
 sub parseServiceLog {
     my $self = shift;
     # parameters:
@@ -67,27 +67,27 @@ sub parseServiceLog {
     my $events = $self->{"serviceEvents"};
     my $centreonDownTime = $self->{"centreonDownTime"};
 
-    my ($allIds, $allNames) = $service->getAllServices();
-    my $currentEvents = $events->getLastStates($allNames);
+    my $serviceIds = $service->getAllServiceIds();
+    my $currentEvents = $events->getLastStates($serviceIds);
     my $logs = $nagiosLog->getLogOfServices($start, $end);
-    my $downTime = $centreonDownTime->getDownTime($allIds, $start, $end, 2);
+    my $downtimes = $centreonDownTime->getDowntimes($serviceIds, $start, $end, 2);
 
     while (my $row = $logs->fetchrow_hashref()) {
-        my $id  = $row->{host_name}.";;".$row->{service_description};
-        if (defined($allIds->{$id})) {
+        my $fullId  = $row->{host_id} . ";;" . $row->{service_id};
+        if (defined($serviceIds->{$fullId})) {
             my $statusCode = $row->{status};
-            if (defined($currentEvents->{$id})) {
-                my $eventInfos =  $currentEvents->{$id}; 
-                # $eventInfos is a reference to a table containing : incident start time | status | state_event_id | in_downtime. The last one is optionnal                
+            if (defined($currentEvents->{$fullId})) {
+                my $eventInfos =  $currentEvents->{$fullId};
+                # $eventInfos is a reference to a table containing : incident start time | status | state_event_id | in_downtime. The last one is optional
                 if ($statusCode ne "" && defined($eventInfos->[1]) && $eventInfos->[1] ne "" && $eventInfos->[1] != $statusCode) {
-                    my ($hostId, $serviceId) = split (";;", $allIds->{$id});
+                    my ($hostId, $serviceId) = split(";;", $fullId);
                     my $result = {};
                     if ($eventInfos->[2] != 0) {
                         # If eventId of log is defined, update the last day event
-                        $result = $events->updateEventEndTime($id, $hostId, $serviceId, $eventInfos->[0], $row->{ctime}, $eventInfos->[1], $eventInfos->[2], $eventInfos->[3], 0, $downTime, $eventInfos->[4]);
+                        $result = $events->updateEventEndTime($hostId, $serviceId, $eventInfos->[0], $row->{ctime}, $eventInfos->[1], $eventInfos->[2], $eventInfos->[3], 0, $downtimes, $eventInfos->[4]);
                     } else {
                         if ($row->{ctime} > $eventInfos->[0]) {
-                            $result = $events->insertEvent($id, $hostId, $serviceId, $eventInfos->[1], $eventInfos->[0], $row->{ctime}, 0, $downTime, $eventInfos->[4]);
+                            $result = $events->insertEvent($hostId, $serviceId, $eventInfos->[1], $eventInfos->[0], $row->{ctime}, 0, $downtimes, $eventInfos->[4]);
                         }
                     }
                     $eventInfos->[0] = $row->{ctime};
@@ -95,22 +95,22 @@ sub parseServiceLog {
                     $eventInfos->[2] = 0;
                     $eventInfos->[3] = 0;
                     $eventInfos->[4] = defined($result->{in_ack}) ? $result->{in_ack} : 0;
-                    $currentEvents->{$id} = $eventInfos;
+                    $currentEvents->{$fullId} = $eventInfos;
                 }
             } else {
-                my @tab;                
-                @tab = ($row->{ctime}, $statusCode, 0, 0, 0);                
-                $currentEvents->{$id} = \@tab;
+                my @tab;
+                @tab = ($row->{ctime}, $statusCode, 0, 0, 0);
+                $currentEvents->{$fullId} = \@tab;
             }
         }
     }
-    $self->insertLastServiceEvents($end, $currentEvents, $allIds, $downTime);
+    $self->insertLastServiceEvents($end, $currentEvents, $serviceIds, $downtimes);
 }
 
 # Parse host logs for given period
 # Parameters:
 # $start: period start
-# $end: period end 
+# $end: period end
 sub parseHostLog {
     my $self = shift;
 
@@ -122,26 +122,26 @@ sub parseHostLog {
     my $events = $self->{"hostEvents"};
     my $centreonDownTime = $self->{"centreonDownTime"};
 
-    my ($allIds, $allNames) = $host->getAllHosts();
-    my $currentEvents = $events->getLastStates($allNames);
+    my $hostIds = $host->getAllHostIds();
+    my $currentEvents = $events->getLastStates($hostIds);
     my $logs = $nagiosLog->getLogOfHosts($start, $end);
-    my $downTime = $centreonDownTime->getDownTime($allIds, $start, $end, 1);
+    my $downtimes = $centreonDownTime->getDowntimes($hostIds, $start, $end, 1);
 
     while (my $row = $logs->fetchrow_hashref()) {
-        my $id  = $row->{host_name};
-        if (defined($allIds->{$id})) {
-            my $statusCode = $row->{status};            
-            
-            if (defined($currentEvents->{$id})) {
-                my $eventInfos =  $currentEvents->{$id}; # $eventInfos is a reference to a table containing : incident start time | status | state_event_id. The last one is optionnal
+        my $hostId  = $row->{host_id};
+        if (defined($hostIds->{$hostId})) {
+            my $statusCode = $row->{status};
+
+            if (defined($currentEvents->{$hostId})) {
+                my $eventInfos =  $currentEvents->{$hostId}; # $eventInfos is a reference to a table containing : incident start time | status | state_event_id. The last one is optionnal
                 if ($statusCode ne "" && defined($eventInfos->[1]) && $eventInfos->[1] ne "" && $eventInfos->[1] != $statusCode) {
                     my $result = {};
                     if ($eventInfos->[2] != 0) {
                         # If eventId of log is defined, update the last day event
-                        $result = $events->updateEventEndTime($id, $allIds->{$id}, $eventInfos->[0], $row->{'ctime'}, $eventInfos->[1], $eventInfos->[2],$eventInfos->[3], 0, $downTime, $eventInfos->[4]);
+                        $result = $events->updateEventEndTime($hostId, $eventInfos->[0], $row->{'ctime'}, $eventInfos->[1], $eventInfos->[2],$eventInfos->[3], 0, $downtimes, $eventInfos->[4]);
                     } else {
                         if ($row->{ctime} > $eventInfos->[0]) {
-                            $result = $events->insertEvent($id, $allIds->{$id}, $eventInfos->[1], $eventInfos->[0], $row->{'ctime'}, 0, $downTime, $eventInfos->[4]);
+                            $result = $events->insertEvent($hostId, $eventInfos->[1], $eventInfos->[0], $row->{'ctime'}, 0, $downtimes, $eventInfos->[4]);
                         }
                     }
                     $eventInfos->[0] = $row->{'ctime'};
@@ -149,15 +149,15 @@ sub parseHostLog {
                     $eventInfos->[2] = 0;
                     $eventInfos->[3] = 0;
                     $eventInfos->[4] = defined($result->{in_ack}) ? $result->{in_ack} : 0;
-                    $currentEvents->{$id} = $eventInfos;
+                    $currentEvents->{$hostId} = $eventInfos;
                 }
             } else {
                 my @tab = ($row->{'ctime'}, $statusCode, 0, 0, 0);
-                $currentEvents->{$id} = \@tab;
+                $currentEvents->{$hostId} = \@tab;
             }
         }
     }
-    $self->insertLastHostEvents($end, $currentEvents, $allIds, $downTime);
+    $self->insertLastHostEvents($end, $currentEvents, $hostIds, $downtimes);
 }
 
 
@@ -165,20 +165,20 @@ sub parseHostLog {
 # Parameters:
 # $end: period end
 # $currentEvents: reference to a hash table that contains last incident details
-# $allIds: reference to a hash table that returns host/service ids for host/service names
+# $serviceIds: reference to a hash table that returns host/service ids for host/service ids
 sub insertLastServiceEvents {
     my $self = shift;
     my $events = $self->{"serviceEvents"};
 
     # parameters:
-    my ($end,$currentEvents, $allIds, $downTime)  = (shift, shift, shift, shift);
+    my ($end, $currentEvents, $serviceIds, $downTime)  = (shift, shift, shift, shift);
 
     while (my ($id, $eventInfos) = each (%$currentEvents)) {
-        my ($hostId, $serviceId) = split (";;", $allIds->{$id});
+        my ($hostId, $serviceId) = split(";;", $serviceIds->{$id});
         if ($eventInfos->[2] != 0) {
-            $events->updateEventEndTime($id, $hostId, $serviceId, $eventInfos->[0], $end, $eventInfos->[1], $eventInfos->[2], $eventInfos->[3], 1, $downTime, $eventInfos->[4]);
+            $events->updateEventEndTime($hostId, $serviceId, $eventInfos->[0], $end, $eventInfos->[1], $eventInfos->[2], $eventInfos->[3], 1, $downTime, $eventInfos->[4]);
         } else {
-            $events->insertEvent($id, $hostId, $serviceId, $eventInfos->[1], $eventInfos->[0], $end, 1, $downTime, $eventInfos->[4]);
+            $events->insertEvent($hostId, $serviceId, $eventInfos->[1], $eventInfos->[0], $end, 1, $downTime, $eventInfos->[4]);
         }
     }
 }
@@ -187,19 +187,19 @@ sub insertLastServiceEvents {
 # Parameters:
 # $end: period end
 # $currentEvents: reference to a hash table that contains last incident details
-# $allIds: reference to a hash table that returns host ids for host names
+# $hostIds: reference to a hash table that returns host ids
 sub insertLastHostEvents {
     my $self = shift;
     my $events = $self->{"hostEvents"};
 
     # parameters:
-    my ($end, $currentEvents, $allIds, $downTime)  = (shift, shift, shift, shift, shift);
+    my ($end, $currentEvents, $hostIds, $downtimes)  = (shift, shift, shift, shift, shift);
 
-    while (my ($id, $eventInfos) = each (%$currentEvents)) {
+    while (my ($hostId, $eventInfos) = each (%$currentEvents)) {
         if ($eventInfos->[2] != 0) {
-            $events->updateEventEndTime($id, $allIds->{$id}, $eventInfos->[0], $end, $eventInfos->[1], $eventInfos->[2], $eventInfos->[3], 1, $downTime, $eventInfos->[4]);
+            $events->updateEventEndTime($hostId, $eventInfos->[0], $end, $eventInfos->[1], $eventInfos->[2], $eventInfos->[3], 1, $downtimes, $eventInfos->[4]);
         } else {
-            $events->insertEvent($id, $allIds->{$id}, $eventInfos->[1], $eventInfos->[0], $end, 1, $downTime, $eventInfos->[4]);
+            $events->insertEvent($hostId, $eventInfos->[1], $eventInfos->[0], $end, 1, $downtimes, $eventInfos->[4]);
         }
     }
 }

--- a/lib/perl/centreon/reporting/CentreonProcessStateEvents.pm
+++ b/lib/perl/centreon/reporting/CentreonProcessStateEvents.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/perl/centreon/reporting/CentreonService.pm
+++ b/lib/perl/centreon/reporting/CentreonService.pm
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
@@ -64,9 +64,9 @@ sub getAllServiceIds {
 
     my %serviceIds;
     # getting services linked to hosts
-    my $query = "SELECT host_id, service_id" .
-                " FROM host, service, host_service_relation" .
-                " WHERE host_id = host_host_id and service_service_id = service_id" .
+    my $query = "SELECT host_host_id as host_id, service_id" .
+                " FROM service, host_service_relation" .
+                " WHERE service_service_id = service_id" .
                 " AND service_register = '1'";
     if ($activated == 1) {
         $query .= " AND `service_activate`='1'";
@@ -80,7 +80,7 @@ sub getAllServiceIds {
     # getting services linked to hostgroup
     $query = "SELECT host_id, service_id" .
         " FROM host, service, host_service_relation hr, hostgroup_relation hgr, hostgroup hg" .
-        " WHERE hr.hostgroup_hg_id is not null" .
+        " WHERE hr.hostgroup_hg_id IS NOT NULL" .
         " AND hr.service_service_id = service_id" .
         " AND hr.hostgroup_hg_id = hgr.hostgroup_hg_id" .
         " AND hgr.host_host_id = host_id" .

--- a/lib/perl/centreon/reporting/CentreonService.pm
+++ b/lib/perl/centreon/reporting/CentreonService.pm
@@ -2,32 +2,32 @@
 # Copyright 2005-2013 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 
@@ -40,7 +40,7 @@ package centreon::reporting::CentreonService;
 # parameters:
 # $logger: instance of class CentreonLogger
 # $centreon: Instance of centreonDB class for connection to Centreon database
-# $centstorage: (optionnal) Instance of centreonDB class for connection to Centstorage database
+# $centstorage: (optional) Instance of centreonDB class for connection to Centstorage database
 sub new {
     my $class = shift;
     my $self = {};
@@ -53,8 +53,8 @@ sub new {
     return $self;
 }
 
-# returns two references to two hash tables => services indexed by id and services indexed by name
-sub getAllServices {
+# returns two references to two hash tables => services indexed by id and services indexed by id
+sub getAllServiceIds {
     my $self = shift;
     my $centreon = $self->{"centreon"};
     my $activated = 1;
@@ -62,11 +62,11 @@ sub getAllServices {
         $activated  = 0;
     }
 
-    my (%service_ids, %service_names);
+    my %serviceIds;
     # getting services linked to hosts
-    my $query = "SELECT service_description, service_id, host_id, host_name".
-                " FROM host, service, host_service_relation".
-                " WHERE host_id = host_host_id and service_service_id = service_id".
+    my $query = "SELECT host_id, service_id" .
+                " FROM host, service, host_service_relation" .
+                " WHERE host_id = host_host_id and service_service_id = service_id" .
                 " AND service_register = '1'";
     if ($activated == 1) {
         $query .= " AND `service_activate`='1'";
@@ -74,47 +74,31 @@ sub getAllServices {
 
     my ($status, $sth) = $centreon->query($query);
     while (my $row = $sth->fetchrow_hashref()) {
-        $service_ids{$row->{'host_name'}.";;".$row->{'service_description'}} = $row->{'host_id'}.";;".$row->{'service_id'};
-        $service_names{$row->{'host_id'}.";;".$row->{'service_id'}} = $row->{'host_name'}.";;".$row->{'service_description'};
+        $serviceIds{$row->{'host_id'} . ";;" . $row->{'service_id'}} = 1;
     }
 
     # getting services linked to hostgroup
-    $query = "SELECT service_description, service_id, host_id, host_name".
-        " FROM host, service, host_service_relation hr, hostgroup_relation hgr, hostgroup hg".
-        " WHERE  hr.hostgroup_hg_id is not null".
-        " AND hr.service_service_id = service_id".
-        " AND hr.hostgroup_hg_id = hgr.hostgroup_hg_id".
-        " AND hgr.host_host_id = host_id".
+    $query = "SELECT host_id, service_id" .
+        " FROM host, service, host_service_relation hr, hostgroup_relation hgr, hostgroup hg" .
+        " WHERE hr.hostgroup_hg_id is not null" .
+        " AND hr.service_service_id = service_id" .
+        " AND hr.hostgroup_hg_id = hgr.hostgroup_hg_id" .
+        " AND hgr.host_host_id = host_id" .
         " AND service_register = '1'";
     if ($activated == 1) {
-        $query .= " AND service_activate='1'".
-                  " AND host_activate = '1'".
+        $query .= " AND service_activate='1'" .
+                  " AND host_activate = '1'" .
                   " AND hg.hg_activate = '1'";
     }
     $query .= " AND hg.hg_id = hgr.hostgroup_hg_id";
 
     ($status, $sth) = $centreon->query($query);
     while (my $row = $sth->fetchrow_hashref()) {
-        $service_ids{$row->{'host_name'}.";;".$row->{'service_description'}} = $row->{'host_id'}.";;".$row->{'service_id'};
-        $service_names{$row->{'host_id'}.";;".$row->{'service_id'}} = $row->{'host_name'}.";;".$row->{'service_description'};
+        $serviceIds{$row->{'host_id'} . ";;" . $row->{'service_id'}} = 1;
     }
     $sth->finish();
 
-    return (\%service_ids, \%service_names);
-}
-
-# Get all services, keys are IDs
-sub getAllServicesByID {
-    my $self = shift;
-    my ($service_ids, $service_names) = $self->getAllServices();    
-    return ($service_ids);
-}
-
-# Get all services, keys are names
-sub getAllservicesByName {
-    my $self = shift;
-    my ($service_ids, $service_names) = $self->getAllServices();    
-    return ($service_names);
+    return \%serviceIds;
 }
 
 1;

--- a/lib/perl/centreon/reporting/CentreonService.pm
+++ b/lib/perl/centreon/reporting/CentreonService.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/perl/centreon/reporting/CentreonServiceStateEvents.pm
+++ b/lib/perl/centreon/reporting/CentreonServiceStateEvents.pm
@@ -1,33 +1,33 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 
@@ -40,7 +40,7 @@ package centreon::reporting::CentreonServiceStateEvents;
 # parameters:
 # $logger: instance of class CentreonLogger
 # $centreon: Instance of centreonDB class for connection to Centreon database
-# $centstorage: (optionnal) Instance of centreonDB class for connection to Centstorage database
+# $centstorage: (optional) Instance of centreonDB class for connection to Centstorage database
 sub new {
     my $class = shift;
     my $self  = {};
@@ -80,9 +80,9 @@ sub getStateEventDurations {
             my @tab = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
             # index 0: OK, index 1: WARNING, index 2: CRITICAL, index 3: UNKNOWN, index 4: DOWNTIME, index 5: UNDETERMINED
             # index 6: OK alerts, index 7: WARNING alerts, index 8: CRITICAL alerts, index 9: UNKNOWN alerts
-            $services{$row->{host_id}.";;".$row->{service_id}} = \@tab;            
+            $services{$row->{host_id}.";;".$row->{service_id}} = \@tab;
         }
-        
+
         my $stats = $services{$row->{host_id}.";;".$row->{service_id}};
         if ($row->{in_downtime} == 0) {
             $stats->[$row->{state}] += $row->{end_time} - $row->{start_time};
@@ -119,7 +119,7 @@ sub getLastStates {
                 " FROM `servicestateevents`".
                 " WHERE `last_update` = 1";
     my ($status, $sth) = $centstorage->query($query);
-    while(my $row = $sth->fetchrow_hashref()) {
+    while (my $row = $sth->fetchrow_hashref()) {
         my $serviceId = $row->{host_id} . ";;" . $row->{service_id};
         if (defined($serviceIds->{$serviceId})) {
             my @tab = ($row->{end_time}, $row->{state}, $row->{servicestateevent_id}, $row->{in_downtime}, $row->{in_ack});

--- a/lib/perl/centreon/reporting/CentreonServiceStateEvents.pm
+++ b/lib/perl/centreon/reporting/CentreonServiceStateEvents.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/perl/centreon/script/dashboardBuilder.pm
+++ b/lib/perl/centreon/script/dashboardBuilder.pm
@@ -2,32 +2,32 @@
 # Copyright 2005-2013 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 
@@ -76,7 +76,7 @@ sub new {
 # program exit function
 sub exit_pgr() {
     my $self = shift;
-    
+
     $self->{logger}->writeLogInfo("Exiting program...");
     exit (0);
 }
@@ -92,7 +92,7 @@ sub getLiveService {
         $result{$row->{"cp_key"}} = $row->{"cp_value"};
     }
     $sth->finish;
-    
+
     # verifying if all variables are set
     if (!defined($result{"report_hour_start"})) {
         $result{"report_hour_start"} = 0;
@@ -118,13 +118,13 @@ sub getLiveService {
 # Initialize objects for program
 sub initVars {
     my $self = shift;
-    
-    # classes to query database tables 
+
+    # classes to query database tables
     $self->{host} = centreon::reporting::CentreonHost->new($self->{logger}, $self->{cdb});
     $self->{service} = centreon::reporting::CentreonService->new($self->{logger}, $self->{cdb});
     $self->{serviceEvents} = centreon::reporting::CentreonServiceStateEvents->new($self->{logger}, $self->{csdb});
     $self->{hostEvents} = centreon::reporting::CentreonHostStateEvents->new($self->{logger}, $self->{csdb});
-    
+
     # Class that builds events
     $self->{dashboard} = centreon::reporting::CentreonDashboard->new($self->{logger}, $self->{csdb});
     $self->{liveService} = $self->getLiveService();
@@ -134,7 +134,7 @@ sub initVars {
 sub getDaysFromPeriod {
     my $self = shift;
     my ($start, $end) = (shift, shift);
-    
+
     my @days;
     # Check if $end is > to current time
     my ($day,$month,$year) = (localtime(time))[3,4,5];
@@ -142,12 +142,12 @@ sub getDaysFromPeriod {
     if ($end > $todayStart) {
         $end = $todayStart;
     }
-    
+
     # get start day as mm/dd/yyyy 00:00
     ($day,$month,$year) = (localtime($start))[3,4,5];
     $start =  mktime(0,0,0,$day,$month,$year,0,0,-1);
     my $previousDay = mktime(0,0,0,$day - 1,$month,$year,0,0,-1);
-    
+
     while ($start < $end) {
         # getting day beginning => 00h 00min
         # if there is few hour gap (time change : winter/summer), we also readjust it
@@ -155,7 +155,7 @@ sub getDaysFromPeriod {
             $start = mktime(0,0,0, ++$day, $month, $year,0,0,-1);
         }
         my $currentDayOfWeek = (localtime($start))[6];
-        
+
         # If in the configuration, this day of week is not selected, the reporting is not calculated
         if (defined($self->{liveService}->{"report_".$weekDays[$currentDayOfWeek]}) && $self->{liveService}->{"report_".$weekDays[$currentDayOfWeek]} == 1) {
             # setting reporting date and time ranges
@@ -166,7 +166,7 @@ sub getDaysFromPeriod {
         } else {
             $day++;
         }
-        
+
         $previousDay = $start;
         $start = mktime(0,0,0, $day, $month, $year,0,0,-1);
     }
@@ -182,7 +182,6 @@ sub rebuildIncidents {
         $self->{logger}->writeLogError("Cannot determine reporting rebuild period");
         $self->{logger}->writeLogError("Please use -s and -e option to defined the rebuild period.");
     } else {
-    
         # Purge tables in order to rebuild statistics
         my $periods = $self->getDaysFromPeriod($start, $end);
         if (!scalar(@$periods)) {
@@ -195,25 +194,25 @@ sub rebuildIncidents {
             $self->{dashboard}->deleteServiceStats($start, $end);
             $self->{dashboard}->deleteHostStats($start, $end);
         }
-    
+
         if (defined($start) && defined($end) && !$serviceOnly) {
-            my ($allIds, $allNames) = $self->{host}->getAllHosts(0);
-        
+            my $hostIds = $self->{host}->getAllHostIds(0);
+
             # archiving logs for each days
             foreach(@$periods) {
                 $self->{logger}->writeLogInfo("[HOST] Processing period: ".localtime($_->{"day_start"})." => ".localtime($_->{"day_end"}));
                 my $hostStateDurations = $self->{hostEvents}->getStateEventDurations($_->{"day_start"}, $_->{"day_end"});
-                $self->{dashboard}->insertHostStats($allNames, $hostStateDurations, $_->{"day_start"}, $_->{"day_end"});
+                $self->{dashboard}->insertHostStats($hostIds, $hostStateDurations, $_->{"day_start"}, $_->{"day_end"});
             }
         }
         if (defined($start) && defined($end) && !$hostOnly) {
-            my ($allIds, $allNames) = $self->{service}->getAllServices(0);
-        
+            my $serviceIds = $self->{service}->getAllServiceIds(0);
+
             # archiving logs for each days
             foreach(@$periods) {
                 $self->{logger}->writeLogInfo("[SERVICE] Processing period: ".localtime($_->{"day_start"})." => ".localtime($_->{"day_end"}));
                 my $serviceStateDurations = $self->{serviceEvents}->getStateEventDurations($_->{"day_start"}, $_->{"day_end"});
-                $self->{dashboard}->insertServiceStats($allNames, $serviceStateDurations, $_->{"day_start"}, $_->{"day_end"});
+                $self->{dashboard}->insertServiceStats($serviceIds, $serviceStateDurations, $_->{"day_start"}, $_->{"day_end"});
             }
         }
     }
@@ -224,7 +223,7 @@ sub rebuildIncidents {
 sub getRebuildOptions {
     my $self = shift;
     my ($paramStartDate, $paramEndDate, $hostOnly, $serviceOnly) = (shift, shift, shift, shift);
-    
+
     if (!defined($hostOnly)) {
         $hostOnly = 0;
     } else {
@@ -239,7 +238,7 @@ sub getRebuildOptions {
 
     my ($start, $end);
     my $purgeType = "truncate";
-    if (defined($paramStartDate)){  
+    if (defined($paramStartDate)){
         if ($paramStartDate =~ /^([0-9]{4})\-([0-9]{2})\-([0-9]{2})$/) {
             $start = mktime(0,0,0,$3,$2 - 1,$1 - 1900,0,0,-1);
             $purgeType = "delete";
@@ -255,7 +254,7 @@ sub getRebuildOptions {
             $self->{logger}->writeLogError("Bad paramater syntax for option [-e|--period-end]. Syntax example: 2011-11-09");
         }
     }
-    
+
     my ($dbStart, $dbEnd) = $self->{hostEvents}->getFirstLastIncidentTimes();
     if (!defined($start)) {
         $start = $dbStart;
@@ -275,20 +274,20 @@ sub run {
     $self->initVars();
 
     $self->{logger}->writeLogInfo("Starting program...");
-    
+
     if (defined($self->{opt_rebuild})) {
         $self->rebuildIncidents($self->getRebuildOptions($self->{opt_startperiod}, $self->{opt_endperiod}, $self->{opt_hostonly}, $self->{opt_serviceonly}));
     } else {
         my $currentTime = time;
         my ($day,$month,$year, $dayOfWeek) = (localtime($currentTime))[3,4,5,6];
-      
-        # getting day of week of date to process 
+
+        # getting day of week of date to process
         if ($dayOfWeek == 0) {
             $dayOfWeek = 6;
         } else {
             $dayOfWeek--;
         }
-    
+
         # If in the configuration, this day of week is not selected, the reporting is not calculated
         if (defined($self->{liveService}->{"report_".$weekDays[$dayOfWeek]}) && $self->{liveService}->{"report_".$weekDays[$dayOfWeek]} != 1) {
             $self->{logger}->writeLogInfo("Reporting must not be calculated for this day, check your configuration");
@@ -298,14 +297,14 @@ sub run {
         # setting reporting date and time ranges
         my $end = mktime(0,$self->{liveService}->{"report_minute_end"},$self->{liveService}->{"report_hour_end"},$day - 1,$month,$year,0,0,-1);
         my $start = mktime(0,$self->{liveService}->{"report_minute_start"},$self->{liveService}->{"report_hour_start"},$day - 1,$month,$year,0,0,-1);
-        
-        my ($serviceIds, $serviceNames) = $self->{service}->getAllServices(0);
-        my ($hostIds, $hostNames) = $self->{host}->getAllHosts(0);
+
+        my $serviceIds = $self->{service}->getAllServiceIds(0);
+        my $hostIds = $self->{host}->getAllHostIds(0);
         $self->{logger}->writeLogInfo("Processing period: ".localtime($start)." => ".localtime($end));
         my $hostStateDurations = $self->{hostEvents}->getStateEventDurations($start, $end);
-        $self->{dashboard}->insertHostStats($hostNames, $hostStateDurations, $start, $end);
+        $self->{dashboard}->insertHostStats($hostIds, $hostStateDurations, $start, $end);
         my $serviceStateDurations = $self->{serviceEvents}->getStateEventDurations($start, $end);
-        $self->{dashboard}->insertServiceStats($serviceNames, $serviceStateDurations, $start, $end);
+        $self->{dashboard}->insertServiceStats($serviceIds, $serviceStateDurations, $start, $end);
     }
     $self->exit_pgr();
 }

--- a/lib/perl/centreon/script/dashboardBuilder.pm
+++ b/lib/perl/centreon/script/dashboardBuilder.pm
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #

--- a/lib/perl/centreon/script/dashboardBuilder.pm
+++ b/lib/perl/centreon/script/dashboardBuilder.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under

--- a/lib/perl/centreon/script/eventReportBuilder.pm
+++ b/lib/perl/centreon/script/eventReportBuilder.pm
@@ -1,33 +1,33 @@
 ################################################################################
-# Copyright 2005-2013 Centreon
+# Copyright 2005-2020 Centreon
 # Centreon is developped by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
-# 
-# This program is free software; you can redistribute it and/or modify it under 
-# the terms of the GNU General Public License as published by the Free Software 
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free Software
 # Foundation ; either version 2 of the License.
-# 
+#
 # This program is distributed in the hope that it will be useful, but WITHOUT ANY
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A 
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 # PARTICULAR PURPOSE. See the GNU General Public License for more details.
-# 
-# You should have received a copy of the GNU General Public License along with 
+#
+# You should have received a copy of the GNU General Public License along with
 # this program; if not, see <http://www.gnu.org/licenses>.
-# 
-# Linking this program statically or dynamically with other modules is making a 
-# combined work based on this program. Thus, the terms and conditions of the GNU 
+#
+# Linking this program statically or dynamically with other modules is making a
+# combined work based on this program. Thus, the terms and conditions of the GNU
 # General Public License cover the whole combination.
-# 
-# As a special exception, the copyright holders of this program give Centreon 
-# permission to link this program with independent modules to produce an executable, 
-# regardless of the license terms of these independent modules, and to copy and 
-# distribute the resulting executable under terms of Centreon choice, provided that 
-# Centreon also meet, for each linked independent module, the terms  and conditions 
-# of the license of that module. An independent module is a module which is not 
-# derived from this program. If you modify this program, you may extend this 
+#
+# As a special exception, the copyright holders of this program give Centreon
+# permission to link this program with independent modules to produce an executable,
+# regardless of the license terms of these independent modules, and to copy and
+# distribute the resulting executable under terms of Centreon choice, provided that
+# Centreon also meet, for each linked independent module, the terms  and conditions
+# of the license of that module. An independent module is a module which is not
+# derived from this program. If you modify this program, you may extend this
 # exception to your version of the program, but you are not obliged to do so. If you
 # do not wish to do so, delete this exception statement from your version.
-# 
+#
 #
 ####################################################################################
 
@@ -77,7 +77,7 @@ sub new {
 # program exit function
 sub exit_pgr() {
     my $self = shift;
-    
+
     $self->{logger}->writeLogInfo("Exiting program...");
     exit (0);
 }
@@ -86,11 +86,11 @@ sub exit_pgr() {
 sub initVars {
     my $self = shift;
     my $centstatus;
-    
+
     # Getting centstatus database name
     $centstatus = $self->{csdb};
-    
-    # classes to query database tables 
+
+    # classes to query database tables
     $self->{host} = centreon::reporting::CentreonHost->new($self->{logger}, $self->{cdb});
     $self->{service} = centreon::reporting::CentreonService->new($self->{logger}, $self->{cdb});
     $self->{nagiosLog} = centreon::reporting::CentreonLog->new($self->{logger}, $self->{csdb});
@@ -98,16 +98,24 @@ sub initVars {
     my $centreonAck = centreon::reporting::CentreonAck->new($self->{logger}, $centstatus);
     $self->{serviceEvents} = centreon::reporting::CentreonServiceStateEvents->new($self->{logger}, $self->{csdb}, $centreonAck, $centreonDownTime);
     $self->{hostEvents} = centreon::reporting::CentreonHostStateEvents->new($self->{logger}, $self->{csdb}, $centreonAck, $centreonDownTime);
-    
+
     # Class that builds events
-    $self->{processEvents} = centreon::reporting::CentreonProcessStateEvents->new($self->{logger}, $self->{host}, $self->{service}, $self->{nagiosLog}, $self->{hostEvents}, $self->{serviceEvents}, $centreonDownTime);
+    $self->{processEvents} = centreon::reporting::CentreonProcessStateEvents->new(
+        $self->{logger},
+        $self->{host},
+        $self->{service},
+        $self->{nagiosLog},
+        $self->{hostEvents},
+        $self->{serviceEvents},
+        $centreonDownTime
+    );
 }
 
-# For a given period returns in a table each    
+# For a given period returns in a table each
 sub getDaysFromPeriod {
     my $self = shift;
     my ($start, $end) = (shift, shift);
-    
+
     my @days;
     # Check if $end is > to current time
     my ($day,$month,$year) = (localtime(time))[3,4,5];
@@ -119,7 +127,7 @@ sub getDaysFromPeriod {
     ($day,$month,$year) = (localtime($start))[3,4,5];
     $start =  mktime(0,0,0,$day,$month,$year,0,0,-1);
     my $previousDay = mktime(0,0,0,$day - 1,$month,$year,0,0,-1);
-    
+
     while ($start < $end) {
         # getting day beginning => 00h 00min
         # if there is few hour gap (time change : winter/summer), we also readjust it
@@ -130,7 +138,7 @@ sub getDaysFromPeriod {
         my $dayEnd = mktime(0, 0, 0, ++$day, $month, $year, 0, 0, -1);
         my %period = (day_start => $start, day_end => $dayEnd);
         $days[scalar(@days)] = \%period;
-        
+
         $previousDay = $start;
         $start = $dayEnd;
     }
@@ -139,7 +147,7 @@ sub getDaysFromPeriod {
 
 sub get_date {
     my ($self, %options) = @_;
-    
+
     my ($date, $midnight);
     if (defined($self->{$options{option_label}})) {
         if ($self->{$options{option_label}} !~ /^([0-9]{4})-([0-9]{2})-([0-9]{2})$/) {
@@ -149,9 +157,9 @@ sub get_date {
         if (!defined($self->{opt_no_validate_date})) {
             require DateTime;
             eval {
-                my $dt = DateTime->new( 
-                    year => $1, 
-                    month => $2, 
+                my $dt = DateTime->new(
+                    year => $1,
+                    month => $2,
                     day => $3);
             };
             if ($@) {
@@ -162,7 +170,7 @@ sub get_date {
         $date = mktime(0,0,0,$3,$2-1,$1-1900,0,0,-1);
         $midnight = mktime(0,0,0,$3+1,$2-1,$1-1900,0,0,-1);
     }
-    
+
     return ($date, $midnight);
 }
 
@@ -170,7 +178,7 @@ sub get_date {
 sub rebuildIncidents {
     my $self = shift;
     my $time_period = shift;
-    
+
     my ($start, $midnight) = $self->get_date(option_label => 'opt_stime', option => '--start-time');
     my ($start2, $end2);
     my ($end) = $self->get_date(option_label => 'opt_etime', option => '--end-time');
@@ -182,13 +190,13 @@ sub rebuildIncidents {
         $self->{logger}->writeLogError("start date couldn't be more recent than end date");
         $self->exit_pgr();
     }
-    
+
     # Empty tables
     $self->{serviceEvents}->truncateStateEvents(start => $start, midnight => $midnight);
-    $self->{hostEvents}->truncateStateEvents(start => $start, midnight => $midnight);    
+    $self->{hostEvents}->truncateStateEvents(start => $start, midnight => $midnight);
     $start = $start2 if (!defined($start));
     $end = $end2 if (!defined($end));
-    
+
     my $periods = $self->getDaysFromPeriod($start, $end);
     # archiving logs for each days
     foreach(@$periods) {
@@ -204,17 +212,17 @@ sub run {
     $self->SUPER::run();
     $self->{logger}->redirect_output();
     $self->initVars();
-    
+
     $self->{logger}->writeLogInfo("Starting program...");
-    
+
     if (defined($self->{opt_rebuild})) {
         $self->rebuildIncidents();
     } else {
         my $currentTime = time;
-        my ($day,$month,$year) = (localtime($currentTime))[3,4,5];
-        my $end = mktime(0,0,0,$day,$month,$year,0,0,-1);
-        my $start = mktime(0,0,0,$day-1,$month,$year,0,0,-1);
-        $self->{logger}->writeLogInfo("Processing period: ".localtime($start)." => ".localtime($end));
+        my ($day,$month,$year) = (localtime($currentTime))[3, 4, 5];
+        my $end = mktime(0, 0, 0, $day, $month, $year, 0, 0, -1);
+        my $start = mktime(0, 0, 0, $day - 1, $month, $year, 0, 0, -1);
+        $self->{logger}->writeLogInfo("Processing period: " . localtime($start) . " => " . localtime($end));
         $self->{processEvents}->parseHostLog($start, $end);
         $self->{processEvents}->parseServiceLog($start, $end);
     }

--- a/lib/perl/centreon/script/eventReportBuilder.pm
+++ b/lib/perl/centreon/script/eventReportBuilder.pm
@@ -1,6 +1,6 @@
 ################################################################################
 # Copyright 2005-2020 Centreon
-# Centreon is developped by : Julien Mathis and Romain Le Merlus under
+# Centreon is developed by : Julien Mathis and Romain Le Merlus under
 # GPL Licence 2.0.
 #
 # This program is free software; you can redistribute it and/or modify it under


### PR DESCRIPTION
## Description

* Manage reporting calculation when a host or service is renamed
* Improve performance on reporting calculation

(Use ids instead of names in reporting scripts)

**Fixes** MON-5694

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Create a passive host "host-passive"
* Set host status to down
* Wait two hours
* Rename the host to "host-passive-renamed"
* Wait next day
* Check in reporting that first two hours are displayed in the reporting (not undetermined)

* Other reporting calculation should also be tested (downtime period...)