### PR TITLE
fix(formGraphTemplate): bad variable name used

### DIFF
--- a/www/include/views/graphTemplates/formGraphTemplate.php
+++ b/www/include/views/graphTemplates/formGraphTemplate.php
@@ -38,7 +38,7 @@ if (!isset($centreon)) {
 }
 
 $graph = [];
-if (($o == "c" || $o == "w") && $graph_id !== false && $graph_Id > 0) {
+if (($o == "c" || $o == "w") && $graph_id !== false && $graph_id > 0) {
     $stmt = $pearDB->prepare('SELECT * FROM giv_graphs_template WHERE graph_id = :graphId LIMIT 1');
     $stmt->bindValue(':graphId', $graph_id, \PDO::PARAM_INT);
     $stmt->execute();


### PR DESCRIPTION
## Description

Wrong variable name used in conditition which prevent from editing and save graph Templates...

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

See the related JIRA ticket for the tests

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
