### PR TITLE
fix(secu): upgrade kind-of dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9409,9 +9409,9 @@
       "integrity": "sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg=="
     },
     "kind-of": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
-      "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "kleur": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "connected-react-router": "^6.5.2",
     "dom-serializer": "^0.1.1",
     "install": "^0.13.0",
+    "kind-of": "^6.0.3",
     "loaders.css": "^0.1.2",
     "moment-timezone": "^0.5.26",
     "numeral": "^2.0.6",


### PR DESCRIPTION
## Description

Upgrade kind-of dependency to latest version (6.0.3)

@kduret , @bdauria Caution, there's still one package reported as highly vulnerable :
![image](https://user-images.githubusercontent.com/34628915/86347647-deda0800-bc5e-11ea-84e9-f5a69a8a627e.png)


**Fixes** # (dependabot)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x (master)
