### PR TITLE
fix(chore): remove errors and improve LDAP logs message

### DIFF
--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -51,7 +51,6 @@ class CentreonLDAP
     private $debugImport = false;
     private $debugPath = "";
 
-    private const DISABLED = true;
     /**
      * Constructor
      * @param \CentreonDB $pearDB The database connection
@@ -796,7 +795,7 @@ class CentreonLDAP
             */
             $this->debug("LDAP Error : Size limit exceeded error. This error was not added to php log. "
                 . "Kindly, check your LDAP server's configuration and your Centreon's LDAP parameters.");
-            return self::DISABLED;
+            return true;
         }
 
         // throwing all errors

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -787,11 +787,12 @@ class CentreonLDAP
     private function errorLdapHandler($errno, $errstr, $errfile, $errline): bool
     {
         if ($errno === 2 && ldap_errno($this->ds) === 4) {
-            /* Silencing : 'size limit exceeded' warnings in the logs
-             As the $searchLimit value needs to be consistent with the ldap server's configuration and
-             as the $sizelimit error thrown is not related with the results.
-             ldap_errno == 4 means LDAP_SIZELIMIT_EXCEEDED
-             $errno == 2 means PHP_WARNING
+            /*
+            Silencing : 'size limit exceeded' warnings in the logs
+            As the $searchLimit value needs to be consistent with the ldap server's configuration and
+            as the size limit error thrown is not related with the results.
+                ldap_errno : 4 = LDAP_SIZELIMIT_EXCEEDED
+                $errno     : 2 = PHP_WARNING
             */
             $this->debug("LDAP Error : Size limit exceeded error. This error was not added to php log. "
                 . "Kindly, check your LDAP server's configuration and your Centreon's LDAP parameters.");

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -51,7 +51,7 @@ class CentreonLDAP
     private $debugImport = false;
     private $debugPath = "";
 
-    private CONST DISABLED = true;
+    private const DISABLED = true;
     /**
      * Constructor
      * @param \CentreonDB $pearDB The database connection

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -809,7 +809,7 @@ class CentreonLDAP
      */
     private function setErrorHandler(): void
     {
-        set_error_handler(array('CentreonLDAP', 'errorLdapHandler'));
+        set_error_handler(array($this, 'errorLdapHandler'));
     }
 
     /**

--- a/www/class/centreonLDAP.class.php
+++ b/www/class/centreonLDAP.class.php
@@ -796,7 +796,7 @@ class CentreonLDAP
     private function debug($msg)
     {
         if ($this->debugImport) {
-            error_log("[" . date("d/m/Y H:i") . "]" . $msg . "\n", 3, $this->debugPath . "ldapsearch.log");
+            error_log("[" . date("d/m/Y H:i") . "] " . $msg . "\n", 3, $this->debugPath . "ldapsearch.log");
         }
     }
 


### PR DESCRIPTION
## Description

Remove these errors in the ldap.log : 

1 :
```
[03-Jul-2020 17:13:13 Europe/Paris] PHP Warning:  ldap_search(): Partial search results returned: Sizelimit exceeded in /usr/share/centreon/www/class/centreonLDAP.class.php on line 600
[03-Jul-2020 17:13:13 Europe/Paris] PHP Stack trace:
[03-Jul-2020 17:13:13 Europe/Paris] PHP   1. {main}() /usr/share/centreon/www/include/configuration/configObject/contact/ldapsearch.php:0
[03-Jul-2020 17:13:13 Europe/Paris] PHP   2. CentreonLDAP->search() /usr/share/centreon/www/include/configuration/configObject/contact/ldapsearch.php:142
[03-Jul-2020 17:13:13 Europe/Paris] PHP   3. ldap_search() /usr/share/centreon/www/class/centreonLDAP.class.php:600
...
``` 
2 : 
```
[06-Nov-2019 15:10:13 Europe/Paris] PHP Warning:  ldap_get_entries() expects parameter 2 to be resource, boolean given in /usr/share/centreon/www/class/centreonLDAP.class.php on line 313
[06-Nov-2019 15:10:13 Europe/Paris] PHP Stack trace:
[06-Nov-2019 15:10:13 Europe/Paris] PHP   1. {main}() /usr/share/centreon/www/index.php:0
[06-Nov-2019 15:10:13 Europe/Paris] PHP   2. include_once() /usr/share/centreon/www/index.php:145
[06-Nov-2019 15:10:13 Europe/Paris] PHP   3. require_once() /usr/share/centreon/www/include/core/login/login.php:59
...
```
3 :
Improve message when LDAP synchronization is disabled or not expected.

**Fixes** # (MON-4486)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)
