### PR TITLE
Fix(monitoring_server): Fixed method to find the local monitoring server

### DIFF
--- a/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
+++ b/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2019 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,14 +29,21 @@ use Centreon\Infrastructure\MonitoringServer\MonitoringServerRepositoryRDB;
 
 interface MonitoringServerRepositoryInterface
 {
-
     /**
-     * Find monitoring servers.
+     * Find monitoring servers taking into account the request parameters.
      *
      * @return MonitoringServer[]
      * @throws \Exception
      */
-    public function findServers(): array;
+    public function findServersWithRequestParameters(): array;
+
+    /**
+     * Find monitoring servers without taking into account the request parameters.
+     *
+     * @return MonitoringServer[]
+     * @throws \Exception
+     */
+    public function findServersWithoutRequestParameters(): array;
 
     /**
      * Find a resource of monitoring servers identified by his name.

--- a/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
+++ b/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2019 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ class MonitoringServerService implements MonitoringServerServiceInterface
     public function findServers(): array
     {
         try {
-            return $this->monitoringServerRepository->findServers();
+            return $this->monitoringServerRepository->findServersWithRequestParameters();
         } catch (\Exception $ex) {
             throw new MonitoringServerException('Error when searching for monitoring servers', 0, $ex);
         }

--- a/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2019 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,9 @@ class MonitoringServerRepositoryRDB extends AbstractRepositoryDRB implements Mon
      */
     public function findLocalServer(): ?MonitoringServer
     {
-        $request = $this->translateDbName('SELECT * FROM `:db`.nagios_server WHERE localhost = \'1\'');
+        $request = $this->translateDbName(
+            'SELECT * FROM `:db`.nagios_server WHERE localhost = \'1\' AND ns_activate = \'1\''
+        );
         $statement = $this->db->query($request);
         if ($statement !== false && ($result = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
             /**
@@ -90,7 +92,7 @@ class MonitoringServerRepositoryRDB extends AbstractRepositoryDRB implements Mon
     /**
      * @inheritDoc
      */
-    public function findServers(): array
+    public function findServersWithRequestParameters(): array
     {
         $this->sqlRequestTranslator->setConcordanceArray([
             'id' => 'id',
@@ -100,20 +102,44 @@ class MonitoringServerRepositoryRDB extends AbstractRepositoryDRB implements Mon
             'is_activate' => 'ns_activate'
         ]);
 
+        // Search
+        $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
+
+        // Sort
+        $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();
+
+        // Pagination
+        $paginationRequest = $this->sqlRequestTranslator->translatePaginationToSql();
+
+        return $this->findServers($searchRequest, $sortRequest, $paginationRequest);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findServersWithoutRequestParameters(): array
+    {
+        return $this->findServers(null, null, null);
+    }
+
+    /**
+     * Find servers.
+     *
+     * @param string|null $searchRequest Search request
+     * @param string|null $sortRequest Sort request
+     * @param string|null $paginationRequest Pagination request
+     * @return MonitoringServer[]
+     * @throws \Exception
+     */
+    private function findServers(?string $searchRequest, ?string $sortRequest, ?string $paginationRequest): array
+    {
         $request = $this->translateDbName(
             'SELECT SQL_CALC_FOUND_ROWS * FROM `:db`.nagios_server'
         );
 
-        // Search
-        $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();
         $request .= !is_null($searchRequest) ? $searchRequest : '';
-
-        // Sort
-        $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();
         $request .= !is_null($sortRequest) ? $sortRequest : ' ORDER BY id DESC';
-
-        // Pagination
-        $request .= $this->sqlRequestTranslator->translatePaginationToSql();
+        $request .= !is_null($paginationRequest) ? $paginationRequest : '';
         $statement = $this->db->prepare($request);
 
         foreach ($this->sqlRequestTranslator->getSearchValues() as $key => $data) {


### PR DESCRIPTION
## Description

Fixed method to find the local monitoring server.
Creating two distinct methods for finding monitoring servers to make the code more explicit.

**Fixes** # (issue)
When we try to find the local monitoring server, the first one found may not be activated.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
