### PR TITLE
fix(apiV1): Correct sortType and order for host in realtime

### DIFF
--- a/www/api/class/centreon_realtime_hosts.class.php
+++ b/www/api/class/centreon_realtime_hosts.class.php
@@ -141,20 +141,20 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
         } else {
             $this->viewType = null;
         }
-        if (isset($this->arguments['sortType'])) {
-            if (strtolower($this->arguments['sortType']) === 'asc' ||
-                strtolower($this->arguments['sortType']) === 'desc') {
-                $this->sortType = $this->arguments['sortType'];
+        if (isset($this->arguments['order'])) {
+            if (strtolower($this->arguments['order']) === 'asc' ||
+                strtolower($this->arguments['order']) === 'desc') {
+                $this->order = $this->arguments['order'];
             } else {
-                throw new \RestBadRequestException('Bad sort type parameter');
+                throw new \RestBadRequestException('Bad order parameter');
             }
         } else {
-            $this->sortType = null;
-        }
-        if (isset($this->arguments['order'])) {
-            $this->order = $this->arguments['order'];
-        } else {
             $this->order = null;
+        }
+        if (isset($this->arguments['sortType'])) {
+            $this->sortType = $this->arguments['sortType'];
+        } else {
+            $this->sortType = null;
         }
     }
 

--- a/www/api/class/centreon_realtime_hosts.class.php
+++ b/www/api/class/centreon_realtime_hosts.class.php
@@ -415,8 +415,11 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
             }
 
             switch ($this->sortType) {
-                case 'name':
-                    $query .= " ORDER BY h.name $q";
+                case 'id':
+                    $query .= "ORDER BY h.host_id $q, h.name";
+                    break;
+                case 'alias':
+                    $query .= "ORDER BY h.alias $q, h.name";
                     break;
                 case 'address':
                     $query .= " ORDER BY IFNULL(inet_aton(h.address), h.address) $q, h.name ";
@@ -428,7 +431,10 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
                     $query .= " ORDER BY h.last_state_change $q, h.name ";
                     break;
                 case 'last_hard_state_change':
-                    $query .= " ORDER BY h.last_hard_state_change $q,h.name ";
+                    $query .= " ORDER BY h.last_hard_state_change $q, h.name ";
+                    break;
+                case 'acknowledged':
+                    $query .= "ORDER BY h.acknowledged $q, h.name";
                     break;
                 case 'last_check':
                     $query .= " ORDER BY h.last_check $q, h.name ";
@@ -436,11 +442,21 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
                 case 'check_attempt':
                     $query .= " ORDER BY h.check_attempt $q, h.name ";
                     break;
+                case 'max_check_attempts':
+                    $query .= "ORDER BY h.max_check_attempts $q, h.name";
+                    break;
+                case 'instance_name':
+                    $query .= "ORDER BY i.name $q, h.name";
+                    break;
                 case 'output':
                     $query .= " ORDER BY h.output $q, h.name ";
                     break;
                 case 'criticality':
                     $query .= " ORDER BY criticality $q, h.name ";
+                    break;
+                case 'name':
+                default:
+                    $query .= " ORDER BY h.name $q";
                     break;
             }
         }


### PR DESCRIPTION
## Description

This PR fix an inversion between sortType and order, and add some missing fields in sortType

This PR close https://github.com/centreon/centreon/pull/8769

**Fixes** # MON-5668

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Do a GET Request like these:
api.domain.tld/centreon/api/index.php?object=centreon_realtime_hosts&action=list&sortType=id&order=desc

You should have as a response a list of hosts sort by ID ordered by descending values
## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
