### PR TITLE
enh(config): Improve message to use Remote Server as proxy, fix #8835

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -6362,10 +6362,10 @@ msgid "Short description of the poller"
 msgstr "Brève description du collecteur"
 
 msgid ""
-"If checked, the Central server will send configuration and external commands directly to the poller "
+"If disabled, the Central server will send configuration and external commands directly to the poller "
 "and will not use the Remote Server as a proxy"
 msgstr ""
-"Si activé, le serveur Central se connectera directement au collecteur pour transférer la configuration"
+"Si désactivé, le serveur Central se connectera directement au collecteur pour transférer la configuration"
 "et les commandes externes et n'utilisera pas le Remote Server comme proxy."
 
 #: centreon-web/www/include/configuration/configDowntime/help.php:8

--- a/www/include/configuration/configServers/formServers.php
+++ b/www/include/configuration/configServers/formServers.php
@@ -223,8 +223,8 @@ if (strcmp($serverType, 'poller') ==  0) {
     );
     $form->addElement('select2', 'remote_additional_id', _('Attach additional Remote Servers'), array(), $attrPoller2);
     $tab = [];
-    $tab[] = $form->createElement('radio', 'remote_server_use_as_proxy', null, _("Yes"), '1');
-    $tab[] = $form->createElement('radio', 'remote_server_use_as_proxy', null, _("No"), '0');
+    $tab[] = $form->createElement('radio', 'remote_server_use_as_proxy', null, _("Enabled"), '1');
+    $tab[] = $form->createElement('radio', 'remote_server_use_as_proxy', null, _("Disabled"), '0');
     $form->addGroup($tab, 'remote_server_use_as_proxy', _("Use the Remote Server as a proxy"), '&nbsp;');
 }
 $form->addElement('text', 'nagios_bin', _("Monitoring Engine Binary"), $attrsText2);

--- a/www/include/configuration/configServers/help.php
+++ b/www/include/configuration/configServers/help.php
@@ -55,6 +55,6 @@ $help['no_proxy'] = dgettext(
 );
 $help['remote_server_use_as_proxy'] = dgettext(
     "help",
-    "If checked, the Central server will send configuration and external commands directly to the poller "
+    "If disabled, the Central server will send configuration and external commands directly to the poller "
     . "and will not use the Remote Server as a proxy."
 );


### PR DESCRIPTION
## Description

Improve the message to use Remote Server as proxy

**Fixes** #8835

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Go to the "Configuration > Pollers > Pollers" menu
Click on the contextual help of the "Use the Remote Server as a proxy" field

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
