### PR TITLE
fix(snmptraps): Unable to import SNMP traps MIBs, fix #8816

### DIFF
--- a/lib/perl/centreon/script/centFillTrapDB.pm
+++ b/lib/perl/centreon/script/centFillTrapDB.pm
@@ -135,9 +135,19 @@ sub insert_into_centreon {
     my ($status, $sth);
 
     if (!$self->existsInDB()) {
-        ($status, $sth) = $self->{centreon_dbc}->query("INSERT INTO `traps` (`traps_name`, `traps_oid`, `traps_status`, `manufacturer_id`, `traps_submit_result_enable`) VALUES (" . $self->{centreon_dbc}->quote($self->{trap_name}) . ", " . $self->{centreon_dbc}->quote($self->{trap_oid}) . ", " . $self->getStatus() . ", " . $self->{centreon_dbc}->quote($self->{opt_m}) . ", '1')");
+        ($status, $sth) = $self->{centreon_dbc}->query(
+            "INSERT INTO `traps` (`traps_name`, `traps_oid`, `traps_status`, `manufacturer_id`, `traps_submit_result_enable`) VALUES ("
+            . $self->{centreon_dbc}->quote($self->{trap_name}) . ", " 
+            . $self->{centreon_dbc}->quote($self->{trap_oid}) . ", " 
+            . $self->{centreon_dbc}->quote($self->getStatus()) . ", " 
+            . $self->{centreon_dbc}->quote($self->{opt_m}) . ", '1')"
+        );
     }
-    ($status, $sth) = $self->{centreon_dbc}->query("UPDATE `traps` SET `traps_args` = " . $self->{centreon_dbc}->quote($self->{trap_format}) . ", `traps_comments` = " . $self->{centreon_dbc}->quote($self->{trap_description}) . " WHERE `traps_oid` = " . $self->{centreon_dbc}->quote($self->{trap_oid}));
+    ($status, $sth) = $self->{centreon_dbc}->query(
+        "UPDATE `traps` SET `traps_args` = " . $self->{centreon_dbc}->quote($self->{trap_format})
+        . ", `traps_comments` = " . $self->{centreon_dbc}->quote($self->{trap_description})
+        . " WHERE `traps_oid` = " . $self->{centreon_dbc}->quote($self->{trap_oid})
+    );
 }
 
 ################


### PR DESCRIPTION
## Description

Unable to import MIBs due to MySQL Strict Mode

**Fixes** #8816

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Try to import MIB containing SNMP Traps definition

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
