### PR TITLE
fix(security): check mib name in comment

### DIFF
--- a/lib/perl/centreon/script/centFillTrapDB.pm
+++ b/lib/perl/centreon/script/centFillTrapDB.pm
@@ -527,7 +527,7 @@ sub main {
             }
 
             my $trap_lookup;
-            if ($mib_name eq '') {
+            if ($mib_name eq '' || $mib_name !~ m/(^[A-Za-z0-9_-]+$)/) {
                 $trap_lookup = $trapname;
             } else {
                 $trap_lookup = "$mib_name\:\:$trapname";


### PR DESCRIPTION
## Description

Check the name of MIB in comment before to use it.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
