### PR TITLE
fix(widget): do not delete preferences when a user delete a shared view

### DIFF
--- a/www/class/centreonCustomView.class.php
+++ b/www/class/centreonCustomView.class.php
@@ -472,13 +472,10 @@ class CentreonCustomView
             if ($this->checkOwnerViewStatus($customViewId) == 0) {
                 //if not other shared view consumed, delete all
                 if (!$this->checkOtherShareViewUnlocked($customViewId, $this->userId)) {
-                    $query = 'DELETE FROM custom_views WHERE custom_view_id = :viewId ';
+                    $query = 'DELETE FROM custom_views WHERE custom_view_id = :viewId';
                     $stmt = $this->db->prepare($query);
                     $stmt->bindParam(':viewId', $customViewId, PDO::PARAM_INT);
-                    $dbResult = $stmt->execute();
-                    if (!$dbResult) {
-                        throw new \Exception("An error occured");
-                    }
+                    $stmt->execute();
                     //if shared view consumed, delete for me
                 } else {
                     $query = 'DELETE FROM custom_view_user_relation ' .
@@ -487,10 +484,7 @@ class CentreonCustomView
                     $stmt = $this->db->prepare($query);
                     $stmt->bindParam(':userId', $this->userId, PDO::PARAM_INT);
                     $stmt->bindParam(':viewId', $customViewId, PDO::PARAM_INT);
-                    $dbResult = $stmt->execute();
-                    if (!$dbResult) {
-                        throw new \Exception("An error occured");
-                    }
+                    $stmt->execute();
                 }
                 //if owner not delete
             } else {
@@ -505,7 +499,7 @@ class CentreonCustomView
                     $stmt->execute();
                 } catch (\PDOException $e) {
                     throw new Exception(
-                        "Error: cannot reset widget preferences , " . $e->getMessage() . "\n"
+                        "Cannot reset widget preferences, " . $e->getMessage() . "\n"
                     );
                 }
             }


### PR DESCRIPTION
## Description

Do not delete preferences when a user delete a shared view

**Fixes** MON-553

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Create a view
* Add widgets to it
* Configure your widgets with specific parameters
* Share the view with another user
* Connect with the user
* Import the view
* Delete the view
* Import the view again

==> The widgets in the view don’t have any parameters set