### PR TITLE
enh(logs): display correctly ACK events on eventLogs page

### DIFF
--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -569,7 +569,7 @@ p.description a, p.description a:visited {
 .pending    {background-color: #2AD1D4;}
 .service_unknown    {background-color: #bcbdc0;}
 .info {background-color: #00bfb3;}
-.ack {background-color: #fcf17f;}
+.ack {background-color: #AA9C24;}
 
 .bdg_dtm:before {
     padding: 2px 4px;

--- a/www/Themes/Centreon-2/style.css
+++ b/www/Themes/Centreon-2/style.css
@@ -569,6 +569,7 @@ p.description a, p.description a:visited {
 .pending    {background-color: #2AD1D4;}
 .service_unknown    {background-color: #bcbdc0;}
 .info {background-color: #00bfb3;}
+.ack {background-color: #fcf17f;}
 
 .bdg_dtm:before {
     padding: 2px 4px;

--- a/www/include/eventLogs/xml/data.php
+++ b/www/include/eventLogs/xml/data.php
@@ -305,10 +305,10 @@ $tab_status_service = array(
     "2" => "CRITICAL",
     "3" => "UNKNOWN"
 );
-$acknowlegementMessageType = array(
+$acknowlegementMessageType = [
     'badgeColor' => 'ack',
     'badgeText' => 'ACK'
-);
+];
 
 /*
  * Create IP Cache

--- a/www/include/eventLogs/xml/data.php
+++ b/www/include/eventLogs/xml/data.php
@@ -849,18 +849,16 @@ if (isset($req) && $req) {
 
         $buffer->startElement("status");
         $buffer->writeAttribute("color", $color);
+        $displayStatus = $log["status"];
         if (
             $log['msg_type'] == HOST_ACKNOWLEDGEMENT_MSG_TYPE
             || $log['msg_type'] == SERVICE_ACKNOWLEDGEMENT_MSG_TYPE
         ) {
             $displayStatus = $acknowlegementMessageType['badgeText'];
-        } else {
-            $displayStatus = $log["status"];
-            if ($log['service_description'] && isset($tab_status_service[$log['status']])) {
-                $displayStatus = $tab_status_service[$log['status']];
-            } elseif (isset($tab_status_host[$log['status']])) {
-                $displayStatus = $tab_status_host[$log['status']];
-            }
+        } elseif ($log['service_description'] && isset($tab_status_service[$log['status']])) {
+            $displayStatus = $tab_status_service[$log['status']];
+        } elseif (isset($tab_status_host[$log['status']])) {
+            $displayStatus = $tab_status_host[$log['status']];
         }
         $buffer->text($displayStatus);
         $buffer->endElement();

--- a/www/include/eventLogs/xml/data.php
+++ b/www/include/eventLogs/xml/data.php
@@ -827,16 +827,14 @@ if (isset($req) && $req) {
             || $log['msg_type'] == SERVICE_ACKNOWLEDGEMENT_MSG_TYPE
         ) {
             $color = $acknowlegementMessageType['badgeColor'];
-        } else {
-            if (isset($log["status"])) {
-                if (
-                    isset($tab_color_service[$log["status"]])
-                    && !empty($log["service_description"])
-                ) {
-                    $color = $tab_color_service[$log["status"]];
-                } elseif (isset($tab_color_host[$log["status"]])) {
-                    $color = $tab_color_host[$log["status"]];
-                }
+        } elseif (isset($log["status"])) {
+            if (
+                isset($tab_color_service[$log["status"]])
+                && !empty($log["service_description"])
+            ) {
+                $color = $tab_color_service[$log["status"]];
+            } elseif (isset($tab_color_host[$log["status"]])) {
+                $color = $tab_color_host[$log["status"]];
             }
         }
 


### PR DESCRIPTION
## Description

This PR intends to display acknowledgements as it is: an event. Before this PR the line related to the ACK appeared with a 'OK' / UP green badge which relates to a service/host status.

![ack](https://user-images.githubusercontent.com/31647811/87938477-eee34b80-ca96-11ea-9b42-9455789f8e76.gif)


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Have some services, hosts in a non-OK status.
- Put an ACK on each of those ressources
- The ACK related lines in the Monitoring  >  Event Logs page should be displayed with a 'ACK' badge

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
