### PR TITLE
fix(serializer): return id property when calling acknowledgement endp…

### DIFF
--- a/config/packages/serializer/Centreon/Acknowledgement.Acknowledgement.yml
+++ b/config/packages/serializer/Centreon/Acknowledgement.Acknowledgement.yml
@@ -5,6 +5,8 @@ Centreon\Domain\Acknowledgement\Acknowledgement:
             groups:
                 - 'ack_main'
                 - 'ack_event_list'
+                - 'ack_service'
+                - 'ack_host'
                 - 'ack_full'
         pollerId:
             type: int


### PR DESCRIPTION
…oint

## Description

This is the result from checking out the API v2 documentation. It occured that when calling the `/monitoring/acknowledgements`
endpoint, the `id` was not returned. IT should be ...

Same goes when retrieving all host/services acks
It gets hard then to use the` /monitoring/acknowledgement/{acknowledgement_id} `endpoint if we can't easily get the id.

**Fixes** # None

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Put an ACK on a service
- CALL the API endpoint `/monitoring/acknowledgements`
- The `id` of the ACK should be returned among the other properties returned

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
