### PR TITLE
fix(security): use user id instead of session id in session page

### DIFF
--- a/www/api/class/centreon_ldap_synchro.class.php
+++ b/www/api/class/centreon_ldap_synchro.class.php
@@ -86,7 +86,7 @@ class CentreonLdapSynchro extends CentreonWebService
         if ($contactId === false) {
             $this->centreonLog->insertLog(
                 3, //ldap.log
-                "LDAP MANUAL SYNC : Error - Chosen contact data are missing."
+                "LDAP MANUAL SYNC : Error - Chosen contact id is not consistent."
             );
             return $result;
         }

--- a/www/api/class/centreon_ldap_synchro.class.php
+++ b/www/api/class/centreon_ldap_synchro.class.php
@@ -93,7 +93,6 @@ class CentreonLdapSynchro extends CentreonWebService
 
         $this->pearDB->beginTransaction();
         try {
-            // (getting the contactId to homogenize the next request's bindValue variable name)
             $resUser = $this->pearDB->prepare(
                 'SELECT `contact_id`, `contact_name` FROM `contact`
                 WHERE `contact_id` = :contactId'

--- a/www/api/class/centreon_ldap_synchro.class.php
+++ b/www/api/class/centreon_ldap_synchro.class.php
@@ -75,7 +75,7 @@ class CentreonLdapSynchro extends CentreonWebService
         $result = false;
 
         $contactId = filter_var(
-            $_POST['contactId'] ?? null,
+            $_POST['contactId'] ?? false,
             FILTER_VALIDATE_INT
         );
 
@@ -83,7 +83,7 @@ class CentreonLdapSynchro extends CentreonWebService
             return $result;
         }
 
-        if (empty($contactId)) {
+        if ($contactId === false) {
             $this->centreonLog->insertLog(
                 3, //ldap.log
                 "LDAP MANUAL SYNC : Error - Chosen contact data are missing."
@@ -93,15 +93,12 @@ class CentreonLdapSynchro extends CentreonWebService
 
         $this->pearDB->beginTransaction();
         try {
-            // getting the contact name and ID for the logs
-            if ($contactId) {
-                // (getting the contactId to homogenize the next request's bindValue variable name)
-                $resUser = $this->pearDB->prepare(
-                    'SELECT `contact_id`, `contact_name` FROM `contact`
-                    WHERE `contact_id` = :contactId'
-                );
-                $resUser->bindValue(':contactId', $contactId, PDO::PARAM_INT);
-            }
+            // (getting the contactId to homogenize the next request's bindValue variable name)
+            $resUser = $this->pearDB->prepare(
+                'SELECT `contact_id`, `contact_name` FROM `contact`
+                WHERE `contact_id` = :contactId'
+            );
+            $resUser->bindValue(':contactId', $contactId, PDO::PARAM_INT);
             $resUser->execute();
             $contact = $resUser->fetch();
 

--- a/www/api/class/centreon_ldap_synchro.class.php
+++ b/www/api/class/centreon_ldap_synchro.class.php
@@ -78,16 +78,12 @@ class CentreonLdapSynchro extends CentreonWebService
             $_POST['contactId'] ?? null,
             FILTER_VALIDATE_INT
         );
-        $sessionId = filter_var(
-            $_POST['sessionId'] ?? null,
-            FILTER_SANITIZE_STRING
-        );
 
         if (!$this->isLdapEnabled()) {
             return $result;
         }
 
-        if (empty($contactId) && empty($sessionId)) {
+        if (empty($contactId)) {
             $this->centreonLog->insertLog(
                 3, //ldap.log
                 "LDAP MANUAL SYNC : Error - Chosen contact data are missing."
@@ -105,13 +101,6 @@ class CentreonLdapSynchro extends CentreonWebService
                     WHERE `contact_id` = :contactId'
                 );
                 $resUser->bindValue(':contactId', $contactId, PDO::PARAM_INT);
-            } elseif ($sessionId) {
-                $resUser = $this->pearDB->prepare(
-                    'SELECT `contact_id`, `contact_name` FROM contact
-                    LEFT JOIN session ON session.user_id = contact.contact_id
-                    WHERE session.session_id = :userSessionId'
-                );
-                $resUser->bindValue(':userSessionId', $sessionId, PDO::PARAM_STR);
             }
             $resUser->execute();
             $contact = $resUser->fetch();

--- a/www/include/options/session/connected_user.php
+++ b/www/include/options/session/connected_user.php
@@ -51,9 +51,9 @@ $action = filter_var(
     FILTER_SANITIZE_STRING
 );
 
-$selectedUserSid = filter_var(
-    $_GET['session'] ?? null, // the sessionId of the chosen user
-    FILTER_SANITIZE_STRING
+$selectedUserId = filter_var(
+    $_GET['user'] ?? null, // the sessionId of the chosen user
+    FILTER_VALIDATE_INT
 );
 
 $currentPage = filter_var(
@@ -61,7 +61,7 @@ $currentPage = filter_var(
     FILTER_VALIDATE_INT
 );
 
-if ($selectedUserSid) {
+if ($selectedUserId) {
     $msg = new CentreonMsg();
     $msg->setTextStyle("bold");
     $msg->setTimeOut("3");
@@ -69,8 +69,8 @@ if ($selectedUserSid) {
     switch ($action) {
         // logout action
         case KICK_USER:
-            $stmt = $pearDB->prepare("DELETE FROM session WHERE session_id = :userSessionId");
-            $stmt->bindValue(':userSessionId', $selectedUserSid, \PDO::PARAM_STR);
+            $stmt = $pearDB->prepare("DELETE FROM session WHERE user_id = :userId");
+            $stmt->bindValue(':userId', $selectedUserId, \PDO::PARAM_INT);
             $stmt->execute();
             $msg->setText(_("User kicked"));
             break;
@@ -122,7 +122,7 @@ for ($cpt = 0; $r = $res->fetch(); $cpt++) {
     if ($centreon->user->admin) {
         // adding the link to be able to kick the user
         $session_data[$cpt]["actions"] =
-            "<a href='./main.php?p=" . $p . "&o=k&session=" . $r['session_id'] . "'>" .
+            "<a href='./main.php?p=" . $p . "&o=k&user=" . $r['user_id'] . "'>" .
                 "<img src='./img/icons/delete.png' border='0' alt='" . _("Kick User") .
                 "' title='" . _("Kick User") . "'>" .
             "</a>";

--- a/www/include/options/session/connected_user.php
+++ b/www/include/options/session/connected_user.php
@@ -52,7 +52,7 @@ $action = filter_var(
 );
 
 $selectedUserId = filter_var(
-    $_GET['user'] ?? null, // the sessionId of the chosen user
+    $_GET['user'] ?? null,
     FILTER_VALIDATE_INT
 );
 
@@ -139,7 +139,7 @@ for ($cpt = 0; $r = $res->fetch(); $cpt++) {
                 "<a href='#'>" .
                     "<img src='./img/icons/refresh.png' border='0' " .
                         "alt='" . _("Synchronize LDAP") . "' title='" . _("Synchronize LDAP") . "' " .
-                        "onclick='submitSync(" . $currentPage . ", \"" . $r['session_id'] . "\")'>" .
+                        "onclick='submitSync(" . $currentPage . ", \"" . $r['user_id'] . "\")'>" .
                 "</a>";
         } else {
             // hiding the synchronization option and details
@@ -171,7 +171,7 @@ $tpl->display("connected_user.ihtml");
     formatDateMoment();
 
     // ask for confirmation when requesting to resynchronize contact data from the LDAP
-    function submitSync(p, sessionId) {
+    function submitSync(p, contactId) {
         // msg = localized message to be displayed in the confirmation popup
         let msg = "<?= _('All this contact sessions will be closed. Are you sure you want to request a ' .
             'synchronization at the next login of this Contact ?'); ?>";
@@ -181,7 +181,7 @@ $tpl->display("connected_user.ihtml");
                 url: './api/internal.php?object=centreon_ldap_synchro&action=requestLdapSynchro',
                 type: 'POST',
                 async: false,
-                data: {sessionId: sessionId},
+                data: {contactId: contactId},
                 success: function(data) {
                     if (data === true) {
                         window.location.href = "?p=" + p;


### PR DESCRIPTION
## Description

This PR fix the Logout User URL on Sessions page.

**Fixes** #4542

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
