### PR TITLE
fix(dashboard): human readable date for reporting timeline detail popin

### DIFF
--- a/www/include/common/javascript/Timeline/src/main/webapp/api/scripts/painters.js
+++ b/www/include/common/javascript/Timeline/src/main/webapp/api/scripts/painters.js
@@ -344,49 +344,12 @@ Timeline.DurationEventPainter.prototype._showBubble = function(x, y, evt) {
         this._theme.event.bubble.imageStyler(img);
         div.appendChild(img);
     }
-    /*
-    var divTitle = doc.createElement("div");
-    var textTitle = doc.createTextNode(title);
-    if (link != null) {
-        var a = doc.createElement("a");
-        a.href = link;
-        a.appendChild(textTitle);
-        divTitle.appendChild(a);
-    } else {
-        divTitle.appendChild(textTitle);
-    }
-    this._theme.event.bubble.titleStyler(divTitle);
-    div.appendChild(divTitle);
-*/
+
     var divBody = doc.createElement("div");
     evt.fillDescription(divBody);
     this._theme.event.bubble.bodyStyler(divBody);
     div.appendChild(divBody);
 
-/*
-    var divTime = doc.createElement("div");
-    evt.fillTime(divTime, this._band.getLabeller());
-    this._theme.event.bubble.timeStyler(divTime);
-    div.appendChild(divTime);
-   */
-
-// get locale and GMT preferences from localStorage
-    var userTimezone = localStorage.getItem('realTimezone');
-    var userLocale = localStorage.getItem('locale');
-    moment.locale(userLocale);
-
-    //creating a collection of occurences
-    jQuery(".isTimeline").each(function(index, element) {
-        var myElement = jQuery(element);
-
-        //forcing a numeric timestamp
-        var currentDate = parseInt(myElement.text()) * 1000;
-
-        //checking the choosen format
-        if (!isNaN(currentDate)) {
-            if (myElement.hasClass("isDate")) {
-                myElement.text(moment(currentDate).tz(userTimezone).format('LL'));
-            }
-        }
-    });
+    // format date in event popin
+    formatDateMoment();
 };

--- a/www/include/reporting/dashboard/xmlInformations/common-Func.php
+++ b/www/include/reporting/dashboard/xmlInformations/common-Func.php
@@ -92,7 +92,7 @@ function fillBuffer($statesTab, $row, $color)
     $detailPopup = '{table class=bulleDashtab}';
     $detailPopup .= '{tr}{td class=bulleDashleft colspan=3}' . $Day .
         ': {span class ="isTimestamp isDate"}';
-    $detailPopup .= date('Y-m-d', $date_start) . '{/span} --  ' . $Duration . ': ' .
+    $detailPopup .= $date_start . '{/span} --  ' . $Duration . ': ' .
         CentreonDuration::toString($totalTime) . '{/td}{td class=bulleDashleft }' . $Alert . '{/td}{/tr}';
     foreach ($statesTab as $key => $value) {
         $detailPopup .= '{tr}' .

--- a/www/include/reporting/dashboard/xmlInformations/common-Func.php
+++ b/www/include/reporting/dashboard/xmlInformations/common-Func.php
@@ -92,7 +92,7 @@ function fillBuffer($statesTab, $row, $color)
     $detailPopup = '{table class=bulleDashtab}';
     $detailPopup .= '{tr}{td class=bulleDashleft colspan=3}' . $Day .
         ': {span class ="isTimestamp isDate"}';
-    $detailPopup .= date('Y-m-d', $date_start) . '{/span} --  ' . $Duration . ': '.
+    $detailPopup .= date('Y-m-d', $date_start) . '{/span} --  ' . $Duration . ': ' .
         CentreonDuration::toString($totalTime) . '{/td}{td class=bulleDashleft }' . $Alert . '{/td}{/tr}';
     foreach ($statesTab as $key => $value) {
         $detailPopup .= '{tr}' .

--- a/www/include/reporting/dashboard/xmlInformations/common-Func.php
+++ b/www/include/reporting/dashboard/xmlInformations/common-Func.php
@@ -92,7 +92,7 @@ function fillBuffer($statesTab, $row, $color)
     $detailPopup = '{table class=bulleDashtab}';
     $detailPopup .= '{tr}{td class=bulleDashleft colspan=3}' . $Day .
         ': {span class ="isTimestamp isDate"}';
-    $detailPopup .= $date_start . '{/span} --  ' . $Duration . ': '.
+    $detailPopup .= date('Y-m-d', $date_start) . '{/span} --  ' . $Duration . ': '.
         CentreonDuration::toString($totalTime) . '{/td}{td class=bulleDashleft }' . $Alert . '{/td}{/tr}';
     foreach ($statesTab as $key => $value) {
         $detailPopup .= '{tr}' .


### PR DESCRIPTION
## Description

This PR aims to display correctly the day displayed in the reporting timeline detail popin.

**/!\ IMPORTANT /!\**

Translation has not been handled since it is not handled for the whole timeline...

**Before**

![3ad82c40-6b99-46fd-82eb-35070377a5ed](https://user-images.githubusercontent.com/31647811/88563420-4141e080-d032-11ea-92b8-d271759719b5.png)

**After**

![image](https://user-images.githubusercontent.com/31647811/88563479-50c12980-d032-11ea-8a53-9c83b2c75435.png)



**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to `Reporting  >  Dashboard  >  Host Groups` for example (servicegroups and hosts should be checked too)
- Click on a part of the timeline
- The detailed popin should be displayed and the "Day: date" should be human readable

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
