### PR TITLE
feat(ui): Refresh the panel when the list is refreshed

### DIFF
--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -3180,6 +3180,7 @@ components:
               example: 0.005
             next_check:
               type: string
+              nullable: true
               format: date-time
               description: "Scheduled date for the next check (ISO8601)"
             next_host_notification:
@@ -3528,6 +3529,7 @@ components:
               example: 0.031
             next_check:
               type: string
+              nullable: true
               format: date-time
               description: "Scheduled date for the next check (ISO8601)"
             performance_data:

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -252,7 +252,8 @@ describe(Details, () => {
     [labelLast24h, '2020-06-19T20:00:00.000Z'],
     [labelLast7Days, '2020-06-13T20:00:00.000Z'],
     [labelLast31Days, '2020-05-20T20:00:00.000Z'],
-  ])(`queries performance graphs with %s period when the Graph tab is selected`,
+  ])(
+    `queries performance graphs with %p period when the Graph tab is selected`,
     async (period, startIsoString) => {
       mockedAxios.get
         .mockResolvedValueOnce({ data: performanceGraphData })
@@ -273,7 +274,8 @@ describe(Details, () => {
           cancelTokenRequestParam,
         ),
       );
-    });
+    },
+  );
 
   it('copies the command line to clipboard when the copy button is clicked', async () => {
     mockedAxios.get.mockResolvedValueOnce({ data: retrievedDetails });
@@ -305,9 +307,6 @@ describe(Details, () => {
       context.setListing({} as ResourceListing);
     });
 
-    await waitFor(() => {
-      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
-
-    });
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalledTimes(2));
   });
 });

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import { last, head } from 'ramda';
 import axios from 'axios';
@@ -8,6 +8,7 @@ import {
   waitFor,
   fireEvent,
   RenderResult,
+  act,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as clipboard from './Body/tabs/Details/clipboard';
@@ -42,23 +43,21 @@ import {
   labelNo,
   labelComment,
 } from '../translatedLabels';
-import { detailsTabId, graphTabId } from './Body/tabs';
-import * as Context from '../Context';
+import { detailsTabId, graphTabId, TabId } from './Body/tabs';
+import Context, { ResourceContext } from '../Context';
 import { cancelTokenRequestParam } from '../testUtils';
+
+import useListing from '../Listing/useListing';
+import useDetails from './useDetails';
+import { ResourceListing } from '../models';
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 jest.mock('../icons/Downtime');
 jest.mock('./Body/tabs/Details/clipboard');
-jest.mock('../Context');
-
-const mockedUseResourceContext = Context.useResourceContext as jest.Mock<
-  unknown
->;
 
 const detailsEndpoint = '/resource';
 const performanceGraphEndpoint = '/performance';
-const statusGraphEndpoint = '/status';
 
 const retrievedDetails = {
   display_name: 'Central',
@@ -115,19 +114,37 @@ const performanceGraphData = {
 
 const currentDateIsoString = '2020-06-20T20:00:00.000Z';
 
-const mockUseResourceContext = ({ openTabId }): void => {
-  mockedUseResourceContext.mockReturnValue({
-    detailsTabIdToOpen: openTabId,
-    selectedDetailsEndpoints: {
-      details: detailsEndpoint,
-      performanceGraph: performanceGraphEndpoint,
-      statusGraph: statusGraphEndpoint,
-    },
-    setDefaultDetailsTabIdToOpen: jest.fn(),
-  });
+let context: ResourceContext;
+
+interface Props {
+  defaultTabId: TabId;
+}
+
+const DetailsTest = ({ defaultTabId }: Props): JSX.Element => {
+  const listingState = useListing();
+  const detailState = useDetails();
+
+  detailState.selectedDetailsEndpoints = {
+    details: detailsEndpoint,
+    performanceGraph: performanceGraphEndpoint,
+  };
+
+  detailState.detailsTabIdToOpen = defaultTabId;
+
+  context = {
+    ...listingState,
+    ...detailState,
+  } as ResourceContext;
+
+  return (
+    <Context.Provider value={context}>
+      <Details />
+    </Context.Provider>
+  );
 };
 
-const renderDetails = (): RenderResult => render(<Details />);
+const renderDetails = (defaultTabId: TabId = detailsTabId): RenderResult =>
+  render(<DetailsTest defaultTabId={defaultTabId} />);
 
 describe(Details, () => {
   beforeEach(() => {
@@ -140,13 +157,16 @@ describe(Details, () => {
   });
 
   it('displays resource details information', async () => {
-    mockUseResourceContext({ openTabId: detailsTabId });
-
     mockedAxios.get.mockResolvedValueOnce({ data: retrievedDetails });
 
     const { getByText, queryByText, getAllByText } = renderDetails();
 
-    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
+    await waitFor(() => {
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        detailsEndpoint,
+        cancelTokenRequestParam,
+      );
+    });
 
     expect(getByText('10')).toBeInTheDocument();
     expect(getByText('CRITICAL')).toBeInTheDocument();
@@ -228,20 +248,18 @@ describe(Details, () => {
     expect(getByText('base_host_alive')).toBeInTheDocument();
   });
 
-  [
-    { period: labelLast24h, startIsoString: '2020-06-19T20:00:00.000Z' },
-    { period: labelLast7Days, startIsoString: '2020-06-13T20:00:00.000Z' },
-    { period: labelLast31Days, startIsoString: '2020-05-20T20:00:00.000Z' },
-  ].forEach(({ period, startIsoString }) =>
-    it(`queries performance and status graphs with ${period} period when the Graph tab is selected and ${period} is selected`, async () => {
-      mockUseResourceContext({ openTabId: graphTabId });
-
-      mockedAxios.get.mockResolvedValueOnce({ data: performanceGraphData });
+  it.each([
+    [labelLast24h, '2020-06-19T20:00:00.000Z'],
+    [labelLast7Days, '2020-06-13T20:00:00.000Z'],
+    [labelLast31Days, '2020-05-20T20:00:00.000Z'],
+  ])(`queries performance graphs with %s period when the Graph tab is selected`,
+    async (period, startIsoString) => {
       mockedAxios.get
+        .mockResolvedValueOnce({ data: performanceGraphData })
         .mockResolvedValueOnce({ data: retrievedDetails })
         .mockResolvedValueOnce({ data: performanceGraphData });
 
-      const { getByText, getAllByText } = renderDetails();
+      const { getByText, getAllByText } = renderDetails(graphTabId);
 
       await waitFor(() => expect(getByText(labelLast24h)).toBeInTheDocument());
 
@@ -255,12 +273,10 @@ describe(Details, () => {
           cancelTokenRequestParam,
         ),
       );
-    }),
-  );
+    });
 
   it('copies the command line to clipboard when the copy button is clicked', async () => {
     mockedAxios.get.mockResolvedValueOnce({ data: retrievedDetails });
-    mockUseResourceContext({ openTabId: detailsTabId });
 
     const mockedClipboard = clipboard as jest.Mocked<typeof clipboard>;
 
@@ -275,5 +291,23 @@ describe(Details, () => {
         retrievedDetails.command_line,
       ),
     );
+  });
+
+  it('refresh the detailed informations panel in same time to refresh listing', async () => {
+    mockedAxios.get.mockResolvedValue({ data: retrievedDetails });
+
+    const { getByText } = renderDetails();
+
+    await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
+    expect(getByText(labelStatusInformation)).toBeInTheDocument();
+
+    act(() => {
+      context.setListing({} as ResourceListing);
+    });
+
+    await waitFor(() => {
+      expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+
+    });
   });
 });

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -295,7 +295,7 @@ describe(Details, () => {
     );
   });
 
-  it('refresh the detailed informations panel in same time to refresh listing', async () => {
+  it('refreshes the details when the listing is updated, async () => {
     mockedAxios.get.mockResolvedValue({ data: retrievedDetails });
 
     const { getByText } = renderDetails();

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -295,7 +295,7 @@ describe(Details, () => {
     );
   });
 
-  it('refreshes the details when the listing is updated, async () => {
+  it('refreshes the details when the listing is updated', async () => {
     mockedAxios.get.mockResolvedValue({ data: retrievedDetails });
 
     const { getByText } = renderDetails();

--- a/www/front_src/src/Resources/Details/index.tsx
+++ b/www/front_src/src/Resources/Details/index.tsx
@@ -46,6 +46,7 @@ const Details = (): JSX.Element | null => {
     setDefaultDetailsTabIdToOpen,
     selectedDetailsEndpoints,
     setSelectedDetailsEndpoints,
+    listing,
   } = useResourceContext();
 
   const {
@@ -68,7 +69,7 @@ const Details = (): JSX.Element | null => {
     sendRequest(detailsEndpoint).then((retrievedDetails) =>
       setDetails(retrievedDetails),
     );
-  }, [detailsEndpoint]);
+  }, [detailsEndpoint, listing]);
 
   return (
     <Paper elevation={5} className={classes.details}>


### PR DESCRIPTION
When the refresh of the resource list is done (manual or automatic) and
the details panel is opened, it will be refreshed at the same time.

Refs : MON-5636

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
