### PR TITLE
fix(broker): Extract correctly IP adress of a proxy configuration

### DIFF
--- a/www/class/config-generate/broker.class.php
+++ b/www/class/config-generate/broker.class.php
@@ -505,7 +505,11 @@ class Broker extends AbstractObjectJSON
                 $proxy = (parse_url($proxyInfo['proxy_url'], PHP_URL_SCHEME)
                             ? (parse_url($proxyInfo['proxy_url'], PHP_URL_SCHEME) . '//:')
                             : 'http://'
-                        ) . $proxy . parse_url($proxyInfo['proxy_url'], PHP_URL_HOST);
+                        ) .  $proxy;
+
+                $proxy .= (filter_var($proxyInfo['proxy_url'], FILTER_VALIDATE_IP))
+                              ? $proxyInfo['proxy_url']
+                              :  parse_url($proxyInfo['proxy_url'], PHP_URL_HOST);
                 if (isset($proxyInfo['proxy_port']) && !empty($proxyInfo['proxy_port'])) {
                     $proxy .= ':' . $proxyInfo['proxy_port'];
                 }

--- a/www/class/config-generate/broker.class.php
+++ b/www/class/config-generate/broker.class.php
@@ -508,8 +508,8 @@ class Broker extends AbstractObjectJSON
                         ) .  $proxy;
 
                 $proxy .= (filter_var($proxyInfo['proxy_url'], FILTER_VALIDATE_IP))
-                              ? $proxyInfo['proxy_url']
-                              :  parse_url($proxyInfo['proxy_url'], PHP_URL_HOST);
+                    ? $proxyInfo['proxy_url']
+                    : parse_url($proxyInfo['proxy_url'], PHP_URL_HOST);
                 if (isset($proxyInfo['proxy_port']) && !empty($proxyInfo['proxy_port'])) {
                     $proxy .= ':' . $proxyInfo['proxy_port'];
                 }


### PR DESCRIPTION
## Description

If the "Configuration > Parameters > Centreon UI > Proxy URL" is only an IP address the parse_url function detect IP as PHP_URL_PATH and not PHP_URL_HOST 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
