### PR TITLE
fix(stats): get stats even if a module fails

### DIFF
--- a/www/class/centreonStatistics.class.php
+++ b/www/class/centreonStatistics.class.php
@@ -33,20 +33,29 @@
  *
  */
 
-require_once _CENTREON_PATH_ . "/www/class/centreonUUID.class.php";
-require_once _CENTREON_PATH_ . "/www/class/centreonGMT.class.php";
-require_once _CENTREON_PATH_ . "/www/class/centreonVersion.class.php";
-require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
-require_once _CENTREON_PATH_ . "/www/class/centreonStatsModules.class.php";
+require_once __DIR__ . '/../../bootstrap.php';
+require_once __DIR__ . '/centreonUUID.class.php';
+require_once __DIR__ . '/centreonGMT.class.php';
+require_once __DIR__ . '/centreonVersion.class.php';
+require_once __DIR__ . '/centreonDB.class.php';
+require_once __DIR__ . '/centreonStatsModules.class.php';
+
+use Psr\Log\LoggerInterface;
 
 class CentreonStatistics
 {
     /**
+     * @var LoggerInterface $logger
+     */
+    private $logger;
+
+    /**
      * CentreonStatistics constructor.
      */
-    public function __construct()
+    public function __construct(LoggerInterface $logger)
     {
         $this->dbConfig = new centreonDB();
+        $this->logger = $logger;
     }
 
     /**
@@ -143,7 +152,7 @@ class CentreonStatistics
             ),
         );
 
-        $oModulesStats = new CentreonStatsModules();
+        $oModulesStats = new CentreonStatsModules($this->logger);
         $modulesData = $oModulesStats->getModulesStatistics();
         foreach ($modulesData as $moduleData) {
             $data['extension'] = array_merge($data['extension'], $moduleData);

--- a/www/class/centreonStatsModules.class.php
+++ b/www/class/centreonStatsModules.class.php
@@ -2,7 +2,7 @@
 
 /*
  * Copyright 2005-2020 Centreon
- * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
  * This program is free software; you can redistribute it and/or modify it under


### PR DESCRIPTION
## Description

get statistics of a module even if it fails

**Fixes** MON-5624

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Throw an error in a module statistics class, and check if it works