### PR TITLE
fix(remote): use URL list instead of IP list to keep scheme and port

### DIFF
--- a/src/CentreonRemote/Application/Clapi/CentreonRemoteServer.php
+++ b/src/CentreonRemote/Application/Clapi/CentreonRemoteServer.php
@@ -108,7 +108,7 @@ class CentreonRemoteServer implements CentreonClapiServiceInterface
 
         echo "Notifying Master...\n";
         $result = "";
-        foreach ($hostList as $host) {
+        foreach ($urlList as $host) {
             echo "  Trying host '$host'... ";
             $result = $this->getDi()['centreon.notifymaster']->pingMaster(
                 $host,


### PR DESCRIPTION
## Description

If the HTTP default port is not the default one or is the Centreon Central sue HTTPS with not 80 redirection. The enableRemote CLAPI command doesn't work

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
