### PR TITLE
fix(api): remove hard coded centreon db name in performance_service

### DIFF
--- a/www/api/class/centreon_performance_service.class.php
+++ b/www/api/class/centreon_performance_service.class.php
@@ -61,7 +61,7 @@ class CentreonPerformanceService extends CentreonConfigurationObjects
      */
     public function getList()
     {
-        global $centreon;
+        global $centreon, $conf_centreon;
 
         $userId = $centreon->user->user_id;
         $isAdmin = $centreon->user->admin;
@@ -112,7 +112,7 @@ class CentreonPerformanceService extends CentreonConfigurationObjects
         }
 
         if ($excludeAnomalyDetection) {
-            $additionalCondition .= 'AND s.service_id NOT IN (SELECT service_id FROM centreon.mod_anomaly_service) ';
+            $additionalCondition .= 'AND s.service_id NOT IN (SELECT service_id FROM ' . $conf_centreon['db'] . '.mod_anomaly_service) ';
         }
         if (isset($this->arguments['hostgroup'])) {
             $additionalCondition .= 'AND (hg.host_id = i.host_id ' .


### PR DESCRIPTION
## Description

Remove hard coded centreon db name in centreon_performance_service internal API class

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
