### PR TITLE
fix(event-view): Fix acknowledge form empty comment provoking infinite load

### DIFF
--- a/www/front_src/src/Resources/Actions/Resource/Acknowledge/index.tsx
+++ b/www/front_src/src/Resources/Actions/Resource/Acknowledge/index.tsx
@@ -5,6 +5,7 @@ import * as Yup from 'yup';
 
 import { Severity, useSnackbar, useRequest } from '@centreon/ui';
 
+import { isNil } from 'ramda';
 import {
   labelRequired,
   labelAcknowledgeCommandSent,
@@ -47,7 +48,7 @@ const AcknowledgeForm = ({
 
   const form = useFormik({
     initialValues: {
-      comment: '',
+      comment: undefined,
       notify: false,
       acknowledgeAttachedResources: false,
     },
@@ -77,7 +78,7 @@ const AcknowledgeForm = ({
       values={form.values}
       handleChange={form.handleChange}
       submitting={sendingAcknowledgeResources}
-      loading={form.values.comment === ''}
+      loading={isNil(form.values.comment)}
     />
   );
 };


### PR DESCRIPTION
## Description

Before: 
![ack-empty-comment](https://user-images.githubusercontent.com/8367233/90227500-f9360280-de14-11ea-83fb-3328bc9bc87e.gif)

After:
![fix-ack-empty-comment](https://user-images.githubusercontent.com/8367233/90227501-f9ce9900-de14-11ea-9df9-f7af8beccedb.gif)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)
