### PR TITLE
fix(widget) can't change position of widgets

### DIFF
--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -723,7 +723,7 @@ class CentreonWidget
      * @throws CentreonWidgetException
      * @throws Exception
      */
-    public function updateWidgetPositions(int $customViewId, array $position = [], bool $permission)
+    public function updateWidgetPositions(int $customViewId, array $positions = [], bool $permission)
     {
         if (!$permission) {
             throw new CentreonWidgetException('You are not allowed to change widget position');


### PR DESCRIPTION
small typo there that break the poistioning of the widgets

## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (MON-5950)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.04.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

without this patch, 
- go in the custom view menu
- create a view and add a few widgets
- change their position
- refresh the page, the position of the widget are back to their default position and not the one you configured


with this patch
- repeat above procedure
- widgets should now be where you've decided

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
