### PR TITLE
fix(event-view): Fix time values displayed as invalid

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -105,7 +105,7 @@ const PerformanceGraph = ({
   });
 
   React.useEffect(() => {
-    sendRequest(endpoint).then((graphData) => {
+    sendRequest('http://localhost:5000/mock/graph').then((graphData) => {
       setTimeSeries(getTimeSeries(graphData));
       setLineData(getLineData(graphData));
       setTitle(graphData.global.title);
@@ -179,7 +179,7 @@ const PerformanceGraph = ({
         <ComposedChart data={timeSeries} stackOffset="sign">
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis
-            dataKey="time"
+            dataKey="timeTick"
             tickFormatter={formatXAxisTick}
             tick={{ fontSize: 13 }}
           />
@@ -192,6 +192,7 @@ const PerformanceGraph = ({
             contentStyle={{ fontFamily }}
             wrapperStyle={{ opacity: 0.7 }}
             isAnimationActive={false}
+            filterNull={false}
           />
         </ComposedChart>
       </ResponsiveContainer>

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -105,7 +105,7 @@ const PerformanceGraph = ({
   });
 
   React.useEffect(() => {
-    sendRequest('http://localhost:5000/mock/graph').then((graphData) => {
+    sendRequest(endpoint).then((graphData) => {
       setTimeSeries(getTimeSeries(graphData));
       setLineData(getLineData(graphData));
       setTitle(graphData.global.title);

--- a/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
+++ b/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
@@ -1,24 +1,27 @@
-import { map, pipe, reduce, filter, pathOr, addIndex } from 'ramda';
+import { map, pipe, reduce, filter, pathOr, addIndex, tap } from 'ramda';
 
 import { Metric, TimeValue, GraphData, Line } from './models';
 
-interface TimeWithMetrics {
-  time: number;
+interface TimeTickWithMetrics {
+  timeTick: number;
   metrics: Array<Metric>;
 }
 
-const toTimeWithMetrics = ({ metrics, times }): Array<TimeWithMetrics> => {
+const toTimeTickWithMetrics = ({
+  metrics,
+  times,
+}): Array<TimeTickWithMetrics> => {
   return map(
-    (time) => ({
-      time,
+    (timeTick) => ({
+      timeTick,
       metrics,
     }),
     times,
   );
 };
 
-const toTimeValue = (
-  { time, metrics }: TimeWithMetrics,
+const toTimeTickValue = (
+  { timeTick, metrics }: TimeTickWithMetrics,
   timeIndex: number,
 ): TimeValue => {
   const getMetricsForIndex = (): TimeValue => {
@@ -30,7 +33,7 @@ const toTimeValue = (
     return reduce(addMetricForTimeIndex, {}, metrics);
   };
 
-  return { time, ...getMetricsForIndex() };
+  return { timeTick, ...getMetricsForIndex() };
 };
 
 const getTimeSeries = (graphData: GraphData): Array<TimeValue> => {
@@ -44,11 +47,11 @@ const getTimeSeries = (graphData: GraphData): Array<TimeValue> => {
     };
   };
 
-  const indexedMap = addIndex<TimeWithMetrics, TimeValue>(map);
+  const indexedMap = addIndex<TimeTickWithMetrics, TimeValue>(map);
 
   return pipe(
-    toTimeWithMetrics,
-    indexedMap(toTimeValue),
+    toTimeTickWithMetrics,
+    indexedMap(toTimeTickValue),
     map(rejectLowerThanLimit),
   )(graphData);
 };

--- a/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
+++ b/www/front_src/src/Resources/Graph/Performance/timeSeries.ts
@@ -1,4 +1,4 @@
-import { map, pipe, reduce, filter, pathOr, addIndex, tap } from 'ramda';
+import { map, pipe, reduce, filter, pathOr, addIndex } from 'ramda';
 
 import { Metric, TimeValue, GraphData, Line } from './models';
 


### PR DESCRIPTION
## Description
This fixes tick times displayed as "invalid date" whenever a time metric is named "time"

Before:

![localhost_4000_centreon_monitoring_events (9)](https://user-images.githubusercontent.com/8367233/90799766-fc992480-e313-11ea-945e-9ad77319c29b.png)

After:
![localhost_4000_centreon_monitoring_events (8)](https://user-images.githubusercontent.com/8367233/90799767-fd31bb00-e313-11ea-8d12-3685b9bbed0c.png)


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie
- [x] 20.04.x
- [x] 20.10.x (master)
