### PR TITLE
fix(event-view): Fix 1024 base metrics value formatting in performance graph

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/Lines.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Lines.tsx
@@ -7,7 +7,7 @@ import { fade } from '@material-ui/core';
 
 import { fontFamily, formatValue } from '.';
 
-const getGraphLines = (lines): Array<JSX.Element> => {
+const getGraphLines = ({ lines, base }): Array<JSX.Element> => {
   const getUnits = (): Array<string> => {
     return pipe(map(prop('unit')), uniq)(lines);
   };
@@ -24,7 +24,9 @@ const getGraphLines = (lines): Array<JSX.Element> => {
             yAxisId={unit}
             key={unit}
             orientation={index === 0 ? 'left' : 'right'}
-            tickFormatter={(tick): string => formatValue({ value: tick, unit })}
+            tickFormatter={(tick): string => {
+              return formatValue({ value: tick, unit, base });
+            }}
             {...props}
           />
         );
@@ -34,7 +36,9 @@ const getGraphLines = (lines): Array<JSX.Element> => {
     return [
       <YAxis
         key="single-y-axis"
-        tickFormatter={(tick): string => formatValue({ value: tick, unit: '' })}
+        tickFormatter={(tick): string => {
+          return formatValue({ value: tick, unit: '', base });
+        }}
         {...props}
       />,
     ];

--- a/www/front_src/src/Resources/Graph/Performance/Lines.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Lines.tsx
@@ -5,7 +5,8 @@ import { pipe, uniq, prop, map } from 'ramda';
 
 import { fade } from '@material-ui/core';
 
-import { fontFamily, formatValue } from '.';
+import { fontFamily } from '.';
+import formatMetricValue from './formatMetricValue';
 
 const getGraphLines = ({ lines, base }): Array<JSX.Element> => {
   const getUnits = (): Array<string> => {
@@ -25,7 +26,7 @@ const getGraphLines = ({ lines, base }): Array<JSX.Element> => {
             key={unit}
             orientation={index === 0 ? 'left' : 'right'}
             tickFormatter={(tick): string => {
-              return formatValue({ value: tick, unit, base });
+              return formatMetricValue({ value: tick, unit, base });
             }}
             {...props}
           />
@@ -37,7 +38,7 @@ const getGraphLines = ({ lines, base }): Array<JSX.Element> => {
       <YAxis
         key="single-y-axis"
         tickFormatter={(tick): string => {
-          return formatValue({ value: tick, unit: '', base });
+          return formatMetricValue({ value: tick, unit: '', base });
         }}
         {...props}
       />,

--- a/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.test.ts
+++ b/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.test.ts
@@ -1,0 +1,20 @@
+import formatMetricValue from '.';
+
+type TestCase = [number, string, 1000 | 1024, string];
+
+describe(formatMetricValue, () => {
+  const cases: Array<TestCase> = [
+    [218857269, '', 1000, '218.86m'],
+    [218857269, '', 1024, '219M'],
+    [0.12232323445, '', 1000, '0.12'],
+    [1024, 'B', 1000, '1K'],
+    [1024, 'B', 1024, '1K'],
+  ];
+
+  it.each(cases)(
+    'formats the given value to a human readable form according to the given unit and base',
+    (value, unit, base, formattedResult) => {
+      expect(formatMetricValue({ value, unit, base })).toEqual(formattedResult);
+    },
+  );
+});

--- a/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.ts
+++ b/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.ts
@@ -1,0 +1,21 @@
+import numeral from 'numeral';
+
+const formatMetricValue = ({ value, unit, base = 1000 }): string => {
+  const base2Units = [
+    'B',
+    'bytes',
+    'bytespersecond',
+    'B/s',
+    'B/sec',
+    'o',
+    'octets',
+  ];
+
+  const base1024 = base2Units.includes(unit) || base === 1024;
+
+  const format = base1024 ? '0b' : '0.[00]a';
+
+  return numeral(value).format(format).replace('B', '');
+};
+
+export default formatMetricValue;

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -7,7 +7,6 @@ import {
   ResponsiveContainer,
   Tooltip,
 } from 'recharts';
-import * as numeral from 'numeral';
 import {
   pipe,
   map,
@@ -32,26 +31,9 @@ import { labelNoDataForThisPeriod } from '../../translatedLabels';
 import LoadingSkeleton from './LoadingSkeleton';
 import Legend from './Legend';
 import getGraphLines from './Lines';
+import formatMetricValue from './formatMetricValue';
 
 const fontFamily = 'Roboto, sans-serif';
-
-const formatValue = ({ value, unit, base = 1000 }): string => {
-  const base2Units = [
-    'B',
-    'bytes',
-    'bytespersecond',
-    'B/s',
-    'B/sec',
-    'o',
-    'octets',
-  ];
-
-  const base1024 = base2Units.includes(unit) || base === 1024;
-
-  const format = base1024 ? '0b' : '0.[00]a';
-
-  return numeral(value).format(format).replace('B', '');
-};
 
 interface Props {
   endpoint: string;
@@ -137,7 +119,7 @@ const PerformanceGraph = ({
       path(['name']),
     )(lineData) as string;
 
-    return [formatValue({ value, unit, base }), legendName];
+    return [formatMetricValue({ value, unit, base }), legendName];
   };
 
   const formatXAxisTick = (tick): string =>
@@ -211,4 +193,4 @@ const PerformanceGraph = ({
 };
 
 export default PerformanceGraph;
-export { fontFamily, formatValue };
+export { fontFamily };


### PR DESCRIPTION
## Description

This fixes the display the value of base 2 metrics (1024 bytes) displayed in base 10 (1000 bytes) instead. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)
