### PR TITLE
fix(event-view): Send search as empty string instead of undefined when saving a filter

### DIFF
--- a/www/front_src/src/Resources/Filter/Edit/index.test.tsx
+++ b/www/front_src/src/Resources/Filter/Edit/index.test.tsx
@@ -73,7 +73,7 @@ const retrievedCustomFilters = {
       {
         name: 'search',
         type: 'text',
-        value: undefined,
+        value: '',
       },
     ],
   })),

--- a/www/front_src/src/Resources/Filter/api/adapters.ts
+++ b/www/front_src/src/Resources/Filter/api/adapters.ts
@@ -72,7 +72,7 @@ const toRawFilter = ({ name, criterias }: Filter): Omit<RawFilter, 'id'> => {
       },
       {
         name: 'search',
-        value: criterias.search,
+        value: criterias.search || '',
         type: 'text',
       },
     ],


### PR DESCRIPTION
## Description
This fixes an error when the search input has never been filled out. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)

