### PR TITLE
fix(resources-status): Fix Timeline infinite scroll showing incoherent results

### DIFF
--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -519,7 +519,7 @@ describe(Details, () => {
         buildListTimelineEventsEndpoint({
           endpoint: timelineEndpoint,
           parameters: {
-            limit: 10,
+            limit: 30,
             page: 1,
             search: {
               lists: [

--- a/www/front_src/src/Resources/Details/index.test.tsx
+++ b/www/front_src/src/Resources/Details/index.test.tsx
@@ -446,7 +446,7 @@ describe(Details, () => {
         buildListTimelineEventsEndpoint({
           endpoint: timelineEndpoint,
           parameters: {
-            limit: 10,
+            limit: 30,
             page: 1,
             search: {
               lists: [

--- a/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
@@ -13,20 +13,7 @@ import {
   Typography,
   CircularProgress,
 } from '@material-ui/core';
-import {
-  prop,
-  isEmpty,
-  cond,
-  always,
-  T,
-  isNil,
-  pipe,
-  equals,
-  sortWith,
-  descend,
-  concat,
-  uniqWith,
-} from 'ramda';
+import { prop, isEmpty, cond, always, T, isNil, concat } from 'ramda';
 
 import { ResourceLinks } from '../../../models';
 import { types } from './Event';
@@ -78,7 +65,7 @@ const TimelineTab = ({ links }: Props): JSX.Element => {
   const [selectedTypes, setSelectedTypes] = React.useState<Array<Type>>(types);
   const [page, setPage] = React.useState(1);
   const [total, setTotal] = React.useState(0);
-  const [limit] = React.useState(10);
+  const [limit] = React.useState(30);
   const [loadingMoreEvents, setLoadingMoreEvents] = React.useState(false);
 
   const { endpoints } = links;

--- a/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
@@ -115,13 +115,16 @@ const TimelineTab = ({ links }: Props): JSX.Element => {
         limit,
         search: getSearch(),
       },
-    }).then((retrievedListing) => {
-      const { meta } = retrievedListing;
-      setTotal(meta.total);
-      setLoadingMoreEvents(false);
+    })
+      .then((retrievedListing) => {
+        const { meta } = retrievedListing;
+        setTotal(meta.total);
 
-      return retrievedListing;
-    });
+        return retrievedListing;
+      })
+      .finally(() => {
+        setLoadingMoreEvents(false);
+      });
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
## Description
This fixes some weird behavior while loading Timeline events and using infinite scroll.

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>
- Select a Resource with more than 10 events
- Select the corresponding Timeline tab in the details panel
- Do some guerilla loading / testing
- Check that the behavior is coherent and the result is always properly loaded   
