### PR TITLE
Add regex filtering to widget compare field

### DIFF
--- a/www/class/centreonUtils.class.php
+++ b/www/class/centreonUtils.class.php
@@ -217,6 +217,12 @@ class CentreonUtils
             case "notlike":
                 $result = "NOT LIKE";
                 break;
+            case "regex":
+                $result = "REGEXP";
+                break;
+            case "notregex":
+                $result = "NOT REGEXP";
+                break;
             default:
                 $result = "";
                 break;

--- a/www/class/centreonWidget/Params/Compare.class.php
+++ b/www/class/centreonWidget/Params/Compare.class.php
@@ -56,7 +56,9 @@ class CentreonWidgetParamsCompare extends CentreonWidgetParams
                 "eq" => "=",
                 "ne" => "!=",
                 "like" => "LIKE",
-                "notlike" => "NOT LIKE"
+                "notlike" => "NOT LIKE",
+                "regex"   => "REGEXP",
+                "notregex"=> "NOT REGEXP"
             );
             $elems[] = $this->quickform->addElement('select', 'op_' . $params['parameter_id'], '', $operands);
             $elems[] = $this->quickform->addElement(
@@ -83,7 +85,7 @@ class CentreonWidgetParamsCompare extends CentreonWidgetParams
             $target = $params['default_value'];
         }
         if (isset($target)) {
-            if (preg_match("/(gt |lt |gte |lte |eq |ne |like |notlike )(.+)/", $target, $matches)) {
+            if (preg_match("/(gt |lt |gte |lte |eq |ne |like |notlike |regex |notregex )(.+)/", $target, $matches)) {
                 $op = trim($matches[1]);
                 $val = trim($matches[2]);
             }


### PR DESCRIPTION
## Description

When configuring the preferences for a widget, for example in the service-monitoring widget, add the ability to use regex filtering on the fields with the "compare" type.

**Fixes** #6126

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [X] 20.04.x
- [X] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Create a new view with a new widget, for example service-monitoring
2. In the widget preferences, set "Host Name" or "Service Description" with the filter "REGEXP" and add a regular expression filter
3. Check if the filter is correctly applied in the widget list

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
