### PR TITLE
fix(filter): update filter on save with returned data

### DIFF
--- a/src/Centreon/Domain/Filter/FilterService.php
+++ b/src/Centreon/Domain/Filter/FilterService.php
@@ -133,7 +133,7 @@ class FilterService extends AbstractCentreonService implements FilterServiceInte
         foreach ($criterias as $criteria) {
             if ($criteria->getType() === 'multi_select' && is_array($criteria->getValue())) {
                 switch ($criteria->getObjectType()) {
-                    case 'host_group':
+                    case 'host_groups':
                         $hostGroupIds = array_column($criteria->getValue(), 'id');
                         $hostGroups = $this->hostGroupService
                             ->filterByContact($this->contact)
@@ -148,7 +148,7 @@ class FilterService extends AbstractCentreonService implements FilterServiceInte
                             $hostGroups
                         ));
                         break;
-                    case 'service_group':
+                    case 'service_groups':
                         $serviceGroupIds = array_column($criteria->getValue(), 'id');
                         $serviceGroups = $this->serviceGroupService
                             ->filterByContact($this->contact)

--- a/tests/php/Centreon/Domain/Filter/FilterServiceTest.php
+++ b/tests/php/Centreon/Domain/Filter/FilterServiceTest.php
@@ -81,7 +81,7 @@ class FilterServiceTest extends TestCase
                       "name" => "linux"
                     ]
                 ])
-                ->setObjectType("host_group"),
+                ->setObjectType("host_groups"),
             (new FilterCriteria())
                 ->setName("service_groups")
                 ->setType("multi_select")
@@ -91,7 +91,7 @@ class FilterServiceTest extends TestCase
                       "name" => "sg_ping"
                     ]
                 ])
-                ->setObjectType("service_group"),
+                ->setObjectType("service_groups"),
             (new FilterCriteria())
                 ->setName("search")
                 ->setType("text")

--- a/www/front_src/src/Resources/Filter/Edit/index.test.tsx
+++ b/www/front_src/src/Resources/Filter/Edit/index.test.tsx
@@ -116,6 +116,9 @@ describe(EditFilterPanel, () => {
     });
 
     const newName = 'New name';
+    const updatedFilter = { ...firstFilter, name: newName };
+
+    mockedAxios.put.mockResolvedValue({ data: updatedFilter });
 
     const renameFilterInput = getByLabelText(
       `${labelFilter}-${firstFilter.id}-${labelName}`,

--- a/www/front_src/src/Resources/Filter/Save/index.test.tsx
+++ b/www/front_src/src/Resources/Filter/Save/index.test.tsx
@@ -20,7 +20,7 @@ import {
   labelSaveAsNew,
   labelName,
 } from '../../translatedLabels';
-import { toRawFilter } from '../api/adapters';
+import { toRawFilter, toFilter } from '../api/adapters';
 import { newFilter } from '../models';
 import { filterEndpoint } from '../api';
 
@@ -192,9 +192,21 @@ describe(SaveMenu, () => {
 
     await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
 
+    const newSearch = 'new search';
+
+    const updatedFilter = toRawFilter({
+      ...toFilter(createdFilter),
+      criterias: {
+        ...toFilter(createdFilter).criterias,
+        search: newSearch,
+      },
+    });
+
+    mockedAxios.put.mockResolvedValue({ data: updatedFilter });
+
     act(() => {
       filterState.setFilter(newFilter);
-      filterState.setNextSearch('toto');
+      filterState.setNextSearch(newSearch);
     });
 
     expect(

--- a/www/front_src/src/Resources/Filter/Save/index.tsx
+++ b/www/front_src/src/Resources/Filter/Save/index.tsx
@@ -55,6 +55,8 @@ const SaveFilterMenu = (): JSX.Element => {
     filter,
     updatedFilter,
     setFilter,
+    setHostGroups,
+    setServiceGroups,
     loadCustomFilters,
     customFilters,
     setEditPanelOpen,
@@ -82,6 +84,10 @@ const SaveFilterMenu = (): JSX.Element => {
 
     loadCustomFilters().then(() => {
       setFilter(newFilter);
+
+      // update criterias with deletable objects
+      setHostGroups(newFilter.criterias.hostGroups);
+      setServiceGroups(newFilter.criterias.serviceGroups);
     });
   };
 
@@ -95,14 +101,14 @@ const SaveFilterMenu = (): JSX.Element => {
   };
 
   const updateFilter = (): void => {
-    sendUpdateFilterRequest(updatedFilter).then(() => {
+    sendUpdateFilterRequest(updatedFilter).then((savedFilter) => {
       closeSaveFilterMenu();
       showMessage({
         message: labelFilterSaved,
         severity: Severity.success,
       });
 
-      loadFiltersAndUpdateCurrent(updatedFilter);
+      loadFiltersAndUpdateCurrent(savedFilter);
     });
   };
 

--- a/www/front_src/src/Resources/Filter/api/index.ts
+++ b/www/front_src/src/Resources/Filter/api/index.ts
@@ -37,10 +37,10 @@ const createFilter = (cancelToken) => (params): Promise<Filter> => {
 };
 
 const updateFilter = (cancelToken) => (params): Promise<Filter> => {
-  return putData<RawFilterWithoutId, Filter>(cancelToken)({
+  return putData<RawFilterWithoutId, RawFilter>(cancelToken)({
     endpoint: `${filterEndpoint}/${params.id}`,
     data: toRawFilter(params),
-  });
+  }).then(toFilter);
 };
 
 interface PatchFilterProps {


### PR DESCRIPTION
## Description

update filter on save with returned data
it allows to remove linked objects which have been deleted from monitoring (hostgroup and servicegroup)

**Fixes** MON-5758

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

* Link a hostgroup to a host
* create a filter which use hostgroup
* delete hostgroup and restart poller
* update filter search parameter and save it
==> the hostgroup should be deleted from the filter