### PR TITLE
fix(filter): initialize filter criterias when given in url

### DIFF
--- a/www/front_src/src/Resources/Filter/index.test.tsx
+++ b/www/front_src/src/Resources/Filter/index.test.tsx
@@ -562,5 +562,55 @@ describe(Filter, () => {
         'Search me two',
       );
     });
+
+    it('resets the filter criterias which are not set in the filter URL query parameter when given', async () => {
+      const savedFilter = {
+        id: '',
+        name: '',
+        criterias: {
+          resourceTypes: [{ id: 'host', name: labelHost }],
+          states: [{ id: 'acknowledged', name: labelAcknowledged }],
+          statuses: [{ id: 'OK', name: labelOk }],
+          hostGroups: [linuxServersHostGroup],
+          serviceGroups: [webAccessServiceGroup],
+          search: 'searching...',
+        },
+      };
+
+      mockedLocalStorageGetItem.mockReturnValue(JSON.stringify(savedFilter));
+
+      const filter = {
+        criterias: {
+          search: 'Search me',
+        },
+      };
+
+      setUrlQueryParameters([
+        {
+          name: 'filter',
+          value: filter,
+        },
+      ]);
+
+      const { getByDisplayValue, queryByText } = renderFilter();
+
+      await waitFor(() => {
+        expect(mockedAxios.get).toHaveBeenCalledTimes(2);
+      });
+
+      expect(getByDisplayValue('Search me')).toBeInTheDocument();
+      expect(queryByText(labelHost)).toBeNull();
+      expect(queryByText(labelAcknowledged)).toBeNull();
+      expect(queryByText(labelOk)).toBeNull();
+      expect(queryByText(linuxServersHostGroup.name)).toBeNull();
+      expect(queryByText(webAccessServiceGroup.name)).toBeNull();
+
+      const filterFromUrlQueryParameters = getUrlQueryParameters()
+        .filter as FilterModel;
+
+      expect(filterFromUrlQueryParameters.criterias.search).toEqual(
+        'Search me',
+      );
+    });
   });
 });

--- a/www/front_src/src/Resources/Filter/useFilter.ts
+++ b/www/front_src/src/Resources/Filter/useFilter.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { hasPath, mergeDeepLeft, mergeDeepRight, pipe } from 'ramda';
+
 import {
   useRequest,
   setUrlQueryParameters,
@@ -62,7 +64,7 @@ const useFilter = (): FilterState => {
     decoder: listCustomFiltersDecoder,
   });
 
-  const { unhandledProblemsFilter } = useFilterModels();
+  const { unhandledProblemsFilter, allFilter, newFilter } = useFilterModels();
   const { toFilter } = useAdapters();
 
   const getDefaultFilter = (): Filter => {
@@ -70,10 +72,14 @@ const useFilter = (): FilterState => {
 
     const urlQueryParameters = getUrlQueryParameters();
 
-    return {
-      ...defaultFilter,
-      ...(urlQueryParameters.filter as Filter),
-    };
+    if (hasPath(['filter'], urlQueryParameters)) {
+      return pipe(
+        mergeDeepLeft(urlQueryParameters.filter as Filter) as (t) => Filter,
+        mergeDeepRight(allFilter) as (t) => Filter,
+      )(newFilter) as Filter;
+    }
+
+    return defaultFilter;
   };
 
   const getDefaultCriterias = (): Criterias => getDefaultFilter().criterias;


### PR DESCRIPTION
## Description

initialize filter criterias when given in url

**Fixes** MON-5216

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

* search in resource status page using search field
* load events view page using filter parameter : `/centreon/monitoring/resources?filter={"criterias":{"resourceTypes":[]}}`
==> search field should be reset to empty