### PR TITLE
enh(resource-tatus): Change Resource link copy icon

### DIFF
--- a/www/front_src/src/Resources/Details/Header.tsx
+++ b/www/front_src/src/Resources/Details/Header.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 
 import { Grid, Typography, makeStyles } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
-import LinkIcon from '@material-ui/icons/Link';
+import CopyIcon from '@material-ui/icons/FileCopy';
 
 import {
   StatusChip,
@@ -105,7 +105,7 @@ const HeaderContent = ({ details }: DetailsSectionProps): JSX.Element => {
           ariaLabel={t(labelCopyLink)}
           onClick={copyResourceLink}
         >
-          <LinkIcon />
+          <CopyIcon fontSize="small" />
         </IconButton>
       </Grid>
     </>


### PR DESCRIPTION
## Description
Before:
![Screenshot from 2020-09-21 11-39-28](https://user-images.githubusercontent.com/8367233/93752785-6cdee280-fbff-11ea-897c-a70d5b3754de.png)

After: 
![Screenshot from 2020-09-21 11-40-27](https://user-images.githubusercontent.com/8367233/93752787-6d777900-fbff-11ea-99d9-489788e4b3fa.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.10.x (master)
