### PR TITLE
enh(resource-status): Make details tab URL query parameters interpretation more robust

### DIFF
--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14605,3 +14605,6 @@ msgstr "Permitir certificado autofirmado"
 
 #  msgid "Disacknowledgement command sent"
 #  msgstr ""
+
+#  msgid "No resource found"
+#  msgstr ""

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15648,3 +15648,6 @@ msgstr "Désacquitter les services attachés aux hôtes"
 
 msgid "Disacknowledgement command sent"
 msgstr "Commande de désacquittement envoyée"
+
+msgid "No resource found"
+msgstr "Pas de ressource trouvée"

--- a/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15053,3 +15053,6 @@ msgstr "Erro ao remover tokens de um contato"
 
 #  msgid "Disacknowledgement command sent"
 #  msgstr ""
+
+#  msgid "No resource found"
+#  msgstr ""

--- a/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15054,3 +15054,6 @@ msgstr "Erro ao remover tokens de um contato"
 
 #  msgid "Resource link copied to the clipboard"
 #  msgstr ""
+
+#  msgid "No resource found"
+#  msgstr ""

--- a/www/front_src/src/Resources/Details/tabs/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/index.tsx
@@ -111,7 +111,13 @@ const tabIdByLabel = {
 };
 
 const getTabIdFromLabel = (label: string): TabId => {
-  return tabIdByLabel[label];
+  const tabId = tabIdByLabel[label];
+
+  if (isNil(tabId)) {
+    return detailsTabId;
+  }
+
+  return tabId;
 };
 
 const getTabLabelFromId = (id: TabId): string => {

--- a/www/front_src/src/Resources/Filter/index.test.tsx
+++ b/www/front_src/src/Resources/Filter/index.test.tsx
@@ -33,6 +33,8 @@ import {
   labelSearchOnFields,
   labelNewFilter,
   labelService,
+  labelUnhandled,
+  labelWarning,
 } from '../translatedLabels';
 import useListing from '../Listing/useListing';
 import useActions from '../Actions/useActions';

--- a/www/front_src/src/Resources/Filter/index.test.tsx
+++ b/www/front_src/src/Resources/Filter/index.test.tsx
@@ -33,8 +33,6 @@ import {
   labelSearchOnFields,
   labelNewFilter,
   labelService,
-  labelUnhandled,
-  labelWarning,
 } from '../translatedLabels';
 import useListing from '../Listing/useListing';
 import useActions from '../Actions/useActions';

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -171,3 +171,4 @@ export const labelDisacknowledgeServices =
   'Disacknowledge services attached to hosts';
 export const labelDisacknowledgementCommandSent =
   'Disacknowledgement command sent';
+export const labelNoResourceFound = 'No resource found';


### PR DESCRIPTION
## Description

This prevents the page to blow up if URL query parameters are invalid. 

To test: just set an invalid details parameter in the URL (either wrong resource id / parent id / type / parent type or invalid tab). The page shouldn't blow up. In case of wrong tab: the details tab is displayed instead. In case of wrong resource parameter: the panel is closed and an error message is displayed.  

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie
- [x] 20.10.x (master)

