### PR TITLE
fix(resource-status/timeline): trigger selectedTypes reload only when timeline is defined

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
@@ -157,7 +157,7 @@ const TimelineTab = ({ details }: TabProps): JSX.Element => {
   }, [page]);
 
   React.useEffect(() => {
-    if (isNil(details)) {
+    if (isNil(details) || isNil(timeline)) {
       return;
     }
 


### PR DESCRIPTION
## Description

This avoids sending 2 API requests when first loading the timeline. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.10.x (master)

