### PR TITLE
fix(log): skip empty lvl3 on topology acl

### DIFF
--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -526,7 +526,8 @@ class CentreonACL
             // We fix topologies according to filter
             foreach ($parentsLvl as $parentLvl1 => $childrenLvl2) {
                 foreach ($childrenLvl2 as $parentLvl2 => $childrenLvl3) {
-                    if (!empty($childrenLvl3)
+                    if (
+                        !empty($childrenLvl3)
                         && isset($this->topology[$childrenLvl3])
                         && isset($this->topology[$parentLvl2])
                         && $this->topology[$childrenLvl3] > $this->topology[$parentLvl2]
@@ -538,7 +539,8 @@ class CentreonACL
                          */
                         $this->topology[$parentLvl2] = $this->topology[$childrenLvl3];
                     }
-                    if (isset($this->topology[$parentLvl2])
+                    if (
+                        isset($this->topology[$parentLvl2])
                         && isset($this->topology[$parentLvl1])
                         && $this->topology[$parentLvl2] > $this->topology[$parentLvl1]
                     ) {

--- a/www/class/centreonACL.class.php
+++ b/www/class/centreonACL.class.php
@@ -443,7 +443,7 @@ class CentreonACL
         }
         $this->checkTopology();
     }
-    
+
     /**
      * Use to check and fix if in the topology, a parent has access rights that
      * can be higher than children when they have the same endpoint.
@@ -457,7 +457,7 @@ class CentreonACL
             $getFirstChildPerLvl = function (array $topologies): array {
                 ksort($topologies, \SORT_ASC);
                 $parentsLvl = [];
-                
+
                 // Classify topologies by parents
                 foreach (array_keys($topologies) as $page) {
                     if (strlen($page) == 1) {
@@ -489,7 +489,7 @@ class CentreonACL
                         }
                     }
                 }
-                
+
                 /**
                  * We keep the first lvl3 child by lvl1.
                  * In this way, we keep the first child available for each parent
@@ -503,12 +503,14 @@ class CentreonACL
                             unset($parentsLvl[$parentLvl1][$parentLvl2]);
                             continue;
                         }
+                        if (empty($childrenLvl3)) {
+                            continue;
+                        }
                         // First reading
                         ksort($childrenLvl3);
                         // We keep the tree of the first child
-                        $parentsLvl[$parentLvl1][$parentLvl2] = is_array($childrenLvl3)
-                            ? array_slice($childrenLvl3, 0, 1, true)[0]
-                            : $childrenLvl3;
+
+                        $parentsLvl[$parentLvl1][$parentLvl2] = array_slice($childrenLvl3, 0, 1, true)[0];
                         /**
                          * The first child has been processed so we set TRUE
                          * to delete all the following children
@@ -518,13 +520,14 @@ class CentreonACL
                 }
                 return $parentsLvl;
             };
-            
+
             $parentsLvl = $getFirstChildPerLvl($this->topology);
-            
+
             // We fix topologies according to filter
             foreach ($parentsLvl as $parentLvl1 => $childrenLvl2) {
                 foreach ($childrenLvl2 as $parentLvl2 => $childrenLvl3) {
-                    if (isset($this->topology[$childrenLvl3])
+                    if (!empty($childrenLvl3)
+                        && isset($this->topology[$childrenLvl3])
                         && isset($this->topology[$parentLvl2])
                         && $this->topology[$childrenLvl3] > $this->topology[$parentLvl2]
                     ) {


### PR DESCRIPTION
## Description


`[24-Jul-2020 06:39:00 Europe/Paris] PHP Notice:  Undefined offset: 0 in /usr/share/centreon/www/class/centreonACL.class.php on line 510
[24-Jul-2020 06:39:00 Europe/Paris] PHP Stack trace:
[24-Jul-2020 06:39:00 Europe/Paris] PHP   1. {main}() /usr/share/centreon/www/include/monitoring/status/Notifications/notifications.php:0
[24-Jul-2020 06:39:00 Europe/Paris] PHP   2. CentreonXMLBGRequest->__construct($dependencyInjector = *uninitialized*, $session_id = *uninitialized*, $dbNeeds = *uninitialized*, $headerType = *uninitialized*, $debug = *uninitialized*, $compress = *uninitialized*, $fullVersion = *uninitialized*) /usr/share/centreon/www/include/monitoring/status/Notifications/notifications.php:49
[24-Jul-2020 06:39:00 Europe/Paris] PHP   3. CentreonACL->__construct($userId = *uninitialized*, $isAdmin = *uninitialized*) /usr/share/centreon/www/class/centreonXMLBGRequest.class.php:169
[24-Jul-2020 06:39:00 Europe/Paris] PHP   4. CentreonACL->setTopology() /usr/share/centreon/www/class/centreonACL.class.php:104
[24-Jul-2020 06:39:00 Europe/Paris] PHP   5. CentreonACL->checkTopology() /usr/share/centreon/www/class/centreonACL.class.php:444
[24-Jul-2020 06:39:00 Europe/Paris] PHP   6. CentreonACL->{closure:/usr/share/centreon/www/class/centreonACL.class.php:457-520}($topologies = *uninitialized*) /usr/share/centreon/www/class/centreonACL.class.php:522
`

**Fixes** MON-6022

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

Watch logs and move on each IHM's pages

