### PR TITLE
MON-6068: Perl lib db query bad looping parameters

### DIFF
--- a/lib/perl/centreon/common/db.pm
+++ b/lib/perl/centreon/common/db.pm
@@ -268,7 +268,7 @@ sub query {
             $status = $self->connect();
             if ($status != -1) {
                 for (my $i = 0; $i < scalar(@{$self->{args}}); $i++) {
-                    my $str_quoted = $self->quote(${$self->{args}}[0]);
+                    my $str_quoted = $self->quote(${$self->{args}}[$i]);
                     $query =~ s/##__ARG__$i##/$str_quoted/;
                 }
                 $self->{args} = [];


### PR DESCRIPTION
## Description

In some case (database disconnect and multiple quotes requests), you can have wrong column updates

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 19.10.x
- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

It's difficult to test.

## Checklist

- [X] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
