### PR TITLE
fix(graph): manage null values

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/Lines.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Lines.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react';
 
 import { Area, Line, YAxis } from 'recharts';
-import { pipe, uniq, prop, map } from 'ramda';
+import { pipe, uniq, prop, map, isNil } from 'ramda';
 
 import { fade } from '@material-ui/core';
 
 import { fontFamily } from '.';
 import formatMetricValue from './formatMetricValue';
+
+const formatTick = ({ unit, base }) => (value): string => {
+  if (isNil(value)) {
+    return '';
+  }
+
+  return formatMetricValue({ value, unit, base }) as string;
+};
 
 const getGraphLines = ({ lines, base }): Array<JSX.Element> => {
   const getUnits = (): Array<string> => {
@@ -25,9 +33,7 @@ const getGraphLines = ({ lines, base }): Array<JSX.Element> => {
             yAxisId={unit}
             key={unit}
             orientation={index === 0 ? 'left' : 'right'}
-            tickFormatter={(tick): string => {
-              return formatMetricValue({ value: tick, unit, base });
-            }}
+            tickFormatter={formatTick({ unit, base })}
             {...props}
           />
         );
@@ -37,9 +43,7 @@ const getGraphLines = ({ lines, base }): Array<JSX.Element> => {
     return [
       <YAxis
         key="single-y-axis"
-        tickFormatter={(tick): string => {
-          return formatMetricValue({ value: tick, unit: '', base });
-        }}
+        tickFormatter={formatTick({ unit: '', base })}
         {...props}
       />,
     ];

--- a/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.test.ts
+++ b/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.test.ts
@@ -1,6 +1,6 @@
 import formatMetricValue from '.';
 
-type TestCase = [number, string, 1000 | 1024, string];
+type TestCase = [number | null, string, 1000 | 1024, string | null];
 
 describe(formatMetricValue, () => {
   const cases: Array<TestCase> = [
@@ -9,6 +9,7 @@ describe(formatMetricValue, () => {
     [0.12232323445, '', 1000, '0.12'],
     [1024, 'B', 1000, '1K'],
     [1024, 'B', 1024, '1K'],
+    [null, 'B', 1024, null],
   ];
 
   it.each(cases)(

--- a/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.ts
+++ b/www/front_src/src/Resources/Graph/Performance/formatMetricValue/index.ts
@@ -1,6 +1,11 @@
 import numeral from 'numeral';
+import { isNil } from 'ramda';
 
-const formatMetricValue = ({ value, unit, base = 1000 }): string => {
+const formatMetricValue = ({ value, unit, base = 1000 }): string | null => {
+  if (isNil(value)) {
+    return null;
+  }
+
   const base2Units = [
     'B',
     'bytes',

--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -120,7 +120,11 @@ const PerformanceGraph = ({
   const sortedLines = sortBy(prop('name'), lineData);
   const displayedLines = reject(propEq('display', false), sortedLines);
 
-  const formatTooltipValue = (value, metric, { unit }): Array<string> => {
+  const formatTooltipValue = (
+    value,
+    metric,
+    { unit },
+  ): Array<string | null> => {
     const legendName = pipe(
       find(propEq('metric', metric)),
       path(['name']),
@@ -183,7 +187,7 @@ const PerformanceGraph = ({
             contentStyle={{ fontFamily }}
             wrapperStyle={{ opacity: 0.7 }}
             isAnimationActive={false}
-            filterNull={false}
+            filterNull
           />
         </ComposedChart>
       </ResponsiveContainer>


### PR DESCRIPTION
## Description

manage null values in graph :
* does not display metric in tooltip if value is null
* does not format null values (avoid conversion to 0)

**Fixes** MON-5813

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [x] 20.04.x
- [x] 20.10.x (master)