### PR TITLE
fix(resource-status/Filter): change Filter local storage key to avoid schema incoherence

### DIFF
--- a/www/front_src/src/Resources/Filter/index.test.tsx
+++ b/www/front_src/src/Resources/Filter/index.test.tsx
@@ -53,7 +53,7 @@ import useDetails from '../Details/useDetails';
 
 const mockedAxios = axios as jest.Mocked<typeof axios>;
 
-const filterStorageKey = 'centreon-events-filter';
+const filterStorageKey = 'centreon-resource-status-filter';
 
 jest.mock('react-redux', () => ({
   useSelector: jest.fn(),

--- a/www/front_src/src/Resources/Filter/storedFilter.ts
+++ b/www/front_src/src/Resources/Filter/storedFilter.ts
@@ -2,7 +2,7 @@ import { isNil } from 'ramda';
 
 import { Filter } from './models';
 
-const key = 'centreon-events-filter';
+const key = 'centreon-resource-status-filter';
 
 let cachedFilter;
 


### PR DESCRIPTION
## Description

The schema has changed since the first 20.04 release and the filter stored might be irrelevant

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)
