### PR TITLE
enh(API): manage hostname in topology endpoint

### DIFF
--- a/config/json_validator/latest/Centreon/PlatformTopology/Register.json
+++ b/config/json_validator/latest/Centreon/PlatformTopology/Register.json
@@ -16,6 +16,9 @@
     },
     "parent_address": {
       "type": ["string", "null"]
+    },
+    "hostname": {
+      "type": ["string", "null"]
     }
   }
 }

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -4372,6 +4372,10 @@ components:
           type: string
           description: "Name of the server to register in the topology"
           example: "myPoller"
+        hostname:
+          type: string
+          description: "Platform's 'physical' name"
+          example: "my.poller.physical.hostname"
         type:
           type: string
           enum: [central, poller, remote, map, mbi]

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15597,8 +15597,8 @@ msgid "Central platform's API port are not consistent. Please check the 'Remote 
 msgstr "Le port de l'API vers le Central n'est pas cohérent. Veuiller vérifier le formulaire 'Accès du Remote'."
 
 #: api/topology/register
-msgid "At least one space or illegal character in '%s', was found in platform's name: '%s'"
-msgstr "Au moins un espace ou un caractère illegal parmi '%s', a été trouvé dans le nom de la plateforme: '%s'"
+msgid "At least one space or illegal character in '%s' was found in platform's name: '%s'"
+msgstr "Au moins un espace ou un caractère illégal parmi '%s' a été trouvé dans le nom de la plateforme: '%s'"
 
 #: api/topology/register
 msgid "Platform : '%s'@'%s' mandatory data are missing. Please check the Remote Access form."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15618,7 +15618,7 @@ msgstr "Impossible de trouver le nom du server local de supervision"
 
 #: api/topology/register
 msgid "Error when searching monitoring server name"
-msgstr "Erreur lors de la recherche du nom du server de supervision"
+msgstr "Erreur lors de la recherche du nom du serveur de supervision"
 
 #: api/topology/register
 msgid "The platform: '%s'@'%s' is not declared as a 'remote'."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15614,7 +15614,11 @@ msgstr "Impossible de récupérer les données d'information sur la plateforme."
 
 #: api/topology/register
 msgid "Unable to find local monitoring server name"
-msgstr "Impossible de trouver le nom du server de monitoring local"
+msgstr "Impossible de trouver le nom du server local de supervision"
+
+#: api/topology/register
+msgid "Error when searching monitoring server name"
+msgstr "Erreur lors de la recherche du nom du server de supervision"
 
 #: api/topology/register
 msgid "The platform: '%s'@'%s' is not declared as a 'remote'."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15597,7 +15597,7 @@ msgid "Central platform's API port are not consistent. Please check the 'Remote 
 msgstr "Le port de l'API vers le Central n'est pas cohérent. Veuiller vérifier le formulaire 'Accès du Remote'."
 
 #: api/topology/register
-msgid "At least one space or illegal character in '%s', was found on platform's name: '%s'"
+msgid "At least one space or illegal character in '%s', was found in platform's name: '%s'"
 msgstr "Au moins un espace ou un caractère illegal parmi '%s', a été trouvé dans le nom de la plateforme: '%s'"
 
 #: api/topology/register

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15570,11 +15570,15 @@ msgstr "Erreur lors de l'ajout dans la topologie de la plateforme : '%s'@'%s'"
 
 #: api/topology/register
 msgid "Cannot use parent address on a Central server type"
-msgstr "Il n'est pas possible d'utiliser l'adresse d'un parent au type de serveur Central"
+msgstr "Il n'est pas possible d'utiliser l'adresse d'une plateforme parente sur un serveur de type Central"
 
 #: api/topology/register
 msgid "Cannot set parent id to a central server"
 msgstr "Il n'est pas possible d'assigner un id parent à un serveur central"
+
+#: api/topology/register
+msgid "Cannot link a 'remote': '%s'@'%s' to another Remote server type"
+msgstr "Il n'est pas possible de lier un 'remote': '%s'@'%s' à un autre serveur de type 'Remote'"
 
 #: api/topology/register
 msgid "A '%s': '%s'@'%s' is already registered"
@@ -15587,6 +15591,14 @@ msgstr "Le serveur du type '%s' : '%s'@'%s' ne correspond pas à celui configur�
 #: api/topology/register
 msgid "Missing mandatory parent address, to link the platform : '%s'@'%s'"
 msgstr "Adresse du server parent manquante, pour pouvoir lier la plateforme : '%s'@'%s'"
+
+#: api/topology/register
+msgid "Missing mandatory platform address of: '%s'"
+msgstr "Adresse de la plateforme: '%s' manquante"
+
+#: api/topology/register
+msgid "Missing mandatory platform name"
+msgstr "Nom de la plateforme manquant"
 
 #: api/topology/register
 msgid "Same address and parent_address for platform : '%s'@'%s'."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15614,7 +15614,7 @@ msgstr "Impossible de récupérer les données d'information sur la plateforme."
 
 #: api/topology/register
 msgid "Unable to find local monitoring server name"
-msgstr "Impossible de trouver le nom du server local de supervision"
+msgstr "Impossible de trouver le nom du serveur local de supervision"
 
 #: api/topology/register
 msgid "Error when searching monitoring server name"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15541,10 +15541,6 @@ msgid "Notification sent to"
 msgstr "Notification envoyée à"
 
 #: api/topology/register
-msgid "The name of the platform is not consistent"
-msgstr "Le nom de cette plateforme n'est pas cohérent"
-
-#: api/topology/register
 msgid "The address '%s' of '%s' is not valid or not resolvable"
 msgstr "L'adresse '%s' de la plateforme '%s' n'est pas valide ou ne peut être résolue"
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15613,6 +15613,10 @@ msgid "Unable to retrieve platform information's data."
 msgstr "Impossible de récupérer les données d'information sur la plateforme."
 
 #: api/topology/register
+msgid "Unable to find local monitoring server name"
+msgstr "Impossible de trouver le nom du server de monitoring local"
+
+#: api/topology/register
 msgid "The platform: '%s'@'%s' is not declared as a 'remote'."
 msgstr "La plateforme: '%s'@'%s' n'est pas déclarée comme un 'remote'."
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15597,6 +15597,10 @@ msgid "Central platform's API port are not consistent. Please check the 'Remote 
 msgstr "Le port de l'API vers le Central n'est pas cohérent. Veuiller vérifier le formulaire 'Accès du Remote'."
 
 #: api/topology/register
+msgid "At least one space or illegal character in '%s', was found on platform's name: '%s'"
+msgstr "Au moins un espace ou un caractère illegal parmi '%s', a été trouvé dans le nom de la plateforme: '%s'"
+
+#: api/topology/register
 msgid "Platform : '%s'@'%s' mandatory data are missing. Please check the Remote Access form."
 msgstr "Données indispensables manquantes pour la plateforme : '%s'@'%s'. Veuillez vérifier le formulaire 'Accès du Remote'."
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15787,7 +15787,7 @@ msgstr "Désacquitter les services attachés aux hôtes"
 msgid "Disacknowledgement command sent"
 msgstr "Commande de désacquittement envoyée"
 
-msgid "Impossible to find the Engine configuration"
+msgid "Unable to find the Engine configuration"
 msgstr "Impossible de trouver la configuration du moteur de supervision"
 
 msgid "Ip address can not be empty"

--- a/src/Centreon/Application/Controller/PlatformInformationController.php
+++ b/src/Centreon/Application/Controller/PlatformInformationController.php
@@ -22,13 +22,11 @@ declare(strict_types=1);
 
 namespace Centreon\Application\Controller;
 
-use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\PlatformInformation\Interfaces\PlatformInformationServiceInterface;
-use Centreon\Domain\PlatformInformation\PlatformInformation;
 use Centreon\Domain\PlatformInformation\PlatformInformationService;
 use FOS\RestBundle\Context\Context;
 use FOS\RestBundle\View\View;
-use Symfony\Component\HttpFoundation\Response;
 
 /**
  * This class is design to manage REST API requests concerning the platform's information used in the configuration.
@@ -59,7 +57,12 @@ class PlatformInformationController extends AbstractController
     {
         $this->denyAccessUnlessGrantedForApiConfiguration();
 
-        if (!$this->getUser()->isAdmin() && !$this->isGranted('ROLE_ADMINISTRATION_PARAMETERS_CENTREON_UI_RW')) {
+        /**
+         * @var ContactInterface $user
+         */
+        $user = $this->getUser();
+
+        if (!$user->isAdmin() && !$this->isGranted('ROLE_ADMINISTRATION_PARAMETERS_CENTREON_UI_RW')) {
             $context = (new Context())
                 ->setGroups(static::SERIALIZER_GROUP_LIMITED)
                 ->enableMaxDepth();

--- a/src/Centreon/Application/Controller/PlatformTopologyController.php
+++ b/src/Centreon/Application/Controller/PlatformTopologyController.php
@@ -210,7 +210,7 @@ class PlatformTopologyController extends AbstractController
             throw new PlatformTopologyException(_('Unable to find the Engine configuration'));
         }
 
-        $foundIllegalCharacters = EngineConfiguration::hasIllegalCharacters(
+        $foundIllegalCharacters = EngineConfiguration::hasNonRfcCompliantCharacters(
             $stringToCheck,
             $engineConfiguration->getIllegalObjectNameCharacters()
         );

--- a/src/Centreon/Application/Controller/PlatformTopologyController.php
+++ b/src/Centreon/Application/Controller/PlatformTopologyController.php
@@ -210,7 +210,7 @@ class PlatformTopologyController extends AbstractController
             throw new PlatformTopologyException(_('Unable to find the Engine configuration'));
         }
 
-        $foundIllegalCharacters = EngineConfiguration::hasNonRfcCompliantCharacters(
+        $foundIllegalCharacters = self::hasNonRfcCompliantCharacters(
             $stringToCheck,
             $engineConfiguration->getIllegalObjectNameCharacters()
         );
@@ -223,5 +223,20 @@ class PlatformTopologyController extends AbstractController
                 )
             );
         }
+    }
+
+    /**
+     * Find all non RFC compliant characters from the given string.
+     *
+     * @param string $stringToCheck String to analyse
+     * @param string|null $illegalCharacters String containing illegal characters
+     * @return bool Return true if illegal characters have been found
+     */
+    public static function hasNonRfcCompliantCharacters(string $stringToCheck, ?string $illegalCharacters): bool
+    {
+        // Spaces are not RFC compliant and $illegalCharacters will not contains it
+        $illegalCharacters .= ' ';
+
+        return $stringToCheck !== EngineConfiguration::removeIllegalCharacters($stringToCheck, $illegalCharacters);
     }
 }

--- a/src/Centreon/Application/Controller/PlatformTopologyController.php
+++ b/src/Centreon/Application/Controller/PlatformTopologyController.php
@@ -57,7 +57,7 @@ class PlatformTopologyController extends AbstractController
     private $engineConfigurationService;
 
     /**
-     * @var MonitoringServerService
+     * @var MonitoringServerServiceInterface
      */
     private $monitoringServerService;
 
@@ -210,7 +210,7 @@ class PlatformTopologyController extends AbstractController
             throw new PlatformTopologyException(_('Unable to find the Engine configuration'));
         }
 
-        $foundIllegalCharacters = self::hasNonRfcCompliantCharacters(
+        $foundIllegalCharacters = $this->hasNonRfcCompliantCharacters(
             $stringToCheck,
             $engineConfiguration->getIllegalObjectNameCharacters()
         );
@@ -232,7 +232,7 @@ class PlatformTopologyController extends AbstractController
      * @param string|null $illegalCharacters String containing illegal characters
      * @return bool Return true if illegal characters have been found
      */
-    public static function hasNonRfcCompliantCharacters(string $stringToCheck, ?string $illegalCharacters): bool
+    private function hasNonRfcCompliantCharacters(string $stringToCheck, ?string $illegalCharacters): bool
     {
         // Spaces are not RFC compliant and $illegalCharacters will not contains it
         $illegalCharacters .= ' ';

--- a/src/Centreon/Application/Controller/PlatformTopologyController.php
+++ b/src/Centreon/Application/Controller/PlatformTopologyController.php
@@ -206,7 +206,7 @@ class PlatformTopologyController extends AbstractController
         if (true === $foundIllegalCharacters) {
             throw new PlatformTopologyException(
                 sprintf(
-                    _("At least one space or illegal character in '%s', was found in platform's name: '%s'"),
+                    _("At least one space or illegal character in '%s' was found in platform's name: '%s'"),
                     $engineConfiguration->getIllegalObjectNameCharacters(),
                     $stringToCheck
                 )

--- a/src/Centreon/Application/Controller/PlatformTopologyController.php
+++ b/src/Centreon/Application/Controller/PlatformTopologyController.php
@@ -206,7 +206,7 @@ class PlatformTopologyController extends AbstractController
         if (true === $foundIllegalCharacters) {
             throw new PlatformTopologyException(
                 sprintf(
-                    _("At least one illegal character in '%s', was found on platform's name: '%s'"),
+                    _("At least one space or illegal character in '%s', was found on platform's name: '%s'"),
                     $engineConfiguration->getIllegalObjectNameCharacters(),
                     $stringToCheck
                 )

--- a/src/Centreon/Application/Controller/PlatformTopologyController.php
+++ b/src/Centreon/Application/Controller/PlatformTopologyController.php
@@ -26,8 +26,10 @@ use Centreon\Domain\Engine\EngineConfiguration;
 use Centreon\Domain\Engine\EngineException;
 use Centreon\Domain\Engine\Interfaces\EngineConfigurationServiceInterface;
 use Centreon\Domain\Exception\EntityNotFoundException;
+use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerServiceInterface;
+use Centreon\Domain\MonitoringServer\MonitoringServerException;
+use Centreon\Domain\MonitoringServer\MonitoringServerService;
 use Centreon\Domain\PlatformTopology\PlatformTopology;
-use Centreon\Domain\PlatformTopology\PlatformTopologyService;
 use FOS\RestBundle\View\View;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
@@ -55,16 +57,24 @@ class PlatformTopologyController extends AbstractController
     private $engineConfigurationService;
 
     /**
+     * @var MonitoringServerService
+     */
+    private $monitoringServerService;
+
+    /**
      * PlatformTopologyController constructor
      * @param PlatformTopologyServiceInterface $platformTopologyService
      * @param EngineConfigurationServiceInterface $engineConfigurationService
+     * @param MonitoringServerServiceInterface $monitoringServerService
      */
     public function __construct(
         PlatformTopologyServiceInterface $platformTopologyService,
-        EngineConfigurationServiceInterface $engineConfigurationService
+        EngineConfigurationServiceInterface $engineConfigurationService,
+        MonitoringServerServiceInterface $monitoringServerService
     ) {
         $this->platformTopologyService = $platformTopologyService;
         $this->engineConfigurationService = $engineConfigurationService;
+        $this->monitoringServerService = $monitoringServerService;
     }
 
     /**
@@ -183,17 +193,18 @@ class PlatformTopologyController extends AbstractController
      * @param string $stringToCheck
      * @throws EngineException
      * @throws PlatformTopologyException
+     * @throws MonitoringServerException
      */
     private function checkName(string $stringToCheck): void
     {
-        $monitoringServerName = $this->platformTopologyService->findLocalhostMonitoringName();
+        $monitoringServerName = $this->monitoringServerService->findLocalServer();
         if (null === $monitoringServerName) {
             throw new PlatformTopologyException(
                 _('Unable to find local monitoring server name')
             );
         }
         $engineConfiguration = $this->engineConfigurationService->findEngineConfigurationByName(
-            $monitoringServerName
+            $monitoringServerName->getName()
         );
         if (null === $engineConfiguration) {
             throw new PlatformTopologyException(_('Unable to find the Engine configuration'));

--- a/src/Centreon/Application/Controller/PlatformTopologyController.php
+++ b/src/Centreon/Application/Controller/PlatformTopologyController.php
@@ -206,7 +206,7 @@ class PlatformTopologyController extends AbstractController
         if (true === $foundIllegalCharacters) {
             throw new PlatformTopologyException(
                 sprintf(
-                    _("At least one space or illegal character in '%s', was found on platform's name: '%s'"),
+                    _("At least one space or illegal character in '%s', was found in platform's name: '%s'"),
                     $engineConfiguration->getIllegalObjectNameCharacters(),
                     $stringToCheck
                 )

--- a/src/Centreon/Application/Controller/PlatformTopologyController.php
+++ b/src/Centreon/Application/Controller/PlatformTopologyController.php
@@ -187,6 +187,11 @@ class PlatformTopologyController extends AbstractController
     private function checkName(string $stringToCheck): void
     {
         $monitoringServerName = $this->platformTopologyService->findLocalhostMonitoringName();
+        if (null === $monitoringServerName) {
+            throw new PlatformTopologyException(
+                _('Unable to find local monitoring server name')
+            );
+        }
         $engineConfiguration = $this->engineConfigurationService->findEngineConfigurationByName(
             $monitoringServerName
         );

--- a/src/Centreon/Domain/Engine/EngineConfiguration.php
+++ b/src/Centreon/Domain/Engine/EngineConfiguration.php
@@ -131,4 +131,25 @@ class EngineConfiguration
         $illegalCharacters = html_entity_decode($illegalCharacters);
         return str_replace(str_split($illegalCharacters), '', $stringToAnalyse);
     }
+
+    /**
+     * Find all illegal characters from the given string.
+     *
+     * @param string $stringToAnalyse String for which we want to remove illegal characters
+     * @param string|null $illegalCharacters String containing illegal characters
+     * @return bool Return true if illegal characters have been found
+     */
+    public static function hasIllegalCharacters(string $stringToAnalyse, ?string $illegalCharacters): bool
+    {
+        if ($illegalCharacters === null) {
+            return false;
+        }
+        $illegalCharactersList = str_split(html_entity_decode($illegalCharacters),1);
+        foreach ($illegalCharactersList as $illegalCharacter) {
+            if (false !== strpos($stringToAnalyse, $illegalCharacter)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/src/Centreon/Domain/Engine/EngineConfiguration.php
+++ b/src/Centreon/Domain/Engine/EngineConfiguration.php
@@ -135,24 +135,15 @@ class EngineConfiguration
     /**
      * Find all illegal characters from the given string.
      *
-     * @param string $stringToAnalyse String for which we want to remove illegal characters
+     * @param string $stringToCheck String to analyse for non RFC compliant characters
      * @param string|null $illegalCharacters String containing illegal characters
      * @return bool Return true if illegal characters have been found
      */
-    public static function hasIllegalCharacters(string $stringToAnalyse, ?string $illegalCharacters): bool
+    public static function hasNonRfcCompliantCharacters(string $stringToCheck, ?string $illegalCharacters): bool
     {
-        if (null === $illegalCharacters) {
-            return false;
-        }
-        $illegalCharactersList = str_split(html_entity_decode($illegalCharacters), 1);
-        // Add space to the list as, space is not compliant with the RFC
-        $illegalCharactersList[] = ' ';
+        // Spaces are not RFC compliant
+        $illegalCharacters .= ' ';
 
-        foreach ($illegalCharactersList as $illegalCharacter) {
-            if (false !== strpos($stringToAnalyse, $illegalCharacter)) {
-                return true;
-            }
-        }
-        return false;
+        return (strlen($stringToCheck) !== strlen(self::removeIllegalCharacters($stringToCheck, $illegalCharacters)));
     }
 }

--- a/src/Centreon/Domain/Engine/EngineConfiguration.php
+++ b/src/Centreon/Domain/Engine/EngineConfiguration.php
@@ -141,10 +141,13 @@ class EngineConfiguration
      */
     public static function hasIllegalCharacters(string $stringToAnalyse, ?string $illegalCharacters): bool
     {
-        if ($illegalCharacters === null) {
+        if (null === $illegalCharacters) {
             return false;
         }
-        $illegalCharactersList = str_split(html_entity_decode($illegalCharacters),1);
+        $illegalCharactersList = str_split(html_entity_decode($illegalCharacters), 1);
+        // Add space to the list as, space is not compliant with the RFC
+        $illegalCharactersList[] = ' ';
+
         foreach ($illegalCharactersList as $illegalCharacter) {
             if (false !== strpos($stringToAnalyse, $illegalCharacter)) {
                 return true;

--- a/src/Centreon/Domain/Engine/EngineConfiguration.php
+++ b/src/Centreon/Domain/Engine/EngineConfiguration.php
@@ -144,6 +144,6 @@ class EngineConfiguration
         // Spaces are not RFC compliant
         $illegalCharacters .= ' ';
 
-        return (strlen($stringToCheck) !== strlen(self::removeIllegalCharacters($stringToCheck, $illegalCharacters)));
+        return $stringToCheck !== self::removeIllegalCharacters($stringToCheck, $illegalCharacters);
     }
 }

--- a/src/Centreon/Domain/Engine/EngineConfiguration.php
+++ b/src/Centreon/Domain/Engine/EngineConfiguration.php
@@ -131,19 +131,4 @@ class EngineConfiguration
         $illegalCharacters = html_entity_decode($illegalCharacters);
         return str_replace(str_split($illegalCharacters), '', $stringToAnalyse);
     }
-
-    /**
-     * Find all illegal characters from the given string.
-     *
-     * @param string $stringToCheck String to analyse for non RFC compliant characters
-     * @param string|null $illegalCharacters String containing illegal characters
-     * @return bool Return true if illegal characters have been found
-     */
-    public static function hasNonRfcCompliantCharacters(string $stringToCheck, ?string $illegalCharacters): bool
-    {
-        // Spaces are not RFC compliant
-        $illegalCharacters .= ' ';
-
-        return $stringToCheck !== self::removeIllegalCharacters($stringToCheck, $illegalCharacters);
-    }
 }

--- a/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+++ b/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
@@ -86,7 +86,7 @@ class HostConfigurationService implements HostConfigurationServiceInterface
                 $host->getMonitoringServer()->getName()
             );
             if ($engineConfiguration === null) {
-                throw new HostConfigurationException(_('Impossible to find the Engine configuration'));
+                throw new HostConfigurationException(_('Unable to find the Engine configuration'));
             }
 
             $safedHostName = EngineConfiguration::removeIllegalCharacters(

--- a/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRepositoryInterface.php
+++ b/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRepositoryInterface.php
@@ -75,10 +75,4 @@ interface PlatformTopologyRepositoryInterface
      * @throws \Exception
      */
     public function findMonitoringIdFromName(string $serverName, bool $isLocalhost): ?PlatformTopology;
-
-    /**
-     * @return string|null
-     * @throws PlatformTopologyException
-     */
-    public function findLocalhostMonitoringName(): ?string;
 }

--- a/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRepositoryInterface.php
+++ b/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRepositoryInterface.php
@@ -75,4 +75,10 @@ interface PlatformTopologyRepositoryInterface
      * @throws \Exception
      */
     public function findMonitoringIdFromName(string $serverName, bool $isLocalhost): ?PlatformTopology;
+
+    /**
+     * @return string|null
+     * @throws PlatformTopologyException
+     */
+    public function findLocalhostMonitoringName(): ?string;
 }

--- a/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRepositoryInterface.php
+++ b/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRepositoryInterface.php
@@ -70,9 +70,8 @@ interface PlatformTopologyRepositoryInterface
      * Search for platform's monitoring Id using its name
      *
      * @param string $serverName
-     * @param bool $isLocalhost
      * @return PlatformTopology|null
      * @throws \Exception
      */
-    public function findMonitoringIdFromName(string $serverName, bool $isLocalhost): ?PlatformTopology;
+    public function findMonitoringIdFromName(string $serverName): ?PlatformTopology;
 }

--- a/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRepositoryInterface.php
+++ b/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRepositoryInterface.php
@@ -67,7 +67,7 @@ interface PlatformTopologyRepositoryInterface
     public function findPlatformTopologyByType(string $serverType): ?PlatformTopology;
 
     /**
-     * Search for platform's monitoring Id using its name
+     * Search for local platform's monitoring Id using its name
      *
      * @param string $serverName
      * @return PlatformTopology|null

--- a/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRepositoryInterface.php
+++ b/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyRepositoryInterface.php
@@ -73,5 +73,5 @@ interface PlatformTopologyRepositoryInterface
      * @return PlatformTopology|null
      * @throws \Exception
      */
-    public function findMonitoringIdFromName(string $serverName): ?PlatformTopology;
+    public function findLocalMonitoringIdFromName(string $serverName): ?PlatformTopology;
 }

--- a/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyServiceInterface.php
+++ b/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyServiceInterface.php
@@ -22,7 +22,9 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\PlatformTopology\Interfaces;
 
+use Centreon\Domain\Engine\EngineException;
 use Centreon\Domain\Exception\EntityNotFoundException;
+use Centreon\Domain\MonitoringServer\MonitoringServerException;
 use Centreon\Domain\PlatformTopology\PlatformTopology;
 use Centreon\Domain\PlatformTopology\PlatformTopologyConflictException;
 use Centreon\Domain\PlatformTopology\PlatformTopologyException;
@@ -35,6 +37,8 @@ interface PlatformTopologyServiceInterface
      *
      * @param PlatformTopology $platformTopology
      * @throws PlatformTopologyConflictException
+     * @throws MonitoringServerException
+     * @throws EngineException
      * @throws PlatformTopologyException
      * @throws EntityNotFoundException
      * @throws PlatformInformationException

--- a/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyServiceInterface.php
+++ b/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyServiceInterface.php
@@ -40,10 +40,4 @@ interface PlatformTopologyServiceInterface
      * @throws PlatformInformationException
      */
     public function addPlatformToTopology(PlatformTopology $platformTopology): void;
-
-    /**
-     * @return string|null
-     * @throws PlatformTopologyException
-     */
-    public function findLocalhostMonitoringName(): ?string;
 }

--- a/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyServiceInterface.php
+++ b/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyServiceInterface.php
@@ -40,4 +40,10 @@ interface PlatformTopologyServiceInterface
      * @throws PlatformInformationException
      */
     public function addPlatformToTopology(PlatformTopology $platformTopology): void;
+
+    /**
+     * @return string|null
+     * @throws PlatformTopologyException
+     */
+    public function findLocalhostMonitoringName(): ?string;
 }

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopology.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopology.php
@@ -56,7 +56,7 @@ class PlatformTopology
     private $name;
 
     /**
-     * @var $hostname platform's real name : "physical name"
+     * @var string|null  platform's real name : "physical name"
      */
     private $hostname;
 

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopology.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopology.php
@@ -155,12 +155,6 @@ class PlatformTopology
      */
     public function setName(?string $name): self
     {
-        $name = filter_var($name, FILTER_SANITIZE_STRING);
-        if (empty($name)) {
-            throw new \InvalidArgumentException(
-                _('The name of the platform is not consistent')
-            );
-        }
         $this->name = $name;
         return $this;
     }

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopology.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopology.php
@@ -164,16 +164,16 @@ class PlatformTopology
      */
     public function getHostname(): ?string
     {
-        return $this->name;
+        return $this->hostname;
     }
 
     /**
-     * @param string|null $name
+     * @param string|null $hostname
      * @return $this
      */
-    public function setHostname(?string $name): self
+    public function setHostname(?string $hostname): self
     {
-        $this->name = $name;
+        $this->hostname = $hostname;
         return $this;
     }
 

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopology.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopology.php
@@ -51,9 +51,14 @@ class PlatformTopology
     private $id;
 
     /**
-     * @var string|null name
+     * @var string|null chosen name : "virtual name"
      */
     private $name;
+
+    /**
+     * @var $hostname platform's real name : "physical name"
+     */
+    private $hostname;
 
     /**
      * @var string|null Server type
@@ -156,6 +161,24 @@ class PlatformTopology
                 _('The name of the platform is not consistent')
             );
         }
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getHostname(): ?string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string|null $name
+     * @return $this
+     */
+    public function setHostname(?string $name): self
+    {
         $this->name = $name;
         return $this;
     }

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -109,7 +109,11 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
             $this->setMonitoringServerId($platformTopology, $isLocalhost);
         }
 
-        $this->checkForAlreadyRegisteredSameNameOrAddress($platformTopology);
+
+        if (PlatformTopology::TYPE_MBI !== $platformTopology->getType()) {
+            $this->checkForAlreadyRegisteredSameNameOrAddress($platformTopology);
+        }
+
         /**
          * @var PlatformTopology|null $registeredParentInTopology
          */

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -264,6 +264,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
                 $registerPayload = [
                     'json' => [
                         "name" => $platformTopology->getName(),
+                        "hostname" => $platformTopology->getHostname(),
                         "type" => $platformTopology->getType(),
                         "address" => $platformTopology->getAddress(),
                         "parent_address" => $platformTopology->getParentAddress()

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -496,7 +496,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
         try {
             $monitoringServerName = $this->platformTopologyRepository->findLocalhostMonitoringName();
         } catch (\Exception $ex) {
-            throw new PlatformTopologyException(_("Error when searching monitoring server name of the platform"));
+            throw new PlatformTopologyException(_("Error when searching monitoring server name"));
         }
         return $monitoringServerName;
     }

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -486,18 +486,4 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
         }
         return null;
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function findLocalhostMonitoringName(): ?string
-    {
-        $monitoringServerName = null;
-        try {
-            $monitoringServerName = $this->platformTopologyRepository->findLocalhostMonitoringName();
-        } catch (\Exception $ex) {
-            throw new PlatformTopologyException(_("Error when searching monitoring server name"));
-        }
-        return $monitoringServerName;
-    }
 }

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -22,6 +22,11 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\PlatformTopology;
 
+use Centreon\Domain\Engine\EngineConfiguration;
+use Centreon\Domain\Engine\EngineException;
+use Centreon\Domain\Engine\Interfaces\EngineConfigurationServiceInterface;
+use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerServiceInterface;
+use Centreon\Domain\MonitoringServer\MonitoringServerException;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyServiceInterface;
 use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyRepositoryInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -62,25 +67,41 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
     /**
      * @var ProxyServiceInterface
      */
-    private $proxy;
+    private $proxyService;
+
+    /**
+     * @var EngineConfigurationServiceInterface
+     */
+    private $engineConfigurationService;
+
+    /**
+     * @var MonitoringServerServiceInterface
+     */
+    private $monitoringServerService;
 
     /**
      * PlatformTopologyService constructor.
      * @param PlatformTopologyRepositoryInterface $platformTopologyRepository
      * @param HttpClientInterface $httpClient
      * @param PlatformInformationServiceInterface $platformInformationService
-     * @param ProxyServiceInterface $proxy
+     * @param ProxyServiceInterface $proxyService
+     * @param EngineConfigurationServiceInterface $engineConfigurationService
+     * @param MonitoringServerServiceInterface $monitoringServerService
      */
     public function __construct(
         PlatformTopologyRepositoryInterface $platformTopologyRepository,
         HttpClientInterface $httpClient,
         PlatformInformationServiceInterface $platformInformationService,
-        ProxyServiceInterface $proxy
+        ProxyServiceInterface $proxyService,
+        EngineConfigurationServiceInterface $engineConfigurationService,
+        MonitoringServerServiceInterface $monitoringServerService
     ) {
         $this->platformTopologyRepository = $platformTopologyRepository;
         $this->httpClient = $httpClient;
         $this->platformInformation = $platformInformationService;
-        $this->proxy = $proxy;
+        $this->proxyService = $proxyService;
+        $this->engineConfigurationService = $engineConfigurationService;
+        $this->monitoringServerService = $monitoringServerService;
     }
 
     /**
@@ -88,27 +109,27 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
      */
     public function addPlatformToTopology(PlatformTopology $platformTopology): void
     {
+        // check entity consistency
+        $this->checkEntityConsistency($platformTopology);
+
         /**
          * Search for already registered central or remote top level server on this platform
          * As only top level platform do not need parent_address and only one should be registered
          */
         if (PlatformTopology::TYPE_CENTRAL === $platformTopology->getType()) {
             // New unique Central top level platform case
-            $this->checkForAlreadyRegisteredPlatformType(PlatformTopology::TYPE_CENTRAL);
-            $this->checkForAlreadyRegisteredPlatformType(PlatformTopology::TYPE_REMOTE);
-            $this->setMonitoringServerId($platformTopology, true);
+            $this->searchAlreadyRegisteredTopLevelPlatformByType(PlatformTopology::TYPE_CENTRAL);
+            $this->searchAlreadyRegisteredTopLevelPlatformByType(PlatformTopology::TYPE_REMOTE);
+            $this->setMonitoringServerId($platformTopology);
         } elseif (PlatformTopology::TYPE_REMOTE === $platformTopology->getType()) {
             // Cannot add a Remote behind another Remote
-            $isLocalhost = false;
-            $this->checkForAlreadyRegisteredPlatformType(PlatformTopology::TYPE_REMOTE);
+            $this->searchAlreadyRegisteredTopLevelPlatformByType(PlatformTopology::TYPE_REMOTE);
             if (null === $platformTopology->getParentAddress()) {
                 // New unique Remote top level platform case
-                $this->checkForAlreadyRegisteredPlatformType(PlatformTopology::TYPE_CENTRAL);
-                $isLocalhost = true;
+                $this->searchAlreadyRegisteredTopLevelPlatformByType(PlatformTopology::TYPE_CENTRAL);
+                $this->setMonitoringServerId($platformTopology);
             }
-            $this->setMonitoringServerId($platformTopology, $isLocalhost);
         }
-
 
         if (PlatformTopology::TYPE_MBI !== $platformTopology->getType()) {
             $this->checkForAlreadyRegisteredSameNameOrAddress($platformTopology);
@@ -117,7 +138,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
         /**
          * @var PlatformTopology|null $registeredParentInTopology
          */
-        $registeredParentInTopology = $this->findParentPlatformAndSetId($platformTopology);
+        $registeredParentInTopology = $this->findParentPlatform($platformTopology);
 
         /**
          * The top level platform is defined as a Remote
@@ -202,9 +223,9 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
 
             /**
              * Getting platform's proxy data
-             * @var Proxy|null $proxy
+             * @var Proxy|null $proxyService
              */
-            $proxy = $this->proxy->getProxy();
+            $proxyService = $this->proxyService->getProxy();
 
             /**
              * Call the API on the n-1 server to register it too
@@ -219,8 +240,8 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
                 // Enable specific options
                 $optionPayload = [];
                 // Enable proxy
-                if (null !== $proxy && !empty((string) $proxy)) {
-                    $optionPayload['proxy'] = (string) $proxy;
+                if (null !== $proxyService && !empty((string) $proxyService)) {
+                    $optionPayload['proxy'] = (string) $proxyService;
                 }
                 // SSL verify_peer
                 if ($foundPlatformInformation->hasApiPeerValidation()) {
@@ -299,7 +320,8 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
                     $returnedMessage = json_decode($registerResponse->getContent(false), true);
 
                     if (!empty($returnedMessage)) {
-                        $errorMessage .= "  /  " . _("Central's response => Code : ") . implode(', ', $returnedMessage);
+                        $errorMessage .= "  /  " . _("Central's response => Code : ") .
+                            implode(', ', $returnedMessage);
                     }
                     throw new PlatformTopologyConflictException(
                         $errorMessage
@@ -354,13 +376,127 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
     }
 
     /**
+     * Get engine configuration's illegal characters and check for illegal characters in hostname
+     * @param string|null $stringToCheck
+     * @throws EngineException
+     * @throws PlatformTopologyException
+     * @throws MonitoringServerException
+     */
+    private function checkName(?string $stringToCheck): void
+    {
+        if (null === $stringToCheck) {
+            return;
+        }
+
+        $monitoringServerName = $this->monitoringServerService->findLocalServer();
+        if (null === $monitoringServerName || null === $monitoringServerName->getName()) {
+            throw new PlatformTopologyException(
+                _('Unable to find local monitoring server name')
+            );
+        }
+
+        $engineConfiguration = $this->engineConfigurationService->findEngineConfigurationByName(
+            $monitoringServerName->getName()
+        );
+        if (null === $engineConfiguration) {
+            throw new PlatformTopologyException(_('Unable to find the Engine configuration'));
+        }
+
+        $foundIllegalCharacters = $this->hasNonRfcCompliantCharacters(
+            $stringToCheck,
+            $engineConfiguration->getIllegalObjectNameCharacters()
+        );
+        if (true === $foundIllegalCharacters) {
+            throw new PlatformTopologyException(
+                sprintf(
+                    _("At least one space or illegal character in '%s' was found in platform's name: '%s'"),
+                    $engineConfiguration->getIllegalObjectNameCharacters(),
+                    $stringToCheck
+                )
+            );
+        }
+    }
+
+    /**
+     * Find all non RFC compliant characters from the given string.
+     *
+     * @param string $stringToCheck String to analyse
+     * @param string|null $illegalCharacters String containing illegal characters
+     * @return bool Return true if illegal characters have been found
+     */
+    private function hasNonRfcCompliantCharacters(string $stringToCheck, ?string $illegalCharacters): bool
+    {
+        // Spaces are not RFC compliant and $illegalCharacters will not contains it
+        $illegalCharacters .= ' ';
+
+        return $stringToCheck !== EngineConfiguration::removeIllegalCharacters($stringToCheck, $illegalCharacters);
+    }
+
+    /**
+     * @param PlatformTopology $platformTopology
+     * @throws EngineException
+     * @throws EntityNotFoundException
+     * @throws MonitoringServerException
+     * @throws PlatformTopologyConflictException
+     * @throws PlatformTopologyException
+     */
+    private function checkEntityConsistency(PlatformTopology $platformTopology): void
+    {
+        // Check non RFC compliant characters in name and hostname
+        if (null === $platformTopology->getName()) {
+            throw new EntityNotFoundException(_("Missing mandatory platform name"));
+        }
+        $this->checkName($platformTopology->getName());
+        $this->checkName($platformTopology->getHostname());
+
+        // Check empty platform's address
+        if (null === $platformTopology->getAddress()) {
+            throw new EntityNotFoundException(
+                sprintf(
+                    _("Missing mandatory platform address of: '%s'"),
+                    $platformTopology->getName()
+                )
+            );
+        }
+
+        // Check empty parent address vs type consistency
+        if (
+            null === $platformTopology->getParentAddress()
+            && !in_array(
+                $platformTopology->getType(),
+                [PlatformTopology::TYPE_CENTRAL, PlatformTopology::TYPE_REMOTE],
+                false
+            )
+        ) {
+            throw new EntityNotFoundException(
+                sprintf(
+                    _("Missing mandatory parent address, to link the platform : '%s'@'%s'"),
+                    $platformTopology->getName(),
+                    $platformTopology->getAddress()
+                )
+            );
+        }
+
+        // or Check for similar parent_address and address
+        if ($platformTopology->getParentAddress() === $platformTopology->getAddress()) {
+            throw new PlatformTopologyConflictException(
+                sprintf(
+                    _("Same address and parent_address for platform : '%s'@'%s'."),
+                    $platformTopology->getName(),
+                    $platformTopology->getAddress()
+                )
+            );
+        }
+    }
+
+    /**
      * Used when parent_address is null, to check if this type of platform is already registered
      *
      * @param string $type platform type to find
      * @throws PlatformTopologyConflictException
      * @throws \Exception
      */
-    private function checkForAlreadyRegisteredPlatformType(string $type): void
+    private function searchAlreadyRegisteredTopLevelPlatformByType(string $type): void
     {
         $foundAlreadyRegisteredPlatformByType = $this->platformTopologyRepository->findPlatformTopologyByType($type);
         if (null !== $foundAlreadyRegisteredPlatformByType) {
@@ -376,19 +512,20 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
     }
 
     /**
-     * Search for platforms nagios_server ID and set it as serverId
+     * Search for platforms monitoring ID and set it as serverId
      *
      * @param PlatformTopology $platformTopology
-     * @param bool $isLocalhost
      * @throws PlatformTopologyConflictException
      * @throws \Exception
      */
-    private function setMonitoringServerId(PlatformTopology $platformTopology, bool $isLocalhost): void
+    private function setMonitoringServerId(PlatformTopology $platformTopology): void
     {
-        $foundServerInNagiosTable = $this->platformTopologyRepository->findMonitoringIdFromName(
-            $platformTopology->getName(),
-            $isLocalhost
-        );
+        $foundServerInNagiosTable = null;
+        if (null !== $platformTopology->getName()) {
+            $foundServerInNagiosTable = $this->platformTopologyRepository->findMonitoringIdFromName(
+                $platformTopology->getName()
+            );
+        }
 
         if (null === $foundServerInNagiosTable) {
             throw new PlatformTopologyConflictException(
@@ -408,9 +545,23 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
      *
      * @param PlatformTopology $platformTopology
      * @throws PlatformTopologyConflictException
+     * @throws EntityNotFoundException
      */
     private function checkForAlreadyRegisteredSameNameOrAddress(PlatformTopology $platformTopology): void
     {
+        // Two next checks are required for phpStan lvl8. But already done in the checkEntityConsistency method
+        if (null === $platformTopology->getName()) {
+            throw new EntityNotFoundException(_("Missing mandatory platform name"));
+        }
+        if (null === $platformTopology->getAddress()) {
+            throw new EntityNotFoundException(
+                sprintf(
+                    _("Missing mandatory platform address of: '%s'"),
+                    $platformTopology->getName()
+                )
+            );
+        }
+
         $isAlreadyRegistered = $this->platformTopologyRepository->isPlatformAlreadyRegisteredInTopology(
             $platformTopology->getAddress(),
             $platformTopology->getName()
@@ -428,7 +579,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
     }
 
     /**
-     * Search for parent platform ID in topology
+     * Search for platform's parent ID in topology
      *
      * @param PlatformTopology $platformTopology
      * @return PlatformTopology|null
@@ -436,7 +587,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
      * @throws PlatformTopologyConflictException
      * @throws \Exception
      */
-    private function findParentPlatformAndSetId(PlatformTopology $platformTopology): ?PlatformTopology
+    private function findParentPlatform(PlatformTopology $platformTopology): ?PlatformTopology
     {
         if (null === $platformTopology->getParentAddress()) {
             return null;
@@ -455,7 +606,21 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
             );
         }
 
-        // Check parent consistency
+        // Avoid to link a remote to another remote
+        if (
+            PlatformTopology::TYPE_REMOTE === $platformTopology->getType()
+            && PlatformTopology::TYPE_REMOTE === $registeredParentInTopology->getType()
+        ) {
+            throw new PlatformTopologyConflictException(
+                sprintf(
+                    _("Unable to link a 'remote': '%s'@'%s' to another remote platform"),
+                    $registeredParentInTopology->getName(),
+                    $registeredParentInTopology->getAddress()
+                )
+            );
+        }
+
+        // Check parent consistency, as the platform can only be linked to a remote or central type
         if (
             !in_array(
                 $registeredParentInTopology->getType(),

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -358,6 +358,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
      *
      * @param string $type platform type to find
      * @throws PlatformTopologyConflictException
+     * @throws \Exception
      */
     private function checkForAlreadyRegisteredPlatformType(string $type): void
     {
@@ -433,6 +434,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
      * @return PlatformTopology|null
      * @throws EntityNotFoundException
      * @throws PlatformTopologyConflictException
+     * @throws \Exception
      */
     private function findParentPlatformAndSetId(PlatformTopology $platformTopology): ?PlatformTopology
     {
@@ -483,5 +485,19 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
             return $registeredParentInTopology;
         }
         return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findLocalhostMonitoringName(): ?string
+    {
+        $monitoringServerName = null;
+        try {
+            $monitoringServerName = $this->platformTopologyRepository->findLocalhostMonitoringName();
+        } catch (\Exception $ex) {
+            throw new PlatformTopologyException(_("Error when searching monitoring server name of the platform"));
+        }
+        return $monitoringServerName;
     }
 }

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -522,7 +522,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
     {
         $foundServerInNagiosTable = null;
         if (null !== $platformTopology->getName()) {
-            $foundServerInNagiosTable = $this->platformTopologyRepository->findMonitoringIdFromName(
+            $foundServerInNagiosTable = $this->platformTopologyRepository->findLocalMonitoringIdFromName(
                 $platformTopology->getName()
             );
         }

--- a/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+++ b/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
@@ -105,7 +105,7 @@ class ServiceConfigurationService extends AbstractCentreonService implements Ser
          */
         $engineConfiguration = $this->engineConfigurationService->findEngineConfigurationByHost($host);
         if ($engineConfiguration === null) {
-            throw new ServiceConfigurationException(_('Impossible to find the Engine configuration'));
+            throw new ServiceConfigurationException(_('Unable to find the Engine configuration'));
         }
 
         $hostTemplateIds = [];

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
@@ -51,8 +51,8 @@ class PlatformTopologyRepositoryRDB extends AbstractRepositoryDRB implements Pla
     {
         $statement = $this->db->prepare(
             $this->translateDbName('
-                INSERT INTO `:db`.platform_topology (`address`, `name`, `type`, `parent_id`, `server_id`)
-                VALUES (:address, :name, :type, :parentId, :serverId)
+                INSERT INTO `:db`.platform_topology (`address`, `name`, `type`, `parent_id`, `server_id`, `hostname`)
+                VALUES (:address, :name, :type, :parentId, :serverId, :hostname)
             ')
         );
         $statement->bindValue(':address', $platformTopology->getAddress(), \PDO::PARAM_STR);
@@ -60,6 +60,7 @@ class PlatformTopologyRepositoryRDB extends AbstractRepositoryDRB implements Pla
         $statement->bindValue(':type', $platformTopology->getType(), \PDO::PARAM_STR);
         $statement->bindValue(':parentId', $platformTopology->getParentId(), \PDO::PARAM_INT);
         $statement->bindValue(':serverId', $platformTopology->getServerId(), \PDO::PARAM_INT);
+        $statement->bindValue(':hostname', $platformTopology->getHostname(), \PDO::PARAM_INT);
         $statement->execute();
     }
 

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
@@ -172,4 +172,21 @@ class PlatformTopologyRepositoryRDB extends AbstractRepositoryDRB implements Pla
 
         return $platformTopology;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function findLocalhostMonitoringName(): ?string
+    {
+        $statement = $this->db->query(
+            $this->translateDbName('
+                SELECT `name`
+                FROM `:db`.nagios_server
+                WHERE `localhost` = \'1\' AND ns_activate = \'1\'
+            ')
+        );
+        $result = $statement->fetch(\PDO::FETCH_ASSOC);
+
+        return (!empty($result['name']) ? $result['name'] : null);
+    }
 }

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
@@ -119,9 +119,8 @@ class PlatformTopologyRepositoryRDB extends AbstractRepositoryDRB implements Pla
     {
         $statement = $this->db->prepare(
             $this->translateDbName('
-                SELECT `address`, `name`
-                FROM `:db`.platform_topology
-                WHERE `type` = :type
+                SELECT * FROM `:db`.platform_topology
+                WHERE `type` = :type AND `parent_id` IS NULL
             ')
         );
         $statement->bindValue(':type', $serverType, \PDO::PARAM_STR);
@@ -145,17 +144,16 @@ class PlatformTopologyRepositoryRDB extends AbstractRepositoryDRB implements Pla
     /**
      * @inheritDoc
      */
-    public function findMonitoringIdFromName(string $serverName, bool $localhost): ?PlatformTopology
+    public function findMonitoringIdFromName(string $serverName): ?PlatformTopology
     {
         $statement = $this->db->prepare(
             $this->translateDbName('
                 SELECT `id`
                 FROM `:db`.nagios_server
-                WHERE `localhost` = :state AND ns_activate = \'1\' AND `name` = :name
+                WHERE `localhost` = \'1\' AND ns_activate = \'1\' AND `name` = :name
             ')
         );
         $statement->bindValue(':name', $serverName, \PDO::PARAM_STR);
-        $statement->bindValue(':state', true === $localhost ? '1' : '0', \PDO::PARAM_STR);
         $statement->execute();
 
         $platformTopology = null;

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
@@ -178,15 +178,20 @@ class PlatformTopologyRepositoryRDB extends AbstractRepositoryDRB implements Pla
      */
     public function findLocalhostMonitoringName(): ?string
     {
-        $statement = $this->db->query(
+        $statement = $this->db->prepare(
             $this->translateDbName('
                 SELECT `name`
                 FROM `:db`.nagios_server
                 WHERE `localhost` = \'1\' AND ns_activate = \'1\'
             ')
         );
-        $result = $statement->fetch(\PDO::FETCH_ASSOC);
+        $statement->execute();
 
-        return (!empty($result['name']) ? $result['name'] : null);
+        $foundName = null;
+        if ($result = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $foundName = $result['name'] ?? null;
+        }
+
+        return $foundName;
     }
 }

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
@@ -144,7 +144,7 @@ class PlatformTopologyRepositoryRDB extends AbstractRepositoryDRB implements Pla
     /**
      * @inheritDoc
      */
-    public function findMonitoringIdFromName(string $serverName): ?PlatformTopology
+    public function findLocalMonitoringIdFromName(string $serverName): ?PlatformTopology
     {
         $statement = $this->db->prepare(
             $this->translateDbName('

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
@@ -172,26 +172,4 @@ class PlatformTopologyRepositoryRDB extends AbstractRepositoryDRB implements Pla
 
         return $platformTopology;
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function findLocalhostMonitoringName(): ?string
-    {
-        $statement = $this->db->prepare(
-            $this->translateDbName('
-                SELECT `name`
-                FROM `:db`.nagios_server
-                WHERE `localhost` = \'1\' AND ns_activate = \'1\'
-            ')
-        );
-        $statement->execute();
-
-        $foundName = null;
-        if ($result = $statement->fetch(\PDO::FETCH_ASSOC)) {
-            $foundName = $result['name'] ?? null;
-        }
-
-        return $foundName;
-    }
 }

--- a/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/PlatformTopology/PlatformTopologyRepositoryRDB.php
@@ -60,7 +60,7 @@ class PlatformTopologyRepositoryRDB extends AbstractRepositoryDRB implements Pla
         $statement->bindValue(':type', $platformTopology->getType(), \PDO::PARAM_STR);
         $statement->bindValue(':parentId', $platformTopology->getParentId(), \PDO::PARAM_INT);
         $statement->bindValue(':serverId', $platformTopology->getServerId(), \PDO::PARAM_INT);
-        $statement->bindValue(':hostname', $platformTopology->getHostname(), \PDO::PARAM_INT);
+        $statement->bindValue(':hostname', $platformTopology->getHostname(), \PDO::PARAM_STR);
         $statement->execute();
     }
 

--- a/tests/api/features/PlatformTopology.feature
+++ b/tests/api/features/PlatformTopology.feature
@@ -132,10 +132,8 @@ Feature:
             }
             """
         Then the response code should be "400"
-        And the response should be equal to:
-            """
-            {"message":"At least one space or illegal character in '~!$&*\"|'<>?,()=' was found in platform's name: 'illegal space found'"}
-            """
+        # Using the string '~!$&*"|'<>?,()=' in the returned message. We cannot test the response message.
+        # as it contains unescaped characters and behat interpret them, so the string are always different.
 
         # Register a platform using name with illegal characters / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:
@@ -148,10 +146,8 @@ Feature:
             }
             """
         Then the response code should be "400"
-        And the response should be equal to:
-            """
-            {"message":"At least one space or illegal character in '~!$&*\"|'<>?,()=' was found in platform's name: 'ill*ga|_character$_found'"}
-            """
+        # Using the string '~!$&*"|'<>?,()=' in the returned message. We cannot test the response message.
+        # as it contains unescaped characters and behat interpret them, so the string are always different.
 
         # Register a platform using hostname with at least one space / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:
@@ -165,10 +161,8 @@ Feature:
             }
             """
         Then the response code should be "400"
-        And the response should be equal to:
-            """
-            {"message":"At least one space or illegal character in '~!$&*\"|'<>?,()=' was found in platform's name: 'found.space_in.host name.wrong'"}
-            """
+        # Using the string '~!$&*"|'<>?,()=' in the returned message. We cannot test the response message.
+        # as it contains unescaped characters and behat interpret them, so the string are always different.
 
         # Register a platform using hostname with illegal characters / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:
@@ -182,10 +176,8 @@ Feature:
             }
             """
         Then the response code should be "400"
-        And the response should be equal to:
-            """
-            {"message":"At least one space or illegal character in '~!$&*\"|'<>?,()=' was found in platform's name: 'found.i|legal.char*cter_!n.hostname'"}
-            """
+        # Using the string '~!$&*"|'<>?,()=' in the returned message. We cannot test the response message.
+        # as it contains unescaped characters and behat interpret them, so the string are always different.
 
         # Register a platform using inconsistent parent_address / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:

--- a/tests/api/features/PlatformTopology.feature
+++ b/tests/api/features/PlatformTopology.feature
@@ -134,7 +134,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found on platform's name: 'illegal space found'"}
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found in platform's name: 'illegal space found'"}
             """
 
         # Register a platform using name with illegal characters / Should fail and an error should be returned
@@ -150,7 +150,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found on platform's name: 'ill*ga|_character$_found'"}
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found in platform's name: 'ill*ga|_character$_found'"}
             """
 
         # Register a platform using hostname with at least one space / Should fail and an error should be returned
@@ -167,7 +167,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found on platform's name: 'found.space_in.host name.wrong'"}
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found in platform's name: 'found.space_in.host name.wrong'"}
             """
 
         # Register a platform using hostname with illegal characters / Should fail and an error should be returned
@@ -184,7 +184,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found on platform's name: 'found.i|legal.char*cter_!n.hostname'"}
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found in platform's name: 'found.i|legal.char*cter_!n.hostname'"}
             """
 
         # Register a platform using inconsistent parent_address / Should fail and an error should be returned

--- a/tests/api/features/PlatformTopology.feature
+++ b/tests/api/features/PlatformTopology.feature
@@ -134,7 +134,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found in platform's name: 'illegal space found'"}
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=' was found in platform's name: 'illegal space found'"}
             """
 
         # Register a platform using name with illegal characters / Should fail and an error should be returned
@@ -150,7 +150,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found in platform's name: 'ill*ga|_character$_found'"}
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=' was found in platform's name: 'ill*ga|_character$_found'"}
             """
 
         # Register a platform using hostname with at least one space / Should fail and an error should be returned
@@ -167,7 +167,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found in platform's name: 'found.space_in.host name.wrong'"}
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=' was found in platform's name: 'found.space_in.host name.wrong'"}
             """
 
         # Register a platform using hostname with illegal characters / Should fail and an error should be returned
@@ -184,7 +184,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found in platform's name: 'found.i|legal.char*cter_!n.hostname'"}
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=' was found in platform's name: 'found.i|legal.char*cter_!n.hostname'"}
             """
 
         # Register a platform using inconsistent parent_address / Should fail and an error should be returned

--- a/tests/api/features/PlatformTopology.feature
+++ b/tests/api/features/PlatformTopology.feature
@@ -58,7 +58,7 @@ Feature:
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "Central2",
+                "name": "Central_2",
                 "type": "central",
                 "address": "1.1.1.11",
                 "hostname": "server.test.localhost.localdomain"
@@ -183,7 +183,7 @@ Feature:
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "inconsistent parent address",
+                "name": "inconsistent_parent_address",
                 "type": "poller",
                 "address": "6.6.6.1",
                 "parent_address": "666.",
@@ -193,14 +193,14 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"The address '666.' of 'inconsistent parent address' is not valid or not resolvable"}
+            {"message":"The address '666.' of 'inconsistent_parent_address' is not valid or not resolvable"}
             """
 
         # Register a poller linked to the Central.
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "my poller",
+                "name": "my_poller",
                 "type": "poller",
                 "address": "1.1.1.1",
                 "parent_address": "1.1.1.10",
@@ -213,7 +213,7 @@ Feature:
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "my poller",
+                "name": "my_poller",
                 "type": "poller",
                 "address": "1.1.1.1",
                 "parent_address": "1.1.1.10"
@@ -222,14 +222,14 @@ Feature:
         Then the response code should be "409"
         And the response should be equal to:
             """
-            {"message":"A platform using the name : 'my poller' or address : '1.1.1.1' already exists"}
+            {"message":"A platform using the name : 'my_poller' or address : '1.1.1.1' already exists"}
             """
 
         # Register a poller using type not formatted as expected / Should be successful
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "my poller 2",
+                "name": "my_poller_2",
                 "type": "pOlLEr",
                 "address": "1.1.1.2",
                 "parent_address": "1.1.1.10",
@@ -242,7 +242,7 @@ Feature:
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "my poller 3",
+                "name": "my_poller_3",
                 "type": "poller",
                 "address": "1.1.1.3",
                 "parent_address": "6.6.6.6",
@@ -252,14 +252,14 @@ Feature:
         Then the response code should be "404"
         And the response should be equal to:
             """
-            {"message":"No parent platform was found for : 'my poller 3'@'1.1.1.3'"}
+            {"message":"No parent platform was found for : 'my_poller_3'@'1.1.1.3'"}
             """
 
         # Register a poller with no parent address / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "my poller 4",
+                "name": "my_poller_4",
                 "type": "poller",
                 "address": "1.1.1.4"
             }
@@ -267,14 +267,14 @@ Feature:
         Then the response code should be "404"
         And the response should be equal to:
             """
-            {"message":"Missing mandatory parent address, to link the platform : 'my poller 4'@'1.1.1.4'"}
+            {"message":"Missing mandatory parent address, to link the platform : 'my_poller_4'@'1.1.1.4'"}
             """
 
         # Register a poller using same address and parent address / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "my poller 4",
+                "name": "my_poller_4",
                 "type": "poller",
                 "address": "1.1.1.4",
                 "parent_address": "1.1.1.4"
@@ -283,14 +283,14 @@ Feature:
         Then the response code should be "409"
         And the response should be equal to:
             """
-            {"message":"Same address and parent_address for platform : 'my poller 4'@'1.1.1.4'."}
+            {"message":"Same address and parent_address for platform : 'my_poller_4'@'1.1.1.4'."}
             """
 
         # Register a platform behind wrong parent type / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "inconsistent parent type",
+                "name": "inconsistent_parent_type",
                 "type": "poller",
                 "address": "6.6.6.1",
                 "parent_address": "1.1.1.2"
@@ -299,5 +299,5 @@ Feature:
         Then the response code should be "409"
         And the response should be equal to:
             """
-            {"message":"Cannot register the 'poller' platform : 'inconsistent parent type'@'6.6.6.1' behind a 'poller' platform"}
+            {"message":"Cannot register the 'poller' platform : 'inconsistent_parent_type'@'6.6.6.1' behind a 'poller' platform"}
             """

--- a/tests/api/features/PlatformTopology.feature
+++ b/tests/api/features/PlatformTopology.feature
@@ -134,7 +134,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=' was found in platform's name: 'illegal space found'"}
+            {"message":"At least one space or illegal character in '~!$&*\"|'<>?,()=' was found in platform's name: 'illegal space found'"}
             """
 
         # Register a platform using name with illegal characters / Should fail and an error should be returned
@@ -150,7 +150,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=' was found in platform's name: 'ill*ga|_character$_found'"}
+            {"message":"At least one space or illegal character in '~!$&*\"|'<>?,()=' was found in platform's name: 'ill*ga|_character$_found'"}
             """
 
         # Register a platform using hostname with at least one space / Should fail and an error should be returned
@@ -167,7 +167,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=' was found in platform's name: 'found.space_in.host name.wrong'"}
+            {"message":"At least one space or illegal character in '~!$&*\"|'<>?,()=' was found in platform's name: 'found.space_in.host name.wrong'"}
             """
 
         # Register a platform using hostname with illegal characters / Should fail and an error should be returned
@@ -184,7 +184,7 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=' was found in platform's name: 'found.i|legal.char*cter_!n.hostname'"}
+            {"message":"At least one space or illegal character in '~!$&*\"|'<>?,()=' was found in platform's name: 'found.i|legal.char*cter_!n.hostname'"}
             """
 
         # Register a platform using inconsistent parent_address / Should fail and an error should be returned

--- a/tests/api/features/PlatformTopology.feature
+++ b/tests/api/features/PlatformTopology.feature
@@ -132,8 +132,8 @@ Feature:
             }
             """
         Then the response code should be "400"
-        # Using the string '~!$&*"|'<>?,()=' in the returned message. We cannot test the response message.
-        # as it contains unescaped characters and behat interpret them, so the string are always different.
+        # Using the string '~!$%^&*\"|'<>?,()=' in the returned message. We cannot test the response message.
+        # as it contains unescaped characters and behat interpret them, so the strings are always different.
 
         # Register a platform using name with illegal characters / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:
@@ -146,8 +146,8 @@ Feature:
             }
             """
         Then the response code should be "400"
-        # Using the string '~!$&*"|'<>?,()=' in the returned message. We cannot test the response message.
-        # as it contains unescaped characters and behat interpret them, so the string are always different.
+        # Using the string '~!$%^&*\"|'<>?,()=' in the returned message. We cannot test the response message.
+        # as it contains unescaped characters and behat interpret them, so the strings are always different.
 
         # Register a platform using hostname with at least one space / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:
@@ -161,8 +161,8 @@ Feature:
             }
             """
         Then the response code should be "400"
-        # Using the string '~!$&*"|'<>?,()=' in the returned message. We cannot test the response message.
-        # as it contains unescaped characters and behat interpret them, so the string are always different.
+        # Using the string '~!$%^&*\"|'<>?,()=' in the returned message. We cannot test the response message.
+        # as it contains unescaped characters and behat interpret them, so the strings are always different.
 
         # Register a platform using hostname with illegal characters / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:
@@ -176,8 +176,8 @@ Feature:
             }
             """
         Then the response code should be "400"
-        # Using the string '~!$&*"|'<>?,()=' in the returned message. We cannot test the response message.
-        # as it contains unescaped characters and behat interpret them, so the string are always different.
+        # Using the string '~!$%^&*\"|'<>?,()=' in the returned message. We cannot test the response message.
+        # as it contains unescaped characters and behat interpret them, so the strings are always different.
 
         # Register a platform using inconsistent parent_address / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:

--- a/tests/api/features/PlatformTopology.feature
+++ b/tests/api/features/PlatformTopology.feature
@@ -33,7 +33,8 @@ Feature:
             {
                 "name": "Central",
                 "type": "central",
-                "address": "1.1.1.10"
+                "address": "1.1.1.10",
+                "hostname": "central.test.localhost.localdomain"
             }
             """
         Then the response code should be "201"
@@ -59,7 +60,8 @@ Feature:
             {
                 "name": "Central2",
                 "type": "central",
-                "address": "1.1.1.11"
+                "address": "1.1.1.11",
+                "hostname": "server.test.localhost.localdomain"
             }
             """
         Then the response code should be "409"
@@ -73,7 +75,7 @@ Feature:
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "Central 2",
+                "name": "Central_2",
                 "type": "central",
                 "address": "1.1.1.11",
                 "parent_address": "1.1.1.10"
@@ -90,23 +92,24 @@ Feature:
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "wrong type server",
+                "name": "wrong_type_server",
                 "type": "server",
                 "address": "6.6.6.1",
-                "parent_address": "1.1.1.10"
+                "parent_address": "1.1.1.10",
+                "hostname": "server.test.localhost.localdomain"
             }
             """
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"The platform type of 'wrong type server'@'6.6.6.1' is not consistent"}
+            {"message":"The platform type of 'wrong_type_server'@'6.6.6.1' is not consistent"}
             """
 
         # Register a platform using inconsistent address / Should fail and an error should be returned
         When I send a POST request to '/beta/platform/topology' with body:
             """
             {
-                "name": "inconsistent address",
+                "name": "inconsistent_address",
                 "type": "poller",
                 "address": "666.",
                 "parent_address": "1.1.1.10"
@@ -115,7 +118,73 @@ Feature:
         Then the response code should be "400"
         And the response should be equal to:
             """
-            {"message":"The address '666.' of 'inconsistent address' is not valid or not resolvable"}
+            {"message":"The address '666.' of 'inconsistent_address' is not valid or not resolvable"}
+            """
+
+        # Register a platform using name with at least one space / Should fail and an error should be returned
+        When I send a POST request to '/beta/platform/topology' with body:
+            """
+            {
+                "name": "illegal space found",
+                "type": "poller",
+                "address": "666.",
+                "parent_address": "1.1.1.10"
+            }
+            """
+        Then the response code should be "400"
+        And the response should be equal to:
+            """
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found on platform's name: 'illegal space found'"}
+            """
+
+        # Register a platform using name with illegal characters / Should fail and an error should be returned
+        When I send a POST request to '/beta/platform/topology' with body:
+            """
+            {
+                "name": "ill*ga|_character$_found",
+                "type": "poller",
+                "address": "666.",
+                "parent_address": "1.1.1.10"
+            }
+            """
+        Then the response code should be "400"
+        And the response should be equal to:
+            """
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found on platform's name: 'ill*ga|_character$_found'"}
+            """
+
+        # Register a platform using hostname with at least one space / Should fail and an error should be returned
+        When I send a POST request to '/beta/platform/topology' with body:
+            """
+            {
+                "name": "space_in_hostname",
+                "type": "poller",
+                "address": "666.",
+                "parent_address": "1.1.1.10",
+                "hostname": "found.space_in.host name.wrong"
+            }
+            """
+        Then the response code should be "400"
+        And the response should be equal to:
+            """
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found on platform's name: 'found.space_in.host name.wrong'"}
+            """
+
+        # Register a platform using hostname with illegal characters / Should fail and an error should be returned
+        When I send a POST request to '/beta/platform/topology' with body:
+            """
+            {
+                "name": "illegal_character_in_hostname",
+                "type": "poller",
+                "address": "666.",
+                "parent_address": "1.1.1.10",
+                "hostname": "found.i|legal.char*cter_!n.hostname"
+            }
+            """
+        Then the response code should be "400"
+        And the response should be equal to:
+            """
+            {"message":"At least one space or illegal character in '~!$%^&*\"|'<>?,()=', was found on platform's name: 'found.i|legal.char*cter_!n.hostname'"}
             """
 
         # Register a platform using inconsistent parent_address / Should fail and an error should be returned
@@ -125,7 +194,8 @@ Feature:
                 "name": "inconsistent parent address",
                 "type": "poller",
                 "address": "6.6.6.1",
-                "parent_address": "666."
+                "parent_address": "666.",
+                "hostname": "poller.test.localhost.localdomain"
             }
             """
         Then the response code should be "400"
@@ -141,7 +211,8 @@ Feature:
                 "name": "my poller",
                 "type": "poller",
                 "address": "1.1.1.1",
-                "parent_address": "1.1.1.10"
+                "parent_address": "1.1.1.10",
+                "hostname": "poller.test.localhost.localdomain"
             }
             """
         Then the response code should be "201"
@@ -169,7 +240,8 @@ Feature:
                 "name": "my poller 2",
                 "type": "pOlLEr",
                 "address": "1.1.1.2",
-                "parent_address": "1.1.1.10"
+                "parent_address": "1.1.1.10",
+                "hostname": "poller2.test.localhost.localdomain"
             }
             """
         Then the response code should be "201"
@@ -181,7 +253,8 @@ Feature:
                 "name": "my poller 3",
                 "type": "poller",
                 "address": "1.1.1.3",
-                "parent_address": "6.6.6.6"
+                "parent_address": "6.6.6.6",
+                "hostname": "poller.test.localhost.localdomain"
             }
             """
         Then the response code should be "404"

--- a/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
+++ b/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
@@ -75,7 +75,7 @@ class PlatformTopologyControllerTest extends TestCase
     /**
      * @var MonitoringServer;
      */
-    protected  $monitoringServer;
+    protected $monitoringServer;
 
     protected $container;
 

--- a/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
+++ b/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
@@ -57,26 +57,6 @@ class PlatformTopologyControllerTest extends TestCase
      */
     protected $platformTopologyService;
 
-    /**
-     * @var EngineConfiguration|null $engineConfiguration
-     */
-    protected $engineConfiguration;
-
-    /**
-     * @var EngineConfigurationServiceInterface&MockObject $engineConfigurationService
-     */
-    protected $engineConfigurationService;
-
-    /**
-     * @var MonitoringServerServiceInterface&MockObject $monitoringServerService
-     */
-    protected $monitoringServerService;
-
-    /**
-     * @var MonitoringServer;
-     */
-    protected $monitoringServer;
-
     protected $container;
 
     protected $request;
@@ -100,23 +80,11 @@ class PlatformTopologyControllerTest extends TestCase
             ->setType($goodJsonPlatformTopology['type'])
             ->setParentAddress($goodJsonPlatformTopology['parent_address']);
 
-        $this->engineConfiguration = (new EngineConfiguration())
-            ->setId(1)
-            ->setIllegalObjectNameCharacters('$!?')
-            ->setMonitoringServerId(1)
-            ->setName('Central');
-
-        $this->monitoringServer = (new MonitoringServer())
-            ->setId(1)
-            ->setName('Central');
-
         $this->badJsonPlatformTopology = json_encode([
             'unknown_property' => 'unknown',
         ]);
 
         $this->platformTopologyService = $this->createMock(PlatformTopologyServiceInterface::class);
-        $this->engineConfigurationService = $this->createMock(EngineConfigurationServiceInterface::class);
-        $this->monitoringServerService = $this->createMock(MonitoringServerServiceInterface::class);
 
         $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
         $authorizationChecker->expects($this->once())
@@ -141,7 +109,7 @@ class PlatformTopologyControllerTest extends TestCase
             ->willReturnOnConsecutiveCalls(
                 $authorizationChecker,
                 new class () {
-                    public function get()
+                    public function get(): string
                     {
                         return __DIR__ . '/../../../../../';
                     }
@@ -154,13 +122,9 @@ class PlatformTopologyControllerTest extends TestCase
     /**
      * test addPlatformToTopology with bad json format
      */
-    public function testAddPlatformToTopologyBadJsonFormat()
+    public function testAddPlatformToTopologyBadJsonFormat(): void
     {
-        $platformTopologyController = new PlatformTopologyController(
-            $this->platformTopologyService,
-            $this->engineConfigurationService,
-            $this->monitoringServerService
-        );
+        $platformTopologyController = new PlatformTopologyController($this->platformTopologyService);
         $platformTopologyController->setContainer($this->container);
 
         $this->request->expects($this->once())
@@ -174,8 +138,9 @@ class PlatformTopologyControllerTest extends TestCase
 
     /**
      * test addPlatformToTopology with conflict
+     * @throws PlatformTopologyException
      */
-    public function testAddPlatformToTopologyConflict()
+    public function testAddPlatformToTopologyConflict(): void
     {
         $this->request->expects($this->any())
             ->method('getContent')
@@ -185,19 +150,7 @@ class PlatformTopologyControllerTest extends TestCase
             ->method('addPlatformToTopology')
             ->will($this->throwException(new PlatformTopologyConflictException('conflict')));
 
-        $this->monitoringServerService->expects($this->exactly(2))
-            ->method('findLocalServer')
-            ->willReturn($this->monitoringServer);
-
-        $this->engineConfigurationService->expects($this->exactly(2))
-            ->method('findEngineConfigurationByName')
-            ->willReturn($this->engineConfiguration);
-
-        $platformTopologyController = new PlatformTopologyController(
-            $this->platformTopologyService,
-            $this->engineConfigurationService,
-            $this->monitoringServerService
-        );
+        $platformTopologyController = new PlatformTopologyController($this->platformTopologyService);
         $platformTopologyController->setContainer($this->container);
 
         $view = $platformTopologyController->addPlatformToTopology($this->request);
@@ -209,8 +162,9 @@ class PlatformTopologyControllerTest extends TestCase
 
     /**
      * test addPlatformToTopology with bad request
+     * @throws PlatformTopologyException
      */
-    public function testAddPlatformToTopologyBadRequest()
+    public function testAddPlatformToTopologyBadRequest(): void
     {
         $this->request->expects($this->any())
             ->method('getContent')
@@ -220,19 +174,7 @@ class PlatformTopologyControllerTest extends TestCase
             ->method('addPlatformToTopology')
             ->will($this->throwException(new PlatformTopologyException('bad request')));
 
-        $this->monitoringServerService->expects($this->exactly(2))
-            ->method('findLocalServer')
-            ->willReturn($this->monitoringServer);
-
-        $this->engineConfigurationService->expects($this->exactly(2))
-            ->method('findEngineConfigurationByName')
-            ->willReturn($this->engineConfiguration);
-
-        $platformTopologyController = new PlatformTopologyController(
-            $this->platformTopologyService,
-            $this->engineConfigurationService,
-            $this->monitoringServerService
-        );
+        $platformTopologyController = new PlatformTopologyController($this->platformTopologyService);
         $platformTopologyController->setContainer($this->container);
 
         $view = $platformTopologyController->addPlatformToTopology($this->request);
@@ -244,8 +186,9 @@ class PlatformTopologyControllerTest extends TestCase
 
     /**
      * test addPlatformToTopology which succeed
+     * @throws PlatformTopologyException
      */
-    public function testAddPlatformToTopologySuccess()
+    public function testAddPlatformToTopologySuccess(): void
     {
         $this->request->expects($this->any())
             ->method('getContent')
@@ -255,19 +198,7 @@ class PlatformTopologyControllerTest extends TestCase
             ->method('addPlatformToTopology')
             ->willReturn(null);
 
-        $this->monitoringServerService->expects($this->exactly(2))
-            ->method('findLocalServer')
-            ->willReturn($this->monitoringServer);
-
-        $this->engineConfigurationService->expects($this->exactly(2))
-            ->method('findEngineConfigurationByName')
-            ->willReturn($this->engineConfiguration);
-
-        $platformTopologyController = new PlatformTopologyController(
-            $this->platformTopologyService,
-            $this->engineConfigurationService,
-            $this->monitoringServerService
-        );
+        $platformTopologyController = new PlatformTopologyController($this->platformTopologyService);
         $platformTopologyController->setContainer($this->container);
 
         $view = $platformTopologyController->addPlatformToTopology($this->request);

--- a/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
+++ b/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
@@ -24,6 +24,9 @@ namespace Tests\Centreon\Application\Controller;
 use Centreon\Application\Controller\PlatformTopologyController;
 use Centreon\Domain\Engine\EngineConfiguration;
 use Centreon\Domain\Engine\Interfaces\EngineConfigurationServiceInterface;
+use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerServiceInterface;
+use Centreon\Domain\MonitoringServer\MonitoringServer;
+use Centreon\Domain\MonitoringServer\MonitoringServerService;
 use Centreon\Domain\PlatformTopology\PlatformTopology;
 use Centreon\Domain\PlatformTopology\PlatformTopologyException;
 use Centreon\Domain\PlatformTopology\PlatformTopologyConflictException;
@@ -64,6 +67,16 @@ class PlatformTopologyControllerTest extends TestCase
      */
     protected $engineConfigurationService;
 
+    /**
+     * @var MonitoringServerServiceInterface&MockObject $monitoringServerService
+     */
+    protected $monitoringServerService;
+
+    /**
+     * @var MonitoringServer;
+     */
+    protected  $monitoringServer;
+
     protected $container;
 
     protected $request;
@@ -93,12 +106,17 @@ class PlatformTopologyControllerTest extends TestCase
             ->setMonitoringServerId(1)
             ->setName('Central');
 
+        $this->monitoringServer = (new MonitoringServer())
+            ->setId(1)
+            ->setName('Central');
+
         $this->badJsonPlatformTopology = json_encode([
             'unknown_property' => 'unknown',
         ]);
 
         $this->platformTopologyService = $this->createMock(PlatformTopologyServiceInterface::class);
         $this->engineConfigurationService = $this->createMock(EngineConfigurationServiceInterface::class);
+        $this->monitoringServerService = $this->createMock(MonitoringServerServiceInterface::class);
 
         $authorizationChecker = $this->createMock(AuthorizationCheckerInterface::class);
         $authorizationChecker->expects($this->once())
@@ -140,7 +158,8 @@ class PlatformTopologyControllerTest extends TestCase
     {
         $platformTopologyController = new PlatformTopologyController(
             $this->platformTopologyService,
-            $this->engineConfigurationService
+            $this->engineConfigurationService,
+            $this->monitoringServerService
         );
         $platformTopologyController->setContainer($this->container);
 
@@ -166,9 +185,9 @@ class PlatformTopologyControllerTest extends TestCase
             ->method('addPlatformToTopology')
             ->will($this->throwException(new PlatformTopologyConflictException('conflict')));
 
-        $this->platformTopologyService->expects($this->exactly(2))
-            ->method('findLocalhostMonitoringName')
-            ->willReturn('Central');
+        $this->monitoringServerService->expects($this->exactly(2))
+            ->method('findLocalServer')
+            ->willReturn($this->monitoringServer);
 
         $this->engineConfigurationService->expects($this->exactly(2))
             ->method('findEngineConfigurationByName')
@@ -176,7 +195,8 @@ class PlatformTopologyControllerTest extends TestCase
 
         $platformTopologyController = new PlatformTopologyController(
             $this->platformTopologyService,
-            $this->engineConfigurationService
+            $this->engineConfigurationService,
+            $this->monitoringServerService
         );
         $platformTopologyController->setContainer($this->container);
 
@@ -200,9 +220,9 @@ class PlatformTopologyControllerTest extends TestCase
             ->method('addPlatformToTopology')
             ->will($this->throwException(new PlatformTopologyException('bad request')));
 
-        $this->platformTopologyService->expects($this->exactly(2))
-            ->method('findLocalhostMonitoringName')
-            ->willReturn('Central');
+        $this->monitoringServerService->expects($this->exactly(2))
+            ->method('findLocalServer')
+            ->willReturn($this->monitoringServer);
 
         $this->engineConfigurationService->expects($this->exactly(2))
             ->method('findEngineConfigurationByName')
@@ -210,7 +230,8 @@ class PlatformTopologyControllerTest extends TestCase
 
         $platformTopologyController = new PlatformTopologyController(
             $this->platformTopologyService,
-            $this->engineConfigurationService
+            $this->engineConfigurationService,
+            $this->monitoringServerService
         );
         $platformTopologyController->setContainer($this->container);
 
@@ -234,9 +255,9 @@ class PlatformTopologyControllerTest extends TestCase
             ->method('addPlatformToTopology')
             ->willReturn(null);
 
-        $this->platformTopologyService->expects($this->exactly(2))
-            ->method('findLocalhostMonitoringName')
-            ->willReturn('Central');
+        $this->monitoringServerService->expects($this->exactly(2))
+            ->method('findLocalServer')
+            ->willReturn($this->monitoringServer);
 
         $this->engineConfigurationService->expects($this->exactly(2))
             ->method('findEngineConfigurationByName')
@@ -244,7 +265,8 @@ class PlatformTopologyControllerTest extends TestCase
 
         $platformTopologyController = new PlatformTopologyController(
             $this->platformTopologyService,
-            $this->engineConfigurationService
+            $this->engineConfigurationService,
+            $this->monitoringServerService
         );
         $platformTopologyController->setContainer($this->container);
 

--- a/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
+++ b/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
@@ -166,6 +166,14 @@ class PlatformTopologyControllerTest extends TestCase
             ->method('addPlatformToTopology')
             ->will($this->throwException(new PlatformTopologyConflictException('conflict')));
 
+        $this->platformTopologyService->expects($this->exactly(2))
+            ->method('findLocalhostMonitoringName')
+            ->willReturn('Central');
+
+        $this->engineConfigurationService->expects($this->exactly(2))
+            ->method('findEngineConfigurationByName')
+            ->willReturn($this->engineConfiguration);
+
         $platformTopologyController = new PlatformTopologyController(
             $this->platformTopologyService,
             $this->engineConfigurationService
@@ -192,6 +200,14 @@ class PlatformTopologyControllerTest extends TestCase
             ->method('addPlatformToTopology')
             ->will($this->throwException(new PlatformTopologyException('bad request')));
 
+        $this->platformTopologyService->expects($this->exactly(2))
+            ->method('findLocalhostMonitoringName')
+            ->willReturn('Central');
+
+        $this->engineConfigurationService->expects($this->exactly(2))
+            ->method('findEngineConfigurationByName')
+            ->willReturn($this->engineConfiguration);
+
         $platformTopologyController = new PlatformTopologyController(
             $this->platformTopologyService,
             $this->engineConfigurationService
@@ -217,6 +233,14 @@ class PlatformTopologyControllerTest extends TestCase
         $this->platformTopologyService->expects($this->any())
             ->method('addPlatformToTopology')
             ->willReturn(null);
+
+        $this->platformTopologyService->expects($this->exactly(2))
+            ->method('findLocalhostMonitoringName')
+            ->willReturn('Central');
+
+        $this->engineConfigurationService->expects($this->exactly(2))
+            ->method('findEngineConfigurationByName')
+            ->willReturn($this->engineConfiguration);
 
         $platformTopologyController = new PlatformTopologyController(
             $this->platformTopologyService,


### PR DESCRIPTION
## Description

Manage the hostname in the payload

The refacto and issue fix have been backported from : 
fix(API): fix register a remote on a central and refacto service (#9091)

**Fixes** # (MON-6093)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

