### PR TITLE
fix(resource-status): Avoid double details refresh and prevents auto refresh from loading the wrong details

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1231,7 +1231,7 @@
       "dev": true
     },
     "@centreon/ui": {
-      "version": "github:centreon/centreon-ui#828536ac665e1f3a4be7c975797fff55619bd431",
+      "version": "github:centreon/centreon-ui#34030380a81f904cbc589612c196897a4d6083db",
       "from": "github:centreon/centreon-ui",
       "requires": {
         "@material-ui/core": "^4.11.0",
@@ -1558,46 +1558,46 @@
       }
     },
     "@jest/globals": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.4.2.tgz",
-      "integrity": "sha512-Ot5ouAlehhHLRhc+sDz2/9bmNv9p5ZWZ9LE1pXGGTCXBasmi5jnYjlgYcYt03FBwLmZXCZ7GrL29c33/XRQiow==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-26.5.2.tgz",
+      "integrity": "sha512-9PmnFsAUJxpPt1s/stq02acS1YHliVBDNfAWMe1bwdRr1iTCfhbNt3ERQXrO/ZfZSweftoA26Q/2yhSVSWQ3sw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^26.3.0",
-        "@jest/types": "^26.3.0",
-        "expect": "^26.4.2"
+        "@jest/environment": "^26.5.2",
+        "@jest/types": "^26.5.2",
+        "expect": "^26.5.2"
       },
       "dependencies": {
         "@jest/environment": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
-          "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.5.2.tgz",
+          "integrity": "sha512-YjhCD/Zhkz0/1vdlS/QN6QmuUdDkpgBdK4SdiVg4Y19e29g4VQYN5Xg8+YuHjdoWGY7wJHMxc79uDTeTOy9Ngw==",
           "dev": true,
           "requires": {
-            "@jest/fake-timers": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/fake-timers": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
-            "jest-mock": "^26.3.0"
+            "jest-mock": "^26.5.2"
           }
         },
         "@jest/fake-timers": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
-          "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.5.2.tgz",
+          "integrity": "sha512-09Hn5Oraqt36V1akxQeWMVL0fR9c6PnEhpgLaYvREXZJAh2H2Y+QLCsl0g7uMoJeoWJAuz4tozk1prbR1Fc1sw==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "@sinonjs/fake-timers": "^6.0.1",
             "@types/node": "*",
-            "jest-message-util": "^26.3.0",
-            "jest-mock": "^26.3.0",
-            "jest-util": "^26.3.0"
+            "jest-message-util": "^26.5.2",
+            "jest-mock": "^26.5.2",
+            "jest-util": "^26.5.2"
           }
         },
         "@jest/types": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -1616,6 +1616,12 @@
             "@types/istanbul-lib-report": "*"
           }
         },
+        "@types/stack-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "dev": true
+        },
         "@types/yargs": {
           "version": "15.0.7",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
@@ -1626,12 +1632,11 @@
           }
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -1670,9 +1675,9 @@
           "dev": true
         },
         "diff-sequences": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-          "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
           "dev": true
         },
         "escape-string-regexp": {
@@ -1682,16 +1687,16 @@
           "dev": true
         },
         "expect": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
-          "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.2.tgz",
+          "integrity": "sha512-ccTGrXZd8DZCcvCz4htGXTkd/LOoy6OEtiDS38x3/VVf6E4AQL0QoeksBiw7BtGR5xDNiRYPB8GN6pfbuTOi7w==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "ansi-styles": "^4.0.0",
             "jest-get-type": "^26.3.0",
-            "jest-matcher-utils": "^26.4.2",
-            "jest-message-util": "^26.3.0",
+            "jest-matcher-utils": "^26.5.2",
+            "jest-message-util": "^26.5.2",
             "jest-regex-util": "^26.0.0"
           }
         },
@@ -1717,15 +1722,15 @@
           "dev": true
         },
         "jest-diff": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-          "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
+          "integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^26.3.0",
+            "diff-sequences": "^26.5.0",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.5.2"
           }
         },
         "jest-get-type": {
@@ -1735,26 +1740,26 @@
           "dev": true
         },
         "jest-matcher-utils": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-          "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
+          "integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "jest-diff": "^26.4.2",
+            "jest-diff": "^26.5.2",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.5.2"
           }
         },
         "jest-message-util": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
-          "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.2.tgz",
+          "integrity": "sha512-Ocp9UYZ5Jl15C5PNsoDiGEk14A4NG0zZKknpWdZGoMzJuGAkVt10e97tnEVMYpk7LnQHZOfuK2j/izLBMcuCZw==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@jest/types": "^26.3.0",
-            "@types/stack-utils": "^1.0.1",
+            "@jest/types": "^26.5.2",
+            "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.2",
@@ -1763,12 +1768,12 @@
           }
         },
         "jest-mock": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
-          "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.5.2.tgz",
+          "integrity": "sha512-9SiU4b5PtO51v0MtJwVRqeGEroH66Bnwtq4ARdNP7jNXbpT7+ByeWNAk4NeT/uHfNSVDXEXgQo1XRuwEqS6Rdw==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*"
           }
         },
@@ -1779,12 +1784,12 @@
           "dev": true
         },
         "jest-util": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
-          "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -1803,12 +1808,12 @@
           }
         },
         "pretty-format": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -2434,9 +2439,9 @@
       }
     },
     "@testing-library/dom": {
-      "version": "7.24.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.3.tgz",
-      "integrity": "sha512-6eW9fUhEbR423FZvoHRwbWm9RUUByLWGayYFNVvqTnQLYvsNpBS4uEuKH9aqr3trhxFwGVneJUonehL3B1sHJw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.24.5.tgz",
+      "integrity": "sha512-oyOp8R2rhmnkOjgrySb4iYc2q73dzvQUAGddpbmicGJdCf4jkLmf5U9zOyobLMLWXbIHHK4UUHHjDTH8tSPLsA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
@@ -2449,9 +2454,9 @@
       },
       "dependencies": {
         "@jest/types": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2480,12 +2485,11 @@
           }
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -2531,12 +2535,12 @@
           "dev": true
         },
         "pretty-format": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -2570,12 +2574,11 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -2663,9 +2666,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "12.1.6",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.6.tgz",
-      "integrity": "sha512-BdSe6cmzDEapTBH3s1NKbzu+GyX5bJKraKwVpM2vZF1+EEWxZr0EiA0z9bA5Nux8P+6nKMOZKsXQrj5q/kicfQ==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.7.tgz",
+      "integrity": "sha512-wuJiPqSQTVIHsYuumv1PAOBjblSrYA5vyN1nkUDF5HgfuWGz44jQsO22u7PQNkuACGYJE4eU0sybX8CzsySv+Q==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.2"
@@ -2719,11 +2722,6 @@
       "requires": {
         "@babel/types": "^7.3.0"
       }
-    },
-    "@types/color-name": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "@types/domhandler": {
       "version": "2.4.1",
@@ -2852,12 +2850,11 @@
           }
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -2950,9 +2947,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "14.11.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
-      "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+      "version": "14.11.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.5.tgz",
+      "integrity": "sha512-jVFzDV6NTbrLMxm4xDSIW/gKnk8rQLF9wAzLWIOg+5nU6ACrIMndeBdXci0FGtqJbP9tQvm6V39eshc96TO2wQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -2982,18 +2979,18 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/ramda": {
-      "version": "0.27.19",
-      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.19.tgz",
-      "integrity": "sha512-BAeH07a6pRfFyoTuwhWJeNNHucbMlwh+imkO2BKOTZ6wpAElOAPyhBdyP1hx4W4sCPDnV/5UetcjZ/RT5lcMTA==",
+      "version": "0.27.21",
+      "resolved": "https://registry.npmjs.org/@types/ramda/-/ramda-0.27.21.tgz",
+      "integrity": "sha512-cVU8ka0FZFpqyCQBRYxX1AUUmnq6AcqsVvMhlh1e/6KCwlgBK5TvoxSa7PHkWgkpZ3JWwFnMLkOa4Rw7yj4z4Q==",
       "dev": true,
       "requires": {
         "ts-toolbelt": "^6.3.3"
       }
     },
     "@types/react": {
-      "version": "16.9.49",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.49.tgz",
-      "integrity": "sha512-DtLFjSj0OYAdVLBbyjhuV9CdGVHCkHn2R+xr3XkBvK2rS1Y1tkc14XSGjYgm5Fjjr90AxH9tiSzc1pCFMGO06g==",
+      "version": "16.9.51",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.51.tgz",
+      "integrity": "sha512-lQa12IyO+DMlnSZ3+AGHRUiUcpK47aakMMoBG8f7HGxJT8Yfe+WE128HIXaHOHVPReAW0oDS3KAI0JI2DDe1PQ==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3050,18 +3047,18 @@
       "dev": true
     },
     "@types/testing-library__jest-dom": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.3.tgz",
-      "integrity": "sha512-5YxiCFA2vk0cxq2LIxYgHBpFlnJvMH9bkUIVNin+1GXT+LZgVOgXBeEyyo2ZrGXMO/KWe1ZV3p7Kb6LJAvJasw==",
+      "version": "5.9.4",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.4.tgz",
+      "integrity": "sha512-6spmpkKOCVCO9XolAR23gfv09Nfd4QByRM3WbnYnPhVfjmOzEKlNrcj6GqFLZKduUvtJIH7Mf5t2TY6rs93zDA==",
       "dev": true,
       "requires": {
         "@types/jest": "*"
       }
     },
     "@types/uglify-js": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
-      "integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.0.tgz",
+      "integrity": "sha512-I0Yd8TUELTbgRHq2K65j8rnDPAzAP+DiaF/syLem7yXwYLsHZhPd+AM2iXsWmf9P2F2NlFCgl5erZPQx9IbM9Q==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -3082,9 +3079,9 @@
       }
     },
     "@types/webpack-sources": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz",
-      "integrity": "sha512-77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.0.0.tgz",
+      "integrity": "sha512-a5kPx98CNFRKQ+wqawroFunvFqv7GHm/3KOI52NY9xWADgc8smu4R6prt4EU/M4QfVjvgBkMqU4fBhw3QfMVkg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -3179,11 +3176,6 @@
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         }
       }
-    },
-    "@use-it/interval": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@use-it/interval/-/interval-0.1.3.tgz",
-      "integrity": "sha512-chshdtDZTFoWA9aszBz1Cc04Ca9NBD2JTi/GMjdJ+HGm4q7Vy1v71+2mm22r7Kfb2nYW+lTRsPcEHdB/VFVHsQ=="
     },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
@@ -3374,9 +3366,9 @@
       }
     },
     "acorn": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
-      "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -3655,19 +3647,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -3702,19 +3694,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -3936,37 +3928,37 @@
       }
     },
     "babel-jest": {
-      "version": "26.3.0",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.3.0.tgz",
-      "integrity": "sha512-sxPnQGEyHAOPF8NcUsD0g7hDCnvLL2XyblRBcgrzTWBB/mAIpWow3n1bEL+VghnnZfreLhFSBsFluRoK2tRK4g==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.5.2.tgz",
+      "integrity": "sha512-U3KvymF3SczA3vOL/cgiUFOznfMET+XDIXiWnoJV45siAp2pLMG8i2+/MGZlAC3f/F6Q40LR4M4qDrWZ9wkK8A==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^26.3.0",
-        "@jest/types": "^26.3.0",
+        "@jest/transform": "^26.5.2",
+        "@jest/types": "^26.5.2",
         "@types/babel__core": "^7.1.7",
         "babel-plugin-istanbul": "^6.0.0",
-        "babel-preset-jest": "^26.3.0",
+        "babel-preset-jest": "^26.5.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "slash": "^3.0.0"
       },
       "dependencies": {
         "@jest/transform": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
-          "integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.5.2.tgz",
+          "integrity": "sha512-AUNjvexh+APhhmS8S+KboPz+D3pCxPvEAGduffaAJYxIFxGi/ytZQkrqcKDUU0ERBAo5R7087fyOYr2oms1seg==",
           "dev": true,
           "requires": {
             "@babel/core": "^7.1.0",
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "babel-plugin-istanbul": "^6.0.0",
             "chalk": "^4.0.0",
             "convert-source-map": "^1.4.0",
             "fast-json-stable-stringify": "^2.0.0",
             "graceful-fs": "^4.2.4",
-            "jest-haste-map": "^26.3.0",
+            "jest-haste-map": "^26.5.2",
             "jest-regex-util": "^26.0.0",
-            "jest-util": "^26.3.0",
+            "jest-util": "^26.5.2",
             "micromatch": "^4.0.2",
             "pirates": "^4.0.1",
             "slash": "^3.0.0",
@@ -3975,9 +3967,9 @@
           }
         },
         "@jest/types": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -4006,12 +3998,11 @@
           }
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -4039,9 +4030,9 @@
           }
         },
         "babel-plugin-jest-hoist": {
-          "version": "26.2.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.2.0.tgz",
-          "integrity": "sha512-B/hVMRv8Nh1sQ1a3EY8I0n4Y1Wty3NrR5ebOyVT302op+DOAau+xNEImGMsUWOC3++ZlMooCytKz+NgN8aKGbA==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-26.5.0.tgz",
+          "integrity": "sha512-ck17uZFD3CDfuwCLATWZxkkuGGFhMij8quP8CNhwj8ek1mqFgbFzRJ30xwC04LLscj/aKsVFfRST+b5PT7rSuw==",
           "dev": true,
           "requires": {
             "@babel/template": "^7.3.3",
@@ -4051,12 +4042,12 @@
           }
         },
         "babel-preset-jest": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.3.0.tgz",
-          "integrity": "sha512-5WPdf7nyYi2/eRxCbVrE1kKCWxgWY4RsPEbdJWFm7QsesFGqjdkyLeu1zRkwM1cxK6EPIlNd6d2AxLk7J+t4pw==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-26.5.0.tgz",
+          "integrity": "sha512-F2vTluljhqkiGSJGBg/jOruA8vIIIL11YrxRcO7nviNTMbbofPSHwnm8mgP7d/wS7wRSexRoI6X1A6T74d4LQA==",
           "dev": true,
           "requires": {
-            "babel-plugin-jest-hoist": "^26.2.0",
+            "babel-plugin-jest-hoist": "^26.5.0",
             "babel-preset-current-node-syntax": "^0.1.3"
           }
         },
@@ -4134,12 +4125,12 @@
           }
         },
         "jest-haste-map": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
-          "integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.2.tgz",
+          "integrity": "sha512-lJIAVJN3gtO3k4xy+7i2Xjtwh8CfPcH08WYjZpe9xzveDaqGw9fVNCpkYu6M525wKFVkLmyi7ku+DxCAP1lyMA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "@types/graceful-fs": "^4.1.2",
             "@types/node": "*",
             "anymatch": "^3.0.3",
@@ -4147,9 +4138,9 @@
             "fsevents": "^2.1.2",
             "graceful-fs": "^4.2.4",
             "jest-regex-util": "^26.0.0",
-            "jest-serializer": "^26.3.0",
-            "jest-util": "^26.3.0",
-            "jest-worker": "^26.3.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.5.2",
+            "jest-worker": "^26.5.0",
             "micromatch": "^4.0.2",
             "sane": "^4.0.3",
             "walker": "^1.0.7"
@@ -4162,9 +4153,9 @@
           "dev": true
         },
         "jest-serializer": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
-          "integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -4172,12 +4163,12 @@
           }
         },
         "jest-util": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
-          "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -4186,9 +4177,9 @@
           }
         },
         "jest-worker": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-          "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -4425,9 +4416,9 @@
       "integrity": "sha512-eqj0hVcJUR57/Ug2zE1Yswsw4LhuqqHhD+8v120T1cl3kjg76QwtyBrdIk4WVwK+lAhBJVYCd/v+4nc4y+8JsA=="
     },
     "babel-preset-current-node-syntax": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.3.tgz",
-      "integrity": "sha512-uyexu1sVwcdFnyq9o8UQYsXwXflIh8LvrF5+cKrYam93ned1CStffB3+BEcsxGSgagoA3GEyjDqO4a/58hyPYQ==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-0.1.4.tgz",
+      "integrity": "sha512-5/INNCYhUGqw7VbVjT/hb3ucjgkVHKXY7lX3ZjlN4gm565VyFmJUrJ/h+h16ECVB38R/9SF6aACydpKMLZ/c9w==",
       "dev": true,
       "requires": {
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -5260,9 +5251,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001137",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001137.tgz",
-      "integrity": "sha512-54xKQZTqZrKVHmVz0+UvdZR6kQc7pJDgfhsMYDG19ID1BWoNnDMFm5Q3uSBSU401pBvKYMsHAt9qhEDcxmk8aw=="
+      "version": "1.0.30001146",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001146.tgz",
+      "integrity": "sha512-VAy5RHDfTJhpxnDdp2n40GPPLp3KqNrXz1QqFv4J64HvArKs8nuNMOWkB3ICOaBTU/Aj4rYAo/ytdQDDFF/Pug=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -6116,9 +6107,9 @@
       }
     },
     "css-what": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.3.0.tgz",
-      "integrity": "sha512-pv9JPyatiPaQ6pf4OvD/dbfm0o5LviWmwxNWzblYf/1u9QZd0ihV+PMwy5jdQWQ3349kZmKEx9WXuSka2dM4cg=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.4.1.tgz",
+      "integrity": "sha512-wHOppVDKl4vTAOWzJt5Ek37Sgd9qq1Bmj/T1OjvicWbU5W7ru7Pqbn0Jdqii3Drx/h+dixHKXNhZYx7blthL7g=="
     },
     "css.escape": {
       "version": "1.5.1",
@@ -6382,14 +6373,14 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
     },
     "decimal.js": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.0.tgz",
-      "integrity": "sha512-vDPw+rDgn3bZe1+F/pyEwb1oMG2XTlRVgAa6B4KccTEpYgF8w6eQllVbQcfIJnZyvzFtFpxnpGtx8dd7DJp/Rw=="
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.2.1.tgz",
+      "integrity": "sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw=="
     },
     "decimal.js-light": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.0.tgz",
-      "integrity": "sha512-b3VJCbd2hwUpeRGG3Toob+CRo8W22xplipNhP3tN7TSVB/cyMX71P1vM2Xjc9H74uV6dS2hDDmo/rHq8L87Upg=="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "decode-uri-component": {
       "version": "0.2.0",
@@ -6650,9 +6641,9 @@
       }
     },
     "dom-accessibility-api": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.2.tgz",
-      "integrity": "sha512-k7hRNKAiPJXD2aBqfahSo4/01cTsKWXf+LqJgglnkN2Nz8TsxXKQBXHhKe0Ye9fEfHEZY49uSA5Sr3AqP/sWKA==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.3.tgz",
+      "integrity": "sha512-yfqzAi1GFxK6EoJIZKgxqJyK6j/OjEFEUi2qkNThD/kUhoCFSG1izq31B5xuxzbJBGw9/67uPtkPMYAzWL7L7Q==",
       "dev": true
     },
     "dom-converter": {
@@ -6721,9 +6712,9 @@
       }
     },
     "domhandler": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.2.0.tgz",
-      "integrity": "sha512-FnT5pxGpykNI10uuwyqae65Ysw7XBQJKDjDjlHgE/rsNtjr1FyGNVNQCVlM5hwcq9wkyWSqB+L5Z+Qa4khwLuA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
       "requires": {
         "domelementtype": "^2.0.1"
       }
@@ -6863,9 +6854,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.573",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.573.tgz",
-      "integrity": "sha512-oypaNmexr8w0m2GX67fGLQ0Xgsd7uXz7GcwaHZ9eW3ZdQ8uA2+V/wXmLdMTk3gcacbqQGAN7CXWG3fOkfKYftw=="
+      "version": "1.3.578",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.578.tgz",
+      "integrity": "sha512-z4gU6dA1CbBJsAErW5swTGAaU2TBzc2mPAonJb00zqW1rOraDo2zfBMDRvaz9cVic+0JEZiYbHWPw/fTaZlG2Q=="
     },
     "elliptic": {
       "version": "6.5.3",
@@ -6992,20 +6983,20 @@
       }
     },
     "es-abstract": {
-      "version": "1.18.0-next.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-      "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+      "version": "1.18.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+      "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
+        "is-callable": "^1.2.2",
         "is-negative-zero": "^2.0.0",
         "is-regex": "^1.1.1",
         "object-inspect": "^1.8.0",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
+        "object.assign": "^4.1.1",
         "string.prototype.trimend": "^1.0.1",
         "string.prototype.trimstart": "^1.0.1"
       }
@@ -8249,12 +8240,11 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -8409,9 +8399,9 @@
       }
     },
     "formik": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/formik/-/formik-2.1.5.tgz",
-      "integrity": "sha512-bWpo3PiqVDYslvrRjTq0Isrm0mFXHiO33D8MS6t6dWcqSFGeYF52nlpCM2xwOJ6tRVRznDkL+zz/iHPL4LDuvQ==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/formik/-/formik-2.1.7.tgz",
+      "integrity": "sha512-n1wviIh0JsvHqj9PufNvOV+fS7mFwh9FfMxxTMnTrKR/uVYMS06DKaivXBlJdDF0qEwTcPHxSmIQ3deFHL3Hsg==",
       "requires": {
         "deepmerge": "^2.1.1",
         "hoist-non-react-statics": "^3.3.0",
@@ -9281,9 +9271,9 @@
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
     },
     "i18next": {
-      "version": "19.7.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.7.0.tgz",
-      "integrity": "sha512-sxZhj6u7HbEYOMx81oGwq5MiXISRBVg2wRY3n6YIbe+HtU8ydzlGzv6ErHdrRKYxATBFssVXYbc3lNZoyB4vfA==",
+      "version": "19.8.2",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-19.8.2.tgz",
+      "integrity": "sha512-YWqkUpwnmeZxbNxhQ4BENC27BlXnq4kD6NlqMUwX7T6ZN3alNnBXsWrh/8mJ37BL5cKMZaqA0k/YUo4o6rLfpA==",
       "requires": {
         "@babel/runtime": "^7.10.1"
       }
@@ -9437,11 +9427,10 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -9515,19 +9504,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -9961,59 +9950,59 @@
       }
     },
     "jest": {
-      "version": "26.4.2",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-26.4.2.tgz",
-      "integrity": "sha512-LLCjPrUh98Ik8CzW8LLVnSCfLaiY+wbK53U7VxnFSX7Q+kWC4noVeDvGWIFw0Amfq1lq2VfGm7YHWSLBV62MJw==",
+      "version": "26.5.2",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-26.5.2.tgz",
+      "integrity": "sha512-4HFabJVwsgDwul/7rhXJ3yFAF/aUkVIXiJWmgFxb+WMdZG39fVvOwYAs8/3r4AlFPc4m/n5sTMtuMbOL3kNtrQ==",
       "dev": true,
       "requires": {
-        "@jest/core": "^26.4.2",
+        "@jest/core": "^26.5.2",
         "import-local": "^3.0.2",
-        "jest-cli": "^26.4.2"
+        "jest-cli": "^26.5.2"
       },
       "dependencies": {
         "@jest/console": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.3.0.tgz",
-          "integrity": "sha512-/5Pn6sJev0nPUcAdpJHMVIsA8sKizL2ZkcKPE5+dJrCccks7tcM7c9wbgHudBJbxXLoTbqsHkG1Dofoem4F09w==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/console/-/console-26.5.2.tgz",
+          "integrity": "sha512-lJELzKINpF1v74DXHbCRIkQ/+nUV1M+ntj+X1J8LxCgpmJZjfLmhFejiMSbjjD66fayxl5Z06tbs3HMyuik6rw==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
-            "jest-message-util": "^26.3.0",
-            "jest-util": "^26.3.0",
+            "jest-message-util": "^26.5.2",
+            "jest-util": "^26.5.2",
             "slash": "^3.0.0"
           }
         },
         "@jest/core": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.4.2.tgz",
-          "integrity": "sha512-sDva7YkeNprxJfepOctzS8cAk9TOekldh+5FhVuXS40+94SHbiicRO1VV2tSoRtgIo+POs/Cdyf8p76vPTd6dg==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/core/-/core-26.5.2.tgz",
+          "integrity": "sha512-LLTo1LQMg7eJjG/+P1NYqFof2B25EV1EqzD5FonklihG4UJKiK2JBIvWonunws6W7e+DhNLoFD+g05tCY03eyA==",
           "dev": true,
           "requires": {
-            "@jest/console": "^26.3.0",
-            "@jest/reporters": "^26.4.1",
-            "@jest/test-result": "^26.3.0",
-            "@jest/transform": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/console": "^26.5.2",
+            "@jest/reporters": "^26.5.2",
+            "@jest/test-result": "^26.5.2",
+            "@jest/transform": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "ansi-escapes": "^4.2.1",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
-            "jest-changed-files": "^26.3.0",
-            "jest-config": "^26.4.2",
-            "jest-haste-map": "^26.3.0",
-            "jest-message-util": "^26.3.0",
+            "jest-changed-files": "^26.5.2",
+            "jest-config": "^26.5.2",
+            "jest-haste-map": "^26.5.2",
+            "jest-message-util": "^26.5.2",
             "jest-regex-util": "^26.0.0",
-            "jest-resolve": "^26.4.0",
-            "jest-resolve-dependencies": "^26.4.2",
-            "jest-runner": "^26.4.2",
-            "jest-runtime": "^26.4.2",
-            "jest-snapshot": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "jest-validate": "^26.4.2",
-            "jest-watcher": "^26.3.0",
+            "jest-resolve": "^26.5.2",
+            "jest-resolve-dependencies": "^26.5.2",
+            "jest-runner": "^26.5.2",
+            "jest-runtime": "^26.5.2",
+            "jest-snapshot": "^26.5.2",
+            "jest-util": "^26.5.2",
+            "jest-validate": "^26.5.2",
+            "jest-watcher": "^26.5.2",
             "micromatch": "^4.0.2",
             "p-each-series": "^2.1.0",
             "rimraf": "^3.0.0",
@@ -10022,42 +10011,42 @@
           }
         },
         "@jest/environment": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.3.0.tgz",
-          "integrity": "sha512-EW+MFEo0DGHahf83RAaiqQx688qpXgl99wdb8Fy67ybyzHwR1a58LHcO376xQJHfmoXTu89M09dH3J509cx2AA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.5.2.tgz",
+          "integrity": "sha512-YjhCD/Zhkz0/1vdlS/QN6QmuUdDkpgBdK4SdiVg4Y19e29g4VQYN5Xg8+YuHjdoWGY7wJHMxc79uDTeTOy9Ngw==",
           "dev": true,
           "requires": {
-            "@jest/fake-timers": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/fake-timers": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
-            "jest-mock": "^26.3.0"
+            "jest-mock": "^26.5.2"
           }
         },
         "@jest/fake-timers": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.3.0.tgz",
-          "integrity": "sha512-ZL9ytUiRwVP8ujfRepffokBvD2KbxbqMhrXSBhSdAhISCw3gOkuntisiSFv+A6HN0n0fF4cxzICEKZENLmW+1A==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-26.5.2.tgz",
+          "integrity": "sha512-09Hn5Oraqt36V1akxQeWMVL0fR9c6PnEhpgLaYvREXZJAh2H2Y+QLCsl0g7uMoJeoWJAuz4tozk1prbR1Fc1sw==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "@sinonjs/fake-timers": "^6.0.1",
             "@types/node": "*",
-            "jest-message-util": "^26.3.0",
-            "jest-mock": "^26.3.0",
-            "jest-util": "^26.3.0"
+            "jest-message-util": "^26.5.2",
+            "jest-mock": "^26.5.2",
+            "jest-util": "^26.5.2"
           }
         },
         "@jest/reporters": {
-          "version": "26.4.1",
-          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.4.1.tgz",
-          "integrity": "sha512-aROTkCLU8++yiRGVxLsuDmZsQEKO6LprlrxtAuzvtpbIFl3eIjgIf3EUxDKgomkS25R9ZzwGEdB5weCcBZlrpQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-26.5.2.tgz",
+          "integrity": "sha512-zvq6Wvy6MmJq/0QY0YfOPb49CXKSf42wkJbrBPkeypVa8I+XDxijvFuywo6TJBX/ILPrdrlE/FW9vJZh6Rf9vA==",
           "dev": true,
           "requires": {
             "@bcoe/v8-coverage": "^0.2.3",
-            "@jest/console": "^26.3.0",
-            "@jest/test-result": "^26.3.0",
-            "@jest/transform": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/console": "^26.5.2",
+            "@jest/test-result": "^26.5.2",
+            "@jest/transform": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "chalk": "^4.0.0",
             "collect-v8-coverage": "^1.0.0",
             "exit": "^0.1.2",
@@ -10068,10 +10057,10 @@
             "istanbul-lib-report": "^3.0.0",
             "istanbul-lib-source-maps": "^4.0.0",
             "istanbul-reports": "^3.0.2",
-            "jest-haste-map": "^26.3.0",
-            "jest-resolve": "^26.4.0",
-            "jest-util": "^26.3.0",
-            "jest-worker": "^26.3.0",
+            "jest-haste-map": "^26.5.2",
+            "jest-resolve": "^26.5.2",
+            "jest-util": "^26.5.2",
+            "jest-worker": "^26.5.0",
             "node-notifier": "^8.0.0",
             "slash": "^3.0.0",
             "source-map": "^0.6.0",
@@ -10081,9 +10070,9 @@
           }
         },
         "@jest/source-map": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.3.0.tgz",
-          "integrity": "sha512-hWX5IHmMDWe1kyrKl7IhFwqOuAreIwHhbe44+XH2ZRHjrKIh0LO5eLQ/vxHFeAfRwJapmxuqlGAEYLadDq6ZGQ==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-26.5.0.tgz",
+          "integrity": "sha512-jWAw9ZwYHJMe9eZq/WrsHlwF8E3hM9gynlcDpOyCb9bR8wEd9ZNBZCi7/jZyzHxC7t3thZ10gO2IDhu0bPKS5g==",
           "dev": true,
           "requires": {
             "callsites": "^3.0.0",
@@ -10092,46 +10081,46 @@
           }
         },
         "@jest/test-result": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.3.0.tgz",
-          "integrity": "sha512-a8rbLqzW/q7HWheFVMtghXV79Xk+GWwOK1FrtimpI5n1la2SY0qHri3/b0/1F0Ve0/yJmV8pEhxDfVwiUBGtgg==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-26.5.2.tgz",
+          "integrity": "sha512-E/Zp6LURJEGSCWpoMGmCFuuEI1OWuI3hmZwmULV0GsgJBh7u0rwqioxhRU95euUuviqBDN8ruX/vP/4bwYolXw==",
           "dev": true,
           "requires": {
-            "@jest/console": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/console": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "@types/istanbul-lib-coverage": "^2.0.0",
             "collect-v8-coverage": "^1.0.0"
           }
         },
         "@jest/test-sequencer": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.4.2.tgz",
-          "integrity": "sha512-83DRD8N3M0tOhz9h0bn6Kl6dSp+US6DazuVF8J9m21WAp5x7CqSMaNycMP0aemC/SH/pDQQddbsfHRTBXVUgog==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-26.5.2.tgz",
+          "integrity": "sha512-XmGEh7hh07H2B8mHLFCIgr7gA5Y6Hw1ZATIsbz2fOhpnQ5AnQtZk0gmP0Q5/+mVB2xygO64tVFQxOajzoptkNA==",
           "dev": true,
           "requires": {
-            "@jest/test-result": "^26.3.0",
+            "@jest/test-result": "^26.5.2",
             "graceful-fs": "^4.2.4",
-            "jest-haste-map": "^26.3.0",
-            "jest-runner": "^26.4.2",
-            "jest-runtime": "^26.4.2"
+            "jest-haste-map": "^26.5.2",
+            "jest-runner": "^26.5.2",
+            "jest-runtime": "^26.5.2"
           }
         },
         "@jest/transform": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.3.0.tgz",
-          "integrity": "sha512-Isj6NB68QorGoFWvcOjlUhpkT56PqNIsXKR7XfvoDlCANn/IANlh8DrKAA2l2JKC3yWSMH5wS0GwuQM20w3b2A==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-26.5.2.tgz",
+          "integrity": "sha512-AUNjvexh+APhhmS8S+KboPz+D3pCxPvEAGduffaAJYxIFxGi/ytZQkrqcKDUU0ERBAo5R7087fyOYr2oms1seg==",
           "dev": true,
           "requires": {
             "@babel/core": "^7.1.0",
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "babel-plugin-istanbul": "^6.0.0",
             "chalk": "^4.0.0",
             "convert-source-map": "^1.4.0",
             "fast-json-stable-stringify": "^2.0.0",
             "graceful-fs": "^4.2.4",
-            "jest-haste-map": "^26.3.0",
+            "jest-haste-map": "^26.5.2",
             "jest-regex-util": "^26.0.0",
-            "jest-util": "^26.3.0",
+            "jest-util": "^26.5.2",
             "micromatch": "^4.0.2",
             "pirates": "^4.0.1",
             "slash": "^3.0.0",
@@ -10140,9 +10129,9 @@
           }
         },
         "@jest/types": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.3.0.tgz",
-          "integrity": "sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.5.2.tgz",
+          "integrity": "sha512-QDs5d0gYiyetI8q+2xWdkixVQMklReZr4ltw7GFDtb4fuJIBCE6mzj2LnitGqCuAlLap6wPyb8fpoHgwZz5fdg==",
           "dev": true,
           "requires": {
             "@types/istanbul-lib-coverage": "^2.0.0",
@@ -10161,6 +10150,12 @@
             "@types/istanbul-lib-report": "*"
           }
         },
+        "@types/stack-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz",
+          "integrity": "sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==",
+          "dev": true
+        },
         "@types/yargs": {
           "version": "15.0.7",
           "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.7.tgz",
@@ -10171,12 +10166,11 @@
           }
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -10293,9 +10287,9 @@
           "dev": true
         },
         "diff-sequences": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.3.0.tgz",
-          "integrity": "sha512-5j5vdRcw3CNctePNYN0Wy2e/JbWT6cAYnXv5OuqPhDpyCGc0uLu2TK0zOCJWNB9kOIfYMSpIulRaDgIi4HJ6Ig==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-26.5.0.tgz",
+          "integrity": "sha512-ZXx86srb/iYy6jG71k++wBN9P9J05UNQ5hQHQd9MtMPvcqXPx/vKU69jfHV637D00Q2gSgPk2D+jSx3l1lDW/Q==",
           "dev": true
         },
         "escape-string-regexp": {
@@ -10322,16 +10316,16 @@
           }
         },
         "expect": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/expect/-/expect-26.4.2.tgz",
-          "integrity": "sha512-IlJ3X52Z0lDHm7gjEp+m76uX46ldH5VpqmU0006vqDju/285twh7zaWMRhs67VpQhBwjjMchk+p5aA0VkERCAA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.2.tgz",
+          "integrity": "sha512-ccTGrXZd8DZCcvCz4htGXTkd/LOoy6OEtiDS38x3/VVf6E4AQL0QoeksBiw7BtGR5xDNiRYPB8GN6pfbuTOi7w==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "ansi-styles": "^4.0.0",
             "jest-get-type": "^26.3.0",
-            "jest-matcher-utils": "^26.4.2",
-            "jest-message-util": "^26.3.0",
+            "jest-matcher-utils": "^26.5.2",
+            "jest-message-util": "^26.5.2",
             "jest-regex-util": "^26.0.0"
           }
         },
@@ -10452,73 +10446,73 @@
           }
         },
         "jest-changed-files": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.3.0.tgz",
-          "integrity": "sha512-1C4R4nijgPltX6fugKxM4oQ18zimS7LqQ+zTTY8lMCMFPrxqBFb7KJH0Z2fRQJvw2Slbaipsqq7s1mgX5Iot+g==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-26.5.2.tgz",
+          "integrity": "sha512-qSmssmiIdvM5BWVtyK/nqVpN3spR5YyvkvPqz1x3BR1bwIxsWmU/MGwLoCrPNLbkG2ASAKfvmJpOduEApBPh2w==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "execa": "^4.0.0",
             "throat": "^5.0.0"
           }
         },
         "jest-cli": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.4.2.tgz",
-          "integrity": "sha512-zb+lGd/SfrPvoRSC/0LWdaWCnscXc1mGYW//NP4/tmBvRPT3VntZ2jtKUONsRi59zc5JqmsSajA9ewJKFYp8Cw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.5.2.tgz",
+          "integrity": "sha512-usm48COuUvRp8YEG5OWOaxbSM0my7eHn3QeBWxiGUuFhvkGVBvl1fic4UjC02EAEQtDv8KrNQUXdQTV6ZZBsoA==",
           "dev": true,
           "requires": {
-            "@jest/core": "^26.4.2",
-            "@jest/test-result": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/core": "^26.5.2",
+            "@jest/test-result": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "chalk": "^4.0.0",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
             "import-local": "^3.0.2",
             "is-ci": "^2.0.0",
-            "jest-config": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "jest-validate": "^26.4.2",
+            "jest-config": "^26.5.2",
+            "jest-util": "^26.5.2",
+            "jest-validate": "^26.5.2",
             "prompts": "^2.0.1",
-            "yargs": "^15.3.1"
+            "yargs": "^15.4.1"
           }
         },
         "jest-config": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.4.2.tgz",
-          "integrity": "sha512-QBf7YGLuToiM8PmTnJEdRxyYy3mHWLh24LJZKVdXZ2PNdizSe1B/E8bVm+HYcjbEzGuVXDv/di+EzdO/6Gq80A==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-26.5.2.tgz",
+          "integrity": "sha512-dqJOnSegNdE5yDiuGHsjTM5gec7Z4AcAMHiW+YscbOYJAlb3LEtDSobXCq0or9EmGQI5SFmKy4T7P1FxetJOfg==",
           "dev": true,
           "requires": {
             "@babel/core": "^7.1.0",
-            "@jest/test-sequencer": "^26.4.2",
-            "@jest/types": "^26.3.0",
-            "babel-jest": "^26.3.0",
+            "@jest/test-sequencer": "^26.5.2",
+            "@jest/types": "^26.5.2",
+            "babel-jest": "^26.5.2",
             "chalk": "^4.0.0",
             "deepmerge": "^4.2.2",
             "glob": "^7.1.1",
             "graceful-fs": "^4.2.4",
-            "jest-environment-jsdom": "^26.3.0",
-            "jest-environment-node": "^26.3.0",
+            "jest-environment-jsdom": "^26.5.2",
+            "jest-environment-node": "^26.5.2",
             "jest-get-type": "^26.3.0",
-            "jest-jasmine2": "^26.4.2",
+            "jest-jasmine2": "^26.5.2",
             "jest-regex-util": "^26.0.0",
-            "jest-resolve": "^26.4.0",
-            "jest-util": "^26.3.0",
-            "jest-validate": "^26.4.2",
+            "jest-resolve": "^26.5.2",
+            "jest-util": "^26.5.2",
+            "jest-validate": "^26.5.2",
             "micromatch": "^4.0.2",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.5.2"
           }
         },
         "jest-diff": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.4.2.tgz",
-          "integrity": "sha512-6T1XQY8U28WH0Z5rGpQ+VqZSZz8EN8rZcBtfvXaOkbwxIEeRre6qnuZQlbY1AJ4MKDxQF8EkrCvK+hL/VkyYLQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-26.5.2.tgz",
+          "integrity": "sha512-HCSWDUGwsov5oTlGzrRM+UPJI/Dpqi9jzeV0fdRNi3Ch5bnoXhnyJMmVg2juv9081zLIy3HGPI5mcuGgXM2xRA==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "diff-sequences": "^26.3.0",
+            "diff-sequences": "^26.5.0",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.5.2"
           }
         },
         "jest-docblock": {
@@ -10531,45 +10525,45 @@
           }
         },
         "jest-each": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.4.2.tgz",
-          "integrity": "sha512-p15rt8r8cUcRY0Mvo1fpkOGYm7iI8S6ySxgIdfh3oOIv+gHwrHTy5VWCGOecWUhDsit4Nz8avJWdT07WLpbwDA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-26.5.2.tgz",
+          "integrity": "sha512-w7D9FNe0m2D3yZ0Drj9CLkyF/mGhmBSULMQTypzAKR746xXnjUrK8GUJdlLTWUF6dd0ks3MtvGP7/xNFr9Aphg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "chalk": "^4.0.0",
             "jest-get-type": "^26.3.0",
-            "jest-util": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "jest-util": "^26.5.2",
+            "pretty-format": "^26.5.2"
           }
         },
         "jest-environment-jsdom": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.3.0.tgz",
-          "integrity": "sha512-zra8He2btIMJkAzvLaiZ9QwEPGEetbxqmjEBQwhH3CA+Hhhu0jSiEJxnJMbX28TGUvPLxBt/zyaTLrOPF4yMJA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-26.5.2.tgz",
+          "integrity": "sha512-fWZPx0bluJaTQ36+PmRpvUtUlUFlGGBNyGX1SN3dLUHHMcQ4WseNEzcGGKOw4U5towXgxI4qDoI3vwR18H0RTw==",
           "dev": true,
           "requires": {
-            "@jest/environment": "^26.3.0",
-            "@jest/fake-timers": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/environment": "^26.5.2",
+            "@jest/fake-timers": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
-            "jest-mock": "^26.3.0",
-            "jest-util": "^26.3.0",
-            "jsdom": "^16.2.2"
+            "jest-mock": "^26.5.2",
+            "jest-util": "^26.5.2",
+            "jsdom": "^16.4.0"
           }
         },
         "jest-environment-node": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.3.0.tgz",
-          "integrity": "sha512-c9BvYoo+FGcMj5FunbBgtBnbR5qk3uky8PKyRVpSfe2/8+LrNQMiXX53z6q2kY+j15SkjQCOSL/6LHnCPLVHNw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-26.5.2.tgz",
+          "integrity": "sha512-YHjnDsf/GKFCYMGF1V+6HF7jhY1fcLfLNBDjhAOvFGvt6d8vXvNdJGVM7uTZ2VO/TuIyEFhPGaXMX5j3h7fsrA==",
           "dev": true,
           "requires": {
-            "@jest/environment": "^26.3.0",
-            "@jest/fake-timers": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/environment": "^26.5.2",
+            "@jest/fake-timers": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
-            "jest-mock": "^26.3.0",
-            "jest-util": "^26.3.0"
+            "jest-mock": "^26.5.2",
+            "jest-util": "^26.5.2"
           }
         },
         "jest-get-type": {
@@ -10579,12 +10573,12 @@
           "dev": true
         },
         "jest-haste-map": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.3.0.tgz",
-          "integrity": "sha512-DHWBpTJgJhLLGwE5Z1ZaqLTYqeODQIZpby0zMBsCU9iRFHYyhklYqP4EiG73j5dkbaAdSZhgB938mL51Q5LeZA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.5.2.tgz",
+          "integrity": "sha512-lJIAVJN3gtO3k4xy+7i2Xjtwh8CfPcH08WYjZpe9xzveDaqGw9fVNCpkYu6M525wKFVkLmyi7ku+DxCAP1lyMA==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "@types/graceful-fs": "^4.1.2",
             "@types/node": "*",
             "anymatch": "^3.0.3",
@@ -10592,71 +10586,71 @@
             "fsevents": "^2.1.2",
             "graceful-fs": "^4.2.4",
             "jest-regex-util": "^26.0.0",
-            "jest-serializer": "^26.3.0",
-            "jest-util": "^26.3.0",
-            "jest-worker": "^26.3.0",
+            "jest-serializer": "^26.5.0",
+            "jest-util": "^26.5.2",
+            "jest-worker": "^26.5.0",
             "micromatch": "^4.0.2",
             "sane": "^4.0.3",
             "walker": "^1.0.7"
           }
         },
         "jest-jasmine2": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.4.2.tgz",
-          "integrity": "sha512-z7H4EpCldHN1J8fNgsja58QftxBSL+JcwZmaXIvV9WKIM+x49F4GLHu/+BQh2kzRKHAgaN/E82od+8rTOBPyPA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-jasmine2/-/jest-jasmine2-26.5.2.tgz",
+          "integrity": "sha512-2J+GYcgLVPTkpmvHEj0/IDTIAuyblGNGlyGe4fLfDT2aktEPBYvoxUwFiOmDDxxzuuEAD2uxcYXr0+1Yw4tjFA==",
           "dev": true,
           "requires": {
             "@babel/traverse": "^7.1.0",
-            "@jest/environment": "^26.3.0",
-            "@jest/source-map": "^26.3.0",
-            "@jest/test-result": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/environment": "^26.5.2",
+            "@jest/source-map": "^26.5.0",
+            "@jest/test-result": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "co": "^4.6.0",
-            "expect": "^26.4.2",
+            "expect": "^26.5.2",
             "is-generator-fn": "^2.0.0",
-            "jest-each": "^26.4.2",
-            "jest-matcher-utils": "^26.4.2",
-            "jest-message-util": "^26.3.0",
-            "jest-runtime": "^26.4.2",
-            "jest-snapshot": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "pretty-format": "^26.4.2",
+            "jest-each": "^26.5.2",
+            "jest-matcher-utils": "^26.5.2",
+            "jest-message-util": "^26.5.2",
+            "jest-runtime": "^26.5.2",
+            "jest-snapshot": "^26.5.2",
+            "jest-util": "^26.5.2",
+            "pretty-format": "^26.5.2",
             "throat": "^5.0.0"
           }
         },
         "jest-leak-detector": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.4.2.tgz",
-          "integrity": "sha512-akzGcxwxtE+9ZJZRW+M2o+nTNnmQZxrHJxX/HjgDaU5+PLmY1qnQPnMjgADPGCRPhB+Yawe1iij0REe+k/aHoA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-26.5.2.tgz",
+          "integrity": "sha512-h7ia3dLzBFItmYERaLPEtEKxy3YlcbcRSjj0XRNJgBEyODuu+3DM2o62kvIFvs3PsaYoIIv+e+nLRI61Dj1CNw==",
           "dev": true,
           "requires": {
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.5.2"
           }
         },
         "jest-matcher-utils": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.4.2.tgz",
-          "integrity": "sha512-KcbNqWfWUG24R7tu9WcAOKKdiXiXCbMvQYT6iodZ9k1f7065k0keUOW6XpJMMvah+hTfqkhJhRXmA3r3zMAg0Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-26.5.2.tgz",
+          "integrity": "sha512-W9GO9KBIC4gIArsNqDUKsLnhivaqf8MSs6ujO/JDcPIQrmY+aasewweXVET8KdrJ6ADQaUne5UzysvF/RR7JYA==",
           "dev": true,
           "requires": {
             "chalk": "^4.0.0",
-            "jest-diff": "^26.4.2",
+            "jest-diff": "^26.5.2",
             "jest-get-type": "^26.3.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.5.2"
           }
         },
         "jest-message-util": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.3.0.tgz",
-          "integrity": "sha512-xIavRYqr4/otGOiLxLZGj3ieMmjcNE73Ui+LdSW/Y790j5acqCsAdDiLIbzHCZMpN07JOENRWX5DcU+OQ+TjTA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-26.5.2.tgz",
+          "integrity": "sha512-Ocp9UYZ5Jl15C5PNsoDiGEk14A4NG0zZKknpWdZGoMzJuGAkVt10e97tnEVMYpk7LnQHZOfuK2j/izLBMcuCZw==",
           "dev": true,
           "requires": {
             "@babel/code-frame": "^7.0.0",
-            "@jest/types": "^26.3.0",
-            "@types/stack-utils": "^1.0.1",
+            "@jest/types": "^26.5.2",
+            "@types/stack-utils": "^2.0.0",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "micromatch": "^4.0.2",
@@ -10665,12 +10659,12 @@
           }
         },
         "jest-mock": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.3.0.tgz",
-          "integrity": "sha512-PeaRrg8Dc6mnS35gOo/CbZovoDPKAeB1FICZiuagAgGvbWdNNyjQjkOaGUa/3N3JtpQ/Mh9P4A2D4Fv51NnP8Q==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-26.5.2.tgz",
+          "integrity": "sha512-9SiU4b5PtO51v0MtJwVRqeGEroH66Bnwtq4ARdNP7jNXbpT7+ByeWNAk4NeT/uHfNSVDXEXgQo1XRuwEqS6Rdw==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*"
           }
         },
@@ -10681,98 +10675,98 @@
           "dev": true
         },
         "jest-resolve": {
-          "version": "26.4.0",
-          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.4.0.tgz",
-          "integrity": "sha512-bn/JoZTEXRSlEx3+SfgZcJAVuTMOksYq9xe9O6s4Ekg84aKBObEaVXKOEilULRqviSLAYJldnoWV9c07kwtiCg==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-26.5.2.tgz",
+          "integrity": "sha512-XsPxojXGRA0CoDD7Vis59ucz2p3cQFU5C+19tz3tLEAlhYKkK77IL0cjYjikY9wXnOaBeEdm1rOgSJjbZWpcZg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
             "jest-pnp-resolver": "^1.2.2",
-            "jest-util": "^26.3.0",
+            "jest-util": "^26.5.2",
             "read-pkg-up": "^7.0.1",
             "resolve": "^1.17.0",
             "slash": "^3.0.0"
           }
         },
         "jest-resolve-dependencies": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.4.2.tgz",
-          "integrity": "sha512-ADHaOwqEcVc71uTfySzSowA/RdxUpCxhxa2FNLiin9vWLB1uLPad3we+JSSROq5+SrL9iYPdZZF8bdKM7XABTQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.5.2.tgz",
+          "integrity": "sha512-LLkc8LuRtxqOx0AtX/Npa2C4I23WcIrwUgNtHYXg4owYF/ZDQShcwBAHjYZIFR06+HpQcZ43+kCTMlQ3aDCYTg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "jest-regex-util": "^26.0.0",
-            "jest-snapshot": "^26.4.2"
+            "jest-snapshot": "^26.5.2"
           }
         },
         "jest-runner": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.4.2.tgz",
-          "integrity": "sha512-FgjDHeVknDjw1gRAYaoUoShe1K3XUuFMkIaXbdhEys+1O4bEJS8Avmn4lBwoMfL8O5oFTdWYKcf3tEJyyYyk8g==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-26.5.2.tgz",
+          "integrity": "sha512-GKhYxtSX5+tXZsd2QwfkDqPIj5C2HqOdXLRc2x2qYqWE26OJh17xo58/fN/mLhRkO4y6o60ZVloan7Kk5YA6hg==",
           "dev": true,
           "requires": {
-            "@jest/console": "^26.3.0",
-            "@jest/environment": "^26.3.0",
-            "@jest/test-result": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/console": "^26.5.2",
+            "@jest/environment": "^26.5.2",
+            "@jest/test-result": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "emittery": "^0.7.1",
             "exit": "^0.1.2",
             "graceful-fs": "^4.2.4",
-            "jest-config": "^26.4.2",
+            "jest-config": "^26.5.2",
             "jest-docblock": "^26.0.0",
-            "jest-haste-map": "^26.3.0",
-            "jest-leak-detector": "^26.4.2",
-            "jest-message-util": "^26.3.0",
-            "jest-resolve": "^26.4.0",
-            "jest-runtime": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "jest-worker": "^26.3.0",
+            "jest-haste-map": "^26.5.2",
+            "jest-leak-detector": "^26.5.2",
+            "jest-message-util": "^26.5.2",
+            "jest-resolve": "^26.5.2",
+            "jest-runtime": "^26.5.2",
+            "jest-util": "^26.5.2",
+            "jest-worker": "^26.5.0",
             "source-map-support": "^0.5.6",
             "throat": "^5.0.0"
           }
         },
         "jest-runtime": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.4.2.tgz",
-          "integrity": "sha512-4Pe7Uk5a80FnbHwSOk7ojNCJvz3Ks2CNQWT5Z7MJo4tX0jb3V/LThKvD9tKPNVNyeMH98J/nzGlcwc00R2dSHQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-26.5.2.tgz",
+          "integrity": "sha512-zArr4DatX/Sn0wswX/AnAuJgmwgAR5rNtrUz36HR8BfMuysHYNq5sDbYHuLC4ICyRdy5ae/KQ+sczxyS9G6Qvw==",
           "dev": true,
           "requires": {
-            "@jest/console": "^26.3.0",
-            "@jest/environment": "^26.3.0",
-            "@jest/fake-timers": "^26.3.0",
-            "@jest/globals": "^26.4.2",
-            "@jest/source-map": "^26.3.0",
-            "@jest/test-result": "^26.3.0",
-            "@jest/transform": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/console": "^26.5.2",
+            "@jest/environment": "^26.5.2",
+            "@jest/fake-timers": "^26.5.2",
+            "@jest/globals": "^26.5.2",
+            "@jest/source-map": "^26.5.0",
+            "@jest/test-result": "^26.5.2",
+            "@jest/transform": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "@types/yargs": "^15.0.0",
             "chalk": "^4.0.0",
             "collect-v8-coverage": "^1.0.0",
             "exit": "^0.1.2",
             "glob": "^7.1.3",
             "graceful-fs": "^4.2.4",
-            "jest-config": "^26.4.2",
-            "jest-haste-map": "^26.3.0",
-            "jest-message-util": "^26.3.0",
-            "jest-mock": "^26.3.0",
+            "jest-config": "^26.5.2",
+            "jest-haste-map": "^26.5.2",
+            "jest-message-util": "^26.5.2",
+            "jest-mock": "^26.5.2",
             "jest-regex-util": "^26.0.0",
-            "jest-resolve": "^26.4.0",
-            "jest-snapshot": "^26.4.2",
-            "jest-util": "^26.3.0",
-            "jest-validate": "^26.4.2",
+            "jest-resolve": "^26.5.2",
+            "jest-snapshot": "^26.5.2",
+            "jest-util": "^26.5.2",
+            "jest-validate": "^26.5.2",
             "slash": "^3.0.0",
             "strip-bom": "^4.0.0",
-            "yargs": "^15.3.1"
+            "yargs": "^15.4.1"
           }
         },
         "jest-serializer": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.3.0.tgz",
-          "integrity": "sha512-IDRBQBLPlKa4flg77fqg0n/pH87tcRKwe8zxOVTWISxGpPHYkRZ1dXKyh04JOja7gppc60+soKVZ791mruVdow==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-serializer/-/jest-serializer-26.5.0.tgz",
+          "integrity": "sha512-+h3Gf5CDRlSLdgTv7y0vPIAoLgX/SI7T4v6hy+TEXMgYbv+ztzbg5PSN6mUXAT/hXYHvZRWm+MaObVfqkhCGxA==",
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -10780,25 +10774,26 @@
           }
         },
         "jest-snapshot": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.4.2.tgz",
-          "integrity": "sha512-N6Uub8FccKlf5SBFnL2Ri/xofbaA68Cc3MGjP/NuwgnsvWh+9hLIR/DhrxbSiKXMY9vUW5dI6EW1eHaDHqe9sg==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-26.5.2.tgz",
+          "integrity": "sha512-MkXIDvEefzDubI/WaDVSRH4xnkuirP/Pz8LhAIDXcVQTmcEfwxywj5LGwBmhz+kAAIldA7XM4l96vbpzltSjqg==",
           "dev": true,
           "requires": {
             "@babel/types": "^7.0.0",
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
+            "@types/babel__traverse": "^7.0.4",
             "@types/prettier": "^2.0.0",
             "chalk": "^4.0.0",
-            "expect": "^26.4.2",
+            "expect": "^26.5.2",
             "graceful-fs": "^4.2.4",
-            "jest-diff": "^26.4.2",
+            "jest-diff": "^26.5.2",
             "jest-get-type": "^26.3.0",
-            "jest-haste-map": "^26.3.0",
-            "jest-matcher-utils": "^26.4.2",
-            "jest-message-util": "^26.3.0",
-            "jest-resolve": "^26.4.0",
+            "jest-haste-map": "^26.5.2",
+            "jest-matcher-utils": "^26.5.2",
+            "jest-message-util": "^26.5.2",
+            "jest-resolve": "^26.5.2",
             "natural-compare": "^1.4.0",
-            "pretty-format": "^26.4.2",
+            "pretty-format": "^26.5.2",
             "semver": "^7.3.2"
           },
           "dependencies": {
@@ -10811,12 +10806,12 @@
           }
         },
         "jest-util": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.3.0.tgz",
-          "integrity": "sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-26.5.2.tgz",
+          "integrity": "sha512-WTL675bK+GSSAYgS8z9FWdCT2nccO1yTIplNLPlP0OD8tUk/H5IrWKMMRudIQQ0qp8bb4k+1Qa8CxGKq9qnYdg==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "chalk": "^4.0.0",
             "graceful-fs": "^4.2.4",
@@ -10825,38 +10820,38 @@
           }
         },
         "jest-validate": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.4.2.tgz",
-          "integrity": "sha512-blft+xDX7XXghfhY0mrsBCYhX365n8K5wNDC4XAcNKqqjEzsRUSXP44m6PL0QJEW2crxQFLLztVnJ4j7oPlQrQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-26.5.2.tgz",
+          "integrity": "sha512-FmJks0zY36mp6Af/5sqO6CTL9bNMU45yKCJk3hrz8d2aIqQIlN1pr9HPIwZE8blLaewOla134nt5+xAmWsx3SQ==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "camelcase": "^6.0.0",
             "chalk": "^4.0.0",
             "jest-get-type": "^26.3.0",
             "leven": "^3.1.0",
-            "pretty-format": "^26.4.2"
+            "pretty-format": "^26.5.2"
           }
         },
         "jest-watcher": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.3.0.tgz",
-          "integrity": "sha512-XnLdKmyCGJ3VoF6G/p5ohbJ04q/vv5aH9ENI+i6BL0uu9WWB6Z7Z2lhQQk0d2AVZcRGp1yW+/TsoToMhBFPRdQ==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.5.2.tgz",
+          "integrity": "sha512-i3m1NtWzF+FXfJ3ljLBB/WQEp4uaNhX7QcQUWMokcifFTUQBDFyUMEwk0JkJ1kopHbx7Een3KX0Q7+9koGM/Pw==",
           "dev": true,
           "requires": {
-            "@jest/test-result": "^26.3.0",
-            "@jest/types": "^26.3.0",
+            "@jest/test-result": "^26.5.2",
+            "@jest/types": "^26.5.2",
             "@types/node": "*",
             "ansi-escapes": "^4.2.1",
             "chalk": "^4.0.0",
-            "jest-util": "^26.3.0",
+            "jest-util": "^26.5.2",
             "string-length": "^4.0.1"
           }
         },
         "jest-worker": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-          "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -10986,12 +10981,12 @@
           }
         },
         "pretty-format": {
-          "version": "26.4.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.4.2.tgz",
-          "integrity": "sha512-zK6Gd8zDsEiVydOCGLkoBoZuqv8VTiHyAbKznXe/gaph/DAeZOmit9yMfgIz5adIgAMMs5XfoYSwAX3jcCO1tA==",
+          "version": "26.5.2",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.5.2.tgz",
+          "integrity": "sha512-VizyV669eqESlkOikKJI8Ryxl/kPpbdLwNdPs2GrbQs18MpySB5S0Yo0N7zkg2xTRiFq4CFw8ct5Vg4a0xP0og==",
           "dev": true,
           "requires": {
-            "@jest/types": "^26.3.0",
+            "@jest/types": "^26.5.2",
             "ansi-regex": "^5.0.0",
             "ansi-styles": "^4.0.0",
             "react-is": "^16.12.0"
@@ -11152,9 +11147,9 @@
           }
         },
         "uuid": {
-          "version": "8.3.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-          "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==",
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
           "dev": true,
           "optional": true
         },
@@ -11338,9 +11333,9 @@
           },
           "dependencies": {
             "acorn": {
-              "version": "6.4.1",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-              "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+              "version": "6.4.2",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+              "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
             }
           }
         },
@@ -11494,9 +11489,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
         },
         "acorn-globals": {
           "version": "4.3.4",
@@ -11696,12 +11691,11 @@
           }
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
@@ -13779,32 +13773,12 @@
       "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
     },
     "object-is": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+      "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      },
-      "dependencies": {
-        "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
-          "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
-          }
-        }
+        "es-abstract": "^1.18.0-next.1"
       }
     },
     "object-keys": {
@@ -13847,19 +13821,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -13878,19 +13852,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -13907,19 +13881,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -13966,19 +13940,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -14020,9 +13994,9 @@
       }
     },
     "open": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/open/-/open-7.2.1.tgz",
-      "integrity": "sha512-xbYCJib4spUdmcs0g/2mK1nKo/jO2T7INClWd/beL7PFkXRWgr8B23ssDHX/USPn2M2IjDR5UdpYs6I67SnTSA==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.3.0.tgz",
+      "integrity": "sha512-mgLwQIx2F/ye9SmbrUkurZCnkoXyXyu9EbHtJZrICjVAJfyMArdHp3KkixGdZx1ZHFPNIwl0DDM1dFFqXbTLZw==",
       "requires": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -14451,9 +14425,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.34",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.34.tgz",
-      "integrity": "sha512-H/7V2VeNScX9KE83GDrDZNiGT1m2H+UTnlinIzhjlLX9hfMUn1mHNnGeX81a1c8JSBdBvqk7c2ZOG6ZPn5itGw==",
+      "version": "7.0.35",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.35.tgz",
+      "integrity": "sha512-3QT8bBJeX/S5zKTTjTCIjRF3If4avAT6kqxcASlTWEtAFCb9NH0OUxNDfgZSWdP5fJnBYCMEWkIFfWeugjzYMg==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -14488,9 +14462,9 @@
       }
     },
     "postcss-calc": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.4.tgz",
-      "integrity": "sha512-0I79VRAd1UTkaHzY9w83P39YGO/M3bG7/tNLrHGEunBolfoGM0hSjrGvjoeaj0JE/zIw5GsI2KZ0UwDJqv5hjw==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.5.tgz",
+      "integrity": "sha512-1tKHutbGtLtEZF6PT4JSihCHfIVldU72mZ8SdZHIYriIZ9fh9k9aWSppaT8rHsyI3dX+KSR+W+Ix9BMY3AODrg==",
       "requires": {
         "postcss": "^7.0.27",
         "postcss-selector-parser": "^6.0.2",
@@ -15572,9 +15546,9 @@
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
     },
     "query-string": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.3.tgz",
-      "integrity": "sha512-dldo2oHe3sg03iPshlHw/64nkaRUJKdS0FW85kmWQkmCkqUbNdNdgkgtAufJcEpjzrx6Q9EW9Y3xqx/rM9pGhw==",
+      "version": "6.13.5",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.5.tgz",
+      "integrity": "sha512-svk3xg9qHR39P3JlHuD7g3nRnyay5mHbrPctEBDUxUkHRifPHXJDhBUycdCC0NBjXoDf44Gb+IsOZL1Uwn8M/Q==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",
@@ -16191,9 +16165,9 @@
           }
         },
         "acorn": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
         },
         "babel-jest": {
           "version": "24.9.0",
@@ -16906,19 +16880,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -18384,19 +18358,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -18413,19 +18387,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -18442,19 +18416,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -18662,9 +18636,9 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
     },
     "synchronous-promise": {
-      "version": "2.0.13",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.13.tgz",
-      "integrity": "sha512-R9N6uDkVsghHePKh1TEqbnLddO2IY25OcsksyFp/qBe7XYd0PVbKEWxhcdMhpLzE1I6skj5l4aEZ3CRxcbArlA=="
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.14.tgz",
+      "integrity": "sha512-XassJA855Rbhsggr5Yr1sms+iDDzkmwfhqPJzl7Lq544+7fjo9NmCpetrvQc33S/HE1JnoI2zA3CLDxTQTpWHA=="
     },
     "systemjs": {
       "version": "6.6.1",
@@ -18821,9 +18795,9 @@
           "dev": true
         },
         "jest-worker": {
-          "version": "26.3.0",
-          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.3.0.tgz",
-          "integrity": "sha512-Vmpn2F6IASefL+DVBhPzI2J9/GJUsqzomdeN+P+dK8/jKxbh8R3BtFnx3FIta7wYlPU62cpJMJQo4kuOowcMnw==",
+          "version": "26.5.0",
+          "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-26.5.0.tgz",
+          "integrity": "sha512-kTw66Dn4ZX7WpjZ7T/SUDgRhapFRKWmisVAF0Rv4Fu8SLFD7eLbqpLvbxVqYhSgaWa7I+bW7pHnbyfNsH6stug==",
           "dev": true,
           "requires": {
             "@types/node": "*",
@@ -19253,9 +19227,9 @@
       "integrity": "sha512-vVJBdtd+wGnUEB7cwiORO7tp8LPTJW9EVH154PJdvx4bG3S4j5gKzdb9hzscKj6hl+HdMsn3tM0G0/0PjAqA0g=="
     },
     "tslib": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.0.tgz",
+      "integrity": "sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw=="
     },
     "tsutils": {
       "version": "3.17.1",
@@ -19588,19 +19562,19 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.17.6",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
-          "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+          "version": "1.17.7",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.7.tgz",
+          "integrity": "sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==",
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
+            "is-callable": "^1.2.2",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
           }
@@ -20074,9 +20048,9 @@
           }
         },
         "acorn": {
-          "version": "6.4.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
+          "version": "6.4.2",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+          "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==",
           "dev": true
         },
         "cacache": {
@@ -20470,9 +20444,9 @@
       }
     },
     "webpack-merge": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.1.4.tgz",
-      "integrity": "sha512-LSmRD59mxREGkCBm9PCW3AaV4doDqxykGlx1NvioEE0FgkT2GQI54Wyvg39ptkiq2T11eRVoV39udNPsQvK+QQ==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.2.0.tgz",
+      "integrity": "sha512-QBglJBg5+lItm3/Lopv8KDDK01+hjdg2azEwi/4vKJ8ZmGPdtJsTpjtNNOW3a4WiqzXdCATtTudOZJngE7RKkA==",
       "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
@@ -20542,9 +20516,9 @@
       "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
     },
     "whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-PcVnO6NiewhkmzV0qn7A+UZ9Xx4maNTI+O+TShmfE4pqjoCMwUMjkvoNhNHPTvgR7QH9Xt3R13iHuWy2sToFxQ==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.3.0.tgz",
+      "integrity": "sha512-BQRf/ej5Rp3+n7k0grQXZj9a1cHtsp4lqj01p59xBWFKdezR8sO37XnpafwNqiFac/v2Il12EIMjX/Y4VZtT8Q==",
       "requires": {
         "lodash.sortby": "^4.7.0",
         "tr46": "^2.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3180,6 +3180,11 @@
         }
       }
     },
+    "@use-it/interval": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@use-it/interval/-/interval-0.1.3.tgz",
+      "integrity": "sha512-chshdtDZTFoWA9aszBz1Cc04Ca9NBD2JTi/GMjdJ+HGm4q7Vy1v71+2mm22r7Kfb2nYW+lTRsPcEHdB/VFVHsQ=="
+    },
     "@webassemblyjs/ast": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.8.5.tgz",

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/pickers": "^3.2.10",
     "@material-ui/styles": "^4.10.0",
+    "@use-it/interval": "^0.1.3",
     "axios": "^0.19.2",
     "classnames": "^2.2.6",
     "clsx": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@material-ui/pickers": "^3.2.10",
     "@material-ui/styles": "^4.10.0",
-    "@use-it/interval": "^0.1.3",
     "axios": "^0.19.2",
     "classnames": "^2.2.6",
     "clsx": "^1.1.1",

--- a/www/front_src/src/Resources/Listing/useLoadResources/index.ts
+++ b/www/front_src/src/Resources/Listing/useLoadResources/index.ts
@@ -29,6 +29,7 @@ const useLoadResources = (): LoadResources => {
     customFilters,
     loadDetails,
     details,
+    selectedResourceId,
   } = useResourceContext();
 
   const refreshIntervalRef = React.useRef<number>();
@@ -96,7 +97,7 @@ const useLoadResources = (): LoadResources => {
 
   React.useEffect(() => {
     initAutorefresh();
-  }, [enabledAutorefresh]);
+  }, [enabledAutorefresh, selectedResourceId]);
 
   React.useEffect(() => {
     return (): void => {

--- a/www/front_src/src/Resources/Listing/useLoadResources/index.ts
+++ b/www/front_src/src/Resources/Listing/useLoadResources/index.ts
@@ -77,7 +77,9 @@ const useLoadResources = (): LoadResources => {
     window.clearInterval(refreshIntervalRef.current);
 
     const interval = enabledAutorefresh
-      ? window.setInterval(load, refreshIntervalMs)
+      ? window.setInterval(() => {
+          load();
+        }, refreshIntervalMs)
       : undefined;
 
     refreshIntervalRef.current = interval;

--- a/www/front_src/src/Resources/Listing/useLoadResources/index.ts
+++ b/www/front_src/src/Resources/Listing/useLoadResources/index.ts
@@ -28,6 +28,7 @@ const useLoadResources = (): LoadResources => {
     enabledAutorefresh,
     customFilters,
     loadDetails,
+    details,
   } = useResourceContext();
 
   const refreshIntervalRef = React.useRef<number>();
@@ -64,6 +65,10 @@ const useLoadResources = (): LoadResources => {
       page,
       search,
     }).then(setListing);
+
+    if (isNil(details)) {
+      return;
+    }
 
     loadDetails();
   };


### PR DESCRIPTION
## Description

This avoids resources being loaded twice and fixes an issue while changing the selected details which loads the previous one. 

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)
