### PR TITLE
fix(openid): fix form missing right braces

### DIFF
--- a/www/include/Administration/parameters/general/form.ihtml
+++ b/www/include/Administration/parameters/general/form.ihtml
@@ -194,7 +194,7 @@
     </tr>
     <tr class="list_one">
         <td class="FormRowField">
-            <img class="helpTooltip" name="openid_connect_verify_peer">{$form.openid_connect_verify_peer.label
+            <img class="helpTooltip" name="openid_connect_verify_peer">{$form.openid_connect_verify_peer.label}
         </td>
         <td class="FormRowValue">{$form.openid_connect_verify_peer.html}</td>
     </tr>


### PR DESCRIPTION
## Description

Missing '}' in form.ihtml


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [ ] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
