### PR TITLE
fix(platformstatus): default apiPort value in remote form

### DIFF
--- a/bin/registerServerTopology.php
+++ b/bin/registerServerTopology.php
@@ -158,7 +158,7 @@ if (isset($opt['template'])) {
 $targetURL = parse_url($configOptions['HOST_ADDRESS']);
 $protocol = $targetURL['scheme'] ?? 'http';
 $host = $targetURL['host'] ?? $targetURL['path'];
-$port = $targetURL['port'] ?? '';
+$port = $targetURL['port'] ?? 80;
 
 
 /**
@@ -265,9 +265,8 @@ if (isRemote($serverType)) {
     $loginCredentialsDb['apiPath'] = $configOptions['ROOT_CENTREON_FOLDER'] ?? 'centreon';
     $loginCredentialsDb['apiPeerValidation'] = isset($configOptions['INSECURE']) ? 'no' : 'yes';
     $loginCredentialsDb['apiScheme'] = $protocol;
-    if (isset($port)) {
-        $loginCredentialsDb['apiPort'] = $port;
-    }
+    $loginCredentialsDb['apiPort'] = $port;
+
     if ($configOptions['PROXY_USAGE'] === true) {
         $loginCredentialsDb['proxy_informations']['proxy_url'] = $configOptions["PROXY_HOST"];
         $loginCredentialsDb['proxy_informations']['proxy_port'] = $configOptions["PROXY_PORT"];

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15798,6 +15798,9 @@ msgstr "URI de l'API du central"
 msgid "Allow self signed certificate."
 msgstr "Autoriser le certificat auto-signé."
 
+msgid "Must be a number between 1 and 65335 included."
+msgstr "Doit être un nombre compris entre 1 et 65335 inclus"
+
 #: www/include/Adrministration/parameters/remote/formRemote.php
 msgid "Remote access"
 msgstr "Accès du Remote"

--- a/www/include/Administration/parameters/remote/DB-Func.php
+++ b/www/include/Administration/parameters/remote/DB-Func.php
@@ -19,7 +19,7 @@
  *
  */
 
-function validateApiPort($port) 
+function validateApiPort($port)
 {
     $port = filter_var($port, FILTER_VALIDATE_INT);
 

--- a/www/include/Administration/parameters/remote/DB-Func.php
+++ b/www/include/Administration/parameters/remote/DB-Func.php
@@ -19,7 +19,8 @@
  *
  */
 
-function validateApiPort($port) {
+function validateApiPort($port) 
+{
     $port = filter_var($port, FILTER_VALIDATE_INT);
 
     if ($port === false || $port < 1 || $port > 65335) {

--- a/www/include/Administration/parameters/remote/DB-Func.php
+++ b/www/include/Administration/parameters/remote/DB-Func.php
@@ -1,5 +1,24 @@
 <?php
 
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
 function validateApiPort($port) {
     $port = filter_var($port, FILTER_VALIDATE_INT);
 

--- a/www/include/Administration/parameters/remote/DB-Func.php
+++ b/www/include/Administration/parameters/remote/DB-Func.php
@@ -1,0 +1,11 @@
+<?php
+
+function validateApiPort($port) {
+    $port = filter_var($port, FILTER_VALIDATE_INT);
+
+    if ($port === false || $port < 1 || $port > 65335) {
+        return false;
+    }
+
+    return true;
+}

--- a/www/include/Administration/parameters/remote/formRemote.php
+++ b/www/include/Administration/parameters/remote/formRemote.php
@@ -25,6 +25,8 @@ if (!isset($centreon)) {
     exit();
 }
 
+require_once 'DB-Func.php';
+
 /*
  * Set encryption parameters
  */
@@ -142,9 +144,10 @@ $form->addElement(
     $attrsText
 );
 $form->addRule('apiPath', _("Required Field"), 'required');
-
+$form->registerRule('validateApiPort', 'callback', 'validateApiPort');
 $form->addElement('text', 'apiPort', _("Port"), ["size" => "8"]);
-$form->addRule('apiPort', _('Must be a number'), 'numeric');
+$form->addRule('apiPort', _('Must be a number between 1 and 65335 included.'), 'validateApiPort');
+$form->addRule('apiPort', _('Required Field'), 'required');
 
 $form->addElement(
     'checkbox',


### PR DESCRIPTION
## Description

Set a default value fort the apiPort in remote server form and while executing the script.

**Fixes** # QA-170

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

## Checklist

- [x] I followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
