### PR TITLE
fix(API): correct message thrown on inconsistant port value

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15605,7 +15605,7 @@ msgid "Same address and parent_address for platform : '%s'@'%s'."
 msgstr "Les adresses de la plateforme : '%s'@'%s' et de son parent sont les mêmes"
 
 #: api/topology/register
-msgid "Central platform's API port are not consistent. Please check the 'Remote Access' form."
+msgid "Central platform's API port is not consistent. Please check the 'Remote Access' form."
 msgstr "Le port de l'API vers le Central n'est pas cohérent. Veuiller vérifier le formulaire 'Accès du Remote'."
 
 #: api/topology/register

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
@@ -290,7 +290,7 @@ class PlatformInformation
      */
     public function getApiPort(): ?int
     {
-        return $this->apiPort;
+        return $this->checkPortConsistency($this->apiPort);
     }
 
     /**
@@ -299,18 +299,7 @@ class PlatformInformation
      */
     public function setApiPort(?int $port): self
     {
-        // auto resolving default scheme port
-        if (null === $port && null !== $this->apiScheme) {
-            if ('https' === $this->apiScheme) {
-                $this->apiPort = 443;
-                return $this;
-            }
-            if ('http' === $this->apiScheme) {
-                $this->apiPort = 80;
-                return $this;
-            }
-        }
-        $this->apiPort = $this->checkPortConsistency($port);
+        $this->apiPort = $port;
         return $this;
     }
 

--- a/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
+++ b/src/Centreon/Domain/PlatformInformation/PlatformInformation.php
@@ -279,7 +279,7 @@ class PlatformInformation
     {
         if (null === $port || 1 > $port || $port > 65535) {
             throw new \InvalidArgumentException(
-                _("Central platform's API port are not consistent. Please check the 'Remote Access' form.")
+                _("Central platform's API port is not consistent. Please check the 'Remote Access' form.")
             );
         }
         return $port;


### PR DESCRIPTION
## Description

When the port is not consistent, the error thrown by the entity was not correctly retrieved in the response, as the entityCreator overrided it

Port consistency check has been moved on the getter instead

eg:  using port = 0
![image](https://user-images.githubusercontent.com/34628915/95893140-d0d07300-0d87-11eb-82d7-e35072575bf7.png)


**Fixes** # (QA-170)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)

