### PR TITLE
fix(register): set default value on https

### DIFF
--- a/bin/registerServerTopology.php
+++ b/bin/registerServerTopology.php
@@ -156,10 +156,10 @@ if (isset($opt['template'])) {
  * Parsing url part from params -h
  */
 $targetURL = parse_url($configOptions['HOST_ADDRESS']);
-$protocol = $targetURL['scheme'] ?? 'http';
 $host = $targetURL['host'] ?? $targetURL['path'];
-$port = $targetURL['port'] ?? 80;
-
+$protocol = $targetURL['scheme'] ?? 'http';
+$defaultPort = ('https' === $protocol) ? 443 : 80;
+$port = $targetURL['port'] ?? $defaultPort;
 
 /**
  * prepare Login payload

--- a/www/include/Administration/parameters/remote/formRemote.ihtml
+++ b/www/include/Administration/parameters/remote/formRemote.ihtml
@@ -56,8 +56,10 @@
 
 function checkSsl(scheme) {
     if (scheme === 'http') {
+        jQuery('#apiPort').val('80');
         jQuery('#apiPeerValidation').css("visibility","hidden");
     } else {
+        jQuery('#apiPort').val('443');
         jQuery('#apiPeerValidation').css("visibility","visible");
     }
 }

--- a/www/include/Administration/parameters/remote/formRemote.php
+++ b/www/include/Administration/parameters/remote/formRemote.php
@@ -145,7 +145,7 @@ $form->addElement(
 );
 $form->addRule('apiPath', _("Required Field"), 'required');
 $form->registerRule('validateApiPort', 'callback', 'validateApiPort');
-$form->addElement('text', 'apiPort', _("Port"), ["size" => "8"]);
+$form->addElement('text', 'apiPort', _("Port"), ["size" => "8", 'id' => 'apiPort']);
 $form->addRule('apiPort', _('Must be a number between 1 and 65335 included.'), 'validateApiPort');
 $form->addRule('apiPort', _('Required Field'), 'required');
 


### PR DESCRIPTION
## Description

If no port is specified in the register script, the port should be set to 443 if the specified url contains an https scheme
Same is required in the Remote access' form

**Fixes** # (MON-6166)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)
