### PR TITLE
enh(API): thrown message on transport exception

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15679,8 +15679,12 @@ msgid "API calling the Central returned a Server exception"
 msgstr "L'API du Central a renvoyé une exception Server"
 
 #: api/topology/register
-msgid "Please check the 'Centreon UI' form and your proxy configuration"
-msgstr "Veuillez vérifier le formulaire 'Centreon Web' et les paramètres de votre proxy"
+msgid "Please check the 'Centreon UI' and 'Remote access' forms"
+msgstr "Veuillez vérifier les formulaires 'Centreon Web' et 'Accès du Remote'"
+
+#: api/topology/register
+msgid "Using these proxy parameters : '%s'"
+msgstr "En utilisant les paramètres proxy suivants : '%s'"
 
 #: api/topology/register
 msgid "Unable to convert Central's API response"

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15695,8 +15695,8 @@ msgid "The platform: '%s'@'%s' cannot be added to the Central linked to this Rem
 msgstr "La plateforme: '%s'@'%s' ne peut pas être ajoutée au Central lié à ce Remote"
 
 #: api/topology/register
-msgid "Central's response => Code : "
-msgstr "Réponse du Central => Code : "
+msgid "Central's response : "
+msgstr "Réponse du Central : "
 
 #: api/topology/register
 msgid "Unable to find the encryption key. Please check the '.env.local.php' file."

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15683,10 +15683,6 @@ msgid "Please check the 'Centreon UI' and 'Remote access' forms"
 msgstr "Veuillez vérifier les formulaires 'Centreon Web' et 'Accès du Remote'"
 
 #: api/topology/register
-msgid "Using these proxy parameters : '%s'"
-msgstr "En utilisant les paramètres proxy suivants : '%s'"
-
-#: api/topology/register
 msgid "Unable to convert Central's API response"
 msgstr "Impossible de convertir la réponse de L'API provenant du Central"
 

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -313,7 +313,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
                     $returnedMessage = json_decode($registerResponse->getContent(false), true);
 
                     if (!empty($returnedMessage)) {
-                        $errorMessage .= "  /  " . _("Central's response => Code : ") .
+                        $errorMessage .= "  /  " . _("Central's response : ") .
                             implode(', ', $returnedMessage);
                     }
                     throw new PlatformTopologyConflictException(

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -321,8 +321,12 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
                     );
                 }
             } catch (TransportExceptionInterface $e) {
+                $message = '';
+                if (!empty($optionPayload['proxy'])) {
+                    $message = ' ' . sprintf(_("Using these proxy parameters : '%s'"), $optionPayload['proxy']);
+                }
                 throw new PlatformTopologyException(
-                    _("Request to the Central's API failed") . (' : ') . $e->getMessage()
+                    _("Request to the Central's API failed") . (' : ') . $e->getMessage() . $message
                 );
             } catch (ClientExceptionInterface $e) {
                 throw new PlatformTopologyException(
@@ -335,7 +339,7 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
             } catch (ServerExceptionInterface $e) {
                 $message = _("API calling the Central returned a Server exception");
                 if (!empty($optionPayload['proxy'])) {
-                    $message .= '. ' . _("Please check the 'Centreon UI' form and your proxy configuration");
+                    $message .= '. ' . _("Please check the 'Centreon UI' and 'Remote access' forms");
                 }
                 throw new PlatformTopologyException(
                     $message . (' : ') . $e->getMessage()

--- a/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+++ b/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
@@ -323,18 +323,18 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
             } catch (TransportExceptionInterface $e) {
                 $message = '';
                 if (!empty($optionPayload['proxy'])) {
-                    $message = ' ' . sprintf(_("Using these proxy parameters : '%s'"), $optionPayload['proxy']);
+                    $message = ' ' . _("Please check the 'Centreon UI' and 'Remote access' forms");
                 }
                 throw new PlatformTopologyException(
-                    _("Request to the Central's API failed") . (' : ') . $e->getMessage() . $message
+                    _("Request to the Central's API failed") . ' : ' . $e->getMessage() . $message
                 );
             } catch (ClientExceptionInterface $e) {
                 throw new PlatformTopologyException(
-                    _("API calling the Central returned a Client exception") . (' : ') . $e->getMessage()
+                    _("API calling the Central returned a Client exception") . ' : ' . $e->getMessage()
                 );
             } catch (RedirectionExceptionInterface $e) {
                 throw new PlatformTopologyException(
-                    _("API calling the Central returned a Redirection exception") . (' : ') . $e->getMessage()
+                    _("API calling the Central returned a Redirection exception") . ' : ' . $e->getMessage()
                 );
             } catch (ServerExceptionInterface $e) {
                 $message = _("API calling the Central returned a Server exception");
@@ -342,15 +342,15 @@ class PlatformTopologyService implements PlatformTopologyServiceInterface
                     $message .= '. ' . _("Please check the 'Centreon UI' and 'Remote access' forms");
                 }
                 throw new PlatformTopologyException(
-                    $message . (' : ') . $e->getMessage()
+                    $message . ' : ' . $e->getMessage()
                 );
             } catch (DecodingExceptionInterface $e) {
                 throw new PlatformTopologyException(
-                    _("Unable to convert Central's API response") . (' : ') . $e->getMessage()
+                    _("Unable to convert Central's API response") . ' : ' . $e->getMessage()
                 );
             } catch (\Exception $e) {
                 throw new PlatformTopologyException(
-                    _("Error from Central's register API") . (' : ') . $e->getMessage()
+                    _("Error from Central's register API") . ' : ' . $e->getMessage()
                 );
             }
         }


### PR DESCRIPTION
## Description

enhance thrown message on transport exception when a proxy is set
correct thrown message as error code has been removed

before
![image](https://user-images.githubusercontent.com/34628915/96274289-9e658680-0fd0-11eb-8bdf-379c6a07474c.png)


after
![image](https://user-images.githubusercontent.com/34628915/96277840-0f0ea200-0fd5-11eb-8de7-8c9c85d86816.png)





**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.04.x
- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x (master)
