### PR TITLE
fix(resource-status/Timeline): replace fragments by divs

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Timeline/Event.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/Event.tsx
@@ -72,6 +72,14 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'flex-start',
     alignItems: 'center',
   },
+  event: {
+    display: 'grid',
+    gridAutoFlow: 'columns',
+    gridTemplateColumns: 'auto 1fr auto',
+    padding: theme.spacing(1),
+    gridGap: theme.spacing(2),
+    alignItems: 'center',
+  },
 }));
 
 interface Props {
@@ -99,7 +107,7 @@ const EventTimelineEvent = ({ event }: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
-    <>
+    <div className={classes.event}>
       <EventIcon color="primary" />
       <div className={classes.info}>
         <Date event={event} />
@@ -113,7 +121,7 @@ const EventTimelineEvent = ({ event }: Props): JSX.Element => {
         <Content event={event} />
       </div>
       <Typography>{`${t(labelTries)}: ${event.tries}`}</Typography>
-    </>
+    </div>
   );
 };
 
@@ -122,7 +130,7 @@ const CommentTimelineEvent = ({ event }: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
-    <>
+    <div className={classes.event}>
       <CommentIcon color="primary" />
       <div className={classes.info}>
         <Date event={event} />
@@ -131,7 +139,7 @@ const CommentTimelineEvent = ({ event }: Props): JSX.Element => {
         </div>
         <Content event={event} />
       </div>
-    </>
+    </div>
   );
 };
 
@@ -140,7 +148,7 @@ const AcknowledgeTimelineEvent = ({ event }: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
-    <>
+    <div className={classes.event}>
       <AcknowledgeChip />
       <div className={classes.info}>
         <Date event={event} />
@@ -149,7 +157,7 @@ const AcknowledgeTimelineEvent = ({ event }: Props): JSX.Element => {
         </div>
         <Content event={event} />
       </div>
-    </>
+    </div>
   );
 };
 
@@ -172,7 +180,7 @@ const DowntimeTimelineEvent = ({ event }: Props): JSX.Element => {
   };
 
   return (
-    <>
+    <div className={classes.event}>
       <DowntimeChip />
       <div className={classes.info}>
         <Date event={event} />
@@ -182,7 +190,7 @@ const DowntimeTimelineEvent = ({ event }: Props): JSX.Element => {
         <Typography variant="caption">{getCaption()}</Typography>
         <Content event={event} />
       </div>
-    </>
+    </div>
   );
 };
 
@@ -191,7 +199,7 @@ const NotificationTimelineEvent = ({ event }: Props): JSX.Element => {
   const classes = useStyles();
 
   return (
-    <>
+    <div className={classes.event}>
       <NotificationIcon color="primary" />
       <div className={classes.info}>
         <Date event={event} />
@@ -202,7 +210,7 @@ const NotificationTimelineEvent = ({ event }: Props): JSX.Element => {
         </div>
         <Content event={event} />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/www/front_src/src/Resources/Details/tabs/Timeline/Events/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/Events/index.tsx
@@ -27,14 +27,6 @@ const useStyles = makeStyles((theme) => ({
     gridGap: theme.spacing(1),
     width: '100%',
   },
-  event: {
-    display: 'grid',
-    gridAutoFlow: 'columns',
-    gridTemplateColumns: 'auto 1fr auto',
-    padding: theme.spacing(1),
-    gridGap: theme.spacing(2),
-    alignItems: 'center',
-  },
 }));
 
 type DateEvents = Array<[string, Array<TimelineEvent>]>;
@@ -96,7 +88,7 @@ const Events = ({
                   const Event = TimelineEventByType[type];
 
                   return (
-                    <Paper key={`${id}-${type}`} className={classes.event}>
+                    <Paper key={`${id}-${type}`}>
                       <Event event={event} />
                     </Paper>
                   );


### PR DESCRIPTION
## Description

Fragments seem to create important lags on firefox in the Timeline tabs, so they have been replaced by divs. 

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.04.x
- [x] 20.10.x (master)
