### PR TITLE
fix(resource-status/Timeline): fix duplicated timeline events

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
@@ -78,7 +78,7 @@ const TimelineTab = ({ details }: TabProps): JSX.Element => {
   );
   const [page, setPage] = React.useState(1);
   const [total, setTotal] = React.useState(0);
-  const [limit] = React.useState(10);
+  const [limit] = React.useState(30);
   const [loadingMoreEvents, setLoadingMoreEvents] = React.useState(false);
 
   const { sendRequest, sending } = useRequest<TimelineListing>({

--- a/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Timeline/index.tsx
@@ -78,7 +78,7 @@ const TimelineTab = ({ details }: TabProps): JSX.Element => {
   );
   const [page, setPage] = React.useState(1);
   const [total, setTotal] = React.useState(0);
-  const [limit] = React.useState(30);
+  const [limit] = React.useState(10);
   const [loadingMoreEvents, setLoadingMoreEvents] = React.useState(false);
 
   const { sendRequest, sending } = useRequest<TimelineListing>({
@@ -147,7 +147,7 @@ const TimelineTab = ({ details }: TabProps): JSX.Element => {
   }, [details]);
 
   React.useEffect(() => {
-    if (isNil(timeline)) {
+    if (isNil(timeline) || page === 1) {
       return;
     }
 


### PR DESCRIPTION
## Description

This fixes the timeline events being duplicated when the refresh button is clicked. 

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Have a resource with more than 30 timeline events
- open the corresponding timeline tab in the details panel
- trigger a load cycle by scrolling to the bottom
- click on the refresh button
--> the events shouldn't be duplicated. 
