### PR TITLE
MON-6228 unattended centos8 support

### DIFF
--- a/unattended.sh
+++ b/unattended.sh
@@ -38,6 +38,7 @@ case "$rhrelease" in
     PHP_BIN="/opt/rh/rh-php72/root/bin/php"
     PHP_ETC="/etc/opt/rh/rh-php72/php.d"
     OS_SPEC_SERVICES="rh-php72-php-fpm httpd24-httpd"
+    PKG_MGR="yum"
     ;;
   '8')
     # CentOS 8 specific part
@@ -48,6 +49,7 @@ case "$rhrelease" in
     PHP_BIN="/bin/php"
     PHP_ETC="/etc/php.d"
     OS_SPEC_SERVICES="php-fpm httpd"
+    PKG_MGR="dnf"
     ;;
   *)
     error_and_exit "This unattended installation script only supports CentOS 7 and CentOS 8. Please check https://documentation.centreon.com/$CENTREON_MAJOR_VERSION/en/installation/introduction.html for alternative installation methods."
@@ -98,12 +100,12 @@ fi
 #
 
 print_step_begin "Centreon official repositories installation"
-yum -q clean all
+$PKG_MGR -q clean all
 
 if [[ $rhrelease == 7 ]]; then
   rpm -q centos-release-scl > /dev/null 2>&1
   if [ "x$?" '!=' x0 ] ; then
-    yum -q install -y centos-release-scl
+    $PKG_MGR -q install -y centos-release-scl
     if [ "x$?" '!=' x0 ] ; then
       error_and_exit "Could not install Software Collections repository (package centos-release-scl)"
     fi
@@ -111,7 +113,7 @@ if [[ $rhrelease == 7 ]]; then
 fi
 rpm -q centreon-release-$CENTREON_MAJOR_VERSION > /dev/null 2>&1
 if [ "x$?" '!=' x0 ] ; then
-  yum -q install -y --nogpgcheck $RELEASE_RPM_URL
+  $PKG_MGR -q install -y --nogpgcheck $RELEASE_RPM_URL
   if [ "x$?" '!=' x0 ] ; then
     error_and_exit "Could not install Centreon repository"
   fi
@@ -123,7 +125,7 @@ print_step_end
 #
 
 print_step_begin "Centreon installation"
-yum -q install -y centreon
+$PKG_MGR -q install -y centreon
 if [ "x$?" '!=' x0 ] ; then
   error_and_exit "Could not install Centreon (package centreon)"
 fi

--- a/unattended.sh
+++ b/unattended.sh
@@ -47,7 +47,7 @@ case "$rhrelease" in
     OS_SPEC_SERVICES="php-fpm httpd"
     ;;
   *)
-    error_and_exit "This unattended installation script only supports CentOS 7. Please check https://documentation.centreon.com/$CENTREON_MAJOR_VERSION/en/installation/introduction.html for alternative installation methods."
+    error_and_exit "This unattended installation script only supports CentOS 7 and CentOS 8. Please check https://documentation.centreon.com/$CENTREON_MAJOR_VERSION/en/installation/introduction.html for alternative installation methods."
     ;;
 esac
 

--- a/unattended.sh
+++ b/unattended.sh
@@ -32,14 +32,12 @@ fi
 rhrelease=$(rpm -E %{rhel})
 case "$rhrelease" in
   '7')
-    # Good to go.
     RELEASE_RPM_URL="http://yum.centreon.com/standard/$CENTREON_MAJOR_VERSION/el7/stable/noarch/RPMS/centreon-release-$CENTREON_MAJOR_VERSION-2.el7.centos.noarch.rpm"
     PHP_BIN="/opt/rh/rh-php72/root/bin/php"
     PHP_ETC="/etc/opt/rh/rh-php72/php.d"
     OS_SPEC_SERVICES="rh-php72-php-fpm httpd24-httpd"
     ;;
   '8')
-    # Good to go.
     dnf -y install dnf-plugins-core epel-release
     dnf -y update gnutls
     dnf config-manager --set-enabled PowerTools

--- a/unattended.sh
+++ b/unattended.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 CENTREON_MAJOR_VERSION="20.10"
+CENTREON_RELEASE_VERSION="$CENTREON_MAJOR_VERSION-2"
 
 function error_and_exit {
   echo -e "$1"
@@ -32,16 +33,18 @@ fi
 rhrelease=$(rpm -E %{rhel})
 case "$rhrelease" in
   '7')
-    RELEASE_RPM_URL="http://yum.centreon.com/standard/$CENTREON_MAJOR_VERSION/el7/stable/noarch/RPMS/centreon-release-$CENTREON_MAJOR_VERSION-2.el7.centos.noarch.rpm"
+    # CentOS 7 specific part
+    RELEASE_RPM_URL="http://yum.centreon.com/standard/$CENTREON_MAJOR_VERSION/el7/stable/noarch/RPMS/centreon-release-$CENTREON_RELEASE_VERSION.el7.centos.noarch.rpm"
     PHP_BIN="/opt/rh/rh-php72/root/bin/php"
     PHP_ETC="/etc/opt/rh/rh-php72/php.d"
     OS_SPEC_SERVICES="rh-php72-php-fpm httpd24-httpd"
     ;;
   '8')
+    # CentOS 8 specific part
     dnf -y install dnf-plugins-core epel-release
     dnf -y update gnutls
     dnf config-manager --set-enabled PowerTools
-    RELEASE_RPM_URL="http://yum.centreon.com/standard/$CENTREON_MAJOR_VERSION/el8/stable/noarch/RPMS/centreon-release-$CENTREON_MAJOR_VERSION-2.el8.noarch.rpm"
+    RELEASE_RPM_URL="http://yum.centreon.com/standard/$CENTREON_MAJOR_VERSION/el8/stable/noarch/RPMS/centreon-release-$CENTREON_RELEASE_VERSION.el8.noarch.rpm"
     PHP_BIN="/bin/php"
     PHP_ETC="/etc/php.d"
     OS_SPEC_SERVICES="php-fpm httpd"


### PR DESCRIPTION
## Description

Enhance unattended.sh script for Centos 8.
The scripts now checks which version of Centos is running and does what has to be done depending on this version.

Also avoid version number redondances in the script in order to simplify later updates.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [ ] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Make a fresh install on a Centos 8 machine and check everything is installed as expected.
As a non regression test: do the same from a Centos 7 machine, check everything is ok.

