### PR TITLE
fix(deps): use proper version of stack-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "less-loader": "^4.0.5",
     "react-test-renderer": "^16.3.1",
     "redux-mock-store": "^1.5.1",
+    "stack-utils": "1.0.1",
     "style-loader": "^0.20.2",
     "uglifyjs-webpack-plugin": "^1.2.4",
     "webpack": "^4.12.0",


### PR DESCRIPTION
## Description

to be compatible with old versions of nodejs (<10)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)