### PR TITLE
enh(resource-status): Make FQDN tile bigger

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
@@ -31,6 +31,7 @@ type Lines = Array<{ key: string; line: JSX.Element | null }>;
 interface DetailCardLines {
   title: string;
   field?: string | number | boolean;
+  xs?: 6 | 12;
   getLines: () => Lines;
 }
 
@@ -107,6 +108,7 @@ const getDetailCardLines = ({
     {
       title: labelFqdn,
       field: details.fqdn,
+      xs: 12,
       getLines: (): Lines => [
         {
           key: 'fqdn',

--- a/www/front_src/src/Resources/Details/tabs/Details/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Details/index.tsx
@@ -134,9 +134,9 @@ const DetailsTab = ({ details }: Props): JSX.Element => {
       )}
       <Grid container spacing={2} alignItems="stretch">
         {getDetailCardLines({ details, toDate, toTime }).map(
-          ({ title, field, getLines }) =>
+          ({ title, field, xs = 6, getLines }) =>
             !isNil(field) && (
-              <Grid key={title} item xs={6}>
+              <Grid key={title} item xs={xs}>
                 <DetailsCard title={t(title)} lines={getLines()} />
               </Grid>
             ),


### PR DESCRIPTION
## Description

![Screenshot from 2020-11-25 11-33-58](https://user-images.githubusercontent.com/8367233/100216219-51030000-2f12-11eb-834e-6aad95945e4a.png)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.10.x
- [x] 21.04.x (master)

