### PR TITLE
fix(secu): enhance default http configuration when using sources

### DIFF
--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1394,6 +1394,11 @@ prepare_apache_config() {
 
     # Prepare apache config
     ${CAT} << __EOT__ > $directory/centreon.apache.conf
+Header set X-Frame-Options: "sameorigin"
+ServerSignature Off
+ServerTokens Prod
+TraceEnable Off
+
 Alias /centreon/api $INSTALL_DIR_CENTREON
 Alias /centreon $INSTALL_DIR_CENTREON/www/
 
@@ -1404,6 +1409,7 @@ Alias /centreon $INSTALL_DIR_CENTREON/www/
 <LocationMatch ^/centreon/api/(latest/|beta/|v[0-9]+/|v[0-9]+\.[0-9]+/)(.*)$>
   ProxyPassMatch fcgi://127.0.0.1:9042${INSTALL_DIR_CENTREON}/api/index.php/\$1
 </LocationMatch>
+
 ProxyTimeout 300
 
 <Directory "$INSTALL_DIR_CENTREON/www">


### PR DESCRIPTION
## Description

disable http trace option and prevent from click-jacking in http configuration set by default when user use the sources to install his platform

**Fixes** # (MON-4751 & MON-4750)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

