### PR TITLE
fix(secu): enhance default http configuration when using sources

### DIFF
--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1275,6 +1275,10 @@ function prepare_apache_config() {
 #
 # Section add by Centreon Install Setup
 #
+Header set X-Frame-Options: "sameorigin"
+ServerSignature Off
+ServerTokens Prod
+TraceEnable Off
 
 Alias /centreon $INSTALL_DIR_CENTREON/www/
 


### PR DESCRIPTION
## Description

disable http trace option and prevent from click-jacking, in http configuration set by default when user uses the sources to install his platform

**Fixes** # (MON-4751 & MON-4750)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
