### PR TITLE
enh(api): user and global parameters endpoints

### DIFF
--- a/config/routes/Centreon/administration/parameters.yaml
+++ b/config/routes/Centreon/administration/parameters.yaml
@@ -1,0 +1,5 @@
+centreon_application_administration_parameters_getparameters:
+  methods: GET
+  path: /administration/parameters
+  controller: 'Centreon\Application\Controller\Administration\ParametersController::getParameters'
+  condition: "request.attributes.get('version.is_beta') == true"

--- a/config/routes/Centreon/user.yaml
+++ b/config/routes/Centreon/user.yaml
@@ -3,3 +3,9 @@ centreon_application_user_getActionsAuthorization:
   path: /users/acl/actions
   controller: 'Centreon\Application\Controller\UserController::getActionsAuthorization'
   condition: "request.attributes.get('version.is_beta') == true"
+
+centreon_application_user_getParameters:
+  methods: GET
+  path: /configuration/users/current/parameters
+  controller: 'Centreon\Application\Controller\UserController::getUserParameters'
+  condition: "request.attributes.get('version.is_beta') == true"

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -269,6 +269,42 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /configuration/users/current/parameters:
+    get:
+      tags:
+        - User parameters
+      summary: "List user parameters"
+      description: "List configured parameters for the current user"
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: Name of the current user
+                    example: Administrator
+                  alias:
+                    type: string
+                    description: Alias of the current user
+                    example: admin
+                  email:
+                    type: string
+                    description: Email of the current user
+                    example: admin@localhost
+                  timezone:
+                    type: string
+                    description: Timezone for the current user
+                    example: Europe/Paris
+                  locale:
+                    type: string
+                    description: Locale of the current user
+                    example: en_US
+        '500':
+          $ref: '#/components/responses/InternalServerError'
   /users/filters/{page_name}:
     get:
       tags:
@@ -2599,6 +2635,28 @@ paths:
                       description: "Token used to retrieve the data linked to the command"
         '403':
           $ref: '#/components/responses/Forbidden'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
+  /administration/parameters:
+    post:
+      tags:
+        - Administration parameters
+      responses:
+        '200':
+            description: "OK"
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    monitoring_default_downtime_duration:
+                      type: string
+                      description: Default downtime duration
+                      example: 3600
+                    monitoring_default_refresh_interval:
+                      type: string
+                      description: Default monitoring refresh interval
+                      example: 15
         '500':
           $ref: '#/components/responses/InternalServerError'
 components:

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -304,6 +304,8 @@ paths:
                     nullable: true
                     description: Locale of the current user
                     example: en_US
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /users/filters/{page_name}:
@@ -2658,6 +2660,8 @@ paths:
                       type: string
                       description: Default monitoring refresh interval
                       example: 15
+        '403':
+          $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
 components:

--- a/doc/API/centreon-api-v2.yaml
+++ b/doc/API/centreon-api-v2.yaml
@@ -301,6 +301,7 @@ paths:
                     example: Europe/Paris
                   locale:
                     type: string
+                    nullable: true
                     description: Locale of the current user
                     example: en_US
         '500':

--- a/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14518,6 +14518,9 @@ msgstr "Permitir certificado autofirmado"
 #  msgid "Error when decoding sent data"
 #  msgstr ""
 
+#  msgid "Error when retrieving selected options"
+#  msgstr ""
+
 #  msgid "Filter id %d not found"
 #  msgstr ""
 

--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15466,6 +15466,9 @@ msgstr "Aucun résultat trouvé"
 msgid "Error when decoding sent data"
 msgstr "Erreur lors du décodage des données envoyées"
 
+msgid "Error when retrieving selected options"
+msgstr "Erreur lors de la récupération des options selectionnées"
+
 msgid "Filter id %d not found"
 msgstr "Filtre id %s non trouvé"
 

--- a/src/Centreon/Application/Controller/Administration/ParametersController.php
+++ b/src/Centreon/Application/Controller/Administration/ParametersController.php
@@ -70,7 +70,6 @@ class ParametersController extends AbstractController
         $this->denyAccessUnlessGrantedForApiConfiguration();
 
         $parameters = [];
-        $options = [];
 
         $options = $this->optionService->findSelectedOptions([
             self::DEFAULT_DOWNTIME_DURATION,

--- a/src/Centreon/Application/Controller/Administration/ParametersController.php
+++ b/src/Centreon/Application/Controller/Administration/ParametersController.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Centreon\Application\Controller\Administration;
 
-
 use Centreon\Application\Controller\AbstractController;
 use Centreon\Domain\Option\Interfaces\OptionServiceInterface;
 use FOS\RestBundle\View\View;

--- a/src/Centreon/Application/Controller/Administration/ParametersController.php
+++ b/src/Centreon/Application/Controller/Administration/ParametersController.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types=1);
+
+namespace Centreon\Application\Controller\Administration;
+
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Option\Interfaces\OptionServiceInterface;
+use FOS\RestBundle\View\View;
+
+/**
+ * Used to get global parameters
+ *
+ * @package Centreon\Application\Controller
+ */
+class ParametersController extends AbstractController
+{
+    /**
+     * @var OptionServiceInterface
+     */
+    private $optionService;
+
+    private const DEFAULT_DOWNTIME_DURATION = 'monitoring_dwt_duration';
+    private const DEFAULT_REFRESH_INTERVAL = 'AjaxTimeReloadMonitoring';
+
+    /**
+     * Needed to make response "more readable"
+     */
+    private const KEY_NAME_CONCORDANCE = [
+        self::DEFAULT_REFRESH_INTERVAL => 'monitoring_default_refresh_interval',
+        self::DEFAULT_DOWNTIME_DURATION => 'monitoring_default_downtime_duration'
+    ];
+
+    public function __construct(OptionServiceInterface $optionService)
+    {
+        $this->optionService = $optionService;
+    }
+
+    /**
+     * Entry point to get global parameters stored in options table
+     *
+     * @return View
+     */
+    public function getParameters(): View
+    {
+        $parameters = [];
+        $options = [];
+
+        $options = $this->optionService->findSelectedOptions([
+            self::DEFAULT_DOWNTIME_DURATION,
+            self::DEFAULT_REFRESH_INTERVAL
+        ]);
+
+        foreach ($options as $option) {
+            $parameters[self::KEY_NAME_CONCORDANCE[$option->getName()]] = $option->getValue();
+        }
+
+        return $this->view($parameters);
+    }
+}

--- a/src/Centreon/Application/Controller/Administration/ParametersController.php
+++ b/src/Centreon/Application/Controller/Administration/ParametersController.php
@@ -18,6 +18,7 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
 namespace Centreon\Application\Controller\Administration;
@@ -50,6 +51,11 @@ class ParametersController extends AbstractController
         self::DEFAULT_DOWNTIME_DURATION => 'monitoring_default_downtime_duration'
     ];
 
+    /**
+     * Parameters constructor.
+     *
+     * @param OptionServiceInterface $optionService
+     */
     public function __construct(OptionServiceInterface $optionService)
     {
         $this->optionService = $optionService;

--- a/src/Centreon/Application/Controller/Administration/ParametersController.php
+++ b/src/Centreon/Application/Controller/Administration/ParametersController.php
@@ -67,6 +67,8 @@ class ParametersController extends AbstractController
      */
     public function getParameters(): View
     {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
         $parameters = [];
         $options = [];
 

--- a/src/Centreon/Application/Controller/UserController.php
+++ b/src/Centreon/Application/Controller/UserController.php
@@ -79,7 +79,13 @@ class UserController extends AbstractController
             'locale' => $user->getLocale()
         ];
 
-        return $this->view($userParameters);
+        return $this->view([
+            'name' => $user->getName(),
+            'alias' => $user->getAlias(),
+            'email' => $user->getEmail(),
+            'timezone' => $user->getTimezone()->getName(),
+            'locale' => $user->getLocale()
+        ]);
     }
 
     /**

--- a/src/Centreon/Application/Controller/UserController.php
+++ b/src/Centreon/Application/Controller/UserController.php
@@ -67,6 +67,8 @@ class UserController extends AbstractController
      */
     public function getUserParameters(): View
     {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
         $user = $this->getUser();
 
         $userParameters = [

--- a/src/Centreon/Application/Controller/UserController.php
+++ b/src/Centreon/Application/Controller/UserController.php
@@ -60,6 +60,25 @@ class UserController extends AbstractController
 
         return $this->view($actions);
     }
+    /**
+     * Entry point to get configured parameters for the current user
+     *
+     * @return View
+     */
+    public function getUserParameters(): View
+    {
+        $user = $this->getUser();
+
+        $userParameters = [
+            'name' => $user->getName(),
+            'alias' => $user->getAlias(),
+            'email' => $user->getEmail(),
+            'timezone' => $user->getTimezone()->getName(),
+            'locale' => $user->getLocale()
+        ];
+
+        return $this->view($userParameters);
+    }
 
     /**
      * Get authorization for a specific role of the current user

--- a/src/Centreon/Application/Controller/UserController.php
+++ b/src/Centreon/Application/Controller/UserController.php
@@ -71,14 +71,6 @@ class UserController extends AbstractController
 
         $user = $this->getUser();
 
-        $userParameters = [
-            'name' => $user->getName(),
-            'alias' => $user->getAlias(),
-            'email' => $user->getEmail(),
-            'timezone' => $user->getTimezone()->getName(),
-            'locale' => $user->getLocale()
-        ];
-
         return $this->view([
             'name' => $user->getName(),
             'alias' => $user->getAlias(),

--- a/src/Centreon/Domain/Option/OptionService.php
+++ b/src/Centreon/Domain/Option/OptionService.php
@@ -50,7 +50,11 @@ class OptionService implements OptionServiceInterface
      */
     public function findSelectedOptions(array $optionsToFind): array
     {
-        $optionsFound = $this->repository->findAllOptions();
+        try {
+            $optionsFound = $this->repository->findAllOptions();
+        } catch (\Throwable $ex) {
+            throw new \Exception(_('Error when retrieving selected options'));
+        }
         $requestedOptions = [];
         foreach ($optionsFound as $option) {
             if (in_array($option->getName(), $optionsToFind)) {

--- a/src/Centreon/Domain/Option/OptionService.php
+++ b/src/Centreon/Domain/Option/OptionService.php
@@ -53,7 +53,7 @@ class OptionService implements OptionServiceInterface
         try {
             $optionsFound = $this->repository->findAllOptions();
         } catch (\Throwable $ex) {
-            throw new \Exception(_('Error when retrieving selected options'));
+            throw new \Exception(_('Error when retrieving selected options'), 0, $ex);
         }
         $requestedOptions = [];
         foreach ($optionsFound as $option) {

--- a/tests/api/Context/UserParametersContext.php
+++ b/tests/api/Context/UserParametersContext.php
@@ -19,6 +19,8 @@
  *
  */
 
+declare(strict_types=1);
+
 namespace Centreon\Test\Api\Context;
 
 use Centreon\Test\Behat\Api\Context\ApiContext;

--- a/tests/api/Context/UserParametersContext.php
+++ b/tests/api/Context/UserParametersContext.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+namespace Centreon\Test\Api\Context;
+
+use Centreon\Test\Behat\Api\Context\ApiContext;
+
+class UserParametersContext extends ApiContext
+{
+}

--- a/tests/api/behat.yml
+++ b/tests/api/behat.yml
@@ -22,12 +22,12 @@ default:
         - Centreon\Test\Api\Context\AuthenticationContext
     user_filter:
       paths: [ "%paths.base%/features/UserFilter.feature" ]
+      contexts:
+        - Centreon\Test\Api\Context\UserFilterContext
     user_parameters:
       paths: [ "%paths.base%/features/UserParameters.feature" ]
       contexts:
         - Centreon\Test\Api\Context\UserParametersContext
-      contexts:
-        - Centreon\Test\Api\Context\UserFilterContext
     check:
       paths: [ "%paths.base%/features/Check.feature" ]
       contexts:

--- a/tests/api/behat.yml
+++ b/tests/api/behat.yml
@@ -22,6 +22,10 @@ default:
         - Centreon\Test\Api\Context\AuthenticationContext
     user_filter:
       paths: [ "%paths.base%/features/UserFilter.feature" ]
+    user_parameters:
+      paths: [ "%paths.base%/features/UserParameters.feature" ]
+      contexts:
+        - Centreon\Test\Api\Context\UserParametersContext
       contexts:
         - Centreon\Test\Api\Context\UserFilterContext
     check:

--- a/tests/api/features/UserParameters.feature
+++ b/tests/api/features/UserParameters.feature
@@ -11,16 +11,15 @@ Feature:
     Given I am logged in
     And the following CLAPI import data:
     """
-    CONTACT;ADD;Test user;tuser;tuser@mail.com;userpassword;1;1;en_US;local"
-    CONTACT;setparam;tuser;timezone;Europe/Paris
+    CONTACT;setparam;admin;timezone;Europe/Paris
     """
     And the configuration is generated and exported
 
     When I send a GET request to '/beta/configuration/users/current/parameters'
     Then the response code should be "200"
-    And the JSON node "name" should be equal to the string "Test user"
-    And the JSON node "alias" should be equal to the string "tuser"
-    And the JSON node "email" should be equal to the string "tuser@email.com"
+    And the JSON node "name" should be equal to the string "admin admin"
+    And the JSON node "alias" should be equal to the string "admin"
+    And the JSON node "email" should be equal to the string "admin@centreon.com"
     And the JSON node "locale" should be equal to the string "en_US"
     And the JSON node "timezone" should be equal to the string "Europe/Paris"
 

--- a/tests/api/features/UserParameters.feature
+++ b/tests/api/features/UserParameters.feature
@@ -1,0 +1,24 @@
+Feature:
+  In order to get information on the current user
+  As a user
+  I want retrieve those information
+
+  Background:
+    Given a running instance of Centreon Web API
+    And the endpoints are described in Centreon Web API documentation
+
+  Scenario: Get user parameters
+    Given I am logged in
+    And the following CLAPI import data:
+    """
+    Test user;tuser;tuser@mail.com;userpassword;1;1;en_US;local"
+    """
+    And the configuration is generated and exported
+
+    When I send a GET request to '/beta/configuration/users/current/parameters'
+    Then the response code should be "200"
+    And the JSON node "name" should be equal to the string "Test user"
+    And the JSON node "alias" should be equal to the string "tuser"
+    And the JSON node "email" should be equal to the string "tuser@email.com"
+    And the JSON node "locale" should be equal to the string "en_US"
+

--- a/tests/api/features/UserParameters.feature
+++ b/tests/api/features/UserParameters.feature
@@ -21,5 +21,5 @@ Feature:
     And the JSON node "alias" should be equal to the string "admin"
     And the JSON node "email" should be equal to the string "admin@centreon.com"
     And the JSON node "locale" should be equal to the string "en_US"
-    And the JSON node "timezone" should be equal to the string "Europe\\\/Paris"
+    And the JSON node "timezone" should contain "Paris"
 

--- a/tests/api/features/UserParameters.feature
+++ b/tests/api/features/UserParameters.feature
@@ -11,7 +11,8 @@ Feature:
     Given I am logged in
     And the following CLAPI import data:
     """
-    Test user;tuser;tuser@mail.com;userpassword;1;1;en_US;local"
+    CONTACT;ADD;Test user;tuser;tuser@mail.com;userpassword;1;1;en_US;local"
+    CONTACT;setparam;tuser;timezone;Europe/Paris
     """
     And the configuration is generated and exported
 
@@ -21,4 +22,5 @@ Feature:
     And the JSON node "alias" should be equal to the string "tuser"
     And the JSON node "email" should be equal to the string "tuser@email.com"
     And the JSON node "locale" should be equal to the string "en_US"
+    And the JSON node "timezone" should be equal to the string "Europe/Paris"
 

--- a/tests/api/features/UserParameters.feature
+++ b/tests/api/features/UserParameters.feature
@@ -21,5 +21,5 @@ Feature:
     And the JSON node "alias" should be equal to the string "admin"
     And the JSON node "email" should be equal to the string "admin@centreon.com"
     And the JSON node "locale" should be equal to the string "en_US"
-    And the JSON node "timezone" should be equal to the string "Europe/Paris"
+    And the JSON node "timezone" should be equal to the string "Europe\\\/Paris"
 


### PR DESCRIPTION
This PR intends to add 2 endpoints
- GET /configuration/users/current/parameters - retrieves information regarding the current user
- GET /administration/parameters - retrieves global informations

**Example of results**

```
For global information
{
    "monitoring_default_refresh_interval": "15",
    "monitoring_default_downtime_duration": "3600"
}

For user information
{
    "name": "centreon centreon",
    "alias": "admin",
    "email": "centreon@localhost",
    "timezone": "Europe/Paris",
    "locale": "en_US"
}
```

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Can be tested by using those endpoints and check the consistency of the values returned.

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
