### PR TITLE
Added fix for quotes and ticks

### DIFF
--- a/lib/perl/centreon/trapd/lib.pm
+++ b/lib/perl/centreon/trapd/lib.pm
@@ -749,7 +749,7 @@ sub readtrap {
     my $variable_fix;
     while (defined(my $line = <$input>)) {
         push(@rawtrap, $line);
-        $line =~ s(`)(')g;	#` Replace any back ticks with regular single quote
+        $line =~ s(`)('\\'')g;	# Replace any back ticks with regular single quote
 
         # Remove escape from quotes if enabled
         if ($args{config}->{remove_backslash_from_quotes} == 1) {
@@ -781,7 +781,7 @@ sub readtrap {
             # If line begins with a double quote (") but does not END in a double quote then we need to merge
             # the following lines together into one until we find the closing double quote.  Allow for escaped quotes.
             # Net-SNMP sometimes divides long lines into multiple lines..
-            if ( ($temp2 =~ /^\"/) && ( ! ($temp2 =~ /\"$/)) ) {
+            if ( ($temp2 =~ /^\"/) && ( ! ($temp2 =~ /\"$/)) || ($temp2 eq "\"") ) {
                 $args{logger}->writeLogDebug("  Multi-line value detected - merging onto one line...");
                 $temp2 =~ s/[\r\n]//g;			# Remove the newline character
                 while (defined(my $line2 = <$input>)) {


### PR DESCRIPTION
## Description

We detected some issues with some traps values:

1. First issue is a trap value that is a multi-line but the first line is just one quote character, the next lines would then not be parsed since it starts and ends with a quote character (line 784)

2. Second issue is with ticks being replaced with regular single quote, when using pre-exec or DSM via the "Special Command" this breaks the bash command that centreontrapd sends (line 752).

3. Third issue is a special case on one trap type that there is a multi-line value, however, the second line ends with a backslashed quote and so the parser assumed it was the end of the value, disabling the option "remove_backslash_from_quotes" fixed the issue however.

I am not sure if these changes are the best way to do it, however it worked on our environment and we stopped having errors on the log.

We had many issues like:

```
Use of uninitialized value $temp2 in scalar chomp at /usr/share/perl5/vendor_perl/centreon/trapd/lib.pm line 751, <FILE> line 13.
Use of uninitialized value $temp2 in pattern match (m//) at /usr/share/perl5/vendor_perl/centreon/trapd/lib.pm line 770, <FILE> line 13.
```

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [X] 19.10.x
- [X] 20.04.x
- [X] 20.10.x
- [X] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

I believe you can test with these traps below:

For first issue:

```
1607355778
UDP: [10.251.36.243]:35873->[10.9.166.14]:162
UDP: [10.251.36.243]:35873->[10.9.166.14]:162
.1.3.6.1.2.1.1.3.0 10:6:01:02.65
.1.3.6.1.6.3.1.1.4.1.0 .1.3.6.1.4.1.9.9.712.0.1
.1.3.6.1.4.1.9.9.712.1.1.2.1.2.0 "..
.
..+.."
.1.3.6.1.4.1.9.9.712.1.1.2.1.3.0 "..
...:.+.."
.1.3.6.1.4.1.9.9.712.1.1.2.1.4.0 "RogueAp!18:8b:9d:a8:05:fd"
.1.3.6.1.4.1.9.9.712.1.1.2.1.5.0 12
.1.3.6.1.4.1.9.9.712.1.1.2.1.6.0 "Unclassified Rogue AP Detected"
.1.3.6.1.4.1.9.9.712.1.1.2.1.7.0 1
.1.3.6.1.4.1.9.9.712.1.1.2.1.8.0 "
..T"
```

For second issue (test it for example with a pre-exec command to get the value and compare it in a bash command or in a DSM command):

```
1607355778
UDP: [172.30.155.69]:57949->[10.9.166.14]:162
UDP: [172.30.155.69]:57949->[10.9.166.14]:162
.1.3.6.1.2.1.1.3.0 2:0:38:46.87
.1.3.6.1.6.3.1.1.4.1.0 .1.3.6.1.6.3.1.1.5.5
.1.3.6.1.4.1.30065.3.10.5.1.0 .1.3.6.1.2.1.100.1.1
.1.3.6.1.4.1.30065.3.10.5.2.0 "`...."
```

For third issue:

```
1607218450
[100.78.116.26]:57967->[10.9.166.14]:162
[100.78.116.26]:57967->[10.9.166.14]:162
.1.3.6.1.2.1.1.3.0 256:0:37:07.53
.1.3.6.1.6.3.1.1.4.1.0 .1.3.6.1.4.1.1453.4.9.1.6.2.1
.1.3.6.1.4.1.1453.4.9.1.5.18.1 119037
.1.3.6.1.4.1.1453.4.9.1.5.18.2 1
.1.3.6.1.4.1.1453.4.9.1.5.18.3 "ccm13"
.1.3.6.1.4.1.1453.4.9.1.5.18.4 "snmp_community"
.1.3.6.1.4.1.1453.4.9.1.5.18.5 4437603
.1.3.6.1.4.1.1453.4.9.1.5.18.6 "..
..\"
.+.."
```

## Checklist

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
