### PR TITLE
fix(api): add resource comments for host issue fixed

### DIFF
--- a/src/Centreon/Domain/Monitoring/Comment/CommentService.php
+++ b/src/Centreon/Domain/Monitoring/Comment/CommentService.php
@@ -222,7 +222,7 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
         } else {
             $accessGroups = $this->accessGroupRepository->findByContact($this->contact);
 
-            if (!empty($resourcesId['host'])) {
+            if (!empty($resourceIds['host'])) {
                 try {
                     $hosts = $this->monitoringRepository
                         ->filterByAccessGroups($accessGroups)
@@ -232,7 +232,7 @@ class CommentService extends AbstractCentreonService implements CommentServiceIn
                 }
             }
 
-            if (!empty($resourcesIds['service'])) {
+            if (!empty($resourceIds['service'])) {
                 try {
                     $services = $this->monitoringRepository
                         ->filterByAccessGroups($accessGroups)

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -708,7 +708,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $statement->execute();
 
         while (false !== ($row = $statement->fetch(\PDO::FETCH_ASSOC))) {
-            $host[] = EntityCreator::createEntityByArray(
+            $hosts[] = EntityCreator::createEntityByArray(
                 Host::class,
                 $row
             );

--- a/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -625,7 +625,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $collector = new StatementCollector();
 
         $request =
-            'SELECT h.*,
+            'SELECT DISTINCT h.*,
             i.name AS poller_name,
               IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS display_name,
               IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS state
@@ -682,7 +682,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 AND acg.acl_group_id IN (' . $this->accessGroupIdToString($this->accessGroups) . ') ';
 
         $request =
-            'SELECT h.*,
+            'SELECT DISTINCT h.*,
             i.name AS poller_name,
               IF (h.display_name LIKE \'_Module_Meta%\', \'Meta\', h.display_name) AS display_name,
               IF (h.display_name LIKE \'_Module_Meta%\', \'0\', h.state) AS state


### PR DESCRIPTION
When trying to add comments using the .../resources/... endpoint for hosts it was not working due to huge typo in variable names causing the issue.

The other issue was that when a resource (host type) was in several accessgroups then the comment was sent n-times.
IT was already fixed for services but not for hosts.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Add comments for host/services resources types using the /resources endpoint with a limited user and admin

## Checklist

- [ x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
