### PR TITLE
fix(poller configuration): Don't override Central IP in platform_topology.

### DIFF
--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -1254,6 +1254,7 @@ function updateServerIntoPlatformTopology(array $pollerInformations, int $server
             parent_id = :parent
             WHERE server_id = :serverId
         ");
+        // do not override platform IP with localhost value
         if ($type === 'central' && $pollerIp === '127.0.0.1') {
             $pollerIp = $platform['address'];
         }

--- a/www/include/configuration/configServers/DB-Func.php
+++ b/www/include/configuration/configServers/DB-Func.php
@@ -1254,6 +1254,9 @@ function updateServerIntoPlatformTopology(array $pollerInformations, int $server
             parent_id = :parent
             WHERE server_id = :serverId
         ");
+        if ($type === 'central' && $pollerIp === '127.0.0.1') {
+            $pollerIp = $platform['address'];
+        }
     } else {
         $statement = $pearDB->prepare("
             INSERT INTO `platform_topology` (`address`, `name`, `type`, `parent_id`, `server_id`)


### PR DESCRIPTION
## Description

This PR ensure that the Central IP isn't override in platform_topology if submitted IP is 127.0.0.1 while updating the Central informations into the Configurations > Pollers Form.

**Fixes** # MON-6467

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Update a Central and leave 127.0.0.1 as IP .
The IP shouldn't be override into centreon.platform_topology

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
