### PR TITLE
enh(api) remove pagination object in meta data of DT and ACK API 

### DIFF
--- a/src/Centreon/Application/Controller/AcknowledgementController.php
+++ b/src/Centreon/Application/Controller/AcknowledgementController.php
@@ -129,7 +129,7 @@ class AcknowledgementController extends AbstractController
                     ? ['pagination' => $requestParameters->toArray()]
                     : $requestParameters->toArray()
             ]
-    )->setContext($context);
+        )->setContext($context);
     }
 
     /**
@@ -145,8 +145,7 @@ class AcknowledgementController extends AbstractController
         RequestParametersInterface $requestParameters,
         int $hostId,
         Request $request
-    ): View
-    {
+    ): View {
         $this->denyAccessUnlessGrantedForApiRealtime();
         $isBeta = (bool) $request->attributes->get('version.is_beta');
         $hostsAcknowledgements = $this->acknowledgementService
@@ -162,7 +161,7 @@ class AcknowledgementController extends AbstractController
                     ? ['pagination' => $requestParameters->toArray()]
                     : $requestParameters->toArray()
             ]
-    )->setContext($context);
+        )->setContext($context);
     }
 
     /**

--- a/src/Centreon/Application/Controller/AcknowledgementController.php
+++ b/src/Centreon/Application/Controller/AcknowledgementController.php
@@ -108,25 +108,28 @@ class AcknowledgementController extends AbstractController
      * Entry point to find the hosts acknowledgements.
      *
      * @param RequestParametersInterface $requestParameters
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
-    public function findHostsAcknowledgements(RequestParametersInterface $requestParameters): View
+    public function findHostsAcknowledgements(RequestParametersInterface $requestParameters, Request $request): View
     {
         $this->denyAccessUnlessGrantedForApiRealtime();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         $hostsAcknowledgements = $this->acknowledgementService
             ->filterByContact($this->getUser())
             ->findHostsAcknowledgements();
 
         $context = (new Context())->setGroups(Acknowledgement::SERIALIZER_GROUPS_HOST);
 
-        return $this->view([
-            'result' => $hostsAcknowledgements,
-            'meta' => [
-                'pagination' => $requestParameters->toArray(),
-            ],
-        ])->setContext($context);
+        return $this->view(
+            [
+                'result' => $hostsAcknowledgements,
+                'meta' => !$isBeta
+                    ? ['pagination' => $requestParameters->toArray()]
+                    : $requestParameters->toArray()
+            ]
+    )->setContext($context);
     }
 
     /**
@@ -134,76 +137,92 @@ class AcknowledgementController extends AbstractController
      *
      * @param RequestParametersInterface $requestParameters
      * @param int $hostId
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
-    public function findAcknowledgementsByHost(RequestParametersInterface $requestParameters, int $hostId): View
+    public function findAcknowledgementsByHost(
+        RequestParametersInterface $requestParameters,
+        int $hostId,
+        Request $request
+    ): View
     {
         $this->denyAccessUnlessGrantedForApiRealtime();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         $hostsAcknowledgements = $this->acknowledgementService
             ->filterByContact($this->getUser())
             ->findAcknowledgementsByHost($hostId);
 
         $context = (new Context())->setGroups(Acknowledgement::SERIALIZER_GROUPS_HOST);
 
-        return $this->view([
-            'result' => $hostsAcknowledgements,
-            'meta' => [
-                'pagination' => $requestParameters->toArray()
+        return $this->view(
+            [
+                'result' => $hostsAcknowledgements,
+                'meta' => !$isBeta
+                    ? ['pagination' => $requestParameters->toArray()]
+                    : $requestParameters->toArray()
             ]
-        ])->setContext($context);
+    )->setContext($context);
     }
 
     /**
      * Entry point to find the services acknowledgements.
      *
      * @param RequestParametersInterface $requestParameters
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
-    public function findServicesAcknowledgements(RequestParametersInterface $requestParameters): View
+    public function findServicesAcknowledgements(RequestParametersInterface $requestParameters, Request $request): View
     {
         $this->denyAccessUnlessGrantedForApiRealtime();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         $servicesAcknowledgements = $this->acknowledgementService
             ->filterByContact($this->getUser())
             ->findServicesAcknowledgements();
         $context = (new Context())->setGroups(Acknowledgement::SERIALIZER_GROUPS_SERVICE);
 
-        return $this->view([
-            'result' => $servicesAcknowledgements,
-            'meta' => [
-                'pagination' => $requestParameters->toArray()
+        return $this->view(
+            [
+                'result' => $servicesAcknowledgements,
+                'meta' => !$isBeta
+                    ? ['pagination' => $requestParameters->toArray()]
+                    : $requestParameters->toArray()
             ]
-        ])->setContext($context);
+        )->setContext($context);
     }
 
     /**
      * Entry point to find acknowledgements linked to a service.
      *
      * @param RequestParametersInterface $requestParameters
+     * @param int $hostId
+     * @param int $serviceId
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
     public function findAcknowledgementsByService(
         RequestParametersInterface $requestParameters,
         int $hostId,
-        int $serviceId
+        int $serviceId,
+        Request $request
     ): View {
         $this->denyAccessUnlessGrantedForApiRealtime();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         $servicesAcknowledgements = $this->acknowledgementService
             ->filterByContact($this->getUser())
             ->findAcknowledgementsByService($hostId, $serviceId);
         $context = (new Context())->setGroups(Acknowledgement::SERIALIZER_GROUPS_SERVICE);
 
-        return $this->view([
-            'result' => $servicesAcknowledgements,
-            'meta' => [
-                'pagination' => $requestParameters->toArray()
+        return $this->view(
+            [
+                'result' => $servicesAcknowledgements,
+                'meta' => !$isBeta
+                    ? ['pagination' => $requestParameters->toArray()]
+                    : $requestParameters->toArray()
             ]
-        ])->setContext($context);
+        )->setContext($context);
     }
 
     /**
@@ -377,6 +396,8 @@ class AcknowledgementController extends AbstractController
      * @param Request $request
      * @param EntityValidator $entityValidator
      * @param SerializerInterface $serializer
+     * @param int $hostId
+     * @param int $serviceId
      * @return View
      * @throws \Exception
      */
@@ -503,25 +524,28 @@ class AcknowledgementController extends AbstractController
      * Entry point to find all acknowledgements.
      *
      * @param RequestParametersInterface $requestParameters
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
-    public function findAcknowledgements(RequestParametersInterface $requestParameters): View
+    public function findAcknowledgements(RequestParametersInterface $requestParameters, Request $request): View
     {
         $this->denyAccessUnlessGrantedForApiRealtime();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         $acknowledgements = $this->acknowledgementService
             ->filterByContact($this->getUser())
             ->findAcknowledgements();
 
         $context = (new Context())->setGroups(Acknowledgement::SERIALIZER_GROUPS_SERVICE);
 
-        return $this->view([
-            'result' => $acknowledgements,
-            'meta' => [
-                'pagination' => $requestParameters->toArray()
+        return $this->view(
+            [
+                'result' => $acknowledgements,
+                'meta' => !$isBeta
+                    ? ['pagination' => $requestParameters->toArray()]
+                    : $requestParameters->toArray()
             ]
-        ])->setContext($context);
+        )->setContext($context);
     }
 
     /**

--- a/src/Centreon/Application/Controller/DowntimeController.php
+++ b/src/Centreon/Application/Controller/DowntimeController.php
@@ -540,8 +540,7 @@ class DowntimeController extends AbstractController
         RequestParametersInterface $requestParameters,
         int $hostId,
         Request $request
-    ): View
-    {
+    ): View {
         $this->denyAccessUnlessGrantedForApiRealtime();
         $isBeta = (bool) $request->attributes->get('version.is_beta');
         /**

--- a/src/Centreon/Application/Controller/DowntimeController.php
+++ b/src/Centreon/Application/Controller/DowntimeController.php
@@ -539,7 +539,8 @@ class DowntimeController extends AbstractController
     public function findDowntimesByHost(
         RequestParametersInterface $requestParameters,
         int $hostId,
-        Request $request): View
+        Request $request
+    ): View
     {
         $this->denyAccessUnlessGrantedForApiRealtime();
         $isBeta = (bool) $request->attributes->get('version.is_beta');

--- a/src/Centreon/Application/Controller/DowntimeController.php
+++ b/src/Centreon/Application/Controller/DowntimeController.php
@@ -356,13 +356,14 @@ class DowntimeController extends AbstractController
      * Entry point to find the last hosts downtimes.
      *
      * @param RequestParametersInterface $requestParameters
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
-    public function findHostDowntimes(RequestParametersInterface $requestParameters): View
+    public function findHostDowntimes(RequestParametersInterface $requestParameters, Request $request): View
     {
         $this->denyAccessUnlessGrantedForApiRealtime();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         /**
          * @var Contact $contact
          */
@@ -374,25 +375,28 @@ class DowntimeController extends AbstractController
 
         $context = (new Context())->setGroups(Downtime::SERIALIZER_GROUPS_MAIN);
 
-        return $this->view([
-            'result' => $hostsDowntime,
-            'meta' => [
-                'pagination' => $requestParameters->toArray()
+        return $this->view(
+            [
+                'result' => $hostsDowntime,
+                'meta' => !$isBeta
+                    ? ['pagination' => $requestParameters->toArray()]
+                    : $requestParameters->toArray()
             ]
-        ])->setContext($context);
+        )->setContext($context);
     }
 
     /**
      * Entry point to find the last services downtimes.
      *
      * @param RequestParametersInterface $requestParameters
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
-    public function findServiceDowntimes(RequestParametersInterface $requestParameters): View
+    public function findServiceDowntimes(RequestParametersInterface $requestParameters, Request $request): View
     {
         $this->denyAccessUnlessGrantedForApiRealtime();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         /**
          * @var Contact $contact
          */
@@ -404,12 +408,14 @@ class DowntimeController extends AbstractController
 
         $context = (new Context())->setGroups(Downtime::SERIALIZER_GROUPS_SERVICE);
 
-        return $this->view([
-            'result' => $servicesDowntimes,
-            'meta' => [
-                'pagination' => $requestParameters->toArray()
+        return $this->view(
+            [
+                'result' => $servicesDowntimes,
+                'meta' => !$isBeta
+                    ? ['pagination' => $requestParameters->toArray()]
+                    : $requestParameters->toArray()
             ]
-        ])->setContext($context);
+        )->setContext($context);
     }
 
     /**
@@ -418,16 +424,18 @@ class DowntimeController extends AbstractController
      * @param RequestParametersInterface $requestParameters
      * @param int $hostId Host id linked to this service
      * @param int $serviceId Service id for which we want to find downtimes
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
     public function findDowntimesByService(
         RequestParametersInterface $requestParameters,
         int $hostId,
-        int $serviceId
+        int $serviceId,
+        Request $request
     ): View {
         $this->denyAccessUnlessGrantedForApiRealtime();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         /**
          * @var Contact $contact
          */
@@ -442,12 +450,14 @@ class DowntimeController extends AbstractController
 
             $context = (new Context())->setGroups(Downtime::SERIALIZER_GROUPS_SERVICE);
 
-            return $this->view([
-                'result' => $downtimesByHost,
-                'meta' => [
-                    'pagination' => $requestParameters->toArray()
+            return $this->view(
+                [
+                    'result' => $downtimesByHost,
+                    'meta' => !$isBeta
+                        ? ['pagination' => $requestParameters->toArray()]
+                        : $requestParameters->toArray()
                 ]
-            ])->setContext($context);
+            )->setContext($context);
         } else {
             return View::create(null, Response::HTTP_NOT_FOUND, []);
         }
@@ -488,13 +498,14 @@ class DowntimeController extends AbstractController
      * Entry point to find the last downtimes.
      *
      * @param RequestParametersInterface $requestParameters
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
-    public function findDowntimes(RequestParametersInterface $requestParameters): View
+    public function findDowntimes(RequestParametersInterface $requestParameters, Request $request): View
     {
         $this->denyAccessUnlessGrantedForApiRealtime();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         /**
          * @var Contact $contact
          */
@@ -506,12 +517,14 @@ class DowntimeController extends AbstractController
 
         $context = (new Context())->setGroups(Downtime::SERIALIZER_GROUPS_SERVICE);
 
-        return $this->view([
-            'result' => $hostsDowntime,
-            'meta' => [
-                'pagination' => $requestParameters->toArray()
+        return $this->view(
+            [
+                'result' => $hostsDowntime,
+                'meta' => !$isBeta
+                    ? ['pagination' => $requestParameters->toArray()]
+                    : $requestParameters->toArray()
             ]
-        ])->setContext($context);
+        )->setContext($context);
     }
 
     /**
@@ -519,13 +532,17 @@ class DowntimeController extends AbstractController
      *
      * @param RequestParametersInterface $requestParameters
      * @param int $hostId Host id for which we want to find downtimes
+     * @param Request $request
      * @return View
      * @throws \Exception
      */
-    public function findDowntimesByHost(RequestParametersInterface $requestParameters, int $hostId): View
+    public function findDowntimesByHost(
+        RequestParametersInterface $requestParameters,
+        int $hostId,
+        Request $request): View
     {
         $this->denyAccessUnlessGrantedForApiRealtime();
-
+        $isBeta = (bool) $request->attributes->get('version.is_beta');
         /**
          * @var Contact $contact
          */
@@ -544,12 +561,14 @@ class DowntimeController extends AbstractController
                 : Downtime::SERIALIZER_GROUPS_MAIN;
             $context = (new Context())->setGroups($contextGroups)->enableMaxDepth();
 
-            return $this->view([
-                'result' => $downtimesByHost,
-                'meta' => [
-                    'pagination' => $requestParameters->toArray()
+            return $this->view(
+                [
+                    'result' => $downtimesByHost,
+                    'meta' => !$isBeta
+                        ? ['pagination' => $requestParameters->toArray()]
+                        : $requestParameters->toArray()
                 ]
-            ])->setContext($context);
+            )->setContext($context);
         } else {
             return View::create(null, Response::HTTP_NOT_FOUND, []);
         }


### PR DESCRIPTION
## Description

Remove pagination object in meta data of API response

    "meta": {
        "page": 1,
        "limit": 10,
        "search": {},
        "sort_by": {},
        "total": 2
    }

doc already without pagination object

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

GET on centreon/api/beta/monitoring/downtimes
GET on centreon/api/beta/monitoring/hosts/downtimes
GET on centreon/api/beta/monitoring/services/downtimes

GET on centreon/api/beta/monitoring/acknowledgements
GET on centreon/api/beta/monitoring/hosts/acknowledgements
GET on centreon/api/beta/monitoring/services/acknowledgements

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
