### PR TITLE
fix(password): Remove the display of the password in HTML file in forms of service, service template, host and host template

### DIFF
--- a/www/class/centreonHost.class.php
+++ b/www/class/centreonHost.class.php
@@ -918,7 +918,7 @@ class CentreonHost
         if (!isset($cmdId)) {
             $cmdId = "";
         }
-        $aMacros = $this->getMacros($host_id, false, $aTemplates, $cmdId);
+        $aMacros = $this->getMacros($host_id, $aTemplates, $cmdId);
         foreach ($aMacros as $macro) {
             foreach ($macroInput as $ind => $input) {
                 if ($input == $macro['macroInput_#index#'] &&
@@ -959,12 +959,11 @@ class CentreonHost
      * This method get the macro attached to the host
      *
      * @param int $iHostId
-     * @param int $bIsTemplate
      * @param array $aListTemplate
      * @param int $iIdCommande
      * @return array
      */
-    public function getMacros($iHostId, $bIsTemplate, $aListTemplate, $iIdCommande, $form = array())
+    public function getMacros($iHostId, $aListTemplate, $iIdCommande, $form = array())
     {
         $macroArray = $this->getMacroFromForm($form, "direct");
         $aMacroTemplate[] = $this->getMacroFromForm($form, "fromTpl");
@@ -1033,18 +1032,16 @@ class CentreonHost
             }
         }
 
-        if (count($aMacroTemplate) > 0) {
-            foreach ($aMacroTemplate as $key => $macr) {
-                foreach ($macr as $mm) {
-                    $mm['macroOldValue_#index#'] = $mm["macroValue_#index#"];
-                    $mm['macroFrom_#index#'] = 'fromTpl';
-                    $mm['source'] = 'fromTpl';
-                    $aTempMacro[] = $mm;
-                }
+        foreach ($aMacroTemplate as $key => $macr) {
+            foreach ($macr as $mm) {
+                $mm['macroOldValue_#index#'] = $mm["macroValue_#index#"];
+                $mm['macroFrom_#index#'] = 'fromTpl';
+                $mm['source'] = 'fromTpl';
+                $aTempMacro[] = $mm;
             }
         }
 
-        if (count($aMacroInCommande) > 0) {
+        if (!empty($aMacroInCommande)) {
             $macroCommande = $aMacroInCommande;
             for ($i = 0; $i < count($macroCommande); $i++) {
                 $macroCommande[$i]['macroOldValue_#index#'] = $macroCommande[$i]["macroValue_#index#"];

--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -2091,3 +2091,49 @@ function get_child($id_page, $lcaTStr)
     $redirect = $DBRESULT->fetchRow();
     return $redirect;
 }
+
+/**
+ * Get the select option.
+ *
+ * @return array<int, int>
+ */
+function getSelectOption()
+{
+    $stringToArray = function ($value) {
+        if (strpos($value, ',') !== false) {
+            return explode(',', $value);
+        }
+        return array();
+    };
+    if (isset($_GET["select"])) {
+        return is_array($_GET["select"])
+            ? $_GET["select"]
+            : $stringToArray($_GET["select"]);
+    } elseif (isset($_POST["select"])) {
+        return is_array($_POST["select"])
+            ? $_POST["select"]
+            : $stringToArray($_POST["select"]);
+    } else {
+        return array();
+    }
+}
+
+/**
+ * Get the duplicate number option.
+ *
+ * @return array<int, int>
+ */
+function getDuplicateNumberOption()
+{
+    if (isset($_GET["dupNbr"])) {
+        return is_array($_GET["dupNbr"])
+            ? $_GET["dupNbr"]
+            : array();
+    } elseif (isset($_POST["dupNbr"])) {
+        return is_array($_POST["dupNbr"])
+            ? $_POST["dupNbr"]
+            : array();
+    } else {
+        return array();
+    }
+}

--- a/www/include/common/common-Func.php
+++ b/www/include/common/common-Func.php
@@ -2103,7 +2103,7 @@ function getSelectOption()
         if (strpos($value, ',') !== false) {
             return explode(',', $value);
         }
-        return array();
+        return array($value);
     };
     if (isset($_GET["select"])) {
         return is_array($_GET["select"])

--- a/www/include/common/templates/cloneMacro.ihtml
+++ b/www/include/common/templates/cloneMacro.ihtml
@@ -27,6 +27,7 @@
                 </span>
             {/foreach}
             <input type='hidden' id='macroTplValue_#index#' name='macroTplValue_#index#' value="" />
+            <input type='hidden' id='macroOriginalName_#index#' name='macroOriginalName_#index#' value="" />
             <input type='hidden' id='macroTplValToDisplay_#index#' name='macroTplValToDisplay_#index#' value="0" />
             <input type='hidden' id='macroDescription_#index#' name='macroDescription_#index#' value="" />
             <input type='hidden' id='macroTpl_#index#' name='macroTpl_#index#' value="" />

--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -455,22 +455,22 @@ jQuery(function() {
 
     });
 
-	/**
-	 * Mechanism to clear the password input field when it gets focus
-	 * and recover its previous value when it lost focus if no new value has been defined.
-	 */
-	jQuery('ul#macro').find('input[id^=\'macroValue_\']').on('click', function () {
-		if (jQuery(this).closest('div').find('input[type=\'checkbox\']:checked').val() === '1') {
-			// It's a password input
-			const actualValue = jQuery(this).val();
-			jQuery(this).val('');
-			jQuery(this).one('focusout', function() {
-				if (jQuery(this).val().length === 0) {
-					jQuery(this).val(actualValue);
-				}
-			});
-		}
-	});
+    /*
+     * Mechanism to clear the password input field when it gets focus
+     * and recover its previous value when it lost focus if no new value has been defined.
+     */
+    jQuery('ul#macro').find('input[id^=\'macroValue_\']').on('click', function () {
+        if (jQuery(this).closest('div').find('input[type=\'checkbox\']:checked').val() === '1') {
+            // It's a password input
+            const actualValue = jQuery(this).val();
+            jQuery(this).val('');
+            jQuery(this).one('focusout', function() {
+                if (jQuery(this).val().length === 0) {
+                    jQuery(this).val(actualValue);
+                }
+            });
+        }
+    });
 
     jQuery(".onemacro").each(function(idx,elem){
         var from = jQuery(elem).find('input[name^=macroFrom]').val();

--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -460,7 +460,7 @@ jQuery(function() {
 	 * and recover its previous value when it lost focus if no new value has been defined.
 	 */
 	jQuery('ul#macro').find('input[id^=\'macroValue_\']').on('click', function () {
-		if (jQuery(this).parents('div').find('input[type=\'checkbox\']:checked').val() === '1') {
+		if (jQuery(this).closest('div').find('input[type=\'checkbox\']:checked').val() === '1') {
 			// It's a password input
 			const actualValue = jQuery(this).val();
 			jQuery(this).val('');

--- a/www/include/configuration/configObject/host/formHost.ihtml
+++ b/www/include/configuration/configObject/host/formHost.ihtml
@@ -455,6 +455,23 @@ jQuery(function() {
 
     });
 
+	/**
+	 * Mechanism to clear the password input field when it gets focus
+	 * and recover its previous value when it lost focus if no new value has been defined.
+	 */
+	jQuery('ul#macro').find('input[id^=\'macroValue_\']').on('click', function () {
+		if (jQuery(this).parents('div').find('input[type=\'checkbox\']:checked').val() === '1') {
+			// It's a password input
+			const actualValue = jQuery(this).val();
+			jQuery(this).val('');
+			jQuery(this).one('focusout', function() {
+				if (jQuery(this).val().length === 0) {
+					jQuery(this).val(actualValue);
+				}
+			});
+		}
+	});
+
     jQuery(".onemacro").each(function(idx,elem){
         var from = jQuery(elem).find('input[name^=macroFrom]').val();
         if (from === "direct") {
@@ -572,7 +589,7 @@ function clonerefreshListener(el){
                            tolerance: "pointer"
                         }
                     );
-                    
+
                     jQuery(".onemacro").each(function(idx,elem){
                         var from = jQuery(elem).find('input[name^=macroFrom]').val();
                         if (from === "direct") {

--- a/www/include/configuration/configObject/host/formHost.php
+++ b/www/include/configuration/configObject/host/formHost.php
@@ -129,6 +129,10 @@ function allInSameInstance($hosts, $instanceId)
  * Database retrieve information for Host
  */
 $host = array();
+
+// Used to store all macro passwords
+$macroPasswords = array();
+
 if (($o == HOST_MODIFY || $o == HOST_WATCH) && $host_id) {
     $DBRESULT = $pearDB->query("SELECT * FROM host, extended_host_information ehi WHERE host_id = '" . $host_id . "' AND ehi.host_host_id = host.host_id LIMIT 1");
 
@@ -310,9 +314,12 @@ if (($o == HOST_MODIFY || $o == HOST_WATCH) && $host_id) {
     // We hide all passwords in the jsData property to prevent them from appearing in the HTML code.
     foreach ($aMacros as $index => $macroValues) {
         if ($macroValues['macroPassword_#index#'] === 1) {
+            $macroPasswords[$index]['password'] = $aMacros[$index]['macroValue_#index#'];
             // It's a password macro
             $aMacros[$index]['macroOldValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
             $aMacros[$index]['macroValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
+            // Keep the original name of the input field in case its name changes.
+            $aMacros[$index]['macroOriginalName_#index#'] = $aMacros[$index]['macroInput_#index#'];
         }
     }
 }
@@ -1212,6 +1219,27 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $hostObj->setValue(insertHostInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        /*
+         * Before saving, we check if a password macro has changed its name to be able to give it the right password
+         * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).
+         */
+        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+            if (array_key_exists('macroOriginalName_' . $index, $_REQUEST)) {
+                $originalMacroName = $_REQUEST['macroOriginalName_' . $index];
+                if ($_REQUEST['macroValue'][$index] === PASSWORD_REPLACEMENT_VALUE) {
+                    /*
+                     * The password has not been changed along with the name, so its value is equal to the wildcard.
+                     * We will therefore recover the password stored for its original name.
+                     */
+                    foreach ($aMacros as $indexMacro => $macroDetails) {
+                        if ($macroDetails['macroInput_#index#'] === $originalMacroName) {
+                            $_REQUEST['macroValue'][$index] = $macroPasswords[$indexMacro]['password'];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
         updateHostInDB($hostObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
         foreach ($select as $value) {

--- a/www/include/configuration/configObject/host/host.php
+++ b/www/include/configuration/configObject/host/host.php
@@ -53,35 +53,13 @@ $host_id = filter_var(
 
 // select can be an array of integer or a string of integers separated by comma
 $select = filter_var_array(
-    call_user_func(function () {
-        $selectValue = array();
-        if (isset($_GET["select"])) {
-            $selectValue = $_GET["select"];
-        } elseif (isset($_POST["select"])) {
-            $selectValue = $_POST["select"];
-        }
-
-        // when the data is sent from the form, the format is "1,2,5"
-        // so we need to split it by comma, and validate that each element is an integer
-        if (!is_array($selectValue)) {
-            $selectValue = array_filter(explode(',', $selectValue));
-        }
-        return $selectValue;
-    }),
+    getSelectOption(),
     FILTER_VALIDATE_INT
 );
 
 // If one data is not correctly typed in array, it will be set to false
 $dupNbr = filter_var_array(
-    call_user_func(function () {
-        if (isset($_GET["dupNbr"])) {
-            return $_GET["dupNbr"];
-        } elseif (isset($_POST["dupNbr"])) {
-            return $_POST["dupNbr"];
-        } else {
-            return array();
-        }
-    }),
+    getDuplicateNumberOption(),
     FILTER_VALIDATE_INT
 );
 

--- a/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -139,7 +139,7 @@ if (($o == "c" || $o == "w") && $host_id) {
         $cmdId = "";
     }
 
-    $macroArray = $hostObj->getMacros($host_id, true, $aTemplates, $cmdId, $_POST);
+    $macroArray = $hostObj->getMacros($host_id, $aTemplates, $cmdId, $_POST);
 }
 
 

--- a/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -43,12 +43,20 @@ $hostObj = new CentreonHost($pearDB);
 #
 $host = array();
 $macroArray = array();
-if (($o == "c" || $o == "w") && $host_id) {
-    if (isset($lockedElements[$host_id])) {
-        $o = "w";
-    }
-    $DBRESULT = $pearDB->query("SELECT * FROM host, extended_host_information ehi WHERE host_id = '".$host_id."' AND ehi.host_host_id = host.host_id LIMIT 1");
+// Used to store all macro passwords
+$macroPasswords = array();
 
+define('PASSWORD_REPLACEMENT_VALUE', '**********');
+
+if (($o == HOST_TEMPLATE_MODIFY || $o == HOST_TEMPLATE_WATCH) && $host_id) {
+    if (isset($lockedElements[$host_id])) {
+        $o = HOST_TEMPLATE_WATCH;
+    }
+    $DBRESULT = $pearDB->query(
+        "SELECT * FROM host, extended_host_information ehi
+        WHERE host_id = " . ((int) $host_id)
+        . " AND ehi.host_host_id = host.host_id LIMIT 1"
+    );
     
     # Set base value
     if ($DBRESULT->numRows()) {
@@ -68,7 +76,11 @@ if (($o == "c" || $o == "w") && $host_id) {
         $DBRESULT->free();
 
         # Set Contact Group
-        $DBRESULT = $pearDB->query("SELECT DISTINCT contactgroup_cg_id FROM contactgroup_host_relation WHERE host_host_id = '".$host_id."'");
+        $DBRESULT = $pearDB->query(
+            "SELECT DISTINCT contactgroup_cg_id 
+            FROM contactgroup_host_relation
+            WHERE host_host_id = " . ((int) $host_id)
+        );
         for ($i = 0; $notifCg = $DBRESULT->fetchRow(); $i++) {
             $host["host_cgs"][$i] = $notifCg["contactgroup_cg_id"];
         }
@@ -77,23 +89,32 @@ if (($o == "c" || $o == "w") && $host_id) {
         /*
 		 * Set Contacts
 		 */
-        $DBRESULT = $pearDB->query("SELECT DISTINCT contact_id FROM contact_host_relation WHERE host_host_id = '".$host_id."'");
+        $DBRESULT = $pearDB->query(
+            "SELECT DISTINCT contact_id FROM contact_host_relation WHERE host_host_id = " . ((int) $host_id)
+        );
         for ($i = 0; $notifC = $DBRESULT->fetchRow(); $i++) {
             $host["host_cs"][$i] = $notifC["contact_id"];
         }
         $DBRESULT->free();
 
         # Set Host Parents
-        $DBRESULT = $pearDB->query("SELECT DISTINCT host_parent_hp_id FROM host_hostparent_relation WHERE host_host_id = '".$host_id."'");
+        $DBRESULT = $pearDB->query(
+            "SELECT DISTINCT host_parent_hp_id FROM host_hostparent_relation WHERE host_host_id = " . ((int) $host_id)
+        );
         for ($i = 0; $parent = $DBRESULT->fetchRow(); $i++) {
             $host["host_parents"][$i] = $parent["host_parent_hp_id"];
         }
         $DBRESULT->free();
 
         # Set Service Templates Childs
-        $DBRESULT = $pearDB->query("SELECT DISTINCT service_service_id FROM host_service_relation WHERE host_host_id = '".$host_id."'");
+        $DBRESULT = $pearDB->query(
+            "SELECT DISTINCT service_service_id FROM host_service_relation WHERE host_host_id = " . ((int) $host_id)
+        );
         for ($i = 0; $svTpl = $DBRESULT->fetchRow(); $i++) {
-            $DBRESULT2 = $pearDB->query("SELECT service_register FROM service WHERE service_id = '".$svTpl['service_service_id']."' LIMIT 1");
+            $DBRESULT2 = $pearDB->query(
+                "SELECT service_register FROM service WHERE service_id = "
+                . ((int) $svTpl['service_service_id']) . " LIMIT 1"
+            );
             $tpReg = $DBRESULT2->fetchRow();
             if ($tpReg['service_register'] == 0) {
                 $host["host_svTpls"][$i] = $svTpl["service_service_id"];
@@ -108,7 +129,8 @@ if (($o == "c" || $o == "w") && $host_id) {
             FROM hostcategories_relation hcr, hostcategories hc
             WHERE hcr.hostcategories_hc_id = hc.hc_id
             AND hc.level IS NULL
-            AND hcr.host_host_id = \''.$host_id.'\'');
+            AND hcr.host_host_id = ' . ((int) $host_id)
+        );
         for ($i = 0; $hc = $DBRESULT->fetchRow(); $i++) {
             $host["host_hcs"][$i] = $hc['hostcategories_hc_id'];
         }
@@ -119,8 +141,8 @@ if (($o == "c" || $o == "w") && $host_id) {
          */
         $res = $pearDB->query("SELECT hc.hc_id 
             FROM hostcategories hc, hostcategories_relation hcr
-            WHERE hcr.host_host_id = " . $pearDB->escape($host_id). "
-            AND hcr.hostcategories_hc_id = hc.hc_id
+            WHERE hcr.host_host_id = " . ((int) $host_id)
+            . " AND hcr.hostcategories_hc_id = hc.hc_id
             AND hc.level IS NOT NULL
             ORDER BY hc.level ASC
             LIMIT 1");
@@ -139,7 +161,55 @@ if (($o == "c" || $o == "w") && $host_id) {
         $cmdId = "";
     }
 
+    if (isset($_REQUEST['macroInput'])) {
+        /**
+         * We don't taking into account the POST data sent from the interface in order the retrieve the original value
+         * of all passwords.
+         */
+        $macroArray = $hostObj->getMacros($host_id, $aTemplates, $cmdId);
+
+        /**
+         * If a password has been modified from the interface, we retrieve the old password existing in the repository
+         * (giving by the $aMacros variable) to inject it before saving.
+         * Passwords will be saved using the $_REQUEST variable.
+         */
+        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+            if (
+                !isset($_REQUEST['macroFrom'][$index])
+                || !isset($_REQUEST['macroPassword'][$index])
+                || $_REQUEST['macroPassword'][$index] !== '1'                      // Not a password
+                || $_REQUEST['macroValue'][$index] !== PASSWORD_REPLACEMENT_VALUE  // The password has not changed
+            ) {
+                continue;
+            }
+            foreach ($macroArray as $macroAlreadyExist) {
+                if (
+                    $macroAlreadyExist['macroInput_#index#'] === $macroName
+                    && $_REQUEST['macroFrom'][$index] === $macroAlreadyExist['source']
+                ) {
+                    /**
+                     * if the password has not been changed, we replace the password coming from the interface with
+                     * the original value (from the repository) before saving.
+                     */
+                    $_REQUEST['macroValue'][$index] = $macroAlreadyExist['macroValue_#index#'];
+                }
+            }
+        }
+    }
+
     $macroArray = $hostObj->getMacros($host_id, $aTemplates, $cmdId, $_POST);
+
+    // We hide all passwords in the jsData property to prevent them from appearing in the HTML code.
+    foreach ($macroArray as $index => $macroValues) {
+        if ($macroValues['macroPassword_#index#'] === 1) {
+            $macroPasswords[$index]['password'] = $macroArray[$index]['macroValue_#index#'];
+            // It's a password macro
+            $macroArray[$index]['macroOldValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
+            $macroArray[$index]['macroValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
+            // Keep the original name of the input field in case its name changes.
+            $macroArray[$index]['macroOriginalName_#index#'] = $macroArray[$index]['macroInput_#index#'];
+        }
+    }
 }
 
 
@@ -169,7 +239,9 @@ $cdata->addJsData('clone-count-template', count($tplArray));
  */
 $host_tmplt_who_use_me = array();
 if (isset($_GET["host_id"]) && $_GET["host_id"]) {
-    $DBRESULT = $pearDB->query("SELECT host_id, host_name FROM host WHERE host_template_model_htm_id = '".$pearDB->escape($_GET["host_id"])."'");
+    $DBRESULT = $pearDB->query(
+        "SELECT host_id, host_name FROM host WHERE host_template_model_htm_id = " . ((int) $_GET["host_id"])
+    );
     while ($host_tmpl_father = $DBRESULT->fetchRow()) {
         $host_tmplt_who_use_me[$host_tmpl_father["host_id"]] = $host_tmpl_father["host_name"];
     }
@@ -180,7 +252,11 @@ if (isset($_GET["host_id"]) && $_GET["host_id"]) {
  * Host Templates comes from DB -> Store in $hTpls Array
  */
 $hTpls = array(null=>null);
-$DBRESULT = $pearDB->query("SELECT host_id, host_name, host_template_model_htm_id FROM host WHERE host_register = '0' AND host_id != '".$host_id."' ORDER BY host_name");
+$DBRESULT = $pearDB->query(
+    "SELECT host_id, host_name, host_template_model_htm_id
+    FROM host
+    WHERE host_register = '0' AND host_id != " . ((int) $host_id) . " ORDER BY host_name"
+);
 while ($hTpl = $DBRESULT->fetchRow()) {
     if (!$hTpl["host_name"]) {
         $hTpl["host_name"] = getMyHostName($hTpl["host_template_model_htm_id"])."'";
@@ -192,7 +268,10 @@ while ($hTpl = $DBRESULT->fetchRow()) {
 $DBRESULT->free();
 # Service Templates comes from DB -> Store in $svTpls Array
 $svTpls = array();
-$DBRESULT = $pearDB->query("SELECT service_id, service_description, service_template_model_stm_id FROM service WHERE service_register = '0' ORDER BY service_description");
+$DBRESULT = $pearDB->query(
+    "SELECT service_id, service_description, service_template_model_stm_id
+    FROM service WHERE service_register = '0' ORDER BY service_description"
+);
 while ($svTpl = $DBRESULT->fetchRow()) {
     if (!$svTpl["service_description"]) {
         $svTpl["service_description"] = getMyServiceName($svTpl["service_template_model_stm_id"])."'";
@@ -258,7 +337,9 @@ $DBRESULT->free();
 */
 $mTp = array();
 $k = 0;
-$DBRESULT = $pearDB->query("SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = '". $host_id ."' ORDER BY `order`");
+$DBRESULT = $pearDB->query(
+    "SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = " . ((int) $host_id) . " ORDER BY `order`"
+);
 while ($multiTp = $DBRESULT->fetchRow()) {
     $mTp[$k] = $multiTp["host_tpl_id"];
     $k++;
@@ -269,7 +350,10 @@ $DBRESULT->free();
 *  Host on demand macro stored in DB
 */
 $j = 0;
-$DBRESULT = $pearDB->query("SELECT host_macro_id, host_macro_name, host_macro_value, host_host_id FROM on_demand_macro_host WHERE host_host_id = '". $host_id ."' ORDER BY `host_macro_id`");
+$DBRESULT = $pearDB->query(
+    "SELECT host_macro_id, host_macro_name, host_macro_value, host_host_id
+    FROM on_demand_macro_host WHERE host_host_id = " . ((int) $host_id) . " ORDER BY `host_macro_id`"
+);
 while ($od_macro = $DBRESULT->fetchRow()) {
     $od_macro_id[$j] = $od_macro["host_macro_id"];
     $od_macro_name[$j] = str_replace("\$_HOST", "", $od_macro["host_macro_name"]);
@@ -344,13 +428,13 @@ unset($_POST['o']);
 ## Form begin
 #
 $form = new HTML_QuickForm('Form', 'post', "?p=".$p);
-if ($o == "a") {
+if ($o == HOST_TEMPLATE_ADD) {
     $form->addElement('header', 'title', _("Add a Host Template"));
-} elseif ($o == "c") {
+} elseif ($o == HOST_TEMPLATE_MODIFY) {
     $form->addElement('header', 'title', _("Modify a Host Template"));
-} elseif ($o == "w") {
+} elseif ($o == HOST_TEMPLATE_WATCH) {
     $form->addElement('header', 'title', _("View a Host Template"));
-} elseif ($o == "mc") {
+} elseif ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title', _("Massive Change"));
 }
 
@@ -360,7 +444,7 @@ if ($o == "a") {
 #
 $form->addElement('header', 'information', _("General Information"));
 # No possibility to change name and alias, because there's no interest
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('text', 'host_name', _("Name"), $attrsText);
     $form->addElement('text', 'host_alias', _("Alias"), $attrsText);
 }
@@ -379,7 +463,7 @@ $form->addElement('select2', 'host_location', _("Timezone / Location"), array(),
 
 $form->addElement('text', 'host_parallel_template', _("Templates"), $hTpls);
 
-if ($o == "mc") {
+if ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_tplp = array();
     $mc_mod_tplp[] = HTML_QuickForm::createElement('radio', 'mc_mod_tplp', null, _("Incremental"), '0');
     $mc_mod_tplp[] = HTML_QuickForm::createElement('radio', 'mc_mod_tplp', null, _("Replacement"), '1');
@@ -421,6 +505,12 @@ $cloneSetMacro[] = $form->addElement(
             'id' => 'macroPassword_#index#',
             'onClick' => 'javascript:change_macro_input_type(this, false)'
         )
+);
+$cloneSetMacro[] = $form->addElement(
+    'hidden',
+    'macroFrom[#index#]',
+    'direct',
+    array('id' => 'macroFrom_#index#')
 );
 
 $cloneSetTemplate = array();
@@ -465,7 +555,7 @@ $hostEHE[] = HTML_QuickForm::createElement('radio', 'host_event_handler_enabled'
 $hostEHE[] = HTML_QuickForm::createElement('radio', 'host_event_handler_enabled', null, _("No"), '0');
 $hostEHE[] = HTML_QuickForm::createElement('radio', 'host_event_handler_enabled', null, _("Default"), '2');
 $form->addGroup($hostEHE, 'host_event_handler_enabled', _("Event Handler Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_event_handler_enabled' => '2'));
 }
 
@@ -487,7 +577,7 @@ $hostACE[] = HTML_QuickForm::createElement('radio', 'host_active_checks_enabled'
 $hostACE[] = HTML_QuickForm::createElement('radio', 'host_active_checks_enabled', null, _("No"), '0');
 $hostACE[] = HTML_QuickForm::createElement('radio', 'host_active_checks_enabled', null, _("Default"), '2');
 $form->addGroup($hostACE, 'host_active_checks_enabled', _("Active Checks Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_active_checks_enabled' => '2'));
 }
 
@@ -495,7 +585,7 @@ $hostPCE[] = HTML_QuickForm::createElement('radio', 'host_passive_checks_enabled
 $hostPCE[] = HTML_QuickForm::createElement('radio', 'host_passive_checks_enabled', null, _("No"), '0');
 $hostPCE[] = HTML_QuickForm::createElement('radio', 'host_passive_checks_enabled', null, _("Default"), '2');
 $form->addGroup($hostPCE, 'host_passive_checks_enabled', _("Passive Checks Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_passive_checks_enabled' => '2'));
 }
 
@@ -518,14 +608,14 @@ $hostNE[] = HTML_QuickForm::createElement('radio', 'host_notifications_enabled',
 $hostNE[] = HTML_QuickForm::createElement('radio', 'host_notifications_enabled', null, _("No"), '0');
 $hostNE[] = HTML_QuickForm::createElement('radio', 'host_notifications_enabled', null, _("Default"), '2');
 $form->addGroup($hostNE, 'host_notifications_enabled', _("Notification Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_notifications_enabled' => '2'));
 }
 
 /*
  * Additive
  */
-if ($o == "mc") {
+if ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $contactAdditive[] = HTML_QuickForm::createElement('radio', 'mc_contact_additive_inheritance', null, _("Yes"), '1');
     $contactAdditive[] = HTML_QuickForm::createElement('radio', 'mc_contact_additive_inheritance', null, _("No"), '0');
     $contactAdditive[] = HTML_QuickForm::createElement('radio', 'mc_contact_additive_inheritance', null, _("Default"), '2');
@@ -539,7 +629,7 @@ if ($o == "mc") {
     $form->addElement('checkbox', 'contact_additive_inheritance', '', _('Contact additive inheritance'));
     $form->addElement('checkbox', 'cg_additive_inheritance', '', _('Contact group additive inheritance'));
 }
-if ($o == "mc") {
+if ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_notifopt_first_notification_delay = array();
     $mc_mod_notifopt_first_notification_delay[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_first_notification_delay', null, _("Incremental"), '0');
     $mc_mod_notifopt_first_notification_delay[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_first_notification_delay', null, _("Replacement"), '1');
@@ -551,7 +641,7 @@ $form->addElement('text', 'host_first_notification_delay', _("First notification
 
 $form->addElement('text', 'host_recovery_notification_delay', _("Recovery notification delay"), $attrsText2);
 
-if ($o == "mc") {
+if ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_hcg = array();
     $mc_mod_hcg[] = HTML_QuickForm::createElement('radio', 'mc_mod_hcg', null, _("Incremental"), '0');
     $mc_mod_hcg[] = HTML_QuickForm::createElement('radio', 'mc_mod_hcg', null, _("Replacement"), '1');
@@ -581,7 +671,7 @@ $form->addElement('select2', 'host_cgs', _("Linked Contact Groups"), array(), $a
 /*
  * Categories
  */
-if ($o == "mc") {
+if ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_hhc = array();
     $mc_mod_hhc[] = HTML_QuickForm::createElement('radio', 'mc_mod_hhc', null, _("Incremental"), '0');
     $mc_mod_hhc[] = HTML_QuickForm::createElement('radio', 'mc_mod_hhc', null, _("Replacement"), '1');
@@ -595,7 +685,7 @@ $attrHostcategory1 = array_merge(
 );
 $form->addElement('select2', 'host_hcs', _("Parent Host Categories"), array(), $attrHostcategory1);
 
-if ($o == "mc") {
+if ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_notifopt_notification_interval = array();
     $mc_mod_notifopt_notification_interval[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_notification_interval', null, _("Incremental"), '0');
     $mc_mod_notifopt_notification_interval[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_notification_interval', null, _("Replacement"), '1');
@@ -605,7 +695,7 @@ if ($o == "mc") {
 
 $form->addElement('text', 'host_notification_interval', _("Notification Interval"), $attrsText2);
 
-if ($o == "mc") {
+if ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_notifopt_timeperiod = array();
     $mc_mod_notifopt_timeperiod[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_timeperiod', null, _("Incremental"), '0');
     $mc_mod_notifopt_timeperiod[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_timeperiod', null, _("Replacement"), '1');
@@ -619,7 +709,7 @@ $attrTimeperiod2 = array_merge(
 );
 $form->addElement('select2', 'timeperiod_tp_id2', _("Notification Period"), array(), $attrTimeperiod2);
 
-if ($o == "mc") {
+if ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_notifopts = array();
     $mc_mod_notifopts[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopts', null, _("Incremental"), '0');
     $mc_mod_notifopts[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopts', null, _("Replacement"), '1');
@@ -647,7 +737,7 @@ $form->addElement('header', 'furtherInfos', _("Additional Information"));
 $hostActivation[] = HTML_QuickForm::createElement('radio', 'host_activate', null, _("Enabled"), '1');
 $hostActivation[] = HTML_QuickForm::createElement('radio', 'host_activate', null, _("Disabled"), '0');
 $form->addGroup($hostActivation, 'host_activate', _("Status"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_activate' => '1'));
 }
 
@@ -656,18 +746,18 @@ $form->addElement('textarea', 'host_comment', _("Comments"), $attrsTextarea);
 #
 ## Sort 2 - Host Relations
 #
-if ($o == "a") {
+if ($o == HOST_TEMPLATE_ADD) {
     $form->addElement('header', 'title2', _("Add relations"));
-} elseif ($o == "c") {
+} elseif ($o == HOST_TEMPLATE_MODIFY) {
     $form->addElement('header', 'title2', _("Modify relations"));
-} elseif ($o == "w") {
+} elseif ($o == HOST_TEMPLATE_WATCH) {
     $form->addElement('header', 'title2', _("View relations"));
-} elseif ($o == "mc") {
+} elseif ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title2', _("Massive Change"));
 }
 
 $form->addElement('header', 'links', _("Relations"));
-if ($o == "mc") {
+if ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_htpl = array();
     $mc_mod_htpl[] = HTML_QuickForm::createElement('radio', 'mc_mod_htpl', null, _("Incremental"), '0');
     $mc_mod_htpl[] = HTML_QuickForm::createElement('radio', 'mc_mod_htpl', null, _("Replacement"), '1');
@@ -684,13 +774,13 @@ $form->addElement('select2', 'host_svTpls', _("Linked Service Templates"), array
 #
 ## Sort 3 - Data treatment
 #
-if ($o == "a") {
+if ($o == HOST_TEMPLATE_ADD) {
     $form->addElement('header', 'title3', _("Add Data Processing"));
-} elseif ($o == "c") {
+} elseif ($o == HOST_TEMPLATE_MODIFY) {
     $form->addElement('header', 'title3', _("Modify Data Processing"));
-} elseif ($o == "w") {
+} elseif ($o == HOST_TEMPLATE_WATCH) {
     $form->addElement('header', 'title3', _("View Data Processing"));
-} elseif ($o == "mc") {
+} elseif ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title2', _("Massive Change"));
 }
 
@@ -700,7 +790,7 @@ $hostOOH[] = HTML_QuickForm::createElement('radio', 'host_obsess_over_host', nul
 $hostOOH[] = HTML_QuickForm::createElement('radio', 'host_obsess_over_host', null, _("No"), '0');
 $hostOOH[] = HTML_QuickForm::createElement('radio', 'host_obsess_over_host', null, _("Default"), '2');
 $form->addGroup($hostOOH, 'host_obsess_over_host', _("Obsess Over Host"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_obsess_over_host' => '2'));
 }
 
@@ -708,7 +798,7 @@ $hostCF[] = HTML_QuickForm::createElement('radio', 'host_check_freshness', null,
 $hostCF[] = HTML_QuickForm::createElement('radio', 'host_check_freshness', null, _("No"), '0');
 $hostCF[] = HTML_QuickForm::createElement('radio', 'host_check_freshness', null, _("Default"), '2');
 $form->addGroup($hostCF, 'host_check_freshness', _("Check Freshness"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_check_freshness' => '2'));
 }
 
@@ -716,7 +806,7 @@ $hostFDE[] = HTML_QuickForm::createElement('radio', 'host_flap_detection_enabled
 $hostFDE[] = HTML_QuickForm::createElement('radio', 'host_flap_detection_enabled', null, _("No"), '0');
 $hostFDE[] = HTML_QuickForm::createElement('radio', 'host_flap_detection_enabled', null, _("Default"), '2');
 $form->addGroup($hostFDE, 'host_flap_detection_enabled', _("Flap Detection Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_flap_detection_enabled' => '2'));
 }
 
@@ -728,7 +818,7 @@ $hostPPD[] = HTML_QuickForm::createElement('radio', 'host_process_perf_data', nu
 $hostPPD[] = HTML_QuickForm::createElement('radio', 'host_process_perf_data', null, _("No"), '0');
 $hostPPD[] = HTML_QuickForm::createElement('radio', 'host_process_perf_data', null, _("Default"), '2');
 $form->addGroup($hostPPD, 'host_process_perf_data', _("Process Perf Data"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_process_perf_data' => '2'));
 }
 
@@ -736,7 +826,7 @@ $hostRSI[] = HTML_QuickForm::createElement('radio', 'host_retain_status_informat
 $hostRSI[] = HTML_QuickForm::createElement('radio', 'host_retain_status_information', null, _("No"), '0');
 $hostRSI[] = HTML_QuickForm::createElement('radio', 'host_retain_status_information', null, _("Default"), '2');
 $form->addGroup($hostRSI, 'host_retain_status_information', _("Retain Status Information"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_retain_status_information' => '2'));
 }
 
@@ -744,18 +834,18 @@ $hostRNI[] = HTML_QuickForm::createElement('radio', 'host_retain_nonstatus_infor
 $hostRNI[] = HTML_QuickForm::createElement('radio', 'host_retain_nonstatus_information', null, _("No"), '0');
 $hostRNI[] = HTML_QuickForm::createElement('radio', 'host_retain_nonstatus_information', null, _("Default"), '2');
 $form->addGroup($hostRNI, 'host_retain_nonstatus_information', _("Retain Non Status Information"), '&nbsp;');
-if ($o != "mc") {
+if ($o != HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('host_retain_nonstatus_information' => '2'));
 }
 
 #
 ## Sort 4 - Extended Infos
 #
-if ($o == "a") {
+if ($o == HOST_TEMPLATE_ADD) {
     $form->addElement('header', 'title4', _("Add a Host Extended Info"));
-} elseif ($o == "c") {
+} elseif ($o == HOST_TEMPLATE_MODIFY) {
     $form->addElement('header', 'title4', _("Modify a Host Extended Info"));
-} elseif ($o == "w") {
+} elseif ($o == HOST_TEMPLATE_WATCH) {
     $form->addElement('header', 'title4', _("View a Host Extended Info"));
 }
 
@@ -787,13 +877,13 @@ $form->addElement('header', 'oreon', _("Centreon"));
 ## Sort 5 - Macros - NAGIOS 3
 #
 
-if ($o == "a") {
+if ($o == HOST_TEMPLATE_ADD) {
     $form->addElement('header', 'title5', _("Add macros"));
-} elseif ($o == "c") {
+} elseif ($o == HOST_TEMPLATE_MODIFY) {
     $form->addElement('header', 'title5', _("Modify macros"));
-} elseif ($o == "w") {
+} elseif ($o == HOST_TEMPLATE_WATCH) {
     $form->addElement('header', 'title5', _("View macros"));
-} elseif ($o == "mc") {
+} elseif ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title5', _("Massive Change"));
 }
 
@@ -812,12 +902,8 @@ $assoc->setValue("0");
 $redirect = $form->addElement('hidden', 'o');
 $redirect->setValue($o);
 if (is_array($select)) {
-    $select_str = null;
-    foreach ($select as $key => $value) {
-        $select_str .= $key.",";
-    }
     $select_pear = $form->addElement('hidden', 'select');
-    $select_pear->setValue($select_str);
+    $select_pear->setValue(implode(',', array_keys($select)));
 }
 
 #
@@ -839,7 +925,7 @@ $form->addRule('host_alias', _("Compulsory Alias"), 'required');
 $form->registerRule('cg_group_exists', 'callback', 'testCg');
 $form->addRule('host_cgs', _('Contactgroups exists. If you try to use a LDAP contactgroup, please verified if a Centreon contactgroup has the same name.'), 'cg_group_exists');
 $from_list_menu = false;
-if ($o == "mc") {
+if ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     if ($form->getSubmitValue("submitMC")) {
         $from_list_menu = false;
     } else {
@@ -856,23 +942,23 @@ $tpl = new Smarty();
 $tpl = initSmartyTpl($path2, $tpl);
 
 # Just watch a host information
-if ($o == "w") {
+if ($o == HOST_TEMPLATE_WATCH) {
     if (!$min && $centreon->user->access->page($p) != 2 && !isset($lockedElements[$host_id])) {
         $form->addElement("button", "change", _("Modify"), array("onClick"=>"javascript:window.location.href='?p=".$p."&o=c&host_id=".$host_id."'"));
     }
     $form->setDefaults($host);
     $form->freeze();
 } # Modify a host information
-elseif ($o == "c") {
+elseif ($o == HOST_TEMPLATE_MODIFY) {
     $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults($host);
 } # Add a host information
-elseif ($o == "a") {
+elseif ($o == HOST_TEMPLATE_ADD) {
     $subA = $form->addElement('submit', 'submitA', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
 } # Massive Change
-elseif ($o == "mc") {
+elseif ($o == HOST_TEMPLATE_MASSIVE_CHANGE) {
     $subMC = $form->addElement('submit', 'submitMC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
 }
@@ -913,10 +999,30 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $hostObj->setValue(insertHostInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        /*
+         * Before saving, we check if a password macro has changed its name to be able to give it the right password
+         * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).
+         */
+        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+            if (array_key_exists('macroOriginalName_' . $index, $_REQUEST)) {
+                $originalMacroName = $_REQUEST['macroOriginalName_' . $index];
+                if ($_REQUEST['macroValue'][$index] === PASSWORD_REPLACEMENT_VALUE) {
+                    /*
+                     * The password has not been changed along with the name, so its value is equal to the wildcard.
+                     * We will therefore recover the password stored for its original name.
+                     */
+                    foreach ($macroArray as $indexMacro => $macroDetails) {
+                        if ($macroDetails['macroInput_#index#'] === $originalMacroName) {
+                            $_REQUEST['macroValue'][$index] = $macroPasswords[$indexMacro]['password'];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
         updateHostInDB($hostObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
-        $select = explode(",", $select);
-        foreach ($select as $key => $value) {
+        foreach ($select as $value) {
             if ($value) {
                 updateHostInDB($value, true);
             }

--- a/www/include/configuration/configObject/service/formService.ihtml
+++ b/www/include/configuration/configObject/service/formService.ihtml
@@ -390,6 +390,23 @@ jQuery(function() {
         }
     });
 
+    /**
+    * Mechanism to clear the password input field when it gets focus
+    * and recover its previous value when it lost focus if no new value has been defined.
+    */
+    jQuery('ul#macro').find('input[id^=\'macroValue_\']').on('click', function () {
+        if (jQuery(this).closest('div').find('input[type=\'checkbox\']:checked').val() === '1') {
+            // It's a password input
+            const actualValue = jQuery(this).val();
+            jQuery(this).val('');
+            jQuery(this).one('focusout', function() {
+                if (jQuery(this).val().length === 0) {
+                  jQuery(this).val(actualValue);
+                }
+            });
+        }
+    });
+
     jQuery(".onemacro").each(function(idx,elem) {
         var from = jQuery(elem).find('input[name^=macroFrom]').val();
         if (from === "direct") {

--- a/www/include/configuration/configObject/service/formService.php
+++ b/www/include/configuration/configObject/service/formService.php
@@ -44,6 +44,9 @@ require_once _CENTREON_PATH_ . 'www/class/centreonContactgroup.class.php';
 
 $serviceObj = new CentreonService($pearDB);
 
+// Used to store all macro passwords
+$macroPasswords = array();
+
 /**
  *
  * Database retrieve information for Service
@@ -62,10 +65,12 @@ function myDecodeService($arg)
 
 if (!$centreon->user->admin) {
     if ($service_id) {
-        $checkres = $pearDB->query("SELECT service_id
-                                        FROM $acldbname.centreon_acl
-                                        WHERE service_id = " . $pearDB->escape($service_id) . "
-                                        AND group_id IN (" . $acl->getAccessGroupsString() . ")");
+        $checkres = $pearDB->query(
+            "SELECT service_id
+            FROM {$acldbname}.centreon_acl
+            WHERE service_id = " . ((int) $service_id)
+            . "  AND group_id IN (" . $acl->getAccessGroupsString() . ")"
+        );
         if (!$checkres->numRows()) {
             $msg = new CentreonMsg();
             $msg->setImage("./img/icons/warning.png");
@@ -120,25 +125,34 @@ $sgs = $acl->getServiceGroupAclConf(null, 'broker', array(
 /* service categories */
 $service_categories = array();
 $scstring = $acl->getServiceCategoriesString();
-$rescat = $pearDB->query("SELECT sc_name, sc_id
-                              FROM service_categories " .
-    "WHERE level IS NULL " .
-    ($scstring != "''" ? $acl->queryBuilder('AND', 'sc_id', $acl->getServiceCategoriesString()) : "") .
-    " ORDER BY sc_name");
+$rescat = $pearDB->query(
+    "SELECT sc_name, sc_id
+    FROM service_categories 
+    WHERE level IS NULL " .
+    ($scstring != "''" ? $acl->queryBuilder('AND', 'sc_id', $acl->getServiceCategoriesString()) : "")
+    . " ORDER BY sc_name"
+);
 while ($scat = $rescat->fetchRow()) {
     $service_categories[$scat['sc_id']] = $scat['sc_name'];
 }
+
+define('PASSWORD_REPLACEMENT_VALUE', '**********');
 
 $cmdId = 0;
 $service = array();
 $serviceTplId = null;
 $initialValues = array();
-if (($o == "c" || $o == "w") && $service_id) {
-    $DBRESULT = $pearDB->query("SELECT *
-                                FROM service
-                                LEFT JOIN extended_service_information esi
-                                ON esi.service_service_id = service_id
-                                WHERE service_id = '" . $service_id . "' LIMIT 1");
+
+$macroPassword = array();
+
+if (($o == SERVICE_MODIFY || $o == SERVICE_WATCH) && $service_id) {
+    $DBRESULT = $pearDB->query(
+        "SELECT *
+        FROM service
+        LEFT JOIN extended_service_information esi
+        ON esi.service_service_id = service_id
+        WHERE service_id = " . ((int) $service_id) . " LIMIT 1"
+    );
     /*
      * Set base value
      */
@@ -149,11 +163,16 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Grab hostgroup || host
      */
-    $DBRESULT = $pearDB->query("SELECT host_host_id
-                                FROM host_service_relation hsr, host
-                                WHERE hsr.service_service_id = '" . $service_id . "'
-                                AND host_host_id IS NOT NULL
-                                AND host_id = host_host_id ORDER BY host_name, host_alias");
+    $DBRESULT = $pearDB->query(
+        "SELECT host_host_id
+        FROM host_service_relation hsr 
+        INNER JOIN host
+            ON host.host_id = hsr.host_host_id
+        WHERE hsr.host_host_id IS NOT NULL
+            AND hsr.service_service_id = " . ((int) $service_id)
+        . " ORDER BY host_name, host_alias"
+    );
+
     while ($parent = $DBRESULT->fetchRow()) {
         if ($parent["host_host_id"]) {
             if (!isset($hosts[$parent['host_host_id']])) {
@@ -165,11 +184,15 @@ if (($o == "c" || $o == "w") && $service_id) {
     }
     $DBRESULT->free();
 
-    $DBRESULT = $pearDB->query("SELECT hostgroup_hg_id
-                                FROM host_service_relation hsr, hostgroup
-                                WHERE hsr.service_service_id = '" . $service_id . "'
-                                AND hostgroup_hg_id IS NOT NULL
-                                AND hostgroup_hg_id = hg_id ORDER BY hg_name, hg_alias");
+    $DBRESULT = $pearDB->query(
+        "SELECT hostgroup_hg_id
+        FROM host_service_relation hsr
+        INNER JOIN hostgroup
+            ON hostgroup.hg_id = hsr.hostgroup_hg_id
+        WHERE hsr.hostgroup_hg_id IS NOT NULL 
+            AND hsr.service_service_id = " . ((int) $service_id)
+        . " ORDER BY hg_name, hg_alias"
+    );
     while ($parent = $DBRESULT->fetchRow()) {
         if ($parent["hostgroup_hg_id"]) {
             if (!isset($hgs[$parent['hostgroup_hg_id']])) {
@@ -200,9 +223,11 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set Contact Group
      */
-    $DBRESULT = $pearDB->query("SELECT DISTINCT contactgroup_cg_id
-                                FROM contactgroup_service_relation
-                                WHERE service_service_id = '" . $service_id . "'");
+    $DBRESULT = $pearDB->query(
+        "SELECT DISTINCT contactgroup_cg_id
+        FROM contactgroup_service_relation
+        WHERE service_service_id = " . ((int) $service_id)
+    );
     for ($i = 0; $notifCg = $DBRESULT->fetchRow(); $i++) {
         if (!isset($notifCgs[$notifCg['contactgroup_cg_id']])) {
             $initialValues['service_cgs'][] = $notifCg["contactgroup_cg_id"];
@@ -215,9 +240,11 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set Contacts
      */
-    $DBRESULT = $pearDB->query("SELECT DISTINCT contact_id
-                                FROM contact_service_relation
-                                WHERE service_service_id = '" . $service_id . "'");
+    $DBRESULT = $pearDB->query(
+        "SELECT DISTINCT contact_id
+        FROM contact_service_relation
+        WHERE service_service_id = " . ((int) $service_id)
+    );
     for ($i = 0; $notifC = $DBRESULT->fetchRow(); $i++) {
         if (!isset($notifCs[$notifC['contact_id']])) {
             $initialValues['service_cs'][] = $notifC['contact_id'];
@@ -230,9 +257,11 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set Service Group Parents
      */
-    $DBRESULT = $pearDB->query("SELECT DISTINCT servicegroup_sg_id
-                                FROM servicegroup_relation
-                                WHERE service_service_id = '" . $service_id . "'");
+    $DBRESULT = $pearDB->query(
+        "SELECT DISTINCT servicegroup_sg_id
+        FROM servicegroup_relation
+        WHERE service_service_id = " . ((int) $service_id)
+    );
     for ($i = 0; $sg = $DBRESULT->fetchRow(); $i++) {
         if (!isset($sgs[$sg['servicegroup_sg_id']])) {
             $initialValues['service_sgs'][] = $sg['servicegroup_sg_id'];
@@ -245,9 +274,11 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set Traps
      */
-    $DBRESULT = $pearDB->query("SELECT DISTINCT traps_id
-                                FROM traps_service_relation
-                                WHERE service_id = '" . $service_id . "'");
+    $DBRESULT = $pearDB->query(
+        "SELECT DISTINCT traps_id
+        FROM traps_service_relation
+        WHERE service_id = " . ((int) $service_id)
+    );
     for ($i = 0; $trap = $DBRESULT->fetchRow(); $i++) {
         $service["service_traps"][$i] = $trap["traps_id"];
     }
@@ -256,13 +287,17 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set Categories
      */
-    $DBRESULT = $pearDB->query("SELECT DISTINCT sc_id
-                                FROM service_categories_relation
-                                WHERE service_service_id = '" . $service_id . "'
-                                AND NOT EXISTS(SELECT sc_id
-                                                FROM service_categories sc
-                                                WHERE sc.sc_id = service_categories_relation.sc_id
-                                                AND sc.level IS NOT NULL)");
+    $DBRESULT = $pearDB->query(
+        "SELECT DISTINCT sc_id
+        FROM service_categories_relation
+        WHERE service_service_id = " . ((int) $service_id)
+        . " AND NOT EXISTS(
+            SELECT sc_id
+            FROM service_categories sc
+            WHERE sc.sc_id = service_categories_relation.sc_id
+            AND sc.level IS NOT NULL
+            )"
+    );
     for ($i = 0; $service_category = $DBRESULT->fetchRow(); $i++) {
         if (!isset($service_categories[$service_category['sc_id']])) {
             $initialValues['service_categories'][] = $service_category['sc_id'];
@@ -275,27 +310,77 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set criticality
      */
-    $res = $pearDB->query("SELECT sc.sc_id
-                            FROM service_categories sc, service_categories_relation scr
-                            WHERE scr.service_service_id = " . $pearDB->escape($service_id) . "
-                            AND scr.sc_id = sc.sc_id
-                            AND sc.level IS NOT NULL
-                            ORDER BY sc.level ASC
-                            LIMIT 1");
+    $res = $pearDB->query(
+        "SELECT sc.sc_id
+        FROM service_categories sc
+        INNER JOIN service_categories_relation scr
+            ON scr.sc_id = sc.sc_id
+        WHERE sc.level IS NOT NULL
+        AND scr.service_service_id = " . ((int) $service_id)
+        . " ORDER BY sc.level ASC LIMIT 1"
+    );
     if ($res->numRows()) {
         $cr = $res->fetchRow();
         $service['criticality_id'] = $cr['sc_id'];
     }
 }
 
-if (($o == "c" || $o == "w") && $service_id) {
+if (($o == SERVICE_MODIFY || $o == SERVICE_WATCH) && $service_id) {
     $aListTemplate = getListTemplates($pearDB, $service_id);
 
     if (!isset($cmdId)) {
         $cmdId = "";
     }
 
+    if (isset($_REQUEST['macroInput'])) {
+        /**
+         * We don't taking into account the POST data sent from the interface in order the retrieve the original value
+         * of all passwords.
+         */
+        $aMacros = $serviceObj->getMacros($service_id, $aListTemplate, $cmdId);
+
+        /**
+         * If a password has been modified from the interface, we retrieve the old password existing in the repository
+         * (giving by the $aMacros variable) to inject it before saving.
+         * Passwords will be saved using the $_REQUEST variable.
+         */
+        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+            if (
+                !isset($_REQUEST['macroFrom'][$index])
+                || !isset($_REQUEST['macroPassword'][$index])
+                || $_REQUEST['macroPassword'][$index] !== '1'                      // Not a password
+                || $_REQUEST['macroValue'][$index] !== PASSWORD_REPLACEMENT_VALUE  // The password has not changed
+            ) {
+                continue;
+            }
+            foreach ($aMacros as $macroAlreadyExist) {
+                if (
+                    $macroAlreadyExist['macroInput_#index#'] === $macroName
+                    && $_REQUEST['macroFrom'][$index] === $macroAlreadyExist['source']
+                ) {
+                    /**
+                     * if the password has not been changed, we replace the password coming from the interface with
+                     * the original value (from the repository) before saving.
+                     */
+                    $_REQUEST['macroValue'][$index] = $macroAlreadyExist['macroValue_#index#'];
+                }
+            }
+        }
+    }
+    // We taking into account the POST data sent from the interface
     $aMacros = $serviceObj->getMacros($service_id, $aListTemplate, $cmdId, $_POST);
+
+    // We hide all passwords in the jsData property to prevent them from appearing in the HTML code.
+    foreach ($aMacros as $index => $macroValues) {
+        if ($macroValues['macroPassword_#index#'] === '1') {
+            $macroPasswords[$index]['password'] = $aMacros[$index]['macroValue_#index#'];
+            // It's a password macro
+            $aMacros[$index]['macroOldValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
+            $aMacros[$index]['macroValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
+            // Keep the original name of the input field in case its name changes.
+            $aMacros[$index]['macroOriginalName_#index#'] = $aMacros[$index]['macroInput_#index#'];
+        }
+    }
 }
 
 $cdata = CentreonData::getInstance();
@@ -308,10 +393,12 @@ $cdata->addJsData('clone-count-macro', count($aMacros));
 
 # Service Templates comes from DB -> Store in $svTpls Array
 $svTpls = array(null => null);
-$DBRESULT = $pearDB->query("SELECT service_id, service_description, service_template_model_stm_id
-                            FROM service
-                            WHERE service_register = '0'
-                            AND service_id != '" . $service_id . "' ORDER BY service_description");
+$DBRESULT = $pearDB->query(
+    "SELECT service_id, service_description, service_template_model_stm_id
+    FROM service
+    WHERE service_register = '0'
+    AND service_id != " . ((int) $service_id) . " ORDER BY service_description"
+);
 while ($svTpl = $DBRESULT->fetchRow()) {
     if (!$svTpl["service_description"]) {
         $svTpl["service_description"] = getMyServiceName($svTpl["service_template_model_stm_id"]) . "'";
@@ -365,10 +452,14 @@ $DBRESULT->free();
 # Traps definition comes from DB -> Store in $traps Array
 $traps = array();
 if (isset($service_id)) {
-    $DBRESULT = $pearDB->query("SELECT t.traps_id, t.traps_name
-                                FROM traps t, traps_service_relation sr
-                                WHERE t.traps_id = sr.traps_id
-                                AND sr.service_id = '" . $service_id . "' ORDER BY t.traps_name");
+    $DBRESULT = $pearDB->query(
+        "SELECT t.traps_id, t.traps_name
+        FROM traps t
+        INNER JOIN traps_service_relation sr
+            ON sr.traps_id = t.traps_id
+        WHERE sr.service_id = " . ((int) $service_id) . " ORDER BY t.traps_name"
+    );
+
     while ($trap = $DBRESULT->fetchRow()) {
         $traps[$trap["traps_id"]] = $trap["traps_name"];
     }
@@ -495,13 +586,13 @@ unset($_POST['o']);
 ## Form begin
 #
 $form = new HTML_QuickForm('Form', 'post', "?p=" . $p);
-if ($o == "a") {
+if ($o == SERVICE_ADD) {
     $form->addElement('header', 'title', _("Add a Service"));
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_MODIFY) {
     $form->addElement('header', 'title', _("Modify a Service"));
-} elseif ($o == "w") {
+} elseif ($o == SERVICE_WATCH) {
     $form->addElement('header', 'title', _("View a Service"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title', _("Massive Change"));
 }
 
@@ -513,7 +604,7 @@ if ($o == "a") {
  * - No possibility to change name and alias, because there's no interest
  * - May be ? #409
  */
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->addElement('text', 'service_description', _("Description"), $attrsText);
 }
 $form->addElement('text', 'service_alias', _("Alias"), $attrsText);
@@ -544,7 +635,7 @@ $serviceIV[] = HTML_QuickForm::createElement('radio', 'service_is_volatile', nul
 $serviceIV[] = HTML_QuickForm::createElement('radio', 'service_is_volatile', null, _("No"), '0');
 $serviceIV[] = HTML_QuickForm::createElement('radio', 'service_is_volatile', null, _("Default"), '2');
 $form->addGroup($serviceIV, 'service_is_volatile', _("Is Volatile"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_is_volatile' => '2'));
 }
 $availableCommandRoute1 = './include/common/webServices/rest/internal.php?object=centreon_configuration_command' .
@@ -559,7 +650,7 @@ $attrCommand1 = array_merge(
     )
 );
 $checkCommandSelect = $form->addElement('select2', 'command_command_id', _("Check Command"), array(), $attrCommand1);
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $checkCommandSelect->addJsCallback(
         'change',
         'setArgument(jQuery(this).closest("form").get(0),"command_command_id","example1");'
@@ -577,7 +668,7 @@ $serviceEHE[] = HTML_QuickForm::createElement('radio', 'service_event_handler_en
 $serviceEHE[] = HTML_QuickForm::createElement('radio', 'service_event_handler_enabled', null, _("No"), '0');
 $serviceEHE[] = HTML_QuickForm::createElement('radio', 'service_event_handler_enabled', null, _("Default"), '2');
 $form->addGroup($serviceEHE, 'service_event_handler_enabled', _("Event Handler Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_event_handler_enabled' => '2'));
 }
 
@@ -604,7 +695,7 @@ $serviceACE[] = HTML_QuickForm::createElement('radio', 'service_active_checks_en
 $serviceACE[] = HTML_QuickForm::createElement('radio', 'service_active_checks_enabled', null, _("No"), '0');
 $serviceACE[] = HTML_QuickForm::createElement('radio', 'service_active_checks_enabled', null, _("Default"), '2');
 $form->addGroup($serviceACE, 'service_active_checks_enabled', _("Active Checks Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_active_checks_enabled' => '2'));
 }
 
@@ -612,7 +703,7 @@ $servicePCE[] = HTML_QuickForm::createElement('radio', 'service_passive_checks_e
 $servicePCE[] = HTML_QuickForm::createElement('radio', 'service_passive_checks_enabled', null, _("No"), '0');
 $servicePCE[] = HTML_QuickForm::createElement('radio', 'service_passive_checks_enabled', null, _("Default"), '2');
 $form->addGroup($servicePCE, 'service_passive_checks_enabled', _("Passive Checks Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_passive_checks_enabled' => '2'));
 }
 $attrTimeperiodRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_timeperiod'
@@ -678,11 +769,11 @@ $serviceNE[] = HTML_QuickForm::createElement('radio', 'service_notifications_ena
 $serviceNE[] = HTML_QuickForm::createElement('radio', 'service_notifications_enabled', null, _("No"), '0');
 $serviceNE[] = HTML_QuickForm::createElement('radio', 'service_notifications_enabled', null, _("Default"), '2');
 $form->addGroup($serviceNE, 'service_notifications_enabled', _("Notification Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_notifications_enabled' => '2'));
 }
 
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $mc_mod_cgs = array();
     $mc_mod_cgs[] = HTML_QuickForm::createElement('radio', 'mc_mod_cgs', null, _("Incremental"), '0');
     $mc_mod_cgs[] = HTML_QuickForm::createElement('radio', 'mc_mod_cgs', null, _("Replacement"), '1');
@@ -702,7 +793,7 @@ $form->addGroup(
     _("Inherit only contacts/contacts group from host"),
     '&nbsp;'
 );
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_use_only_contacts_from_host' => '0'));
 }
 
@@ -710,7 +801,7 @@ if ($o != "mc") {
  * Additive
  */
 
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $contactAdditive[] = HTML_QuickForm::createElement('radio', 'mc_contact_additive_inheritance', null, _("Yes"), '1');
     $contactAdditive[] = HTML_QuickForm::createElement('radio', 'mc_contact_additive_inheritance', null, _("No"), '0');
     $contactAdditive[] = HTML_QuickForm::createElement(
@@ -765,7 +856,7 @@ $attrContactgroup1 = array_merge(
 $form->addElement('select2', 'service_cgs', _("Implied Contact Groups"), array(), $attrContactgroup1);
 
 
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $mc_mod_notifopt_first_notification_delay = array();
     $mc_mod_notifopt_first_notification_delay[] = &HTML_QuickForm::createElement(
         'radio',
@@ -794,7 +885,7 @@ $form->addElement('text', 'service_first_notification_delay', _("First notificat
 
 $form->addElement('text', 'service_recovery_notification_delay', _("Recovery notification delay"), $attrsText2);
 
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $mc_mod_notifopt_notification_interval = array();
     $mc_mod_notifopt_notification_interval[] = &HTML_QuickForm::createElement(
         'radio',
@@ -821,7 +912,7 @@ if ($o == "mc") {
 
 $form->addElement('text', 'service_notification_interval', _("Notification Interval"), $attrsText2);
 
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $mc_mod_notifopt_timeperiod = array();
     $mc_mod_notifopt_timeperiod[] = &HTML_QuickForm::createElement(
         'radio',
@@ -849,7 +940,7 @@ $attrTimeperiod2 = array_merge(
 );
 $form->addElement('select2', 'timeperiod_tp_id2', _("Notification Period"), array(), $attrTimeperiod2);
 
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $mc_mod_notifopts = array();
     $mc_mod_notifopts[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopts', null, _("Incremental"), '0');
     $mc_mod_notifopts[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopts', null, _("Replacement"), '1');
@@ -921,7 +1012,7 @@ $form->addElement('header', 'furtherInfos', _("Additional Information"));
 $serviceActivation[] = HTML_QuickForm::createElement('radio', 'service_activate', null, _("Enabled"), '1');
 $serviceActivation[] = HTML_QuickForm::createElement('radio', 'service_activate', null, _("Disabled"), '0');
 $form->addGroup($serviceActivation, 'service_activate', _("Status"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_activate' => '1'));
 }
 $form->addElement('textarea', 'service_comment', _("Comments"), $attrsTextarea);
@@ -929,17 +1020,17 @@ $form->addElement('textarea', 'service_comment', _("Comments"), $attrsTextarea);
 #
 ## Sort 2 - Service Relations
 #
-if ($o == "a") {
+if ($o == SERVICE_ADD) {
     $form->addElement('header', 'title2', _("Add relations"));
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_MODIFY) {
     $form->addElement('header', 'title2', _("Modify relations"));
-} elseif ($o == "w") {
+} elseif ($o == SERVICE_WATCH) {
     $form->addElement('header', 'title2', _("View relations"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title2', _("Massive Change"));
 }
 
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $mc_mod_Pars = array();
     $mc_mod_Pars[] = HTML_QuickForm::createElement('radio', 'mc_mod_Pars', null, _("Incremental"), '0');
     $mc_mod_Pars[] = HTML_QuickForm::createElement('radio', 'mc_mod_Pars', null, _("Replacement"), '1');
@@ -977,7 +1068,7 @@ if ($form_service_type == "BYHOSTGROUP") {
 
 // Service relations
 $form->addElement('header', 'links', _("Relations"));
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $mc_mod_sgs = array();
     $mc_mod_sgs[] = HTML_QuickForm::createElement('radio', 'mc_mod_sgs', null, _("Incremental"), '0');
     $mc_mod_sgs[] = HTML_QuickForm::createElement('radio', 'mc_mod_sgs', null, _("Replacement"), '1');
@@ -996,7 +1087,7 @@ if ($sgReadOnly === true) {
 }
 
 $form->addElement('header', 'traps', _("SNMP Traps"));
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $mc_mod_traps = array();
     $mc_mod_traps[] = HTML_QuickForm::createElement('radio', 'mc_mod_traps', null, _("Incremental"), '0');
     $mc_mod_traps[] = HTML_QuickForm::createElement('radio', 'mc_mod_traps', null, _("Replacement"), '1');
@@ -1014,13 +1105,13 @@ $form->addElement('select2', 'service_traps', _("Service Trap Relation"), array(
 #
 ## Sort 3 - Data treatment
 #
-if ($o == "a") {
+if ($o == SERVICE_ADD) {
     $form->addElement('header', 'title3', _("Add Data Processing"));
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_MODIFY) {
     $form->addElement('header', 'title3', _("Modify Data Processing"));
-} elseif ($o == "w") {
+} elseif ($o == SERVICE_WATCH) {
     $form->addElement('header', 'title3', _("View Data Processing"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title2', _("Massive Change"));
 }
 
@@ -1030,7 +1121,7 @@ $serviceOOS[] = HTML_QuickForm::createElement('radio', 'service_obsess_over_serv
 $serviceOOS[] = HTML_QuickForm::createElement('radio', 'service_obsess_over_service', null, _("No"), '0');
 $serviceOOS[] = HTML_QuickForm::createElement('radio', 'service_obsess_over_service', null, _("Default"), '2');
 $form->addGroup($serviceOOS, 'service_obsess_over_service', _("Obsess Over Service"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_obsess_over_service' => '2'));
 }
 
@@ -1038,7 +1129,7 @@ $serviceCF[] = HTML_QuickForm::createElement('radio', 'service_check_freshness',
 $serviceCF[] = HTML_QuickForm::createElement('radio', 'service_check_freshness', null, _("No"), '0');
 $serviceCF[] = HTML_QuickForm::createElement('radio', 'service_check_freshness', null, _("Default"), '2');
 $form->addGroup($serviceCF, 'service_check_freshness', _("Check Freshness"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_check_freshness' => '2'));
 }
 
@@ -1046,7 +1137,7 @@ $serviceFDE[] = HTML_QuickForm::createElement('radio', 'service_flap_detection_e
 $serviceFDE[] = HTML_QuickForm::createElement('radio', 'service_flap_detection_enabled', null, _("No"), '0');
 $serviceFDE[] = HTML_QuickForm::createElement('radio', 'service_flap_detection_enabled', null, _("Default"), '2');
 $form->addGroup($serviceFDE, 'service_flap_detection_enabled', _("Flap Detection Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_flap_detection_enabled' => '2'));
 }
 
@@ -1058,7 +1149,7 @@ $serviceRSI[] = HTML_QuickForm::createElement('radio', 'service_retain_status_in
 $serviceRSI[] = HTML_QuickForm::createElement('radio', 'service_retain_status_information', null, _("No"), '0');
 $serviceRSI[] = HTML_QuickForm::createElement('radio', 'service_retain_status_information', null, _("Default"), '2');
 $form->addGroup($serviceRSI, 'service_retain_status_information', _("Retain Status Information"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_retain_status_information' => '2'));
 }
 
@@ -1066,20 +1157,20 @@ $serviceRNI[] = HTML_QuickForm::createElement('radio', 'service_retain_nonstatus
 $serviceRNI[] = HTML_QuickForm::createElement('radio', 'service_retain_nonstatus_information', null, _("No"), '0');
 $serviceRNI[] = HTML_QuickForm::createElement('radio', 'service_retain_nonstatus_information', null, _("Default"), '2');
 $form->addGroup($serviceRNI, 'service_retain_nonstatus_information', _("Retain Non Status Information"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_retain_nonstatus_information' => '2'));
 }
 
 #
 ## Sort 4 - Extended Infos
 #
-if ($o == "a") {
+if ($o == SERVICE_ADD) {
     $form->addElement('header', 'title4', _("Add an Extended Info"));
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_MODIFY) {
     $form->addElement('header', 'title4', _("Modify an Extended Info"));
-} elseif ($o == "w") {
+} elseif ($o == SERVICE_WATCH) {
     $form->addElement('header', 'title4', _("View an Extended Info"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title3', _("Massive Change"));
 }
 
@@ -1116,7 +1207,7 @@ $attrGraphtemplate1 = array_merge(
 );
 $form->addElement('select2', 'graph_id', _("Graph Template"), array(), $attrGraphtemplate1);
 
-if ($o == "mc") {
+if ($o == SERVICE_MASSIVE_CHANGE) {
     $mc_mod_sc = array();
     $mc_mod_sc[] = HTML_QuickForm::createElement('radio', 'mc_mod_sc', null, _("Incremental"), '0');
     $mc_mod_sc[] = HTML_QuickForm::createElement('radio', 'mc_mod_sc', null, _("Replacement"), '1');
@@ -1136,13 +1227,13 @@ $form->addElement('select2', 'service_categories', _("Categories"), array(), $at
 /*
  * Sort 5
  */
-if ($o == "a") {
+if ($o == SERVICE_ADD) {
     $form->addElement('header', 'title5', _("Add macros"));
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_MODIFY) {
     $form->addElement('header', 'title5', _("Modify macros"));
-} elseif ($o == "w") {
+} elseif ($o == SERVICE_WATCH) {
     $form->addElement('header', 'title5', _("View macros"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title5', _("Massive Change"));
 }
 
@@ -1166,12 +1257,8 @@ $init = $form->addElement('hidden', 'initialValues');
 $init->setValue(serialize($initialValues));
 
 if (is_array($select)) {
-    $select_str = null;
-    foreach ($select as $key => $value) {
-        $select_str .= $key . ",";
-    }
     $select_pear = $form->addElement('hidden', 'select');
-    $select_pear->setValue($select_str);
+    $select_pear->setValue(implode(',', array_keys($select)));
 }
 
 /*
@@ -1179,7 +1266,7 @@ if (is_array($select)) {
  */
 $form->applyFilter('__ALL__', 'myTrim');
 $from_list_menu = false;
-if ($o != "mc") {
+if ($o != SERVICE_MASSIVE_CHANGE) {
     $form->addRule('service_description', _("Compulsory Name"), 'required');
     # If we are using a Template, no need to check the value, we hope there are in the Template
     if (!$form->getSubmitValue("service_template_model_stm_id")) {
@@ -1223,7 +1310,7 @@ if ($o != "mc") {
     );
 
     $form->setRequiredNote("<font style='color: red;'>*</font>&nbsp;" . _("Required fields"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_MASSIVE_CHANGE) {
     if ($form->getSubmitValue("submitMC")) {
         $from_list_menu = false;
     } else {
@@ -1249,7 +1336,7 @@ $tpl->assign(
 );
 
 // Just watch a host information
-if ($o == "w") {
+if ($o == SERVICE_WATCH) {
     if (!$min && $centreon->user->access->page($p) != 2) {
         $form->addElement(
             "button",
@@ -1260,7 +1347,7 @@ if ($o == "w") {
     }
     $form->setDefaults($service);
     $form->freeze();
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_MODIFY) {
     // Modify a service information
     $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement(
@@ -1270,11 +1357,11 @@ if ($o == "w") {
         array("onClick" => "history.go(0);", "class" => "btc bt_default")
     );
     $form->setDefaults($service);
-} elseif ($o == "a") {
+} elseif ($o == SERVICE_ADD) {
     // Add a service information
     $subA = $form->addElement('submit', 'submitA', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_MASSIVE_CHANGE) {
     // Massive Change
     $subMC = $form->addElement('submit', 'submitMC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
@@ -1310,16 +1397,36 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $serviceObj->setValue(insertServiceInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        /*
+         * Before saving, we check if a password macro has changed its name to be able to give it the right password
+         * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).
+         */
+        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+            if (array_key_exists('macroOriginalName_' . $index, $_REQUEST)) {
+                $originalMacroName = $_REQUEST['macroOriginalName_' . $index];
+                if ($_REQUEST['macroValue'][$index] === PASSWORD_REPLACEMENT_VALUE) {
+                    /*
+                     * The password has not been changed along with the name, so its value is equal to the wildcard.
+                     * We will therefore recover the password stored for its original name.
+                     */
+                    foreach ($aMacros as $indexMacro => $macroDetails) {
+                        if ($macroDetails['macroInput_#index#'] === $originalMacroName) {
+                            $_REQUEST['macroValue'][$index] = $macroPasswords[$indexMacro]['password'];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
         updateServiceInDB($serviceObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
-        $select = explode(",", $select);
-        foreach ($select as $key => $value) {
+        foreach ($select as $value) {
             if ($value) {
                 updateServiceInDB($value, true);
             }
         }
     }
-    $o = "w";
+    $o = SERVICE_WATCH;
     $valid = true;
 } elseif ($form->isSubmitted()) {
     $tpl->assign("argChecker", "<font color='red'>" . $form->getElementError("argChecker") . "</font>");

--- a/www/include/configuration/configObject/service/serviceByHost.php
+++ b/www/include/configuration/configObject/service/serviceByHost.php
@@ -40,18 +40,18 @@ if (!isset($centreon)) {
 global $form_service_type;
 $form_service_type = "BYHOST";
 
-
-isset($_GET["service_id"]) ? $sG = $_GET["service_id"] : $sG = null;
-isset($_POST["service_id"]) ? $sP = $_POST["service_id"] : $sP = null;
-$sG ? $service_id = CentreonDB::escape($sG) : $service_id = CentreonDB::escape($sP);
-
-isset($_GET["select"]) ? $cG = $_GET["select"] : $cG = null;
-isset($_POST["select"]) ? $cP = $_POST["select"] : $cP = null;
-$cG ? $select = $cG : $select = $cP;
-
-isset($_GET["dupNbr"]) ? $cG = $_GET["dupNbr"] : $cG = null;
-isset($_POST["dupNbr"]) ? $cP = $_POST["dupNbr"] : $cP = null;
-$cG ? $dupNbr = $cG : $dupNbr = $cP;
+$service_id = filter_var(
+    call_user_func(function () {
+        if (isset($_GET["service_id"])) {
+            return $_GET["service_id"];
+        } elseif (isset($_POST["service_id"])) {
+            return $_POST["service_id"];
+        } else {
+            return null;
+        }
+    }),
+    FILTER_VALIDATE_INT
+);
 
 /*
  * Pear library
@@ -71,23 +71,39 @@ $path = "./include/configuration/configObject/service/";
 require_once $path."DB-Func.php";
 require_once "./include/common/common-Func.php";
 
+// select can be an array of integer or a string of integers separated by comma
+$select = filter_var_array(
+    getSelectOption(),
+    FILTER_VALIDATE_INT
+);
+
+// If one data is not correctly typed in array, it will be set to false
+$dupNbr = filter_var_array(
+    getDuplicateNumberOption(),
+    FILTER_VALIDATE_INT
+);
+
 /*
  * Create a suffix for file name in order to redirect service by hostgroup
  * on a good page.
  */
 $linkType = '';
 
-/*
- * Check if a service is a service by hostgroup or not
- */
-$request = "SELECT * FROM host_service_relation WHERE service_service_id = '".(int)$service_id."'";
-$DBRESULT = $pearDB->query($request);
-while ($data = $DBRESULT->fetchRow()) {
-    if (isset($data["hostgroup_hg_id"]) && $data["hostgroup_hg_id"] != "") {
-        $linkType = 'Group';
-        $form_service_type = "BYHOSTGROUP";
+if ($service_id !== false) {
+    /*
+     * Check if a service is a service by hostgroup or not
+     */
+    $DBRESULT = $pearDB->query(
+        "SELECT * FROM host_service_relation WHERE service_service_id = " . ((int) $service_id)
+    );
+    while ($data = $DBRESULT->fetchRow()) {
+        if (isset($data["hostgroup_hg_id"]) && $data["hostgroup_hg_id"] != "") {
+            $linkType = 'Group';
+            $form_service_type = "BYHOSTGROUP";
+        }
     }
 }
+
 
 /*
  * Check options
@@ -109,48 +125,54 @@ if ($ret['topology_page'] != "" && $p != $ret['topology_page']) {
 $acl = $centreon->user->access;
 $acldbname = $acl->getNameDBAcl();
 
+define('SERVICE_ADD', 'a');
+define('SERVICE_WATCH', 'w');
+define('SERVICE_MODIFY', 'c');
+define('SERVICE_MASSIVE_CHANGE', 'mc');
+define('SERVICE_DIVISION', 'dv');
+define('SERVICE_ACTIVATION', 's');
+define('SERVICE_MASSIVE_ACTIVATION', 'ms');
+define('SERVICE_DEACTIVATION', 'u');
+define('SERVICE_MASSIVE_DEACTIVATION', 'mu');
+define('SERVICE_DUPLICATION', 'm');
+define('SERVICE_DELETION', 'd');
+
 switch ($o) {
-    case "a":
-        require_once($path."formService.php");
-        break; #Add a service
-    case "w":
-        require_once($path."formService.php");
-        break; #Watch a service
-    case "c":
-        require_once($path."formService.php");
-        break; #Modify a service
-    case "mc":
-        require_once($path."formService.php");
-        break; #Massive change
-    case "dv":
+    case SERVICE_ADD:
+    case SERVICE_WATCH:
+    case SERVICE_MODIFY:
+    case SERVICE_MASSIVE_CHANGE:
+        require_once($path . "formService.php");
+        break;
+    case SERVICE_DIVISION:
         divideGroupedServiceInDB(null, isset($select) ? $select : array());
-        require_once($path."listServiceByHost$linkType.php");
-        break; # Divide service linked to n hosts
-    case "s":
+        require_once($path . "listServiceByHost$linkType.php");
+        break;
+    case SERVICE_ACTIVATION:
         enableServiceInDB($service_id);
-        require_once($path."listServiceByHost$linkType.php");
-        break; #Activate a service
-    case "ms":
+        require_once($path . "listServiceByHost$linkType.php");
+        break;
+    case SERVICE_MASSIVE_ACTIVATION:
         enableServiceInDB(null, isset($select) ? $select : array());
-        require_once($path."listServiceByHost$linkType.php");
+        require_once($path . "listServiceByHost$linkType.php");
         break;
-    case "u":
+    case SERVICE_DEACTIVATION:
         disableServiceInDB($service_id);
-        require_once($path."listServiceByHost$linkType.php");
-        break; #Desactivate a service
-    case "mu":
-        disableServiceInDB(null, isset($select) ? $select : array());
-        require_once($path."listServiceByHost$linkType.php");
+        require_once($path . "listServiceByHost$linkType.php");
         break;
-    case "m":
+    case SERVICE_MASSIVE_DEACTIVATION:
+        disableServiceInDB(null, isset($select) ? $select : array());
+        require_once($path . "listServiceByHost$linkType.php");
+        break;
+    case SERVICE_DUPLICATION:
         multipleServiceInDB(isset($select) ? $select : array(), $dupNbr);
-        require_once($path."listServiceByHost$linkType.php");
-        break; #Duplicate n services
-    case "d":
+        require_once($path . "listServiceByHost$linkType.php");
+        break;
+    case SERVICE_DELETION:
         deleteServiceInDB(isset($select) ? $select : array());
-        require_once($path."listServiceByHost$linkType.php");
-        break; #Delete n services
+        require_once($path . "listServiceByHost$linkType.php");
+        break;
     default:
-        require_once($path."listServiceByHost$linkType.php");
+        require_once($path . "listServiceByHost$linkType.php");
         break;
 }

--- a/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+++ b/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
@@ -50,15 +50,25 @@ function myDecodeSvTP($arg)
     return html_entity_decode($arg, ENT_QUOTES, "UTF-8");
 }
 
+define('PASSWORD_REPLACEMENT_VALUE', '**********');
+
 $cmdId = 0;
 $serviceTplId = null;
 $service = array();
 $serviceObj = new CentreonService($pearDB);
-if (($o == "c" || $o == "w") && $service_id) {
+// Used to store all macro passwords
+$macroPasswords = array();
+
+if (($o == SERVICE_TEMPLATE_MODIFY || $o == SERVICE_TEMPLATE_WATCH) && $service_id) {
     if (isset($lockedElements[$service_id])) {
-        $o = "w";
+        $o = SERVICE_TEMPLATE_WATCH;
     }
-    $DBRESULT = $pearDB->query("SELECT * FROM service LEFT JOIN extended_service_information esi ON esi.service_service_id = service_id WHERE service_id = '".$service_id."'  LIMIT 1");
+    $DBRESULT = $pearDB->query(
+        "SELECT * FROM service 
+        LEFT JOIN extended_service_information esi
+            ON esi.service_service_id = service_id
+        WHERE service_id = " . ((int) $service_id) . "  LIMIT 1"
+    );
     // Set base value
     $service_list = $DBRESULT->fetchRow();
     $service = array_map("myDecodeSvTP", $service_list);
@@ -68,7 +78,9 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Grab hostgroup || host
      */
-    $DBRESULT = $pearDB->query("SELECT * FROM host_service_relation hsr WHERE hsr.service_service_id = '".$service_id."'");
+    $DBRESULT = $pearDB->query(
+        "SELECT * FROM host_service_relation hsr WHERE hsr.service_service_id = " . ((int) $service_id)
+    );
     while ($parent = $DBRESULT->fetchRow()) {
         if ($parent["host_host_id"]) {
             $service["service_hPars"][$parent["host_host_id"]] = $parent["host_host_id"];
@@ -94,7 +106,11 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set Contact Group
      */
-    $DBRESULT = $pearDB->query("SELECT DISTINCT contactgroup_cg_id FROM contactgroup_service_relation WHERE service_service_id = '".$service_id."'");
+    $DBRESULT = $pearDB->query(
+        "SELECT DISTINCT contactgroup_cg_id 
+        FROM contactgroup_service_relation
+        WHERE service_service_id = " . ((int) $service_id)
+    );
     for ($i = 0; $notifCg = $DBRESULT->fetchRow(); $i++) {
         $service["service_cgs"][$i] = $notifCg["contactgroup_cg_id"];
     }
@@ -103,7 +119,11 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set Contact Group
      */
-    $DBRESULT = $pearDB->query("SELECT DISTINCT contact_id FROM contact_service_relation WHERE service_service_id = '".$service_id."'");
+    $DBRESULT = $pearDB->query(
+        "SELECT DISTINCT contact_id
+        FROM contact_service_relation
+        WHERE service_service_id = " . ((int) $service_id)
+    );
     for ($i = 0; $notifC = $DBRESULT->fetchRow(); $i++) {
         $service["service_cs"][$i] = $notifC["contact_id"];
     }
@@ -112,7 +132,11 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set Service Group Parents
      */
-    $DBRESULT = $pearDB->query("SELECT DISTINCT servicegroup_sg_id FROM servicegroup_relation WHERE service_service_id = '".$service_id."'");
+    $DBRESULT = $pearDB->query(
+        "SELECT DISTINCT servicegroup_sg_id
+        FROM servicegroup_relation
+        WHERE service_service_id = " . ((int) $service_id)
+    );
     for ($i = 0; $sg = $DBRESULT->fetchRow(); $i++) {
         $service["service_sgs"][$i] = $sg["servicegroup_sg_id"];
     }
@@ -121,7 +145,11 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set Traps
      */
-    $DBRESULT = $pearDB->query("SELECT DISTINCT traps_id FROM traps_service_relation WHERE service_id = '".$service_id."'");
+    $DBRESULT = $pearDB->query(
+        "SELECT DISTINCT traps_id
+        FROM traps_service_relation
+        WHERE service_id = " . ((int) $service_id)
+    );
     for ($i = 0; $trap = $DBRESULT->fetchRow(); $i++) {
         $service["service_traps"][$i] = $trap["traps_id"];
     }
@@ -130,11 +158,16 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set Categories
      */
-    $DBRESULT = $pearDB->query('SELECT DISTINCT scr.sc_id 
-                    FROM service_categories_relation scr, service_categories sc
-                    WHERE scr.sc_id = sc.sc_id
-                    AND sc.level IS NULL
-                    AND scr.service_service_id = \''.$service_id.'\'');
+    $DBRESULT = $pearDB->query(
+        'SELECT DISTINCT scr.sc_id 
+        FROM service_categories_relation scr
+        INNER JOIN service_categories sc
+            ON sc.sc_id = scr.sc_id
+        WHERE sc.level IS NULL
+            AND scr.service_service_id = ' . ((int) $service_id)
+    );
+
+
     for ($i = 0; $service_category = $DBRESULT->fetchRow(); $i++) {
         $service["service_categories"][$i] = $service_category["sc_id"];
     }
@@ -143,13 +176,16 @@ if (($o == "c" || $o == "w") && $service_id) {
     /*
      * Set criticality
      */
-    $res = $pearDB->query("SELECT sc.sc_id 
-                            FROM service_categories sc, service_categories_relation scr
-                            WHERE scr.service_service_id = " . $pearDB->escape($service_id). "
-                            AND scr.sc_id = sc.sc_id
-                            AND sc.level IS NOT NULL
-                            ORDER BY sc.level ASC
-                            LIMIT 1");
+    $res = $pearDB->query(
+        "SELECT sc.sc_id 
+        FROM service_categories sc
+        INNER JOIN service_categories_relation scr
+            ON scr.sc_id = sc.sc_id 
+        WHERE sc.level IS NOT NULL
+            AND scr.service_service_id = " . ((int) $service_id). "
+        ORDER BY sc.level ASC
+        LIMIT 1"
+    );
     if ($res->numRows()) {
         $cr = $res->fetchRow();
         $service['criticality_id'] = $cr['sc_id'];
@@ -161,7 +197,57 @@ if (($o == "c" || $o == "w") && $service_id) {
     if (!isset($cmdId)) {
         $cmdId = "";
     }
+
+    if (isset($_REQUEST['macroInput'])) {
+        /**
+         * We don't taking into account the POST data sent from the interface in order the retrieve the original value
+         * of all passwords.
+         */
+        $aMacros = $serviceObj->getMacros($service_id, $aListTemplate, $cmdId);
+
+        /**
+         * If a password has been modified from the interface, we retrieve the old password existing in the repository
+         * (giving by the $aMacros variable) to inject it before saving.
+         * Passwords will be saved using the $_REQUEST variable.
+         */
+        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+            if (
+                !isset($_REQUEST['macroFrom'][$index])
+                || !isset($_REQUEST['macroPassword'][$index])
+                || $_REQUEST['macroPassword'][$index] !== '1'                      // Not a password
+                || $_REQUEST['macroValue'][$index] !== PASSWORD_REPLACEMENT_VALUE  // The password has not changed
+            ) {
+                continue;
+            }
+            foreach ($aMacros as $macroAlreadyExist) {
+                if (
+                    $macroAlreadyExist['macroInput_#index#'] === $macroName
+                    && $_REQUEST['macroFrom'][$index] === $macroAlreadyExist['source']
+                ) {
+                    /**
+                     * if the password has not been changed, we replace the password coming from the interface with
+                     * the original value (from the repository) before saving.
+                     */
+                    $_REQUEST['macroValue'][$index] = $macroAlreadyExist['macroValue_#index#'];
+                }
+            }
+        }
+    }
+
+    // We taking into account the POST data sent from the interface
     $aMacros = $serviceObj->getMacros($service_id, $aListTemplate, $cmdId);
+
+    // We hide all passwords in the jsData property to prevent them from appearing in the HTML code.
+    foreach ($aMacros as $index => $macroValues) {
+        if ($macroValues['macroPassword_#index#'] === '1') {
+            $macroPasswords[$index]['password'] = $aMacros[$index]['macroValue_#index#'];
+            // It's a password macro
+            $aMacros[$index]['macroOldValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
+            $aMacros[$index]['macroValue_#index#'] = PASSWORD_REPLACEMENT_VALUE;
+            // Keep the original name of the input field in case its name changes.
+            $aMacros[$index]['macroOriginalName_#index#'] = $aMacros[$index]['macroInput_#index#'];
+        }
+    }
 }
 
 /*
@@ -194,7 +280,11 @@ $DBRESULT->free();
  */
 $svc_tmplt_who_use_me = array();
 if (isset($_GET["service_id"]) && $_GET["service_id"]) {
-    $DBRESULT = $pearDB->query("SELECT service_description, service_id FROM service WHERE service_template_model_stm_id = '".$pearDB->escape($_GET["service_id"])."'");
+    $DBRESULT = $pearDB->query(
+        "SELECT service_description, service_id
+        FROM service
+        WHERE service_template_model_stm_id = " . ((int) $_GET["service_id"])
+    );
     while ($service_tmpl_father = $DBRESULT->fetchRow()) {
         $svc_tmplt_who_use_me[$service_tmpl_father["service_id"]] = $service_tmpl_father["service_description"];
     }
@@ -205,7 +295,13 @@ if (isset($_GET["service_id"]) && $_GET["service_id"]) {
  * Service Templates comes from DB -> Store in $svTpls Array
  */
 $svTpls = array(null => null);
-$DBRESULT = $pearDB->query("SELECT service_id, service_description, service_template_model_stm_id FROM service WHERE service_register = '0' AND service_id != '".$service_id."' ORDER BY service_description");
+$DBRESULT = $pearDB->query(
+    "SELECT service_id, service_description, service_template_model_stm_id
+    FROM service
+    WHERE service_register = '0'
+        AND service_id != " . ((int) $service_id)
+    . " ORDER BY service_description"
+);
 while ($svTpl = $DBRESULT->fetchRow()) {
     if (!$svTpl["service_description"]) {
         $svTpl["service_description"] = getMyServiceName($svTpl["service_template_model_stm_id"])."'";
@@ -381,13 +477,13 @@ unset($_POST['o']);
 ## Form begin
 #
 $form = new HTML_QuickForm('Form', 'post', "?p=".$p);
-if ($o == "a") {
+if ($o == SERVICE_TEMPLATE_ADD) {
     $form->addElement('header', 'title', _("Add a Service Template Model"));
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_TEMPLATE_MODIFY) {
     $form->addElement('header', 'title', _("Modify a Service Template Model"));
-} elseif ($o == "w") {
+} elseif ($o == SERVICE_TEMPLATE_WATCH) {
     $form->addElement('header', 'title', _("View a Service Template Model"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title', _("Massive Change"));
 }
 
@@ -396,7 +492,7 @@ if ($o == "a") {
 #
 $form->addElement('header', 'information', _("General Information"));
 
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('text', 'service_description', _("Name"), $attrsText);
 }
 $form->addElement('text', 'service_alias', _("Alias"), $attrsText);
@@ -426,7 +522,7 @@ $serviceIV[] = HTML_QuickForm::createElement('radio', 'service_is_volatile', nul
 $serviceIV[] = HTML_QuickForm::createElement('radio', 'service_is_volatile', null, _("No"), '0');
 $serviceIV[] = HTML_QuickForm::createElement('radio', 'service_is_volatile', null, _("Default"), '2');
 $form->addGroup($serviceIV, 'service_is_volatile', _("Is volatile"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_is_volatile' => '2'));
 }
 
@@ -438,7 +534,7 @@ $attrCommand1 = array_merge(
     )
 );
 $checkCommandSelect = $form->addElement('select2', 'command_command_id', _("Check Command"), array(), $attrCommand1);
-if ($o == "mc") {
+if ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $checkCommandSelect->addJsCallback('change', 'setArgument(jQuery(this).closest("form").get(0),"command_command_id","example1");');
 } else {
     $checkCommandSelect->addJsCallback('change', 'changeCommand(this.value);');
@@ -453,7 +549,7 @@ $serviceEHE[] = HTML_QuickForm::createElement('radio', 'service_event_handler_en
 $serviceEHE[] = HTML_QuickForm::createElement('radio', 'service_event_handler_enabled', null, _("No"), '0');
 $serviceEHE[] = HTML_QuickForm::createElement('radio', 'service_event_handler_enabled', null, _("Default"), '2');
 $form->addGroup($serviceEHE, 'service_event_handler_enabled', _("Event Handler Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_event_handler_enabled' => '2'));
 }
 $attrCommand2 = array_merge(
@@ -471,7 +567,7 @@ $serviceACE[] = HTML_QuickForm::createElement('radio', 'service_active_checks_en
 $serviceACE[] = HTML_QuickForm::createElement('radio', 'service_active_checks_enabled', null, _("No"), '0');
 $serviceACE[] = HTML_QuickForm::createElement('radio', 'service_active_checks_enabled', null, _("Default"), '2');
 $form->addGroup($serviceACE, 'service_active_checks_enabled', _("Active Checks Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_active_checks_enabled' => '2'));
 }
 
@@ -479,7 +575,7 @@ $servicePCE[] = HTML_QuickForm::createElement('radio', 'service_passive_checks_e
 $servicePCE[] = HTML_QuickForm::createElement('radio', 'service_passive_checks_enabled', null, _("No"), '0');
 $servicePCE[] = HTML_QuickForm::createElement('radio', 'service_passive_checks_enabled', null, _("Default"), '2');
 $form->addGroup($servicePCE, 'service_passive_checks_enabled', _("Passive Checks Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_passive_checks_enabled' => '2'));
 }
 
@@ -539,11 +635,11 @@ $serviceNE[] = HTML_QuickForm::createElement('radio', 'service_notifications_ena
 $serviceNE[] = HTML_QuickForm::createElement('radio', 'service_notifications_enabled', null, _("No"), '0');
 $serviceNE[] = HTML_QuickForm::createElement('radio', 'service_notifications_enabled', null, _("Default"), '2');
 $form->addGroup($serviceNE, 'service_notifications_enabled', _("Notification Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_notifications_enabled' => '2'));
 }
 
-if ($o == "mc") {
+if ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_cgs = array();
     $mc_mod_cgs[] = HTML_QuickForm::createElement('radio', 'mc_mod_cgs', null, _("Incremental"), '0');
     $mc_mod_cgs[] = HTML_QuickForm::createElement('radio', 'mc_mod_cgs', null, _("Replacement"), '1');
@@ -554,7 +650,7 @@ if ($o == "mc") {
 /*
  * Additive
  */
-if ($o == "mc") {
+if ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $contactAdditive[] = HTML_QuickForm::createElement('radio', 'mc_contact_additive_inheritance', null, _("Yes"), '1');
     $contactAdditive[] = HTML_QuickForm::createElement('radio', 'mc_contact_additive_inheritance', null, _("No"), '0');
     $contactAdditive[] = HTML_QuickForm::createElement('radio', 'mc_contact_additive_inheritance', null, _("Default"), '2');
@@ -589,7 +685,7 @@ $attrContactgroup1 = array_merge(
 $form->addElement('select2', 'service_cgs', _("Implied Contact Groups"), array(), $attrContactgroup1);
 
 
-if ($o == "mc") {
+if ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_notifopt_first_notification_delay = array();
     $mc_mod_notifopt_first_notification_delay[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_first_notification_delay', null, _("Incremental"), '0');
     $mc_mod_notifopt_first_notification_delay[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_first_notification_delay', null, _("Replacement"), '1');
@@ -601,7 +697,7 @@ $form->addElement('text', 'service_first_notification_delay', _("First notificat
 
 $form->addElement('text', 'service_recovery_notification_delay', _("Recovery notification delay"), $attrsText2);
 
-if ($o == "mc") {
+if ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_notifopt_notification_interval = array();
     $mc_mod_notifopt_notification_interval[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_notification_interval', null, _("Incremental"), '0');
     $mc_mod_notifopt_notification_interval[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_notification_interval', null, _("Replacement"), '1');
@@ -611,7 +707,7 @@ if ($o == "mc") {
 
 $form->addElement('text', 'service_notification_interval', _("Notification Interval"), $attrsText2);
 
-if ($o == "mc") {
+if ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_notifopt_timeperiod = array();
     $mc_mod_notifopt_timeperiod[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_timeperiod', null, _("Incremental"), '0');
     $mc_mod_notifopt_timeperiod[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopt_timeperiod', null, _("Replacement"), '1');
@@ -625,7 +721,7 @@ $attrTimeperiod2 = array_merge(
 );
 $form->addElement('select2', 'timeperiod_tp_id2', _("Notification Period"), array(), $attrTimeperiod2);
 
-if ($o == "mc") {
+if ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_notifopts = array();
     $mc_mod_notifopts[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopts', null, _("Incremental"), '0');
     $mc_mod_notifopts[] = &HTML_QuickForm::createElement('radio', 'mc_mod_notifopts', null, _("Replacement"), '1');
@@ -655,7 +751,7 @@ $form->addElement('header', 'furtherInfos', _("Additional Information"));
 $serviceActivation[] = HTML_QuickForm::createElement('radio', 'service_activate', null, _("Enabled"), '1');
 $serviceActivation[] = HTML_QuickForm::createElement('radio', 'service_activate', null, _("Disabled"), '0');
 $form->addGroup($serviceActivation, 'service_activate', _("Status"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_activate' => '1'));
 }
 $form->addElement('textarea', 'service_comment', _("Comments"), $attrsTextarea);
@@ -663,19 +759,19 @@ $form->addElement('textarea', 'service_comment', _("Comments"), $attrsTextarea);
 #
 ## Sort 2 - Service relations
 #
-if ($o == "a") {
+if ($o == SERVICE_TEMPLATE_ADD) {
     $form->addElement('header', 'title2', _("Add relations"));
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_TEMPLATE_MODIFY) {
     $form->addElement('header', 'title2', _("Modify relations"));
-} elseif ($o == "w") {
+} elseif ($o == SERVICE_TEMPLATE_WATCH) {
     $form->addElement('header', 'title2', _("View relations"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title2', _("Massive Change"));
 }
 
 $form->addElement('header', 'links', _("Relations"));
 
-if ($o == "mc") {
+if ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_traps = array();
     $mc_mod_traps[] = HTML_QuickForm::createElement('radio', 'mc_mod_traps', null, _("Incremental"), '0');
     $mc_mod_traps[] = HTML_QuickForm::createElement('radio', 'mc_mod_traps', null, _("Replacement"), '1');
@@ -690,7 +786,7 @@ $attrTrap1 = array_merge(
 $form->addElement('select2', 'service_traps', _("Service Trap Relation"), array(), $attrTrap1);
 
 
-if ($o == "mc") {
+if ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_Pars = array();
     $mc_mod_Pars[] = HTML_QuickForm::createElement('radio', 'mc_mod_Pars', null, _("Incremental"), '0');
     $mc_mod_Pars[] = HTML_QuickForm::createElement('radio', 'mc_mod_Pars', null, _("Replacement"), '1');
@@ -702,13 +798,13 @@ if ($o == "mc") {
 ## Sort 3 - Data treatment
 ##
 
-if ($o == "a") {
+if ($o == SERVICE_TEMPLATE_ADD) {
     $form->addElement('header', 'title3', _("Add Data Processing"));
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_TEMPLATE_MODIFY) {
     $form->addElement('header', 'title3', _("Modify Data Processing"));
-} elseif ($o == "w") {
+} elseif ($o == SERVICE_TEMPLATE_WATCH) {
     $form->addElement('header', 'title3', _("View Data Processing"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title2', _("Massive Change"));
 }
 
@@ -718,7 +814,7 @@ $servicePC[] = HTML_QuickForm::createElement('radio', 'service_parallelize_check
 $servicePC[] = HTML_QuickForm::createElement('radio', 'service_parallelize_check', null, _("No"), '0');
 $servicePC[] = HTML_QuickForm::createElement('radio', 'service_parallelize_check', null, _("Default"), '2');
 $form->addGroup($servicePC, 'service_parallelize_check', _("Parallel Check"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_parallelize_check' => '2'));
 }
 
@@ -726,7 +822,7 @@ $serviceOOS[] = HTML_QuickForm::createElement('radio', 'service_obsess_over_serv
 $serviceOOS[] = HTML_QuickForm::createElement('radio', 'service_obsess_over_service', null, _("No"), '0');
 $serviceOOS[] = HTML_QuickForm::createElement('radio', 'service_obsess_over_service', null, _("Default"), '2');
 $form->addGroup($serviceOOS, 'service_obsess_over_service', _("Obsess Over Service"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_obsess_over_service' => '2'));
 }
 
@@ -734,7 +830,7 @@ $serviceCF[] = HTML_QuickForm::createElement('radio', 'service_check_freshness',
 $serviceCF[] = HTML_QuickForm::createElement('radio', 'service_check_freshness', null, _("No"), '0');
 $serviceCF[] = HTML_QuickForm::createElement('radio', 'service_check_freshness', null, _("Default"), '2');
 $form->addGroup($serviceCF, 'service_check_freshness', _("Check Freshness"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_check_freshness' => '2'));
 }
 
@@ -742,7 +838,7 @@ $serviceFDE[] = HTML_QuickForm::createElement('radio', 'service_flap_detection_e
 $serviceFDE[] = HTML_QuickForm::createElement('radio', 'service_flap_detection_enabled', null, _("No"), '0');
 $serviceFDE[] = HTML_QuickForm::createElement('radio', 'service_flap_detection_enabled', null, _("Default"), '2');
 $form->addGroup($serviceFDE, 'service_flap_detection_enabled', _("Flap Detection Enabled"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_flap_detection_enabled' => '2'));
 }
 
@@ -754,7 +850,7 @@ $servicePPD[] = HTML_QuickForm::createElement('radio', 'service_process_perf_dat
 $servicePPD[] = HTML_QuickForm::createElement('radio', 'service_process_perf_data', null, _("No"), '0');
 $servicePPD[] = HTML_QuickForm::createElement('radio', 'service_process_perf_data', null, _("Default"), '2');
 $form->addGroup($servicePPD, 'service_process_perf_data', _("Process Perf Data"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_process_perf_data' => '2'));
 }
 
@@ -762,7 +858,7 @@ $serviceRSI[] = HTML_QuickForm::createElement('radio', 'service_retain_status_in
 $serviceRSI[] = HTML_QuickForm::createElement('radio', 'service_retain_status_information', null, _("No"), '0');
 $serviceRSI[] = HTML_QuickForm::createElement('radio', 'service_retain_status_information', null, _("Default"), '2');
 $form->addGroup($serviceRSI, 'service_retain_status_information', _("Retain Status Information"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_retain_status_information' => '2'));
 }
 
@@ -770,20 +866,20 @@ $serviceRNI[] = HTML_QuickForm::createElement('radio', 'service_retain_nonstatus
 $serviceRNI[] = HTML_QuickForm::createElement('radio', 'service_retain_nonstatus_information', null, _("No"), '0');
 $serviceRNI[] = HTML_QuickForm::createElement('radio', 'service_retain_nonstatus_information', null, _("Default"), '2');
 $form->addGroup($serviceRNI, 'service_retain_nonstatus_information', _("Retain Non Status Information"), '&nbsp;');
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(array('service_retain_nonstatus_information' => '2'));
 }
 
 #
 ## Sort 4 - Extended Infos
 #
-if ($o == "a") {
+if ($o == SERVICE_TEMPLATE_ADD) {
     $form->addElement('header', 'title4', _("Add an Extended Info"));
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_TEMPLATE_MODIFY) {
     $form->addElement('header', 'title4', _("Modify an Extended Info"));
-} elseif ($o == "w") {
+} elseif ($o == SERVICE_TEMPLATE_WATCH) {
     $form->addElement('header', 'title4', _("View an Extended Info"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title2', _("Massive Change"));
 }
 
@@ -813,7 +909,7 @@ $attrGraphtemplate1 = array_merge(
 );
 $form->addElement('select2', 'graph_id', _("Graph Template"), array(), $attrGraphtemplate1);
 
-if ($o == "mc") {
+if ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $mc_mod_sc = array();
     $mc_mod_sc[] = HTML_QuickForm::createElement('radio', 'mc_mod_sc', null, _("Incremental"), '0');
     $mc_mod_sc[] = HTML_QuickForm::createElement('radio', 'mc_mod_sc', null, _("Replacement"), '1');
@@ -830,13 +926,13 @@ $form->addElement('select2', 'service_categories', _("Categories"), array(), $at
 /*
  * Sort 5 - Macros - Nagios 3
  */
-if ($o == "a") {
+if ($o == SERVICE_TEMPLATE_ADD) {
     $form->addElement('header', 'title5', _("Add macros"));
-} elseif ($o == "c") {
+} elseif ($o == SERVICE_TEMPLATE_MODIFY) {
     $form->addElement('header', 'title5', _("Modify macros"));
-} elseif ($o == "w") {
+} elseif ($o == SERVICE_TEMPLATE_WATCH) {
     $form->addElement('header', 'title5', _("View macros"));
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('header', 'title5', _("Massive Change"));
 }
 
@@ -854,24 +950,20 @@ $service_register = 0;
 $redirect = $form->addElement('hidden', 'o');
 $redirect->setValue($o);
 if (is_array($select)) {
-    $select_str = null;
-    foreach ($select as $key => $value) {
-        $select_str .= $key.",";
-    }
     $select_pear = $form->addElement('hidden', 'select');
-    $select_pear->setValue($select_str);
+    $select_pear->setValue(implode(',', array_keys($select)));
 }
 
 $form->applyFilter('__ALL__', 'myTrim');
 $from_list_menu = false;
-if ($o != "mc") {
+if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->addRule('service_description', _("Compulsory Name"), 'required');
     $form->addRule('service_alias', _("Compulsory Name"), 'required');
     $form->registerRule('exist', 'callback', 'testServiceTemplateExistence');
     $form->addRule('service_description', _("Name is already in use"), 'exist');
     $form->registerRule('cg_group_exists', 'callback', 'testCg2');
     $form->addRule('service_cgs', _('Contactgroups exists. If you try to use a LDAP contactgroup, please verified if a Centreon contactgroup has the same name.'), 'cg_group_exists');
-} elseif ($o == "mc") {
+} elseif ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     if ($form->getSubmitValue("submitMC")) {
         $from_list_menu = false;
     } else {
@@ -896,20 +988,20 @@ $tpl = initSmartyTpl($path2, $tpl);
 
 unset($service['service_template_model_stm_id']);
 # Just watch a host information
-if ($o == "w") {
+if ($o == SERVICE_TEMPLATE_WATCH) {
     if (!$min && $centreon->user->access->page($p) != 2 && !isset($lockedElements[$service_id])) {
         $form->addElement("button", "change", _("Modify"), array("onClick"=>"javascript:window.location.href='?p=".$p."&o=c&service_id=".$service_id."'"));
     }
     $form->setDefaults($service);
     $form->freeze();
-} elseif ($o == "c") {    // Modify a service information
+} elseif ($o == SERVICE_TEMPLATE_MODIFY) {    // Modify a service information
     $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
     $form->setDefaults($service);
-} elseif ($o == "a") {    // Add a service information
+} elseif ($o == SERVICE_TEMPLATE_ADD) {    // Add a service information
     $subA = $form->addElement('submit', 'submitA', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
-} elseif ($o == "mc") {   // Massive Change
+} elseif ($o == SERVICE_TEMPLATE_MASSIVE_CHANGE) {   // Massive Change
     $subMC = $form->addElement('submit', 'submitMC', _("Save"), array("class" => "btc bt_success"));
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
 }
@@ -944,10 +1036,30 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $serviceObj->setValue(insertServiceInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        /*
+         * Before saving, we check if a password macro has changed its name to be able to give it the right password
+         * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).
+         */
+        foreach ($_REQUEST['macroInput'] as $index => $macroName) {
+            if (array_key_exists('macroOriginalName_' . $index, $_REQUEST)) {
+                $originalMacroName = $_REQUEST['macroOriginalName_' . $index];
+                if ($_REQUEST['macroValue'][$index] === PASSWORD_REPLACEMENT_VALUE) {
+                    /*
+                     * The password has not been changed along with the name, so its value is equal to the wildcard.
+                     * We will therefore recover the password stored for its original name.
+                     */
+                    foreach ($aMacros as $indexMacro => $macroDetails) {
+                        if ($macroDetails['macroInput_#index#'] === $originalMacroName) {
+                            $_REQUEST['macroValue'][$index] = $macroPasswords[$indexMacro]['password'];
+                            break;
+                        }
+                    }
+                }
+            }
+        }
         updateServiceInDB($serviceObj->getValue());
     } elseif ($form->getSubmitValue("submitMC")) {
-        $select = explode(",", $select);
-        foreach ($select as $key => $value) {
+        foreach ($select as $value) {
             if ($value) {
                 updateServiceInDB($value, true);
             }
@@ -955,7 +1067,7 @@ if ($form->validate() && $from_list_menu == false) {
     }
     $action = $form->getSubmitValue("action");
     if (!$action["action"]["action"]) {
-        $o = "w";
+        $o = SERVICE_TEMPLATE_WATCH;
     } else {
         $o = null;
     }


### PR DESCRIPTION
## Description

Remove the display of the password in HTML file in forms of service, service template, host and host template.

Fixes # (issue)

The password type input fields of the macros were displayed in plain text in the HTML file.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
