### PR TITLE
enh(ci): add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
-/.github    @kduret
-*.php       @centreon/centreon-php @kduret @adr-mo @sc979
+/.github/ /.git* /.project /Jenkinsfile /selinux/ /project/ *.sh *.md                                                                  @centreon/centreon-ci
+
+/src/ /config/ /composer.* /tests/api/ /tests/php/ /tests/clapi_export/ /features/ /www/ /tmpl/ /bin/ /*.xml /phpstan.neon *.php       @centreon/centreon-php
+
+/www/front_src/ /package* /webpack* /babel.config.js /tsconfig.json /.prettierrc.js /.eslint* /.csslintrc                              @centreon/centreon-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 /.github    @kduret
-*.php       centreon/centreon-php
+*.php       @centreon/centreon-php

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 /.github    @kduret
-*.php       @centreon/centreon-php
+*.php       @centreon/centreon-php @kduret @adr-mo @sc979

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-/.github/ /.git* /.project /Jenkinsfile /selinux/ /project/ *.sh *.md                                                                  @centreon/centreon-ci
+/.github/ /.git* /.project /Jenkinsfile /selinux/ /project/ *.sh *.md                                                                        @centreon/centreon-ci
 
-/src/ /config/ /composer.* /tests/api/ /tests/php/ /tests/clapi_export/ /features/ /www/ /tmpl/ /bin/ /*.xml /phpstan.neon *.php       @centreon/centreon-php
+/src/ /config/ /composer.* /tests/api/ /tests/php/ /tests/clapi_export/ /features/ /www/ /tmpl/ /bin/ /*.xml /phpstan.neon *.php             @centreon/centreon-php
 
-/www/front_src/ /package* /webpack* /babel.config.js /tsconfig.json /.prettierrc.js /.eslint* /.csslintrc                              @centreon/centreon-frontend
+/www/front_src/ package.json package-lock.json webpack* babel.config.js tsconfig.json .prettierrc.js .eslint* .csslintrc *.ts *.tsx *.jsx    @centreon/centreon-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+/.github    @kduret
+*.php       centreon/centreon-php

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * Copyright 2005-2017 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * Copyright 2005-2017 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under


### PR DESCRIPTION
add codeowners file for following teams : 
- centreon-ci
- centreon-php
- centreon-frontend

It allows to assign reviewers automatically when a pull request is opened