### PR TITLE
fix(ci): use delta to detect coding style errors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,22 +85,19 @@ try {
 
         recordIssues(
           enabledForFailure: true,
-          ignoreFailedBuilds: false,
-          qualityGates: [[threshold: 1, type: 'NEW', unstable: false]],
+          qualityGates: [[threshold: 1, type: 'DELTA', unstable: false]],
           tool: phpCodeSniffer(id: 'phpcs', name: 'phpcs', pattern: 'codestyle-be.xml'),
           referenceJobName: 'centreon-web/master'
         )
         recordIssues(
           enabledForFailure: true,
-          ignoreFailedBuilds: false,
-          qualityGates: [[threshold: 1, type: 'NEW', unstable: false]],
+          qualityGates: [[threshold: 1, type: 'DELTA', unstable: false]],
           tool: phpStan(id: 'phpstan', name: 'phpstan', pattern: 'phpstan.xml'),
           referenceJobName: 'centreon-web/master'
         )
         recordIssues(
           enabledForFailure: true,
           failOnError: true,
-          ignoreFailedBuilds: false,
           qualityGates: [[threshold: 1, type: 'NEW', unstable: false]],
           tool: esLint(id: 'eslint', name: 'eslint', pattern: 'codestyle-fe.xml'),
           referenceJobName: 'centreon-web/master'


### PR DESCRIPTION
## Description

use delta to detect coding style errors
cause sometimes, "new" algorithm detects all previous warnings as new and fails job...

note from jenkins warning ng plugin documentation : 
```
New
Selects the total number of new issues in the current build with respect to the reference build.
New issues will be calculated by a sophisticated algorithm, that tries to track issues from build to build,
even if the source code has been modified.
Note that this algorithm sometimes detects outstanding warnings as new,
e.g., if a source file has been refactored heavily.
```

**Fixes** MON-6419

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check CI