### PR TITLE
fix(customViews): avoid injection when adding a widget

### DIFF
--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -224,21 +224,23 @@ class CentreonWidget
     /**
      * Add widget to view
      *
-     * @param array $params
+     * @param int $customViewId
+     * @param int $widgetModelId
+     * @param string $widgetTitle
      * @throws CentreonWidgetException
      */
-    public function addWidget($params)
+    public function addWidget($customViewId, $widgetModelId, $widgetTitle)
     {
-        if (!isset($params['custom_view_id'])
-            || !isset($params['widget_model_id'])
-            || !isset($params['widget_title'])
+        if (!isset($customViewId)
+            || !isset($widgetModelId)
+            || !isset($widgetTitle)
         ) {
             throw new CentreonWidgetException('No custom view or no widget selected');
         }
         $queryValues = array();
         $query = 'INSERT INTO widgets (title, widget_model_id) VALUES (?, ?)';
-        $queryValues[] = (string)$params['widget_title'];
-        $queryValues[] = (int)$params['widget_model_id'];
+        $queryValues[] = $widgetTitle;
+        $queryValues[] = $widgetModelId;
         $stmt = $this->db->prepare($query);
         $res = $this->db->execute($stmt, $queryValues);
         if (PEAR::isError($res)) {
@@ -251,7 +253,7 @@ class CentreonWidget
             'WHERE custom_view_id = ?';
 
         $stmt = $this->db->prepare($query);
-        $res = $this->db->execute($stmt, array((int)$params['custom_view_id']));
+        $res = $this->db->execute($stmt, array($customViewId));
         if (PEAR::isError($res)) {
             throw new Exception('Bad Request');
         }
@@ -273,7 +275,7 @@ class CentreonWidget
             'WHERE custom_view_id = ?';
 
         $stmt = $this->db->prepare($query);
-        $res = $this->db->execute($stmt, array((int)$params['custom_view_id']));
+        $res = $this->db->execute($stmt, array($customViewId));
         if (PEAR::isError($res)) {
             throw new Exception('Bad Request');
         }
@@ -310,11 +312,11 @@ class CentreonWidget
             $newPosition = '0_' . $rowNb;
         }
 
-        $lastId = $this->getLastInsertedWidgetId($params['widget_title']);
+        $lastId = $this->getLastInsertedWidgetId($widgetTitle);
         $queryValues = array();
 
         $query = 'INSERT INTO widget_views (custom_view_id, widget_id, widget_order) VALUES (?, ?, ?)';
-        $queryValues[] = (int)$params['custom_view_id'];
+        $queryValues[] = $customViewId;
         $queryValues[] = (int)$lastId;
         $queryValues[] = (string)$newPosition;
         $stmt = $this->db->prepare($query);

--- a/www/class/centreonWidget.class.php
+++ b/www/class/centreonWidget.class.php
@@ -231,10 +231,7 @@ class CentreonWidget
      */
     public function addWidget($customViewId, $widgetModelId, $widgetTitle)
     {
-        if (!isset($customViewId)
-            || !isset($widgetModelId)
-            || !isset($widgetTitle)
-        ) {
+        if (!isset($customViewId, $widgetModelId, $widgetTitle)) {
             throw new CentreonWidgetException('No custom view or no widget selected');
         }
         $queryValues = array();

--- a/www/include/home/customViews/action.php
+++ b/www/include/home/customViews/action.php
@@ -54,16 +54,13 @@ $action = $_POST['action'];
 
 $postFilter = array(
     'widget_id' => array(
-        'filter' => FILTER_VALIDATE_INT,
-        'options' => array('default' => false)
+        'filter' => FILTER_VALIDATE_INT
     ),
     'custom_view_id' => array(
-        'filter' => FILTER_VALIDATE_INT,
-        'options' => array('default' => false)
+        'filter' => FILTER_VALIDATE_INT
     ),
     'widget_model_id' => array(
-        'filter' => FILTER_VALIDATE_INT,
-        'options' => array('default' => false)
+        'filter' => FILTER_VALIDATE_INT
     ),
     'widget_title' => array(
         'filter' => FILTER_SANITIZE_STRING,

--- a/www/include/home/customViews/action.php
+++ b/www/include/home/customViews/action.php
@@ -51,6 +51,28 @@ if (!isset($_POST['action']) || !isset($_SESSION['centreon'])) {
 
 $centreon = $_SESSION['centreon'];
 $action = $_POST['action'];
+
+$postFilter = array(
+    'widget_id' => array(
+        'filter' => FILTER_VALIDATE_INT,
+        'options' => array('default' => false)
+    ),
+    'custom_view_id' => array(
+        'filter' => FILTER_VALIDATE_INT,
+        'options' => array('default' => false)
+    ),
+    'widget_model_id' => array(
+        'filter' => FILTER_VALIDATE_INT,
+        'options' => array('default' => false)
+    ),
+    'widget_title' => array(
+        'filter' => FILTER_SANITIZE_STRING,
+        'options' => array('default' => '')
+    )
+);
+
+$postInputs = filter_input_array(INPUT_POST, $postFilter);
+
 $db = new CentreonDB();
 if (CentreonSession::checkSession(session_id(), $db) == 0) {
     exit();
@@ -109,7 +131,11 @@ try {
     } elseif ($action == "deleteView" && $customViewId) {
         $viewObj->deleteCustomView($customViewId);
     } elseif ($action == "addWidget") {
-        $widgetObj->addWidget($_POST);
+        $widgetObj->addWidget(
+            $postInputs['custom_view_id'],
+            $postInputs['widget_model_id'],
+            $postInputs['widget_title']
+        );
     } elseif ($action == "setDefault") {
         $viewObj->setDefault($customViewId);
     } elseif ($action == "setRotate" && isset($_POST['timer'])) {


### PR DESCRIPTION
## Description

Injection was fixed on 2.8.x when renaming a widget title.
This PR intends to do the same but when adding a widget.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Follow instructions provided in the JIRA issue

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
