### PR TITLE
chore(ci): use discoverGitReferenceBuild instead of manually set reference build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,18 +78,17 @@ try {
           ])
         }
 
+        discoverGitReferenceBuild()
         recordIssues(
           enabledForFailure: true,
           qualityGates: [[threshold: 1, type: 'DELTA', unstable: false]],
           tool: phpCodeSniffer(id: 'phpcs', name: 'phpcs', pattern: 'codestyle-be.xml'),
-          referenceJobName: 'centreon-web/master',
           trendChartType: 'NONE'
         )
         recordIssues(
           enabledForFailure: true,
           qualityGates: [[threshold: 1, type: 'DELTA', unstable: false]],
           tool: phpStan(id: 'phpstan', name: 'phpstan', pattern: 'phpstan.xml'),
-          referenceJobName: 'centreon-web/master',
           trendChartType: 'NONE'
         )
         recordIssues(
@@ -97,7 +96,6 @@ try {
           failOnError: true,
           qualityGates: [[threshold: 1, type: 'NEW', unstable: false]],
           tool: esLint(id: 'eslint', name: 'eslint', pattern: 'codestyle-fe.xml'),
-          referenceJobName: 'centreon-web/master',
           trendChartType: 'NONE'
         )
 


### PR DESCRIPTION
## Description

use discoverGitReferenceBuild instead of manually set reference build
this is needed by new warning ng plugin version

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 19.10.x
- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check CI