### PR TITLE
[20.10.x] fix(Resource-status/Listing): Use the new URL path

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
 module.exports = {
+  root: true,
   extends: './node_modules/@centreon/frontend-core/eslint/typescript'
 };

--- a/www/front_src/src/Resources/Listing/columns/Url.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Url.tsx
@@ -6,8 +6,6 @@ import IconLink from '@material-ui/icons/Link';
 
 import { IconButton, ComponentColumnProps } from '@centreon/ui';
 
-import { labelUrl } from '../../translatedLabels';
-
 const UrlColumn = ({ row }: ComponentColumnProps): JSX.Element | null => {
   const notesPath = ['links', 'externals', 'notes'];
 
@@ -26,8 +24,8 @@ const UrlColumn = ({ row }: ComponentColumnProps): JSX.Element | null => {
       }}
     >
       <IconButton
-        title={title || labelUrl}
-        ariaLabel={title || labelUrl}
+        title={title || endpoint}
+        ariaLabel={title || endpoint}
         onClick={(): null => {
           return null;
         }}

--- a/www/front_src/src/Resources/Listing/columns/Url.tsx
+++ b/www/front_src/src/Resources/Listing/columns/Url.tsx
@@ -9,10 +9,10 @@ import { IconButton, ComponentColumnProps } from '@centreon/ui';
 import { labelUrl } from '../../translatedLabels';
 
 const UrlColumn = ({ row }: ComponentColumnProps): JSX.Element | null => {
-  const endpoint = path<string | undefined>(
-    ['links', 'externals', 'notes_url'],
-    row,
-  );
+  const notesPath = ['links', 'externals', 'notes'];
+
+  const endpoint = path<string | undefined>([...notesPath, 'url'], row);
+  const title = path<string | undefined>([...notesPath, 'label'], row);
 
   if (isNil(endpoint) || isEmpty(endpoint)) {
     return null;
@@ -26,8 +26,8 @@ const UrlColumn = ({ row }: ComponentColumnProps): JSX.Element | null => {
       }}
     >
       <IconButton
-        title={labelUrl}
-        ariaLabel={labelUrl}
+        title={title || labelUrl}
+        ariaLabel={title || labelUrl}
         onClick={(): null => {
           return null;
         }}


### PR DESCRIPTION
## Description

This uses the new URL path from the Listing API response as well as the Notes label if delivered. 

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 20.10.x

<h2> How this pull request can be tested ? </h2>
- Configure a Resource to add a Notes URL
- Configure another one to add a Notes URL and a Notes label
- Make sure the first one has a clickable anchor with the Notes URL as title
- Make sure the second one has a clickable anchor with the Notes label as title
- 