### PR TITLE
fix(sec): fix check command setter name

### DIFF
--- a/src/Centreon/Application/Controller/MonitoringResourceController.php
+++ b/src/Centreon/Application/Controller/MonitoringResourceController.php
@@ -314,7 +314,7 @@ class MonitoringResourceController extends AbstractController
         try {
             $this->monitoring->hidePasswordInHostCommandLine($host);
         } catch (\Throwable $ex) {
-            $host->setCommandLine(
+            $host->setCheckCommand(
                 sprintf(_('Unable to hide passwords in command (Reason: %s)'), $ex->getMessage())
             );
         }


### PR DESCRIPTION
## Description

fix check command setter name
`setCommandLine` does not exist on host entity

**Fixes** MON-6204

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 19.10.x
- [x] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)