### PR TITLE
fix(ui): Modification for the Downtime translation in Timeline

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15322,7 +15322,7 @@ msgid "Host group"
 msgstr "Groupe d'hôtes"
 
 msgid "Downtime"
-msgstr "Plannifier une plage de maintenance"
+msgstr "Plage de maintenance"
 
 msgid "In downtime"
 msgstr "En plage de maintenance"


### PR DESCRIPTION
## Description

When UI is in french , "Downtime" is not translated by the good words in Timeline => "Planifier une plage de maintenance" instead of "Plage de maintenance"


## Type of change

- [X] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 21.04.x
- [x] 21.10 (master)

<h2> How this pull request can be tested ? </h2>

Set UI in French and add downtime in resources status , check if in timeline event for downtime transaltio is right.
