### PR TITLE
enh(unattended): unattended immediatly check if run by root

### DIFF
--- a/unattended.sh
+++ b/unattended.sh
@@ -697,6 +697,10 @@ function update_after_installation() {
 #####################################################
 ################ MAIN SCRIPT EXECUTION ##############
 
+if [[ $EUID -ne 0 ]]; then
+	error_and_exit "This script must be run as root"
+fi
+
 ## Process the provided arguments in line
 case "$1" in
 

--- a/unattended.sh
+++ b/unattended.sh
@@ -697,7 +697,7 @@ function update_after_installation() {
 #####################################################
 ################ MAIN SCRIPT EXECUTION ##############
 
-if [[ $EUID -ne 0 ]]; then
+if [ $EUID -ne 0 ]; then
 	error_and_exit "This script must be run as root"
 fi
 


### PR DESCRIPTION
The `unattended.sh` script must be run by root.
This change adds an immediate and explicit control of this requirement.