### PR TITLE
fix(notification): correct undefined variable

### DIFF
--- a/www/include/monitoring/status/Notifications/notifications.php
+++ b/www/include/monitoring/status/Notifications/notifications.php
@@ -50,6 +50,8 @@ $obj = new CentreonXMLBGRequest($sid, 1, 1, 0, 1);
 if (!isset($_SESSION['centreon'])) {
     exit;
 }
+$centreon = $_SESSION['centreon'];
+
 if (!isset($obj->session_id) || !CentreonSession::checkSession($sid, $obj->DB)) {
     exit;
 }


### PR DESCRIPTION
## Description

Correct undefined variable in `/var/log/httpd/error_log` : 
```
[Wed Apr 28 07:23:17.497905 2021] [:error] [pid 317] [client 172.17.0.1:33300] PHP Notice:  Undefined variable: centreon in /usr/share/centreon/www/include/monitoring/status/Notifications/notifications.php on line 117, referer: http://172.17.0.2/centreon/main.php
[Wed Apr 28 07:23:17.497937 2021] [:error] [pid 317] [client 172.17.0.1:33300] PHP Notice:  Trying to get property of non-object in /usr/share/centreon/www/include/monitoring/status/Notifications/notifications.php on line 117, referer: http://172.17.0.2/centreon/main.php
[Wed Apr 28 07:23:17.497945 2021] [:error] [pid 317] [client 172.17.0.1:33300] PHP Fatal error:  Call to a member function get_id() on a non-object in /usr/share/centreon/www/include/monitoring/status/Notifications/notifications.php on line 117, referer: http://172.17.0.2/centreon/main.php
```

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 2.8.x
- [ ] 19.10.x
- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x (master)
