### PR TITLE
fix(apache): avoid 404 redirection on react routes

### DIFF
--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1423,11 +1423,7 @@ ProxyTimeout 300
         php_admin_value engine Off
     </IfModule>
 
-    RewriteRule ^index\.html$ - [L]
-    RewriteCond %{REQUEST_FILENAME} !-f
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteRule . /index.html [L]
-    ErrorDocument 404 /centreon/index.html
+    FallbackResource /centreon/index.html
 
     AddType text/plain hbs
 </Directory>


### PR DESCRIPTION
## Description

avoid 404 redirection on react routes

**Fixes** MON-6528

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

go directlly to following url : http://<centreon_address>/monitoring/resources
Check in browser console that no 404 error is thrown
