### PR TITLE
fix(UI): Manage not filled curves

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/Lines.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/Lines.tsx
@@ -74,7 +74,10 @@ const getGraphLines = ({
         const props = {
           dataKey: metric,
           dot: false,
-          fill: transparency ? fade(areaColor, transparency * 0.01) : undefined,
+          fill:
+            transparency && areaColor && filled
+              ? fade(areaColor, transparency * 0.01)
+              : 'transparent',
           isAnimationActive: false,
           opacity: highlight === false ? 0.3 : 1,
           stroke: lineColor,


### PR DESCRIPTION
## Description

This fixes curves that are not filled and with an area color equal to `null`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Create / Modify a curve which is not filled and the area color should be empty
- Go to Resource Status
- Hover your mouse on the graph icon which contains the created / modified curve
- -> The graph is displayed correctly

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
