### PR TITLE
[WAIT BE] feat(UI): Implement Business Activities in resources listing

### DIFF
--- a/www/front_src/src/Resources/Listing/columns/index.tsx
+++ b/www/front_src/src/Resources/Listing/columns/index.tsx
@@ -1,4 +1,14 @@
-import { pipe, split, head, propOr, T } from 'ramda';
+import {
+  pipe,
+  split,
+  head,
+  propOr,
+  T,
+  isNil,
+  cond,
+  always,
+  propEq,
+} from 'ramda';
 
 import { makeStyles } from '@material-ui/core';
 
@@ -21,8 +31,15 @@ import {
   labelMonitoringServer,
   labelNotification,
   labelCheck,
+  labelHealth,
+  labelCalculationMethod,
 } from '../../translatedLabels';
 import truncate from '../../truncate';
+import {
+  Resource,
+  ResourceAdditionals,
+  ResourceCalculationMethod,
+} from '../../models';
 
 import StateColumn from './State';
 import GraphColumn from './Graph';
@@ -219,6 +236,32 @@ export const getColumns = ({ actions, t }: ColumnProps): Array<Column> => [
     label: t(labelCheck),
     rowMemoProps: ['passive_checks', 'active_checks'],
     type: ColumnType.component,
+  },
+  {
+    getFormattedString: ({ additionals }) =>
+      `${isNil(additionals?.health) ? '' : additionals.health}`,
+    id: 'health',
+    label: t(labelHealth),
+    sortable: true,
+    type: ColumnType.string,
+  },
+  {
+    getFormattedString: ({ additionals }: Resource) =>
+      additionals
+        ? cond<ResourceAdditionals, string>([
+            [
+              propEq('calculation_method', ResourceCalculationMethod.ratio),
+              always(
+                `${additionals.calculation_method} ${additionals.calculation_ratio_mode}`,
+              ),
+            ],
+            [T, always(`${additionals.calculation_method}`)],
+          ])(additionals as ResourceAdditionals)
+        : '',
+    id: 'calculation_method',
+    label: t(labelCalculationMethod),
+    sortable: true,
+    type: ColumnType.string,
   },
 ];
 

--- a/www/front_src/src/Resources/decoders.ts
+++ b/www/front_src/src/Resources/decoders.ts
@@ -107,7 +107,7 @@ const commonDecoders = {
       JsonDecoder.isExactly('h'),
       JsonDecoder.isExactly('m'),
       JsonDecoder.isExactly('s'),
-      JsonDecoder.isExactly('a'),
+      JsonDecoder.isExactly('ba'),
     ],
     'ResourceShortType',
   ),

--- a/www/front_src/src/Resources/decoders.ts
+++ b/www/front_src/src/Resources/decoders.ts
@@ -1,6 +1,7 @@
 import { JsonDecoder } from 'ts.data.json';
 
 import {
+  ResourceCalculationMethod,
   Icon,
   Notes,
   Parent,
@@ -29,7 +30,10 @@ const commonDecoders = {
   additionals: JsonDecoder.optional(
     JsonDecoder.object<ResourceAdditionals>(
       {
-        calculation_method: JsonDecoder.string,
+        calculation_method: JsonDecoder.enumeration<ResourceCalculationMethod>(
+          ResourceCalculationMethod,
+          'Resource Calculation Method',
+        ),
         calculation_ratio_mode: JsonDecoder.optional(JsonDecoder.string),
         health: JsonDecoder.optional(JsonDecoder.number),
       },

--- a/www/front_src/src/Resources/decoders.ts
+++ b/www/front_src/src/Resources/decoders.ts
@@ -5,6 +5,7 @@ import {
   Notes,
   Parent,
   Resource,
+  ResourceAdditionals,
   ResourceEndpoints,
   ResourceExternals,
   ResourceLinks,
@@ -25,6 +26,16 @@ const statusDecoder = JsonDecoder.object<Status>(
 const commonDecoders = {
   acknowledged: JsonDecoder.optional(JsonDecoder.boolean),
   active_checks: JsonDecoder.optional(JsonDecoder.boolean),
+  additionals: JsonDecoder.optional(
+    JsonDecoder.object<ResourceAdditionals>(
+      {
+        calculation_method: JsonDecoder.string,
+        calculation_ratio_mode: JsonDecoder.optional(JsonDecoder.string),
+        health: JsonDecoder.optional(JsonDecoder.number),
+      },
+      'ResourceAdditionals',
+    ),
+  ),
   duration: JsonDecoder.optional(JsonDecoder.string),
   icon: JsonDecoder.optional(
     JsonDecoder.object<Icon>(
@@ -38,7 +49,6 @@ const commonDecoders = {
   id: JsonDecoder.number,
   in_downtime: JsonDecoder.optional(JsonDecoder.boolean),
   information: JsonDecoder.optional(JsonDecoder.string),
-
   last_check: JsonDecoder.optional(JsonDecoder.string),
   links: JsonDecoder.optional(
     JsonDecoder.object<ResourceLinks>(
@@ -55,20 +65,22 @@ const commonDecoders = {
           },
           'ResourceLinksEndpoints',
         ),
-        externals: JsonDecoder.object<ResourceExternals>(
-          {
-            action_url: JsonDecoder.optional(JsonDecoder.string),
-            notes: JsonDecoder.optional(
-              JsonDecoder.object<Notes>(
-                {
-                  label: JsonDecoder.optional(JsonDecoder.string),
-                  url: JsonDecoder.string,
-                },
-                'ResourceLinksExternalNotes',
+        externals: JsonDecoder.optional(
+          JsonDecoder.object<ResourceExternals>(
+            {
+              action_url: JsonDecoder.optional(JsonDecoder.string),
+              notes: JsonDecoder.optional(
+                JsonDecoder.object<Notes>(
+                  {
+                    label: JsonDecoder.optional(JsonDecoder.string),
+                    url: JsonDecoder.string,
+                  },
+                  'ResourceLinksExternalNotes',
+                ),
               ),
-            ),
-          },
-          'ResourceLinksExternals',
+            },
+            'ResourceLinksExternals',
+          ),
         ),
         uris: JsonDecoder.object<ResourceUris>(
           {
@@ -91,6 +103,7 @@ const commonDecoders = {
       JsonDecoder.isExactly('h'),
       JsonDecoder.isExactly('m'),
       JsonDecoder.isExactly('s'),
+      JsonDecoder.isExactly('a'),
     ],
     'ResourceShortType',
   ),
@@ -101,6 +114,7 @@ const commonDecoders = {
       JsonDecoder.isExactly('host'),
       JsonDecoder.isExactly('metaservice'),
       JsonDecoder.isExactly('service'),
+      JsonDecoder.isExactly('business-activity'),
     ],
     'ResourceType',
   ),

--- a/www/front_src/src/Resources/models.ts
+++ b/www/front_src/src/Resources/models.ts
@@ -6,7 +6,7 @@ export type ResourceType =
   | 'metaservice'
   | 'business-activity';
 
-export type ResourceShortType = 'h' | 's' | 'm' | 'a';
+export type ResourceShortType = 'h' | 's' | 'm' | 'ba';
 
 export interface NamedEntity {
   id: number;

--- a/www/front_src/src/Resources/models.ts
+++ b/www/front_src/src/Resources/models.ts
@@ -95,8 +95,15 @@ export interface ResourceLinks {
   uris: ResourceUris;
 }
 
+export enum ResourceCalculationMethod {
+  bestStatus = 'best status',
+  impact = 'impact',
+  ratio = 'ratio',
+  worstStatus = 'worst status',
+}
+
 export interface ResourceAdditionals {
-  calculation_method: string;
+  calculation_method: ResourceCalculationMethod;
   calculation_ratio_mode?: string;
   health?: number;
 }

--- a/www/front_src/src/Resources/models.ts
+++ b/www/front_src/src/Resources/models.ts
@@ -1,8 +1,12 @@
 import { ListingModel } from '@centreon/ui';
 
-export type ResourceType = 'host' | 'service' | 'metaservice';
+export type ResourceType =
+  | 'host'
+  | 'service'
+  | 'metaservice'
+  | 'business-activity';
 
-export type ResourceShortType = 'h' | 's' | 'm';
+export type ResourceShortType = 'h' | 's' | 'm' | 'a';
 
 export interface NamedEntity {
   id: number;
@@ -24,6 +28,7 @@ export interface Status {
 export interface Resource extends NamedEntity {
   acknowledged?: boolean;
   active_checks?: boolean;
+  additionals?: ResourceAdditionals;
   duration?: string;
   icon?: Icon;
   in_downtime?: boolean;
@@ -86,8 +91,14 @@ export interface ResourceExternals {
 
 export interface ResourceLinks {
   endpoints: ResourceEndpoints;
-  externals: ResourceExternals;
+  externals?: ResourceExternals;
   uris: ResourceUris;
+}
+
+export interface ResourceAdditionals {
+  calculation_method: string;
+  calculation_ratio_mode?: string;
+  health?: number;
 }
 
 export type TranslationType = (label: string) => string;

--- a/www/front_src/src/Resources/translatedLabels.ts
+++ b/www/front_src/src/Resources/translatedLabels.ts
@@ -213,3 +213,5 @@ export const labelCalculationType = 'Calculation type';
 export const labelSelectAtLeastOneColumn =
   'At least one column must be selected';
 export const labelMaxDuration1Year = 'The duration must be lesser than a year';
+export const labelHealth = 'Health';
+export const labelCalculationMethod = 'Calculation method';


### PR DESCRIPTION
## Description

This displays business activities in Resources listing and add two optional columns 'Health' and 'Calculation method'
![Screenshot 2021-06-03 at 18 35 54](https://user-images.githubusercontent.com/12515407/120680440-98a6ad80-c49a-11eb-8e56-276a6b0aceb9.png)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Add business activities with different calculation method
- Go to Resource Status
- -> The business acitvities are listed in the listing
- Add the 'Health' and 'Calculation method' columns
- -> The columns displays the correct calculation method and health for each Business Activities

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
