### PR TITLE
Fix(UI): Parse graph dates following the locale

### DIFF
--- a/www/front_src/src/Resources/Graph/Performance/index.tsx
+++ b/www/front_src/src/Resources/Graph/Performance/index.tsx
@@ -28,6 +28,7 @@ import { useRequest, getData } from '@centreon/ui';
 import { timeFormat, dateTimeFormat } from '../format';
 import { parseAndFormat } from '../../dateTime';
 import { labelNoDataForThisPeriod } from '../../translatedLabels';
+import { useUserContext } from '../../../Provider/UserContext';
 
 import getTimeSeries, { getLineData } from './timeSeries';
 import { GraphData, TimeValue, Line as LineModel } from './models';
@@ -81,6 +82,7 @@ const PerformanceGraph = ({
 }: Props): JSX.Element | null => {
   const classes = useStyles({ graphHeight });
   const { t } = useTranslation();
+  const { locale } = useUserContext();
 
   const [timeSeries, setTimeSeries] = React.useState<Array<TimeValue>>([]);
   const [lineData, setLineData] = React.useState<Array<LineModel>>([]);
@@ -135,10 +137,10 @@ const PerformanceGraph = ({
   };
 
   const formatXAxisTick = (tick): string =>
-    parseAndFormat({ isoDate: tick, to: xAxisTickFormat });
+    parseAndFormat({ isoDate: tick, locale, to: xAxisTickFormat });
 
   const formatTooltipTime = (tick): string =>
-    parseAndFormat({ isoDate: tick, to: dateTimeFormat });
+    parseAndFormat({ isoDate: tick, locale, to: dateTimeFormat });
 
   const getLineByMetric = (metric): LineModel => {
     return find(propEq('metric', metric), lineData) as LineModel;

--- a/www/front_src/src/Resources/Graph/format.ts
+++ b/www/front_src/src/Resources/Graph/format.ts
@@ -1,5 +1,5 @@
-const timeFormat = 'HH:mm';
-const dateTimeFormat = 'MM/DD HH:mm';
-const dateFormat = 'MM/DD';
+const timeFormat = 'LT';
+const dateTimeFormat = 'L LT';
+const dateFormat = 'LT';
 
 export { timeFormat, dateTimeFormat, dateFormat };

--- a/www/front_src/src/Resources/dateTime.ts
+++ b/www/front_src/src/Resources/dateTime.ts
@@ -2,11 +2,15 @@ import moment from 'moment';
 
 interface ParseAndFormatProps {
   isoDate: string;
+  locale?: string;
   to: string;
 }
 
-const parseAndFormat = ({ isoDate, to }: ParseAndFormatProps): string =>
-  moment.parseZone(isoDate).format(to);
+const parseAndFormat = ({ isoDate, to, locale }: ParseAndFormatProps): string =>
+  moment
+    .parseZone(isoDate)
+    .locale(locale || 'en')
+    .format(to);
 
 const getFormattedDateTime = (isoDate: string): string =>
   parseAndFormat({ isoDate, to: 'MM/DD/YYYY HH:mm' });

--- a/www/front_src/src/Resources/dateTime.ts
+++ b/www/front_src/src/Resources/dateTime.ts
@@ -9,7 +9,7 @@ interface ParseAndFormatProps {
 const parseAndFormat = ({ isoDate, to, locale }: ParseAndFormatProps): string =>
   moment
     .parseZone(isoDate)
-    .locale(locale || 'en')
+    .locale(locale?.substring(0, 2) || 'en')
     .format(to);
 
 const getFormattedDateTime = (isoDate: string): string =>


### PR DESCRIPTION
## Description

This fixes dates display by parsing them following the user locale
https://www.loom.com/share/4890658634d84e94a76709adec27b78a

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a servie with graph data
- Switch the profile language to French (or another language than English)
- Open the service's graph in the panel
- Move your mouse over the graph
- -> The date time are displayed using the correct language

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
