### PR TITLE
Fix(UI): Fix service selection on services list

### DIFF
--- a/www/front_src/src/Resources/Details/tabs/Services/index.tsx
+++ b/www/front_src/src/Resources/Details/tabs/Services/index.tsx
@@ -73,6 +73,7 @@ const ServicesTab = ({ details }: TabProps): JSX.Element => {
     setSelectedResourceParentType,
     setOpenDetailsTabId,
     selectedResourceId,
+    selectedResourceUuid,
   } = useResourceContext();
 
   const [services, setServices] = React.useState<Array<Service>>();
@@ -98,11 +99,11 @@ const ServicesTab = ({ details }: TabProps): JSX.Element => {
 
   const selectService = (service) => (): void => {
     setOpenDetailsTabId(detailsTabId);
-    setSelectedResourceUuid(service.uuid);
+    setSelectedResourceUuid(`${selectedResourceUuid}-s${service.id}`);
     setSelectedResourceId(service.id);
-    setSelectedResourceType(service.type);
-    setSelectedResourceParentType(service?.parent?.type);
-    setSelectedResourceParentId(service?.parent?.id);
+    setSelectedResourceType('service');
+    setSelectedResourceParentType('host');
+    setSelectedResourceParentId(selectedResourceId);
   };
 
   const getContent = (): JSX.Element => {


### PR DESCRIPTION
## Description

This fix the service selection on the services list
https://www.loom.com/share/3ac18c043966421295ab830d78f06c8c

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [x] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Add a host with some services
- On Resource Status, open the host details panel
- Select the "Services" tab
- Click on a service name
- -> The selected service details panel is displayed without any error

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
