### PR TITLE
MON-11758 fix conf export fail because of centreontrapd

### DIFF
--- a/lib/perl/centreon/script/centreontrapd.pm
+++ b/lib/perl/centreon/script/centreontrapd.pm
@@ -753,7 +753,6 @@ sub submitResult_do {
         } else {
             $submit = '/bin/echo "' . $prefix . "[$datetime] $str\" >> " . $self->{cmdFile};
         }
-        $submit = '/bin/echo "' . $prefix . "[$datetime] $str\" >> " . $self->{cmdFile};
     } else {
         $str =~ s/'/'\\''/g;
         $str =~ s/"/\\"/g;


### PR DESCRIPTION
## Description

on a centreon central server that is receiving a lot of snmp traps, the configuration export will fail most of the time because the /var/lib/centreon/centcore.pm file owner is centreon:centreon with a chmod 644 that doesn't let apache write into this file. 

This situation shouldn't happen because centreontrapd must write in `/var/lib/centreon/centcore/<date>-traps` files. But the removed line overwrite the case where we try to write in those files.

**Fixes**  #4236

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

- put centreontrapd in info mode instead of error (sed -i 's/error/info/' /etc/sysconf/centreontrapd)
- restart centreontrapd (service centreontrapd restart)
- send a trap to your central server (you must have a working host and with a passive service receiving traps monitored by your central)
- in the centreontrapd.log file you should see something like this 

```bash
2021-07-06 15:11:11 - INFO - 8049 - SUBMIT: Force service status via passive check update
2021-07-06 15:11:11 - INFO - 8049 - SUBMIT: Launched command: /bin/echo "EXTERNALCMD:2:[1625577071] PROCESS_SERVICE_CHECK_RESULT;medracdg1;TRAP - Bonding;0;OK" >> /var/lib/centreon/centcore.cmd
```
This is not what we want, we don't want centreontrapd to write in the centcore.cmd file

with the patch you should have something like this : 

```bash
2021-07-06 15:11:11 - INFO - 8049 - SUBMIT: Force service status via passive check update
2021-07-06 15:11:11 - INFO - 8049 - SUBMIT: Launched command: /bin/echo "EXTERNALCMD:2:[1625577071] PROCESS_SERVICE_CHECK_RESULT;medracdg1;TRAP - Bonding;0;OK" >> /var/lib/centreon/centcore/1625577071-traps
```
## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
