### PR TITLE
fix(ci): Sonar quality gate fix

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -287,32 +287,11 @@ try {
           trendChartType: 'NONE'
         )
       }
-
-      def reportFilePath = "target/sonar/report-task.txt"
-      def reportTaskFileExists = fileExists "${reportFilePath}"
-      if (reportTaskFileExists) {
-        echo "Found report task file"
-        def taskProps = readProperties file: "${reportFilePath}"
-        echo "taskId[${taskProps['ceTaskId']}]"
-        timeout(time: 10, unit: 'MINUTES') {
-          while (true) {
-            sleep 10
-            def taskStatusResult    =
-            sh(returnStdout: true, script: "curl -s -X GET -u ${authString} \'${sonarProps['sonar.host.url']}/api/ce/task?id=${taskProps['ceTaskId']}\'")
-            echo "taskStatusResult[${taskStatusResult}]"
-            def taskStatus  = new JsonSlurper().parseText(taskStatusResult).task.status
-            echo "taskStatus[${taskStatus}]"
-            // Status can be SUCCESS, ERROR, PENDING, or IN_PROGRESS. The last two indicate it's
-            // not done yet.
-            if (taskStatus != "IN_PROGRESS" && taskStatus != "PENDING") {
-              break;
-            }
-            def qualityGate = waitForQualityGate()
-            if (qualityGate.status != 'OK') {
-              currentBuild.result = 'FAIL'
-            }
-          }
-        }
+      // sonarQube step to get qualityGate result
+      sleep 60
+      def qualityGate = waitForQualityGate()
+      if (qualityGate.status != 'OK') {
+        error "Pipeline aborted due to quality gate failure: ${qualityGate.status}"
       }
       if ((currentBuild.result ?: 'SUCCESS') != 'SUCCESS') {
         error("Quality gate failure: ${qualityGate.status}.");

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -288,7 +288,7 @@ try {
         )
       }
       // sonarQube step to get qualityGate result
-      sleep 60
+      sleep 120
       def qualityGate = waitForQualityGate()
       if (qualityGate.status != 'OK') {
         error "Pipeline aborted due to quality gate failure: ${qualityGate.status}"


### PR DESCRIPTION
## Description

Fixing timeout on qg with sleeping before getting the sonar webhook. Sleep will be removed when sonar will be migrated.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)