### PR TITLE
enh(CI): Remove sleep 120 from quality gate stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -287,7 +287,6 @@ try {
         )
       }
       // sonarQube step to get qualityGate result
-      sleep 120
       def qualityGate = waitForQualityGate()
       if (qualityGate.status != 'OK') {
         error "Pipeline aborted due to quality gate failure: ${qualityGate.status}"


### PR DESCRIPTION
## Description

Remove Sleep120 from CI Quality Gate stage.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
