### PR TITLE
fix(ci/build) Increasing the memory limit for the phpstan syntax analyser

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -54,6 +54,8 @@
       <arg value="absolute" />
       <arg value="--no-interaction" />
       <arg value="--no-progress" />
+      <arg value="--memory-limit" />
+      <arg value="512M" />
     </exec>
   </target>
 


### PR DESCRIPTION
## Description

The branch cannot be built due to a memory limit error during the phpstan analysis.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
