### PR TITLE
chore(ci): set manually reference build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -228,7 +228,9 @@ try {
 
   stage('Quality gate') {
     node {
-      discoverGitReferenceBuild()
+      discoverGitReferenceBuild(
+        referenceJob: 'centreon/master'
+      )
 
       if (hasBackendChanges) {
         unstash 'ut-be.xml'


### PR DESCRIPTION
## Description

chore(ci): set manually reference build

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)