### PR TITLE
fix(security): hide Keycloak tokens in CentreonUI form

### DIFF
--- a/www/include/Administration/parameters/DB-Func.php
+++ b/www/include/Administration/parameters/DB-Func.php
@@ -736,18 +736,29 @@ function updateGeneralConfigData($gopt_id = null)
         isset($ret["keycloak_realm"]) && $ret["keycloak_realm"] != null
             ? $pearDB->escape($ret["keycloak_realm"]) : ""
     );
-    updateOption(
-        $pearDB,
-        "keycloak_client_id",
-        isset($ret["keycloak_client_id"]) && $ret["keycloak_client_id"] != null
-            ? $pearDB->escape($ret["keycloak_client_id"]) : ""
-    );
-    updateOption(
-        $pearDB,
-        "keycloak_client_secret",
-        isset($ret["keycloak_client_secret"]) && $ret["keycloak_client_secret"] != null
-            ? $pearDB->escape($ret["keycloak_client_secret"]) : ""
-    );
+
+    if (
+        isset($ret["keycloak_client_id"])
+        && $ret["keycloak_client_id"] !== CentreonAuth::PWS_OCCULTATION
+    ) {
+        updateOption(
+            $pearDB,
+            "keycloak_client_id",
+            $pearDB->escape($ret["keycloak_client_id"])
+        );
+    }
+
+    if (
+        isset($ret["keycloak_client_secret"])
+        && $ret["keycloak_client_secret"] !== CentreonAuth::PWS_OCCULTATION
+    ) {
+        updateOption(
+            $pearDB,
+            "keycloak_client_secret",
+            $pearDB->escape($ret["keycloak_client_secret"])
+        );
+    }
+
     updateOption(
         $pearDB,
         "centreon_support_email",

--- a/www/include/Administration/parameters/general/form.php
+++ b/www/include/Administration/parameters/general/form.php
@@ -280,8 +280,18 @@ $form->addElement('text', 'keycloak_blacklist_clients', _('Keycloak blacklist cl
 $form->addElement('text', 'keycloak_url', _('Keycloak Server Url'), array('size' => 50));
 $form->addElement('text', 'keycloak_redirect_url', _('Keycloak Redirect Url'), array('size' => 50));
 $form->addElement('text', 'keycloak_realm', _('Keycloak Client Realm'), array('size' => 50));
-$form->addElement('text', 'keycloak_client_id', _('Keycloak Client ID'), array('size' => 50));
-$form->addElement('text', 'keycloak_client_secret', _('Keycloak Client Secret'), array('size' => 50));
+$form->addElement(
+    'password',
+    'keycloak_client_id',
+    _('Keycloak Client ID'),
+    array('size' => 50, 'autocomplete' => 'off')
+);
+$form->addElement(
+    'password',
+    'keycloak_client_secret',
+    _('Keycloak Client Secret'),
+    array('size' => 50, 'autocomplete' => 'off')
+);
 
 /*
  * Support Email


### PR DESCRIPTION
## Description

This PR hide Keycloak tokens in CentreonUI form for 20.04.x

**Fixes** # MON-10849

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x (master)

## Checklist

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
