### PR TITLE
enh(ci): adding QA branches as scheduled job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -444,7 +444,7 @@ try {
       }
     }
 
-    if (env.BUILD == 'REFERENCE') {
+    if (env.BUILD == 'REFERENCE' || env.BUILD == 'QA') {
       build job: "centreon-autodiscovery/${env.BRANCH_NAME}", wait: false
       build job: "centreon-awie/${env.BRANCH_NAME}", wait: false
       build job: "centreon-license-manager/${env.BRANCH_NAME}", wait: false


### PR DESCRIPTION
## Description

In order to have QA branches containers builded automatically after a centreon web develop or dev-xx.xx.x successfull build

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.04.x
- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>
Check from Jenkins GUI if develop branch  of modules have been triggered by web develop branch.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
