### PR TITLE
fix(unattended): changed ol8 epel to epel8 for Oracle case

### DIFF
--- a/unattended.sh
+++ b/unattended.sh
@@ -360,9 +360,10 @@ function set_required_prerequisite() {
             ;;
 
         oraclelinux-release* | enterprise-release*)
-            BASE_PACKAGES=(dnf-plugins-core oracle-epel-release-el8)
+            BASE_PACKAGES=(dnf-plugins-core)
             $PKG_MGR config-manager --set-enabled ol8_codeready_builder
-            ;;
+            dnf install http://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+	    ;;
         esac
 
         install_remi_repo
@@ -678,7 +679,7 @@ function install_central() {
 		}
 		echo $timezoneName;
 	' 2>/dev/null)
-	echo "date.timezone = $timezone" >>$PHP_ETC/50-centreon.ini
+	echo "date.timezone = $timezone" >> $PHP_ETC/50-centreon.ini
 
 	log "INFO" "PHP date.timezone set to [$timezone]"
 

--- a/unattended.sh
+++ b/unattended.sh
@@ -362,7 +362,7 @@ function set_required_prerequisite() {
         oraclelinux-release* | enterprise-release*)
             BASE_PACKAGES=(dnf-plugins-core)
             $PKG_MGR config-manager --set-enabled ol8_codeready_builder
-            dnf install http://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+            dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 	    ;;
         esac
 


### PR DESCRIPTION
## Description

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

Using Oracle EPEL8 repository alone causes the installation to fail when remi 8 release has to be installed.
This has been changed to standard EPEL8 instead.
As it looks like, no package seems to be brought from Oracle EPEL 8.
**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.04.x
- [ ] 20.10.x
- [ ] 21.04.x
- [x] 21.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
