### PR TITLE
enh(conf): add SameSite parameter to apache conf

### DIFF
--- a/libinstall/functions
+++ b/libinstall/functions
@@ -1401,7 +1401,7 @@ ServerTokens Prod
 
 <VirtualHost *:80>
     Header set X-Frame-Options: "sameorigin"
-    Header always edit Set-Cookie ^(.*)$ $1;HttpOnly
+    Header always edit Set-Cookie ^(.*)$ $1;HttpOnly;SameSite=Strict
     ServerSignature Off
     TraceEnable Off
 


### PR DESCRIPTION
## Description

This PR intends to add SameSite parameter to apache conf

packaging installation is handle here: https://github.com/centreon/centreon-build/pull/819

**Fixes** # MON-12056

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [x] 20.10.x
- [x] 21.04.x
- [x] 21.10.x
- [x] 22.04.x (master)

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have made corresponding changes to the **documentation**.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
