### PR TITLE
fix(translation): fix invalid character in translation file

### DIFF
--- a/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16725,7 +16725,7 @@ msgstr "Erreur lors de la mise à jour d'un utilisateur"
 msgid "Error in reading the themes available to the user"
 msgstr "Erreur dans la lecture des thèmes disponibles pour l'utilisateur"
 
-msgid "Error when updating the user\'s theme"
+msgid "Error when updating the user\\'s theme"
 msgstr "Erreur lors de la mise à jour du thème de l'utilisateur"
 
 msgid "Error while searching for the user"


### PR DESCRIPTION
## Description

fix invalid character in translation file

**Fixes** MON-13160

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)