### PR TITLE
fix(ci): clean workspace before unstash rpm

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -285,23 +285,21 @@ try {
     'rpm packaging centos7': {
       node {
         checkoutCentreonBuild()
-        deleteDir 'output'
         unstash 'tar-sources'
         sh "./centreon-build/jobs/web/${serie}/mon-web-package.sh centos7"
         archiveArtifacts artifacts: "rpms-centos7.tar.gz"
         stash name: "rpms-centos7", includes: 'output/noarch/*.rpm'
-        deleteDir 'output'
+        sh 'rm -rf output'
       }
     },
     'rpm packaging alma8': {
       node {
         checkoutCentreonBuild()
-        deleteDir 'output'
         unstash 'tar-sources'
         sh "./centreon-build/jobs/web/${serie}/mon-web-package.sh alma8"
         archiveArtifacts artifacts: "rpms-alma8.tar.gz"
         stash name: "rpms-alma8", includes: 'output/noarch/*.rpm'
-        deleteDir 'output'
+        sh 'rm -rf output'
       }
     },
     'Debian 11 packaging': {
@@ -363,6 +361,7 @@ try {
       parallelSteps[osBuild] = {
         node {
           checkoutCentreonBuild()
+          sh 'rm -rf output'
           unstash "rpms-${osBuild}"
           sh "./centreon-build/jobs/web/${serie}/mon-web-bundle.sh ${osBuild}"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -285,6 +285,7 @@ try {
     'rpm packaging centos7': {
       node {
         checkoutCentreonBuild()
+        sh 'rm -rf output'
         unstash 'tar-sources'
         sh "./centreon-build/jobs/web/${serie}/mon-web-package.sh centos7"
         archiveArtifacts artifacts: "rpms-centos7.tar.gz"
@@ -295,6 +296,7 @@ try {
     'rpm packaging alma8': {
       node {
         checkoutCentreonBuild()
+        sh 'rm -rf output'
         unstash 'tar-sources'
         sh "./centreon-build/jobs/web/${serie}/mon-web-package.sh alma8"
         archiveArtifacts artifacts: "rpms-alma8.tar.gz"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -285,23 +285,23 @@ try {
     'rpm packaging centos7': {
       node {
         checkoutCentreonBuild()
-        sh 'rm -rf output'
+        deleteDir 'output'
         unstash 'tar-sources'
         sh "./centreon-build/jobs/web/${serie}/mon-web-package.sh centos7"
         archiveArtifacts artifacts: "rpms-centos7.tar.gz"
         stash name: "rpms-centos7", includes: 'output/noarch/*.rpm'
-        sh 'rm -rf output'
+        deleteDir 'output'
       }
     },
     'rpm packaging alma8': {
       node {
         checkoutCentreonBuild()
-        sh 'rm -rf output'
+        deleteDir 'output'
         unstash 'tar-sources'
         sh "./centreon-build/jobs/web/${serie}/mon-web-package.sh alma8"
         archiveArtifacts artifacts: "rpms-alma8.tar.gz"
         stash name: "rpms-alma8", includes: 'output/noarch/*.rpm'
-        sh 'rm -rf output'
+        deleteDir 'output'
       }
     },
     'Debian 11 packaging': {


### PR DESCRIPTION
## Description

clean workspace before unstash rpm

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 20.10.x
- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x (master)