### PR TITLE
fix(websso) remove exception when REMOTE_USER does not exist

### DIFF
--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/WebSSO.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/WebSSO.php
@@ -221,6 +221,7 @@ class WebSSO implements ProviderAuthenticationInterface
             $this->error('login header attribute not found in server environment', [
                 'login_header_attribute' => $customConfiguration->getLoginHeaderAttribute()
             ]);
+
             throw new InvalidArgumentException('Missing Login Attribute');
         }
     }

--- a/centreon/src/EventSubscriber/WebSSOEventSubscriber.php
+++ b/centreon/src/EventSubscriber/WebSSOEventSubscriber.php
@@ -121,13 +121,17 @@ class WebSSOEventSubscriber implements EventSubscriberInterface
         }
 
         $this->info('Starting authentication with WebSSO');
-        $provider->authenticateOrFail(
-            LoginRequest::createForSSO($request->getClientIp())
-        );
+        try {
+            $provider->authenticateOrFail(
+                LoginRequest::createForSSO($request->getClientIp())
+            );
 
-        $user = $provider->findUserOrFail();
-        $this->createSession($request, $provider);
-        $this->info('Authenticated successfully', ['user' => $user->getAlias()]);
+            $user = $provider->findUserOrFail();
+            $this->createSession($request, $provider);
+            $this->info('Authenticated successfully', ['user' => $user->getAlias()]);
+        } catch (\InvalidArgumentException $exception) {
+            $this->info($exception->getMessage());
+        }
     }
 
     /**

--- a/centreon/tests/php/EventSubscriber/WebSSOEventSubscriberTest.php
+++ b/centreon/tests/php/EventSubscriber/WebSSOEventSubscriberTest.php
@@ -340,7 +340,7 @@ it('should throw an exception when login attribute environment variable is not s
         ->method('start');
 
     $this->subscriber->loginWebSSOUser($this->event);
-})->throws(\InvalidArgumentException::class, 'Missing Login Attribute');
+});
 
 it('should throw an exception when login matching regexp returns an invalid result', function () {
     $this->request->cookies = new InputBag();


### PR DESCRIPTION
## Description

Remove exception when REMOTE_USER does not exist

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Configure Web SSO without installing mod openidc, mod mellon, kerberos...
- Try to reach the login page
- Try to login through the API

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).