### PR TITLE
fix wrong reload acl button position

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -105,7 +105,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-        
+
       - uses: ./.github/actions/web-frontend-component-test
         with:
           working_directory: centreon
@@ -249,7 +249,34 @@ jobs:
           push: true
           tags: registry-docker.centreon.com/docker-global/${{ matrix.project }}-widgets-${{ matrix.distrib }}:${{ github.head_ref || github.ref_name }}
 
-  test-e2e:
+  api-integration-test:
+    needs: [dockerize]
+    uses: ./.github/workflows/behat-test.yml
+    with:
+      name: api
+      module_name: centreon
+      image_name: centreon-web
+      features_path: tests/api/features
+      config_file: tests/api/behat.yml
+    secrets:
+      nexus_username: ${{ secrets.ARTI_USER }}
+      nexus_password: ${{ secrets.ARTI_PASSWD }}
+      composer_token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+
+  legacy-e2e-test:
+    needs: [dockerize]
+    uses: ./.github/workflows/behat-test.yml
+    with:
+      name: e2e
+      module_name: centreon
+      image_name: centreon-web
+      features_path: features
+    secrets:
+      nexus_username: ${{ secrets.ARTI_USER }}
+      nexus_password: ${{ secrets.ARTI_PASSWD }}
+      composer_token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
+
+  e2e-test:
     runs-on: ubuntu-22.04
     needs: [dockerize]
 
@@ -287,7 +314,7 @@ jobs:
           comment_mode: failures
           junit_files: centreon/tests/e2e/cypress-result.xml
 
-  test-performances:
+  performances-test:
     runs-on: ubuntu-22.04
     needs: [dockerize]
 
@@ -316,36 +343,9 @@ jobs:
           name: lighthouse-report
           path: centreon/lighthouse/report/lighthouseci-index.html
 
-  api-integration-test:
-    needs: [dockerize]
-    uses: ./.github/workflows/behat-test.yml
-    with:
-      name: api
-      module_name: centreon
-      image_name: centreon-web
-      features_path: tests/api/features
-      config_file: tests/api/behat.yml
-    secrets:
-      nexus_username: ${{ secrets.ARTI_USER }}
-      nexus_password: ${{ secrets.ARTI_PASSWD }}
-      composer_token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
-
-  legacy-e2e-test:
-    needs: [api-integration-test]
-    uses: ./.github/workflows/behat-test.yml
-    with:
-      name: e2e
-      module_name: centreon
-      image_name: centreon-web
-      features_path: features
-    secrets:
-      nexus_username: ${{ secrets.ARTI_USER }}
-      nexus_password: ${{ secrets.ARTI_PASSWD }}
-      composer_token: ${{ secrets.CENTREON_TECHNIQUE_PAT }}
-
   deliver-rpm:
     runs-on: ubuntu-22.04
-    needs: [test-e2e, test-performances, legacy-e2e-test]
+    needs: [api-integration-test, legacy-e2e-test, e2e-test, performances-test]
     strategy:
       matrix:
         distrib: [el7, el8]
@@ -366,7 +366,7 @@ jobs:
 
   deliver-deb:
     runs-on: ubuntu-22.04
-    needs: [test-e2e, test-performances, legacy-e2e-test]
+    needs: [api-integration-test, legacy-e2e-test, e2e-test, performances-test]
     strategy:
       matrix:
         distrib: [bullseye]

--- a/ci/scripts/web-packaging-deb.sh
+++ b/ci/scripts/web-packaging-deb.sh
@@ -32,5 +32,4 @@ cp -rp packaging/debian .
 #packaging
 sed -i "s/^centreon:version=.*$/centreon:version=$(echo $VERSION | egrep -o '^[0-9][0-9].[0-9][0-9]')/" debian/substvars
 debmake -f "${AUTHOR}" -e "${AUTHOR_EMAIL}" -u "$VERSION" -y -r "${DISTRIB}"
-debuild-pbuilder
-cd ../
+debuild-pbuilder --no-lintian


### PR DESCRIPTION
## Description

when you go to administraton → acl → reload acl menu, you’ll have the list of your connected users in a table. The last column should display the reload icon.

instead, the icon is displayed at the top of the page
![image](https://user-images.githubusercontent.com/11978823/212842008-586349c0-9047-4c3d-9916-73aac0dbab49.png)


jira: MON-15591

**Fixes** #11625 (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

without this PR: 

- connect a non admin user to your centreon
- use private mode or another web brower to log in with an admin user
- with your admin user, go to the administration -> acl  -> reload acl menu
- you'll notice that the reload acl icon is displayed at the top of the page instead of being in the right column of the table

with this patch, the icon is now displayed where it should be

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
