### PR TITLE
enh(recurrentDowntime): only apply downtimes on enabled resources

### DIFF
--- a/centreon/www/class/centreonDowntime.Broker.class.php
+++ b/centreon/www/class/centreonDowntime.Broker.class.php
@@ -302,7 +302,7 @@ class CentreonDowntimeBroker extends CentreonDowntime
     {
         $approachingDowntimes = array();
 
-        $downtimes = $this->getDowntime();
+        $downtimes = $this->getForEnabledResources();
 
         $gmtObj = new CentreonGMT($this->db);
 

--- a/centreon/www/class/centreonDowntime.class.php
+++ b/centreon/www/class/centreonDowntime.class.php
@@ -324,9 +324,10 @@ class CentreonDowntime
 
             $statement = $this->db->prepare($query);
             $statement->bindValue(':downtimeId', $downtimeId, \PDO::PARAM_INT);
+            $statement->setFetchMode(\PDO::FETCH_ASSOC);
             $statement->execute();
 
-            while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            foreach ($statement as $record) {
                 $relations[$resourceType][] = [
                     'id' => $record['resource_id'],
                     'activated' => $record['activated']
@@ -370,9 +371,7 @@ class CentreonDowntime
             AND dtr.host_host_id = h.host_id
             AND h.host_activate = '1'";
 
-        $statement = $this->db->query($request);
-
-        while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+        foreach ($this->db->query($request, \PDO::FETCH_ASSOC) as $record) {
             $downtimes[] = $record;
         }
 
@@ -445,9 +444,7 @@ class CentreonDowntime
                 AND dtr.service_service_id = s.service_id
                 AND h.host_activate = '1'";
 
-        $statement = $this->db->query($request);
-
-        while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+        foreach ($this->db->query($request, \PDO::FETCH_ASSOC) as $record) {
             $downtimes[] = $record;
         }
 
@@ -489,9 +486,7 @@ class CentreonDowntime
             AND hgr.hostgroup_hg_id = hg.hg_id
             AND hg.hg_activate = '1'";
 
-        $statement = $this->db->query($request);
-
-        while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+        foreach ($this->db->query($request, \PDO::FETCH_ASSOC) as $record) {
             $downtimes[] = $record;
         }
 
@@ -560,9 +555,7 @@ class CentreonDowntime
                 AND hsr.hostgroup_hg_id = hgr.hostgroup_hg_id
                 AND hgr.host_host_id = h.host_id";
 
-        $statement = $this->db->query($request);
-
-        while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+        foreach ($this->db->query($request, \PDO::FETCH_ASSOC) as $record) {
             $downtimes[] = $record;
         }
 

--- a/centreon/www/class/centreonDowntime.class.php
+++ b/centreon/www/class/centreonDowntime.class.php
@@ -412,18 +412,18 @@ class CentreonDowntime
                 h.host_id,
                 h.host_name,
                 s.service_id,
-                s.service_description,
+                s.service_description
             FROM downtime_period dtp,
                 downtime dt,
                 downtime_service_relation dtr,
                 service s,
                 host h,
                 host_service_relation hsr
-            WHERE dtp.dt_id = dtr.dt_id,
-                AND dtp.dt_id = dt.dt_id,
-                AND dtr.service_service_id = s.service_id,
-                AND hsr.service_service_id = s.service_id,
-                AND hsr.host_host_id = h.host_id,
+            WHERE dtp.dt_id = dtr.dt_id
+                AND dtp.dt_id = dt.dt_id
+                AND dtr.service_service_id = s.service_id
+                AND hsr.service_service_id = s.service_id
+                AND hsr.host_host_id = h.host_id
                 AND h.host_id = dtr.host_host_id
                 AND s.service_activate = '1'
             UNION

--- a/centreon/www/class/centreonDowntime.class.php
+++ b/centreon/www/class/centreonDowntime.class.php
@@ -282,14 +282,16 @@ class CentreonDowntime
         foreach (array_keys($relations) as $resourceType) {
             switch ($resourceType) {
                 case 'hosts':
-                    $query = 'SELECT
-                        dhr.host_host_id AS resource_id,
-                        h.host_activate AS activated
-                    FROM downtime_host_relation dhr
-                    INNER JOIN host h
-                        ON dhr.host_host_id = h.host_id
-                    WHERE
-                        dt_id = :downtimeId';
+                    $query = <<<'SQL'
+                        SELECT
+                            dhr.host_host_id AS resource_id,
+                            h.host_activate AS activated
+                        FROM downtime_host_relation dhr
+                        INNER JOIN host h
+                            ON dhr.host_host_id = h.host_id
+                        WHERE
+                            dt_id = :downtimeId';
+                        SQL;
                     break;
                 case 'hostgroups':
                     $query = 'SELECT

--- a/centreon/www/class/centreonDowntime.class.php
+++ b/centreon/www/class/centreonDowntime.class.php
@@ -265,193 +265,308 @@ class CentreonDowntime
     }
 
     /**
-     * Get the list of relations for a downtime
+     * Intends to return hosts, hostgroups, services, servicesgroups linked to the recurrent downtime
      *
-     * <code>
-     * $return_array =
-     *  array(
-     *      'host' => array, // The list of host id
-     *      'hostgrp' => array, // The list of hostgroup id
-     *      'svc' => array, // The list of service id
-     *      'svcgrp' => array, // The list of servicegroup id
-     *  )
-     * </code>
-     *
-     * @param int $id The downtime id
-     * @return array The list of relations
+     * @param integer $downtimeId
+     * @return array
      */
-    public function getRelations($id)
+    public function getRelations(int $downtimeId): array
     {
-        $list = array(
-            "host" => array(),
-            "hostgrp" => array(),
-            "svc" => array(),
-            "svcgrp" => array()
-        );
-        foreach (array_keys($list) as $type) {
-            switch ($type) {
-                case 'host':
-                    $query = "SELECT host_host_id as obj_id FROM downtime_host_relation WHERE dt_id = :id";
+        $relations = [
+            'hosts' => [],
+            'hostgroups' => [],
+            'services' => [],
+            'servicegroups' => [],
+        ];
+
+        foreach (array_keys($relations) as $resourceType) {
+            switch ($resourceType) {
+                case 'hosts':
+                    $query = 'SELECT
+                        dhr.host_host_id AS resource_id,
+                        h.host_activate AS activated
+                    FROM downtime_host_relation dhr
+                    INNER JOIN host h
+                        ON dhr.host_host_id = h.host_id
+                    WHERE
+                        dt_id = :downtimeId';
                     break;
-                case 'hostgrp':
-                    $query = "SELECT hg_hg_id as obj_id FROM downtime_hostgroup_relation WHERE dt_id = :id";
+                case 'hostgroups':
+                    $query = 'SELECT
+                        dhgr.hg_hg_id AS resource_id,
+                        hg.hg_activate AS activated
+                    FROM downtime_hostgroup_relation dhgr
+                    INNER JOIN hostgroup hg
+                        ON dhgr.hg_hg_id = hg.hg_id
+                    WHERE
+                        dt_id = :downtimeId';
                     break;
-                case 'svc':
-                    $query = "SELECT CONCAT(host_host_id, CONCAT('-', service_service_id)) as obj_id " .
-                        "FROM downtime_service_relation WHERE dt_id = :id";
+                case 'services':
+                    $query = 'SELECT CONCAT(dsr.host_host_id, CONCAT(\'-\', dsr.service_service_id)) AS resource_id,
+                        s.service_activate AS activated
+                    FROM downtime_service_relation dsr
+                    INNER JOIN service s
+                        ON dsr.service_service_id = s.service_id
+                    WHERE
+                        dt_id = :downtimeId';
                     break;
-                case 'svcgrp':
-                    $query = "SELECT sg_sg_id as obj_id FROM downtime_servicegroup_relation WHERE dt_id = :id";
+                case 'servicegroups':
+                    $query = 'SELECT
+                        dsgr.sg_sg_id AS resource_id,
+                        sg.sg_activate AS activated
+                    FROM downtime_servicegroup_relation dsgr
+                    INNER JOIN servicegroup sg
+                        ON dsgr.sg_sg_id = sg.sg_id
+                    WHERE
+                        dt_id = :downtimeId';
                     break;
             }
-            $res = $this->db->prepare($query);
-            $res->bindValue(':id', $id, PDO::PARAM_INT);
-            $res->execute();
-            while ($row = $res->fetch()) {
-                $list[$type][] = $row['obj_id'];
+
+            $statement = $this->db->prepare($query);
+            $statement->bindValue(':downtimeId', $downtimeId, \PDO::PARAM_INT);
+            $statement->execute();
+
+            while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+                $relations[$resourceType][] = [
+                    'id' => $record['resource_id'],
+                    'activated' => $record['activated']
+                ];
             }
-            $res->closeCursor();
+
+            $statement->closeCursor();
         }
 
-        return $list;
+        return $relations;
     }
 
-    public function getHostDowntimes()
+    /**
+     * Returns all downtimes configured for enabled hosts
+     *
+     * @return array
+     */
+    public function getForEnabledHosts()
     {
-        $hostDowntimes = array();
+        $downtimes = [];
 
-        $query = 'SELECT dt.dt_id, dt.dt_activate, dtp.dtp_start_time, dtp.dtp_end_time, dtp.dtp_day_of_week, '
-            . 'dtp.dtp_month_cycle, dtp.dtp_day_of_month, dtp.dtp_fixed, dtp.dtp_duration, '
-            . 'h.host_id, h.host_name, NULL as service_id, NULL as service_description '
-            . 'FROM downtime_period dtp, downtime dt, '
-            . 'downtime_host_relation dtr, host h '
-            . 'WHERE dtp.dt_id = dtr.dt_id AND dtp.dt_id = dt.dt_id '
-            . 'AND dtr.host_host_id = h.host_id';
+        $request = "SELECT dt.dt_id,
+            dt.dt_activate,
+            dtp.dtp_start_time,
+            dtp.dtp_end_time,
+            dtp.dtp_day_of_week,
+            dtp.dtp_month_cycle,
+            dtp.dtp_day_of_month,
+            dtp.dtp_fixed,
+            dtp.dtp_duration,
+            h.host_id,
+            h.host_name,
+            NULL as service_id,
+            NULL as service_description
+        FROM downtime_period dtp,
+            downtime dt,
+            downtime_host_relation dtr,
+            host h
+        WHERE dtp.dt_id = dtr.dt_id
+            AND dtp.dt_id = dt.dt_id
+            AND dtr.host_host_id = h.host_id
+            AND h.host_activate = '1'";
 
-        try {
-            $res = $this->db->query($query);
-            while ($row = $res->fetch()) {
-                $hostDowntimes[] = $row;
-            }
-        } catch (\PDOException $e) {
-            // Nothing to do
+        $statement = $this->db->query($request);
+
+        while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $downtimes[] = $record;
         }
 
-        return $hostDowntimes;
+        return $downtimes;
     }
 
-    public function getServiceDowntimes()
+    /**
+     * Returns all downtimes configured for enabled services
+     *
+     * @return array
+     */
+    public function getForEnabledServices()
     {
-        $serviceDowntimes = array();
+        $downtimes = [];
 
-        $query = 'SELECT dt.dt_id, dt.dt_activate, dtp.dtp_start_time, dtp.dtp_end_time, dtp.dtp_day_of_week, '
-            . 'dtp.dtp_month_cycle, dtp.dtp_day_of_month, dtp.dtp_fixed, dtp.dtp_duration, '
-            . 'h.host_id, h.host_name, s.service_id, s.service_description '
-            . 'FROM downtime_period dtp, downtime dt, downtime_service_relation dtr, '
-            . 'service s, host h, host_service_relation hsr '
-            . 'WHERE dtp.dt_id = dtr.dt_id '
-            . 'AND dtp.dt_id = dt.dt_id '
-            . 'AND dtr.service_service_id = s.service_id '
-            . 'AND hsr.service_service_id = s.service_id '
-            . 'AND hsr.host_host_id = h.host_id '
-            . 'AND h.host_id = dtr.host_host_id '
-            . 'UNION '
-            . 'SELECT dt.dt_id, dt.dt_activate, dtp.dtp_start_time, dtp.dtp_end_time, '
-            . 'dtp.dtp_day_of_week, dtp.dtp_month_cycle, dtp.dtp_day_of_month, dtp.dtp_fixed, '
-            . 'dtp.dtp_duration, s.service_description as obj_name, '
-            . 'dtr.service_service_id as obj_id, h.host_name as host_name, h.host_id '
-            . 'FROM downtime_period dtp, downtime dt, downtime_service_relation dtr, service s, '
-            . 'host h, hostgroup_relation hgr, host_service_relation hsr '
-            . 'WHERE '
-            . 'dtp.dt_id = dtr.dt_id '
-            . 'AND dtp.dt_id = dt.dt_id '
-            . 'AND dtr.host_host_id = h.host_id '
-            . 'AND hsr.hostgroup_hg_id = hgr.hostgroup_hg_id '
-            . 'AND hgr.host_host_id = h.host_id '
-            . 'AND s.service_id = hsr.service_service_id '
-            . 'AND dtr.service_service_id = s.service_id';
+        $request = "SELECT dt.dt_id,
+            dt.dt_activate,
+            dtp.dtp_start_time,
+            dtp.dtp_end_time,
+            dtp.dtp_day_of_week,
+            dtp.dtp_month_cycle,
+            dtp.dtp_day_of_month,
+            dtp.dtp_fixed,
+            dtp.dtp_duration,
+            h.host_id,
+            h.host_name,
+            s.service_id,
+            s.service_description,
+        FROM downtime_period dtp,
+            downtime dt,
+            downtime_service_relation dtr,
+            service s,
+            host h,
+            host_service_relation hsr
+        WHERE dtp.dt_id = dtr.dt_id,
+            AND dtp.dt_id = dt.dt_id,
+            AND dtr.service_service_id = s.service_id,
+            AND hsr.service_service_id = s.service_id,
+            AND hsr.host_host_id = h.host_id,
+            AND h.host_id = dtr.host_host_id
+            AND s.service_activate = '1'
+        UNION
+            SELECT dt.dt_id,
+                dt.dt_activate,
+                dtp.dtp_start_time,
+                dtp.dtp_end_time,
+                dtp.dtp_day_of_week,
+                dtp.dtp_month_cycle,
+                dtp.dtp_day_of_month,
+                dtp.dtp_fixed,
+                dtp.dtp_duration,
+                s.service_description as obj_name,
+                dtr.service_service_id as obj_id,
+                h.host_name as host_name,
+                h.host_id
+            FROM downtime_period dtp,
+                downtime dt,
+                downtime_service_relation dtr,
+                service s,
+                host h,
+                hostgroup_relation hgr,
+                host_service_relation hsr
+            WHERE
+                dtp.dt_id = dtr.dt_id
+                AND dtp.dt_id = dt.dt_id
+                AND dtr.host_host_id = h.host_id
+                AND hsr.hostgroup_hg_id = hgr.hostgroup_hg_id
+                AND hgr.host_host_id = h.host_id
+                AND s.service_id = hsr.service_service_id
+                AND dtr.service_service_id = s.service_id
+                AND h.host_activate = '1'";
 
-        try {
-            $res = $this->db->query($query);
-            while ($row = $res->fetch()) {
-                $serviceDowntimes[] = $row;
-            }
-        } catch (\PDOException $e) {
-            // Nothing to do
+        $statement = $this->db->query($request);
+
+        while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $downtimes[] = $record;
         }
 
-        return $serviceDowntimes;
+        return $downtimes;
     }
 
-    public function getHostgroupDowntimes()
+    /**
+     * Returns all downtimes configured for enabled hostgroups
+     *
+     * @return array
+     */
+    public function getForEnabledHostgroups()
     {
-        $hostgroupDowntimes = array();
+        $downtimes = [];
 
-        $query = 'SELECT dt.dt_id, dt.dt_activate, dtp.dtp_start_time, dtp.dtp_end_time, dtp.dtp_day_of_week, '
-            . 'dtp.dtp_month_cycle, dtp.dtp_day_of_month, dtp.dtp_fixed, dtp.dtp_duration, '
-            . 'h.host_id, h.host_name, NULL as service_id, NULL as service_description '
-            . 'FROM downtime_period dtp, downtime dt, '
-            . 'downtime_hostgroup_relation dhr, '
-            . 'host h, hostgroup_relation hgr '
-            . 'WHERE dtp.dt_id = dhr.dt_id '
-            . 'AND dtp.dt_id = dt.dt_id '
-            . 'AND dhr.hg_hg_id = hgr.hostgroup_hg_id '
-            . 'AND hgr.host_host_id = h.host_id ';
+        $request = "SELECT dt.dt_id,
+            dt.dt_activate,
+            dtp.dtp_start_time,
+            dtp.dtp_end_time,
+            dtp.dtp_day_of_week,
+            dtp.dtp_month_cycle,
+            dtp.dtp_day_of_month,
+            dtp.dtp_fixed,
+            dtp.dtp_duration,
+            h.host_id,
+            h.host_name,
+            NULL as service_id,
+            NULL as service_description
+        FROM downtime_period dtp,
+            downtime dt,
+            downtime_hostgroup_relation dhr,
+            host h,
+            hostgroup_relation hgr,
+            hostgroup hg
+        WHERE dtp.dt_id = dhr.dt_id
+            AND dtp.dt_id = dt.dt_id
+            AND dhr.hg_hg_id = hgr.hostgroup_hg_id
+            AND hgr.host_host_id = h.host_id
+            AND hgr.hostgroup_hg_id = hg.hg_id
+            AND hg.hg_activate = '1'";
 
-        try {
-            $res = $this->db->query($query);
-            while ($row = $res->fetch()) {
-                $hostgroupDowntimes[] = $row;
-            }
-        } catch (\PDOException $e) {
-            // Nothing to do
+        $statement = $this->db->query($request);
+
+        while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $downtimes[] = $record;
         }
 
-        return $hostgroupDowntimes;
+        return $downtimes;
     }
 
-    public function getServicegroupDowntimes()
+    public function getForEnabledServicegroups()
     {
-        $servicegroupDowntimes = array();
+        $downtimes = [];
 
-        $query = 'SELECT dt.dt_id, dt.dt_activate, dtp.dtp_start_time, dtp.dtp_end_time, dtp.dtp_day_of_week, '
-            . 'dtp.dtp_month_cycle, dtp.dtp_day_of_month, dtp.dtp_fixed, dtp.dtp_duration, '
-            . 'h.host_id, h.host_name, s.service_id, s.service_description '
-            . 'FROM downtime_period dtp, downtime dt, '
-            . 'downtime_servicegroup_relation dtr, servicegroup_relation sgr, '
-            . 'service s, host h '
-            . 'WHERE dtp.dt_id = dtr.dt_id '
-            . 'AND dtp.dt_id = dt.dt_id '
-            . 'AND dtr.sg_sg_id = sgr.servicegroup_sg_id '
-            . 'AND sgr.host_host_id = h.host_id '
-            . 'AND sgr.service_service_id = s.service_id '
-            . 'UNION DISTINCT '
-            . 'SELECT dt.dt_id, dt.dt_activate, dtp.dtp_start_time, dtp.dtp_end_time, dtp.dtp_day_of_week, '
-            . 'dtp.dtp_month_cycle, dtp.dtp_day_of_month, dtp.dtp_fixed, dtp.dtp_duration, '
-            . 'h.host_id, h.host_name, s.service_id, s.service_description '
-            . 'FROM downtime_period dtp, downtime dt, '
-            . 'downtime_servicegroup_relation dtr, '
-            . 'host_service_relation hsr, hostgroup_relation hgr, '
-            . 'service s, host h, servicegroup_relation sgr '
-            . 'WHERE dtp.dt_id = dtr.dt_id '
-            . 'AND dtp.dt_id = dt.dt_id '
-            . 'AND dtr.sg_sg_id = sgr.servicegroup_sg_id '
-            . 'AND sgr.hostgroup_hg_id IS NOT NULL '
-            . 'AND sgr.hostgroup_hg_id = hsr.hostgroup_hg_id '
-            . 'AND hsr.service_service_id = s.service_id '
-            . 'AND hsr.hostgroup_hg_id = hgr.hostgroup_hg_id '
-            . 'AND hgr.host_host_id = h.host_id ';
+        $request = "SELECT dt.dt_id,
+            dt.dt_activate,
+            dtp.dtp_start_time,
+            dtp.dtp_end_time,
+            dtp.dtp_day_of_week,
+            dtp.dtp_month_cycle,
+            dtp.dtp_day_of_month,
+            dtp.dtp_fixed,
+            dtp.dtp_duration,
+            h.host_id,
+            h.host_name,
+            s.service_id,
+            s.service_description
+        FROM downtime_period dtp,
+            downtime dt,
+            downtime_servicegroup_relation dtr,
+            servicegroup_relation sgr,
+            service s,
+            host h,
+	        servicegroup sg
+        WHERE dtp.dt_id = dtr.dt_id
+            AND dtp.dt_id = dt.dt_id
+            AND dtr.sg_sg_id = sgr.servicegroup_sg_id
+            AND sgr.host_host_id = h.host_id
+            AND sgr.service_service_id = s.service_id
+            AND sgr.servicegroup_sg_id = sg.sg_id
+	        AND sg.sg_activate = '1'
+        UNION DISTINCT
+            SELECT dt.dt_id,
+                dt.dt_activate,
+                dtp.dtp_start_time,
+                dtp.dtp_end_time,
+                dtp.dtp_day_of_week,
+                dtp.dtp_month_cycle,
+                dtp.dtp_day_of_month,
+                dtp.dtp_fixed,
+                dtp.dtp_duration,
+                h.host_id,
+                h.host_name,
+                s.service_id,
+                s.service_description
+            FROM downtime_period dtp,
+                downtime dt,
+                downtime_servicegroup_relation dtr,
+                host_service_relation hsr,
+                hostgroup_relation hgr,
+                service s,
+                host h,
+                servicegroup_relation sgr
+            WHERE dtp.dt_id = dtr.dt_id
+                AND dtp.dt_id = dt.dt_id
+                AND dtr.sg_sg_id = sgr.servicegroup_sg_id
+                AND sgr.hostgroup_hg_id IS NOT NULL
+                AND sgr.hostgroup_hg_id = hsr.hostgroup_hg_id
+                AND hsr.service_service_id = s.service_id
+                AND hsr.hostgroup_hg_id = hgr.hostgroup_hg_id
+                AND hgr.host_host_id = h.host_id";
 
-        try {
-            $res = $this->db->query($query);
-            while ($row = $res->fetch()) {
-                $servicegroupDowntimes[] = $row;
-            }
-        } catch (\PDOException $e) {
-            // Nothing to do
+        $statement = $this->db->query($request);
+
+        while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $downtimes[] = $record;
         }
 
-        return $servicegroupDowntimes;
+        return $downtimes;
     }
 
     /**
@@ -459,17 +574,17 @@ class CentreonDowntime
      *
      * @return array All downtimes
      */
-    public function getDowntime()
+    public function getForEnabledResources()
     {
-        if (!is_null($this->downtimes)) {
+        if (! is_null($this->downtimes)) {
             return $this->downtimes;
         }
 
         $downtimes = array_merge(
-            $this->getHostDowntimes(),
-            $this->getServiceDowntimes(),
-            $this->getHostgroupDowntimes(),
-            $this->getServicegroupDowntimes()
+            $this->getForEnabledHosts(),
+            $this->getForEnabledServices(),
+            $this->getForEnabledServicegroups(),
+            $this->getForEnabledHostgroups()
         );
 
         /* Remove duplicate downtimes */

--- a/centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+++ b/centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
@@ -40,6 +40,60 @@ if (!isset($centreon)) {
     exit();
 }
 
+/**
+ * GetUserAclAllowedResources returns allowed resources for the user regarding resource type
+ *
+ * @param CentreonACL $userAcl
+ * @param string $resourceType
+ */
+function getUserAclAllowedResources(CentreonACL $userAcl, string $resourceType)
+{
+    return match ($resourceType) {
+        'hosts' => $userAcl->getHostAclConf(null, 'broker'),
+        'servicegroups' => $userAcl->getServiceGroupAclConf(null, 'broker'),
+        'hostgroups' => $userAcl->getHostGroupAclConf(null, 'broker'),
+    };
+}
+
+/**
+ * Check resources access regarding selected resources
+ *
+ * @param CentreonACL $userAcl
+ * @param int[] $selectedResources
+ * @param string $resourceType
+ * @return bool
+ **/
+function checkResourcesRelations(CentreonACL $userAcl, array $selectedResources, string $resourceType): bool
+{
+    $allowedResources = getUserAclAllowedResources($userAcl, $resourceType);
+
+    $selectedResourceIds = array_map(
+        function (array $resource) {
+            return $resource['id'];
+        },
+        $selectedResources
+    );
+
+    $diff = array_diff($selectedResourceIds, array_keys($allowedResources));
+
+    if (empty($diff)) {
+        return true;
+    }
+
+    /**
+     * checking that remain diff is not filled with disabled hosts
+     */
+    foreach ($selectedResources as $resource) {
+        if (
+            in_array($resource['id'], $diff)
+            && $resource['activated'] === '0'
+        ) {
+            continue;
+        }
+    }
+
+    return true;
+}
 
 /*
  * QuickForm Rules
@@ -64,7 +118,7 @@ function testDowntimeNameExistence($downtimeName = null)
 }
 
 if (($o == 'c' || $o == 'w') && isset($_GET['dt_id'])) {
-    $id = $_GET['dt_id'];
+    $id = filter_var($_GET['dt_id'], FILTER_VALIDATE_INT);
 } else {
     $o = 'a';
 }
@@ -87,21 +141,24 @@ $attrHosts = array(
     'datasourceOrigin' => 'ajax',
     'availableDatasetRoute' => $hostsRoute,
     'multiple' => true,
-    'linkedObject' => 'centreonHost'
+    'linkedObject' => 'centreonHost',
+    'showDisabled' => true
 );
 $hostgroupsRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_hostgroup&action=list';
 $attrHostgroups = array(
     'datasourceOrigin' => 'ajax',
     'availableDatasetRoute' => $hostgroupsRoute,
     'multiple' => true,
-    'linkedObject' => 'centreonHostgroups'
+    'linkedObject' => 'centreonHostgroups',
+    'showDisabled' => true
 );
 $servicesRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_service&action=list';
 $attrServices = array(
     'datasourceOrigin' => 'ajax',
     'availableDatasetRoute' => $servicesRoute,
     'multiple' => true,
-    'linkedObject' => 'centreonService'
+    'linkedObject' => 'centreonService',
+    'showDisabled' => true
 );
 $servicegroupsRoute = './include/common/webServices/rest/internal.php' .
     '?object=centreon_configuration_servicegroup&action=list';
@@ -109,7 +166,8 @@ $attrServicegroups = array(
     'datasourceOrigin' => 'ajax',
     'availableDatasetRoute' => $servicegroupsRoute,
     'multiple' => true,
-    'linkedObject' => 'centreonServicegroups'
+    'linkedObject' => 'centreonServicegroups',
+    'showDisabled' => true
 );
 
 /*
@@ -166,7 +224,7 @@ $routeAttrHostgroup = './include/common/webServices/rest/internal.php?object=cen
     '&action=defaultValues&target=downtime&field=hostgroup_relation&id=' . $downtime_id;
 $attrHostgroup1 = array_merge(
     $attrHostgroups,
-    array('defaultDatasetRoute' => $routeAttrHostgroup)
+    array('defaultDatasetRoute' => $routeAttrHostgroup),
 );
 $form->addElement('select2', 'hostgroup_relation', _("Linked with Host Groups"), array(), $attrHostgroup1);
 
@@ -200,16 +258,16 @@ $form->setRequiredNote("<i class='red'>*</i>&nbsp;" . _("Required fields"));
 
 if ($o == "c" || $o == 'w') {
     $infos = $downtime->getInfos($id);
-    $relations = $downtime->getRelations($id);
+    $relations = $downtime->getRelations((int) $id);
     $default_dt = array(
         'dt_id' => $id,
         'downtime_name' => $infos['name'],
         'downtime_description' => $infos['description'],
         'downtime_activate' => $infos['activate'],
-        'host_relation' => $relations['host'],
-        'hostgroup_relation' => $relations['hostgrp'],
-        'svc_relation' => $relations['svc'],
-        'svcgroup_relation' => $relations['svcgrp']
+        'host_relations' => $relations['hosts'],
+        'hostgroup_relations' => $relations['hostgroups'],
+        'service_relations' => $relations['services'],
+        'servicegroup_relations' => $relations['servicegroups']
     );
 }
 
@@ -220,10 +278,14 @@ if ($o == "c" || $o == 'w') {
 $tpl = new Smarty();
 $tpl = initSmartyTpl($path, $tpl);
 
+/**
+ * $o parameter possible values
+ *
+ * $o = w - Watch the recurrent downtime = no possible edit
+ * $o = c - Edit the recurrent downtime
+ * $o = a - Add a recurrent downtime
+ */
 if ($o == "w") {
-    /*
-	 * Just watch a host information
-	 */
     if (!$min && $centreon->user->access->page($p) != 2) {
         $form->addElement("button", "change", _("Modify"), array(
             "onClick" => "javascript:window.location.href='?p=" . $p . "&o=c&dt_id=" . $id . "'",
@@ -233,39 +295,23 @@ if ($o == "w") {
     $form->setDefaults($default_dt);
     $form->freeze();
 } elseif ($o == "c") {
-    /*
-	 * Modify a service information
-	 */
-    require_once _CENTREON_PATH_ . "/www/class/centreonACL.class.php";
-
+    /**
+     * Only search for ACL if the user is not admin
+     */
     $userId = $centreon->user->user_id;
-    $isAdmin = $centreon->user->admin;
-    $acl = new CentreonACL($userId, $isAdmin);
+    $userIsAdmin = $centreon->user->admin;
 
-    //check host resources
-    $host = $acl->getHostAclConf(null, 'broker');
-    $accessHost = array_keys($host);
-    $result = array_diff($default_dt['host_relation'], $accessHost);
-    if (!empty($result)) {
-        $form->addElement('text', 'msgacl', _("error"), 'error');
-        $form->freeze();
-    } else {
-        //check hostgroup resources
-        $hgs = $acl->getHostGroupAclConf(null, 'broker');
-        $accessHg = array_keys($hgs);
-        $result = array_diff($default_dt['hostgroup_relation'], $accessHg);
-        if (!empty($result)) {
+    if ($userIsAdmin !== '1') {
+        require_once _CENTREON_PATH_ . "/www/class/centreonACL.class.php";
+        $userAcl = new CentreonACL($userId, $userIsAdmin);
+
+        if (
+            ! checkResourcesRelations($userAcl, $default_dt['host_relations'], 'hosts')
+            || ! checkResourcesRelations($userAcl, $default_dt['hostgroup_relations'], 'hostgroups')
+            || ! checkResourcesRelations($userAcl, $default_dt['servicegroup_relations'], 'servicegroups')
+        ) {
             $form->addElement('text', 'msgacl', _("error"), 'error');
             $form->freeze();
-        } else {
-            //check servicegroup resources
-            $sgs = $acl->getServiceGroupAclConf(null, 'broker');
-            $accessSg = array_keys($sgs);
-            $result = array_diff($default_dt['svcgroup_relation'], $accessSg);
-            if (!empty($result)) {
-                $form->addElement('text', 'msgacl', _("error"), 'error');
-                $form->freeze();
-            }
         }
     }
 
@@ -283,9 +329,6 @@ if ($o == "w") {
     );
     $form->setDefaults($default_dt);
 } elseif ($o == "a") {
-    /*
-	 * Add a service information
-	 */
     $subA = $form->addElement(
         'button',
         'submitA',
@@ -326,10 +369,12 @@ if ($form->validate()) {
             $tpl->assign('period_err', _("The end time must be greater than the start time."));
         }
     }
-    if ((!isset($values['host_relation']) || count($values['host_relation']) == 0)
-        && (!isset($values['hostgroup_relation']) || count($values['hostgroup_relation']) == 0)
-        && (!isset($values['svc_relation']) || count($values['svc_relation']) == 0)
-        && (!isset($values['svcgroup_relation']) || count($values['svcgroup_relation']) == 0)
+    /** validate that at least one relation has been configured */
+    if (
+        (! isset($values['host_relation']) || count($values['host_relation']) == 0)
+        && (! isset($values['hostgroup_relation']) || count($values['hostgroup_relation']) == 0)
+        && (! isset($values['svc_relation']) || count($values['svc_relation']) == 0)
+        && (! isset($values['svcgroup_relation']) || count($values['svcgroup_relation']) == 0)
     ) {
         $valid = false;
         $tpl->assign('msg_err', _('No relation set for this downtime'));

--- a/centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+++ b/centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
@@ -68,27 +68,22 @@ function checkResourcesRelations(CentreonACL $userAcl, array $selectedResources,
     $allowedResources = getUserAclAllowedResources($userAcl, $resourceType);
 
     $selectedResourceIds = array_map(
-        function (array $resource) {
-            return $resource['id'];
-        },
+        static fn (array $resource) => $resource['id'],
         $selectedResources
     );
 
     $diff = array_diff($selectedResourceIds, array_keys($allowedResources));
 
-    if (empty($diff)) {
+    if ($diff === []) {
         return true;
     }
 
-    /**
-     * checking that remain diff is not filled with disabled hosts
-     */
     foreach ($selectedResources as $resource) {
         if (
             in_array($resource['id'], $diff)
-            && $resource['activated'] === '0'
+            && $resource['activated'] === '1'
         ) {
-            continue;
+            return false;
         }
     }
 
@@ -371,10 +366,10 @@ if ($form->validate()) {
     }
     /** validate that at least one relation has been configured */
     if (
-        (! isset($values['host_relation']) || count($values['host_relation']) == 0)
-        && (! isset($values['hostgroup_relation']) || count($values['hostgroup_relation']) == 0)
-        && (! isset($values['svc_relation']) || count($values['svc_relation']) == 0)
-        && (! isset($values['svcgroup_relation']) || count($values['svcgroup_relation']) == 0)
+        (! isset($values['host_relation']) || count($values['host_relation']) === 0)
+        && (! isset($values['hostgroup_relation']) || count($values['hostgroup_relation']) === 0)
+        && (! isset($values['svc_relation']) || count($values['svc_relation']) === 0)
+        && (! isset($values['svcgroup_relation']) || count($values['svcgroup_relation']) === 0)
     ) {
         $valid = false;
         $tpl->assign('msg_err', _('No relation set for this downtime'));


### PR DESCRIPTION
## Description

This PR intends to change several things:
- In the recurrent downtime form now resources that are disabled are indicated in the select2 with a string "disabled"
- In the recurrent downtime form only resources that are not accessible through ACL will trigger an error message for a standard user
- The recurrent downtimes will only be set on resources that are enabled.

Example of issue encountered and fixed by this PR

- I create a hostgroup disabled linked to 3 hosts
- I create a recurrent downtime linked to this disabled hostgroup
- When comes the time for the downtime to start the hosts linked to the hostgroup were set in downtime...

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

See jira ticket for details

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
