### PR TITLE
feat(contact): Define a default page for new users

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -55,8 +55,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
     {
         $request = $this->translateDbName(
             'SELECT contact.*, cp.password AS contact_passwd, t.topology_url,
-            t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name,
-            COALESCE(contact.default_page, template.default_page) as default_page
+            t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name, t.topology_page as default_page
             FROM `:db`.contact
             LEFT JOIN centreon.contact as template
                 ON contact.contact_template_id = template.contact_id
@@ -90,8 +89,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
     {
         $request = $this->translateDbName(
             'SELECT contact.*, cp.password AS contact_passwd, t.topology_url,
-            t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name,
-            COALESCE(contact.default_page, template.default_page) as default_page
+            t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name, t.topology_page as default_page
             FROM `:db`.contact
             LEFT JOIN centreon.contact as template
                 ON contact.contact_template_id = template.contact_id
@@ -124,8 +122,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
     {
         $request = $this->translateDbName(
             'SELECT contact.*, cp.password AS contact_passwd, t.topology_url,
-            t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name,
-            COALESCE(contact.default_page, template.default_page) as default_page
+            t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name, t.topology_page as default_page
             FROM `:db`.contact
             LEFT JOIN centreon.contact as template
                 ON contact.contact_template_id = template.contact_id
@@ -157,8 +154,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
     {
         $request = $this->translateDbName(
             'SELECT contact.*, cp.password AS contact_passwd, t.topology_url,
-            t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name,
-            COALESCE(contact.default_page, template.default_page) as default_page
+            t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name, t.topology_page as default_page
             FROM `:db`.contact
             LEFT JOIN centreon.contact as template
                 ON contact.contact_template_id = template.contact_id
@@ -194,8 +190,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
         $statement = $this->db->prepare(
             $this->translateDbName(
                 "SELECT contact.*, cp.password AS contact_passwd, t.topology_url,
-                t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name,
-                COALESCE(contact.default_page, template.default_page) as default_page
+                t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name, t.topology_page as default_page
                 FROM `:db`.contact
                 LEFT JOIN centreon.contact as template
                     ON contact.contact_template_id = template.contact_id

--- a/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -405,7 +405,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
         } else {
             if ($contact['contact_template_id'] !== null) {
                 $request = $this->translateDbName(
-                    "SELECT contact.* FROM `:db`.contact WHERE contact_id = :contact_template_id"
+                    "SELECT default_page FROM `:db`.contact WHERE contact_id = :contact_template_id"
                 );
                 $statement = $this->db->prepare($request);
                 $statement->bindValue(

--- a/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -433,7 +433,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
                         $contactTemplate['default_page'],
                         (bool)$topology['is_react']
                     );
-                    if (!empty($topology['topology_url_opt'])) {
+                    if (! empty($topology['topology_url_opt'])) {
                         $page->setUrlOptions($data['topology_url_opt']);
                     }
                 }

--- a/centreon/www/class/centreon-clapi/centreonContact.class.php
+++ b/centreon/www/class/centreon-clapi/centreonContact.class.php
@@ -61,6 +61,7 @@ class CentreonContact extends CentreonObject
     public const ORDER_ACCESS = 5;
     public const ORDER_LANG = 6;
     public const ORDER_AUTHTYPE = 7;
+    public const ORDER_DEFAULT_PAGE = 8;
     public const HOST_NOTIF_TP = "hostnotifperiod";
     public const SVC_NOTIF_TP = "svcnotifperiod";
     public const HOST_NOTIF_CMD = "hostnotifcmd";
@@ -271,6 +272,7 @@ class CentreonContact extends CentreonObject
         $this->initUserAccess($params);
         $this->initLang($params);
         $this->initAuthenticationType($params);
+        $this->initDefaultPage($params);
 
         $this->params = array_merge($this->params, $this->addParams);
         $this->checkParameters();
@@ -371,6 +373,18 @@ class CentreonContact extends CentreonObject
     protected function initAuthenticationType(array $params): void
     {
         $this->addParams['contact_auth_type'] = $params[static::ORDER_AUTHTYPE];
+    }
+
+    /**
+     * Initialize default page
+     *
+     * @param array<int,mixed> $params
+     */
+    protected function initDefaultPage(array $params): void
+    {
+        if (isset($params[static::ORDER_DEFAULT_PAGE])) {
+            $this->addParams['default_page'] = $params[static::ORDER_DEFAULT_PAGE];
+        }
     }
 
     /**

--- a/centreon/www/class/centreon-clapi/centreonContactTemplate.class.php
+++ b/centreon/www/class/centreon-clapi/centreonContactTemplate.class.php
@@ -51,6 +51,7 @@ class CentreonContactTemplate extends CentreonContact
     public const ORDER_ACCESS = 4;
     public const ORDER_LANG = 5;
     public const ORDER_AUTHTYPE = 6;
+    public const ORDER_DEFAULT_PAGE = 7;
 
     /**
      * Constructor
@@ -91,6 +92,7 @@ class CentreonContactTemplate extends CentreonContact
         $this->initUserAccess($params);
         $this->initLang($params);
         $this->initAuthenticationType($params);
+        $this->initDefaultPage($params);
 
         $this->params = array_merge($this->params, $this->addParams);
         $this->checkParameters();

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1253,6 +1253,13 @@ function sanitizeFormContactParameters(array $ret): array
                     }
                 }
                 break;
+            case 'default_page':
+                $bindParams[':' . $inputName] = [
+                    \PDO::PARAM_INT => (filter_var($inputValue, FILTER_VALIDATE_INT) === false)
+                        ? null
+                        : (int) $inputValue
+                ];
+                break;
             case 'contact_auth_type':
                 if (!empty($inputValue)) {
                     $inputValue = \HtmlAnalyzer::sanitizeAndRemoveTags($inputValue);

--- a/centreon/www/include/configuration/configObject/contact/formContact.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/formContact.ihtml
@@ -128,6 +128,7 @@
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="password2"> {$form.contact_passwd2.label}</td><td class="FormRowValue">{$form.contact_passwd2.html}</td></tr>
         {/if}
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="language"> {$form.contact_lang.label}</td><td class="FormRowValue">{$form.contact_lang.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="default_page"> {$form.default_page.label}</td><td class="FormRowValue">{$form.default_page.html}</td></tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="location"> {$form.contact_location.label}</td><td class="FormRowValue">{$form.contact_location.html}</td></tr>
         {if $o != "mc"}
         <tr class="list_two">

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -609,7 +609,7 @@ if (! empty($aclUser)) {
             // select parent from level 2 if level 3 is missing
             $pageId = $parentLvl3 ?: $parentLvl2;
 
-            if (!$isThirdLevelMenu && $translatedPages[$pageId]['show']) {
+            if (! $isThirdLevelMenu && $translatedPages[$pageId]['show']) {
                 /**
                  * We show only first and second level
                  */

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -500,12 +500,12 @@ if (! empty($aclUser)) {
 
         // Classify topologies by parents
         foreach (array_keys($topologies) as $page) {
-            if (strlen($page) == 1) {
+            if (strlen($page) === 1) {
                 // MENU level 1
                 if (! array_key_exists($page, $parentsLvl)) {
                     $parentsLvl[$page] = [];
                 }
-            } elseif (strlen($page) == 3) {
+            } elseif (strlen($page) === 3) {
                 // MENU level 2
                 $parentLvl1 = substr($page, 0, 1);
                 if (! array_key_exists($parentLvl1, $parentsLvl)) {
@@ -514,7 +514,7 @@ if (! empty($aclUser)) {
                 if (! array_key_exists($page, $parentsLvl[$parentLvl1])) {
                     $parentsLvl[$parentLvl1][$page] = [];
                 }
-            } elseif (strlen($page) == 5) {
+            } elseif (strlen($page) === 5) {
                 // MENU level 3
                 $parentLvl1 = substr($page, 0, 1);
                 $parentLvl2 = substr($page, 0, 3);
@@ -537,14 +537,12 @@ if (! empty($aclUser)) {
      * Check if at least one child can be shown
      */
     $oneChildCanBeShown = function () use (&$childrenLvl3, &$translatedPages): bool {
-        $isCanBeShow = false;
         foreach ($childrenLvl3 as $topologyPage) {
             if ($translatedPages[$topologyPage]['show']) {
-                $isCanBeShow = true;
-                break;
+                return true;
             }
         }
-        return $isCanBeShow;
+        return false;
     };
 
     $topologies = $createTopologyTree($acls);
@@ -607,7 +605,7 @@ if (! empty($aclUser)) {
             }
 
             // select parent from level 2 if level 3 is missing
-            $pageId = $parentLvl3 ?: $parentLvl2;
+            $pageId = $parentLvl3 ?? $parentLvl2;
 
             if (! $isThirdLevelMenu && $translatedPages[$pageId]['show']) {
                 /**

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -518,7 +518,7 @@ if (! empty($aclUser)) {
                 // MENU level 3
                 $parentLvl1 = substr($page, 0, 1);
                 $parentLvl2 = substr($page, 0, 3);
-                if (!array_key_exists($parentLvl1, $parentsLvl)) {
+                if (! array_key_exists($parentLvl1, $parentsLvl)) {
                     $parentsLvl[$parentLvl1] = [];
                 }
                 if (!array_key_exists($parentLvl2, $parentsLvl[$parentLvl1])) {

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -508,7 +508,7 @@ if (! empty($aclUser)) {
             } elseif (strlen($page) == 3) {
                 // MENU level 2
                 $parentLvl1 = substr($page, 0, 1);
-                if (!array_key_exists($parentLvl1, $parentsLvl)) {
+                if (! array_key_exists($parentLvl1, $parentsLvl)) {
                     $parentsLvl[$parentLvl1] = [];
                 }
                 if (!array_key_exists($page, $parentsLvl[$parentLvl1])) {

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -502,7 +502,7 @@ if (! empty($aclUser)) {
         foreach (array_keys($topologies) as $page) {
             if (strlen($page) == 1) {
                 // MENU level 1
-                if (!array_key_exists($page, $parentsLvl)) {
+                if (! array_key_exists($page, $parentsLvl)) {
                     $parentsLvl[$page] = [];
                 }
             } elseif (strlen($page) == 3) {

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -511,7 +511,7 @@ if (! empty($aclUser)) {
                 if (! array_key_exists($parentLvl1, $parentsLvl)) {
                     $parentsLvl[$parentLvl1] = [];
                 }
-                if (!array_key_exists($page, $parentsLvl[$parentLvl1])) {
+                if (! array_key_exists($page, $parentsLvl[$parentLvl1])) {
                     $parentsLvl[$parentLvl1][$page] = [];
                 }
             } elseif (strlen($page) == 5) {

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -370,17 +370,17 @@ if ($o != MASSIVE_CHANGE) {
  * Contact template used
  */
 $form->addElement(
-    'select', 
-    'contact_template_id', 
-    _("Contact template used"), 
-    $contactTpl, 
+    'select',
+    'contact_template_id',
+    _("Contact template used"),
+    $contactTpl,
     [
-        "id" => "contact_template_id", 
+        "id" => "contact_template_id",
         "data-testid" => "contact_template_id"
     ]
 );
 $form->addElement('header', 'furtherAddress', _("Additional Addresses"));
-for ($i=0; $i < 6; $i++) { 
+for ($i=0; $i < 6; $i++) {
     $attrsText["id"] = "contact_address" . $i + 1;
     $attrsText["data-testid"] = "contact_address" . $i + 1;
     $form->addElement('text', 'contact_address' . $i+1, _("Address" . $i + 1), $attrsText);
@@ -479,6 +479,147 @@ if ($o !== MASSIVE_CHANGE) {
     );
 }
 
+/* ------------------------ Topoogy ---------------------------- */
+$pages = [null => ""];
+$aclUser = $centreon->user->lcaTStr;
+if (!empty($aclUser)) {
+    $acls = array_flip(explode(',', $aclUser));
+    /**
+     * Transform [1, 2, 101, 202, 10101, 20201] to :
+     *
+     * 1
+     *   101
+     *     10101
+     * 2
+     *   202
+     *     20201
+     */
+    $createTopologyTree = function (array $topologies): array {
+        ksort($topologies, \SORT_ASC);
+        $parentsLvl = [];
+
+        // Classify topologies by parents
+        foreach (array_keys($topologies) as $page) {
+            if (strlen($page) == 1) {
+                // MENU level 1
+                if (!array_key_exists($page, $parentsLvl)) {
+                    $parentsLvl[$page] = [];
+                }
+            } elseif (strlen($page) == 3) {
+                // MENU level 2
+                $parentLvl1 = substr($page, 0, 1);
+                if (!array_key_exists($parentLvl1, $parentsLvl)) {
+                    $parentsLvl[$parentLvl1] = [];
+                }
+                if (!array_key_exists($page, $parentsLvl[$parentLvl1])) {
+                    $parentsLvl[$parentLvl1][$page] = [];
+                }
+            } elseif (strlen($page) == 5) {
+                // MENU level 3
+                $parentLvl1 = substr($page, 0, 1);
+                $parentLvl2 = substr($page, 0, 3);
+                if (!array_key_exists($parentLvl1, $parentsLvl)) {
+                    $parentsLvl[$parentLvl1] = [];
+                }
+                if (!array_key_exists($parentLvl2, $parentsLvl[$parentLvl1])) {
+                    $parentsLvl[$parentLvl1][$parentLvl2] = [];
+                }
+                if (!in_array($page, $parentsLvl[$parentLvl1][$parentLvl2])) {
+                    $parentsLvl[$parentLvl1][$parentLvl2][] = $page;
+                }
+            }
+        }
+
+        return $parentsLvl;
+    };
+
+    /**
+     * Check if at least one child can be shown
+     */
+    $oneChildCanBeShown = function () use (&$childrenLvl3, &$translatedPages): bool {
+        $isCanBeShow = false;
+        foreach ($childrenLvl3 as $topologyPage) {
+            if ($translatedPages[$topologyPage]['show']) {
+                $isCanBeShow = true;
+                break;
+            }
+        }
+        return $isCanBeShow;
+    };
+
+    $topologies = $createTopologyTree($acls);
+
+    /**
+     * Retrieve the name of all topologies available for this user
+     */
+    $aclTopologies = $pearDB->query(
+        "SELECT topology_page, topology_name, topology_show "
+        . "FROM topology "
+        . "WHERE topology_page IN ($aclUser)"
+    );
+
+    $translatedPages = [];
+
+    while ($topology = $aclTopologies->fetch(\PDO::FETCH_ASSOC)) {
+        $translatedPages[$topology['topology_page']] = [
+            'i18n' => _($topology['topology_name']),
+            'show' => ((int)$topology['topology_show'] === 1)
+        ];
+    }
+
+    /**
+     * Create flat tree for menu with the topologies names
+     * [item1Id] = menu1 > submenu1 > item1
+     * [item2Id] = menu2 > submenu2 > item2
+     */
+    foreach ($topologies as $parentLvl1 => $childrenLvl2) {
+        $parentNameLvl1 = $translatedPages[$parentLvl1]['i18n'];
+        foreach ($childrenLvl2 as $parentLvl2 => $childrenLvl3) {
+            $parentNameLvl2 = $translatedPages[$parentLvl2]['i18n'];
+            $isThirdLevelMenu = false;
+            $parentLvl3 = null;
+
+            if ($oneChildCanBeShown()) {
+                /**
+                 * There is at least one child that can be shown then we can
+                 * process the third level
+                 */
+                foreach ($childrenLvl3 as $parentLvl3) {
+                    if ($translatedPages[$parentLvl3]['show']) {
+                        $parentNameLvl3 = $translatedPages[$parentLvl3]['i18n'];
+
+                        if ($parentNameLvl2 === $parentNameLvl3) {
+                            /**
+                             * The name between lvl2 and lvl3 are equals.
+                             * We keep only lvl1 and lvl3
+                             */
+                            $pages[$parentLvl3] = $parentNameLvl1 . ' > '
+                                . $parentNameLvl3;
+                        } else {
+                            $pages[$parentLvl3] = $parentNameLvl1 . ' > '
+                                . $parentNameLvl2 . ' > '
+                                . $parentNameLvl3;
+                        }
+                    }
+                }
+
+                $isThirdLevelMenu = true;
+            }
+
+            // select parent from level 2 if level 3 is missing
+            $pageId = $parentLvl3 ?: $parentLvl2;
+
+            if (!$isThirdLevelMenu && $translatedPages[$pageId]['show']) {
+                /**
+                 * We show only first and second level
+                 */
+                $pages[$pageId] =
+                    $parentNameLvl1 . ' > ' . $parentNameLvl2;
+            }
+        }
+    }
+}
+
 $form->addElement(
     'select',
     'contact_lang',
@@ -489,6 +630,7 @@ $form->addElement(
         "data-testid" => "contact_lang"
     ]
 );
+$form->addElement('select', 'default_page', _("Default page"), $pages);
 $form->addElement(
     'select',
     'contact_type_msg',

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -521,7 +521,7 @@ if (! empty($aclUser)) {
                 if (! array_key_exists($parentLvl1, $parentsLvl)) {
                     $parentsLvl[$parentLvl1] = [];
                 }
-                if (!array_key_exists($parentLvl2, $parentsLvl[$parentLvl1])) {
+                if (! array_key_exists($parentLvl2, $parentsLvl[$parentLvl1])) {
                     $parentsLvl[$parentLvl1][$parentLvl2] = [];
                 }
                 if (!in_array($page, $parentsLvl[$parentLvl1][$parentLvl2])) {

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -524,7 +524,7 @@ if (! empty($aclUser)) {
                 if (! array_key_exists($parentLvl2, $parentsLvl[$parentLvl1])) {
                     $parentsLvl[$parentLvl1][$parentLvl2] = [];
                 }
-                if (!in_array($page, $parentsLvl[$parentLvl1][$parentLvl2])) {
+                if (! in_array($page, $parentsLvl[$parentLvl1][$parentLvl2])) {
                     $parentsLvl[$parentLvl1][$parentLvl2][] = $page;
                 }
             }

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -482,7 +482,7 @@ if ($o !== MASSIVE_CHANGE) {
 /* ------------------------ Topoogy ---------------------------- */
 $pages = [null => ""];
 $aclUser = $centreon->user->lcaTStr;
-if (!empty($aclUser)) {
+if (! empty($aclUser)) {
     $acls = array_flip(explode(',', $aclUser));
     /**
      * Transform [1, 2, 101, 202, 10101, 20201] to :

--- a/centreon/www/include/configuration/configObject/contact/help.php
+++ b/centreon/www/include/configuration/configObject/contact/help.php
@@ -80,6 +80,11 @@ $help["centreon_login"] = dgettext("help", "Specify if the contact is allowed to
 $help["password"] = dgettext("help", "Define the password for the centreon login here.");
 $help["password2"] = dgettext("help", "Enter the password again.");
 $help["language"] = dgettext("help", "Define the default language for the user for the centreon front-end here.");
+$help["default_page"] = dgettext(
+    "help",
+    "Define the default page for the user when he logs in." .
+    "(Acls must be defined so that the pages can be shown)"
+);
 $help["admin"] = dgettext(
     "help",
     "Specify if the user has administrative permissions. Administrators are not restricted by access " .

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.ihtml
@@ -39,6 +39,7 @@
             <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="contact_name"> {$form.contact_name.label}</td><td class="FormRowValue">{$form.contact_name.html}</td></tr>
         {/if}
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="pager"> {$form.contact_template_id.label}</td><td class="FormRowValue">{$form.contact_template_id.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="default_page"> {$form.default_page.label}</td><td class="FormRowValue">{$form.default_page.html}</td></tr>
         <tr class="list_lvl_1">
             <td class="ListColLvl1_name" colspan="2">
                 <h4>{$form.header.notification}</h4>

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -260,7 +260,7 @@ if (!empty($aclUser)) {
                 // MENU level 3
                 $parentLvl1 = substr($page, 0, 1);
                 $parentLvl2 = substr($page, 0, 3);
-                if (!array_key_exists($parentLvl1, $parentsLvl)) {
+                if (! array_key_exists($parentLvl1, $parentsLvl)) {
                     $parentsLvl[$parentLvl1] = [];
                 }
                 if (!array_key_exists($parentLvl2, $parentsLvl[$parentLvl1])) {

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -221,6 +221,148 @@ if ($o != "mc") {
  */
 $form->addElement('select', 'contact_template_id', _("Contact template used"), $contactTpl);
 
+/* ------------------------ Topoogy ---------------------------- */
+$pages = [];
+$aclUser = $centreon->user->lcaTStr;
+if (!empty($aclUser)) {
+    $acls = array_flip(explode(',', $aclUser));
+    /**
+     * Transform [1, 2, 101, 202, 10101, 20201] to :
+     *
+     * 1
+     *   101
+     *     10101
+     * 2
+     *   202
+     *     20201
+     */
+    $createTopologyTree = function (array $topologies): array {
+        ksort($topologies, \SORT_ASC);
+        $parentsLvl = [];
+
+        // Classify topologies by parents
+        foreach (array_keys($topologies) as $page) {
+            if (strlen($page) == 1) {
+                // MENU level 1
+                if (!array_key_exists($page, $parentsLvl)) {
+                    $parentsLvl[$page] = [];
+                }
+            } elseif (strlen($page) == 3) {
+                // MENU level 2
+                $parentLvl1 = substr($page, 0, 1);
+                if (!array_key_exists($parentLvl1, $parentsLvl)) {
+                    $parentsLvl[$parentLvl1] = [];
+                }
+                if (!array_key_exists($page, $parentsLvl[$parentLvl1])) {
+                    $parentsLvl[$parentLvl1][$page] = [];
+                }
+            } elseif (strlen($page) == 5) {
+                // MENU level 3
+                $parentLvl1 = substr($page, 0, 1);
+                $parentLvl2 = substr($page, 0, 3);
+                if (!array_key_exists($parentLvl1, $parentsLvl)) {
+                    $parentsLvl[$parentLvl1] = [];
+                }
+                if (!array_key_exists($parentLvl2, $parentsLvl[$parentLvl1])) {
+                    $parentsLvl[$parentLvl1][$parentLvl2] = [];
+                }
+                if (!in_array($page, $parentsLvl[$parentLvl1][$parentLvl2])) {
+                    $parentsLvl[$parentLvl1][$parentLvl2][] = $page;
+                }
+            }
+        }
+
+        return $parentsLvl;
+    };
+
+    /**
+     * Check if at least one child can be shown
+     */
+    $oneChildCanBeShown = function () use (&$childrenLvl3, &$translatedPages): bool {
+        $isCanBeShow = false;
+        foreach ($childrenLvl3 as $topologyPage) {
+            if ($translatedPages[$topologyPage]['show']) {
+                $isCanBeShow = true;
+                break;
+            }
+        }
+        return $isCanBeShow;
+    };
+
+    $topologies = $createTopologyTree($acls);
+
+    /**
+     * Retrieve the name of all topologies available for this user
+     */
+    $aclTopologies = $pearDB->query(
+        "SELECT topology_page, topology_name, topology_show "
+        . "FROM topology "
+        . "WHERE topology_page IN ($aclUser)"
+    );
+
+    $translatedPages = [];
+
+    while ($topology = $aclTopologies->fetch(\PDO::FETCH_ASSOC)) {
+        $translatedPages[$topology['topology_page']] = [
+            'i18n' => _($topology['topology_name']),
+            'show' => ((int)$topology['topology_show'] === 1)
+        ];
+    }
+
+    /**
+     * Create flat tree for menu with the topologies names
+     * [item1Id] = menu1 > submenu1 > item1
+     * [item2Id] = menu2 > submenu2 > item2
+     */
+    foreach ($topologies as $parentLvl1 => $childrenLvl2) {
+        $parentNameLvl1 = $translatedPages[$parentLvl1]['i18n'];
+        foreach ($childrenLvl2 as $parentLvl2 => $childrenLvl3) {
+            $parentNameLvl2 = $translatedPages[$parentLvl2]['i18n'];
+            $isThirdLevelMenu = false;
+            $parentLvl3 = null;
+
+            if ($oneChildCanBeShown()) {
+                /**
+                 * There is at least one child that can be shown then we can
+                 * process the third level
+                 */
+                foreach ($childrenLvl3 as $parentLvl3) {
+                    if ($translatedPages[$parentLvl3]['show']) {
+                        $parentNameLvl3 = $translatedPages[$parentLvl3]['i18n'];
+
+                        if ($parentNameLvl2 === $parentNameLvl3) {
+                            /**
+                             * The name between lvl2 and lvl3 are equals.
+                             * We keep only lvl1 and lvl3
+                             */
+                            $pages[$parentLvl3] = $parentNameLvl1 . ' > '
+                                . $parentNameLvl3;
+                        } else {
+                            $pages[$parentLvl3] = $parentNameLvl1 . ' > '
+                                . $parentNameLvl2 . ' > '
+                                . $parentNameLvl3;
+                        }
+                    }
+                }
+
+                $isThirdLevelMenu = true;
+            }
+
+            // select parent from level 2 if level 3 is missing
+            $pageId = $parentLvl3 ?: $parentLvl2;
+
+            if (!$isThirdLevelMenu && $translatedPages[$pageId]['show']) {
+                /**
+                 * We show only first and second level
+                 */
+                $pages[$pageId] =
+                    $parentNameLvl1 . ' > ' . $parentNameLvl2;
+            }
+        }
+    }
+}
+
+$form->addElement('select', 'default_page', _("Default page"), $pages);
 $form->addElement('header', 'furtherAddress', _("Additional Addresses"));
 $form->addElement('text', 'contact_address1', _("Address1"), $attrsText);
 $form->addElement('text', 'contact_address2', _("Address2"), $attrsText);

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -263,7 +263,7 @@ if (!empty($aclUser)) {
                 if (! array_key_exists($parentLvl1, $parentsLvl)) {
                     $parentsLvl[$parentLvl1] = [];
                 }
-                if (!array_key_exists($parentLvl2, $parentsLvl[$parentLvl1])) {
+                if (! array_key_exists($parentLvl2, $parentsLvl[$parentLvl1])) {
                     $parentsLvl[$parentLvl1][$parentLvl2] = [];
                 }
                 if (!in_array($page, $parentsLvl[$parentLvl1][$parentLvl2])) {

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -266,7 +266,7 @@ if (!empty($aclUser)) {
                 if (! array_key_exists($parentLvl2, $parentsLvl[$parentLvl1])) {
                     $parentsLvl[$parentLvl1][$parentLvl2] = [];
                 }
-                if (!in_array($page, $parentsLvl[$parentLvl1][$parentLvl2])) {
+                if (! in_array($page, $parentsLvl[$parentLvl1][$parentLvl2])) {
                     $parentsLvl[$parentLvl1][$parentLvl2][] = $page;
                 }
             }

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -253,7 +253,7 @@ if (!empty($aclUser)) {
                 if (!array_key_exists($parentLvl1, $parentsLvl)) {
                     $parentsLvl[$parentLvl1] = [];
                 }
-                if (!array_key_exists($page, $parentsLvl[$parentLvl1])) {
+                if (! array_key_exists($page, $parentsLvl[$parentLvl1])) {
                     $parentsLvl[$parentLvl1][$page] = [];
                 }
             } elseif (strlen($page) == 5) {

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -351,7 +351,7 @@ if (!empty($aclUser)) {
             // select parent from level 2 if level 3 is missing
             $pageId = $parentLvl3 ?: $parentLvl2;
 
-            if (!$isThirdLevelMenu && $translatedPages[$pageId]['show']) {
+            if (! $isThirdLevelMenu && $translatedPages[$pageId]['show']) {
                 /**
                  * We show only first and second level
                  */

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -224,7 +224,7 @@ $form->addElement('select', 'contact_template_id', _("Contact template used"), $
 /* ------------------------ Topoogy ---------------------------- */
 $pages = [];
 $aclUser = $centreon->user->lcaTStr;
-if (!empty($aclUser)) {
+if (! empty($aclUser)) {
     $acls = array_flip(explode(',', $aclUser));
     /**
      * Transform [1, 2, 101, 202, 10101, 20201] to :

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -250,7 +250,7 @@ if (!empty($aclUser)) {
             } elseif (strlen($page) == 3) {
                 // MENU level 2
                 $parentLvl1 = substr($page, 0, 1);
-                if (!array_key_exists($parentLvl1, $parentsLvl)) {
+                if (! array_key_exists($parentLvl1, $parentsLvl)) {
                     $parentsLvl[$parentLvl1] = [];
                 }
                 if (! array_key_exists($page, $parentsLvl[$parentLvl1])) {

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -224,7 +224,7 @@ $form->addElement('select', 'contact_template_id', _("Contact template used"), $
 /* ------------------------ Topoogy ---------------------------- */
 $pages = [];
 $aclUser = $centreon->user->lcaTStr;
-if (! empty($aclUser)) {
+if ($aclUser !== '')) {
     $acls = array_flip(explode(',', $aclUser));
     /**
      * Transform [1, 2, 101, 202, 10101, 20201] to :

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -224,7 +224,7 @@ $form->addElement('select', 'contact_template_id', _("Contact template used"), $
 /* ------------------------ Topoogy ---------------------------- */
 $pages = [];
 $aclUser = $centreon->user->lcaTStr;
-if ($aclUser !== '')) {
+if ($aclUser !== '') {
     $acls = array_flip(explode(',', $aclUser));
     /**
      * Transform [1, 2, 101, 202, 10101, 20201] to :

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -244,7 +244,7 @@ if (! empty($aclUser)) {
         foreach (array_keys($topologies) as $page) {
             if (strlen($page) == 1) {
                 // MENU level 1
-                if (!array_key_exists($page, $parentsLvl)) {
+                if (! array_key_exists($page, $parentsLvl)) {
                     $parentsLvl[$page] = [];
                 }
             } elseif (strlen($page) == 3) {

--- a/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
@@ -242,12 +242,12 @@ if (! empty($aclUser)) {
 
         // Classify topologies by parents
         foreach (array_keys($topologies) as $page) {
-            if (strlen($page) == 1) {
+            if (strlen($page) === 1) {
                 // MENU level 1
                 if (! array_key_exists($page, $parentsLvl)) {
                     $parentsLvl[$page] = [];
                 }
-            } elseif (strlen($page) == 3) {
+            } elseif (strlen($page) === 3) {
                 // MENU level 2
                 $parentLvl1 = substr($page, 0, 1);
                 if (! array_key_exists($parentLvl1, $parentsLvl)) {
@@ -256,7 +256,7 @@ if (! empty($aclUser)) {
                 if (! array_key_exists($page, $parentsLvl[$parentLvl1])) {
                     $parentsLvl[$parentLvl1][$page] = [];
                 }
-            } elseif (strlen($page) == 5) {
+            } elseif (strlen($page) === 5) {
                 // MENU level 3
                 $parentLvl1 = substr($page, 0, 1);
                 $parentLvl2 = substr($page, 0, 3);
@@ -279,14 +279,12 @@ if (! empty($aclUser)) {
      * Check if at least one child can be shown
      */
     $oneChildCanBeShown = function () use (&$childrenLvl3, &$translatedPages): bool {
-        $isCanBeShow = false;
         foreach ($childrenLvl3 as $topologyPage) {
             if ($translatedPages[$topologyPage]['show']) {
-                $isCanBeShow = true;
-                break;
+              return true;
             }
         }
-        return $isCanBeShow;
+        return false;
     };
 
     $topologies = $createTopologyTree($acls);
@@ -349,7 +347,7 @@ if (! empty($aclUser)) {
             }
 
             // select parent from level 2 if level 3 is missing
-            $pageId = $parentLvl3 ?: $parentLvl2;
+            $pageId = $parentLvl3 ?? $parentLvl2;
 
             if (! $isThirdLevelMenu && $translatedPages[$pageId]['show']) {
                 /**


### PR DESCRIPTION
## Description

Define a default page, after login, for new users

- Add “Default page” from MyAccount to contact and contact template page
- Add “Default page” for user CLAPI configuration

**Fixes** # MON-7427

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

**Set default page for template UI**

1. configure a contact template with default page (custom views for example)
2. create a contact using this template
3. connect to centreon with contact
4. check that default page is correct

**Set default page for users using UI**

1. configure a contact with default page (custom views for example)
2. connect to centreon with contact
3. check that default page is correct

**Set default page for template CLAPI**

1. configure a default page parameter for a contact template

2. edit template using UI and validate change

**Set default page for users using CLAPI**

1. configure a default page parameter for a contact

2. edit contact using UI and validate change

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-7427]: https://centreon.atlassian.net/browse/MON-7427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ