### PR TITLE
improve contact_ldap_dn verification

### DIFF
--- a/centreon/www/class/centreonAuth.LDAP.class.php
+++ b/centreon/www/class/centreonAuth.LDAP.class.php
@@ -106,7 +106,7 @@ class CentreonAuthLDAP
      */
     public function checkPassword()
     {
-        if (!isset($this->contactInfos['contact_ldap_dn']) || (empty($this->contactInfos['contact_ldap_dn']))) {
+        if (!isset($this->contactInfos['contact_ldap_dn']) || empty($this->contactInfos['contact_ldap_dn'])) {
             $this->contactInfos['contact_ldap_dn'] = $this->ldap->findUserDn($this->contactInfos['contact_alias']);
         } elseif (
             ($userDn = $this->ldap->findUserDn($this->contactInfos['contact_alias']))

--- a/centreon/www/class/centreonAuth.LDAP.class.php
+++ b/centreon/www/class/centreonAuth.LDAP.class.php
@@ -106,7 +106,7 @@ class CentreonAuthLDAP
      */
     public function checkPassword()
     {
-        if (empty($this->contactInfos['contact_ldap_dn'])) {
+        if (!isset($this->contactInfos['contact_ldap_dn']) || (empty($this->contactInfos['contact_ldap_dn']))) {
             $this->contactInfos['contact_ldap_dn'] = $this->ldap->findUserDn($this->contactInfos['contact_alias']);
         } elseif (
             ($userDn = $this->ldap->findUserDn($this->contactInfos['contact_alias']))


### PR DESCRIPTION
## Description

When using a posix LDAP configuration (it may not be related to posix, just adding this detail just to be sure). If you use the auto import option. The contact_ldap_dn entry is not set instead of just being empty. This results in a fail authentication if the contact needs to be imported in Centreon.


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- I don't know if this issue is reproductible but the idea is to have a posix ldap configuration with auto import
- try to log in with a user from the ldap that is not yet in centreon
- it may fail

with the patch, it shouldn't

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
