### PR TITLE
fix codeowner for src folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 
 .snyk           @centreon/centreon-security
 
-**/src/                 @centreon/centreon-php
+/centreon/src/                 @centreon/centreon-php
 **/config/              @centreon/centreon-php
 **/composer.*           @centreon/centreon-php
 **/tests/api/           @centreon/centreon-php

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,6 @@
 
 .snyk           @centreon/centreon-security
 
-/centreon/src/                 @centreon/centreon-php
 **/config/              @centreon/centreon-php
 **/composer.*           @centreon/centreon-php
 **/tests/api/           @centreon/centreon-php


### PR DESCRIPTION
## Description
we try to fix the issue of assigning owners from "contreon/php" to "only frontend  PR"

the issue is showing in this PR 
https://github.com/centreon/centreon/pull/165#event-7843095018
![issue](https://user-images.githubusercontent.com/109956462/203027653-f2478bdc-b932-452a-a9f8-8f8c022aebd7.PNG)
 
## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
