### PR TITLE
[enh](ldap): add ldap connection timeout to avoid infinite connection

### DIFF
--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15362,6 +15362,12 @@ msgstr "No ha guardado los cambios, ¿quiere continuar?"
 #  msgid "Confirm"
 #  msgstr "Confirmar"
 
+#  msgid "Bad LDAP filter syntax"
+#  msgstr ""
+
+#  msgid "LDAP connection timeout"
+#  msgstr ""
+
 #  msgid "Vault configuration with these properties already exists"
 #  msgstr ""
 

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15362,7 +15362,7 @@ msgstr "No ha guardado los cambios, ¿quiere continuar?"
 #  msgid "Confirm"
 #  msgstr "Confirmar"
 
-#  msgid "Bad LDAP filter syntax"
+#  msgid "Incorrect LDAP filter syntax"
 #  msgstr ""
 
 #  msgid "LDAP connection timeout"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5661,6 +5661,12 @@ msgstr "Toutes les sessions de ce contact seront supprimées. Êtes-vous sûr de
 msgid "Synchronize LDAP"
 msgstr "Synchroniser avec le LDAP"
 
+msgid "Bad LDAP filter syntax"
+msgstr "Mauvaise syntaxe du filtre LDAP"
+
+msgid "LDAP connection timeout"
+msgstr "Délai d'attente de connexion LDAP"
+
 msgid "No LDAP configuration enabled !"
 msgstr "Aucune configuration LDAP active !"
 

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5661,7 +5661,7 @@ msgstr "Toutes les sessions de ce contact seront supprimées. Êtes-vous sûr de
 msgid "Synchronize LDAP"
 msgstr "Synchroniser avec le LDAP"
 
-msgid "Bad LDAP filter syntax"
+msgid "Incorrect LDAP filter syntax"
 msgstr "Mauvaise syntaxe du filtre LDAP"
 
 msgid "LDAP connection timeout"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15823,6 +15823,12 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 #  msgid "Confirm"
 #  msgstr "Confirme"
 
+#  msgid "Bad LDAP filter syntax"
+#  msgstr ""
+
+#  msgid "LDAP connection timeout"
+#  msgstr ""
+
 #  msgid "Vault configuration with these properties already exists"
 #  msgstr ""
 

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15823,7 +15823,7 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 #  msgid "Confirm"
 #  msgstr "Confirme"
 
-#  msgid "Bad LDAP filter syntax"
+#  msgid "Incorrect LDAP filter syntax"
 #  msgstr ""
 
 #  msgid "LDAP connection timeout"

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15811,7 +15811,7 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 #  msgid "Confirm"
 #  msgstr "Confirme"
 
-#  msgid "Bad LDAP filter syntax"
+#  msgid "Incorrect LDAP filter syntax"
 #  msgstr ""
 
 #  msgid "LDAP connection timeout"

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15811,6 +15811,13 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 #  msgid "Confirm"
 #  msgstr "Confirme"
 
+#  msgid "Bad LDAP filter syntax"
+#  msgstr ""
+
+#  msgid "LDAP connection timeout"
+#  msgstr ""
+
+
 #  msgid "Vault configuration with these properties already exists"
 #  msgstr ""
 

--- a/centreon/www/class/CentreonLDAPAdmin.class.php
+++ b/centreon/www/class/CentreonLDAPAdmin.class.php
@@ -68,6 +68,7 @@ class CentreonLdapAdmin
         $tab = array(
             'ldap_store_password',
             'ldap_auto_import',
+            'ldap_connection_timeout',
             'ldap_search_limit',
             'ldap_search_timeout',
             'ldap_contact_tmpl',

--- a/centreon/www/class/centreon-clapi/centreonLDAP.class.php
+++ b/centreon/www/class/centreon-clapi/centreonLDAP.class.php
@@ -79,6 +79,7 @@ class CentreonLDAP extends CentreonObject
             'ldap_contact_tmpl' => '',
             'ldap_default_cg' => '',
             'ldap_dns_use_domain' => '',
+            'ldap_connection_timeout' => '',
             'ldap_search_limit' => '',
             'ldap_search_timeout' => '',
             'ldap_srv_dns' => '',

--- a/centreon/www/class/centreonLDAP.class.php
+++ b/centreon/www/class/centreonLDAP.class.php
@@ -95,6 +95,12 @@ class CentreonLDAP
             $this->debugImport = false;
         }
 
+        $connectionTimeout = null;
+        $dbConnectionTimeout = $this->getLdapHostParameters($arId, 'ldap_connection_timeout');
+        if (!empty($dbConnectionTimeout['ari_value'])) {
+            $connectionTimeout = $dbConnectionTimeout['ari_value'];
+        }
+
         $searchTimeout = 5;
         $tempSearchTimeout = $this->getLdapHostParameters($arId, 'ldap_search_timeout');
         if (!empty($tempSearchTimeout['ari_value'])) {
@@ -120,6 +126,7 @@ class CentreonLDAP
                 $ldap = [
                     'host' => $entry['target'],
                     'id' => $arId,
+                    'connection_timeout' => $connectionTimeout,
                     'search_timeout' => $searchTimeout,
                     'info' => $this->getInfoUseDnsConnect(),
                 ];
@@ -137,6 +144,7 @@ class CentreonLDAP
                 $ldap = [
                     'host' => $row['host_address'],
                     'id' => $arId,
+                    'connection_timeout' => $connectionTimeout,
                     'search_timeout' => $searchTimeout,
                     'info' => $this->getInfoUseDnsConnect(),
                 ];
@@ -198,6 +206,9 @@ class CentreonLDAP
             $this->debug('LDAP Connect : trying url : ' . $url);
             $this->setErrorHandler();
             $this->ds = ldap_connect($url);
+            if (!empty($ldap['connection_timeout'])) {
+                ldap_set_option($this->ds, LDAP_OPT_NETWORK_TIMEOUT, $ldap['connection_timeout']);
+            }
             ldap_set_option($this->ds, LDAP_OPT_REFERRALS, 0);
             $protocol_version = 3;
             if (isset($ldap['info']['protocol_version'])) {

--- a/centreon/www/class/centreonLDAP.class.php
+++ b/centreon/www/class/centreonLDAP.class.php
@@ -97,7 +97,7 @@ class CentreonLDAP
 
         $connectionTimeout = null;
         $dbConnectionTimeout = $this->getLdapHostParameters($arId, 'ldap_connection_timeout');
-        if (!empty($dbConnectionTimeout['ari_value'])) {
+        if (! empty($dbConnectionTimeout['ari_value'])) {
             $connectionTimeout = $dbConnectionTimeout['ari_value'];
         }
 

--- a/centreon/www/class/centreonLDAP.class.php
+++ b/centreon/www/class/centreonLDAP.class.php
@@ -206,7 +206,7 @@ class CentreonLDAP
             $this->debug('LDAP Connect : trying url : ' . $url);
             $this->setErrorHandler();
             $this->ds = ldap_connect($url);
-            if (!empty($ldap['connection_timeout'])) {
+            if (! empty($ldap['connection_timeout'])) {
                 ldap_set_option($this->ds, LDAP_OPT_NETWORK_TIMEOUT, $ldap['connection_timeout']);
             }
             ldap_set_option($this->ds, LDAP_OPT_REFERRALS, 0);

--- a/centreon/www/include/Administration/parameters/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/DB-Func.php
@@ -492,6 +492,13 @@ function updateLdapConfigData($gopt_id = null)
     );
     updateOption(
         $pearDB,
+        "ldap_connection_timeout",
+        !empty($ret["ldap_connection_timeout"])
+            ? htmlentities($ret["ldap_connection_timeout"], ENT_QUOTES, "UTF-8")
+            : "NULL"
+    );
+    updateOption(
+        $pearDB,
         "ldap_search_timeout",
         isset($ret["ldap_search_timeout"]) && $ret["ldap_search_timeout"] != null
             ? htmlentities($ret["ldap_search_timeout"], ENT_QUOTES, "UTF-8") : "NULL"

--- a/centreon/www/include/Administration/parameters/ldap/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/ldap/DB-Func.php
@@ -58,13 +58,6 @@ function minimalValue(int $value): bool
  */
 function checkLdapFilterSyntax(string $filterValue): bool
 {
-    if (! preg_match('/=%s\)/', $filterValue)) {
-        return false;
-    }
-
-    if (! preg_match('/^(\s*\((?:[&|](?1)+|(?:!(?1))|[a-zA-Z][a-zA-Z0-9-]*[<>~]?=[^()]*)\s*\)\s*)$/', $filterValue)) {
-        return false;
-    }
-
-    return true;
+    return preg_match('/=%s\)/', $filterValue)
+        && preg_match('/^(\s*\((?:[&|](?1)+|(?:!(?1))|[a-zA-Z][a-zA-Z0-9-]*[<>~]?=[^()]*)\s*\)\s*)$/', $filterValue);
 }

--- a/centreon/www/include/Administration/parameters/ldap/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/ldap/DB-Func.php
@@ -58,7 +58,7 @@ function minimalValue(int $value): bool
  */
 function checkLdapFilterSyntax(string $filterValue): bool
 {
-    if (!preg_match('/=%s\)/', $filterValue)) {
+    if (! preg_match('/=%s\)/', $filterValue)) {
         return false;
     }
 

--- a/centreon/www/include/Administration/parameters/ldap/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/ldap/DB-Func.php
@@ -62,7 +62,7 @@ function checkLdapFilterSyntax(string $filterValue): bool
         return false;
     }
 
-    if (!preg_match('/^(\s*\((?:[&|](?1)+|(?:!(?1))|[a-zA-Z][a-zA-Z0-9-]*[<>~]?=[^()]*)\s*\)\s*)$/', $filterValue)) {
+    if (! preg_match('/^(\s*\((?:[&|](?1)+|(?:!(?1))|[a-zA-Z][a-zA-Z0-9-]*[<>~]?=[^()]*)\s*\)\s*)$/', $filterValue)) {
         return false;
     }
 

--- a/centreon/www/include/Administration/parameters/ldap/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/ldap/DB-Func.php
@@ -51,3 +51,20 @@ function minimalValue(int $value): bool
 
     return false;
 }
+
+/**
+ * @param string $filterValue
+ * @return bool
+ */
+function checkLdapFilterSyntax(string $filterValue): bool
+{
+    if (!preg_match('/=%s\)/', $filterValue)) {
+        return false;
+    }
+
+    if (!preg_match('/^(\s*\((?:[&|](?1)+|(?:!(?1))|[a-zA-Z][a-zA-Z0-9-]*[<>~]?=[^()]*)\s*\)\s*)$/', $filterValue)) {
+        return false;
+    }
+
+    return true;
+}

--- a/centreon/www/include/Administration/parameters/ldap/form.ihtml
+++ b/centreon/www/include/Administration/parameters/ldap/form.ihtml
@@ -12,6 +12,7 @@
 		<td class="FormRowField"><img class="helpTooltip" name="ldap_auto_import" /><span>{$form.ldap_auto_import.label}</span></td>
 		<td class="FormRowValue">{$form.ldap_auto_import.html}&nbsp;&nbsp;<input type="button" onClick="javascript:location.href='./main.get.php?p=60301&o=li'" class="btc bt_info" value='{$manualImport}'></td>
 	</tr>
+	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="ldap_connection_timeout" /><span>{$form.ldap_connection_timeout.label}</span></td><td class="FormRowValue">{$form.ldap_connection_timeout.html}</td></tr>
 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ldap_search_limit" /><span>{$form.ldap_search_limit.label}</span></td><td class="FormRowValue">{$form.ldap_search_limit.html}</td></tr>
 	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="ldap_search_timeout" /><span>{$form.ldap_search_timeout.label}</span></td><td class="FormRowValue">{$form.ldap_search_timeout.html}</td></tr>
 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ldap_contact_tmpl" /><span>{$form.ldap_contact_tmpl.label}</span></td><td class="FormRowValue">{$form.ldap_contact_tmpl.html}{if $o != 'w'}&nbsp;

--- a/centreon/www/include/Administration/parameters/ldap/form.php
+++ b/centreon/www/include/Administration/parameters/ldap/form.php
@@ -182,7 +182,7 @@ $form->registerRule('checkLdapFilter', 'callback', 'checkLdapFilterSyntax');
 $form->addElement('text', 'user_base_search', _("Search user base DN"), $attrsText);
 $form->addElement('text', 'group_base_search', _("Search group base DN"), $attrsText);
 $form->addElement('text', 'user_filter', _("User filter"), $attrsText);
-$form->addRule('user_filter', _("Bad LDAP filter syntax"), 'checkLdapFilter');
+$form->addRule('user_filter', _("Incorrect LDAP filter syntax"), 'checkLdapFilter');
 $form->addElement('text', 'alias', _("Login attribute"), $attrsText);
 $form->addElement('text', 'user_group', _("User group attribute"), $attrsText);
 $form->addElement('text', 'user_name', _("User displayname attribute"), $attrsText);
@@ -191,7 +191,7 @@ $form->addElement('text', 'user_lastname', _("User lastname attribute"), $attrsT
 $form->addElement('text', 'user_email', _("User email attribute"), $attrsText);
 $form->addElement('text', 'user_pager', _("User pager attribute"), $attrsText);
 $form->addElement('text', 'group_filter', _("Group filter"), $attrsText);
-$form->addRule('group_filter', _("Bad LDAP filter syntax"), 'checkLdapFilter');
+$form->addRule('group_filter', _("Incorrect LDAP filter syntax"), 'checkLdapFilter');
 $form->addElement('text', 'group_name', _("Group attribute"), $attrsText);
 $form->addElement('text', 'group_member', _("Group member attribute"), $attrsText);
 

--- a/centreon/www/include/Administration/parameters/ldap/form.php
+++ b/centreon/www/include/Administration/parameters/ldap/form.php
@@ -98,6 +98,7 @@ $form->addGroup($ldapUseDns, 'ldap_srv_dns', _("Use service DNS"), '&nbsp;');
 
 $form->addElement('text', 'ldap_dns_use_domain', _("Alternative domain for ldap"), $attrsText);
 
+$form->addElement('text', 'ldap_connection_timeout', _('LDAP connection timeout'), $attrsText2);
 $form->addElement('text', 'ldap_search_limit', _('LDAP search size limit'), $attrsText2);
 $form->addElement('text', 'ldap_search_timeout', _('LDAP search timeout'), $attrsText2);
 
@@ -177,9 +178,11 @@ $form->addElement(
     array('0' => "", 'Active Directory' => _("Active Directory"), 'Okta' => _("Okta"), 'Posix' => _("Posix")),
     array('id' => 'ldap_template', 'onchange' => 'applyTemplate(this.value);')
 );
+$form->registerRule('checkLdapFilter', 'callback', 'checkLdapFilterSyntax');
 $form->addElement('text', 'user_base_search', _("Search user base DN"), $attrsText);
 $form->addElement('text', 'group_base_search', _("Search group base DN"), $attrsText);
 $form->addElement('text', 'user_filter', _("User filter"), $attrsText);
+$form->addRule('user_filter', _("Bad LDAP filter syntax"), 'checkLdapFilter');
 $form->addElement('text', 'alias', _("Login attribute"), $attrsText);
 $form->addElement('text', 'user_group', _("User group attribute"), $attrsText);
 $form->addElement('text', 'user_name', _("User displayname attribute"), $attrsText);
@@ -188,6 +191,7 @@ $form->addElement('text', 'user_lastname', _("User lastname attribute"), $attrsT
 $form->addElement('text', 'user_email', _("User email attribute"), $attrsText);
 $form->addElement('text', 'user_pager', _("User pager attribute"), $attrsText);
 $form->addElement('text', 'group_filter', _("Group filter"), $attrsText);
+$form->addRule('group_filter', _("Bad LDAP filter syntax"), 'checkLdapFilter');
 $form->addElement('text', 'group_name', _("Group attribute"), $attrsText);
 $form->addElement('text', 'group_member', _("Group member attribute"), $attrsText);
 
@@ -217,6 +221,7 @@ $defaultOpt = array(
     'ldap_dns_use_tls' => '0',
     'ldap_contact_tmpl' => '0',
     'ldap_default_cg' => '0',
+    'ldap_connection_timeout' => '5',
     'ldap_search_limit' => '60',
     'ldap_auto_sync' => '1', // synchronization on user's login is enabled by default
     'ldap_sync_interval' => '1', // minimal value of the interval between two LDAP synchronizations

--- a/centreon/www/include/Administration/parameters/ldap/help.php
+++ b/centreon/www/include/Administration/parameters/ldap/help.php
@@ -23,6 +23,7 @@ $help['ldap_srv_dns'] = dgettext('help', 'Use the DNS service for get LDAP host'
 $help['ldap_srv_dns_ssl'] = dgettext('help', 'Enable SSL connection');
 $help['ldap_srv_dns_tls'] = dgettext('help', 'Enable TLS connection');
 $help['ldap_dns_use_domain'] = dgettext('help', 'Set the domain for search the service');
+$help['ldap_connection_timeout'] = dgettext('help', 'Connection timeout');
 $help['ldap_search_limit'] = dgettext('help', 'Search size limit');
 $help['ldap_search_timeout'] = dgettext('help', 'Search timeout');
 $help['ldapConf'] = dgettext(

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -75,6 +75,7 @@ INSERT INTO `options` (`key`, `value`) VALUES
 ('ldap_auth_enable', '0'),
 ('ldap_auto_import', '0'),
 ('ldap_srv_dns', '0'),
+('ldap_connection_timeout','5'),
 ('ldap_dns_use_domain', ''),
 ('ldap_search_timeout','60'),
 ('ldap_search_limit','60'),

--- a/centreon/www/install/php/Update-22.10.0-beta.1.php
+++ b/centreon/www/install/php/Update-22.10.0-beta.1.php
@@ -111,12 +111,6 @@ try {
     $errorMessage = "Unable to delete 'appKey' information from database";
     $pearDB->query("DELETE FROM `informations` WHERE `key` = 'appKey'");
 
-    $errorMessage = "Unable to add default ldap connection timeout";
-    $pearDB->query(
-        "INSERT INTO auth_ressource_info (ar_id, ari_name, ari_value)
-        (SELECT ar_id, 'ldap_connection_timeout', '' FROM auth_ressource)"
-    );
-
     $errorMessage = "Impossible to add new BBDO streams";
     createBbdoStreamConfigurationForms($pearDB);
 

--- a/centreon/www/install/php/Update-22.10.0-beta.1.php
+++ b/centreon/www/install/php/Update-22.10.0-beta.1.php
@@ -111,6 +111,12 @@ try {
     $errorMessage = "Unable to delete 'appKey' information from database";
     $pearDB->query("DELETE FROM `informations` WHERE `key` = 'appKey'");
 
+    $errorMessage = "Unable to add default ldap connection timeout";
+    $pearDB->query(
+        "INSERT INTO auth_ressource_info (ar_id, ari_name, ari_value)
+        (SELECT ar_id, 'ldap_connection_timeout', '' FROM auth_ressource)"
+    );
+
     $errorMessage = "Impossible to add new BBDO streams";
     createBbdoStreamConfigurationForms($pearDB);
 

--- a/centreon/www/install/php/Update-23.04.0-beta.1.php
+++ b/centreon/www/install/php/Update-23.04.0-beta.1.php
@@ -89,10 +89,14 @@ try {
         WHERE `PathName_js` = './include/common/javascript/color_picker_mb.js'"
     );
 
+
+    // Transactional queries
+    $pearDB->beginTransaction();
+
     // check if entry ldap_connection_timeout exist
     $query = $pearDB->query("SELECT * FROM auth_ressource_info WHERE ari_name = 'ldap_connection_timeout'");
     $ldapResult = $query->fetchAll(PDO::FETCH_ASSOC);
-// insert entry ldap_connection_timeout  with default value
+    // insert entry ldap_connection_timeout  with default value
     if (! $ldapResult) {
         $errorMessage = "Unable to add default ldap connection timeout";
         $pearDB->query(
@@ -100,9 +104,6 @@ try {
                         (SELECT ar_id, 'ldap_connection_timeout', '' FROM auth_ressource)"
         );
     }
-
-    // Transactional queries
-    $pearDB->beginTransaction();
 
     $errorMessage = 'Unable to update illegal characters fields from engine configuration of pollers';
     $decodeIllegalCharactersNagios($pearDB);

--- a/centreon/www/install/php/Update-23.04.0-beta.1.php
+++ b/centreon/www/install/php/Update-23.04.0-beta.1.php
@@ -90,7 +90,7 @@ try {
     );
 
     // check if entry ldap_connection_timeout exist
-    $query = $pearDB->query("SELECT * FROM auth_ressource_info WHERE ari_name = 'ldap_connection_timeout' and ari_value != ''");
+    $query = $pearDB->query("SELECT * FROM auth_ressource_info WHERE ari_name = 'ldap_connection_timeout'");
     $ldapResult = $query->fetchAll(PDO::FETCH_ASSOC);
 // insert entry ldap_connection_timeout  with default value
     if (! $ldapResult) {

--- a/centreon/www/install/php/Update-23.04.0-beta.1.php
+++ b/centreon/www/install/php/Update-23.04.0-beta.1.php
@@ -89,6 +89,18 @@ try {
         WHERE `PathName_js` = './include/common/javascript/color_picker_mb.js'"
     );
 
+    // check if entry ldap_connection_timeout exist
+    $query = $pearDB->query("SELECT * FROM auth_ressource_info WHERE ari_name = 'ldap_connection_timeout' and ari_value != ''");
+    $ldapResult = $query->fetchAll(PDO::FETCH_ASSOC);
+// insert entry ldap_connection_timeout  with default value
+    if (! $ldapResult) {
+        $errorMessage = "Unable to add default ldap connection timeout";
+        $pearDB->query(
+            "INSERT INTO auth_ressource_info (ar_id, ari_name, ari_value)
+                        (SELECT ar_id, 'ldap_connection_timeout', '' FROM auth_ressource)"
+        );
+    }
+
     // Transactional queries
     $pearDB->beginTransaction();
 


### PR DESCRIPTION
## Description

add default connection-timeout value to avoid infinit loop

Also the hard coded timeout should be a parameter that can be defined in the LDAP form

**Fixes** # MON-3511

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Go to ‘Administration > Parameters > LDAP’
2. Add an incorrect LDAP configuration (host or port) but enable it with timeout value (5 for example)
3. Check /var/log/centreon/ldap.log
4. Try to connect with login/user
5. Check in log that a timeout is this defined (5 seconds)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-3511]: https://centreon.atlassian.net/browse/MON-3511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ