### PR TITLE
fix(security): Fix path transversal to display images in configuration

### DIFF
--- a/centreon/www/include/common/getHiddenImage.php
+++ b/centreon/www/include/common/getHiddenImage.php
@@ -56,13 +56,14 @@ if (isset($_GET["id"]) && $_GET["id"] && is_numeric($_GET["id"])) {
     $statement->bindValue(':img_id', $_GET["id"], \PDO::PARAM_INT);
     $statement->execute();
     while ($img = $statement->fetch(\PDO::FETCH_ASSOC)) {
-        $imgpath = $logos_path . $img["dir_name"] . "/" . $img["img_path"];
-        if (!is_file($imgpath)) {
-            $imgpath = _CENTREON_PATH_ . 'www/img/media/' . $img["dir_name"] . "/" . $img["img_path"];
+        $imgDirName = basename($img["dir_name"]);
+        $imgName = basename($img["img_path"]);
+        $imgPath = $logos_path . $imgDirName . "/" . $imgName;
+        if (!is_file($imgPath)) {
+            $imgPath = _CENTREON_PATH_ . 'www/img/media/' . $imgDirName . "/" . $imgName;
         }
-
-        if (is_file($imgpath)) {
-            $fd = fopen($imgpath, "r");
+        if (is_file($imgPath)) {
+            $fd = fopen($imgPath, "r");
             $buffer = null;
             while (!feof($fd)) {
                 $buffer .= fgets($fd, 4096);


### PR DESCRIPTION
## Description

Sanitized paths when displaying images in configuration
File: centreon/www/include/common/getHiddenImage.php

**Fixes** # MON-15880

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Go to “Configuration > Services > Categories”
2. Edit/create a category
3. Enable “Severity type”
4. Add an icon
5. Check if icon is displayed

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
