### PR TITLE
enh(openid): handle absolute url for token endpoint

### DIFF
--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -734,12 +734,15 @@ class OpenIdProvider implements OpenIdProviderInterface
             $data["client_secret"] = $customConfiguration->getClientSecret();
         }
 
+        $url = str_starts_with($customConfiguration->getTokenEndpoint(), '/')
+            ? $customConfiguration->getBaseUrl() . $customConfiguration->getTokenEndpoint()
+            : $customConfiguration->getTokenEndpoint();
+
         // Send the request to IDP
         try {
             return $this->client->request(
                 'POST',
-                $customConfiguration->getBaseUrl() . '/' .
-                ltrim($customConfiguration->getTokenEndpoint(), '/'),
+                $url,
                 [
                     'headers' => $headers,
                     'body' => $data,


### PR DESCRIPTION
## Description

This PR intends to handle absolute url for token endpoint

**Fixes** # MON-15735

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Configure an openid configuration
- set an absolute url as Token endpoint
- Save the form
- Connect using openid
- User should be authenticated

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
