### PR TITLE
fix wrong data structure for close ticket

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/class/automatic.class.php
@@ -689,8 +689,12 @@ class Automatic
         $rv = ['code' => 0, 'message' => 'no ticket found for host: ' . $host['name']];
 
         if ($ticketId) {
+            $closeTicketData = [
+                $ticketId => []
+            ];
+
             try {
-                $providerClass->closeTicket([$ticketId]);
+                $providerClass->closeTicket($closeTicketData);
                 $this->changeMacroHost($macroName, $host);
                 $rv = ['code' => 0, 'message' => 'ticket ' . $ticketId . ' has been closed'];
             } catch (Exception $e) {
@@ -717,11 +721,15 @@ class Automatic
         $ticketId = $this->getServiceTicket($params, $macroName);
 
         $rv = ['code' => 0, 'message' => 'no ticket found for service: '
-               . $service['host_name'] . " " . $service['description']];
+            . $service['host_name'] . " " . $service['description']];
 
         if ($ticketId) {
+            $closeTicketData = [
+                $ticketId => []
+            ];
+
             try {
-                $providerClass->closeTicket([$ticketId]);
+                $providerClass->closeTicket($closeTicketData);
                 $this->changeMacroService($macroName, $service);
                 $rv = ['code' => 0, 'message' => 'ticket ' . $ticketId . ' has been closed'];
             } catch (Exception $e) {


### PR DESCRIPTION
## Description

when you use the api to close a ticket with your provider, it will fail. This is caused by a wrong data structure that is sent to the provider

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- have a working open ticket provider
- open a ticket
- close the ticket using the open ticket api

without this patch, it won't work. With it, it will work fine

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
