### PR TITLE
fix(security): Fix path transversal when user change default image directory

### DIFF
--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -252,17 +252,17 @@ try {
             "FROM `view_img`, `view_img_dir`, `view_img_dir_relation` " .
             "WHERE dir_dir_parent_id = dir_id AND img_img_id = img_id"
         );
-        $NagiosPathImg = basename($centreon->optGen["nagios_path_img"]);
+        $nagiosPathImg = basename($centreon->optGen["nagios_path_img"]);
         while ($images = $DBRESULT_imgs->fetchrow()) {
             $dirAlias = basename($images["dir_alias"]);
             $imgName = basename($images["img_path"]);
-            if (!is_dir($NagiosPathImg . "/" . $dirAlias)) {
-                $mkdirResult = @mkdir($NagiosPathImg . "/" . $dirAlias);
+            if (!is_dir($nagiosPathImg . "/" . $dirAlias)) {
+                $mkdirResult = @mkdir($nagiosPathImg . "/" . $dirAlias);
             }
             if (file_exists(_CENTREON_PATH_ . "www/img/media/" . $dirAlias . "/" . $imgName)) {
                 $copyResult = @copy(
                     _CENTREON_PATH_ . "www/img/media/" . $dirAlias . "/" . $imgName,
-                    $NagiosPathImg . "/" . $dirAlias . "/" . $imgName
+                    $nagiosPathImg . "/" . $dirAlias . "/" . $imgName
                 );
             }
         }

--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -252,14 +252,17 @@ try {
             "FROM `view_img`, `view_img_dir`, `view_img_dir_relation` " .
             "WHERE dir_dir_parent_id = dir_id AND img_img_id = img_id"
         );
+        $NagiosPathImg = basename($centreon->optGen["nagios_path_img"]);
         while ($images = $DBRESULT_imgs->fetchrow()) {
-            if (!is_dir($centreon->optGen["nagios_path_img"] . "/" . $images["dir_alias"])) {
-                $mkdirResult = @mkdir($centreon->optGen["nagios_path_img"] . "/" . $images["dir_alias"]);
+            $dirAlias = basename($images["dir_alias"]);
+            $imgName = basename($images["img_path"]);
+            if (!is_dir($NagiosPathImg . "/" . $dirAlias)) {
+                $mkdirResult = @mkdir($NagiosPathImg . "/" . $dirAlias);
             }
-            if (file_exists(_CENTREON_PATH_ . "www/img/media/" . $images["dir_alias"] . "/" . $images["img_path"])) {
+            if (file_exists(_CENTREON_PATH_ . "www/img/media/" . $dirAlias . "/" . $imgName)) {
                 $copyResult = @copy(
-                    _CENTREON_PATH_ . "www/img/media/" . $images["dir_alias"] . "/" . $images["img_path"],
-                    $centreon->optGen["nagios_path_img"] . "/" . $images["dir_alias"] . "/" . $images["img_path"]
+                    _CENTREON_PATH_ . "www/img/media/" . $dirAlias . "/" . $imgName,
+                    $NagiosPathImg . "/" . $dirAlias . "/" . $imgName
                 );
             }
         }


### PR DESCRIPTION
## Description
Sanitized paths when image directory changes
File: centreon/www/include/configuration/configGenerate/xml/moveFiles.php

**Fixes** # MON-15881

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. add an image to an host
2. change image directory (“Administration  >  Parameters  >  Monitoring”)
3. upload a new image and add it to a new host
4. deploy configuration
5. You must see both image associated to hosts in “Monitoring > Resources Status”

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
