### PR TITLE
Fix(security): fix path transversal for images management

### DIFF
--- a/centreon/www/class/centreonImageManager.php
+++ b/centreon/www/class/centreonImageManager.php
@@ -154,6 +154,8 @@ class CentreonImageManager extends centreonFileManager
         }
         // Create directory if not exist
         if ($img_info['dir_alias'] != $this->destinationDir) {
+            $img_info["img_path"] = basename($img_info["img_path"]);
+            $img_info["dir_alias"] = basename($img_info["dir_alias"]);
             $old = $this->mediaPath . $img_info['dir_alias'] . '/' . $img_info["img_path"];
             $new = $this->mediaPath . $this->destinationDir . '/' . $img_info["img_path"];
             $this->moveImage($old, $new);

--- a/centreon/www/class/centreonMedia.class.php
+++ b/centreon/www/class/centreonMedia.class.php
@@ -180,7 +180,7 @@ class CentreonMedia
     {
         $mediaDirectory = $this->getMediaDirectory();
 
-        $fullPath = $mediaDirectory . '/' . $dirname;
+        $fullPath = $mediaDirectory . '/' . basename($dirname);
 
         // Create directory and nested folder structure
         if (! is_dir($fullPath)) {

--- a/centreon/www/include/options/media/images/DB-Func.php
+++ b/centreon/www/include/options/media/images/DB-Func.php
@@ -228,8 +228,6 @@ function moveImg($img_id, $dir_alias)
         $dir_alias = $image_info_dir_alias;
     }
     if ($dir_alias != $img_info["dir_alias"]) {
-
-
         $oldpath = $mediadir . $image_info_dir_alias . "/" . $image_info_path;
         $newpath = $mediadir . $dir_alias . "/" . $image_info_path;
 


### PR DESCRIPTION
## Description

Sanitized paths for images management in : 
- centreon/www/include/options/media/images/DB-Func.php
- centreon/www/class/centreonMedia.class.php
- centreon/www/class/centreonImageManager.php
**Fixes** # MON-15878

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Add a new image into a new directory and validate that image have been uploaded into Centreon
- Delete last image from a directory and validate that image have been deleted and also empty directory
` ls /usr/share/centreon/www/img/media/`
- Rename image and check that image have been renamed

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
