### PR TITLE
Cannot drag'n drop columns when listing is scrolled (backport)

### DIFF
--- a/centreon/packages/ui/src/Listing/Header/index.tsx
+++ b/centreon/packages/ui/src/Listing/Header/index.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
 import { equals, find, isEmpty, map, not, pick, propEq } from 'ramda';
-import { DraggableSyntheticListeners, rectIntersection } from '@dnd-kit/core';
-import { rectSortingStrategy } from '@dnd-kit/sortable';
+import { closestCenter, DraggableSyntheticListeners } from '@dnd-kit/core';
+import { horizontalListSortingStrategy } from '@dnd-kit/sortable';
 
 import {
   TableHead,
@@ -179,11 +179,11 @@ const ListingHeader = ({
           updateSortableItemsOnItemsChange
           Content={Content}
           additionalProps={[sortField, sortOrder]}
-          collisionDetection={rectIntersection}
+          collisionDetection={closestCenter}
           itemProps={['id']}
           items={visibleColumns}
           memoProps={memoProps}
-          sortingStrategy={rectSortingStrategy}
+          sortingStrategy={horizontalListSortingStrategy}
           onDragEnd={({ items }): void => {
             onSelectColumns?.(items);
           }}


### PR DESCRIPTION
## Description

fix column sorting on scroll down in the listing component

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1.Go to Resources Status
2.Display several lines to display scroll bar
3.Scroll
4.Try to change columns order

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
