### PR TITLE
Fix(security): handle path security in centreon broker statistics

### DIFF
--- a/centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+++ b/centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
@@ -154,6 +154,10 @@ function createArrayStats($arrayFromJson)
 
 function parseStatsFile($statfile)
 {
+    //handle path traversal vulnerability
+    if (strpos($statfile, '..') !== false) {
+        throw new Exception('Path traversal found');
+    }
     $jsonc_content = file_get_contents($statfile);
     $json_stats = json_decode($jsonc_content, true);
 
@@ -309,7 +313,7 @@ try {
     $perf_info = array();
     $perf_err = array();
     while ($row = $stmt->fetch()) {
-        $statsfile = $row['cache_directory'] . '/' . $row['config_name'] . '-stats.json';
+        $statsfile = $row['cache_directory'] . '/' . basename($row['config_name']) . '-stats.json';
         if ($defaultPoller != $selectedPoller) {
             $statsfile = _CENTREON_CACHEDIR_ . '/broker-stats/' . $selectedPoller . '/' . $row['config_name'] . '.json';
         }


### PR DESCRIPTION
## Description

Sanitized path when displaying Centreon Broker statistics
File: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php

**Fixes** # MON-15882

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to “Administration > Platform Status > Broker Statistics ”
- Check that information is displayed

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
