### PR TITLE
fix(conf) fix broker conf export and form translation

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17202,3 +17202,6 @@ msgstr "Impossible de créer la configuration du coffre-fort"
 
 msgid "Vault provider does not exist"
 msgstr "Le fournisseur de coffre-fort n'existe pas"
+
+msgid "Event queues maximum total size"
+msgstr "Taille maximale de l’ensemble des queues d'évènements"

--- a/centreon/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
+++ b/centreon/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
@@ -752,6 +752,11 @@ class CentreonCentbrokerCfg extends CentreonObject
                 . $element['config_name'] . $this->delim
                 . "pool_size" . $this->delim
                 . $poolSize . "\n";
+            echo $this->action . $this->delim
+                . "SETPARAM" . $this->delim
+                . $element['config_name'] . $this->delim
+                . "event_queues_total_size" . $this->delim
+                . ($element['event_queues_total_size'] ?? '') . "\n";
             $sql = "SELECT config_key, config_value, config_group, config_group_id
             		FROM cfg_centreonbroker_info
             		WHERE config_id = ?


### PR DESCRIPTION
## Description

New input event_queues_total_max_size was not exported with clapi, and label was not translated in UI form

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
