### PR TITLE
enh(resources): reduce performance issue for user under ACL

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/Repository/ResourceACLProviders/HostACLProvider.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/ResourceACLProviders/HostACLProvider.php
@@ -27,10 +27,21 @@ use Core\Domain\RealTime\Model\ResourceTypes\HostResourceType;
 
 class HostACLProvider implements ResourceACLProviderInterface
 {
+    /**
+     * @inheritDoc
+     */
     public function getACLSubRequest(): string
     {
         $requestPattern = 'resources.type = %d AND resources.id = acl.host_id AND acl.service_id IS NULL';
 
         return sprintf($requestPattern, HostResourceType::TYPE_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function usesIndex(): bool
+    {
+        return false;
     }
 }

--- a/centreon/src/Core/Resources/Infrastructure/Repository/ResourceACLProviders/MetaServiceACLProvider.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/ResourceACLProviders/MetaServiceACLProvider.php
@@ -27,10 +27,21 @@ use Core\Domain\RealTime\Model\ResourceTypes\MetaServiceResourceType;
 
 class MetaServiceACLProvider implements ResourceACLProviderInterface
 {
+    /**
+     * @inheritDoc
+     */
     public function getACLSubRequest(): string
     {
         $requestPattern = 'resources.type = %d AND resources.parent_id = acl.host_id AND resources.id = acl.service_id';
 
         return sprintf($requestPattern, MetaServiceResourceType::TYPE_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function usesIndex(): bool
+    {
+        return true;
     }
 }

--- a/centreon/src/Core/Resources/Infrastructure/Repository/ResourceACLProviders/ResourceACLProviderInterface.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/ResourceACLProviders/ResourceACLProviderInterface.php
@@ -25,5 +25,17 @@ namespace Core\Resources\Infrastructure\Repository\ResourceACLProviders;
 
 interface ResourceACLProviderInterface
 {
+    /**
+     * Returns the ACL sub request for a given resource type
+     *
+     * @return string
+     */
     public function getACLSubRequest(): string;
+
+    /**
+     * Indicates is sub request matches indexation pattern
+     *
+     * @return bool
+     */
+    public function usesIndex(): bool;
 }

--- a/centreon/src/Core/Resources/Infrastructure/Repository/ResourceACLProviders/ServiceACLProvider.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/ResourceACLProviders/ServiceACLProvider.php
@@ -27,10 +27,21 @@ use Core\Domain\RealTime\Model\ResourceTypes\ServiceResourceType;
 
 class ServiceACLProvider implements ResourceACLProviderInterface
 {
+    /**
+     * @inheritDoc
+     */
     public function getACLSubRequest(): string
     {
         $requestPattern = 'resources.type = %d AND resources.parent_id = acl.host_id AND resources.id = acl.service_id';
 
         return sprintf($requestPattern, ServiceResourceType::TYPE_ID);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function usesIndex(): bool
+    {
+        return true;
     }
 }


### PR DESCRIPTION
This PR intends to address performance issues on Resource Status page.
Issue was that a subpart of the ACL request was not using the indexation (for the hosts). 

Tests played bellow were done on a platform with the following load

<img width="655" alt="image" src="https://user-images.githubusercontent.com/31647811/204662283-5756bb69-4fe6-423f-befa-77370c7e0a17.png">

Without  the patch for an user under basic ACL

<img width="1418" alt="image" src="https://user-images.githubusercontent.com/31647811/204663213-18116884-1284-48b2-abcd-c7c9d5811169.png">

With the patch for an user under basic ACL

<img width="1330" alt="image" src="https://user-images.githubusercontent.com/31647811/204663322-0c84badf-add4-4812-94c0-75070be8b3b9.png">

Results are the same. Tests were done using different LIMIT(s) / filter types and so on. Performance gets improved for each use cases.

**Although this patch needs to be discussed with PHP backend Team as it is not optimal.**

Indexed tagged iterator / tagged iterator with priority could be used instead to somehow identify ACL subrequests that uses the indexation pattern or not.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
