### PR TITLE
fix(test) remove api version

### DIFF
--- a/centreon/tests/api/features/ConfigurationAccessGroups.feature
+++ b/centreon/tests/api/features/ConfigurationAccessGroups.feature
@@ -8,7 +8,7 @@ Feature: List Access Group API
 
   Scenario: List Access Groups as an admin user
     Given I am logged in
-    And the endpoints are described in Centreon Web API documentation (version: 22.10)
+    And the endpoints are described in Centreon Web API documentation
 
     When I send a GET request to '/api/latest/configuration/access-groups'
     Then the response code should be "200"

--- a/centreon/tests/api/features/ConfigurationContactTemplates.feature
+++ b/centreon/tests/api/features/ConfigurationContactTemplates.feature
@@ -8,7 +8,7 @@ Feature: List Contact Templates API
 
   Scenario: List Contact Templates as an admin user
     Given I am logged in
-    And the endpoints are described in Centreon Web API documentation (version: 22.10)
+    And the endpoints are described in Centreon Web API documentation
 
     When I send a GET request to '/api/latest/configuration/contacts/templates'
     Then the response code should be "200"


### PR DESCRIPTION
## Description

Fix behat error as doc api in 22.10 doesn't exist anymore in develop branch 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
