### PR TITLE
fix(secu): Fix path transversal in centreon.Config.Poller.class.php

### DIFF
--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -405,7 +405,8 @@ class CentreonConfigPoller
         $this->testPollerId($variables);
 
         $poller_id = $this->getPollerId($variables);
-
+        //sanitize poller id against traversal path vulnerability
+        $poller_id = basename($poller_id);
         $config_generate->configPollerFromId($poller_id, $login);
 
         /* Change files owner */
@@ -510,10 +511,18 @@ class CentreonConfigPoller
             /* Change files owner */
             if ($apacheUser != "") {
                 foreach (glob($Nagioscfg["cfg_dir"] . '/*.{json,cfg}', GLOB_BRACE) as $file) {
+                    //handle path traversal vulnerability
+                    if (strpos($file, '..') !== false) {
+                        throw new Exception('Path traversal found');
+                    }
                     @chown($file, $apacheUser);
                     @chgrp($file, $apacheUser);
                 }
                 foreach (glob($Nagioscfg["cfg_dir"] . "/*.DEBUG") as $file) {
+                    //handle path traversal vulnerability
+                    if (strpos($file, '..') !== false) {
+                        throw new Exception('Path traversal found');
+                    }
                     @chown($file, $apacheUser);
                     @chgrp($file, $apacheUser);
                 }
@@ -559,6 +568,10 @@ class CentreonConfigPoller
                 /* Change files owner */
                 if ($apacheUser != "") {
                     foreach (glob(rtrim($centreonBrokerDirCfg, "/") . "/" . "/*.{xml,json,cfg}", GLOB_BRACE) as $file) {
+                        //handle path traversal vulnerability
+                        if (strpos($file, '..') !== false) {
+                            throw new Exception('Path traversal found');
+                        }
                         @chown($file, $apacheUser);
                         @chgrp($file, $apacheUser);
                     }
@@ -693,6 +706,10 @@ class CentreonConfigPoller
             mkdir("{$trapdPath}/{$pollerId}");
         }
         $filename = "{$trapdPath}/{$pollerId}/centreontrapd.sdb";
+        //handle path traversal vulnerability
+        if (strpos($filename, '..') !== false) {
+            throw new Exception('Path traversal found');
+        }
         passthru("$centreonDir/bin/generateSqlLite '{$pollerId}' '{$filename}' 2>&1");
         exec("echo 'SYNCTRAP:" . $pollerId . "' >> " . $this->centcore_pipe, $stdout, $return);
         return $return;


### PR DESCRIPTION
## Description

Sanitized paths when generating configuration using CLAPI
File: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
**Fixes** # MON-15877

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Install a central and a poller
2. Configure SNMP traps for a resource on a distant poller
3. Generate configuration using:
 `centreon -u admin -p 'centreon' -a APPLYCFG -v <POLLER_ID>`
4. Check if files are copied into /etc/centreon-engine directory
5. Check if files are copied into /etc/centreon-broker directory
6. Check if /etc/snmp/centreon_traps/centreontrapd.sdb file is present

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
