### PR TITLE
enh(ceip): Improved retrieving of OS name and version

### DIFF
--- a/centreon/www/class/centreonVersion.class.php
+++ b/centreon/www/class/centreonVersion.class.php
@@ -155,28 +155,16 @@ class CentreonVersion
      */
     public function getVersionSystem()
     {
-        $data = array();
+        $data = [];
 
         if (function_exists("shell_exec") && is_readable("/etc/os-release")) {
             $result = shell_exec('cat /etc/os-release');
-            // Get keys
-            $listOfKeys = preg_match_all('/.*=/', $result, $matches);
-            $listOfKeys = $matches[0];
-            // Get values
-            $listOfValues = preg_match_all('/=.*/', $result, $matches);
-            $listOfValues = $matches[0];
-            // Remove "=" symbol and apply lower case
-            array_walk($listOfKeys, function(&$v, $k){
-                $v = strtolower(str_replace('=', '', $v));
-            });
-            array_walk($listOfValues, function(&$v, $k){
-                $v = preg_replace('/=|"/', '', $v);
-            });
-            // Create array with keys/values
-            $result = array_combine($listOfKeys, $listOfValues);
 
-            $data['OS_name'] = $result['name'];
-            $data['OS_version'] = $result['version_id'];
+            preg_match_all('/(.*)="?(.*)"?/', $result, $matches, PREG_PATTERN_ORDER);
+            $osRelease = array_combine($matches[1], $matches[2]);
+
+            $data['OS_name'] = $osRelease['NAME'];
+            $data['OS_version'] = $osRelease['VERSION_ID'];
         }
 
         return $data;

--- a/centreon/www/class/centreonVersion.class.php
+++ b/centreon/www/class/centreonVersion.class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2005-2018 Centreon
+ * Copyright 2005-2023 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -157,14 +157,28 @@ class CentreonVersion
     {
         $data = array();
 
-        // Get OS version
         if (function_exists("shell_exec") && is_readable("/etc/os-release")) {
-            $os = shell_exec('cat /etc/os-release');
-            if (preg_match_all('/ID=?"(.*)?"/', $os, $matches)) {
-                $data['OS_name'] = $matches[1][0];
-                $data['OS_version'] = $matches[1][1];
-            }
+            $result = shell_exec('cat /etc/os-release');
+            // Get keys
+            $listOfKeys = preg_match_all('/.*=/', $result, $matches);
+            $listOfKeys = $matches[0];
+            // Get values
+            $listOfValues = preg_match_all('/=.*/', $result, $matches);
+            $listOfValues = $matches[0];
+            // Remove "=" symbol and apply lower case
+            array_walk($listOfKeys, function(&$v, $k){
+                $v = strtolower(str_replace('=', '', $v));
+            });
+            array_walk($listOfValues, function(&$v, $k){
+                $v = preg_replace('/=|"/', '', $v);
+            });
+            // Create array with keys/values
+            $result = array_combine($listOfKeys, $listOfValues);
+
+            $data['OS_name'] = $result['name'];
+            $data['OS_version'] = $result['version_id'];
         }
+
         return $data;
     }
 


### PR DESCRIPTION
## Description

Parse correctly /etc/os-release in order to get correct OS name and version

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
