### PR TITLE
Fix warning when using clapi with downtimes

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonRtAcknowledgement.class.php
+++ b/centreon/www/class/centreon-clapi/centreonRtAcknowledgement.class.php
@@ -183,10 +183,10 @@ class CentreonRtAcknowledgement extends CentreonObject
         }
         $type = $parameters[0];
 
-        return [
+        return array(
             'type' => $type,
             'resource' => $resource,
-        ];
+	);
     }
 
     /**

--- a/centreon/www/class/centreon-clapi/centreonRtDowntime.class.php
+++ b/centreon/www/class/centreon-clapi/centreonRtDowntime.class.php
@@ -190,7 +190,15 @@ class CentreonRtDowntime extends CentreonObject
      */
     private function parseShowParameters($parameters)
     {
-        list($type, $resource) = explode(';', $parameters);
+        $parameters = explode(';', $parameters);
+        if (count($parameters) === 1) {
+            $resource = '';
+        } elseif (count($parameters) === 2) {
+            $resource = $parameters[1];
+        } else {
+            throw new CentreonClapiException('Bad parameters');
+        }
+        $type = $parameters[0];
 
         return array(
             'type' => $type,


### PR DESCRIPTION
## Description

This PR unifies parseShowParameters between CentreonRtDowntime and CentreonRtAcknowledgement classes für CLAPI to get rid of the following message:
```
PHP Warning:  Undefined array key 1 in /usr/share/centreon/www/class/centreon-clapi/centreonRtDowntime.class.php on line 174
```

**Partially Fixes** [#centreon-archived/11673](https://github.com/)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Use CLAPI to add and remove Host and Service-Downtimes

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
