### PR TITLE
fix(security): Fix path transversal when exporting SNMP traps database to poller

### DIFF
--- a/centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+++ b/centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
@@ -152,6 +152,10 @@ if ($form->validate()) {
             }
             if ($tab['localhost'] && $tab['snmp_trapd_path_conf']) {
                 $trapdPath = $tab['snmp_trapd_path_conf'];
+                //handle path traversal vulnerability
+                if (strpos($trapdPath, '..') !== false) {
+                    throw new Exception('Path traversal found');
+                }
             }
         }
         if (isset($ret["generate"]) && $ret["generate"]) {


### PR DESCRIPTION
## Description

Sanitized path when exporting SNMP traps database to a poller
File: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php

**Fixes** # MON-15886

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Install a central and a poller
2. Configure SNMP trap to a resource on a distant poller
3. Go to “Configuration > SNMP Traps > Generate”
4. Select your poller and click on “Generate”
5. Check if /etc/snmp/centreon_traps/centreontrapd.sdb file is present

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
