### PR TITLE
Expand cypress visual testing to tests managed by Jest (tests RTL)

### DIFF
--- a/centreon/cypress.config.ts
+++ b/centreon/cypress.config.ts
@@ -1,27 +1,30 @@
 const { defineConfig } = require('cypress');
 const {
-  addMatchImageSnapshotPlugin,
+  addMatchImageSnapshotPlugin
 } = require('cypress-image-snapshot/plugin');
 
-const webpackConfig = require('./webpack.config.dev');
+const webpackConfig = require('./webpack.config.cypress');
 
 module.exports = defineConfig({
   component: {
     devServer: {
       bundler: 'webpack',
       framework: 'react',
-      webpackConfig,
+      webpackConfig
     },
     setupNodeEvents: (on, config) => {
       addMatchImageSnapshotPlugin(on, config);
     },
     specPattern: './www/front_src/src/**/*.cypress.spec.tsx',
-    supportFile: './cypress/support/component.tsx',
+    supportFile: './cypress/support/component.tsx'
+  },
+  env: {
+    baseUrl: 'http://localhost:9090'
   },
   reporter: 'junit',
   reporterOptions: {
-    mochaFile: 'cypress/results/cypress-fe.xml',
+    mochaFile: 'cypress/results/cypress-fe.xml'
   },
   video: true,
-  videosFolder: 'cypress/results/videos',
+  videosFolder: 'cypress/results/videos'
 });

--- a/centreon/cypress/support/commands.tsx
+++ b/centreon/cypress/support/commands.tsx
@@ -1,9 +1,61 @@
+/* eslint-disable @typescript-eslint/no-namespace */
+
 import { addMatchImageSnapshotCommand } from 'cypress-image-snapshot/command';
+import '@testing-library/cypress/add-commands';
+import 'cypress-msw-interceptor';
 
 addMatchImageSnapshotCommand({
   capture: 'viewport',
   customDiffConfig: { threshold: 0.1 },
   customSnapshotsDir: './cypress/visual-testing-snapshots',
   failureThreshold: 0.03,
-  failureThresholdType: 'percent',
+  failureThresholdType: 'percent'
 });
+
+declare global {
+  namespace Cypress {
+    interface Chainable {
+      interceptAPIRequest: (
+        props: InterceptAPIRequestProps
+      ) => Cypress.Chainable;
+      interceptRequest: (method, path, mock, alias) => Cypress.Chainable;
+      waitForRequest: (alias) => Cypress.Chainable;
+    }
+  }
+}
+
+export enum Method {
+  DELETE = 'DELETE',
+  GET = 'GET',
+  PATCH = 'PATCH',
+  POST = 'POST',
+  PUT = 'PUT'
+}
+
+export interface InterceptAPIRequestProps {
+  alias: string;
+  method: Method;
+  path: string;
+  response: object | Array<object>;
+  statusCode?: number;
+}
+
+Cypress.Commands.add(
+  'interceptAPIRequest',
+  ({
+    method,
+    path,
+    response,
+    alias,
+    statusCode = 200
+  }: InterceptAPIRequestProps): void => {
+    cy.interceptRequest(
+      method,
+      path,
+      async (req, res, ctx) => {
+        return res(ctx.delay(500), ctx.json(response), ctx.status(statusCode));
+      },
+      alias
+    );
+  }
+);

--- a/centreon/cypress/support/component.tsx
+++ b/centreon/cypress/support/component.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'cypress-msw-interceptor';
 
 import './commands';
 import { mount } from 'cypress/react18';

--- a/centreon/package.json
+++ b/centreon/package.json
@@ -38,6 +38,7 @@
     "cross-env": "^7.0.3",
     "cypress": "10.6.0",
     "cypress-image-snapshot": "^4.0.1",
+    "cypress-msw-interceptor": "^2.1.0",
     "eslint": "^8.8.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "^8.3.0",
@@ -63,6 +64,7 @@
     "jest-junit": "^13.0.0",
     "jsdom": "^19.0.0",
     "mockdate": "^3.0.5",
+    "msw": "^0.49.1",
     "prettier": "^2.5.1",
     "process": "^0.11.10",
     "react-beautiful-dnd-test-utils": "^4.1.1",
@@ -146,5 +148,8 @@
   },
   "workspaces": [
     "packages/*"
-  ]
+  ],
+  "msw": {
+    "workerDirectory": "www/front_src/public"
+  }
 }

--- a/centreon/webpack.config.cypress.js
+++ b/centreon/webpack.config.cypress.js
@@ -1,0 +1,95 @@
+const path = require('path');
+const os = require('os');
+
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+const { merge } = require('webpack-merge');
+
+const {
+  getDevConfiguration,
+  devJscTransformConfiguration,
+  devRefreshJscTransformConfiguration
+} = require('./packages/js-config/webpack/patch/dev');
+const getBaseConfiguration = require('./webpack.config');
+
+const devServerPort = 9090;
+
+const interfaces = os.networkInterfaces();
+const externalInterface = Object.keys(interfaces).find(
+  (interfaceName) =>
+    !interfaceName.includes('docker') &&
+    interfaces[interfaceName][0].family === 'IPv4' &&
+    interfaces[interfaceName][0].internal === false &&
+    !process.env.IS_STATIC_PORT_FORWARDED
+);
+
+const devServerAddress = externalInterface
+  ? interfaces[externalInterface][0].address
+  : 'localhost';
+
+const publicPath = `http://${devServerAddress}:${devServerPort}/static/`;
+
+const isServeMode = process.env.WEBPACK_ENV === 'serve';
+const isDevelopmentMode = process.env.WEBPACK_ENV === 'development';
+
+const plugins = isServeMode ? [new ReactRefreshWebpackPlugin()] : [];
+
+const output =
+  isServeMode || isDevelopmentMode
+    ? {
+        publicPath
+      }
+    : {};
+
+const getStaticDirectoryPath = (moduleName) =>
+  `${__dirname}/www/modules/${moduleName}/static`;
+
+const modules = [
+  {
+    getDirectoryPath: getStaticDirectoryPath,
+    name: 'centreon-license-manager'
+  },
+  {
+    getDirectoryPath: getStaticDirectoryPath,
+    name: 'centreon-autodiscovery-server'
+  },
+  { getDirectoryPath: getStaticDirectoryPath, name: 'centreon-bam-server' },
+  {
+    getDirectoryPath: getStaticDirectoryPath,
+    name: 'centreon-augmented-services'
+  },
+  {
+    getDirectoryPath: () => `${__dirname}/www/modules/centreon-map4-web-client`,
+    name: 'centreon-map4-web-client'
+  }
+];
+
+module.exports = merge(
+  getBaseConfiguration(
+    isServeMode
+      ? devRefreshJscTransformConfiguration
+      : devJscTransformConfiguration
+  ),
+  getDevConfiguration(),
+  {
+    devServer: {
+      compress: true,
+      hot: true,
+      port: devServerPort,
+      static: [
+        {
+          directory: `${__dirname}/www/front_src/public`,
+          publicPath: '/'
+        }
+      ]
+    },
+    output,
+    plugins,
+    resolve: {
+      alias: {
+        '@mui/material': path.resolve('./node_modules/@mui/material'),
+        dayjs: path.resolve('./node_modules/dayjs'),
+        'react-router-dom': path.resolve('./node_modules/react-router-dom')
+      }
+    }
+  }
+);

--- a/centreon/www/front_src/public/mockServiceWorker.js
+++ b/centreon/www/front_src/public/mockServiceWorker.js
@@ -1,0 +1,303 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (0.49.1).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = '3d6b9f06410d179a7f7404d4bf4c3c70'
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+self.addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: INTEGRITY_CHECKSUM,
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
+
+  // Bypass server-sent events.
+  if (accept.includes('text/event-stream')) {
+    return
+  }
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  // Generate unique request ID.
+  const requestId = Math.random().toString(16).slice(2)
+
+  event.respondWith(
+    handleRequest(event, requestId).catch((error) => {
+      if (error.name === 'NetworkError') {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url,
+        )
+        return
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
+      console.error(
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+        request.method,
+        request.url,
+        `${error.name}: ${error.message}`,
+      )
+    }),
+  )
+})
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: Object.fromEntries(clonedResponse.headers.entries()),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const clonedRequest = request.clone()
+
+  function passthrough() {
+    // Clone the request because it might've been already used
+    // (i.e. its body has been read and sent to the client).
+    const headers = Object.fromEntries(clonedRequest.headers.entries())
+
+    // Remove MSW-specific request headers so the bypassed requests
+    // comply with the server's CORS preflight check.
+    // Operate with the headers as an object because request "Headers"
+    // are immutable.
+    delete headers['x-msw-bypass']
+
+    return fetch(clonedRequest, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Bypass requests with the explicit bypass header.
+  // Such requests can be issued by "ctx.fetch()".
+  if (request.headers.get('x-msw-bypass') === 'true') {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body: await request.text(),
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return passthrough()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.data
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a "respondWith" promise emulates a network error.
+      throw networkError
+    }
+  }
+
+  return passthrough()
+}
+
+function sendToClient(client, message) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [channel.port2])
+  })
+}
+
+function sleep(timeMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeMs)
+  })
+}
+
+async function respondWithMock(response) {
+  await sleep(response.delay)
+  return new Response(response.body, response)
+}


### PR DESCRIPTION
## Description

Rework Jest RTL tests to Cypress component testing for at least : 

Listing
Filter

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
