### PR TITLE
fix(ci): add unique key cache for packaging and sign

### DIFF
--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -66,7 +66,7 @@ runs:
         echo "[DEBUG] - Branch name: $BRANCHNAME"
 
         case "$BRANCHNAME" in
-          develop | dev-[2-9][0-9].[0-9][0-9].x | fix-delivery-createrepo)
+          develop | dev-[2-9][0-9].[0-9][0-9].x | fix-delivery-createrepo | fix-rpmsign)
             SUBREPO="unstable"
             ;;
           release* | hotfix*)

--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -66,7 +66,7 @@ runs:
         echo "[DEBUG] - Branch name: $BRANCHNAME"
 
         case "$BRANCHNAME" in
-          develop | dev-[2-9][0-9].[0-9][0-9].x | fix-delivery-createrepo | fix-rpmsign)
+          develop | dev-[2-9][0-9].[0-9][0-9].x | fix-rpmsign)
             SUBREPO="unstable"
             ;;
           release* | hotfix*)

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -127,7 +127,11 @@ jobs:
       - run: export GPG_TTY=$(tty)
         shell: bash
 
-      - run: rpmsign --addsign ./*.${{ inputs.package_extension }}
+      - run: |
+          pwd
+          ls -lath *.rpm
+          rpmsign --addsign ./*.${{ inputs.package_extension }}
+          ls -lath *.rpm
         shell: bash
 
       - uses: actions/cache@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -140,4 +140,4 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ./*.${{ inputs.package_extension }}
-          key: ${{ inputs.cache_key }}
+          key: signed-${{ inputs.cache_key }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,7 +97,7 @@ jobs:
           major_version: ${{ inputs.major_version }}
           minor_version: ${{ inputs.minor_version }}
           release: ${{ inputs.release }}
-          cache_key: unsigned-${{ inputs.cache_key }}
+          cache_key: ${{ inputs.cache_key }}-unsigned
 
   sign:
     if: ${{ inputs.package_extension == 'rpm' }}
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ./*.${{ inputs.package_extension }}
-          key: unsigned-${{ inputs.cache_key }}
+          key: ${{ inputs.cache_key }}-unsigned
 
       - run: echo "HOME=/root" >> $GITHUB_ENV
         shell: bash
@@ -140,4 +140,4 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ./*.${{ inputs.package_extension }}
-          key: signed-${{ inputs.cache_key }}
+          key: ${{ inputs.cache_key }}-signed

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -140,4 +140,4 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ./*.${{ inputs.package_extension }}
-          key: ${{ inputs.cache_key }}
+          key: ${{ inputs.cache_key }}-signed

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,7 +97,7 @@ jobs:
           major_version: ${{ inputs.major_version }}
           minor_version: ${{ inputs.minor_version }}
           release: ${{ inputs.release }}
-          cache_key: ${{ inputs.cache_key }}-unsigned
+          cache_key: unsigned-${{ inputs.cache_key }}
 
   sign:
     if: ${{ inputs.package_extension == 'rpm' }}
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ./*.${{ inputs.package_extension }}
-          key: ${{ inputs.cache_key }}-unsigned
+          key: unsigned-${{ inputs.cache_key }}
 
       - run: echo "HOME=/root" >> $GITHUB_ENV
         shell: bash
@@ -140,4 +140,4 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ./*.${{ inputs.package_extension }}
-          key: ${{ inputs.cache_key }}-signed
+          key: ${{ inputs.cache_key }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -124,6 +124,9 @@ jobs:
       - run: echo "HOME=/root" >> $GITHUB_ENV
         shell: bash
 
+      - run: export GPG_TTY=$(tty)
+        shell: bash
+
       - run: rpmsign --addsign ./*.${{ inputs.package_extension }}
         shell: bash
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -132,6 +132,8 @@ jobs:
           ls -lath *.rpm
           rpmsign --addsign ./*.${{ inputs.package_extension }}
           ls -lath *.rpm
+          echo "check signature"
+          rpm -qpi *.rpm
         shell: bash
 
       - uses: actions/cache@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -140,4 +140,4 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ./*.${{ inputs.package_extension }}
-          key: ${{ inputs.cache_key }}-signed
+          key: ${{ inputs.cache_key }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -97,7 +97,7 @@ jobs:
           major_version: ${{ inputs.major_version }}
           minor_version: ${{ inputs.minor_version }}
           release: ${{ inputs.release }}
-          cache_key: ${{ inputs.cache_key }}
+          cache_key: ${{ inputs.cache_key }}-unsigned
 
   sign:
     if: ${{ inputs.package_extension == 'rpm' }}
@@ -119,7 +119,7 @@ jobs:
       - uses: actions/cache@v3
         with:
           path: ./*.${{ inputs.package_extension }}
-          key: ${{ inputs.cache_key }}
+          key: ${{ inputs.cache_key }}-unsigned
 
       - run: echo "HOME=/root" >> $GITHUB_ENV
         shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -134,6 +134,7 @@ jobs:
           ls -lath *.rpm
           echo "check signature"
           rpm -qpi *.rpm
+          md5sum *.rpm
         shell: bash
 
       - uses: actions/cache@v3


### PR DESCRIPTION
## Description

added a unique key cache to handle the output from rpm sign properly

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
