### PR TITLE
Fix(security): Sanitize queries in the list of broker configurations dev-22.04.x

### DIFF
--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
@@ -88,7 +88,7 @@ if (isset($_POST['searchCB']) || isset($_GET['searchCB'])) {
 
 $aclCond = "";
 if (!$centreon->user->admin && count($allowedBrokerConf)) {
-    if ($search) {
+    if ($search !== '') {
         $aclCond = " AND ";
     } else {
         $aclCond = " WHERE ";
@@ -96,19 +96,27 @@ if (!$centreon->user->admin && count($allowedBrokerConf)) {
     $aclCond .= "config_id IN (" . implode(',', array_keys($allowedBrokerConf)) . ") ";
 }
 
-if ($search) {
-    $rq = "SELECT SQL_CALC_FOUND_ROWS config_id, config_name, ns_nagios_server, config_activate " .
+if ($search !== '') {
+    $cfgBrokerStmt = $pearDB->prepare(
+        "SELECT SQL_CALC_FOUND_ROWS config_id, config_name, ns_nagios_server, config_activate " .
         "FROM cfg_centreonbroker " .
-        "WHERE config_name LIKE '%" . $search . "%'" . $aclCond .
+        "WHERE config_name LIKE :search" . $aclCond .
         " ORDER BY config_name " .
-        "LIMIT " . $num * $limit . ", " . $limit;
+        "LIMIT :scoop, :limit"
+    );
+    $cfgBrokerStmt->bindValue(':search', '%' . $search . '%', \PDO::PARAM_STR);
 } else {
-    $rq = "SELECT SQL_CALC_FOUND_ROWS config_id, config_name, ns_nagios_server, config_activate " .
+    $cfgBrokerStmt = $pearDB->prepare(
+        "SELECT SQL_CALC_FOUND_ROWS config_id, config_name, ns_nagios_server, config_activate " .
         "FROM cfg_centreonbroker " . $aclCond .
         " ORDER BY config_name " .
-        "LIMIT " . $num * $limit . ", " . $limit;
+        "LIMIT :scoop, :limit"
+    );
 }
-$dbResult = $pearDB->query($rq);
+
+$cfgBrokerStmt->bindValue(':scoop', (int) $num * (int) $limit, \PDO::PARAM_INT);
+$cfgBrokerStmt->bindValue(':limit', (int) $limit, \PDO::PARAM_INT);
+$cfgBrokerStmt->execute();
 
 // Get results numbers
 $rows = $pearDB->query("SELECT FOUND_ROWS()")->fetchColumn();
@@ -131,7 +139,7 @@ $statementBrokerInfo = $pearDB->prepare(
     "AND config_id = :config_id"
 );
 
-for ($i = 0; $config = $dbResult->fetch(); $i++) {
+for ($i = 0; $config = $cfgBrokerStmt->fetch(); $i++) {
     $moptions = "";
     $selectedElements = $form->addElement('checkbox', "select[" . $config['config_id'] . "]");
 


### PR DESCRIPTION
## Description
Queries should be sanitized (if possible) 

**Fixes** # MON-15377

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

Configuration  >  Pollers  >  Broker configuration
check if list still visual in both users (admin and non admin)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
