### PR TITLE
fix(security): Sanitize queries in the list of service groups dev-22.04.x

### DIFF
--- a/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
@@ -55,20 +55,39 @@ if (isset($_POST['searchSG']) || isset($_GET['searchSG'])) {
     //restoring saved values
     $search = $centreon->historySearch[$url]["search"] ?? null;
 }
+$conditionStr = "";
+$sgStrParams = [];
+if (!$acl->admin && $sgString) {
+    $sgStrList = explode(',', $sgString);
+    foreach ($sgStrList as $index => $sgId) {
+        $sgStrParams[':sg_' . $index] = (int) str_replace("'", "", $sgId);
+    }
+    $queryParams = implode(',', array_keys($sgStrParams));
 
-if ($search) {
-    $rq = "SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate FROM servicegroup " .
-        "WHERE (sg_name LIKE '%" . $search . "%' " .
-        "OR sg_alias LIKE '%" . $search . "%') " .
-        $acl->queryBuilder('AND', 'sg_id', $sgString) .
-        " ORDER BY sg_name LIMIT " . $num * $limit . ", " . $limit;
-} else {
-    $rq = "SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate FROM servicegroup " .
-        $acl->queryBuilder('WHERE', 'sg_id', $sgString) .
-        " ORDER BY sg_name LIMIT " . $num * $limit . ", " . $limit;
+    if ($search !== '') {
+        $conditionStr = "AND sg_id IN (" . $queryParams . ")";
+    } else {
+        $conditionStr = "WHERE sg_id IN (" . $queryParams . ")";
+    }
 }
 
-$dbResult = $pearDB->query($rq);
+if ($search !== '') {
+    $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate" .
+        " FROM servicegroup WHERE (sg_name LIKE :search  OR sg_alias LIKE :search) " . $conditionStr .
+        " ORDER BY sg_name LIMIT :offset, :limit");
+
+    $statement->bindValue(':search', '%' . $search . '%', \PDO::PARAM_STR);
+} else {
+    $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sg_id, sg_name, sg_alias, sg_activate" .
+        " FROM servicegroup " . $conditionStr . " ORDER BY sg_name LIMIT :offset, :limit");
+}
+foreach ($sgStrParams as $key => $sgId) {
+    $statement->bindValue($key, $sgId, \PDO::PARAM_INT);
+}
+$statement->bindValue(':offset', (int) $num * (int) $limit, \PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, \PDO::PARAM_INT);
+$statement->execute();
+
 $rows = $pearDB->query("SELECT FOUND_ROWS()")->fetchColumn();
 
 include "./include/common/checkPagination.php";
@@ -102,7 +121,7 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 $elemArr = array();
 $centreonToken = createCSRFToken();
 
-for ($i = 0; $sg = $dbResult->fetch(); $i++) {
+for ($i = 0; $sg = $statement->fetch(\PDO::FETCH_ASSOC); $i++) {
     $selectedElements = $form->addElement('checkbox', "select[" . $sg['sg_id'] . "]");
     $moptions = "";
     if ($sg["sg_activate"]) {


### PR DESCRIPTION
## Description
Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

Where

In file www/include/configuration/configObject/servicegroup/listServiceGroup.php

[Line 70]

**Fixes** # MON-15379

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

go to service group listing
check if search , pagination and number of lines to show  works

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
