### PR TITLE
fix(security): Sanitize queries in service category dev-22.10.x

### DIFF
--- a/centreon/www/include/configuration/configObject/service_categories/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service_categories/DB-Func.php
@@ -157,10 +157,11 @@ function multipleServiceCategorieInDB($sc = [], $nbrDup = [])
                 $maxId = $statement->fetch();
                 $scAcl[$maxId['maxid']] = $key;
                 $query = "INSERT INTO service_categories_relation (service_service_id, sc_id) " .
-                    "(SELECT service_service_id, " . $maxId['maxid'] .
+                    "(SELECT service_service_id, :max_id" .
                     " FROM service_categories_relation WHERE sc_id = :sc_id)";
                 $statement = $pearDB->prepare($query);
                 $statement->bindValue(':sc_id', $key, \PDO::PARAM_INT);
+                $statement->bindValue(':max_id', $maxId['maxid'], \PDO::PARAM_INT);
                 $statement->execute();
             }
         }


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

Where

In file www/include/configuration/configObject/service_categories/DB-Func.php

**Fixes** # MON-15370

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

 
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
