### PR TITLE
fix(security): Sanitized queries in the list of meta service  dev-21.10.x

### DIFF
--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.php
@@ -98,17 +98,37 @@ $calcType = array("AVE" => _("Average"), "SOM" => _("Sum"), "MIN" => _("Min"), "
 /*
  * Meta Service list
  */
-if ($search) {
-    $rq = "SELECT * FROM meta_service " .
-        "WHERE meta_name LIKE '%" . $search . "%' " .
-        $acl->queryBuilder("AND", "meta_id", $metaStr) .
-        " ORDER BY meta_name LIMIT " . $num * $limit . ", " . $limit;
-} else {
-    $rq = "SELECT * FROM meta_service " .
-        $acl->queryBuilder("WHERE", "meta_id", $metaStr) .
-        " ORDER BY meta_name LIMIT " . $num * $limit . ", " . $limit;
+$conditionStr = "";
+$metaStrParams = [];
+//binding query params for non admin  acl rules
+if (!$acl->admin && $metaStr) {
+    $metaStrList = explode(',', $metaStr);
+    foreach ($metaStrList as $index => $metaId) {
+        $metaStrParams[':meta_' . $index] = (int) str_replace("'", "", $metaId);
+    }
+    $queryParams = implode(',', array_keys($metaStrParams));
+
+    if ($search !== '') {
+        $conditionStr = "AND meta_id IN (" . $queryParams . ")";
+    } else {
+        $conditionStr = "WHERE meta_id IN (" . $queryParams . ")";
+    }
 }
-$dbResult = $pearDB->query($rq);
+if ($search !== '') {
+    $statement = $pearDB->prepare("SELECT * FROM meta_service " .
+        "WHERE meta_name LIKE :search " . $conditionStr .
+        " ORDER BY meta_name LIMIT :offset, :limit");
+    $statement->bindValue(':search', '%' . $search . '%', \PDO::PARAM_STR);
+} else {
+    $statement = $pearDB->prepare("SELECT * FROM meta_service " . $conditionStr .
+        " ORDER BY meta_name LIMIT :offset, :limit");
+}
+foreach ($metaStrParams as $key => $metaId) {
+    $statement->bindValue($key, $metaId, \PDO::PARAM_INT);
+}
+$statement->bindValue(':offset', (int) $num * (int) $limit, \PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, \PDO::PARAM_INT);
+$statement->execute();
 
 $form = new HTML_QuickFormCustom('select_form', 'GET', "?p=" . $p);
 
@@ -126,7 +146,7 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 $elemArr = array();
 $centreonToken = createCSRFToken();
 
-for ($i = 0; $ms = $dbResult->fetch(); $i++) {
+for ($i = 0; $ms = $statement->fetch(\PDO::FETCH_ASSOC); $i++) {
     $moptions = "";
     $selectedElements = $form->addElement('checkbox', "select[" . $ms['meta_id'] . "]");
     if ($ms["meta_select_mode"] == 1) {


### PR DESCRIPTION
## Description

Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

Where

In file www/include/configuration/configObject/meta_service/listMetaService.php

**Fixes** # MON-15371

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

check if meta service listing's page works as usual

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
[MON-15371](https://centreon.atlassian.net/browse/MON-15371)