### PR TITLE
fix(security): Sanitize queries in the list of trap groups dev-22.04.x

### DIFF
--- a/centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+++ b/centreon/www/include/configuration/configObject/traps-groups/listGroups.php
@@ -57,13 +57,16 @@ if (isset($_POST['searchTM']) || isset($_GET['searchTM'])) {
 
 $searchTool = null;
 if ($search) {
-    $searchTool = " WHERE (traps_group_name LIKE '%" . $search . "%')";
+    $searchTool = " WHERE (traps_group_name LIKE :search )";
 }
-
-$dbResult = $pearDB->query(
-    "SELECT SQL_CALC_FOUND_ROWS * FROM traps_group " . $searchTool .
-    " ORDER BY traps_group_name LIMIT " . $num * $limit . ", " . $limit
-);
+$statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS * FROM traps_group " . $searchTool .
+    " ORDER BY traps_group_name LIMIT  :offset, :limit");
+if ($search) {
+    $statement->bindValue(':search', '%' . $search . '%', \PDO::PARAM_STR);
+}
+$statement->bindValue(':offset', (int) $num * (int) $limit, \PDO::PARAM_INT);
+$statement->bindValue(':limit', $limit, \PDO::PARAM_INT);
+$statement->execute();
 
 $rows = $pearDB->query("SELECT FOUND_ROWS()")->fetchColumn();
 
@@ -95,7 +98,7 @@ $form->addElement('submit', 'Search', _("Search"), $attrBtnSuccess);
 
 // Fill a tab with a multidimensional Array we put in $tpl
 $elemArr = array();
-for ($i = 0; $group = $dbResult->fetch(); $i++) {
+for ($i = 0; $group = $statement->fetch(\PDO::FETCH_ASSOC); $i++) {
     $moptions = "";
     $selectedElements = $form->addElement('checkbox', "select[" . $group['traps_group_id'] . "]");
     $moptions = "&nbsp;<input onKeypress=\"if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) " .


### PR DESCRIPTION
## Description
Queries should be sanitized (if possible) and bound using PDO statement to reduce attack surface and clean legacy code

Where

In file www/include/configuration/configObject/traps-groups/listGroups.php
**Fixes** # MON-15374

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

navigate to : Configuration  >  SNMP Traps  >  Group
check if page works as before

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
