### PR TITLE
Fix : event log page is very slow for non-admins

### DIFF
--- a/centreon/www/include/eventLogs/Paginator.php
+++ b/centreon/www/include/eventLogs/Paginator.php
@@ -22,12 +22,25 @@ declare(strict_types=1);
 
 class Paginator
 {
+    /**
+     * Maximum number of pages displayed after / before the current page
+     */
     const PAGER_SPAN = 5;
 
+    /**
+     * @param int $currentPageNb
+     * @param int $totalRecordsCount
+     * @param int $nbResultsPerPage
+     */
     public function __construct(private int $currentPageNb, private int $totalRecordsCount, private int $nbResultsPerPage)
     {
     }
 
+    /**
+     * Generates an array with available pages
+     *
+     * @return <string|int, <string|int|bool>>
+     */
     public function generatePages(): array
     {
         $pages = [];
@@ -57,6 +70,12 @@ class Paginator
         return $pages;
     }
 
+    /**
+     * Genearetes an array with data for given page
+     *
+     * @param int $pageNb
+     * @return <string,string|int|bool>
+     */
     private function generatePage(int $pageNb): array
     {
         return [

--- a/centreon/www/include/eventLogs/Paginator.php
+++ b/centreon/www/include/eventLogs/Paginator.php
@@ -1,0 +1,69 @@
+<?php
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+class Paginator
+{
+    const PAGER_SPAN = 5;
+
+    public function __construct(private int $currentPageNb, private int $totalRecordsCount, private int $nbResultsPerPage)
+    {
+    }
+
+    public function generatePages(): array
+    {
+        $pages = [];
+        $lowestPageNb = $this->currentPageNb;
+        $highestPageNb = $this->currentPageNb;
+
+        if ($this->currentPageNb > 1) {
+            $pages['previous'] = $this->generatePage($this->currentPageNb - 1);
+        }
+
+        for ($i = self::PAGER_SPAN; $lowestPageNb > 0 && $i > 0; $i--) {
+            $lowestPageNb--;
+        }
+
+        for ($i2 = 0; $i2 < (self::PAGER_SPAN + $i); $i2++) {
+            $highestPageNb++;
+        }
+
+        for ($i = $lowestPageNb; $i <= $highestPageNb; $i++) {
+            $pages[$i] = $this->generatePage($i);
+        }
+
+        if ($this->nbResultsPerPage < $this->totalRecordsCount) {
+            $pages['next'] = $this->generatePage($this->currentPageNb + 1);
+        }
+
+        return $pages;
+    }
+
+    private function generatePage(int $pageNb): array
+    {
+        return [
+            'url_page' => sprintf('&num=%d&limit=%d', $pageNb, $this->nbResultsPerPage),
+            'label_page' => ($pageNb + 1),
+            'num' => $pageNb,
+            'active' => $pageNb === $this->currentPageNb,
+        ];
+    }
+}

--- a/centreon/www/include/eventLogs/xml/PaginationRenderer.php
+++ b/centreon/www/include/eventLogs/xml/PaginationRenderer.php
@@ -28,6 +28,12 @@ class PaginationRenderer
     {
     }
 
+    /**
+     * Renders navigation pages as xml nodes
+     *
+     * @param <string|int, <string|int|bool>> $pages
+     * @return void
+     */
     public function render(array $pages): void
     {
         if (count($pages) <= 1) {
@@ -35,19 +41,26 @@ class PaginationRenderer
         }
 
         $previousBtnText = array_key_exists('previous', $pages) ? $pages['previous']['num'] : null;
-        $this->renderNavigation('prev', (string) $previousBtnText);
+        $this->addNavigation('prev', (string) $previousBtnText);
 
         foreach ($pages as $key => $page) {
             if (is_numeric($key)) {
-                $this->renderPage($page);
+                $this->addPage($page);
             }
         }
 
         $nextBtnText = array_key_exists('next', $pages) ? $pages['next']['num'] : null;
-        $this->renderNavigation('next', (string) $nextBtnText);
+        $this->addNavigation('next', (string) $nextBtnText);
     }
 
-    private function renderNavigation(string $elName, ?string $text): void
+    /**
+     * Ads next or previous page into the xml as a new node
+     *
+     * @param string $elName
+     * @param string|null $text
+     * @return void
+     */
+    private function addNavigation(string $elName, ?string $text): void
     {
         $this->buffer->startElement($elName);
         if (is_string($text)) {
@@ -60,7 +73,13 @@ class PaginationRenderer
         $this->buffer->endElement();
     }
 
-    private function renderPage(array $page)
+    /**
+     * Ads navigation page into the xml as a new node
+     *
+     * @param array $page
+     * @return void
+     */
+    private function addPage(array $page)
     {
         $this->buffer->startElement('page');
         $this->buffer->writeElement('selected', $page['active'] ? '1' : '0');

--- a/centreon/www/include/eventLogs/xml/PaginationRenderer.php
+++ b/centreon/www/include/eventLogs/xml/PaginationRenderer.php
@@ -1,0 +1,72 @@
+<?php
+/*
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+include_once _CENTREON_PATH_ . 'www/class/centreonXML.class.php';
+
+class PaginationRenderer
+{
+    public function __construct(private CentreonXML $buffer)
+    {
+    }
+
+    public function render(array $pages): void
+    {
+        if (count($pages) <= 1) {
+            return;
+        }
+
+        $previousBtnText = array_key_exists('previous', $pages) ? $pages['previous']['num'] : null;
+        $this->renderNavigation('prev', (string) $previousBtnText);
+
+        foreach ($pages as $key => $page) {
+            if (is_numeric($key)) {
+                $this->renderPage($page);
+            }
+        }
+
+        $nextBtnText = array_key_exists('next', $pages) ? $pages['next']['num'] : null;
+        $this->renderNavigation('next', (string) $nextBtnText);
+    }
+
+    private function renderNavigation(string $elName, ?string $text): void
+    {
+        $this->buffer->startElement($elName);
+        if (is_string($text)) {
+            $this->buffer->writeAttribute('show', 'true');
+            $this->buffer->text($text);
+        } else {
+            $this->buffer->writeAttribute('show', 'false');
+            $this->buffer->text('none');
+        }
+        $this->buffer->endElement();
+    }
+
+    private function renderPage(array $page)
+    {
+        $this->buffer->startElement('page');
+        $this->buffer->writeElement('selected', $page['active'] ? '1' : '0');
+        $this->buffer->writeElement('num', $page['num']);
+        $this->buffer->writeElement('url_page', $page['url_page']);
+        $this->buffer->writeElement('label_page', $page['label_page']);
+        $this->buffer->endElement();
+    }
+}

--- a/centreon/www/include/eventLogs/xml/data.php
+++ b/centreon/www/include/eventLogs/xml/data.php
@@ -713,6 +713,7 @@ if (isset($req) && $req) {
     if ($export !== "1") {
         $offset = $num * $limit;
         $queryValues['offset'] = [\PDO::PARAM_INT => $offset];
+        // The query retrieves more than $limit results (in order to display next n-th pages)
         $queryValues['limit'] = [\PDO::PARAM_INT => ($limit * Paginator::PAGER_SPAN)];
         $limitReq = " LIMIT :offset, :limit";
     }
@@ -746,10 +747,11 @@ if (isset($req) && $req) {
 
 
     require_once './PaginationRenderer.php';
-
+    // generate pages for navigation
     $paginator = new Paginator($num, $rows, $limit);
     $pages = $paginator->generatePages();
 
+    // add generated pages into xml
     $paginationRenderer = new PaginationRenderer($buffer);
     $paginationRenderer->render($pages);
 
@@ -757,6 +759,7 @@ if (isset($req) && $req) {
      * Full Request
      */
     $cpts = 0;
+    // The query retrieves more than $limit results, but only the first $limit elements should be displayed
     foreach (array_slice($logs, 0, $limit) as $log) {
         $buffer->startElement("line");
         $buffer->writeElement("msg_type", $log["msg_type"]);


### PR DESCRIPTION
## Description

This PR removes first and last page links in event logs page in order to increase page performance

**Fixes** # (issue)
MON-14657

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Create a huge data in event logs and render on event logs page.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
