### PR TITLE
(debian) (install) Verify if exists default apache configuration

### DIFF
--- a/centreon/packaging/debian/centreon-web-apache.postinst
+++ b/centreon/packaging/debian/centreon-web-apache.postinst
@@ -9,8 +9,11 @@ if [ "$1" = "configure" ] ; then
     a2enmod alias proxy proxy_fcgi
     a2enconf php8.0-fpm
     a2dismod php8.0
-    # Remove default Debian Apache configuration
-    rm /etc/apache2/sites-enabled/000-default.conf
+    # Remove default Debian Apache configuration (if exists)
+    if [ -L /etc/apache2/sites-enabled/000-default.conf ]; then
+      echo "Removing Apache default configuration file ..."
+      rm /etc/apache2/sites-enabled/000-default.conf
+    fi
     # Restart apache2
     systemctl restart apache2 php8.0-fpm
   fi


### PR DESCRIPTION
## Description

When an update is made or even if the symbolic link no longer exists, an error is generated in the `rm` command, so we check first if the symbolic link really exists.

```
rm: cannot remove '/etc/apache2/sites-enabled/000-default.conf': No such file or directory
```

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
