### PR TITLE
fix(ci): Use proper names for test reports

### DIFF
--- a/.github/actions/cypress-e2e-testing/action.yml
+++ b/.github/actions/cypress-e2e-testing/action.yml
@@ -55,6 +55,6 @@ runs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: ${{ always() }}
       with:
-        check_name: web-e2e-tests-report
+        check_name: ${{ steps.formatFeatureFilePath.outputs.value }}
         comment_mode: failures
         junit_files: ${{ inputs.module }}/tests/e2e/cypress/results/reports/cypress-fe.xml

--- a/.github/actions/cypress-e2e-testing/action.yml
+++ b/.github/actions/cypress-e2e-testing/action.yml
@@ -55,6 +55,6 @@ runs:
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: ${{ always() }}
       with:
-        check_name: ${{ steps.formatFeatureFilePath.outputs.value }}
+        check_name: e2e-tests-report-${{ steps.formatFeatureFilePath.outputs.value }}
         comment_mode: failures
         junit_files: ${{ inputs.module }}/tests/e2e/cypress/results/reports/cypress-fe.xml


### PR DESCRIPTION
## Description

All e2e tests had "web-e2e-tests-report" as a name this PR should take care of it.

**Fixes** # MON-16186

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
