### PR TITLE
fix: Fixed issue pagination not displayed in all legacy pages

### DIFF
--- a/centreon/www/Themes/Generic-theme/style.css
+++ b/centreon/www/Themes/Generic-theme/style.css
@@ -1852,7 +1852,6 @@ span.show-disabled[disabled]::after {
 }
 .ToolbarTable {
     margin: 6px 0px;
-    font-size: 0;
 }
 .ToolbarTR          {padding-left:10px;}
 .ToolbarTR td:first-child {


### PR DESCRIPTION
## Description

Fixed issue pagination not displayed in all legacy pages

**Fixes** # MON-16013

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>
 Duplicate entries  like more than 10 in each listing page and check if pages numbers apears

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
