### PR TITLE
Fix(upgrade): Field 'app_key' doesn't have a default value QUERY : INSERT INTO remote_servers

### DIFF
--- a/centreon/www/install/php/Update-22.04.8.php
+++ b/centreon/www/install/php/Update-22.04.8.php
@@ -39,8 +39,10 @@ try {
     $errorMessage = 'Unable to update illegal characters fields from engine configuration of pollers';
     decodeIllegalCharactersNagios($pearDB);
 
-    $errorMessage = "Unable to remove app_key column";
-    $pearDB->query("ALTER TABLE `remote_servers` DROP COLUMN `app_key`");
+    if ($pearDB->isColumnExist('remote_servers', 'app_key') === 1) {
+        $errorMessage = "Unable to remove app_key column";
+        $pearDB->query("ALTER TABLE `remote_servers` DROP COLUMN `app_key`");
+    }
 
     $pearDB->commit();
 } catch (\Exception $e) {


### PR DESCRIPTION
## Description


 fix the initial error (Field 'app_key' doesn't have a default value QUERY : INSERT INTO remote_servers) for > 22.04.6

**Fixes** # MON-15744

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Upgrade a Centreon platform from version < 22.04.6
2. Create a Remote Server using wizard
3. Check that Remote Server is created without SQL errors

 

1. Install a Centreon platform with 22.04.x version
2. Create a Remote Server using wizard
3. Check that Remote Server is created without SQL errors

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
