### PR TITLE
remote server wizard form inputs doesnt have margin

### DIFF
--- a/centreon/www/front_src/src/PollerWizard/forms/wizardButtons.tsx
+++ b/centreon/www/front_src/src/PollerWizard/forms/wizardButtons.tsx
@@ -18,7 +18,7 @@ const WizardButtons = ({
   disabled,
   type
 }: Props): JSX.Element => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslation();
 
   const label = equals(type, WizardButtonsTypes.Next)

--- a/centreon/www/front_src/src/PollerWizard/pollerStep1/index.tsx
+++ b/centreon/www/front_src/src/PollerWizard/pollerStep1/index.tsx
@@ -36,7 +36,7 @@ const PollerWizardStepOne = ({
   goToNextStep,
   goToPreviousStep
 }: Props): JSX.Element => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslation();
   const [waitList, setWaitList] = useState<Array<WaitList> | null>(null);
   const [initialized, setInitialized] = useState(false);

--- a/centreon/www/front_src/src/PollerWizard/pollerStep2/index.tsx
+++ b/centreon/www/front_src/src/PollerWizard/pollerStep2/index.tsx
@@ -37,7 +37,7 @@ const PollerWizardStepTwo = ({
   goToNextStep,
   goToPreviousStep
 }: Props): JSX.Element => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslation();
   const navigate = useNavigate();
 

--- a/centreon/www/front_src/src/PollerWizard/remoteServerStep1/index.tsx
+++ b/centreon/www/front_src/src/PollerWizard/remoteServerStep1/index.tsx
@@ -54,7 +54,7 @@ const RemoteServerWizardStepOne = ({
   goToNextStep,
   goToPreviousStep
 }: Props): JSX.Element => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslation();
   const [waitList, setWaitList] = useState<Array<WaitList> | null>(null);
   const [initialized, setInitialized] = useState(false);

--- a/centreon/www/front_src/src/PollerWizard/remoteServerStep2/index.tsx
+++ b/centreon/www/front_src/src/PollerWizard/remoteServerStep2/index.tsx
@@ -33,7 +33,7 @@ const RemoteServerWizardStepTwo = ({
   goToNextStep,
   goToPreviousStep
 }: Props): JSX.Element => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslation();
   const [pollers, setPollers] = useState<Array<Poller> | null>(null);
 

--- a/centreon/www/front_src/src/PollerWizard/serverConfigurationWizard/index.tsx
+++ b/centreon/www/front_src/src/PollerWizard/serverConfigurationWizard/index.tsx
@@ -26,7 +26,7 @@ const ServerConfigurationWizard = ({
   changeServerType,
   goToNextStep
 }: Props): JSX.Element => {
-  const classes = useStyles();
+  const { classes } = useStyles();
   const { t } = useTranslation();
 
   const [serverType, setServerType] = useState<number>(1);


### PR DESCRIPTION
## Description

The Remote Server Wizard form input doesn’t have margin between them anymore.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
