### PR TITLE
switch to lightmode on logout

### DIFF
--- a/centreon/www/front_src/src/Header/UserMenu/index.tsx
+++ b/centreon/www/front_src/src/Header/UserMenu/index.tsx
@@ -2,6 +2,7 @@ import { MouseEvent, RefObject, useEffect, useRef, useState } from 'react';
 
 import { useTranslation, withTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
+import { useAtom } from 'jotai';
 import { useUpdateAtom } from 'jotai/utils';
 import { equals, gt, isNil, not, __ } from 'ramda';
 import { makeStyles } from 'tss-react/mui';
@@ -31,7 +32,7 @@ import {
   useSnackbar,
   useLocaleDateTimeFormat
 } from '@centreon/ui';
-import { ThemeMode } from '@centreon/ui-context';
+import { ThemeMode, userAtom } from '@centreon/ui-context';
 
 import SwitchMode from '../SwitchThemeMode/index';
 import Clock from '../Clock';
@@ -199,6 +200,8 @@ const UserMenu = ({ headerRef }: Props): JSX.Element => {
   const { showSuccessMessage } = useSnackbar();
   const { toHumanizedDuration } = useLocaleDateTimeFormat();
 
+  const [user, setUser] = useAtom(userAtom);
+
   const setAreUserParametersLoaded = useUpdateAtom(areUserParametersLoadedAtom);
   const setPasswordResetInformationsAtom = useUpdateAtom(
     passwordResetInformationsAtom
@@ -230,6 +233,10 @@ const UserMenu = ({ headerRef }: Props): JSX.Element => {
       setHoveredNavigationItems(null);
       navigate(reactRoutes.login);
       showSuccessMessage(t(labelYouHaveBeenLoggedOut));
+      setUser({
+        ...user,
+        themeMode: ThemeMode.light
+      });
     });
   };
 


### PR DESCRIPTION
## Description

we tried to fix the following issue : 

Login page uses the dark theme after log out

Received result

The login page uses the dark theme

Expected result

The login page uses the light theme

preview of the fix : 


https://user-images.githubusercontent.com/109956462/209309941-4dd4d96c-eda8-4739-9b81-c2dd88ca8146.mp4



## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>


#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
