### PR TITLE
FIX(security): vulnerabilities in color_picker dev-22.04.x

### DIFF
--- a/centreon/www/include/common/javascript/color_picker.php
+++ b/centreon/www/include/common/javascript/color_picker.php
@@ -34,7 +34,6 @@
  * SVN : $URL$
  * SVN : $Id$
  */
-require_once __DIR__ . '/../../../class/HtmlAnalyzer.php';
 
 $n = "";
 $name = "";
@@ -49,25 +48,12 @@ function filter_get($str)
     return null;
 }
 
-if (function_exists("filter_var")) {
-    $n = \HtmlAnalyzer::sanitizeAndRemoveTags($_GET["n"]);
-    $name = \HtmlAnalyzer::sanitizeAndRemoveTags($_GET["name"]);
-    $title = \HtmlAnalyzer::sanitizeAndRemoveTags($_GET["title"]);
-    if (isset($_GET["hcolor"])) {
-        $hcolor = \HtmlAnalyzer::sanitizeAndRemoveTags($_GET["hcolor"]);
-    }
-} else {
-    $n = filter_get($_GET["n"]);
-    $name = filter_get($_GET["name"]);
-    $title = filter_get($_GET["title"]);
-    if (isset($_GET["hcolor"])) {
-        $hcolor = filter_get($_GET["hcolor"]);
-    }
+$n = htmlspecialchars(filter_get($_GET["n"]), ENT_QUOTES, 'UTF-8');
+$name = htmlspecialchars(filter_get($_GET["name"]), ENT_QUOTES, 'UTF-8');
+$title = htmlspecialchars(filter_get($_GET["title"]), ENT_QUOTES, 'UTF-8');
+if (isset($_GET["hcolor"])) {
+    $hcolor = htmlspecialchars(filter_get($_GET["hcolor"]), ENT_QUOTES, 'UTF-8');
 }
-$n = htmlspecialchars($n, ENT_QUOTES, 'UTF-8');
-$name = htmlspecialchars($name, ENT_QUOTES, 'UTF-8');
-$title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
-$hcolor = htmlspecialchars($hcolor, ENT_QUOTES, 'UTF-8');
 $name1 = $n . "";
 $name2 = $n . "_color";
 


### PR DESCRIPTION
## Description

Fix  vulnerabilities
delete missfunctional code due to cherry-pick from develop + delete call of non-existing file inside color-picker.php 
**Fixes** # MON-15376

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.04.x
- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x (master)

<h2> How this pull request can be tested ? </h2>

1. Go to “Monitoring > Performance > Curves”
2. Create/Edit a curve
3. Modify color of curve
4. Save

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
