### PR TITLE
fix(ui): avoid double call to userTimezone.php

### DIFF
--- a/centreon/tests/e2e/cypress/e2e/Local-authentication/01-local-authentication/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Local-authentication/01-local-authentication/index.ts
@@ -276,7 +276,7 @@ Then('user can not change password unless the minimum time has passed', () => {
     .find('#validForm input[name="submitC"]')
     .click();
 
-  cy.getRefreshDataOnIframe()
+  cy.wait('@getTimeZone')
     .getIframeBody()
     .find('#Form')
     .find('#validForm input[name="change"]')

--- a/centreon/tests/e2e/cypress/support/Commands.ts
+++ b/centreon/tests/e2e/cypress/support/Commands.ts
@@ -183,10 +183,6 @@ Cypress.Commands.add('removeACL', (): Cypress.Chainable => {
   });
 });
 
-Cypress.Commands.add('getRefreshDataOnIframe', () => {
-  return cy.wait(['@getTimeZone', '@getTimeZone']);
-});
-
 interface GetByLabelProps {
   label: string;
   tag?: string;
@@ -214,7 +210,6 @@ declare global {
       executeCommandsViaClapi: (fixtureFile: string) => Cypress.Chainable;
       getByLabel: ({ tag, label }: GetByLabelProps) => Cypress.Chainable;
       getIframeBody: () => Cypress.Chainable;
-      getRefreshDataOnIframe: () => Cypress.Chainable;
       hoverRootMenuItem: (rootItemNumber: number) => Cypress.Chainable;
       isInProfileMenu: (targetedMenu: string) => Cypress.Chainable;
       loginByTypeOfUser: ({

--- a/centreon/www/include/core/header/htmlHeader.php
+++ b/centreon/www/include/core/header/htmlHeader.php
@@ -284,7 +284,7 @@ if ($result = $statement->fetch(\PDO::FETCH_ASSOC)) {
                 }
             }
             ?>
-            check_session(<?php $tM ?>);
+            check_session(<?php echo $tM ?>);
         });
     </script>
     <script src="./include/common/javascript/xslt.js" type="text/javascript"></script>


### PR DESCRIPTION
## Description

avoid double call to userTimezone.php
This should fix random failuer on cypress test

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check github actions