### PR TITLE
enh(CI): replacing wait second by wait request 'getTimeZone'

### DIFF
--- a/centreon/tests/e2e/cypress/e2e/Local-authentication/01-local-authentication/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Local-authentication/01-local-authentication/index.ts
@@ -147,7 +147,7 @@ Then(
       .find('#validForm input[name="submitC"]')
       .click();
 
-    cy.wait(1000)
+    cy.wait('@getTimeZone')
       .getIframeBody()
       .find('#Form')
       .find('#tab1')
@@ -293,7 +293,7 @@ Then('user can not change password unless the minimum time has passed', () => {
     .find('#validForm input[name="submitC"]')
     .click();
 
-  cy.wait(1000)
+  cy.wait('@getTimeZone')
     .getIframeBody()
     .find('#Form')
     .find('#tab1')
@@ -326,7 +326,7 @@ Then('user can not reuse the last passwords more than 3 times', () => {
     .find('#validForm input[name="submitC"]')
     .click();
 
-  cy.wait(1000)
+  cy.wait('@getTimeZone')
     .getIframeBody()
     .find('#Form')
     .find('#tab1')

--- a/centreon/tests/e2e/cypress/test.ts
+++ b/centreon/tests/e2e/cypress/test.ts
@@ -1,3 +1,0 @@
-const test = 'OK';
-
-export default test;


### PR DESCRIPTION
## Description

Replacing wait second by wait request 'getTimeZone' on Local-authentication cypress e2e test.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Run github action on CI or run cypress e2e test on local.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
