### PR TITLE
enh(ci): Add rpm delivery cleanup and structure 2110

### DIFF
--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -19,6 +19,12 @@ inputs:
   version:
     description: "Centreon packaged version"
     required: true
+  minor_version:
+    description: "Centreon packaged version"
+    required: true
+  release:
+    description: The release number
+    required: true
   cache_key:
     description: "The cached package key"
     required: true
@@ -77,15 +83,22 @@ runs:
           echo "[DEBUG] - Arch: $ARCH"
 
           MAJOR=$VERSION
+          MINOR=${{ inputs.minor_version }}
+          RELEASE=${{ inputs.release }}
           DISTRIB=$DISTRIB
           REPOTYPE=${{ inputs.stability }}
           ARCH=$ARCH
           PROJECT=${{ inputs.module_name }}
-          FOLDER=$(basename $FILE .rpm)
           PROJECT_PATH="standard"
-          TARGET="/srv/centreon-yum/yum.centreon.com/$PROJECT_PATH/$MAJOR/$DISTRIB/$REPOTYPE/$ARCH/$PROJECT/$FOLDER"
-          PROJECT_LOCATION="/srv/centreon-yum/yum.centreon.com/$PROJECT_PATH/$MAJOR/$DISTRIB/$REPOTYPE/$ARCH/$PROJECT"
-          METADATAS="/srv/centreon-yum/yum.centreon.com/$PROJECT_PATH/$MAJOR/$DISTRIB/$REPOTYPE/$ARCH"
+
+          # Delivery with proper repository structure according to stability
+          if [ "${{ inputs.stability }}" == stable ]; then
+            TARGET="/srv/centreon-yum/yum.centreon.com/$PROJECT_PATH/$MAJOR/$DISTRIB/$REPOTYPE/$ARCH/RPMS"
+          else
+            FOLDER="centreon-$PROJECT-$MAJOR.$MINOR-$RELEASE"
+            TARGET="/srv/centreon-yum/yum.centreon.com/$PROJECT_PATH/$MAJOR/$DISTRIB/$REPOTYPE/$ARCH/$PROJECT/$FOLDER"
+            PROJECT_LOCATION="/srv/centreon-yum/yum.centreon.com/$PROJECT_PATH/$MAJOR/$DISTRIB/$REPOTYPE/$ARCH/$PROJECT"
+          fi
 
           echo "[DEBUG] - Folder: $FOLDER"
           echo "[DEBUG] - Project : $PROJECT"
@@ -97,8 +110,16 @@ runs:
           #ssh -o StrictHostKeyChecking=no "${{ inputs.yum_repo_address }}" "ls -drc $PROJECT_LOCATION/* 2>&- | head -n -6 | xargs rm -rf"
         done
 
+        # Cleanup is done on unstable repository only
+        if [ "${{ inputs.stability }}" == unstable ]; then
+          ssh -o StrictHostKeyChecking=no "${{ inputs.yum_repo_address }}" "ls -drc $PROJECT_LOCATION/* 2>&- | head -n -1 | xargs rm -rf"
+        fi
+
+        # Update repository metadata
+        METADATAS="/srv/centreon-yum/yum.centreon.com/$PROJECT_PATH/$MAJOR/$DISTRIB/$REPOTYPE/$ARCH"
         ssh -o StrictHostKeyChecking=no "${{ inputs.yum_repo_address }}" "sh "${{ inputs.update_repo_path }}" $METADATAS" 2>&-
 
+        # Invalidate cloudfront cache
         ID="${{ inputs.cloudfront_id }}"
         PATHS="/$PROJECT_PATH/$MAJOR/$DISTRIB/$REPOTYPE/$ARCH/*"
         ITERATIONS=1

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -79,6 +79,8 @@ jobs:
           repository_name: standard
           distrib: ${{ matrix.distrib }}
           version: ${{ needs.get-version.outputs.major_version }}
+          minor_version: ${{ needs.get-version.outputs.minor_version }}
+          release: ${{ needs.get-version.outputs.release }}
           nexus_username: ${{ secrets.ARTI_USER }}
           nexus_password: ${{ secrets.ARTI_PASSWD }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -79,6 +79,8 @@ jobs:
           repository_name: standard
           distrib: ${{ matrix.distrib }}
           version: ${{ needs.get-version.outputs.major_version }}
+          minor_version: ${{ needs.get-version.outputs.minor_version }}
+          release: ${{ needs.get-version.outputs.release }}
           nexus_username: ${{ secrets.ARTI_USER }}
           nexus_password: ${{ secrets.ARTI_PASSWD }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -77,6 +77,8 @@ jobs:
           repository_name: standard
           distrib: ${{ matrix.distrib }}
           version: ${{ needs.get-version.outputs.major_version }}
+          minor_version: ${{ needs.get-version.outputs.minor_version }}
+          release: ${{ needs.get-version.outputs.release }}
           nexus_username: ${{ secrets.REPOS_USERNAME }}
           nexus_password: ${{ secrets.REPOS_PASSWORD }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -79,6 +79,8 @@ jobs:
           repository_name: standard
           distrib: ${{ matrix.distrib }}
           version: ${{ needs.get-version.outputs.major_version }}
+          minor_version: ${{ needs.get-version.outputs.minor_version }}
+          release: ${{ needs.get-version.outputs.release }}
           nexus_username: ${{ secrets.ARTI_USER }}
           nexus_password: ${{ secrets.ARTI_PASSWD }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -410,6 +410,8 @@ jobs:
           repository_name: standard
           distrib: ${{ matrix.distrib }}
           version: ${{ needs.get-version.outputs.major_version }}
+          minor_version: ${{ needs.get-version.outputs.minor_version }}
+          release: ${{ needs.get-version.outputs.release }}
           nexus_username: ${{ secrets.ARTI_USER }}
           nexus_password: ${{ secrets.ARTI_PASSWD }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}

--- a/.github/workflows/widget-delivery.yml
+++ b/.github/workflows/widget-delivery.yml
@@ -7,6 +7,13 @@ on:
       major_version:
         required: true
         type: string
+      minor_version:
+        required: true
+        type: string
+      release:
+        description: The release number
+        required: true
+        type: string
       stability:
         required: true
         type: string
@@ -46,12 +53,14 @@ jobs:
       - name: Delivery
         uses: ./.github/actions/rpm-delivery
         with:
-          module_name: ${{ inputs.widget_name }}
+          module_name: widget-${{ inputs.widget_name }}
           repository_name: standard
           distrib: ${{ matrix.distrib }}
           version: ${{ inputs.major_version }}
-          nexus_username: ${{ secrets.artifactory_username }}
-          nexus_password: ${{ secrets.artifactory_password }}
+          minor_version: ${{ inputs.minor_version }}          
+          release: ${{ inputs.release }}
+          nexus_username: ${{ secrets.nexus_username}}
+          nexus_password: ${{ secrets.nexus_password }}
           cache_key: ${{ github.sha }}-${{ github.run_id }}-rpm-${{ matrix.distrib }}
           yum_repo_url: ${{ secrets.YUM_REPO_ADDRESS }}
           update_repo_path: ${{ secrets.UPDATE_REPO_PATH }}

--- a/.github/workflows/widget-engine-status.yml
+++ b/.github/workflows/widget-engine-status.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: engine-status
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-global-health.yml
+++ b/.github/workflows/widget-global-health.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: global-health
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-graph-monitoring.yml
+++ b/.github/workflows/widget-graph-monitoring.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: graph-monitoring
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-grid-map.yml
+++ b/.github/workflows/widget-grid-map.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: grid-map
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-host-monitoring.yml
+++ b/.github/workflows/widget-host-monitoring.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: host-monitoring
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-hostgroup-monitoring.yml
+++ b/.github/workflows/widget-hostgroup-monitoring.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: hostgroup-monitoring
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-httploader.yml
+++ b/.github/workflows/widget-httploader.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: httploader
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-live-top10-cpu-usage.yml
+++ b/.github/workflows/widget-live-top10-cpu-usage.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: live-top10-cpu-usage
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-live-top10-memory-usage.yml
+++ b/.github/workflows/widget-live-top10-memory-usage.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: live-top10-memory-usage
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-service-monitoring.yml
+++ b/.github/workflows/widget-service-monitoring.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: service-monitoring
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-servicegroup-monitoring.yml
+++ b/.github/workflows/widget-servicegroup-monitoring.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: servicegroup-monitoring
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}

--- a/.github/workflows/widget-tactical-overview.yml
+++ b/.github/workflows/widget-tactical-overview.yml
@@ -43,6 +43,8 @@ jobs:
     with:
       widget_name: tactical-overview
       major_version: ${{ needs.get-version.outputs.major_version }}
+      minor_version: ${{ needs.get-version.outputs.minor_version }}
+      release: ${{ needs.get-version.outputs.release }}
       stability: ${{ needs.get-version.outputs.stability }}
     secrets:
       artifactory_username: ${{ secrets.REPOS_USERNAME }}


### PR DESCRIPTION
## Description

Add rpm delivery repository cleanup after delivery to avoid having too many rpms and slowdown of repository browsing
Add rpm unstable and testing repository structure to properly match the old structure and allow cleanup

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
