### PR TITLE
Increase service monitoring widget performance

### DIFF
--- a/widgets/centreon-widget-service-monitoring/service-monitoring/configs.xml
+++ b/widgets/centreon-widget-service-monitoring/service-monitoring/configs.xml
@@ -71,7 +71,7 @@
       <option value="last_state_change" label="Duration"/>
       <option value="last_hard_state_change" label="Hard State Duration"/>
     </preference>
-    <preference label="Order By status (second sort)" name="order_by2" defaultValue="" type="sort">
+    <preference label="Order By status (second sort)&lt;br/&gt; &lt;span style=&quot;color:red&quot;&gt;(Be aware this might have impact on performances)&lt;/span&gt;" name="order_by2" defaultValue="" type="sort">
       <option value="h_state" label="Host Status"/>
       <option value="s_state" label="Service Status"/>
     </preference>

--- a/widgets/centreon-widget-service-monitoring/service-monitoring/src/index.php
+++ b/widgets/centreon-widget-service-monitoring/service-monitoring/src/index.php
@@ -114,7 +114,8 @@ $aStateType = ['1' => 'H', '0' => 'S'];
 $mainQueryParameters = [];
 
 // Build Query
-$query = 'SELECT SQL_CALC_FOUND_ROWS h.host_id,
+$query = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT 
+    h.host_id,
     h.name as hostname,
     h.alias as hostalias,
     s.latency,
@@ -363,7 +364,7 @@ if (!$centreon->user->admin) {
         AND acl.service_id = s.service_id
         AND acl.group_id IN (" . $groupList . ") ";
 }
-$orderBy = 'hostname ASC , description ASC';
+$orderBy = 'hostname ASC ';
 
 if (isset($preferences['order_by']) && trim($preferences['order_by']) != '') {
     $aOrder = explode(' ', $preferences['order_by']);
@@ -383,8 +384,6 @@ if (isset($preferences['order_by']) && trim($preferences['order_by']) != '') {
         $orderBy .= ', ' . $aOrder[0] . ' ' . $aOrder[1];
     }
 }
-
-$query .= 'GROUP BY hostname, description ';
 
 if (trim($orderBy)) {
     $query .= "ORDER BY " . $orderBy;


### PR DESCRIPTION
## Description

** This PR improves performance of service monitoring widget. It replaces GROUP BY part from SQL requests with DISTINCT.
A warning message is displayed at secondary order filed in the preference configuration form

This is a cherry pick of https://github.com/centreon/centreon/pull/289

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Compare performance before and after widget installation

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
