### PR TITLE
enh(CI): Update local-authentication e2e tests for fix random fail on CI

### DIFF
--- a/centreon/tests/e2e/cypress/e2e/Local-authentication/01-local-authentication/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Local-authentication/01-local-authentication/index.ts
@@ -54,16 +54,15 @@ beforeEach(() => {
 });
 
 Given('an administrator deploying a new Centreon platform', () =>
-  cy
-    .loginByTypeOfUser({ jsonName: 'admin', preserveToken: true })
-    .wait('@getNavigationList')
+  cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: true })
 );
 
 When('the administrator opens the authentication configuration menu', () => {
-  cy.navigateTo({
-    page: 'Authentication',
-    rootItemNumber: 4
-  })
+  cy.wait('@getNavigationList')
+    .navigateTo({
+      page: 'Authentication',
+      rootItemNumber: 4
+    })
     .get('div[role="tablist"] button')
     .eq(0)
     .contains('Password security policy');
@@ -163,16 +162,14 @@ Then(
 Given(
   'an administrator configuring a Centreon platform and an existing user account with password up to date',
   () => {
-    cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: true }).wait(
-      '@getNavigationList'
-    );
+    cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: true });
   }
 );
 
 When(
   'the administrator sets valid password expiration policy durations in password expiration policy configuration and the user password expires',
   () => {
-    cy.navigateTo({
+    cy.wait('@getNavigationList').navigateTo({
       page: 'Authentication',
       rootItemNumber: 4
     });
@@ -221,16 +218,14 @@ Then('the existing user can not authenticate and is notified about it', () => {
 Given(
   'an administrator configuring a Centreon platform and an existing user account with a first password',
   () => {
-    cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: true }).wait(
-      '@getNavigationList'
-    );
+    cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: true });
   }
 );
 
 When(
   'the administrator enables the password reuseability and a user attempts to change its password multiple times in a row',
   () => {
-    cy.navigateTo({
+    cy.wait('@getNavigationList').navigateTo({
       page: 'Authentication',
       rootItemNumber: 4
     });
@@ -350,15 +345,13 @@ Then('user can not reuse the last passwords more than 3 times', () => {
 });
 
 Given('an existing password policy configuration and 2 non admin users', () => {
-  cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: true }).wait(
-    '@getNavigationList'
-  );
+  cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: true });
 });
 
 When(
   'the administrator adds or remove a user from the excluded user list',
   () => {
-    cy.navigateTo({
+    cy.wait('@getNavigationList').navigateTo({
       page: 'Authentication',
       rootItemNumber: 4
     });
@@ -427,16 +420,14 @@ Then(
 Given(
   'an administrator configuring a Centreon platform and an existing user account not blocked',
   () => {
-    cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: true }).wait(
-      '@getNavigationList'
-    );
+    cy.loginByTypeOfUser({ jsonName: 'admin', preserveToken: true });
   }
 );
 
 When(
   'the administrator sets valid password blocking policy and the user attempts to login multiple times',
   () => {
-    cy.navigateTo({
+    cy.wait('@getNavigationList').navigateTo({
       page: 'Authentication',
       rootItemNumber: 4
     });


### PR DESCRIPTION
## Description

Updating cypress e2e test for local-authentication. This will fix random fail on GHA CI/CD. The commands "wait('getNavigationList')" on code.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Run GHA CI/CD or run Cypress E2E testing on local.

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
