### PR TITLE
Style(media): Buttons are not well displayed in media image directory dev-22.10.x

### DIFF
--- a/centreon/www/Themes/Generic-theme/style.css
+++ b/centreon/www/Themes/Generic-theme/style.css
@@ -1896,7 +1896,9 @@ font-size: 12px;
     text-align:justify;
 }
 
-#validForm label {padding:2px 4px;}
+#validForm label {
+    padding: 2px 18px;
+}
 
 .FormFooter,.ListColFooter5,.ListColFooter5 a,.ListColFooterCenter,.ListColFooterLeft,.ListColFooterRight   {font-size:12px;font-weight:700;padding-right:10px;}
 .ListColFooterRight,.ListColRight,.Toolbar_pagelimit {text-align:right;}

--- a/centreon/www/include/options/media/images/formDirectory.php
+++ b/centreon/www/include/options/media/images/formDirectory.php
@@ -179,12 +179,16 @@ if ($o == IMAGE_MOVE) {
     } else {
         $confirm = "";
     }
-    $subC = $form->addElement('submit', 'submitC', _("Save"));
+    $subC = $form->addElement('submit', 'submitC', _("Save"),['class' => 'btc bt_success']);
     $res = $form->addElement(
         "button",
         "cancel",
         _("Cancel"),
-        array("onClick" => "javascript:window.location.href='?p=$p'")
+        [
+            "class" => "btc bt_success",
+            "onClick" => "javascript:window.location.href='?p=$p'"
+        ]
+
     );
     $form->setDefaults($dir);
 }

--- a/centreon/www/include/options/media/images/formImg.php
+++ b/centreon/www/include/options/media/images/formImg.php
@@ -172,10 +172,10 @@ $form->addElement(
     "button",
     "cancel",
     _("Cancel"),
-    array(
-        "onClick" => "javascript:window.location.href='?p=$p'"
-    ),
-    array("class" => "btc bt_default")
+    [
+        "onClick" => "javascript:window.location.href='?p=$p'",
+        "class" => "btc bt_default"
+    ]
 );
 
 $form->addElement('textarea', 'img_comment', _("Comments"), $attrsTextarea);


### PR DESCRIPTION
## Description

Checkbox and buttons are hard to see in both dark & light mode 
**Fixes** # MON-15999
![image](https://user-images.githubusercontent.com/108519266/210248814-75f118e8-7004-4159-af51-3dae430d9439.png)
![image](https://user-images.githubusercontent.com/108519266/210248881-de1c6622-60d3-410d-88fd-839c05023a01.png)
![image](https://user-images.githubusercontent.com/108519266/210248984-8801ff21-5a9f-4b0c-9692-459e303a2a7a.png)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Go to administration → parameters → images 

 1- Add a new image in new directory 
 2- click on folder name and see if buttons and checkbox are displayed well

After that click on the directory name 

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-15999]: https://centreon.atlassian.net/browse/MON-15999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ