### PR TITLE
MON-16229 : fix console warnings

### DIFF
--- a/centreon/packages/ui/package.json
+++ b/centreon/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centreon/ui",
-  "version": "23.4.10",
+  "version": "23.4.11-MON-16229/fix-console-warnings.0",
   "description": "Centreon UI Components",
   "main": "src",
   "scripts": {

--- a/centreon/packages/ui/src/InputField/Select/index.tsx
+++ b/centreon/packages/ui/src/InputField/Select/index.tsx
@@ -81,7 +81,6 @@ const SelectField = ({
     <FormControl error={!isNil(error)} fullWidth={fullWidth} size="small">
       {label && <InputLabel>{label}</InputLabel>}
       <Select
-        disableUnderline
         displayEmpty
         fullWidth={fullWidth}
         inputProps={{

--- a/centreon/packages/ui/src/InputField/Text/index.tsx
+++ b/centreon/packages/ui/src/InputField/Text/index.tsx
@@ -93,7 +93,6 @@ const TextField = forwardRef(
               },
               className
             ),
-            disableUnderline: true,
             endAdornment: EndAdornment && (
               <OptionalLabelInputAdornment label={label} position="end">
                 <EndAdornment />

--- a/centreon/www/front_src/src/Header/RessourceStatusCounter/index.tsx
+++ b/centreon/www/front_src/src/Header/RessourceStatusCounter/index.tsx
@@ -75,19 +75,7 @@ const RessourceStatusCounter = <
 
   const hasPending = data.pending > 0;
 
-  return (
-    <ClickAwayListener
-      onClickAway={(): void => {
-        if (!toggled) {
-          return;
-        }
-
-        toggleDetailedView();
-      }}
-    >
-      {children({ data, hasPending, toggleDetailedView, toggled })}
-    </ClickAwayListener>
-  );
+  return children({ data, hasPending, toggleDetailedView, toggled })
 };
 
 export default RessourceStatusCounter;

--- a/centreon/www/front_src/src/Header/UserMenu/index.tsx
+++ b/centreon/www/front_src/src/Header/UserMenu/index.tsx
@@ -113,7 +113,7 @@ const useStyles = makeStyles()((theme) => ({
     paddingLeft: theme.spacing(3)
   },
   listItem: {
-    '&:first-child': {
+    '&:first-of-type': {
       borderBottom: `1px solid ${theme.palette.divider}`
     },
     '&:hover': {
@@ -124,7 +124,7 @@ const useStyles = makeStyles()((theme) => ({
         ? theme.palette.common.white
         : theme.palette.primary.main
     },
-    '&:last-child': {
+    '&:last-of-type': {
       borderTop: `1px solid ${theme.palette.divider}`
     },
     padding: theme.spacing(1)


### PR DESCRIPTION
## Description

Solve console warnings. No feature changes expected. 
Changes occurred in Resources Status and Authentication pages

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # ([MON-16229](https://centreon.atlassian.net/browse/MON-16229))

fix console warnings by : 

- removing deprecated `disableUnderline` prop on MUI input field
- using `:first-of-type` and `:last-of-type` instead of `:first-child` and `:last-child` pseudo selector 
- removing unnecessary `clickAwayContainer` from RessourceStatusCounter 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-16229]: https://centreon.atlassian.net/browse/MON-16229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ