### PR TITLE
enh(host): remove password on SNMP Community

### DIFF
--- a/centreon/src/Centreon/Domain/Log/LegacyLogger.php
+++ b/centreon/src/Centreon/Domain/Log/LegacyLogger.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,12 +23,9 @@ declare(strict_types=1);
 namespace Centreon\Domain\Log;
 
 use Psr\Log\LoggerInterface;
-use Centreon\Domain\Log\LoggerTrait;
 
 /**
- * This class is designed to be used in legacy codebase to use a logger
- *
- * @package Centreon\Domain\Log
+ * This class is designed to be used in legacy codebase to use a logger.
  */
 class LegacyLogger implements LoggerInterface
 {
@@ -44,9 +41,14 @@ class LegacyLogger implements LoggerInterface
         log as traitLog;
     }
 
+    public function __construct()
+    {
+        $this->addIgnoreClass(__CLASS__);
+    }
+
     public function emergency($message, array $context = []): void
     {
-        $this->traitEmergency($message, $context);
+        $this->traitEmergency((string) $message, $context);
     }
 
     /**
@@ -54,7 +56,7 @@ class LegacyLogger implements LoggerInterface
      */
     public function alert($message, array $context = []): void
     {
-        $this->traitAlert($message, $context);
+        $this->traitAlert((string) $message, $context);
     }
 
     /**
@@ -62,7 +64,7 @@ class LegacyLogger implements LoggerInterface
      */
     public function critical($message, array $context = []): void
     {
-        $this->traitCritical($message, $context);
+        $this->traitCritical((string) $message, $context);
     }
 
     /**
@@ -70,7 +72,7 @@ class LegacyLogger implements LoggerInterface
      */
     public function error($message, array $context = []): void
     {
-        $this->traitError($message, $context);
+        $this->traitError((string) $message, $context);
     }
 
     /**
@@ -78,7 +80,7 @@ class LegacyLogger implements LoggerInterface
      */
     public function warning($message, array $context = []): void
     {
-        $this->traitWarning($message, $context);
+        $this->traitWarning((string) $message, $context);
     }
 
     /**
@@ -86,7 +88,7 @@ class LegacyLogger implements LoggerInterface
      */
     public function notice($message, array $context = []): void
     {
-        $this->traitNotice($message, $context);
+        $this->traitNotice((string) $message, $context);
     }
 
     /**
@@ -94,7 +96,7 @@ class LegacyLogger implements LoggerInterface
      */
     public function info($message, array $context = []): void
     {
-        $this->traitInfo($message, $context);
+        $this->traitInfo((string) $message, $context);
     }
 
     /**
@@ -102,7 +104,7 @@ class LegacyLogger implements LoggerInterface
      */
     public function debug($message, array $context = []): void
     {
-        $this->traitDebug($message, $context);
+        $this->traitDebug((string) $message, $context);
     }
 
     /**
@@ -110,6 +112,6 @@ class LegacyLogger implements LoggerInterface
      */
     public function log($level, $message, array $context = []): void
     {
-        $this->traitLog($level, $message, $context);
+        $this->traitLog($level, (string) $message, $context);
     }
 }

--- a/centreon/src/Centreon/Domain/Log/LoggerTrait.php
+++ b/centreon/src/Centreon/Domain/Log/LoggerTrait.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -27,28 +27,21 @@ use Psr\Log\LoggerInterface;
 
 /**
  * This class is design to provide all the methods for recording events.
- *
- * @package Centreon\Domain\Log
  */
 trait LoggerTrait
 {
-    /**
-     * @var ContactInterface
-     */
-    private $loggerContact;
+    private ?ContactInterface $loggerContact = null;
 
-    /**
-     * @var LoggerInterface
-     */
-    private $logger;
+    private ?LoggerInterface $logger = null;
 
-    /**
-     * @var ContactForDebug
-     */
-    private $loggerContactForDebug;
+    private ?ContactForDebug $loggerContactForDebug = null;
+
+    /** @var string[] */
+    private array $ignoredFiles = [];
 
     /**
      * @param ContactInterface $loggerContact
+     *
      * @required
      */
     public function setLoggerContact(ContactInterface $loggerContact): void
@@ -58,6 +51,7 @@ trait LoggerTrait
 
     /**
      * @param ContactForDebug $loggerContactForDebug
+     *
      * @required
      */
     public function setLoggerContactForDebug(ContactForDebug $loggerContactForDebug): void
@@ -67,20 +61,33 @@ trait LoggerTrait
 
     /**
      * @param LoggerInterface $centreonLogger
+     *
      * @required
      */
     public function setLogger(LoggerInterface $centreonLogger): void
     {
         $this->logger = $centreonLogger;
+        $this->addIgnoreClass(LoggerTrait::class);
+    }
+
+    public function addIgnoreClass(string $className): void
+    {
+        if (class_exists($className) || trait_exists($className)) {
+            $reflexion = new \ReflectionClass($className);
+            if ($filename = $reflexion->getFileName()) {
+                $this->ignoredFiles[] = $filename;
+            }
+        }
     }
 
     /**
      * @param string $message
      * @param mixed[] $context
      * @param callable|null $callable
+     *
      * @see \Psr\Log\LoggerInterface::emergency()
      */
-    private function emergency(string $message, array $context = [], callable $callable = null): void
+    private function emergency(string $message, array $context = [], ?callable $callable = null): void
     {
         if ($this->canBeLogged()) {
             if ($callable !== null) {
@@ -94,9 +101,10 @@ trait LoggerTrait
      * @param string $message
      * @param mixed[] $context
      * @param callable|null $callable
+     *
      * @see \Psr\Log\LoggerInterface::alert()
      */
-    private function alert(string $message, array $context = [], callable $callable = null): void
+    private function alert(string $message, array $context = [], ?callable $callable = null): void
     {
         if ($this->canBeLogged()) {
             if ($callable !== null) {
@@ -110,9 +118,10 @@ trait LoggerTrait
      * @param string $message
      * @param mixed[] $context
      * @param callable|null $callable
+     *
      * @see \Psr\Log\LoggerInterface::critical()
      */
-    private function critical(string $message, array $context = [], callable $callable = null): void
+    private function critical(string $message, array $context = [], ?callable $callable = null): void
     {
         if ($this->canBeLogged()) {
             if ($callable !== null) {
@@ -126,9 +135,10 @@ trait LoggerTrait
      * @param string $message
      * @param mixed[] $context
      * @param callable|null $callable
+     *
      * @see \Psr\Log\LoggerInterface::error()
      */
-    private function error(string $message, array $context = [], callable $callable = null): void
+    private function error(string $message, array $context = [], ?callable $callable = null): void
     {
         if ($this->canBeLogged()) {
             if ($callable !== null) {
@@ -142,9 +152,10 @@ trait LoggerTrait
      * @param string $message
      * @param mixed[] $context
      * @param callable|null $callable
+     *
      * @see \Psr\Log\LoggerInterface::warning()
      */
-    private function warning(string $message, array $context = [], callable $callable = null): void
+    private function warning(string $message, array $context = [], ?callable $callable = null): void
     {
         if ($this->canBeLogged()) {
             if ($callable !== null) {
@@ -158,9 +169,10 @@ trait LoggerTrait
      * @param string $message
      * @param mixed[] $context
      * @param callable|null $callable
+     *
      * @see \Psr\Log\LoggerInterface::notice()
      */
-    private function notice(string $message, array $context = [], callable $callable = null): void
+    private function notice(string $message, array $context = [], ?callable $callable = null): void
     {
         if ($this->canBeLogged()) {
             if ($callable !== null) {
@@ -174,9 +186,10 @@ trait LoggerTrait
      * @param string $message
      * @param mixed[] $context
      * @param callable|null $callable
+     *
      * @see \Psr\Log\LoggerInterface::info()
      */
-    private function info(string $message, array $context = [], callable $callable = null): void
+    private function info(string $message, array $context = [], ?callable $callable = null): void
     {
         if ($this->canBeLogged()) {
             if ($callable !== null) {
@@ -190,9 +203,10 @@ trait LoggerTrait
      * @param string $message
      * @param mixed[] $context
      * @param callable|null $callable
+     *
      * @see \Psr\Log\LoggerInterface::debug()
      */
-    private function debug(string $message, array $context = [], callable $callable = null): void
+    private function debug(string $message, array $context = [], ?callable $callable = null): void
     {
         if ($this->canBeLogged()) {
             if ($callable !== null) {
@@ -207,10 +221,12 @@ trait LoggerTrait
      * @param string $message
      * @param mixed[] $context
      * @param callable|null $callable
+     *
      * @throws \Psr\Log\InvalidArgumentException
+     *
      * @see \Psr\Log\LoggerInterface::log()
      */
-    private function log($level, string $message, array $context = [], callable $callable = null): void
+    private function log($level, string $message, array $context = [], ?callable $callable = null): void
     {
         if ($this->canBeLogged()) {
             if ($callable !== null) {
@@ -222,15 +238,29 @@ trait LoggerTrait
 
     /**
      * @param string $message
+     *
      * @return string
      */
     private function prefixMessage(string $message): string
     {
         $debugTrace = debug_backtrace();
-        $callingClass = (count($debugTrace) >= 2)
-            ? $debugTrace[1]['class'] . ':' . $debugTrace[1]['line']
-            : get_called_class();
-        return sprintf('[%s]: %s', $callingClass, $message);
+        /**
+         * @var array{file: string, line: int} $trace
+         */
+        foreach ($debugTrace as $trace) {
+            $file = $trace['file'];
+            if (in_array($file, $this->ignoredFiles, true)) {
+                continue;
+            }
+            if (str_starts_with($file, _CENTREON_PATH_)) {
+                $file = mb_substr($file, mb_strlen(_CENTREON_PATH_));
+            }
+            $callingClass = $file . ':' . $trace['line'];
+
+            return sprintf('[%s]: %s', $callingClass, $message);
+        }
+
+        return '';
     }
 
     /**
@@ -239,6 +269,7 @@ trait LoggerTrait
     private function canBeLogged(): bool
     {
         return $this->logger !== null
+            && $this->loggerContact !== null
             && $this->loggerContactForDebug !== null
             && $this->loggerContactForDebug->isValidForContact($this->loggerContact);
     }

--- a/centreon/src/Centreon/Domain/Log/LoggerTrait.php
+++ b/centreon/src/Centreon/Domain/Log/LoggerTrait.php
@@ -243,7 +243,7 @@ trait LoggerTrait
      */
     private function prefixMessage(string $message): string
     {
-        $debugTrace = debug_backtrace();
+        $debugTrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
         /**
          * @var array{file: string, line: int} $trace
          */

--- a/centreon/www/class/centreonLog.class.php
+++ b/centreon/www/class/centreonLog.class.php
@@ -44,7 +44,6 @@ class CentreonUserLog
     public const TYPE_SQL = 2;
     public const TYPE_LDAP = 3;
     public const TYPE_UPGRADE = 4;
-    public const TYPE_VAULT = 5;
 
     /*
      * Constructor
@@ -77,7 +76,6 @@ class CentreonUserLog
         $this->errorType[self::TYPE_SQL] = $this->path . "/sql-error.log";
         $this->errorType[self::TYPE_LDAP] = $this->path . "/ldap.log";
         $this->errorType[self::TYPE_UPGRADE] = $this->path . "/upgrade.log";
-        $this->errorType[self::TYPE_VAULT] = $this->path . "/vault.log";
     }
 
     /*

--- a/centreon/www/include/common/javascript/centreon/macroPasswordField.js
+++ b/centreon/www/include/common/javascript/centreon/macroPasswordField.js
@@ -55,10 +55,3 @@ function change_macro_input_type(box, must_disable) {
         }
     }
 }
-
-function change_snmp_community_input_type(box) {
-    let snmpCommunityInput = jQuery('input[name="host_snmp_community"]');
-    if (typeof snmpCommunityInput[0] != 'undefined') {
-        snmpCommunityInput[0].type = box.checked ? 'password' : 'text';
-    }
-}

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -1605,12 +1605,12 @@ function updateHost($host_id = null, $from_MC = false, $cfg = null)
                 $httpClient
             );
 
+            // If no more fields are password types, we delete the host from the vault has it will not be read.
             if (
                 ! preg_match('/^secret::\d+::/', $bindParams[':host_snmp_community'][\PDO::PARAM_STR])
                 && empty($passwordTypeData)
                 && ! empty($hostSecrets)
             ) {
-                // If no more fields are password types, we delete the host from the vault has it will not be read.
                 deleteHostFromVault($vaultConfiguration, (int) $host_id, $clientToken, $centreonLog, $httpClient);
             } elseif (! empty($passwordTypeData)) {
                 //Replace olds vault values by the new ones
@@ -1802,7 +1802,6 @@ function updateHost_MC($host_id = null)
 function updateHostHostParent($host_id = null, $ret = array())
 {
     global $form, $pearDB;
-
     if (!$host_id) {
         return;
     }

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -1681,7 +1681,7 @@ function updateHost_MC($host_id = null)
             unset($ret[$name]);
         }
     }
-    if (array_key_exists('host_snmp_community', $ret) && preg_match('/^secret::\\d+::/', $ret['host_snmp_community'])) {
+    if (array_key_exists('host_snmp_community', $ret) && preg_match('/^secret::\d+::/', $ret['host_snmp_community'])) {
         unset($ret['host_snmp_community']);
     }
     $bindParams = sanitizeFormHostParameters($ret);

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -1147,7 +1147,7 @@ function insertHost($ret, $macro_on_demand = null, $server_id = null)
 
     //Check if a vault configuration exists
     $vaultConfiguration = getVaultConfiguration();
-    //If there is a vault configuration write into vault
+    //If there is a vault configuration and host snmp community is defined, write into vault
     if ($vaultConfiguration !== null && $bindParams[':host_snmp_community'][\PDO::PARAM_STR] !== null) {
         try {
             $passwordTypeData = [
@@ -1584,6 +1584,7 @@ function updateHost($host_id = null, $from_MC = false, $cfg = null)
     if ($vaultConfiguration !== null) {
         try {
             $passwordTypeData = [];
+            //If the SNMP Community is defined and is not a vault path it should be updated.
             if (
                 array_key_exists(':host_snmp_community', $bindParams)
                 && ! preg_match('/^secret::\d+::/', $bindParams[':host_snmp_community'][\PDO::PARAM_STR])
@@ -1609,7 +1610,7 @@ function updateHost($host_id = null, $from_MC = false, $cfg = null)
                 && empty($passwordTypeData)
                 && ! empty($hostSecrets)
             ) {
-                // If no more fields are password types, we delete the host from the vault has it will not be readen.
+                // If no more fields are password types, we delete the host from the vault has it will not be read.
                 deleteHostFromVault($vaultConfiguration, (int) $host_id, $clientToken, $centreonLog, $httpClient);
             } elseif (! empty($passwordTypeData)) {
                 //Replace olds vault values by the new ones
@@ -1748,6 +1749,7 @@ function updateHost_MC($host_id = null)
     if ($vaultConfiguration !== null) {
         try {
             $passwordTypeData = [];
+            //If the SNMP Community is defined and is not a vault path it should be updated.
             if(
                 array_key_exists(':host_snmp_community', $bindParams)
                 && ! preg_match('/^secret::\d+::/', $bindParams[':host_snmp_community'][\PDO::PARAM_STR])

--- a/centreon/www/include/configuration/configObject/host/formHost.ihtml
+++ b/centreon/www/include/configuration/configObject/host/formHost.ihtml
@@ -80,7 +80,6 @@
 		        <td class="FormRowField"><img class="helpTooltip" name="snmp_options"> {$form.host_snmp_community.label} & {$form.host_snmp_version.label}</td>
 		        <td class="FormRowValue">
 					{$form.host_snmp_community.html}&nbsp;&nbsp;{$form.host_snmp_version.html}
-					&nbsp;&nbsp;{$form.host_snmp_community_is_password.label}&nbsp;{$form.host_snmp_community_is_password.html}
 				</td>
 		    </tr>
             {if isset($form.nagios_server_id.label)}

--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -101,15 +101,6 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
     // Set base value
     $host_list = $statement->fetch();
     $host = array_map("myDecode", $host_list);
-
-    if (
-        ! empty($host['host_snmp_community'])
-        && (bool) $host['host_snmp_community_is_password'] === true
-        && ! preg_match('/^secret::\\d+::/', $host['host_snmp_community'])
-    ) {
-        $host['host_snmp_community'] = PASSWORD_REPLACEMENT_VALUE;
-    }
-
     $cmdId = $host['command_command_id'];
 
     // Set Host Notification Options
@@ -379,16 +370,6 @@ if ($o !== HOST_MASSIVE_CHANGE) {
 }
 $form->addElement('text', 'host_snmp_community', _("SNMP Community"), $attrsText);
 $form->addElement('select', 'host_snmp_version', _("Version"), array(null => null, 1 => "1", "2c" => "2c", 3 => "3"));
-$form->addElement(
-    'checkbox',
-    'host_snmp_community_is_password',
-    _('Password'),
-    null,
-    [
-        'id' => 'host_snmp_community_is_password',
-        'onClick' => 'javascript:change_snmp_community_input_type(this)'
-    ]
-);
 
 /*
  * Include GMT Class

--- a/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -67,13 +67,7 @@ if (($o === HOST_TEMPLATE_MODIFY || $o === HOST_TEMPLATE_WATCH) && isset($host_i
     # Set base value
     if ($statement->rowCount()) {
         $host = array_map("myDecode", $statement->fetch());
-        if (
-            ! empty($host['host_snmp_community'])
-            && (bool) $host['host_snmp_community_is_password'] === true
-            && ! preg_match('/^secret::\\d+::/', $host['host_snmp_community'])
-        ) {
-            $host['host_snmp_community'] = PASSWORD_REPLACEMENT_VALUE;
-        }
+
         $cmdId = $host['command_command_id'];
         # Set Host Notification Options
         $tmp = explode(',', $host["host_notification_options"]);
@@ -278,16 +272,6 @@ if ($o !== HOST_TEMPLATE_MASSIVE_CHANGE) {
 $form->addElement('text', 'host_address', _("Address"), $attrsText);
 $form->addElement('select', 'host_snmp_version', _("Version"), array(null => null, 1 => "1", "2c" => "2c", 3 => "3"));
 $form->addElement('text', 'host_snmp_community', _("SNMP Community"), $attrsText);
-$form->addElement(
-    'checkbox',
-    'host_snmp_community_is_password',
-    _('Password'),
-    null,
-    [
-        'id' => 'host_snmp_community_is_password',
-        'onClick' => 'javascript:change_snmp_community_input_type(this)'
-    ]
-);
 
 $timeAvRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_timezone&action=list';
 $timeDeRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_timezone'

--- a/centreon/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -239,7 +239,7 @@ if (!is_null($host_id)) {
             " AND s.enabled = 1 ";
         $DBRESULT = $pearDBO->query($rq);
 
-        $tab_status_service = array(0 => "OK", 1 => "WARNING", 2 => "CRITICAL", "3" => "UNKNOWN", "4" => "PENDING");
+        $tab_status_service = array(0 => "OK", 1 => "WARNING", 2 => "CRITICAL", 3 => "UNKNOWN", 4 => "PENDING");
         $tab_class_service = array(
             "ok" => 'service_ok',
             "warning" => 'service_warning',
@@ -301,10 +301,13 @@ if (!is_null($host_id)) {
             if (isset($data['performance_data'])) {
                 $data['performance_data'] = $data['performance_data'];
             }
+            if ($data["current_state"] === null || !in_array($data["current_state"], array_keys($tab_status_service))) {
+                $data["current_state"] = 4; // default to PENDING
+            }
             if ($data["service_description"] == $svc_description) {
                 $service_status = $data;
             }
-            if (!isset($tab_status[$data["current_state"]])) {
+            if (!isset($tab_status[$tab_status_service[$data["current_state"]]])) {
                 $tab_status[$tab_status_service[$data["current_state"]]] = 0;
             }
             $tab_status[$tab_status_service[$data["current_state"]]]++;

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -1365,7 +1365,6 @@ CREATE TABLE `host` (
   `host_acknowledgement_timeout` int(11) DEFAULT NULL,
   `host_stalking_options` varchar(200) DEFAULT NULL,
   `host_snmp_community` varchar(255) DEFAULT NULL,
-  `host_snmp_community_is_password` enum('0', '1') DEFAULT '0' NOT NULL,
   `host_snmp_version` varchar(255) DEFAULT NULL,
   `host_location` int(11) DEFAULT '0',
   `host_comment` text,

--- a/centreon/www/install/php/Update-23.04.0-beta.1.php
+++ b/centreon/www/install/php/Update-23.04.0-beta.1.php
@@ -42,8 +42,6 @@ try {
         WHERE `PathName_js` = './include/common/javascript/color_picker_mb.js'"
     );
 
-    $errorMessage = "Impossible to add column 'host_snmp_community_is_password' to host table";
-    addSNMPCommunityIsPasswordColumn($pearDB);
     // Transactional queries
     $pearDB->beginTransaction();
 
@@ -111,26 +109,5 @@ function decodeIllegalCharactersNagios(CentreonDB $pearDB): void
         $statement->bindValue(':illegal_macro_output_chars', $modified['illegal_macro_output_chars'], \PDO::PARAM_STR);
         $statement->bindValue(':nagios_id', $modified['nagios_id'], \PDO::PARAM_INT);
         $statement->execute();
-    }
-}
-
-/**
- * Add host_snmp_community_is_password column to host table.
- * This column purpose is to save the SNMP Community has a password and avoid display of sensitive information in UI.
- * If Vault Configurations exists the SNMP Community will be added to the vault if it's a password.
- *
- * @param CentreonDB $pearDB
- * @return void
- */
-function addSNMPCommunityIsPasswordColumn(CentreonDB $pearDB): void
-{
-    if ($pearDB->isColumnExist('host', 'host_snmp_community_is_password') === 0) {
-        $pearDB->query(
-            <<<'SQL'
-                ALTER TABLE `host`
-                ADD COLUMN host_snmp_community_is_password enum('0','1') DEFAULT '0' NOT NULL
-                AFTER `host_snmp_community`
-            SQL
-        );
     }
 }


### PR DESCRIPTION
## Description

This PR intends to remove the password checkbox on SNMP Community. Instead of managing SNMP Community as password,
If a vault configuration exist, the SNMP Community will automatically be write on the vault, else we keep the existing behaviour (stored as clear value in database)

**Fixes** # MON-16224

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
