### PR TITLE
fix(UI): Modal title overlapping and hiding modal content

### DIFF
--- a/centreon/packages/ui/package.json
+++ b/centreon/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centreon/ui",
-  "version": "23.4.12-MON-16373-modal-title-overide-title-text-box.1",
+  "version": "23.4.12-MON-16373-modal-title-overide-title-text-box.2",
   "description": "Centreon UI Components",
   "main": "src",
   "scripts": {

--- a/centreon/packages/ui/package.json
+++ b/centreon/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centreon/ui",
-  "version": "23.4.11-MON-16373-modal-title-overide-title-text-box.0",
+  "version": "23.4.12-MON-16373-modal-title-overide-title-text-box.1",
   "description": "Centreon UI Components",
   "main": "src",
   "scripts": {

--- a/centreon/packages/ui/package.json
+++ b/centreon/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centreon/ui",
-  "version": "23.4.11",
+  "version": "23.4.11-MON-16373-modal-title-overide-title-text-box.0",
   "description": "Centreon UI Components",
   "main": "src",
   "scripts": {

--- a/centreon/packages/ui/src/Dialog/index.tsx
+++ b/centreon/packages/ui/src/Dialog/index.tsx
@@ -18,6 +18,12 @@ interface StylesProps {
 
 const useStyles = makeStyles<StylesProps>()((theme, { contentWidth }) => ({
   dialogContent: {
+    // we use both this additional class and the MUI one to increase specificity
+    // MUI override the padding of this element using a selector of type .title + .content
+    // so we need an higher specificity selector
+    '&.MuiDialogContent-root': {
+      paddingTop: theme.spacing(1)
+    },
     width: contentWidth
   }
 }));

--- a/centreon/packages/ui/src/Dialog/index.tsx
+++ b/centreon/packages/ui/src/Dialog/index.tsx
@@ -18,7 +18,7 @@ interface StylesProps {
 
 const useStyles = makeStyles<StylesProps>()((theme, { contentWidth }) => ({
   dialogContent: {
-    // we use both this additional class and the MUI one to increase specificity
+    // We use both this additional class and the MUI one to increase specificity
     // MUI override the padding of this element using a selector of type .title + .content
     // so we need an higher specificity selector
     '&.MuiDialogContent-root': {


### PR DESCRIPTION
## Description

The modal content would be hidden, especially when starting with a labelled input. 
adding a small margin in between the title and content solve the issue. 

to test : open common modals and tests that no content is partially hidden by the header of the modal

**Fixes** # ([issue)](https://centreon.atlassian.net/browse/MON-16373)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
