### PR TITLE
fix(upgrade): Move alter table before transaction and add missing request

### DIFF
--- a/centreon/www/install/php/Update-22.04.8.php
+++ b/centreon/www/install/php/Update-22.04.8.php
@@ -27,8 +27,18 @@ $centreonLog = new CentreonLog();
 $versionOfTheUpgrade = 'UPGRADE - 22.04.8: ';
 
 try {
+    if ($pearDB->isColumnExist('remote_servers', 'app_key') === 1) {
+        $errorMessage = "Unable to remove app_key column";
+        $pearDB->query("ALTER TABLE `remote_servers` DROP COLUMN `app_key`");
+    }
+
     // Transactional queries
     $pearDB->beginTransaction();
+    $errorMessage = "Impossible to delete color picker topology_js entries";
+    $pearDB->query(
+        "DELETE FROM `topology_JS`
+        WHERE `PathName_js` = './include/common/javascript/color_picker_mb.js'"
+    );
 
     $errorMessage = 'Unable to update illegal characters fields from engine configuration of pollers';
     decodeIllegalCharactersNagios($pearDB);


### PR DESCRIPTION
## Description

This PR Intends to Move alter table query before transaction and add missing request in Update-22.04.8 script

**Fixes** # MON-16442

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Perform Upgrade, no errors should occurs, SQL Request should be played

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
