### PR TITLE
fix(web): update pending link on deprecated pages 22.10.x

### DIFF
--- a/centreon/www/front_src/src/Header/RessourceStatusCounter/Service/index.tsx
+++ b/centreon/www/front_src/src/Header/RessourceStatusCounter/Service/index.tsx
@@ -118,7 +118,7 @@ const ServiceStatusCounter = (): JSX.Element => {
     statuses: pendingCriterias.value as Array<SelectEntry>,
   });
   const pendingServicesLink = use_deprecated_pages
-    ? '/main.php?p=20201&o=svc&statusFilter=&search='
+    ? '/main.php?p=20201&o=svc&statusFilter=pending&search='
     : getServiceResourcesUrl({
         statusCriterias: pendingCriterias,
       });


### PR DESCRIPTION
## Description

On deprecated pages, when we clicked on Pending services in the top counter, there was no filter.

**Fixes** MON-15750

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x (master)
