### PR TITLE
fix(web): update query to get right acl groups and generate graph

### DIFF
--- a/centreon/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/centreon/www/include/views/graphs/generateGraphs/generateImage.php
@@ -198,7 +198,7 @@ if (!$isAdmin) {
 
     $aclGroupsQueryBinds = [];
     foreach ($aclGroupsExploded as $key => $value) {
-            $aclGroupsQueryBinds[':acl_group_' . $key] = str_replace("'","",$value);
+        $aclGroupsQueryBinds[':acl_group_' . $key] = str_replace("'","",$value);
     }
     $aclGroupBinds = implode(',', array_keys($aclGroupsQueryBinds));
     $sql = "SELECT service_id FROM centreon_acl WHERE host_id = :host_id AND service_id = :service_id

--- a/centreon/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/centreon/www/include/views/graphs/generateGraphs/generateImage.php
@@ -191,24 +191,11 @@ if (!$isAdmin) {
     unset($statement);
     $hostId = $row['host_id'];
     $serviceId = $row['service_id'];
-    $aclGroupsExploded = explode(',', $aclGroups);
-    if (empty($aclGroupsExploded)) {
-        throw new \Exception('Access denied');
-    }
-
-    $aclGroupsQueryBinds = [];
-    foreach ($aclGroupsExploded as $key => $value) {
-        $aclGroupsQueryBinds[':acl_group_' . $key] = $value;
-    }
-    $aclGroupBinds = implode(',', array_keys($aclGroupsQueryBinds));
     $sql = "SELECT service_id FROM centreon_acl WHERE host_id = :host_id AND service_id = :service_id
-        AND group_id IN ($aclGroupBinds)";
+        AND group_id IN ($aclGroups)";
     $statement = $pearDBO->prepare($sql);
     $statement->bindValue(':host_id', (int) $hostId, \PDO::PARAM_INT);
     $statement->bindValue(':service_id', (int) $serviceId, \PDO::PARAM_INT);
-    foreach ($aclGroupsQueryBinds as $key => $value) {
-        $statement->bindValue($key, (int) $value, \PDO::PARAM_INT);
-    }
     $statement->execute();
     if (!$statement->rowCount()) {
         die('Access denied');

--- a/centreon/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/centreon/www/include/views/graphs/generateGraphs/generateImage.php
@@ -191,11 +191,24 @@ if (!$isAdmin) {
     unset($statement);
     $hostId = $row['host_id'];
     $serviceId = $row['service_id'];
+    $aclGroupsExploded = explode(',', $aclGroups);
+    if (empty($aclGroupsExploded)) {
+        throw new \Exception('Access denied');
+    }
+
+    $aclGroupsQueryBinds = [];
+    foreach ($aclGroupsExploded as $key => $value) {
+            $aclGroupsQueryBinds[':acl_group_' . $key] = str_replace("'","",$value);
+    }
+    $aclGroupBinds = implode(',', array_keys($aclGroupsQueryBinds));
     $sql = "SELECT service_id FROM centreon_acl WHERE host_id = :host_id AND service_id = :service_id
-        AND group_id IN ($aclGroups)";
+        AND group_id IN ($aclGroupBinds)";
     $statement = $pearDBO->prepare($sql);
     $statement->bindValue(':host_id', (int) $hostId, \PDO::PARAM_INT);
     $statement->bindValue(':service_id', (int) $serviceId, \PDO::PARAM_INT);
+    foreach ($aclGroupsQueryBinds as $key => $value) {
+        $statement->bindValue($key, (int) $value, \PDO::PARAM_INT);
+    }
     $statement->execute();
     if (!$statement->rowCount()) {
         die('Access denied');


### PR DESCRIPTION
## Description

The previous query didn't get the right ACL groups and the non-admin user can't generate PNG from the Graph page.
I tested it with one and more groups.

**Fixes** MON-16467

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)