### PR TITLE
enh(apiv2): allow Throwable into Response constructors

### DIFF
--- a/centreon/src/Core/Application/Common/UseCase/AbstractPresenter.php
+++ b/centreon/src/Core/Application/Common/UseCase/AbstractPresenter.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,27 +18,23 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
 namespace Core\Application\Common\UseCase;
 
-use Symfony\Component\HttpFoundation\Response;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractPresenter implements PresenterInterface
 {
-    /**
-     * @var ResponseStatusInterface|null
-     */
+    /** @var ResponseStatusInterface|null */
     private ?ResponseStatusInterface $responseStatus = null;
-    /**
-     * @var array<string, mixed>
-     */
+
+    /** @var array<string, mixed> */
     private array $responseHeaders = [];
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     private mixed $presentedData = null;
 
     /**

--- a/centreon/src/Core/Application/Common/UseCase/AbstractResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/AbstractResponse.php
@@ -23,6 +23,27 @@ declare(strict_types=1);
 
 namespace Core\Application\Common\UseCase;
 
-class ErrorAuthenticationConditionsResponse extends ForbiddenResponse
+/**
+ * This is standard Error Response which accepts either
+ * - a string which will be translated
+ * - a Throwable from which we will get the message.
+ */
+abstract class AbstractResponse implements ResponseStatusInterface
 {
+    /**
+     * @param string|\Throwable $message
+     */
+    public function __construct(private readonly string|\Throwable $message)
+    {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getMessage(): string
+    {
+        return \is_string($this->message)
+            ? _($this->message)
+            : $this->message->getMessage();
+    }
 }

--- a/centreon/src/Core/Application/Common/UseCase/BodyResponseInterface.php
+++ b/centreon/src/Core/Application/Common/UseCase/BodyResponseInterface.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,6 +18,7 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
 namespace Core\Application\Common\UseCase;

--- a/centreon/src/Core/Application/Common/UseCase/ErrorResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/ErrorResponse.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,20 +23,11 @@ declare(strict_types=1);
 
 namespace Core\Application\Common\UseCase;
 
-class ErrorResponse implements ResponseStatusInterface
+/**
+ * This is standard Error Response which accepts
+ * - a string which will be translated
+ * - a Throwable from which we will get the message.
+ */
+class ErrorResponse extends AbstractResponse
 {
-    /**
-     * @param string $message
-     */
-    public function __construct(private string $message)
-    {
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getMessage(): string
-    {
-        return _($this->message);
-    }
 }

--- a/centreon/src/Core/Application/Common/UseCase/ForbiddenResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/ForbiddenResponse.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,24 +18,11 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
 namespace Core\Application\Common\UseCase;
 
-class ForbiddenResponse implements ResponseStatusInterface
+class ForbiddenResponse extends AbstractResponse
 {
-    /**
-     * @param string $message
-     */
-    public function __construct(private string $message)
-    {
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getMessage(): string
-    {
-        return _($this->message);
-    }
 }

--- a/centreon/src/Core/Application/Common/UseCase/IncompatibilityResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/IncompatibilityResponse.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/centreon/src/Core/Application/Common/UseCase/InvalidArgumentResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/InvalidArgumentResponse.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,20 +23,6 @@ declare(strict_types=1);
 
 namespace Core\Application\Common\UseCase;
 
-class InvalidArgumentResponse implements ResponseStatusInterface
+class InvalidArgumentResponse extends AbstractResponse
 {
-    /**
-     * @param string $message
-     */
-    public function __construct(private string $message)
-    {
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getMessage(): string
-    {
-        return _($this->message);
-    }
 }

--- a/centreon/src/Core/Application/Common/UseCase/NoContentResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/NoContentResponse.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/centreon/src/Core/Application/Common/UseCase/NotFoundResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/NotFoundResponse.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,20 +23,17 @@ declare(strict_types=1);
 
 namespace Core\Application\Common\UseCase;
 
-class NotFoundResponse implements ResponseStatusInterface
+class NotFoundResponse extends AbstractResponse
 {
     /**
-     * @param string $objectNotFound
+     * @param string|\Throwable $objectNotFound
      */
-    public function __construct(private string $objectNotFound)
+    public function __construct(string|\Throwable $objectNotFound)
     {
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getMessage(): string
-    {
-        return _($this->objectNotFound . ' not found');
+        parent::__construct(
+            \is_string($objectNotFound)
+                ? $objectNotFound . ' not found'
+                : $objectNotFound
+        );
     }
 }

--- a/centreon/src/Core/Application/Common/UseCase/PaymentRequiredResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/PaymentRequiredResponse.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,24 +18,11 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
 namespace Core\Application\Common\UseCase;
 
-class PaymentRequiredResponse implements ResponseStatusInterface
+class PaymentRequiredResponse extends AbstractResponse
 {
-    /**
-     * @param string $message
-     */
-    public function __construct(private string $message)
-    {
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getMessage(): string
-    {
-        return _($this->message);
-    }
 }

--- a/centreon/src/Core/Application/Common/UseCase/PresenterInterface.php
+++ b/centreon/src/Core/Application/Common/UseCase/PresenterInterface.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -56,6 +56,7 @@ interface PresenterInterface
      * Return the response stored in the presenter.
      *
      * Useful for handle case where show is not called (e.g for a redirection)
+     *
      * @return mixed
      */
     public function getPresentedData(): mixed;

--- a/centreon/src/Core/Application/Common/UseCase/ResponseStatusInterface.php
+++ b/centreon/src/Core/Application/Common/UseCase/ResponseStatusInterface.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/centreon/src/Core/Application/Common/UseCase/UnauthorizedResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/UnauthorizedResponse.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,20 +23,6 @@ declare(strict_types=1);
 
 namespace Core\Application\Common\UseCase;
 
-class UnauthorizedResponse implements ResponseStatusInterface
+class UnauthorizedResponse extends AbstractResponse
 {
-    /**
-     * @param string $message
-     */
-    public function __construct(private string $message)
-    {
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getMessage(): string
-    {
-        return _($this->message);
-    }
 }

--- a/centreon/src/Core/Infrastructure/Common/Presenter/JsonFormatter.php
+++ b/centreon/src/Core/Infrastructure/Common/Presenter/JsonFormatter.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,33 +45,33 @@ class JsonFormatter implements PresenterFormatterInterface
     {
         if (is_object($data)) {
             switch (true) {
-                case is_a($data, NotFoundResponse::class):
+                case $data instanceof NotFoundResponse:
                     $this->debug('Data not found. Generating a not found response');
 
                     return $this->generateJsonErrorResponse($data, Response::HTTP_NOT_FOUND, $headers);
-                case is_a($data, ErrorResponse::class):
+                case $data instanceof ErrorResponse:
                     $this->debug('Data error. Generating an error response');
 
                     return $this->generateJsonErrorResponse($data, Response::HTTP_INTERNAL_SERVER_ERROR, $headers);
-                case is_a($data, InvalidArgumentResponse::class):
+                case $data instanceof InvalidArgumentResponse:
                     $this->debug('Invalid argument. Generating an error response');
 
                     return $this->generateJsonErrorResponse($data, Response::HTTP_BAD_REQUEST, $headers);
-                case is_a($data, UnauthorizedResponse::class):
+                case $data instanceof UnauthorizedResponse:
                     $this->debug('Unauthorized. Generating an error response');
 
                     return $this->generateJsonErrorResponse($data, Response::HTTP_UNAUTHORIZED, $headers);
-                case is_a($data, PaymentRequiredResponse::class):
+                case $data instanceof PaymentRequiredResponse:
                     $this->debug('Payment required. Generating an error response');
 
                     return $this->generateJsonErrorResponse($data, Response::HTTP_PAYMENT_REQUIRED, $headers);
-                case is_a($data, ForbiddenResponse::class):
+                case $data instanceof ForbiddenResponse:
                     $this->debug('Forbidden. Generating an error response');
 
                     return $this->generateJsonErrorResponse($data, Response::HTTP_FORBIDDEN, $headers);
-                case is_a($data, CreatedResponse::class):
+                case $data instanceof CreatedResponse:
                     return $this->generateJsonResponse($data, Response::HTTP_CREATED, $headers);
-                case is_a($data, NoContentResponse::class):
+                case $data instanceof NoContentResponse:
                     return $this->generateJsonResponse(null, Response::HTTP_NO_CONTENT, $headers);
                 default:
                     return $this->generateJsonResponse($data, Response::HTTP_OK, $headers);


### PR DESCRIPTION
## Description

This allow the use of Throwables into the constructor of Responses.
Currently, the constructors accept only a string which is translated.

Passing a custom exception wil avoid a double translation + enhance the lisibility of UseCases.

Jira: **MON-16462**

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

The CI alone is enough to test this PR.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
