### PR TITLE
enh(host): change SNMP Community input type to password

### DIFF
--- a/centreon/features/bootstrap/HostConfigurationContext.php
+++ b/centreon/features/bootstrap/HostConfigurationContext.php
@@ -354,6 +354,9 @@ class HostConfigurationContext extends CentreonContext
                     $this->currentPage = $this->currentPage->inspect($this->duplicatedProperties['name']);
                     $object = $this->currentPage->getProperties();
                     foreach ($this->duplicatedProperties as $key => $value) {
+                        if ($key === "snmp_community") {
+                            $value = self::PASSWORD_REPLACEMENT_VALUE;
+                        }
                         if ($value != $object[$key]) {
                             $this->tableau[] = $key;
                         }

--- a/centreon/features/bootstrap/HostConfigurationContext.php
+++ b/centreon/features/bootstrap/HostConfigurationContext.php
@@ -9,6 +9,7 @@ use Centreon\Test\Behat\Configuration\HostTemplateConfigurationPage;
 
 class HostConfigurationContext extends CentreonContext
 {
+    public const PASSWORD_REPLACEMENT_VALUE = '**********';
     protected $currentPage;
 
     protected $host2 = array(
@@ -308,6 +309,7 @@ class HostConfigurationContext extends CentreonContext
                     $this->currentPage = new HostConfigurationListingPage($this);
                     $this->currentPage = $this->currentPage->inspect($this->updatedProperties['name']);
                     $object = $this->currentPage->getProperties();
+                    $object['snmp_community'] = self::PASSWORD_REPLACEMENT_VALUE
                     foreach ($this->updatedProperties as $key => $value) {
                         if ($value != $object[$key]) {
                             $this->tableau[] = $key;

--- a/centreon/features/bootstrap/HostConfigurationContext.php
+++ b/centreon/features/bootstrap/HostConfigurationContext.php
@@ -309,8 +309,10 @@ class HostConfigurationContext extends CentreonContext
                     $this->currentPage = new HostConfigurationListingPage($this);
                     $this->currentPage = $this->currentPage->inspect($this->updatedProperties['name']);
                     $object = $this->currentPage->getProperties();
-                    $object['snmp_community'] = self::PASSWORD_REPLACEMENT_VALUE
                     foreach ($this->updatedProperties as $key => $value) {
+                        if ($key === "snmp_community") {
+                            $value = self::PASSWORD_REPLACEMENT_VALUE;
+                        }
                         if ($value != $object[$key]) {
                             $this->tableau[] = $key;
                         }

--- a/centreon/features/bootstrap/HostTemplateBasicsOperationsContext.php
+++ b/centreon/features/bootstrap/HostTemplateBasicsOperationsContext.php
@@ -338,9 +338,11 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
                     $this->currentPage = new HostTemplateConfigurationListingPage($this);
                     $this->currentPage = $this->currentPage->inspect($this->updatedProperties['name']);
                     $object = $this->currentPage->getProperties();
-                    $objec['snmp_community'] = self::PASSWORD_REPLACEMENT_VALUE;
                     foreach ($this->updatedProperties as $key => $value) {
                         if ($value != $object[$key]) {
+                            if ($key === "snmp_community") {
+                                $value = self::PASSWORD_REPLACEMENT_VALUE;
+                            }
                             if (is_array($value)) {
                                 $value = implode(' ', $value);
                             }

--- a/centreon/features/bootstrap/HostTemplateBasicsOperationsContext.php
+++ b/centreon/features/bootstrap/HostTemplateBasicsOperationsContext.php
@@ -389,6 +389,9 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
                     $object = $this->currentPage->getProperties();
                     foreach ($this->duplicatedProperties as $key => $value) {
                         if ($value != $object[$key]) {
+                            if ($key === "snmp_community") {
+                                $value = self::PASSWORD_REPLACEMENT_VALUE;
+                            }
                             if (is_array($value)) {
                                 $value = implode(' ', $value);
                             }

--- a/centreon/features/bootstrap/HostTemplateBasicsOperationsContext.php
+++ b/centreon/features/bootstrap/HostTemplateBasicsOperationsContext.php
@@ -7,6 +7,7 @@ use Centreon\Test\Behat\Configuration\HostCategoryConfigurationPage;
 
 class HostTemplateBasicsOperationsContext extends CentreonContext
 {
+    public const PASSWORD_REPLACEMENT_VALUE = '**********';
     protected $currentPage;
 
     protected $hostCategory1 = array(
@@ -337,6 +338,7 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
                     $this->currentPage = new HostTemplateConfigurationListingPage($this);
                     $this->currentPage = $this->currentPage->inspect($this->updatedProperties['name']);
                     $object = $this->currentPage->getProperties();
+                    $objec['snmp_community'] = self::PASSWORD_REPLACEMENT_VALUE;
                     foreach ($this->updatedProperties as $key => $value) {
                         if ($value != $object[$key]) {
                             if (is_array($value)) {

--- a/centreon/features/bootstrap/MassiveChangeHostsContext.php
+++ b/centreon/features/bootstrap/MassiveChangeHostsContext.php
@@ -9,6 +9,7 @@ use Centreon\Test\Behat\Configuration\HostCategoryConfigurationPage;
 
 class MassiveChangeHostsContext extends CentreonContext
 {
+    public const PASSWORD_REPLACEMENT_VALUE = '**********';
     protected $currentPage;
 
     protected $host1 = array(
@@ -322,7 +323,7 @@ class MassiveChangeHostsContext extends CentreonContext
                 $this->spin(
                     function ($context) use ($hostProperties) {
                         $object = $context->currentPage->getProperties();
-                        $object["snmp_community"] = PASSWORD_REPLACEMENT_VALUE;
+                        $object["snmp_community"] = self::PASSWORD_REPLACEMENT_VALUE;
                         foreach ($hostProperties as $key => $value) {
                             if ($value != $object[$key]) {
                                 $context->notUpdatedProperties[] = $key;

--- a/centreon/features/bootstrap/MassiveChangeHostsContext.php
+++ b/centreon/features/bootstrap/MassiveChangeHostsContext.php
@@ -322,6 +322,7 @@ class MassiveChangeHostsContext extends CentreonContext
                 $this->spin(
                     function ($context) use ($hostProperties) {
                         $object = $context->currentPage->getProperties();
+                        $object["snmp_community"] = PASSWORD_REPLACEMENT_VALUE;
                         foreach ($hostProperties as $key => $value) {
                             if ($value != $object[$key]) {
                                 $context->notUpdatedProperties[] = $key;

--- a/centreon/features/bootstrap/MassiveChangeHostsContext.php
+++ b/centreon/features/bootstrap/MassiveChangeHostsContext.php
@@ -323,8 +323,10 @@ class MassiveChangeHostsContext extends CentreonContext
                 $this->spin(
                     function ($context) use ($hostProperties) {
                         $object = $context->currentPage->getProperties();
-                        $object["snmp_community"] = self::PASSWORD_REPLACEMENT_VALUE;
                         foreach ($hostProperties as $key => $value) {
+                            if ($key === "snmp_community") {
+                                $value = self::PASSWORD_REPLACEMENT_VALUE;
+                            }
                             if ($value != $object[$key]) {
                                 $context->notUpdatedProperties[] = $key;
                             }

--- a/centreon/www/include/common/javascript/centreon/macroPasswordField.js
+++ b/centreon/www/include/common/javascript/centreon/macroPasswordField.js
@@ -55,3 +55,7 @@ function change_macro_input_type(box, must_disable) {
         }
     }
 }
+
+function change_snmp_community_input_type(input) {
+    input.type = 'text';
+}

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -1475,6 +1475,9 @@ function updateHost($host_id = null, $from_MC = false, $cfg = null)
         $ret["command_command_id_arg2"] = str_replace("\r", "#R#", $ret["command_command_id_arg2"]);
     }
     $ret["host_name"] = $host->checkIllegalChar($ret["host_name"], $server_id);
+    if ($ret['host_snmp_community'] === PASSWORD_REPLACEMENT_VALUE) {
+        unset($ret['host_snmp_community']);
+    }
     $bindParams = sanitizeFormHostParameters($ret);
 
     $rq = "UPDATE host SET ";

--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -103,6 +103,10 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
     $host = array_map("myDecode", $host_list);
     $cmdId = $host['command_command_id'];
 
+    if (! empty($host['host_snmp_community'])) {
+        $host['host_snmp_community'] = PASSWORD_REPLACEMENT_VALUE;
+    }
+
     // Set Host Notification Options
     $tmp = explode(',', $host["host_notification_options"]);
     foreach ($tmp as $key => $value) {
@@ -368,7 +372,19 @@ if ($o !== HOST_MASSIVE_CHANGE) {
         )
     );
 }
-$form->addElement('text', 'host_snmp_community', _("SNMP Community"), $attrsText);
+
+switch ($o) {
+    case HOST_ADD:
+    case HOST_MASSIVE_CHANGE:
+        $form->addElement('text', 'host_snmp_community', _("SNMP Community"), $attrsText);
+        break;
+    default:
+        $snmpAttribute = $attrsText;
+        $snmpAttribute['onClick'] = 'javascript:change_snmp_community_input_type(this)';
+        $form->addElement('password', 'host_snmp_community', _("SNMP Community"), $snmpAttribute);
+        break;
+}
+
 $form->addElement('select', 'host_snmp_version', _("Version"), array(null => null, 1 => "1", "2c" => "2c", 3 => "3"));
 
 /*

--- a/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -67,6 +67,9 @@ if (($o === HOST_TEMPLATE_MODIFY || $o === HOST_TEMPLATE_WATCH) && isset($host_i
     # Set base value
     if ($statement->rowCount()) {
         $host = array_map("myDecode", $statement->fetch());
+        if (! empty($host['host_snmp_community'])) {
+            $host['host_snmp_community'] = PASSWORD_REPLACEMENT_VALUE;
+        }
 
         $cmdId = $host['command_command_id'];
         # Set Host Notification Options
@@ -271,7 +274,17 @@ if ($o !== HOST_TEMPLATE_MASSIVE_CHANGE) {
 }
 $form->addElement('text', 'host_address', _("Address"), $attrsText);
 $form->addElement('select', 'host_snmp_version', _("Version"), array(null => null, 1 => "1", "2c" => "2c", 3 => "3"));
-$form->addElement('text', 'host_snmp_community', _("SNMP Community"), $attrsText);
+switch ($o) {
+    case HOST_TEMPLATE_ADD:
+    case HOST_TEMPLATE_MASSIVE_CHANGE:
+        $form->addElement('text', 'host_snmp_community', _("SNMP Community"), $attrsText);
+        break;
+    default:
+        $snmpAttribute = $attrsText;
+        $snmpAttribute['onClick'] = 'javascript:change_snmp_community_input_type(this)';
+        $form->addElement('password', 'host_snmp_community', _("SNMP Community"), $snmpAttribute);
+        break;
+}
 
 $timeAvRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_timezone&action=list';
 $timeDeRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_timezone'


### PR DESCRIPTION
## Description
This PR intends to change SNMP Community input type to password

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- x ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create an host
- On Creation Form, the SNMP Community should be an input text
- Update the host
- The SNMP Community input should be password
- Click on the input
- The input should switch to text and the value should be "*******"

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
