### PR TITLE
fix: Unreadable buttons in anomaly detection page dev-22.10.x

### DIFF
--- a/centreon/www/Themes/Generic-theme/style.css
+++ b/centreon/www/Themes/Generic-theme/style.css
@@ -671,7 +671,7 @@ p.description a, p.description a:visited {
     padding: 4px 10px ;
     border: none !important;
     outline: none !important;
-    color: var(--btc-color) ;
+    color: var(--btc-color) !important;
     cursor: pointer;
 }
 


### PR DESCRIPTION
## Description
 
Choose another color  for the button in light mode and dark mode for it to correspond to the current theme and that can easily be readable without hovering them.

**Fixes** # MON-16161

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

With Anomaly Detection module installed, 

go to Configuration > Services > Anomaly Detection, 

click on Create from analysis
![anomaly dark](https://user-images.githubusercontent.com/108519266/208959010-21891758-049f-44b3-86bc-2bd2d428ca19.PNG)
![anomaly light](https://user-images.githubusercontent.com/108519266/208959013-458e21f1-6312-47bd-80b0-62eb05ec2ccd.PNG)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-16161]: https://centreon.atlassian.net/browse/MON-16161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ