### PR TITLE
enh(APIv2): possibility to return 409 Conflict HTTP response

### DIFF
--- a/centreon/doc/API/centreon-api-v23.04.yaml
+++ b/centreon/doc/API/centreon-api-v23.04.yaml
@@ -1004,6 +1004,8 @@ paths:
           $ref: '#/components/responses/BadRequest'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /configuration/timeperiods/{id}:
@@ -3969,19 +3971,7 @@ paths:
         '201':
           description: "OK"
         '409':
-          description: "Conflict. More details are specified in the response"
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  code:
-                    type: integer
-                    format: int64
-                    example: 409
-                  message:
-                    type: string
-                    example: "A platform using the name : 'myPoller' or address : '1.1.1.2' already exists"
+          $ref: '#/components/responses/Conflict'
         '400':
           $ref: '#/components/responses/BadRequest'
         '403':
@@ -4854,6 +4844,20 @@ components:
               message:
                 type: string
                 example: "Property 'name' not found"
+    Conflict:
+      description: "Conflict. More details are specified in the response"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              code:
+                type: integer
+                format: int64
+                example: 409
+              message:
+                type: string
+                example: "A platform using the name : 'myPoller' or address : '1.1.1.2' already exists"
     Forbidden:
       description: "Forbidden"
       content:

--- a/centreon/doc/API/centreon-api-v23.04.yaml
+++ b/centreon/doc/API/centreon-api-v23.04.yaml
@@ -329,6 +329,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /configuration/hosts/categories/{host_category_id}:

--- a/centreon/doc/API/centreon-api-v23.04.yaml
+++ b/centreon/doc/API/centreon-api-v23.04.yaml
@@ -463,6 +463,8 @@ paths:
                 $ref: '#/components/schemas/Configuration.Host.Group'
         '403':
           $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /configuration/hosts/groups/{hostgroup_id}:

--- a/centreon/doc/API/centreon-api-v23.04.yaml
+++ b/centreon/doc/API/centreon-api-v23.04.yaml
@@ -1087,6 +1087,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /configuration/users:

--- a/centreon/src/Core/Application/Common/UseCase/ConflictResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/ConflictResponse.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Application\Common\UseCase;
+
+/**
+ * This is standard Error Response which accepts
+ * - a string which will be translated
+ * - a Throwable from which we will get the message.
+ */
+class ConflictResponse extends AbstractResponse
+{
+}

--- a/centreon/src/Core/HostCategory/Application/UseCase/AddHostCategory/AddHostCategory.php
+++ b/centreon/src/Core/HostCategory/Application/UseCase/AddHostCategory/AddHostCategory.php
@@ -26,10 +26,10 @@ namespace Core\HostCategory\Application\UseCase\AddHostCategory;
 use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ConflictResponse;
 use Core\Application\Common\UseCase\CreatedResponse;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
-use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\HostCategory\Application\Exception\HostCategoryException;
 use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
@@ -61,14 +61,14 @@ final class AddHostCategory
                     'user_id' => $this->user->getId(),
                 ]);
                 $presenter->setResponseStatus(
-                    new ForbiddenResponse(HostCategoryException::addNotAllowed()->getMessage())
+                    new ForbiddenResponse(HostCategoryException::addNotAllowed())
                 );
             } elseif ($this->readHostCategoryRepository->existsByName(trim($request->name))) {
                 $this->error('Host category name already exists', [
                     'hostcategory_name' => trim($request->name),
                 ]);
                 $presenter->setResponseStatus(
-                    new InvalidArgumentResponse(HostCategoryException::hostNameAlreadyExists()->getMessage())
+                    new ConflictResponse(HostCategoryException::hostNameAlreadyExists())
                 );
             } else {
                 $newHostCategory = new NewHostCategory(trim($request->name), trim($request->alias));
@@ -78,7 +78,7 @@ final class AddHostCategory
                 $hostCategory = $this->readHostCategoryRepository->findById($hostCategoryId);
                 if (! $hostCategory) {
                     $presenter->setResponseStatus(
-                        new ErrorResponse(HostCategoryException::errorWhileRetrievingJustCreated()->getMessage())
+                        new ErrorResponse(HostCategoryException::errorWhileRetrievingJustCreated())
                     );
 
                     return;
@@ -90,7 +90,7 @@ final class AddHostCategory
             }
         } catch (\Throwable $ex) {
             $presenter->setResponseStatus(
-                new ErrorResponse(HostCategoryException::addHostCategory($ex)->getMessage())
+                new ErrorResponse(HostCategoryException::addHostCategory($ex))
             );
             $this->error($ex->getMessage());
         }

--- a/centreon/src/Core/HostCategory/Infrastructure/API/AddHostCategory/AddHostCategoryPresenter.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/API/AddHostCategory/AddHostCategoryPresenter.php
@@ -1,23 +1,23 @@
 <?php
 
 /*
-* Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* https://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*
-*/
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
 
 declare(strict_types=1);
 
@@ -39,6 +39,7 @@ class AddHostCategoryPresenter extends AbstractPresenter
         protected PresenterFormatterInterface $presenterFormatter,
         readonly private Router $router
     ) {
+        parent::__construct($presenterFormatter);
     }
 
     /**

--- a/centreon/src/Core/HostCategory/Infrastructure/API/FindHostCategories/FindHostCategoriesPresenter.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/API/FindHostCategories/FindHostCategoriesPresenter.php
@@ -1,23 +1,23 @@
 <?php
 
 /*
-* Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-* https://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-* For more information : contact@centreon.com
-*
-*/
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
 
 declare(strict_types=1);
 
@@ -38,6 +38,7 @@ class FindHostCategoriesPresenter extends AbstractPresenter
         private RequestParametersInterface $requestParameters,
         protected PresenterFormatterInterface $presenterFormatter,
     ) {
+        parent::__construct($presenterFormatter);
     }
 
     /**
@@ -58,7 +59,7 @@ class FindHostCategoriesPresenter extends AbstractPresenter
 
         parent::present([
             'result' => $result,
-            'meta' => $this->requestParameters->toArray()
+            'meta' => $this->requestParameters->toArray(),
         ]);
     }
 }

--- a/centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
+++ b/centreon/src/Core/HostGroup/Application/Exceptions/HostGroupException.php
@@ -25,6 +25,8 @@ namespace Core\HostGroup\Application\Exceptions;
 
 class HostGroupException extends \Exception
 {
+    public const CODE_CONFLICT = 1;
+
     /**
      * @return self
      */
@@ -75,6 +77,6 @@ class HostGroupException extends \Exception
      */
     public static function nameAlreadyExists(string $hostGroupName): self
     {
-        return new self(sprintf(_("The host group name '%s' already exists"), $hostGroupName));
+        return new self(sprintf(_("The host group name '%s' already exists"), $hostGroupName), self::CODE_CONFLICT);
     }
 }

--- a/centreon/src/Core/Infrastructure/Common/Presenter/JsonFormatter.php
+++ b/centreon/src/Core/Infrastructure/Common/Presenter/JsonFormatter.php
@@ -24,10 +24,17 @@ declare(strict_types=1);
 namespace Core\Infrastructure\Common\Presenter;
 
 use Centreon\Domain\Log\LoggerTrait;
-use Core\Application\Common\UseCase\{
-    BodyResponseInterface, CreatedResponse, ErrorResponse, ForbiddenResponse,
-    InvalidArgumentResponse, NoContentResponse, NotFoundResponse, PaymentRequiredResponse,
-    ResponseStatusInterface, UnauthorizedResponse
+use Core\Application\Common\UseCase\{BodyResponseInterface,
+    ConflictResponse,
+    CreatedResponse,
+    ErrorResponse,
+    ForbiddenResponse,
+    InvalidArgumentResponse,
+    NoContentResponse,
+    NotFoundResponse,
+    PaymentRequiredResponse,
+    ResponseStatusInterface,
+    UnauthorizedResponse
 };
 use Symfony\Component\HttpFoundation\{JsonResponse, Response};
 
@@ -69,6 +76,10 @@ class JsonFormatter implements PresenterFormatterInterface
                     $this->debug('Forbidden. Generating an error response');
 
                     return $this->generateJsonErrorResponse($data, Response::HTTP_FORBIDDEN, $headers);
+                case $data instanceof ConflictResponse:
+                    $this->debug('Conflict. Generating an error response');
+
+                    return $this->generateJsonErrorResponse($data, Response::HTTP_CONFLICT, $headers);
                 case $data instanceof CreatedResponse:
                     return $this->generateJsonResponse($data, Response::HTTP_CREATED, $headers);
                 case $data instanceof NoContentResponse:
@@ -112,8 +123,8 @@ class JsonFormatter implements PresenterFormatterInterface
      * @param int $code
      * @param array<string, mixed> $headers
      *
-     * @throws \InvalidArgumentException
      * @throws \TypeError
+     * @throws \InvalidArgumentException
      *
      * @return JsonResponse
      */
@@ -129,8 +140,8 @@ class JsonFormatter implements PresenterFormatterInterface
      * @param int $code
      * @param array<string, mixed> $headers
      *
-     * @throws \InvalidArgumentException
      * @throws \TypeError
+     * @throws \InvalidArgumentException
      *
      * @return JsonResponse
      */

--- a/centreon/src/Core/TimePeriod/Application/UseCase/AddTimePeriod/AddTimePeriod.php
+++ b/centreon/src/Core/TimePeriod/Application/UseCase/AddTimePeriod/AddTimePeriod.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace Core\TimePeriod\Application\UseCase\AddTimePeriod;
 
 use Centreon\Domain\Log\LoggerTrait;
-use Core\Application\Common\UseCase\{CreatedResponse, ErrorResponse, PresenterInterface};
+use Core\Application\Common\UseCase\{ConflictResponse, CreatedResponse, ErrorResponse, PresenterInterface};
 use Core\TimePeriod\Application\Exception\TimePeriodException;
 use Core\TimePeriod\Application\Repository\ReadTimePeriodRepositoryInterface;
 use Core\TimePeriod\Application\Repository\WriteTimePeriodRepositoryInterface;
@@ -59,7 +59,7 @@ class AddTimePeriod
             if ($this->readTimePeriodRepository->nameAlreadyExists($request->name)) {
                 $this->error('A time period with this name already exists');
                 $presenter->setResponseStatus(
-                    new ErrorResponse(TimePeriodException::nameAlreadyExists($request->name)->getMessage())
+                    new ConflictResponse(TimePeriodException::nameAlreadyExists($request->name))
                 );
 
                 return;
@@ -79,7 +79,7 @@ class AddTimePeriod
                 ['message' => $ex->getMessage(), 'trace' => $ex->getTraceAsString()]
             );
             $presenter->setResponseStatus(
-                new ErrorResponse(TimePeriodException::errorWhenAddingTimePeriod()->getMessage())
+                new ErrorResponse(TimePeriodException::errorWhenAddingTimePeriod())
             );
         }
     }

--- a/centreon/src/Core/TimePeriod/Application/UseCase/UpdateTimePeriod/UpdateTimePeriod.php
+++ b/centreon/src/Core/TimePeriod/Application/UseCase/UpdateTimePeriod/UpdateTimePeriod.php
@@ -25,9 +25,7 @@ namespace Core\TimePeriod\Application\UseCase\UpdateTimePeriod;
 
 use Assert\AssertionFailedException;
 use Centreon\Domain\Log\LoggerTrait;
-use Core\Application\Common\UseCase\{
-    ErrorResponse, NoContentResponse, NotFoundResponse, PresenterInterface
-};
+use Core\Application\Common\UseCase\{ConflictResponse, ErrorResponse, NoContentResponse, NotFoundResponse, PresenterInterface};
 use Core\TimePeriod\Application\Exception\TimePeriodException;
 use Core\TimePeriod\Application\Repository\ReadTimePeriodRepositoryInterface;
 use Core\TimePeriod\Application\Repository\WriteTimePeriodRepositoryInterface;
@@ -60,7 +58,7 @@ class UpdateTimePeriod
             if ($this->readTimePeriodRepository->nameAlreadyExists($request->name, $request->id)) {
                 $this->error('Time period name already exists');
                 $presenter->setResponseStatus(
-                    new ErrorResponse(TimePeriodException::nameAlreadyExists($request->name)->getMessage())
+                    new ConflictResponse(TimePeriodException::nameAlreadyExists($request->name))
                 );
 
                 return;
@@ -73,7 +71,7 @@ class UpdateTimePeriod
                 ['message' => $ex->getMessage(), 'trace' => $ex->getTraceAsString()]
             );
             $presenter->setResponseStatus(
-                new ErrorResponse(TimePeriodException::errorOnUpdate($request->id)->getMessage())
+                new ErrorResponse(TimePeriodException::errorOnUpdate($request->id))
             );
         }
     }

--- a/centreon/tests/api/features/CloudHostGroup.feature
+++ b/centreon/tests/api/features/CloudHostGroup.feature
@@ -112,7 +112,7 @@ Feature:
     """
     {"name": "test-add2"}
     """
-    Then the response code should be "500"
+    Then the response code should be "409"
 
   Scenario: Host group add with unknown fields for the cloud platform
     Given I am logged in

--- a/centreon/tests/api/features/HostCategory.feature
+++ b/centreon/tests/api/features/HostCategory.feature
@@ -223,3 +223,12 @@ Feature:
         "comments": "blablabla"
     }
     """
+    When I send a POST request to '/api/latest/configuration/hosts/categories' with body:
+    """
+    {
+        "name": "host-cat-name",
+        "alias": "host-cat-alias",
+        "comments": "blablabla"
+    }
+    """
+    Then the response code should be "409"

--- a/centreon/tests/api/features/HostGroup.feature
+++ b/centreon/tests/api/features/HostGroup.feature
@@ -395,7 +395,7 @@ Feature:
     """
     {"name": "test-add2"}
     """
-    Then the response code should be "500"
+    Then the response code should be "409"
 
   Scenario: Host group add with a READ user is forbidden
     Given the following CLAPI import data:

--- a/centreon/tests/api/features/TimePeriodConfiguration.feature
+++ b/centreon/tests/api/features/TimePeriodConfiguration.feature
@@ -108,11 +108,11 @@ Feature:
         ]
     }
     """
-    Then the response code should be 500
+    Then the response code should be 409
     And the JSON should be equal to:
     """
     {
-        "code": 500,
+        "code": 409,
         "message": "The time period name 'test_name' already exists"
     }
     """

--- a/centreon/tests/api/features/TimePeriodConfiguration.feature
+++ b/centreon/tests/api/features/TimePeriodConfiguration.feature
@@ -34,6 +34,7 @@ Feature:
         ]
     }
     """
+    Then the response code should be "201"
     When I send a GET request to '/api/latest/configuration/timeperiods?search={"name": "test_name"}'
     Then the response code should be "200"
     And the JSON should be equal to:
@@ -144,6 +145,36 @@ Feature:
     }
     """
     Then the response code should be 204
+
+    When I send a POST request to '/api/latest/configuration/timeperiods' with body:
+    """
+    {
+        "name": "already_exists",
+        "alias": "already_exists_alias",
+        "days": [],
+        "templates": [1],
+        "exceptions": []
+    }
+    """
+    Then the response code should be 201
+    When I send a PUT request to '/api/latest/configuration/timeperiods/5' with body:
+    """
+    {
+        "name": "already_exists",
+        "alias": "already_exists_alias",
+        "days": [],
+        "templates": [1],
+        "exceptions": []
+    }
+    """
+    Then the response code should be 409
+    And the JSON should be equal to:
+    """
+    {
+        "code": 409,
+        "message": "The time period name 'already_exists' already exists"
+    }
+    """
 
     When I send a GET request to '/api/latest/configuration/timeperiods?search={"name": "test_name2"}'
     Then the response code should be "200"

--- a/centreon/tests/php/Core/HostCategory/Application/UseCase/AddHostCategory/AddHostCategoryTest.php
+++ b/centreon/tests/php/Core/HostCategory/Application/UseCase/AddHostCategory/AddHostCategoryTest.php
@@ -24,10 +24,10 @@ declare(strict_types=1);
 namespace Tests\Core\HostCategory\Application\UseCase\AddHostCategory;
 
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ConflictResponse;
 use Core\Application\Common\UseCase\CreatedResponse;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
-use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\HostCategory\Application\Exception\HostCategoryException;
 use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
 use Core\HostCategory\Application\Repository\WriteHostCategoryRepositoryInterface;
@@ -100,7 +100,7 @@ it('should present an InvalidArgumentResponse when name is already used', functi
     ($this->useCase)($this->request, $this->presenter);
 
     expect($this->presenter->getResponseStatus())
-        ->toBeInstanceOf(InvalidArgumentResponse::class)
+        ->toBeInstanceOf(ConflictResponse::class)
         ->and($this->presenter->getResponseStatus()?->getMessage())
         ->toBe(HostCategoryException::hostNameAlreadyExists()->getMessage());
 });

--- a/centreon/tests/php/Core/HostGroup/Application/UseCase/AddHostGroup/AddHostGroupTest.php
+++ b/centreon/tests/php/Core/HostGroup/Application/UseCase/AddHostGroup/AddHostGroupTest.php
@@ -26,6 +26,7 @@ namespace Tests\Core\HostGroup\Application\UseCase\AddHostGroup;
 use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Core\Application\Common\UseCase\ConflictResponse;
 use Core\Application\Common\UseCase\CreatedResponse;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
@@ -131,7 +132,7 @@ it(
         ($this->useCase)($this->testedAddHostGroupRequest, $this->presenter);
 
         expect($this->presenter->getResponseStatus())
-            ->toBeInstanceOf(ErrorResponse::class)
+            ->toBeInstanceOf(ConflictResponse::class)
             ->and($this->presenter->getResponseStatus()?->getMessage())
             ->toBe(HostGroupException::nameAlreadyExists($this->testedAddHostGroupRequest->name)->getMessage());
     }

--- a/centreon/tests/php/Core/TimePeriod/Application/UseCase/AddTimePeriod/AddTimePeriodTest.php
+++ b/centreon/tests/php/Core/TimePeriod/Application/UseCase/AddTimePeriod/AddTimePeriodTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace Tests\Core\TimePeriod\Application\UseCase\AddTimePeriod;
 
 use Core\Infrastructure\Common\Api\DefaultPresenter;
-use Core\Application\Common\UseCase\{CreatedResponse, ErrorResponse};
+use Core\Application\Common\UseCase\{ConflictResponse, CreatedResponse, ErrorResponse};
 use Core\Infrastructure\Common\Presenter\JsonFormatter;
 use Core\TimePeriod\Application\Exception\TimePeriodException;
 use Core\TimePeriod\Application\Repository\{ReadTimePeriodRepositoryInterface, WriteTimePeriodRepositoryInterface};
@@ -69,7 +69,7 @@ it('should present an ErrorResponse when the name already exists', function () {
     $useCase($request, $presenter);
 
     expect($presenter->getResponseStatus())
-        ->toBeInstanceOf(ErrorResponse::class)
+        ->toBeInstanceOf(ConflictResponse::class)
         ->and($presenter->getResponseStatus()?->getMessage())
         ->toBe(TimePeriodException::nameAlreadyExists($nameToFind)->getMessage());
 });

--- a/centreon/tests/php/Core/TimePeriod/Application/UseCase/UpdateTimePeriod/UpdateTimePeriodTest.php
+++ b/centreon/tests/php/Core/TimePeriod/Application/UseCase/UpdateTimePeriod/UpdateTimePeriodTest.php
@@ -24,7 +24,7 @@ declare(strict_types=1);
 namespace Tests\Core\TimePeriod\Application\UseCase\UpdateTimePeriod;
 
 use Core\Infrastructure\Common\Api\DefaultPresenter;
-use Core\Application\Common\UseCase\{ErrorResponse, NoContentResponse, NotFoundResponse};
+use Core\Application\Common\UseCase\{ConflictResponse, ErrorResponse, NoContentResponse, NotFoundResponse};
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Core\TimePeriod\Application\Exception\TimePeriodException;
 use Core\TimePeriod\Domain\Model\TimePeriod;
@@ -102,7 +102,7 @@ it('should present an ErrorResponse when the time period name already exists', f
     $useCase($request, $presenter);
 
     expect($presenter->getResponseStatus())
-        ->toBeInstanceOf(ErrorResponse::class)
+        ->toBeInstanceOf(ConflictResponse::class)
         ->and($presenter->getResponseStatus()->getMessage())
         ->toBe(TimePeriodException::nameAlreadyExists($request->name)->getMessage());
 });


### PR DESCRIPTION
## Description

Add a `ConflictResponse` matching http status code `409`

Jira: **MON-16449**

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Tests from CI should be sufficient for this PR because the TWO refactors are covereing by behat tests.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
