### PR TITLE
fix(sql) remove intersect query in upgrade

### DIFF
--- a/centreon/www/install/php/Update-22.04.0-beta.1.php
+++ b/centreon/www/install/php/Update-22.04.0-beta.1.php
@@ -492,19 +492,22 @@ function migrateBrokerConfigOutputsToUnifiedSql(CentreonDB $pearDB): void
     $blockIds = array_map(fn ($typeId) => "{$outputTag}_{$typeId}", $typeIds);
 
     // Retrieve broker config ids to migrate
-    $subqueries = [];
     $bindedValues = [];
     foreach ($blockIds as $key => $blockId) {
-        $subqueries[] = "SELECT DISTINCT(config_id) FROM cfg_centreonbroker_info
-            WHERE config_group = 'output' AND config_key = 'blockId' AND config_value = :blockId_{$key}";
         $bindedValues[":blockId_{$key}"] = $blockId;
     }
-    $stmt = $pearDB->prepare(implode(' INTERSECT ', $subqueries));
+    $stmt = $pearDB->prepare(
+        "SELECT config_value, config_id FROM cfg_centreonbroker_info
+        WHERE config_group = 'output' AND config_key = 'blockId'
+        AND config_value IN (" . implode(", ", array_keys($bindedValues)) . ")"
+    );
     foreach ($bindedValues as $param => $value) {
         $stmt->bindValue($param, $value, \PDO::PARAM_STR);
     }
     $stmt->execute();
-    $configIds = $stmt->fetchAll(\PDO::FETCH_COLUMN, 0);
+
+    $configResults = $stmt->fetchAll(\PDO::FETCH_COLUMN|\PDO::FETCH_GROUP);
+    $configIds = array_intersect($configResults[$blockIds[0]], $configResults[$blockIds[1]]);
     if (empty($configIds)) {
         throw new \Exception("Cannot find broker config ids to migrate");
     }


### PR DESCRIPTION
## Description

"INTERSECT" statement is not supported by MySQL in upgrade file
This PR move intersect responsibility to php instead of sql

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
