### PR TITLE
feat(clapi): handle snmp community storage in vault 

### DIFF
--- a/centreon/lib/Centreon/Object/Host/Host.php
+++ b/centreon/lib/Centreon/Object/Host/Host.php
@@ -35,6 +35,10 @@
 
 require_once "Centreon/Object/Object.php";
 
+use Centreon\Domain\Log\LegacyLogger;
+use Core\Security\Vault\Domain\Model\VaultConfiguration;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+
 /**
  * Used for interacting with hosts
  *
@@ -45,4 +49,239 @@ class Centreon_Object_Host extends Centreon_Object
     protected $table = "host";
     protected $primaryKey = "host_id";
     protected $uniqueLabelField = "host_name";
+    private static ?ReadVaultConfigurationRepositoryInterface $repository = null;
+
+    /**
+     * Update host table
+     *
+     * @param $hostId
+     * @param array $params
+     * @return void
+     */
+    public function update($hostId, $params = [])
+    {
+        parent::update($hostId, $params);
+        $vaultConfiguration = $this->getVaultConfiguration();
+        if ($vaultConfiguration !== null) {
+            try {
+                $httpClient = new CentreonRestHttp();
+                $logger = $this->getLogger();
+                $clientToken = $this->authenticateToVault($vaultConfiguration, $logger, $httpClient);
+                $hostSecrets = $this->getHostSecretsFromVault(
+                    $vaultConfiguration,
+                    $hostId,
+                    $clientToken,
+                    $logger,
+                    $httpClient
+                );
+
+                if (array_key_exists('host_snmp_community', $params)) {
+                    //Replace olds vault values by the new ones
+                    $hostSecrets['_HOSTSNMPCOMMUNITY'] = $params['host_snmp_community'];
+                    $this->writeSecretsInVault(
+                        $vaultConfiguration,
+                        $hostId,
+                        $clientToken,
+                        $hostSecrets,
+                        $logger,
+                        $httpClient
+                    );
+                    $this->updateHostTablesWithVaultPath($vaultConfiguration, $hostId, $this->db);
+                }
+            } catch (\Throwable $ex) {
+                error_log((string) $ex);
+            }
+        }
+
+    }
+
+    /**
+     * Get vault configurations
+     *
+     * @return VaultConfiguration|null
+     */
+    private function getVaultConfiguration(): ?VaultConfiguration
+    {
+        $readVaultConfigurationRepository = self::getVaultConfigurationRepositoryInstance();
+
+        return $readVaultConfigurationRepository->findDefaultVaultConfiguration();
+    }
+
+    /**
+     * Get Client Token for Vault.
+     *
+     * @param VaultConfiguration $vaultConfiguration
+     * @param LegacyLogger $logger
+     * @param CentreonRestHttp $httpClient
+     * @return string
+     * @throws \Throwable
+     */
+    private function authenticateToVault(
+        VaultConfiguration $vaultConfiguration,
+        LegacyLogger $logger,
+        CentreonRestHttp $httpClient
+    ): string {
+        try {
+            $url = $vaultConfiguration->getAddress() . ':' . $vaultConfiguration->getPort() . '/v1/auth/approle/login';
+            $body = [
+                "role_id" => $vaultConfiguration->getRoleId(),
+                "secret_id" => $vaultConfiguration->getSecretId(),
+            ];
+            $logger->info('Authenticating to Vault: ' . $url);
+            $loginResponse = $httpClient->call($url, "POST", $body);
+        } catch (\Throwable $ex) {
+            $logger->error($url . " did not respond with a 2XX status");
+            throw $ex;
+        }
+
+        if (! isset($loginResponse['auth']['client_token'])) {
+            $logger->error($url . " Unable to retrieve client token from Vault");
+            throw new \Exception('Unable to authenticate to Vault');
+        }
+        return $loginResponse['auth']['client_token'];
+    }
+
+    /**
+     * Get host secrets data from vault
+     *
+     * @param VaultConfiguration $vaultConfiguration
+     * @param integer $hostId
+     * @param string $clientToken
+     * @param LegacyLogger $logger
+     * @param CentreonRestHttp $httpClient
+     * @return array<string, mixed>
+     * @throws \Throwable
+     */
+    private function getHostSecretsFromVault(
+        VaultConfiguration $vaultConfiguration,
+        int $hostId,
+        string $clientToken,
+        LegacyLogger $logger,
+        CentreonRestHttp $httpClient
+    ): array {
+        $url = $vaultConfiguration->getAddress() . ':' . $vaultConfiguration->getPort() . '/v1/'
+            . $vaultConfiguration->getStorage() . '/monitoring/hosts/' . $hostId;
+            $logger->info(sprintf("Search Host %d secrets at: %s", $hostId, $url));
+        try {
+            $content = $httpClient->call($url, 'GET', null, ['X-Vault-Token: ' . $clientToken]);
+        } catch (\RestNotFoundException $ex) {
+            $logger->info(sprintf("Host %d not found in vault", $hostId));
+
+            return [];
+        } catch (\Exception $ex) {
+            $logger->error(sprintf('Unable to get secrets for host : %d', $hostId));
+            throw $ex;
+        }
+        if (array_key_exists('data', $content)) {
+            return $content['data'];
+        }
+
+        return [];
+    }
+
+    /**
+     * Write Host secrets data in vault.
+     *
+     * @param VaultConfiguration $vaultConfiguration
+     * @param integer $hostId
+     * @param string $clientToken
+     * @param array<string,mixed> $passwordTypeData
+     * @param LegacyLogger $logger
+     * @param CentreonRestHttp $httpClient
+     * @throws \Exception
+     */
+    private function writeSecretsInVault(
+        VaultConfiguration $vaultConfiguration,
+        int $hostId,
+        string $clientToken,
+        array $passwordTypeData,
+        LegacyLogger $logger,
+        CentreonRestHttp $httpClient
+    ): void {
+        try {
+            $url = $vaultConfiguration->getAddress() . ':' . $vaultConfiguration->getPort()
+                . '/v1/' . $vaultConfiguration->getStorage()
+                . '/monitoring/hosts/' . $hostId;
+                $logger->info(
+                    "Writing Host Secrets at : " . $url,
+                    ["host_id" => $hostId, "secrets" => implode(", ", array_keys($passwordTypeData))]
+                );
+            $httpClient->call($url, "POST", $passwordTypeData, ['X-Vault-Token: ' . $clientToken]);
+        } catch(\Exception $ex) {
+            $logger->error(
+                "Unable to write host secrets into vault",
+                [
+                    "message" => $ex->getMessage(),
+                    "trace" => $ex->getTraceAsString(),
+                    "host_id" => $hostId,
+                    "secrets" => implode(", ", array_keys($passwordTypeData))
+                ]
+            );
+
+            throw $ex;
+        }
+
+        $logger->info(sprintf("Write successfully secrets in vault: %s", implode(', ', array_keys($passwordTypeData))));
+    }
+
+    /**
+     * Update host table with secrets path on vault.
+     *
+     * @param VaultConfiguration $vaultConfiguration
+     * @param integer $hostId
+     * @param \CentreonDB $pearDB
+     * @throws \Throwable
+     */
+    private function updateHostTablesWithVaultPath(
+        VaultConfiguration $vaultConfiguration,
+        int $hostId,
+        \CentreonDB $pearDB
+    ): void {
+        $path = "secret::" . $vaultConfiguration->getId() . "::" . $vaultConfiguration->getStorage()
+            . "/centreon/hosts/" . $hostId;
+
+        $statementUpdateHost = $pearDB->prepare(
+            <<<SQL
+                UPDATE `host` SET host_snmp_community = :path WHERE host_id = :hostId
+            SQL
+        );
+        $statementUpdateHost->bindValue(':path', $path, \PDO::PARAM_STR);
+        $statementUpdateHost->bindValue(':hostId', (int) $hostId);
+        $statementUpdateHost->execute();
+    }
+
+    /**
+     * Singleton for Repository Instanciation
+     *
+     * @return ReadVaultConfigurationRepositoryInterface
+     */
+    private static function getVaultConfigurationRepositoryInstance(): ReadVaultConfigurationRepositoryInterface
+    {
+        if (self::$repository === null) {
+            $kernel = \App\Kernel::createForWeb();
+            self::$repository = $kernel->getContainer()->get(
+                Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface::class
+            );
+        }
+
+        return self::$repository;
+    }
+
+    /**
+     * Get logger
+     *
+     * @return LegacyLogger
+     */
+    private function getLogger(): LegacyLogger
+    {
+        try {
+            $kernel = \App\Kernel::createForWeb();
+            $logger = $kernel->getContainer()->get(\Centreon\Domain\Log\LegacyLogger::class);
+        } catch(\Throwable $ex) {
+            error_log((string) $ex);
+            throw $ex;
+        }
+
+        return $logger;
+    }
 }

--- a/centreon/lib/Centreon/Object/Host/Host.php
+++ b/centreon/lib/Centreon/Object/Host/Host.php
@@ -238,7 +238,7 @@ class Centreon_Object_Host extends Centreon_Object
         \CentreonDB $pearDB
     ): void {
         $path = "secret::" . $vaultConfiguration->getId() . "::" . $vaultConfiguration->getStorage()
-            . "/centreon/hosts/" . $hostId;
+            . "/monitoring/hosts/" . $hostId;
 
         $statementUpdateHost = $pearDB->prepare(
             <<<SQL


### PR DESCRIPTION
## Description

This PR intends to handle host snmp community storage in vault.

**Fixes** # MON-16227

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Given a Centreon with a Vault Configured
When i update a host SNMP Community with CLAPI
Then its value should be stored in the vault and the path should be stored in centreon configuration database

When I generate an export file
The clear value should be gather from the vault and write into the export file

When I import a file
The clear value should be stored in database

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
