### PR TITLE
enh(CI): Adding cypress components test parallelization

### DIFF
--- a/.github/actions/web-frontend-component-test/action.yml
+++ b/.github/actions/web-frontend-component-test/action.yml
@@ -1,8 +1,10 @@
 name: "Web Cypress Component Testing"
 description: "Web Cypress Component Testing"
-inputs:
-  working_directory:
-    description: The frontend directory
+  module:
+    description: "Module on test will be run."
+    required: true
+  spec_file_path:
+    description: "Path of spec file."
     required: true
 
 runs:
@@ -12,25 +14,30 @@ runs:
       with:
         version: 7
 
+    - uses: mad9000/actions-find-and-replace-string@2
+      id: formatSpecFilePath
+      with:
+          source: ${{ inputs.spec_file_path }}
+          find: '/'
+          replace: '-'
+
     - name: Cypress web component testing
-      uses: cypress-io/github-action@v4
+      uses: cypress-io/github-action@f626f218526295bf4255defd3aa6eb98f9eeffd6
       with:
         browser: chrome
         component: true
         install-command: pnpm install
-        working-directory: ${{ inputs.working_directory }}
+        working-directory: ${{ inputs.module }}
+        spec: www/front_src/src/**/${{ inputs.spec_file_path }}
+        publish-summary: false
 
     - name: Archive videos
       uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
-        name: cypress-videos
-        path: ${{ inputs.working_directory }}/cypress/results/videos
+        name: cypress-videos-${{ steps.formatSpecFilePath.outputs.value }}
+        path: ${{ inputs.module }}/cypress/results/videos
 
-    - name: Publish tests report
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      if: ${{ always() }}
-      with:
-        check_name: web-frontend-component-tests-report
-        comment_mode: failures
-        junit_files: ${{ inputs.working_directory }}/cypress/results/cypress-fe.xml
+    - name: Rename cypress report
+      run: mv ${{ inputs.module }}/cypress/results/reports/cypress-fe.xml ${{ inputs.working_directory }}/cypress/results/reports/${{ steps.formatSpecFilePath.outputs.value }}.xml
+      shell: bash

--- a/.github/workflows/cypress-component-parallelization.yml
+++ b/.github/workflows/cypress-component-parallelization.yml
@@ -1,0 +1,71 @@
+on:
+  workflow_call:
+    inputs:
+      name:
+        required: true
+        type: string
+      module_name:
+        required: true
+        type: string
+      specs_path:
+        required: true
+        type: string
+
+jobs:
+  cypress-component-test-list:
+    runs-on: ubuntu-22.04
+    outputs:
+      specs: ${{ steps.list-specs.outputs.specs }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: List of specs
+        id: list-specs
+        run: |
+          cd ${{ inputs.module_name }}
+          echo "specs=$(find ${{ inputs.specs_path }} -type f -name "*.cypress.spec.tsx" -printf "%P\n" | sort | jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+
+  cypress-component-test-run:
+    needs: [cypress-component-test-list]
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: true
+      matrix:
+        spec: ${{ fromJson(needs.cypress-component-test-list.outputs.specs) }}
+    name: ${{ matrix.spec }}
+
+    steps:
+      - name: Cypress component testing
+        uses: ./.github/actions/web-frontend-component-test
+        with:
+          module: centreon
+          spec_file_path: ${{matrix.spec}}
+
+      - name: Upload components tests Results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ inputs.name }}-test-reports
+          path: centreon/cypress/results/reports/*.xml
+
+  cypress-component-test-report:
+    needs: [cypress-component-test-run]
+    if: always()
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: ${{ inputs.name }}-test-reports
+          path: ${{ inputs.name }}-xunit-reports
+
+      - name: Publish tests report
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: ${{ always() }}
+        with:
+          check_name: ${{ inputs.name }}-tests-report
+          comment_mode: failures
+          junit_files: ${{ inputs.name }}-xunit-reports/**/*.xml

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -198,9 +198,12 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - uses: ./.github/actions/web-frontend-component-test
+      - uses: ./.github/workflows/cypress-component-parallelization.yml
         with:
-          working_directory: centreon
+          name: component
+          module_name: centreon
+          image_name: centreon-web
+          specs_path: www/front_src/src/**
 
   backend-unit-test:
     runs-on: ubuntu-22.04

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -202,7 +202,6 @@ jobs:
         with:
           name: component
           module_name: centreon
-          image_name: centreon-web
           specs_path: www/front_src/src/**
 
   backend-unit-test:


### PR DESCRIPTION
## Description

Adding cypress component test parallelization on CI/CD. 

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Run GHA CI/CD on Github

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
