### PR TITLE
enh(media): Display available disk space in media upload page  dev-22.10.x

### DIFF
--- a/centreon/www/include/options/media/images/listImg.ihtml
+++ b/centreon/www/include/options/media/images/listImg.ihtml
@@ -19,6 +19,10 @@
 				{$form.o1.html}
 				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
 				<a href='#' class="btc bt_info ml-1" onClick="window.open('./main.php?p={$p}&o=sd&min=1','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=350, height=250');">{$syncDir}</a>
+				<label >
+					{$availiableSpace} {$Available}
+				</label>
+
 			</td>
 			{php}
 			   include('./include/common/pagination.php');
@@ -66,6 +70,9 @@
 				{$form.o2.html}
 				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>&nbsp;&nbsp;
 				<a href='#' class="btc bt_info ml-1" onClick="window.open('./main.php?p={$p}&o=sd&min=1','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=350, height=250');">{$syncDir}</a>
+				<a >
+					{$availiableSpace}  {$Available}
+				</a>
 			</td>
 			
 			{php}

--- a/centreon/www/include/options/media/images/listImg.php
+++ b/centreon/www/include/options/media/images/listImg.php
@@ -148,6 +148,20 @@ for ($i = 0; $elem = $res->fetchRow(); $i++) {
 }
 
 $tpl->assign("elemArr", $elemArr);
+
+/*
+ * Calculate availiable disk's space
+ */
+
+$diskStmnt = $pearDB->query("SELECT value FROM options AS o WHERE  o.key = 'nagios_path_img'")->fetch();
+
+$bytes = disk_free_space($diskStmnt["value"]);
+$units = ['B', 'KB', 'MB', 'GB', 'TB'];
+$class = min((int)log($bytes, 1024), count($units) - 1);
+$availiableSpace = sprintf('%1.2f', $bytes / pow(1024, $class)) . ' ' . $units[$class];
+$tpl->assign("availiableSpace", $availiableSpace);
+$tpl->assign("Available", _("Available"));
+
 /*
  * Different messages we put in the template
  */


### PR DESCRIPTION
## Description
Given an administrator accessing to “Administration > Parameters > Media > Images”
He can see available disk space on FS where are stored media (path is defined into centreon.options.nagios_path_img table like “/usr/share/centreon//www/img/media/”
![image](https://user-images.githubusercontent.com/108519266/211494833-042fd4a5-279c-4691-8a07-b1566cc5a156.png)
**Fixes** # MON-15826

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Get path from “Administration > Parameters > Media > Images” menu
- Use “df -h” to know free space on system
- Compare with value displayed in UI

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
