### PR TITLE
fix(oidc): role mapping issue when checking the attribute path

### DIFF
--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -1172,11 +1172,11 @@ class OpenIdProvider implements OpenIdProviderInterface
             $configuredClaimValues = [$configuredClaimValues[0]];
         }
 
-        $this->rolesMappingFromProvider = $providerConditions;
-
         if (is_string($providerConditions)) {
             $providerConditions = explode(",", $providerConditions);
         }
+
+        $this->rolesMappingFromProvider = $providerConditions;
 
         $this->validateAclAttributeOrFail($providerConditions, $configuredClaimValues);
     }


### PR DESCRIPTION
## Description

If the Idp respond with a string instead of an array when we check the attribute path, we got an error.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Your Idp must include a string instead of an array in the attribute path node

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
