### PR TITLE
enh(host): store macros into vault

### DIFF
--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -63,6 +63,24 @@ class CentreonHost
     protected $serviceObj;
 
     /**
+     * Macros formatted by id
+     * [
+     *  0 => [
+     *    "macroKey" => "KEY"
+     *    "macroValue" => "value"
+     *    "isPassword" => "1"
+     *  ],
+     *  1 => [
+     *    "macroKey" => "KEY_1"
+     *    "macroValue" => "value_1"
+     *    "macroPassword" => "1"
+     *  ]
+     * ]
+     * @var array
+     */
+    private array $formattedMacros = [];
+
+    /**
      * Constructor
      *
      * @param CentreonDB $db
@@ -851,6 +869,13 @@ class CentreonHost
                 }
                 $cnt++;
                 $stored[strtolower($value)] = true;
+                $dbResult = $this->db->query("SELECT MAX(host_macro_id) FROM on_demand_macro_host");
+                $macroId = $dbResult->fetch();
+                $this->formattedMacros[(int) $macroId['MAX(host_macro_id)']] = [
+                    "macroName" => '_HOST' . strtoupper($value),
+                    "macroValue" => $macrovalues[$key],
+                    "macroPassword" => $macroPassword[$key] ?? '0',
+                ];
             }
         }
     }
@@ -2551,5 +2576,15 @@ class CentreonHost
         if (!$dbResult) {
             throw new \Exception('Error while delete host ' . $hostName);
         }
+    }
+
+    /**
+     * Get Macros Information Unified by id
+     *
+     * @return array<array<string,string>>
+     */
+    public function getFormattedMacros(): array
+    {
+        return $this->formattedMacros;
     }
 }

--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -66,13 +66,13 @@ class CentreonHost
      * Macros formatted by id
      * ex:
      * [
-     *  0 => [
-     *    "macroKey" => "KEY"
+     *  1 => [
+     *    "macroName" => "KEY"
      *    "macroValue" => "value"
      *    "isPassword" => "1"
      *  ],
-     *  1 => [
-     *    "macroKey" => "KEY_1"
+     *  2 => [
+     *    "macroName" => "KEY_1"
      *    "macroValue" => "value_1"
      *    "macroPassword" => "1"
      *    "originalName" => "MACRO_1"
@@ -2589,7 +2589,12 @@ class CentreonHost
     /**
      * Get Macros Information Unified by id
      *
-     * @return array<int,array<string,string>>
+     * @return array<int,array{
+     *  macroName: string,
+     *  macroValue: string,
+     *  macroPassword: string,
+     *  originalName?: string
+     * }>
      */
     public function getFormattedMacros(): array
     {

--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -64,6 +64,7 @@ class CentreonHost
 
     /**
      * Macros formatted by id
+     * ex:
      * [
      *  0 => [
      *    "macroKey" => "KEY"
@@ -74,6 +75,7 @@ class CentreonHost
      *    "macroKey" => "KEY_1"
      *    "macroValue" => "value_1"
      *    "macroPassword" => "1"
+     *    "originalName" => "MACRO_1"
      *  ]
      * ]
      * @var array

--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -1592,7 +1592,6 @@ class CentreonHost
 
         $container[\CentreonLicense\ServiceProvider::LM_PRODUCT_NAME] = 'epp';
         $container[\CentreonLicense\ServiceProvider::LM_HOST_CHECK] = true;
-
         if (!$container[\CentreonLicense\ServiceProvider::LM_LICENSE]) {
             return false;
         }
@@ -2592,7 +2591,7 @@ class CentreonHost
      * @return array<int,array{
      *  macroName: string,
      *  macroValue: string,
-     *  macroPassword: string,
+     *  macroPassword: '0'|'1',
      *  originalName?: string
      * }>
      */

--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -869,6 +869,8 @@ class CentreonHost
                 }
                 $cnt++;
                 $stored[strtolower($value)] = true;
+
+                //Format macros to improve handling on form submit.
                 $dbResult = $this->db->query("SELECT MAX(host_macro_id) FROM on_demand_macro_host");
                 $macroId = $dbResult->fetch();
                 $this->formattedMacros[(int) $macroId['MAX(host_macro_id)']] = [

--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -876,6 +876,10 @@ class CentreonHost
                     "macroValue" => $macrovalues[$key],
                     "macroPassword" => $macroPassword[$key] ?? '0',
                 ];
+                if (isset($_REQUEST['macroOriginalName_' . $key])) {
+                    $this->formattedMacros[(int) $macroId['MAX(host_macro_id)']]['originalName']
+                        = '_HOST' . $_REQUEST['macroOriginalName_' . $key];
+                }
             }
         }
     }

--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -69,7 +69,7 @@ class CentreonHost
      *  1 => [
      *    "macroName" => "KEY"
      *    "macroValue" => "value"
-     *    "isPassword" => "1"
+     *    "macroPassword" => "1"
      *  ],
      *  2 => [
      *    "macroName" => "KEY_1"

--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -2589,7 +2589,7 @@ class CentreonHost
     /**
      * Get Macros Information Unified by id
      *
-     * @return array<array<string,string>>
+     * @return array<int,array<string,string>>
      */
     public function getFormattedMacros(): array
     {

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3268,7 +3268,12 @@ function prepareUpdatePayload(?string $hostSNMPCommunity, array $macros, array $
  * Add new macros and SNMP Community to the write in vault payload
  *
  * @param string|null $hostSNMPCommunity
- * @param array<int,array<string,string>> $macros
+ * @param array<int,array{
+ *      macroName: string,
+ *      macroValue: string,
+ *      macroPassword: '0'|'1',
+ *      originalName?: string
+ * }> $macros
  * @param array<string,string> $hostSecretsFromVault
  * @return array<string,string>
  */

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -1816,10 +1816,7 @@ function updateHost_MC($hostId = null)
                 $hostSecretsFromVault
             );
 
-            // If no more fields are password types, we delete the host from the vault has it will not be read.
-            if (empty($updateHostPayload)) {
-                deleteHostFromVault($vaultConfiguration, (int) $hostId, $clientToken, $logger, $httpClient);
-            } else {
+            if (! empty($updateHostPayload)) {
                 writeSecretsInVault(
                     $vaultConfiguration,
                     $hostId,
@@ -1831,9 +1828,12 @@ function updateHost_MC($hostId = null)
                 $hostPath = "secret::" . $vaultConfiguration->getId() . "::"
                     . $vaultConfiguration->getStorage()
                     . "/monitoring/hosts/" . $hostId;
+                //Store vault path for SNMP Community
                 if (array_key_exists(SNMP_COMMUNITY_MACRO_NAME, $updateHostPayload)){
                     updateHostTableWithVaultPath($pearDB, $hostPath, $hostId);
                 }
+
+                //Store vault path for macros
                 if (! empty($macroPasswordIds)) {
                     updateOnDemandMacroHostTableWithVaultPath($pearDB, $macroPasswordIds, $hostPath);
                 }
@@ -3114,7 +3114,7 @@ function updateHostTableWithVaultPath(\CentreonDB $pearDB, string $hostPath, int
  * Update on_demand_macro_host table with secrets path on vault.
  *
  * @param \CentreonDB $pearDB
- * @param int[] $macroIds
+ * @param non-empty-array<int> $macroIds
  * @param string $hostPath
  * @throws \Throwable
  */
@@ -3211,7 +3211,12 @@ function deleteHostFromVault(
  * And update their value or delete them if they are no more setted.
  *
  * @param string|null $hostSNMPCommunity
- * @param array<int,array<string,string>> $macros
+ * @param array<int,array{
+     *  macroName: string,
+     *  macroValue: string,
+     *  macroPassword: string,
+     *  originalName?: string
+     * }> $macros
  * @param array<string,string> $hostSecretsFromVault
  * @return array<string,string>
  */

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3096,6 +3096,7 @@ function writeSecretsInVault(
  * @param \CentreonDB $pearDB
  * @param string $hostPath
  * @param integer $hostId
+ * @throws \Throwable
  */
 function updateHostTableWithVaultPath(\CentreonDB $pearDB, string $hostPath, int $hostId): void
 {
@@ -3115,6 +3116,7 @@ function updateHostTableWithVaultPath(\CentreonDB $pearDB, string $hostPath, int
  * @param \CentreonDB $pearDB
  * @param int[] $macroIds
  * @param string $hostPath
+ * @throws \Throwable
  */
 function updateOnDemandMacroHostTableWithVaultPath(\CentreonDB $pearDB, array $macroIds, string $hostPath): void
 {

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3222,18 +3222,6 @@ function deleteHostFromVault(
  */
 function prepareUpdatePayload(?string $hostSNMPCommunity, array $macros, array $hostSecretsFromVault): array
 {
-    $formPasswordValues = [];
-
-    //Add macros to payload if they are password type and their values have changed
-    foreach($macros as $macroInfos) {
-        if (
-            $macroInfos['macroPassword'] === '1'
-            && ! preg_match(VAULT_PATH_REGEX, $macroInfos['macroValue'])
-        ) {
-            $formPasswordValues[$macroInfos['macroName']] = $macroInfos['macroValue'];
-        }
-    }
-
     //Unset existing macros on vault if they no more exist while submitting the form
     foreach(array_keys($hostSecretsFromVault) as $secretKey) {
         if ($secretKey !== SNMP_COMMUNITY_MACRO_NAME) {
@@ -3250,6 +3238,16 @@ function prepareUpdatePayload(?string $hostSNMPCommunity, array $macros, array $
         }
     }
 
+    //Add macros to payload if they are password type and their values have changed
+    foreach($macros as $macroInfos) {
+        if (
+            $macroInfos['macroPassword'] === '1'
+            && ! preg_match(VAULT_PATH_REGEX, $macroInfos['macroValue'])
+        ) {
+            $hostSecretsFromVault[$macroInfos['macroName']] = $macroInfos['macroValue'];
+        }
+    }
+
     //Unset existing SNMP Community if it no more exists while submitting the form
     if (
         array_key_exists(SNMP_COMMUNITY_MACRO_NAME, $hostSecretsFromVault)
@@ -3260,12 +3258,10 @@ function prepareUpdatePayload(?string $hostSNMPCommunity, array $macros, array $
 
     //Add SNMP Community if a new value has been set
     if ($hostSNMPCommunity !== null && ! preg_match(VAULT_PATH_REGEX, $hostSNMPCommunity)) {
-        $formPasswordValues[SNMP_COMMUNITY_MACRO_NAME] = $hostSNMPCommunity;
+        $hostSecretsFromVault[SNMP_COMMUNITY_MACRO_NAME] = $hostSNMPCommunity;
     }
 
-    $result = array_diff($formPasswordValues, $hostSecretsFromVault);
-
-    return array_merge($hostSecretsFromVault, $result);
+    return $hostSecretsFromVault;
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3194,35 +3194,6 @@ function deleteHostFromVault(
 }
 
 /**
- * Add SNMP Community to Password Type data sent to the vault.
- *
- * @param array<string,mixed> $bindParams
- * @return array<string,string>
- */
-function getSecretsValues(array $bindParams, array $macros): array
-{
-    //If the SNMP Community is defined and is not a vault path it should be updated.
-    $passwordTypeData = [];
-    foreach ($bindParams as $token => $bindValue) {
-        foreach ($bindValue as $value) {
-            if (preg_match(VAULT_PATH_REGEX, $value)) {
-                continue 2;
-            }
-        }
-        if ($token === ':host_snmp_community') {
-            $passwordTypeData['_HOSTSNMPCOMMUNITY'] = $bindParams[$token][\PDO::PARAM_STR];
-        }
-    }
-
-    foreach($macros as $macroInfos) {
-        if ($macroInfos['macroPassword'] === '1' && ! preg_match(VAULT_PATH_REGEX, $macroInfos['macroValue'])) {
-            $passwordTypeData[$macroInfos['macroName']] = $macroInfos['macroValue'];
-        }
-    }
-    return $passwordTypeData;
-}
-
-/**
  * Prepare the write in vault payload while updating an host.
  *
  * This method will compare the secrets already stored in the vault with the secrets submitted by the form
@@ -3285,8 +3256,8 @@ function prepareUpdatePayload(?string $hostSNMPCommunity, array $macros, array $
  * Add new macros and SNMP Community to the write in vault payload
  *
  * @param string|null $hostSNMPCommunity
- * @param array $macros
- * @param array $hostSecretsFromVault
+ * @param array<int,array<string,string>> $macros
+ * @param array<string,string> $hostSecretsFromVault
  * @return array<string,string>
  */
 function prepareUpdateMCPayload(?string $hostSNMPCommunity, array $macros, array $hostSecretsFromVault)
@@ -3311,8 +3282,8 @@ function prepareUpdateMCPayload(?string $hostSNMPCommunity, array $macros, array
 /**
  * Store all the ids of password macros that have been updated
  *
- * @param array $macros
- * @return array
+ * @param array<int,array<string,string> $macros
+ * @return int[]
  */
 function getIdOfUpdatedPasswordMacros(array $macros): array
 {

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3214,7 +3214,7 @@ function deleteHostFromVault(
  * @param array<int,array{
      *  macroName: string,
      *  macroValue: string,
-     *  macroPassword: string,
+     *  macroPassword: '0'|'1',
      *  originalName?: string
      * }> $macros
  * @param array<string,string> $hostSecretsFromVault

--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -104,9 +104,9 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
     $cmdId = $host['command_command_id'];
 
     //Store the clear value before offuscate it
-    $clearHostSNMPCommunityValue = null;
+    $hostSNMPCommunityRawValue = null;
     if (! empty($host['host_snmp_community'])) {
-        $clearHostSNMPCommunityValue = $host['host_snmp_community'];
+        $hostSNMPCommunityRawValue = $host['host_snmp_community'];
         $host['host_snmp_community'] = PASSWORD_REPLACEMENT_VALUE;
     }
 
@@ -1221,7 +1221,7 @@ if ($form->validate() && $from_list_menu == false) {
         //Replace offuscation by clear value if the value doesn't have change
         $snmpCommunity = $form->getSubmitValue("host_snmp_community");
         if ($snmpCommunity === PASSWORD_REPLACEMENT_VALUE) {
-            $_REQUEST['host_snmp_community'] = $clearHostSNMPCommunityValue;
+            $_REQUEST['host_snmp_community'] = $hostSNMPCommunityRawValue;
         }
 
         /*

--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -103,7 +103,9 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
     $host = array_map("myDecode", $host_list);
     $cmdId = $host['command_command_id'];
 
+    $clearHostSNMPCommunityValue = null;
     if (! empty($host['host_snmp_community'])) {
+        $clearHostSNMPCommunityValue = $host['host_snmp_community'];
         $host['host_snmp_community'] = PASSWORD_REPLACEMENT_VALUE;
     }
 
@@ -1215,6 +1217,10 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $hostObj->setValue(insertHostInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        $snmpCommunity = $form->getSubmitValue("host_snmp_community");
+        if ($snmpCommunity === PASSWORD_REPLACEMENT_VALUE) {
+            $_REQUEST['host_snmp_community'] = $clearHostSNMPCommunityValue;
+        }
         /*
          * Before saving, we check if a password macro has changed its name to be able to give it the right password
          * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).

--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -103,6 +103,7 @@ if (($o === HOST_MODIFY || $o === HOST_WATCH) && isset($host_id)) {
     $host = array_map("myDecode", $host_list);
     $cmdId = $host['command_command_id'];
 
+    //Store the clear value before offuscate it
     $clearHostSNMPCommunityValue = null;
     if (! empty($host['host_snmp_community'])) {
         $clearHostSNMPCommunityValue = $host['host_snmp_community'];
@@ -1217,10 +1218,12 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $hostObj->setValue(insertHostInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        //Replace offuscation by clear value if the value doesn't have change
         $snmpCommunity = $form->getSubmitValue("host_snmp_community");
         if ($snmpCommunity === PASSWORD_REPLACEMENT_VALUE) {
             $_REQUEST['host_snmp_community'] = $clearHostSNMPCommunityValue;
         }
+
         /*
          * Before saving, we check if a password macro has changed its name to be able to give it the right password
          * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).

--- a/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -68,9 +68,9 @@ if (($o === HOST_TEMPLATE_MODIFY || $o === HOST_TEMPLATE_WATCH) && isset($host_i
     if ($statement->rowCount()) {
         $host = array_map("myDecode", $statement->fetch());
         //Store the clear value before offuscate it
-        $clearHostSNMPCommunityValue = null;
+        $hostSNMPCommunityRawValue = null;
         if (! empty($host['host_snmp_community'])) {
-            $clearHostSNMPCommunityValue = $host['host_snmp_community'];
+            $hostSNMPCommunityRawValue = $host['host_snmp_community'];
             $host['host_snmp_community'] = PASSWORD_REPLACEMENT_VALUE;
         }
 
@@ -996,7 +996,7 @@ if ($form->validate() && $from_list_menu == false) {
         //Replace offuscation by clear value if the value doesn't have change
         $snmpCommunity = $form->getSubmitValue("host_snmp_community");
         if ($snmpCommunity === PASSWORD_REPLACEMENT_VALUE) {
-            $_REQUEST['host_snmp_community'] = $clearHostSNMPCommunityValue;
+            $_REQUEST['host_snmp_community'] = $hostSNMPCommunityRawValue;
         }
         /*
          * Before saving, we check if a password macro has changed its name to be able to give it the right password

--- a/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -67,6 +67,8 @@ if (($o === HOST_TEMPLATE_MODIFY || $o === HOST_TEMPLATE_WATCH) && isset($host_i
     # Set base value
     if ($statement->rowCount()) {
         $host = array_map("myDecode", $statement->fetch());
+        //Store the clear value before offuscate it
+        $clearHostSNMPCommunityValue = null;
         if (! empty($host['host_snmp_community'])) {
             $clearHostSNMPCommunityValue = $host['host_snmp_community'];
             $host['host_snmp_community'] = PASSWORD_REPLACEMENT_VALUE;
@@ -991,6 +993,7 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $hostObj->setValue(insertHostInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        //Replace offuscation by clear value if the value doesn't have change
         $snmpCommunity = $form->getSubmitValue("host_snmp_community");
         if ($snmpCommunity === PASSWORD_REPLACEMENT_VALUE) {
             $_REQUEST['host_snmp_community'] = $clearHostSNMPCommunityValue;

--- a/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -68,6 +68,7 @@ if (($o === HOST_TEMPLATE_MODIFY || $o === HOST_TEMPLATE_WATCH) && isset($host_i
     if ($statement->rowCount()) {
         $host = array_map("myDecode", $statement->fetch());
         if (! empty($host['host_snmp_community'])) {
+            $clearHostSNMPCommunityValue = $host['host_snmp_community'];
             $host['host_snmp_community'] = PASSWORD_REPLACEMENT_VALUE;
         }
 
@@ -990,6 +991,10 @@ if ($form->validate() && $from_list_menu == false) {
     if ($form->getSubmitValue("submitA")) {
         $hostObj->setValue(insertHostInDB());
     } elseif ($form->getSubmitValue("submitC")) {
+        $snmpCommunity = $form->getSubmitValue("host_snmp_community");
+        if ($snmpCommunity === PASSWORD_REPLACEMENT_VALUE) {
+            $_REQUEST['host_snmp_community'] = $clearHostSNMPCommunityValue;
+        }
         /*
          * Before saving, we check if a password macro has changed its name to be able to give it the right password
          * instead of wildcards (PASSWORD_REPLACEMENT_VALUE).


### PR DESCRIPTION
## Description

This PR intends to store Host/HostTemplate custom macros into vault when a vault configuration exists

**Fixes** # MON-16392

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
