### PR TITLE
fix(upgrade): remove duplicate methods definition

### DIFF
--- a/centreon/www/install/php/Update-22.10.0-beta.1.php
+++ b/centreon/www/install/php/Update-22.10.0-beta.1.php
@@ -26,6 +26,51 @@ $centreonLog = new CentreonLog();
 $versionOfTheUpgrade = 'UPGRADE - 22.10.0-beta.1: ';
 $errorMessage = '';
 
+/**
+ * Manage relations between remote servers and nagios servers
+ *
+ * @param \CentreonDB $pearDB
+ */
+$migrateRemoteServerRelations = function(\CentreonDB $pearDB): void
+{
+    $processedIps = [];
+
+    $selectServerStatement = $pearDB->prepare(
+        "SELECT id FROM nagios_server WHERE ns_ip_address = :ip_address"
+    );
+    $deleteRemoteStatement = $pearDB->prepare(
+        "DELETE FROM remote_servers WHERE id = :id"
+    );
+    $updateRemoteStatement = $pearDB->prepare(
+        "UPDATE remote_servers SET server_id = :server_id WHERE id = :id"
+    );
+
+    $result = $pearDB->query(
+        "SELECT id, ip FROM remote_servers"
+    );
+    while ($remote = $result->fetch()) {
+        $remoteIp = $remote['ip'];
+        $remoteId = $remote['id'];
+        if (in_array($remoteIp, $processedIps)) {
+            $deleteRemoteStatement->bindValue(':id', $remoteId, \PDO::PARAM_INT);
+            $deleteRemoteStatement->execute();
+        }
+
+        $processedIps[] = $remoteIp;
+
+        $selectServerStatement->bindValue(':ip_address', $remoteIp, \PDO::PARAM_STR);
+        $selectServerStatement->execute();
+        if ($server = $selectServerStatement->fetch()) {
+            $updateRemoteStatement->bindValue(':server_id', $server['id'], \PDO::PARAM_INT);
+            $updateRemoteStatement->bindValue(':id', $remoteId, \PDO::PARAM_INT);
+            $updateRemoteStatement->execute();
+        } else {
+            $deleteRemoteStatement->bindValue(':id', $remoteId, \PDO::PARAM_INT);
+            $deleteRemoteStatement->execute();
+        }
+    }
+}
+
 try {
     $errorMessage = "Impossible to update 'cb_field' table";
     $pearDB->query("ALTER TABLE cb_field MODIFY description VARCHAR(510) DEFAULT NULL");
@@ -88,7 +133,7 @@ try {
             ADD COLUMN `server_id` int(11) NOT NULL"
         );
 
-        migrateRemoteServerRelations($pearDB);
+        $migrateRemoteServerRelations($pearDB);
 
         $errorMessage = "Unable to add foreign key constraint of remote_servers.server_id";
         $pearDB->query(
@@ -116,51 +161,6 @@ try {
     );
 
     throw new \Exception($versionOfTheUpgrade . $errorMessage, (int) $e->getCode(), $e);
-}
-
-/**
- * Manage relations between remote servers and nagios servers
- *
- * @param \CentreonDB $pearDB
- */
-function migrateRemoteServerRelations(\CentreonDB $pearDB): void
-{
-    $processedIps = [];
-
-    $selectServerStatement = $pearDB->prepare(
-        "SELECT id FROM nagios_server WHERE ns_ip_address = :ip_address"
-    );
-    $deleteRemoteStatement = $pearDB->prepare(
-        "DELETE FROM remote_servers WHERE id = :id"
-    );
-    $updateRemoteStatement = $pearDB->prepare(
-        "UPDATE remote_servers SET server_id = :server_id WHERE id = :id"
-    );
-
-    $result = $pearDB->query(
-        "SELECT id, ip FROM remote_servers"
-    );
-    while ($remote = $result->fetch()) {
-        $remoteIp = $remote['ip'];
-        $remoteId = $remote['id'];
-        if (in_array($remoteIp, $processedIps)) {
-            $deleteRemoteStatement->bindValue(':id', $remoteId, \PDO::PARAM_INT);
-            $deleteRemoteStatement->execute();
-        }
-
-        $processedIps[] = $remoteIp;
-
-        $selectServerStatement->bindValue(':ip_address', $remoteIp, \PDO::PARAM_STR);
-        $selectServerStatement->execute();
-        if ($server = $selectServerStatement->fetch()) {
-            $updateRemoteStatement->bindValue(':server_id', $server['id'], \PDO::PARAM_INT);
-            $updateRemoteStatement->bindValue(':id', $remoteId, \PDO::PARAM_INT);
-            $updateRemoteStatement->execute();
-        } else {
-            $deleteRemoteStatement->bindValue(':id', $remoteId, \PDO::PARAM_INT);
-            $deleteRemoteStatement->execute();
-        }
-    }
 }
 
 /**

--- a/centreon/www/install/php/Update-22.10.2.php
+++ b/centreon/www/install/php/Update-22.10.2.php
@@ -93,7 +93,7 @@ try {
     $pearDB->beginTransaction();
 
     $errorMessage = 'Unable to update illegal characters fields from engine configuration of pollers';
-    decodeIllegalCharactersNagios($pearDB);
+    $decodeIllegalCharactersNagios($pearDB);
 
     $pearDB->commit();
 } catch (\Exception $e) {

--- a/centreon/www/install/php/Update-22.10.3.php
+++ b/centreon/www/install/php/Update-22.10.3.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */

--- a/centreon/www/install/php/Update-22.10.4.php
+++ b/centreon/www/install/php/Update-22.10.4.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * https://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -23,7 +23,7 @@ require_once __DIR__ . '/../../class/centreonLog.class.php';
 $centreonLog = new CentreonLog();
 
 //error specific content
-$versionOfTheUpgrade = 'UPGRADE - 22.10.2: ';
+$versionOfTheUpgrade = 'UPGRADE - 22.10.4: ';
 $errorMessage = '';
 
 /**
@@ -83,17 +83,17 @@ try {
         );
     }
 
+    // Transactional queries
+    $pearDB->beginTransaction();
+
     $errorMessage = "Impossible to delete color picker topology_js entries";
     $pearDB->query(
         "DELETE FROM `topology_JS`
         WHERE `PathName_js` = './include/common/javascript/color_picker_mb.js'"
     );
 
-    // Transactional queries
-    $pearDB->beginTransaction();
-
     $errorMessage = 'Unable to update illegal characters fields from engine configuration of pollers';
-    decodeIllegalCharactersNagios($pearDB);
+    $decodeIllegalCharactersNagios($pearDB);
 
     $pearDB->commit();
 } catch (\Exception $e) {

--- a/centreon/www/install/php/Update-22.10.5.php
+++ b/centreon/www/install/php/Update-22.10.5.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */

--- a/centreon/www/install/php/Update-23.04.0-beta.1.php
+++ b/centreon/www/install/php/Update-23.04.0-beta.1.php
@@ -26,52 +26,13 @@ $centreonLog = new CentreonLog();
 $versionOfTheUpgrade = 'UPGRADE - 23.04.0-beta.1: ';
 $errorMessage = '';
 
-try {
-    if ($pearDB->isColumnExist('cfg_centreonbroker', 'event_queues_total_size') === 0) {
-        $errorMessage = "Impossible to update cfg_centreonbroker table";
-        $pearDB->query(
-            "ALTER TABLE `cfg_centreonbroker`
-            ADD COLUMN `event_queues_total_size` INT(11) DEFAULT NULL
-            AFTER `event_queue_max_size`"
-        );
-    }
-
-    $errorMessage = "Impossible to delete color picker topology_js entries";
-    $pearDB->query(
-        "DELETE FROM `topology_JS`
-        WHERE `PathName_js` = './include/common/javascript/color_picker_mb.js'"
-    );
-
-    // Transactional queries
-    $pearDB->beginTransaction();
-
-    $errorMessage = 'Unable to update illegal characters fields from engine configuration of pollers';
-    decodeIllegalCharactersNagios($pearDB);
-
-    $pearDB->commit();
-} catch (\Exception $e) {
-    if ($pearDB->inTransaction()) {
-        $pearDB->rollBack();
-    }
-
-    $centreonLog->insertLog(
-        4,
-        $versionOfTheUpgrade . $errorMessage
-        . ' - Code : ' . (int) $e->getCode()
-        . ' - Error : ' . $e->getMessage()
-        . ' - Trace : ' . $e->getTraceAsString()
-    );
-
-    throw new \Exception($versionOfTheUpgrade . $errorMessage, (int) $e->getCode(), $e);
-}
-
 /**
  * Update illegal_object_name_chars + illegal_macro_output_chars fields from cf_nagios table.
  * The aim is to decode entities from them.
  *
  * @param CentreonDB $pearDB
  */
-function decodeIllegalCharactersNagios(CentreonDB $pearDB): void
+$decodeIllegalCharactersNagios = function(CentreonDB $pearDB): void
 {
     $configs = $pearDB->query(
         <<<'SQL'
@@ -110,4 +71,43 @@ function decodeIllegalCharactersNagios(CentreonDB $pearDB): void
         $statement->bindValue(':nagios_id', $modified['nagios_id'], \PDO::PARAM_INT);
         $statement->execute();
     }
+};
+
+try {
+    if ($pearDB->isColumnExist('cfg_centreonbroker', 'event_queues_total_size') === 0) {
+        $errorMessage = "Impossible to update cfg_centreonbroker table";
+        $pearDB->query(
+            "ALTER TABLE `cfg_centreonbroker`
+            ADD COLUMN `event_queues_total_size` INT(11) DEFAULT NULL
+            AFTER `event_queue_max_size`"
+        );
+    }
+
+    $errorMessage = "Impossible to delete color picker topology_js entries";
+    $pearDB->query(
+        "DELETE FROM `topology_JS`
+        WHERE `PathName_js` = './include/common/javascript/color_picker_mb.js'"
+    );
+
+    // Transactional queries
+    $pearDB->beginTransaction();
+
+    $errorMessage = 'Unable to update illegal characters fields from engine configuration of pollers';
+    $decodeIllegalCharactersNagios($pearDB);
+
+    $pearDB->commit();
+} catch (\Exception $e) {
+    if ($pearDB->inTransaction()) {
+        $pearDB->rollBack();
+    }
+
+    $centreonLog->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage
+        . ' - Code : ' . (int) $e->getCode()
+        . ' - Error : ' . $e->getMessage()
+        . ' - Trace : ' . $e->getTraceAsString()
+    );
+
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, (int) $e->getCode(), $e);
 }


### PR DESCRIPTION
## Description

This PR intends to fix methods duplication while upgrading from < 22.04.8 to >= 22.10.2
This duplication cause the APIv2 Upgrade endpoint to create a fatal error and fail the upgrade.
**Fixes** # MON-16637

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

 - Upgrade using APIv2 upgrade endpoint from a version < 22.04.8 to a version >= 22.10.2
 - Upgrade should succeed
 - Upgrade using UI Upgrade Wizard from a version < 22.04.8 to a version >= 22.10.2
 - Upgrade should succeed

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
