### PR TITLE
enh (RT): Optimisation of SQL queries to reduce callbacks on the legacy services monitoring page.

### DIFF
--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -673,7 +673,7 @@ class CentreonHost
      */
     public function replaceMacroInString($hostParam, $string, $antiLoop = null)
     {
-        if (! preg_match('/(?:\$[0-9a-zA-Z_-]+\$)/', $string)) {
+        if (! preg_match('/\$[0-9a-zA-Z_-]+\$/', $string)) {
             return $string;
         }
         if (is_numeric($hostParam)) {

--- a/centreon/www/class/centreonService.class.php
+++ b/centreon/www/class/centreonService.class.php
@@ -325,7 +325,7 @@ class CentreonService
      */
     public function replaceMacroInString($svc_id, $string, $antiLoop = null, $instanceId = null)
     {
-        if (! preg_match('/(?:\$[0-9a-zA-Z_-]+\$)/', $string)) {
+        if (! preg_match('/\$[0-9a-zA-Z_-]+\$/', $string)) {
             return $string;
         }
         $query = <<<SQL

--- a/centreon/www/class/centreonService.class.php
+++ b/centreon/www/class/centreonService.class.php
@@ -325,19 +325,29 @@ class CentreonService
      */
     public function replaceMacroInString($svc_id, $string, $antiLoop = null, $instanceId = null)
     {
-        $rq = "SELECT service_register FROM service WHERE service_id = '" . $svc_id . "' LIMIT 1";
-        $DBRES = $this->db->query($rq);
-        if (!$DBRES->rowCount()) {
+        if (! preg_match('/(?:\$[0-9a-zA-Z_-]+\$)/', $string)) {
             return $string;
         }
-        $row = $DBRES->fetchRow();
+        $query = <<<SQL
+          SELECT service_register, service_description
+          FROM service
+          WHERE service_id = :service_id LIMIT 1
+        SQL;
+        $statement = $this->db->prepare($query);
+        $statement->bindValue(':service_id', (int) $svc_id, \PDO::PARAM_INT);
+        $statement->execute();
+
+        if (!$statement->rowCount()) {
+            return $string;
+        }
+        $row = $statement->fetchRow();
 
         /*
          * replace if not template
          */
         if ($row['service_register'] == 1) {
             if (preg_match('/\$SERVICEDESC\$/', $string)) {
-                $string = str_replace("\$SERVICEDESC\$", $this->getServiceDesc($svc_id), $string);
+                $string = str_replace("\$SERVICEDESC\$", $row['service_description'], $string);
             }
             if (!is_null($instanceId) && preg_match("\$INSTANCENAME\$", $string)) {
                 $string = str_replace("\$INSTANCENAME\$", $this->instanceObj->getParam($instanceId, 'name'), $string);

--- a/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -145,7 +145,7 @@ $request = <<<SQL
     INNER JOIN instances i
       ON h.instance_id = i.instance_id
     INNER JOIN services s
-      ON s.host_id = h.host_id
+      ON s.host_id = h.host_id 
     SQL;
 
 if (!$obj->is_admin) {

--- a/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -145,11 +145,12 @@ $request = <<<SQL
     INNER JOIN instances i
       ON h.instance_id = i.instance_id
     INNER JOIN services s
-      ON s.host_id = h.host_id 
+      ON s.host_id = h.host_id
     SQL;
 
 if (!$obj->is_admin) {
     $request .= <<<SQL
+        
         INNER JOIN centreon_acl
             ON centreon_acl.host_id = h.host_id
             AND centreon_acl.service_id = s.service_id
@@ -159,30 +160,33 @@ if (!$obj->is_admin) {
 
 if (isset($hostgroups) && $hostgroups != 0) {
     $request .= <<<SQL
+        
         INNER JOIN hosts_hostgroups hg
             ON hg.host_id = h.host_id
-            AND hg.hostgroup_id = :hostGroup
+            AND hg.hostgroup_id = :hostGroupId
         INNER JOIN hostgroups hg2
             ON hg2.hostgroup_id = hg.hostgroup_id
         SQL;
 
-    $queryValues['hostGroup'] = [\PDO::PARAM_INT => $hostgroups];
+    $queryValues['hostGroupId'] = [\PDO::PARAM_INT => $hostgroups];
 }
 
 if (isset($servicegroups) && $servicegroups != 0) {
     $request .= <<<SQL
+        
         INNER JOIN services_servicegroups ssg
             ON ssg.service_id = s.service_id
-            AND ssg.servicegroup_id = :serviceGroup
+            AND ssg.servicegroup_id = :serviceGroupId
         INNER JOIN servicegroups sg
             ON sg.servicegroup_id = ssg.servicegroup_id
         SQL;
 
-    $queryValues['serviceGroup'] = [\PDO::PARAM_INT => $servicegroups];
+    $queryValues['serviceGroupId'] = [\PDO::PARAM_INT => $servicegroups];
 }
 
 if ($criticalityId) {
     $request .= <<<SQL
+        
         INNER JOIN customvariables cvs
             ON cvs.service_id = s.service_id
             AND cvs.host_id = h.host_id
@@ -195,6 +199,7 @@ if ($criticalityId) {
 }
 
 $request .= <<<SQL
+
     LEFT JOIN index_data idx
         ON idx.host_id = h.host_id
         AND idx.service_id = s.service_id
@@ -214,6 +219,7 @@ $request .= <<<SQL
 
 if ($hostToSearch) {
     $request .= <<<SQL
+        
         AND (h.name LIKE :hostToSearch
         OR h.alias LIKE :hostToSearch
         OR h.address LIKE :hostToSearch)
@@ -229,12 +235,13 @@ if ($outputToSearch) {
     $queryValues['outputToSearch'] = [\PDO::PARAM_STR => '%' . $outputToSearch . '%'];
 }
 if (!empty($instance) && $instance != -1) {
-    $request .= " AND h.instance_id = :instance";
-    $queryValues['instance'] = [\PDO::PARAM_INT => $instance];
+    $request .= " AND h.instance_id = :instanceId";
+    $queryValues['instanceId'] = [\PDO::PARAM_INT => $instance];
 }
 
 if ($statusService == 'svc_unhandled') {
     $request .= <<<SQL
+        
         AND s.state_type = 1
         AND s.acknowledged = 0
         AND s.scheduled_downtime_depth = 0

--- a/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -115,33 +115,6 @@ $queryValues = [];
 // Graphs Tables
 $graphs = [];
 
-// Get Service status
-$instance_filter = " ";
-if (!empty($instance) && $instance != -1) {
-    $instance_filter = " AND h.instance_id = :instance";
-    $queryValues['instance'] = [\PDO::PARAM_INT => $instance];
-}
-
-$searchHost = " ";
-if ($hostToSearch) {
-    $searchHost = " AND (h.name LIKE :hostToSearch
-        OR h.alias LIKE :hostToSearch
-        OR h.address LIKE :hostToSearch) ";
-    $queryValues['hostToSearch'] = [\PDO::PARAM_STR => '%' . $hostToSearch . '%'];
-}
-
-$searchService = " ";
-if ($serviceToSearch) {
-    $searchService = " AND (s.description LIKE :serviceToSearch OR s.display_name LIKE :serviceToSearch) ";
-    $queryValues['serviceToSearch'] = [\PDO::PARAM_STR => '%' . $serviceToSearch . '%'];
-}
-
-$searchOutput = " ";
-if ($outputToSearch) {
-    $searchOutput = " AND s.output LIKE :outputToSearch ";
-    $queryValues['outputToSearch'] = [\PDO::PARAM_STR => '%' . $outputToSearch . '%'];
-}
-
 $tabOrder = [];
 $tabOrder["criticality_id"] = " ORDER BY isnull " . $order . ", criticality " . $order . ", h.name, s.description ";
 $tabOrder["host_name"] = " ORDER BY h.name " . $order . ", s.description ";
@@ -154,7 +127,8 @@ $tabOrder["current_attempt"] = " ORDER BY s.check_attempt " . $order . ", h.name
 $tabOrder["output"] = " ORDER BY s.output " . $order . ", h.name, s.description";
 $tabOrder["default"] = $tabOrder['criticality_id'];
 
-$request = "SELECT SQL_CALC_FOUND_ROWS DISTINCT h.name, h.alias, h.address, h.host_id, s.description,
+$request = <<<SQL
+    SELECT SQL_CALC_FOUND_ROWS DISTINCT h.name, h.alias, h.address, h.host_id, s.description,
     s.service_id, s.notes, s.notes_url, s.action_url, s.max_check_attempts,
     s.icon_image, s.display_name, s.state, s.output as plugin_output,
     s.state_type, s.check_attempt as current_attempt, s.last_update as status_update_time, s.last_state_change,
@@ -172,65 +146,100 @@ $request = "SELECT SQL_CALC_FOUND_ROWS DISTINCT h.name, h.alias, h.address, h.ho
       ON h.instance_id = i.instance_id
     INNER JOIN services s
       ON s.host_id = h.host_id
-    LEFT JOIN index_data idx
-      ON idx.host_id = h.host_id
-      AND idx.service_id = s.service_id
-      AND idx.hidden = '0'
-    LEFT JOIN metrics m
-      ON m.index_id = idx.id ";
+    SQL;
+
+if (!$obj->is_admin) {
+    $request .= <<<SQL
+        INNER JOIN centreon_acl
+            ON centreon_acl.host_id = h.host_id
+            AND centreon_acl.service_id = s.service_id
+            AND group_id IN ({$obj->grouplistStr})
+        SQL;
+}
 
 if (isset($hostgroups) && $hostgroups != 0) {
-    $request .= "INNER JOIN hosts_hostgroups hg
-        ON hg.host_id = h.host_id
-        AND hg.hostgroup_id = :hostGroup
-    INNER JOIN hostgroups hg2
-        ON hg2.hostgroup_id = hg.hostgroup_id";
+    $request .= <<<SQL
+        INNER JOIN hosts_hostgroups hg
+            ON hg.host_id = h.host_id
+            AND hg.hostgroup_id = :hostGroup
+        INNER JOIN hostgroups hg2
+            ON hg2.hostgroup_id = hg.hostgroup_id
+        SQL;
 
     $queryValues['hostGroup'] = [\PDO::PARAM_INT => $hostgroups];
 }
 
 if (isset($servicegroups) && $servicegroups != 0) {
-    $request .= "INNER JOIN services_servicegroups ssg
-        ON ssg.service_id = s.service_id
-        AND ssg.servicegroup_id = :serviceGroup
-    INNER JOIN servicegroups sg
-        ON sg.servicegroup_id = ssg.servicegroup_id";
+    $request .= <<<SQL
+        INNER JOIN services_servicegroups ssg
+            ON ssg.service_id = s.service_id
+            AND ssg.servicegroup_id = :serviceGroup
+        INNER JOIN servicegroups sg
+            ON sg.servicegroup_id = ssg.servicegroup_id
+        SQL;
 
     $queryValues['serviceGroup'] = [\PDO::PARAM_INT => $servicegroups];
 }
 
 if ($criticalityId) {
-    $request .= "INNER JOIN customvariables cvs
-        ON cvs.service_id = s.service_id
-        AND cvs.host_id = h.host_id
-        AND cvs.name = 'CRITICALITY_ID'
-        AND cvs.value = :criticalityValue";
+    $request .= <<<SQL
+        INNER JOIN customvariables cvs
+            ON cvs.service_id = s.service_id
+            AND cvs.host_id = h.host_id
+            AND cvs.name = 'CRITICALITY_ID'
+            AND cvs.value = :criticalityValue
+        SQL;
 
     // the variable bounded to criticalityValue must be an integer. But is inserted in a DB's varchar column
     $queryValues['criticalityValue'] = [\PDO::PARAM_STR => $criticalityId];
 }
-if (!$obj->is_admin) {
-    $request .= ", centreon_acl ";
-}
-$request .= " LEFT JOIN customvariables cv
-    ON (
-        s.service_id = cv.service_id
-        AND cv.host_id = s.host_id
-        AND cv.name = 'CRITICALITY_LEVEL'
-    )
+
+$request .= <<<SQL
+    LEFT JOIN index_data idx
+        ON idx.host_id = h.host_id
+        AND idx.service_id = s.service_id
+        AND idx.hidden = '0'
+    LEFT JOIN metrics m
+        ON m.index_id = idx.id
+    LEFT JOIN customvariables cv
+        ON (
+            s.service_id = cv.service_id
+            AND cv.host_id = s.host_id
+            AND cv.name = 'CRITICALITY_LEVEL'
+        )
     WHERE s.enabled = 1
     AND h.enabled = 1
-    AND h.name NOT LIKE '\_Module\_BAM%' "
-    . $searchHost
-    . $searchService
-    . $searchOutput
-    . $instance_filter;
+    AND h.name NOT LIKE '\_Module\_BAM%'
+    SQL;
+
+if ($hostToSearch) {
+    $request .= <<<SQL
+        AND (h.name LIKE :hostToSearch
+        OR h.alias LIKE :hostToSearch
+        OR h.address LIKE :hostToSearch)
+        SQL;
+    $queryValues['hostToSearch'] = [\PDO::PARAM_STR => '%' . $hostToSearch . '%'];
+}
+if ($serviceToSearch) {
+    $request .= " AND (s.description LIKE :serviceToSearch OR s.display_name LIKE :serviceToSearch) ";
+    $queryValues['serviceToSearch'] = [\PDO::PARAM_STR => '%' . $serviceToSearch . '%'];
+}
+if ($outputToSearch) {
+    $request .= " AND s.output LIKE :outputToSearch ";
+    $queryValues['outputToSearch'] = [\PDO::PARAM_STR => '%' . $outputToSearch . '%'];
+}
+if (!empty($instance) && $instance != -1) {
+    $request .= " AND h.instance_id = :instance";
+    $queryValues['instance'] = [\PDO::PARAM_INT => $instance];
+}
 
 if ($statusService == 'svc_unhandled') {
-    $request .= " AND s.state_type = 1
+    $request .= <<<SQL
+        AND s.state_type = 1
         AND s.acknowledged = 0
         AND s.scheduled_downtime_depth = 0
-        AND h.acknowledged = 0 AND h.scheduled_downtime_depth = 0 ";
+        AND h.acknowledged = 0 AND h.scheduled_downtime_depth = 0
+        SQL;
 }
 
 if ($statusService === 'svc_unhandled' || $statusService === 'svcpb') {
@@ -265,12 +274,6 @@ if ($statusService === 'svc_unhandled' || $statusService === 'svcpb') {
             $request .= " AND s.state = 4 ";
             break;
     }
-}
-
-// ACL activation
-if (!$obj->is_admin) {
-    $request .= " AND h.host_id = centreon_acl.host_id
-        AND s.service_id = centreon_acl.service_id AND group_id IN (" . $obj->grouplistStr . ") ";
 }
 
 // Sort order by

--- a/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -438,7 +438,7 @@ if (!$sqlError) {
             }
             $obj->XML->writeElement(
                 "hnu",
-                CentreonUtils::escapeSecure($obj->hostObj->replaceMacroInString($data["host_id"], $hostNotesUrl))
+                CentreonUtils::escapeSecure($obj->hostObj->replaceMacroInString($data["name"], $hostNotesUrl))
             );
 
             $hostActionUrl = "none";

--- a/centreon/www/include/monitoring/status/Services/xsl/service.xsl
+++ b/centreon/www/include/monitoring/status/Services/xsl/service.xsl
@@ -294,7 +294,7 @@
             </xsl:if>
         </td>
         <td class="ListColRight">
-            <xsl:if test="svc_index &gt; 0">
+            <xsl:if test="hasGraph &gt; 0">
                 <xsl:element name="a">
                     <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/>;<xsl:value-of select="sdl"/></xsl:attribute>
                     <xsl:element name="span">


### PR DESCRIPTION
## Description

The aim is to reduce the number of requests when monitoring services.
In a typical case, reduction from ~80 to ~20 queries

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Deactivate the broker
2. Connect to the Centreon platform and access the http://lcentreon_ip/centreon/main.php?p=20201 page (Legacy Services Monitoring page)
3. Copy/paste the url called by Centreon to retrieve the real time services in a new browser tab (url: centreon/include/monitoring/status/Services/xml/serviceXML.php ?....)
5. Close the Centreon main page
6. Check the number of queries in the database: `show status like 'Queries';``
7. Refresh the tab where the serviceXML.php url is located.
8. Check the number of queries in the database again: show status like 'Queries'.

Do the subtraction.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
