### PR TITLE
fix: innodb_additional_mem_pool_size deprecated  for dev-22.04.x

### DIFF
--- a/centreon/packaging/debian/extra/centreon-database/80-centreon.cnf
+++ b/centreon/packaging/debian/extra/centreon-database/80-centreon.cnf
@@ -15,9 +15,7 @@ read_rnd_buffer_size = 256K
 max_allowed_packet = 8M
 
 # For 4 Go Ram
-#innodb_additional_mem_pool_size=512M
 #innodb_buffer_pool_size=512M
 
 # For 8 Go Ram
-#innodb_additional_mem_pool_size=1G
 #innodb_buffer_pool_size=1G

--- a/centreon/packaging/src/centreon-mysql.cnf
+++ b/centreon/packaging/src/centreon-mysql.cnf
@@ -15,9 +15,7 @@ read_rnd_buffer_size = 256K
 max_allowed_packet = 8M
 
 # For 4 Go Ram
-#innodb_additional_mem_pool_size=512M
 #innodb_buffer_pool_size=512M
 
 # For 8 Go Ram
-#innodb_additional_mem_pool_size=1G
 #innodb_buffer_pool_size=1G


### PR DESCRIPTION
## Description

innodb_additional_mem_pool_size is deprecated since the MariaDB version 10.2, Centreon needs higher versions so we can delete it of this file.

**Fixes** # MON-16025

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Default Centreon configuration for DBMS are:

centreon/packaging/src/centreon-mysql.cnf

centreon/packaging/debian/extra/centreon-database/80-centreon.cnf

**How to test**
Install a new Centreon platform (enterprise linux 7 or 8 and Debian)

Check in centreon.cnf file that innodb_additional_mem_pool_size is not present
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
