### PR TITLE
fix(APIv2): "is_activated" field was not saved for AddHostSeverity

### DIFF
--- a/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityRepository.php
+++ b/centreon/src/Core/HostSeverity/Infrastructure/Repository/DbWriteHostSeverityRepository.php
@@ -26,6 +26,7 @@ namespace Core\HostSeverity\Infrastructure\Repository;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Infrastructure\DatabaseConnection;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Core\Common\Infrastructure\RequestParameters\Normalizer\BoolToEnumNormalizer;
 use Core\HostSeverity\Application\Repository\WriteHostSeverityRepositoryInterface;
 use Core\HostSeverity\Domain\Model\NewHostSeverity;
 
@@ -70,8 +71,8 @@ class DbWriteHostSeverityRepository extends AbstractRepositoryRDB implements Wri
         $request = $this->translateDbName(
             <<<'SQL'
                 INSERT INTO `:db`.hostcategories
-                (hc_name, hc_alias, hc_comment, level, icon_id) VALUES
-                (:name, :alias, :comment, :level, :icon_id)
+                (hc_name, hc_alias, hc_comment, level, icon_id, hc_activate) VALUES
+                (:name, :alias, :comment, :level, :icon_id, :activate)
                 SQL
         );
         $statement = $this->db->prepare($request);
@@ -81,6 +82,7 @@ class DbWriteHostSeverityRepository extends AbstractRepositoryRDB implements Wri
         $statement->bindValue(':comment', $hostSeverity->getComment(), \PDO::PARAM_STR);
         $statement->bindValue(':level', $hostSeverity->getLevel(), \PDO::PARAM_INT);
         $statement->bindValue(':icon_id', $hostSeverity->getIconId(), \PDO::PARAM_INT);
+        $statement->bindValue(':activate', (new BoolToEnumNormalizer())->normalize($hostSeverity->isActivated()));
 
         $statement->execute();
 


### PR DESCRIPTION
## Description

Jira MON-15458

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Try to add a host severity with `is_activated` to `false` : it should be stored as `false` and NOT `true`.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
