### PR TITLE
CLAPI import without HTML escaping and better line processing

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -716,7 +716,7 @@ class CentreonAPI
      */
     public function launchAction($exit = true)
     {
-        $action = htmlspecialchars(strtoupper($this->action), ENT_QUOTES, 'UTF-8');
+        $action = strtoupper($this->action);
 
         /**
          * Debug
@@ -799,32 +799,32 @@ class CentreonAPI
         $handle = fopen($filename, 'r');
         if ($handle) {
             $i = 0;
-            while ($string = fgets($handle)) {
+            while (($string = fgets($handle)) !== false) {
                 $i++;
-                $tab = preg_split('/;/', $string);
-                if (strlen(trim($string)) != 0 && !preg_match('/^\{OBJECT_TYPE\}/', $string)) {
-                    $this->object = htmlspecialchars(trim($tab[0]), ENT_QUOTES, 'UTF-8');
-                    $this->action = htmlspecialchars(trim($tab[1]), ENT_QUOTES, 'UTF-8');
-                    $this->variables = htmlspecialchars(
-                        trim(substr($string, strlen($tab[0] . ";" . $tab[1] . ";"))),
-                        ENT_QUOTES,
-                        'UTF-8'
-                    );
-                    if ($this->debug == 1) {
-                        print "Object : " . $this->object . "\n";
-                        print "Action : " . $this->action . "\n";
-                        print "VARIABLES : " . $this->variables . "\n\n";
-                    }
-                    try {
-                        $this->launchActionForImport();
-                    } catch (CentreonClapiException $e) {
-                        echo "Line $i : " . $e->getMessage() . "\n";
-                    } catch (\Exception $e) {
-                        echo "Line $i : " . $e->getMessage() . "\n";
-                    }
-                    if ($this->return_code) {
-                        $globalReturn = 1;
-                    }
+                $string = trim($string);
+                if (strlen($string) == 0) continue;
+                if (substr($string, 0, 1)  === '#') continue;
+                if (substr($string, 0, 13) === '{OBJECT_TYPE}') continue;
+     
+                $tab = explode(';', $string, 3);
+                $this->object = trim($tab[0]);
+                $this->action = trim($tab[1]);
+                $this->variables = trim($tab[2]);
+       
+                if ($this->debug == 1) {
+                    print "Object : " . $this->object . "\n";
+                    print "Action : " . $this->action . "\n";
+                    print "VARIABLES : " . $this->variables . "\n\n";
+                }
+                try {
+                    $this->launchActionForImport();
+                } catch (CentreonClapiException $e) {
+                    echo "Line $i : " . $e->getMessage() . "\n";
+                } catch (\Exception $e) {
+                    echo "Line $i : " . $e->getMessage() . "\n";
+                }
+                if ($this->return_code) {
+                    $globalReturn = 1;
                 }
             }
             fclose($handle);
@@ -834,7 +834,7 @@ class CentreonAPI
 
     public function launchActionForImport()
     {
-        $action = htmlspecialchars(strtoupper($this->action), ENT_QUOTES, 'UTF-8');
+        $action = strtoupper($this->action);
         /**
          * Debug
          */


### PR DESCRIPTION
- revert ab0c043bf4d4e137e1713f99058635c6928e6e6c (irrelevant and buggy)
- correct line reading (support empty lines)
- add the possibility to have commented lines (starting with #)
- don't use regexp unnecessarily
- split only the first 3 parts (simpler)

## Description

CLAPI import functions improvements : 
- don't convert HTML special chars (useless, revert #147, see #784)
- read each non-empty lines (skipping empty lines or lines with only spaces)
- bonus: support for commented lines (skip line starting with a `#`)
- don't use functions with RegExp when it's unnecessary (`preg_split`, `preg_match`)
- only split for necessary parts : object, action and everything else for variables
  - it's not the place to deal with the variables content
  - avoid the extraction with `subtr`/`strlen` to get the variables

**Fixes** #784 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Look at the #784 examples.

With this patch, you can correctly import any lines containing some special chars (`'`, `"`, `<`, `>`...) and yes this is useful and even more sometimes required !
For example, think about arguments for NRPE commands with filters definitions, like `--arg="filter=mounted=1 and type='fixed'"` or `--arg=warning=used > 50%`

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
