### PR TITLE
enh (RT): Optimisation of SQL queries to reduce callbacks on the legacy hosts monitoring page

### DIFF
--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -682,7 +682,7 @@ class CentreonHost
               WHERE host_id = :hostId 
               LIMIT 1';
             $stmt = $this->db->prepare($query);
-            $stmt->bindParam(':hostId', (int) $hostParam, \PDO::PARAM_INT);
+            $stmt->bindValue(':hostId', (int) $hostParam, \PDO::PARAM_INT);
         } elseif (is_string($hostParam)) {
             $query = 'SELECT host_id, ns.nagios_server_id, host_register, host_address, host_name, host_alias
               FROM host
@@ -691,7 +691,7 @@ class CentreonHost
               WHERE host_name = :hostName
               LIMIT 1';
             $stmt = $this->db->prepare($query);
-            $stmt->bindParam(':hostName', $hostParam);
+            $stmt->bindValue(':hostName', $hostParam);
         } else {
             return $string;
         }
@@ -750,7 +750,7 @@ class CentreonHost
                 'WHERE host_host_id = :hostId ' .
                 'AND host_macro_name LIKE :macro';
             $stmt = $this->db->prepare($query);
-            $stmt->bindParam(':hostId', $hostId, PDO::PARAM_INT);
+            $stmt->bindValue(':hostId', $hostId, PDO::PARAM_INT);
             $stmt->bindParam(':macro', $matches[1][$i], PDO::PARAM_STR);
             $dbResult = $stmt->execute();
             if (!$dbResult) {
@@ -764,7 +764,7 @@ class CentreonHost
         if ($i) {
             $query2 = 'SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = :host ORDER BY `order`';
             $stmt2 = $this->db->prepare($query2);
-            $stmt2->bindParam(':host', $hostId, PDO::PARAM_INT);
+            $stmt2->bindValue(':host', $hostId, PDO::PARAM_INT);
             $dbResult = $stmt2->execute();
             if (!$dbResult) {
                 throw new \Exception("An error occured");

--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -63,15 +63,13 @@ class CentreonHost
     protected $serviceObj;
 
     /**
-     * Constructor
-     *
      * @param CentreonDB $db
-     * @return void
+     * @throws PDOException
      */
-    public function __construct($db)
+    public function __construct(CentreonDB $db)
     {
         $this->db = $db;
-        $this->instanceObj = new CentreonInstance($db);
+        $this->instanceObj = CentreonInstance::getInstance($db);
         $this->serviceObj = new CentreonService($db);
     }
 

--- a/centreon/www/class/centreonInstance.class.php
+++ b/centreon/www/class/centreonInstance.class.php
@@ -42,6 +42,10 @@ class CentreonInstance
     protected $dbo;
     protected $params;
     protected $instances;
+    /**
+     * @var CentreonInstance|null $staticInstance
+     */
+    private static ?CentreonInstance $staticInstance = null;
 
     /**
      * Constructor
@@ -57,6 +61,20 @@ class CentreonInstance
         }
         $this->instances = array();
         $this->initParams();
+    }
+
+    /**
+     * @param CentreonDB $db
+     * @param CentreonDB|null $dbo
+     * @return CentreonInstance
+     * @throws PDOException
+     */
+    public static function getInstance(CentreonDB $db, ?CentreonDB $dbo = null): CentreonInstance
+    {
+        if (self::$staticInstance === null) {
+            self::$staticInstance = new CentreonInstance($db, $dbo);
+        }
+        return self::$staticInstance;
     }
 
     /**

--- a/centreon/www/class/centreonInstance.class.php
+++ b/centreon/www/class/centreonInstance.class.php
@@ -71,10 +71,7 @@ class CentreonInstance
      */
     public static function getInstance(CentreonDB $db, ?CentreonDB $dbo = null): CentreonInstance
     {
-        if (self::$staticInstance === null) {
-            self::$staticInstance = new CentreonInstance($db, $dbo);
-        }
-        return self::$staticInstance;
+        return self::$staticInstance ??= new self($db, $dbo);
     }
 
     /**

--- a/centreon/www/class/centreonService.class.php
+++ b/centreon/www/class/centreonService.class.php
@@ -75,7 +75,7 @@ class CentreonService
             $this->dbMon = $dbMon;
         }
 
-        $this->instanceObj = new CentreonInstance($db);
+        $this->instanceObj = CentreonInstance::getInstance($db, $dbMon);
     }
 
     /**

--- a/centreon/www/class/centreonXMLBGRequest.class.php
+++ b/centreon/www/class/centreonXMLBGRequest.class.php
@@ -141,7 +141,7 @@ class CentreonXMLBGRequest
          * Init Objects
          */
         $this->hostObj = new CentreonHost($this->DB);
-        $this->serviceObj = new CentreonService($this->DB);
+        $this->serviceObj = new CentreonService($this->DB, $this->DBC);
 
         /*
          * Init Object Monitoring

--- a/centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+++ b/centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
@@ -58,7 +58,7 @@ if (!isset($obj->session_id) || !CentreonSession::checkSession($obj->session_id,
 }
 
 $criticality = new CentreonCriticality($obj->DB);
-$instanceObj = CentreonInstance::getInstance($obj->DB, $this->DBC);
+$instanceObj = CentreonInstance::getInstance($obj->DB, $obj->DBC);
 $media = new CentreonMedia($obj->DB);
 $hostObj = new CentreonHost($obj->DB);
 

--- a/centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+++ b/centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
@@ -45,20 +45,22 @@ include_once _CENTREON_PATH_ . "www/class/centreonUtils.class.php";
  * Create XML Request Objects
  */
 CentreonSession::start();
-$obj = new CentreonXMLBGRequest($dependencyInjector, session_id(), 1, 1, 0, 1);
 
 if (!isset($_SESSION['centreon'])) {
     exit;
 }
 $centreon = $_SESSION['centreon'];
-$criticality = new CentreonCriticality($obj->DB);
-$instanceObj = new CentreonInstance($obj->DB);
-$media = new CentreonMedia($obj->DB);
 
+$obj = new CentreonXMLBGRequest($dependencyInjector, session_id(), 1, 1, 0, 1);
 if (!isset($obj->session_id) || !CentreonSession::checkSession($obj->session_id, $obj->DB)) {
     print "Bad Session ID";
     exit();
 }
+
+$criticality = new CentreonCriticality($obj->DB);
+$instanceObj = CentreonInstance::getInstance($obj->DB, $this->DBC);
+$media = new CentreonMedia($obj->DB);
+$hostObj = new CentreonHost($obj->DB);
 
 // Set Default Poller
 $obj->getDefaultFilters();
@@ -83,10 +85,10 @@ $statusHost = isset($_GET['statusHost']) ? \HtmlAnalyzer::sanitizeAndRemoveTags(
 $statusFilter = isset($_GET['statusFilter']) ? \HtmlAnalyzer::sanitizeAndRemoveTags($_GET['statusFilter']) : '';
 $order = isset($_GET['order']) && $_GET['order'] === "DESC" ? "DESC" : "ASC";
 
-if (isset($_GET['sort_type']) && $_GET['sort_type'] == "host_name") {
+if (isset($_GET['sort_type']) && $_GET['sort_type'] === "host_name") {
     $sort_type = "name";
 } else {
-    if ($o == "hpb" || $o == "h_unhandled") {
+    if ($o === "hpb" || $o === "h_unhandled") {
         $sort_type = $obj->checkArgument("sort_type", $_GET, "");
     } else {
         $sort_type = $obj->checkArgument("sort_type", $_GET, "host_name");
@@ -107,72 +109,88 @@ $queryValues = [];
 /*
  * Get Host status
  */
-$rq1 = " SELECT SQL_CALC_FOUND_ROWS DISTINCT h.state,
-    h.acknowledged,
-    h.passive_checks,
-    h.active_checks,
-    h.notify,
-    h.last_state_change,
-    h.last_hard_state_change,
-    h.output,
-    h.last_check,
-    h.address,
-    h.name,
-    h.alias,
-    h.action_url,
-    h.notes_url,
-    h.notes,
-    h.icon_image,
-    h.icon_image_alt,
-    h.max_check_attempts,
-    h.state_type,
-    h.check_attempt,
-    h.scheduled_downtime_depth,
-    h.host_id,
-    h.flapping,
-    hph.parent_id AS is_parent,
-    i.name AS instance_name,
-    cv.value AS criticality,
-    cv.value IS NULL AS isnull
-    FROM instances i, ";
+$rq1 = <<<SQL
+    SELECT SQL_CALC_FOUND_ROWS DISTINCT 
+        h.state,
+        h.acknowledged,
+        h.passive_checks,
+        h.active_checks,
+        h.notify,
+        h.last_state_change,
+        h.last_hard_state_change,
+        h.output,
+        h.last_check,
+        h.address,
+        h.name,
+        h.alias,
+        h.action_url,
+        h.notes_url,
+        h.notes,
+        h.icon_image,
+        h.icon_image_alt,
+        h.max_check_attempts,
+        h.state_type,
+        h.check_attempt,
+        h.scheduled_downtime_depth,
+        h.host_id,
+        h.flapping,
+        hph.parent_id AS is_parent,
+        i.name AS instance_name,
+        cv.value AS criticality,
+        cv.value IS NULL AS isnull
+        FROM instances i
+    INNER JOIN hosts h 
+        ON h.instance_id = i.instance_id
+    SQL;
+
 if (!$obj->is_admin) {
-    $rq1 .= " centreon_acl, ";
+    $rq1 .= <<<SQL
+
+    INNER JOIN centreon_acl
+        ON centreon_acl.host_id = h.host_id
+        AND centreon_acl.group_id IN ({$obj->grouplistStr})
+    SQL;
 }
+
 if ($hostgroups) {
-    $rq1 .= " hosts_hostgroups hhg, hostgroups hg, ";
+    $rq1 .= <<<SQL
+
+        INNER JOIN hosts_hostgroups hhg
+            ON hhg.host_id = h.host_id
+        INNER JOIN hostgroups hg
+            ON hg.hostgroup_id = :hostgroup
+            AND hg.hostgroup_id = hhg.hostgroup_id
+        SQL;
+    $queryValues['hostgroup'] = [\PDO::PARAM_INT => $hostgroups];
 }
+
 if ($criticalityId) {
-    $rq1 .= "customvariables cvs, ";
+    $rq1 .= <<<SQL
+
+        INNER JOIN customvariables cvs
+            ON cvs.host_id = h.host_id
+            AND cvs.name = 'CRITICALITY_ID'
+            AND cvs.service_id = 0
+            AND cvs.value = :criticalityId
+        SQL;
+    $queryValues['criticalityId'] = [\PDO::PARAM_STR => $criticalityId];
 }
-$rq1 .= " `hosts` h
+
+$rq1 .= <<<SQL
+    
     LEFT JOIN hosts_hosts_parents hph
-    ON hph.parent_id = h.host_id
+        ON hph.parent_id = h.host_id
     LEFT JOIN `customvariables` cv
-    ON (cv.host_id = h.host_id AND cv.service_id = 0 AND cv.name = 'CRITICALITY_LEVEL')
+        ON (cv.host_id = h.host_id AND cv.service_id = 0 AND cv.name = 'CRITICALITY_LEVEL')
     WHERE h.name NOT LIKE '\_Module\_%'
-    AND h.instance_id = i.instance_id ";
+        AND h.instance_id = i.instance_id
+    SQL;
 
-if ($criticalityId) {
-    $rq1 .= " AND h.host_id = cvs.host_id
-        AND cvs.name = 'CRITICALITY_ID'
-        AND cvs.service_id = 0
-        AND cvs.value = :criticalityId ";
-    $queryValues['criticalityId'] = [
-        \PDO::PARAM_STR => $criticalityId
-    ];
-}
-
-if (!$obj->is_admin) {
-    $rq1 .= " AND h.host_id = centreon_acl.host_id " .
-        $obj->access->queryBuilder("AND", "centreon_acl.group_id", $obj->grouplistStr);
-}
 if ($search != "") {
     $rq1 .= " AND (h.name LIKE :search
         OR h.alias LIKE :search
         OR h.address LIKE :search) ";
-    $queryValues['search'] = [
-        \PDO::PARAM_STR => '%' . $search . '%'
-    ];
+    $queryValues['search'] = [\PDO::PARAM_STR => '%' . $search . '%'];
 }
 
 if ($statusHost == "h_unhandled") {
@@ -192,15 +210,6 @@ if ($statusFilter == "up") {
     $rq1 .= " AND h.state = 2 ";
 } elseif ($statusFilter == "pending") {
     $rq1 .= " AND h.state = 4 ";
-}
-
-if ($hostgroups) {
-    $rq1 .= " AND h.host_id = hhg.host_id
-        AND hg.hostgroup_id = :hostgroup
-        AND hhg.hostgroup_id = hg.hostgroup_id";
-    $queryValues['hostgroup'] = [
-        \PDO::PARAM_INT => $hostgroups
-    ];
 }
 
 if ($instance != -1 && !empty($instance)) {
@@ -392,17 +401,16 @@ while ($data = $dbResult->fetch()) {
     $obj->XML->writeElement("parenth", $parenth);
     $obj->XML->writeElement("delim", $delim);
 
-    $hostObj = new CentreonHost($obj->DB);
     if ($data["notes"] != "") {
         $obj->XML->writeElement(
             "hnn",
             CentreonUtils::escapeSecure(
                 $hostObj->replaceMacroInString(
-                    $data["name"],
+                    $data["host_id"],
                     str_replace(
-                        "\$HOSTNAME\$",
+                        'HOSTNAME$',
                         $data["name"],
-                        str_replace("\$HOSTADDRESS\$", $data["address"], $data["notes"])
+                        str_replace('$HOSTADDRESS$', $data["address"], $data["notes"])
                     )
                 )
             )
@@ -412,24 +420,23 @@ while ($data = $dbResult->fetch()) {
     }
 
     if ($data["notes_url"] != "") {
-        $str = $data['notes_url'];
-        $str = str_replace("\$HOSTNAME\$", $data['name'], $str);
-        $str = str_replace("\$HOSTALIAS\$", $data['alias'], $str);
-        $str = str_replace("\$HOSTADDRESS\$", $data['address'], $str);
-        $str = str_replace("\$HOSTNOTES\$", $data['notes'], $str);
-        $str = str_replace("\$INSTANCENAME\$", $data['instance_name'], $str);
+        $str = str_replace('$HOSTNAME$', $data['name'], $data['notes_url']);
+        $str = str_replace('$HOSTALIAS$', $data['alias'], $str);
+        $str = str_replace('$HOSTADDRESS$', $data['address'], $str);
+        $str = str_replace('$HOSTNOTES$', $data['notes'], $str);
+        $str = str_replace('$INSTANCENAME$', $data['instance_name'], $str);
 
-        $str = str_replace("\$HOSTSTATEID\$", $data['state'], $str);
-        $str = str_replace("\$HOSTSTATE\$", $obj->statusHost[$data['state']], $str);
+        $str = str_replace('$HOSTSTATEID$', $data['state'], $str);
+        $str = str_replace('$HOSTSTATE$', $obj->statusHost[$data['state']], $str);
 
         $str = str_replace(
-            "\$INSTANCEADDRESS\$",
+            '$INSTANCEADDRESS$',
             $instanceObj->getParam($data['instance_name'], 'ns_ip_address'),
             $str
         );
         $obj->XML->writeElement(
             "hnu",
-            CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], $str))
+            CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["host_id"], $str))
         );
     } else {
         $obj->XML->writeElement("hnu", "none");
@@ -437,23 +444,23 @@ while ($data = $dbResult->fetch()) {
 
     if ($data["action_url"] != "") {
         $str = $data['action_url'];
-        $str = str_replace("\$HOSTNAME\$", $data['name'], $str);
-        $str = str_replace("\$HOSTALIAS\$", $data['alias'], $str);
-        $str = str_replace("\$HOSTADDRESS\$", $data['address'], $str);
-        $str = str_replace("\$HOSTNOTES\$", $data['notes'], $str);
-        $str = str_replace("\$INSTANCENAME\$", $data['instance_name'], $str);
+        $str = str_replace('$HOSTNAME$', $data['name'], $str);
+        $str = str_replace('$HOSTALIAS$', $data['alias'], $str);
+        $str = str_replace('$HOSTADDRESS$', $data['address'], $str);
+        $str = str_replace('$HOSTNOTES$', $data['notes'], $str);
+        $str = str_replace('$INSTANCENAME$', $data['instance_name'], $str);
 
-        $str = str_replace("\$HOSTSTATEID\$", $data['state'], $str);
-        $str = str_replace("\$HOSTSTATE\$", $obj->statusHost[$data['state']], $str);
+        $str = str_replace('$HOSTSTATEID$', $data['state'], $str);
+        $str = str_replace('$HOSTSTATE$', $obj->statusHost[$data['state']], $str);
 
         $str = str_replace(
-            "\$INSTANCEADDRESS\$",
+            '$INSTANCEADDRESS$',
             $instanceObj->getParam($data['instance_name'], 'ns_ip_address'),
             $str
         );
         $obj->XML->writeElement(
             "hau",
-            CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["name"], $str))
+            CentreonUtils::escapeSecure($hostObj->replaceMacroInString($data["host_id"], $str))
         );
     } else {
         $obj->XML->writeElement("hau", "none");


### PR DESCRIPTION
## Description

The aim is to reduce the number of requests when monitoring hosts.
In a typical case, reduction:
- As admin: 74 to 11 queries
- As non admin: 89 to 26 queries

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Deactivate the broker
2. Connect to the Centreon platform and access the http://lcentreon_ip/centreon/main.php?p=20202 page (Legacy Hosts Monitoring page)
3. Copy/paste the url called by Centreon to retrieve the real time hosts in a new browser tab (url: centreon/include/monitoring/status/Hosts/xml/hostXML.php ?....)
5. Close the Centreon main page
6. Check the number of queries in the database: `show status like 'Queries';``
7. Refresh the tab where the hostXML.php url is located.
8. Check the number of queries in the database again: show status like 'Queries'.

Do the subtraction.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
