### PR TITLE
chore(Debian): reorganizes dependencies to resolves confict

### DIFF
--- a/centreon/packaging/debian/control
+++ b/centreon/packaging/debian/control
@@ -11,8 +11,7 @@ Package: centreon
 Architecture: all
 Depends:
     centreon-central (>= ${centreon:version}~),
-    centreon-database (>= ${centreon:version}~),
-    sudo
+    centreon-database (>= ${centreon:version}~)
 Description: Centreon is a network, system, applicative supervision and monitoring tool,
  it is based upon the most effective Open Source monitoring engine : Nagios.
  Centreon provides a new frontend and new functionnalities to Nagios.
@@ -122,11 +121,9 @@ Depends:
     php8.1-grpc,
     php8.1-protobuf,
     php-pear,
-    ntp,
-    rrdtool,
-    bsd-mailx,
-    sudo,
-    nagios-images
+    rrdtool
+Recommends: ntp | bsd-mailx
+Suggests: nagios-images
 Description: This package contains WebUI files.
 
 Package: centreon-perl-libs


### PR DESCRIPTION
When an environment already has a dependency package installed, but uses another alternative, there may be conflicts.

The example described in the ticket happens with the ntp package, in this case we solved it by putting it as a recommended package.

**Fixes** # (issue)
Superseeds : https://github.com/centreon/centreon-archived/pull/12063

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x (master)
