### PR TITLE
[enh](ldap): add ldap connection timeout to avoid infinite connection (dev-21.10.x)

### DIFF
--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -14757,3 +14757,228 @@ msgstr ""
 
 #  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
 #  msgstr ""
+
+# msgid "Export to CSV"
+# msgstr ""
+
+msgid "Service severity"
+msgstr "Criticidad del servicio"
+
+msgid "Service severity level"
+msgstr "Nivel de criticidad del servicio"
+
+msgid "Host severity"
+msgstr "Criticidad del host"
+
+msgid "Host severity level"
+msgstr "Nivel de criticidad del host"
+
+#  msgid "Listening address (optional)"
+#  msgstr ""
+
+#  msgid "Listening port"
+#  msgstr ""
+
+#  msgid "Transport protocol"
+#  msgstr ""
+
+#  msgid "Authorization token (optional)"
+#  msgstr ""
+
+#  msgid "Private key path"
+#  msgstr ""
+
+#  msgid "Certificate path"
+#  msgstr ""
+
+#  msgid "Compression"
+#  msgstr ""
+
+#  msgid "Enable retention"
+#  msgstr ""
+
+#  msgid "Filter on event categories"
+#  msgstr ""
+
+#  msgid "Server address"
+#  msgstr ""
+
+#  msgid "Server port"
+#  msgstr ""
+
+#  msgid "Retry interval (in seconds)"
+#  msgstr ""
+
+#  msgid "Trusted CA's certificate path (optional)"
+#  msgstr ""
+
+#  msgid "Certificate Common Name (optional)"
+#  msgstr ""
+
+# msgid "CSV"
+# msgstr ""
+
+#  msgid "Poller Configuration Actions / Poller Management"
+#  msgstr ""
+
+#  msgid "Create and edit pollers"
+#  msgstr ""
+
+#  msgid "Delete pollers"
+#  msgstr ""
+
+#  msgid "Deploy configuration"
+#  msgstr ""
+
+msgid "Are you sure you want to change the size of the envelope? Please note that the new envelope size will only be applied from now on. The old envelope will stay the same."
+msgstr "¿Está seguro de que desea cambiar el tamaño del sobre? El nuevo tamaño de sobre se aplicará inmediatamente."
+
+msgid "Changes to the envelope size will be applied only from now on."
+msgstr "Los cambios en el tamaño del sobre se aplicarán inmediatamente."
+
+msgid "Manage envelope size"
+msgstr "Administrar el tamaño del sobre"
+
+msgid "Reset to default value"
+msgstr "Establecer en el valor predeterminado"
+
+msgid "points outside of the envelope"
+msgstr "puntos fuera del sobre"
+
+msgid "Edit anomaly detection data"
+msgstr "Editar datos de detección de anomalías"
+
+#  msgid "Enable/disable resource"
+#  msgstr ""
+
+#  msgid "Note"
+#  msgstr ""
+
+#  msgid "Note URL"
+#  msgstr ""
+
+#  msgid "Geographic coordinates"
+#  msgstr ""
+
+#  msgid "Members"
+#  msgstr ""
+
+#  msgid "Monitoring settings"
+#  msgstr ""
+
+#  msgid "Classification"
+#  msgstr ""
+
+#  msgid "Hosts (simplified)"
+#  msgstr ""
+
+#  msgid "Templates (simplified)"
+#  msgstr ""
+
+#  msgid "Host Groups (simplified)"
+#  msgstr ""
+
+msgid "You have unsaved changes, do you want to proceed?"
+msgstr "No ha guardado los cambios, ¿quiere continuar?"
+
+#  msgid "Confirm"
+#  msgstr "Confirmar"
+
+#  msgid "Incorrect LDAP filter syntax"
+#  msgstr ""
+
+#  msgid "LDAP connection timeout"
+#  msgstr ""
+
+#  msgid "Vault configuration with these properties already exists"
+#  msgstr ""
+
+#  msgid "Impossible to create vault configuration"
+#  msgstr ""
+
+#  msgid "Vault provider does not exist"
+#  msgstr ""
+
+#  msgid "You are not allowed to access host categories"
+#  msgstr ""
+
+#  msgid "Error while searching for host categories"
+#  msgstr ""
+
+#  msgid "You are not allowed to delete host categories"
+#  msgstr ""
+
+#  msgid "Host category not found"
+#  msgstr ""
+
+#  msgid "Error while deleting host category"
+#  msgstr ""
+
+#  msgid "Error while searching for host groups"
+#  msgstr ""
+
+#  msgid "You are not allowed to access host groups"
+#  msgstr ""
+
+#  msgid "You are not allowed to perform write operations on host groups"
+#  msgstr ""
+
+#  msgid "Host group not found"
+#  msgstr ""
+
+#  msgid "Error while deleting a host group"
+#  msgstr ""
+
+#  msgid "Error while adding a host group"
+#  msgstr ""
+
+#  msgid "The host group name '%s' already exists"
+#  msgstr ""
+
+#  msgid "Error while retrieving just created host group"
+#  msgstr ""
+
+#  msgid "The host group icon '%s' with id '%d' does not exist"
+#  msgstr ""
+
+#  msgid "You are not allowed to create host categories"
+#  msgstr ""
+
+#  msgid "Host category name already exists"
+#  msgstr ""
+
+#  msgid "Error while creating host category"
+#  msgstr ""
+
+#  msgid "You are not allowed to access host severities"
+#  msgstr ""
+
+#  msgid "Error while searching for host severities"
+#  msgstr ""
+
+#  msgid "You are not allowed to delete host severities"
+#  msgstr ""
+
+#  msgid "Error while deleting host severity"
+#  msgstr ""
+
+#  msgid "Error while creating host severity"
+#  msgstr ""
+
+#  msgid "You are not allowed to create host severities"
+#  msgstr ""
+
+#  msgid "Error while retrieving recently created host severity"
+#  msgstr ""
+
+#  msgid "Host severity name already exists"
+#  msgstr ""
+
+#  msgid "The host severity icon with id '%d' does not exist"
+#  msgstr ""
+
+#  msgid "You are not allowed to access time periods"
+#  msgstr ""
+
+#  msgid "You are not allowed to edit time periods"
+#  msgstr ""

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -5675,6 +5675,12 @@ msgstr "Toutes les sessions de ce contact seront supprimées. Êtes-vous sûr de
 msgid "Synchronize LDAP"
 msgstr "Synchroniser avec le LDAP"
 
+msgid "Incorrect LDAP filter syntax"
+msgstr "Mauvaise syntaxe du filtre LDAP"
+
+msgid "LDAP connection timeout"
+msgstr "Délai d'attente de connexion LDAP"
+
 msgid "No LDAP configuration enabled !"
 msgstr "Aucune configuration LDAP active !"
 

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -11796,7 +11796,7 @@ msgstr "Escala"
 
 #: centreon-web/www/install/smarty_translate.php:414
 msgid "Service category"
-msgstr "Categoria do Serviço"
+msgstr "Categoria de Serviço"
 
 #: centreon-web/www/install/smarty_translate.php:438
 msgid "Service Scheduling Options"

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -11781,7 +11781,7 @@ msgstr "Grupo de traps SNMP"
 
 #: centreon-web/www/install/smarty_translate.php:387
 msgid "Host category"
-msgstr "Categoria do Host"
+msgstr "Categoria de Host"
 
 #: centreon-web/www/install/smarty_translate.php:393
 msgid "Informations"
@@ -15191,8 +15191,331 @@ msgstr ""
 # msgid "Soft"
 # msgstr ""
 
-# msgid "Force active checks"
+# msgid "You are disconnected"
+# msgstr ""
+
+# msgid "Centreon is loading..."
+# msgstr ""
+
+# msgid "Login succeeded"
+# msgstr ""
+
+# msgid "Login"
+# msgstr ""
+
+# msgid "Centreon Logo"
+# msgstr ""
+
+# msgid "You are not allowed to see this page"
+# msgstr ""
+
+# msgid "This page could not be found"
+# msgstr ""
+
+# msgid "Display the password"
+# msgstr ""
+
+# msgid "Hide the password"
+# msgstr ""
+
+# msgid "You have been logged out"
+# msgstr ""
+
+# msgid "Profile"
+# msgstr ""
+
+# msgid "Password security policy"
+# msgstr ""
+
+# msgid "OpenID Connect Configuration"
+# msgstr ""
+
+# msgid "Define OpenID Connect configuration"
+# msgstr ""
+
+# msgid "Invalid URL"
+# msgstr ""
+
+# msgid "Invalid IP Address"
+# msgstr ""
+
+# msgid "Failed to save OpenID Connect configuration"
+# msgstr ""
+
+# msgid "OpenID Connect configuration saved"
+# msgstr ""
+
+# msgid "Enable OpenID Connect authentication"
+# msgstr ""
+
+# msgid "Authentication mode"
+# msgstr ""
+
+# msgid "Base URL"
+# msgstr ""
+
+# msgid "Authorization endpoint"
+# msgstr ""
+
+# msgid "Token endpoint"
+# msgstr ""
+
+# msgid "Introspection token endpoint"
+# msgstr ""
+
+# msgid "User information endpoint"
+# msgstr ""
+
+# msgid "End session endpoint"
+# msgstr ""
+
+# msgid "Scopes"
+# msgstr ""
+
+# msgid "Login claim value"
+# msgstr ""
+
+# msgid "Client ID"
+# msgstr ""
+
+# msgid "Client secret"
 # msgstr ""
 
 #  msgid "Warning, maximum size exceeded for input '%s' (max: %d), it will be truncated upon saving"
+#  msgstr ""
+
+# msgid "Export to CSV"
+# msgstr ""
+
+msgid "Service severity"
+msgstr "Severidade de serviço"
+
+msgid "Service severity level"
+msgstr "Nível de Severidade de serviço"
+
+msgid "Host severity"
+msgstr "Severidade de host"
+
+msgid "Host severity level"
+msgstr "Nível de Severidade de host"
+
+#  msgid "Listening address (optional)"
+#  msgstr ""
+
+#  msgid "Listening port"
+#  msgstr ""
+
+#  msgid "Transport protocol"
+#  msgstr ""
+
+#  msgid "Authorization token (optional)"
+#  msgstr ""
+
+#  msgid "Private key path"
+#  msgstr ""
+
+#  msgid "Certificate path"
+#  msgstr ""
+
+#  msgid "Compression"
+#  msgstr ""
+
+#  msgid "Enable retention"
+#  msgstr ""
+
+#  msgid "Filter on event categories"
+#  msgstr ""
+
+#  msgid "Server address"
+#  msgstr ""
+
+#  msgid "Server port"
+#  msgstr ""
+
+#  msgid "Retry interval (in seconds)"
+#  msgstr ""
+
+#  msgid "Trusted CA's certificate path (optional)"
+#  msgstr ""
+
+#  msgid "Certificate Common Name (optional)"
+#  msgstr ""
+
+# msgid "As displayed"
+# msgstr ""
+
+# msgid "Medium size"
+# msgstr ""
+
+# msgid "Small size"
+# msgstr ""
+
+# msgid "CSV"
+# msgstr ""
+
+#  msgid "Poller Configuration Actions / Poller Management"
+#  msgstr ""
+
+#  msgid "Create and edit pollers"
+#  msgstr ""
+
+#  msgid "Delete pollers"
+#  msgstr ""
+
+#  msgid "Deploy configuration"
+#  msgstr ""
+
+msgid "Are you sure you want to change the size of the envelope? Please note that the new envelope size will only be applied from now on. The old envelope will stay the same."
+msgstr "Tem certeza de que deseja alterar o tamanho do envelope? O novo tamanho de envelope será aplicado imediatamente."
+
+msgid "Changes to the envelope size will be applied only from now on."
+msgstr "As alterações no tamanho do envelope serão aplicadas imediatamente"
+
+msgid "Manage envelope size"
+msgstr "Gerenciar o tamanho do envelope"
+
+msgid "Reset to default value"
+msgstr "Definir para o valor padrão"
+
+msgid "points outside of the envelope"
+msgstr "pontos fora do envelope"
+
+msgid "Edit anomaly detection data"
+msgstr "Editar dados de detecção de anomalias"
+
+#  msgid "Enable/disable resource"
+#  msgstr ""
+
+#  msgid "Note"
+#  msgstr ""
+
+#  msgid "Note URL"
+#  msgstr ""
+
+#  msgid "Geographic coordinates"
+#  msgstr ""
+
+#  msgid "Members"
+#  msgstr ""
+
+#  msgid "Monitoring settings"
+#  msgstr ""
+
+#  msgid "Classification"
+#  msgstr ""
+
+#  msgid "Hosts (simplified)"
+#  msgstr ""
+
+#  msgid "Templates (simplified)"
+#  msgstr ""
+
+#  msgid "Host Groups (simplified)"
+#  msgstr ""
+
+msgid "You have unsaved changes, do you want to proceed?"
+msgstr "Você não salvou as alterações, deseja continuar?"
+
+#  msgid "Confirm"
+#  msgstr "Confirme"
+
+#  msgid "Incorrect LDAP filter syntax"
+#  msgstr ""
+
+#  msgid "LDAP connection timeout"
+#  msgstr ""
+
+
+#  msgid "Vault configuration with these properties already exists"
+#  msgstr ""
+
+#  msgid "Impossible to create vault configuration"
+#  msgstr ""
+
+#  msgid "Vault provider does not exist"
+#  msgstr ""
+
+#  msgid "You are not allowed to access host categories"
+#  msgstr ""
+
+#  msgid "Error while searching for host categories"
+#  msgstr ""
+
+#  msgid "You are not allowed to delete host categories"
+#  msgstr ""
+
+#  msgid "Host category not found"
+#  msgstr ""
+
+#  msgid "Error while deleting host category"
+#  msgstr ""
+
+
+#  msgid "Error while searching for host groups"
+#  msgstr ""
+
+#  msgid "You are not allowed to access host groups"
+#  msgstr ""
+
+#  msgid "You are not allowed to perform write operations on host groups"
+#  msgstr ""
+
+#  msgid "Host group not found"
+#  msgstr ""
+
+#  msgid "Error while deleting a host group"
+#  msgstr ""
+
+#  msgid "Error while adding a host group"
+#  msgstr ""
+
+#  msgid "The host group name '%s' already exists"
+#  msgstr ""
+
+#  msgid "Error while retrieving just created host group"
+#  msgstr ""
+
+#  msgid "The host group icon '%s' with id '%d' does not exist"
+#  msgstr ""
+
+#  msgid "You are not allowed to create host categories"
+#  msgstr ""
+
+#  msgid "Host category name already exists"
+#  msgstr ""
+
+#  msgid "Error while creating host category"
+#  msgstr ""
+
+#  msgid "You are not allowed to access host severities"
+#  msgstr ""
+
+#  msgid "Error while searching for host severities"
+#  msgstr ""
+
+#  msgid "You are not allowed to delete host severities"
+#  msgstr ""
+
+#  msgid "Error while deleting host severity"
+#  msgstr ""
+
+#  msgid "Error while creating host severity"
+#  msgstr ""
+
+#  msgid "You are not allowed to create host severities"
+#  msgstr ""
+
+#  msgid "Error while retrieving recently created host severity"
+#  msgstr ""
+
+#  msgid "Host severity name already exists"
+#  msgstr ""
+
+#  msgid "The host severity icon with id '%d' does not exist"
+#  msgstr ""
+
+#  msgid "You are not allowed to access time periods"
+#  msgstr ""
+
+#  msgid "You are not allowed to edit time periods"
 #  msgstr ""

--- a/centreon/www/class/CentreonLDAPAdmin.class.php
+++ b/centreon/www/class/CentreonLDAPAdmin.class.php
@@ -1,0 +1,680 @@
+<?php
+
+/*
+ * Copyright 2005-2021 Centreon
+ * Centreon is developed by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+/**
+ * Ldap Administration class
+ */
+class CentreonLdapAdmin
+{
+    /**
+     * @object centreonLog
+     */
+    public $centreonLog;
+
+    private $db;
+
+    /**
+     * Constructor
+     *
+     * @param CentreonDB $pearDB The database connection
+     */
+    public function __construct($pearDB)
+    {
+        $this->db = $pearDB;
+        $this->centreonLog = new CentreonLog();
+    }
+
+    /**
+     * Get ldap parameters
+     *
+     * @return array
+     * @todo sanitize the inputs to avoid XSS
+     */
+    public function getLdapParameters()
+    {
+        $tab = array(
+            'ldap_store_password',
+            'ldap_auto_import',
+            'ldap_connection_timeout',
+            'ldap_search_limit',
+            'ldap_search_timeout',
+            'ldap_contact_tmpl',
+            'ldap_default_cg',
+            'ldap_srv_dns',
+            'ldap_dns_use_ssl',
+            'ldap_dns_use_tls',
+            'ldap_dns_use_domain',
+            'bind_dn',
+            'bind_pass',
+            'protocol_version',
+            'ldap_template',
+            'user_base_search',
+            'group_base_search',
+            'user_filter',
+            'alias',
+            'user_group',
+            'user_name',
+            'user_firstname',
+            'user_lastname',
+            'user_email',
+            'user_pager',
+            'group_filter',
+            'group_name',
+            'group_member',
+            'ldap_auto_sync', // is auto synchronization enabled
+            'ldap_sync_interval' // unsigned integer interval between two LDAP synchronization
+        );
+        return $tab;
+    }
+
+    /**
+     * Update Ldap servers
+     *
+     * @param int $arId | auth resource id
+     */
+    protected function updateLdapServers($arId): void
+    {
+        $statement = $this->db->prepare(
+            "DELETE FROM auth_ressource_host WHERE auth_ressource_id = :id"
+        );
+        $statement->bindValue(':id', $arId, PDO::PARAM_INT);
+        $statement->execute();
+
+        if (isset($_REQUEST['address'])) {
+            $subRequest = '';
+            $bindValues = [];
+            $bindIndex = 0;
+            foreach ($_REQUEST['address'] as $index => $address) {
+                $bindValues[':address_' . $bindIndex] = [PDO::PARAM_STR => $address];
+                $bindValues[':port_' . $bindIndex] = [PDO::PARAM_INT => $_REQUEST['port'][$index]];
+                $bindValues[':tls_' . $bindIndex] = [PDO::PARAM_STR => isset($_REQUEST['tls'][$index]) ? '1' : '0'];
+                $bindValues[':ssl_' . $bindIndex] = [PDO::PARAM_STR => isset($_REQUEST['ssl'][$index]) ? '1' : '0'];
+                $bindValues[':order_' . $bindIndex] = [PDO::PARAM_INT => $bindIndex + 1];
+                if (! empty($subRequest)) {
+                    $subRequest .= ', ';
+                }
+                $subRequest .=
+                    '(:id, :address_' . $bindIndex . ', :port_' . $bindIndex . ', :ssl_' . $bindIndex
+                    . ', :tls_' . $bindIndex     . ', :order_' . $bindIndex . ')';
+                $bindIndex++;
+            }
+
+            if (! empty($subRequest)) {
+                $bindValues[':id'] = [PDO::PARAM_INT => (int) $arId];
+                $statement = $this->db->prepare(
+                    "INSERT INTO auth_ressource_host
+                    (auth_ressource_id, host_address, host_port, use_ssl, use_tls, host_order)
+                    VALUES " . $subRequest
+                );
+                foreach ($bindValues as $bindKey => $bindValue) {
+                    $bindType = key($bindValue);
+                    $statement->bindValue($bindKey, $bindValue[$bindType], $bindType);
+                }
+                $statement->execute();
+            }
+        }
+    }
+
+    /**
+     * Set ldap options
+     *
+     * 'ldap_auth_enable', 'ldap_auto_import', 'ldap_srv_dns', 'ldap_search_limit', 'ldap_search_timeout'
+     * and 'ldap_dns_use_ssl', 'ldap_dns_use_tls', 'ldap_dns_use_domain' if ldap_srv_dns = 1
+     *
+     * @param array<string, mixed> $options The list of options
+     * @param int $arId
+     * @return int resource auth id
+     */
+    public function setGeneralOptions(array $options, $arId = 0): int
+    {
+        $isUpdate = ((int)$arId !== 0);
+
+        $gopt = $this->getGeneralOptions($arId);
+        if (isset($gopt["bind_pass"]) && $gopt["bind_pass"] === CentreonAuth::PWS_OCCULTATION && $isUpdate === false) {
+            unset($gopt["bind_pass"]);
+        }
+        if (
+            !count($gopt)
+            && isset($options['ar_name'])
+            && isset($options['ar_description'])
+        ) {
+            if (!isset($options['ar_sync_base_date'])) {
+                $options['ar_sync_base_date'] = time();
+                $this->centreonLog->insertLog(
+                    3,
+                    "LDAP PARAM - Warning the reference date wasn\'t set for LDAP : " . $options['ar_name']
+                );
+            }
+            $statement = $this->db->prepare(
+                "INSERT INTO auth_ressource (ar_name, ar_description, ar_type, ar_enable, ar_sync_base_date) 
+                VALUES (:name, :description, 'ldap', :is_enabled, :sync_date)"
+            );
+            $statement->bindValue(':name', $options['ar_name'], PDO::PARAM_STR);
+            $statement->bindValue(':description', $options['ar_description'], PDO::PARAM_STR);
+            $statement->bindValue(':is_enabled', $options['ldap_auth_enable']['ldap_auth_enable'], PDO::PARAM_STR);
+            $statement->bindValue(':sync_date', $options['ar_sync_base_date'], PDO::PARAM_INT);
+            $statement->execute();
+
+            $statement = $this->db->prepare(
+                "SELECT MAX(ar_id) as last_id
+                FROM auth_ressource
+                WHERE ar_name = :name"
+            );
+            $statement->bindValue(':name', $options['ar_name'], PDO::PARAM_STR);
+            $statement->execute();
+            $row = $statement->fetch();
+            $arId = $row['last_id'];
+            unset($statement);
+        } else {
+            $statement = $this->db->prepare(
+                "UPDATE auth_ressource
+                    SET ar_name = :name,
+                        ar_description = :description,
+                        ar_enable = :is_enabled,
+                        ar_sync_base_date = :sync_date
+                WHERE ar_id = :id"
+            );
+            $statement->bindValue(':name', $options['ar_name'], PDO::PARAM_STR);
+            $statement->bindValue(':description', $options['ar_description'], PDO::PARAM_STR);
+            $statement->bindValue(':is_enabled', $options['ldap_auth_enable']['ldap_auth_enable'], PDO::PARAM_STR);
+            $statement->bindValue(':sync_date', $options['ar_sync_base_date'], PDO::PARAM_INT);
+            $statement->bindValue(':id', $arId, PDO::PARAM_INT);
+            $statement->execute();
+        }
+        $knownParameters = $this->getLdapParameters();
+        if (
+            isset($options["bind_pass"])
+            && $options["bind_pass"] === CentreonAuth::PWS_OCCULTATION
+            && $isUpdate === true
+        ) {
+            unset($options["bind_pass"]);
+        }
+        foreach ($options as $key => $value) {
+            if (!in_array($key, $knownParameters)) {
+                continue;
+            }
+            if (is_array($value)) { //radio buttons
+                $value = $value[$key];
+            }
+            // Make all attributes lowercase since ldap_get_entries
+            // converts them to lowercase.
+            if (
+                in_array(
+                    $key,
+                    array(
+                        "alias",
+                        "user_name",
+                        "user_email",
+                        "user_pager",
+                        "user_firstname",
+                        "user_lastname",
+                        "group_name",
+                        "group_member"
+                    )
+                )
+            ) {
+                $value = strtolower($value);
+            }
+            if (isset($gopt[$key])) {
+                $statement = $this->db->prepare(
+                    "UPDATE `auth_ressource_info`
+                        SET `ari_value` = :value
+                    WHERE `ari_name` = :name
+                        AND `ar_id` = :id"
+                );
+            } else {
+                $statement = $this->db->prepare(
+                    "INSERT INTO `auth_ressource_info`
+                    (`ar_id`, `ari_name`, `ari_value`)
+                    VALUES (:id, :name, :value)"
+                );
+            }
+            $statement->bindValue(':value', $value, PDO::PARAM_STR);
+            $statement->bindValue(':name', $key, PDO::PARAM_STR);
+            $statement->bindValue(':id', $arId, PDO::PARAM_INT);
+            $statement->execute();
+        }
+        $this->updateLdapServers($arId);
+
+        /* Remove contact passwords if store password option is disabled */
+        $this->manageContactPasswords($arId);
+
+        return $arId;
+    }
+
+    /**
+     * Get the general options
+     *
+     * @param int $arId
+     * @return array
+     */
+    public function getGeneralOptions($arId)
+    {
+        $gopt = [];
+        $statement = $this->db->prepare(
+            "SELECT `ari_name`, `ari_value` FROM `auth_ressource_info`
+            WHERE `ari_name` <> 'bind_pass'
+            AND ar_id = :id"
+        );
+        $statement->bindValue(':id', $arId, PDO::PARAM_INT);
+        $statement->execute();
+        while ($row = $statement->fetch()) {
+            $gopt[$row['ari_name']] = $row['ari_value'];
+        }
+        $gopt['bind_pass'] = CentreonAuth::PWS_OCCULTATION;
+        return $gopt;
+    }
+
+    /**
+     * Add a Ldap server
+     * (Possibility of a dead code)
+     *
+     * @param int $arId
+     * @param array<string, mixed> $params
+     * @return void
+     */
+    public function addServer($arId, $params = []): void
+    {
+        $statement = $this->db->prepare(
+            "INSERT INTO auth_ressource_host
+            (auth_ressource_id, host_address, host_port, use_ssl, use_tls, host_order)
+            VALUES (:id, :address, :port, :ssl, :tls, :order)"
+        );
+        $statement->bindValue(':id', $arId, PDO::PARAM_INT);
+        $statement->bindValue(':address', $params['hostname'], PDO::PARAM_STR);
+        $statement->bindValue(':port', $params['port'], PDO::PARAM_INT);
+        $statement->bindValue(':ssl', isset($params['use_ssl']) ? 1 : 0, PDO::PARAM_INT);
+        $statement->bindValue(':tls', isset($params['use_tls']) ? 1 : 0, PDO::PARAM_INT);
+        $statement->bindValue(':order', $params['order'], PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    /**
+     * Modify a Ldap server
+     *
+     * @param int $arId
+     * @param array<string, mixed> $params
+     * @return void
+     */
+    public function modifyServer($arId, $params = array()): void
+    {
+        if (!isset($params['order']) || !isset($params['id'])) {
+            return;
+        }
+        $use_ssl = isset($params['use_ssl']) ? 1 : 0;
+        $use_tls = isset($params['use_tls']) ? 1 : 0;
+
+        $statement = $this->db->prepare(
+            "UPDATE auth_ressource_host
+            SET host_address = :address,
+                host_port = :port,
+                host_order = :order,
+                use_ssl = :ssl,
+                use_tls = :tls
+            WHERE ldap_host_id = :id AND auth_ressource_id = :resource_id"
+        );
+        $statement->bindValue(':address', $params['hostname'], PDO::PARAM_STR);
+        $statement->bindValue(':port', $params['port'], PDO::PARAM_INT);
+        $statement->bindValue(':order', $params['order'], PDO::PARAM_INT);
+        $statement->bindValue(':ssl', isset($params['use_ssl']) ? 1 : 0, PDO::PARAM_INT);
+        $statement->bindValue(':tls', isset($params['use_tls']) ? 1 : 0, PDO::PARAM_INT);
+        $statement->bindValue(':id', $params['id'], PDO::PARAM_INT);
+        $statement->bindValue(':resource_id', $arId, PDO::PARAM_INT);
+        $statement->execute();
+    }
+
+    /**
+     * Add a template
+     * (Possibility of a dead code)
+     *
+     * @param array $options A hash table with options for connections and search in ldap
+     * @return int|bool The id of connection, false on error
+     */
+    public function addTemplate(array $options = [])
+    {
+        try {
+            $this->db->query(
+                "INSERT INTO auth_ressource (ar_type, ar_enable) VALUES ('ldap_tmpl', '0')"
+            );
+        } catch (\PDOException $e) {
+            return false;
+        }
+        try {
+            $dbResult = $this->db->query("SELECT MAX(ar_id) as id FROM auth_ressource WHERE ar_type = 'ldap_tmpl'");
+            $row = $dbResult->fetch();
+        } catch (\PDOException $e) {
+            return false;
+        }
+        $id = $row['id'];
+        foreach ($options as $name => $value) {
+            try {
+                $statement = $this->db->prepare(
+                    "INSERT INTO auth_ressource_info
+                    (ar_id, ari_name, ari_value)
+                    VALUES (:id, :name, :value)"
+                );
+                $statement->bindValue(':id', $id, PDO::PARAM_INT);
+                $statement->bindValue(':name', $name, PDO::PARAM_STR);
+                $statement->bindValue(':value', $value, PDO::PARAM_STR);
+                $statement->execute();
+            } catch (\PDOException $e) {
+                return false;
+            }
+        }
+        return $id;
+    }
+
+    /**
+     * Modify a template
+     * (Possibility of a dead code)
+     *
+     * @param int The id of the template
+     * @param array $options A hash table with options for connections and search in ldap
+     * @return bool
+     */
+    public function modifyTemplate($id, array $options = []): bool
+    {
+        /*
+         * Load configuration
+         */
+        $config = $this->getTemplate($id);
+
+        foreach ($options as $key => $value) {
+            try {
+                if (isset($config[$key])) {
+                    $statement = $this->db->prepare(
+                        "UPDATE auth_ressource_info 
+                        SET ari_value = :value
+                        WHERE ar_id = :id AND ari_name = :name"
+                    );
+                } else {
+                    $statement = $this->db->prepare(
+                        "INSERT INTO auth_ressource_info
+                        (ar_id, ari_name, ari_value)
+                        VALUES (:id, :name, :value)"
+                    );
+                }
+                $statement->bindValue(':value', $value, PDO::PARAM_STR);
+                $statement->bindValue(':name', $key, PDO::PARAM_STR);
+                $statement->bindValue(':id', $id, PDO::PARAM_INT);
+                $statement->execute();
+            } catch (\PDOException $e) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Get the template information
+     *
+     * @param int $id The template id, if 0 get the template
+     * @return array<string, string>
+     */
+    public function getTemplate($id = 0): array
+    {
+        if ($id == 0) {
+            $res = $this->db->query(
+                "SELECT ar_id 
+                 FROM auth_ressource 
+                 WHERE ar_type = 'ldap_tmpl'"
+            );
+            if ($res->rowCount() == 0) {
+                return array();
+            }
+            $row = $res->fetch();
+            $id = $row['ar_id'];
+        }
+        $statement = $this->db->prepare(
+            "SELECT ari_name, ari_value
+             FROM auth_ressource_info
+             WHERE ar_id = :id"
+        );
+        $statement->bindValue(':id', $id, PDO::PARAM_INT);
+        $statement->execute();
+        $list = [];
+        while ($row = $statement->fetch()) {
+            $list[$row['ari_name']] = $row['ari_value'];
+        }
+        return $list;
+    }
+
+    /**
+     * Get the default template for Active Directory
+     *
+     * @return array
+     */
+    public function getTemplateAd()
+    {
+        $infos = array();
+        $infos['user_filter'] = "(&(samAccountName=%s)(objectClass=user)(samAccountType=805306368))";
+        $attr = array();
+        $attr['alias'] = 'samaccountname';
+        $attr['email'] = 'mail';
+        $attr['name'] = 'name';
+        $attr['pager'] = 'mobile';
+        $attr['group'] = 'memberOf';
+        $attr['firstname'] = 'givenname';
+        $attr['lastname'] = 'sn';
+        $infos['user_attr'] = $attr;
+        $infos['group_filter'] = "(&(samAccountName=%s)(objectClass=group)(samAccountType=268435456))";
+        $attr = array();
+        $attr['group_name'] = 'samaccountname';
+        $attr['member'] = 'member';
+        $infos['group_attr'] = $attr;
+        return $infos;
+    }
+
+    /**
+     * Get the default template for ldap
+     *
+     * @return array
+     */
+    public function getTemplateLdap()
+    {
+        $infos = array();
+        $infos['user_filter'] = "(&(uid=%s)(objectClass=inetOrgPerson))";
+        $attr = array();
+        $attr['alias'] = 'uid';
+        $attr['email'] = 'mail';
+        $attr['name'] = 'cn';
+        $attr['pager'] = 'mobile';
+        $attr['group'] = '';
+        $attr['firstname'] = 'givenname';
+        $attr['lastname'] = 'sn';
+        $infos['user_attr'] = $attr;
+        $infos['group_filter'] = "(&(cn=%s)(objectClass=groupOfNames))";
+        $attr = array();
+        $attr['group_name'] = 'cn';
+        $attr['member'] = 'member';
+        $infos['group_attr'] = $attr;
+        return $infos;
+    }
+
+    /**
+     * Get LDAP configuration list
+     *
+     * @param string $search
+     * @param string $offset
+     * @param int $limit
+     * @return mixed[]
+     */
+    public function getLdapConfigurationList($search = "", $offset = null, $limit = null): array
+    {
+        $request = "SELECT ar_id, ar_enable, ar_name, ar_description, ar_sync_base_date FROM auth_ressource ";
+
+        $bindValues = [];
+        if ($search !== "") {
+            $request .= "WHERE ar_name LIKE :search ";
+            $bindValues[':search'] = [PDO::PARAM_STR => '%' . $search . '%'];
+        }
+        $request .= "ORDER BY ar_name ";
+        if (!is_null($offset) && !is_null($limit)) {
+            $request .= "LIMIT :offset,:limit";
+            $bindValues[':offset'] = [PDO::PARAM_INT => $offset];
+            $bindValues[':limit'] = [PDO::PARAM_INT => $limit];
+        }
+        $statement = $this->db->prepare($request);
+        foreach ($bindValues as $bindKey => $bindValue) {
+            $bindType = key($bindValue);
+            $statement->bindValue($bindKey, $bindValue[$bindType], $bindType);
+        }
+        $statement->execute();
+        $configuration = [];
+        while ($row = $statement->fetch()) {
+            $configuration[] = $row;
+        }
+        return $configuration;
+    }
+
+    /**
+     * Delete ldap configuration
+     *
+     * @param mixed[] $configList
+     * @return void
+     */
+    public function deleteConfiguration(array $configList = []): void
+    {
+        if (count($configList)) {
+            $configIds = [];
+            foreach ($configList as $configId) {
+                if (is_numeric($configId)) {
+                    $configIds[] = (int) $configId;
+                }
+            }
+            if (count($configIds)) {
+                $this->db->query(
+                    'DELETE FROM auth_ressource WHERE ar_id IN (' . implode(',', $configIds) . ')'
+                );
+            }
+        }
+    }
+
+    /**
+     * Enable/Disable ldap configuration
+     *
+     * @param int $status
+     * @param mixed[] $configList
+     * @return void
+     */
+    public function setStatus($status, $configList = array()): void
+    {
+        if (count($configList)) {
+            $configIds = [];
+            foreach ($configList as $configId) {
+                if (is_numeric($configId)) {
+                    $configIds[] = (int) $configId;
+                }
+            }
+            if (count($configIds)) {
+                $statement = $this->db->prepare(
+                    'UPDATE auth_ressource 
+                    SET ar_enable = :is_enabled
+                    WHERE ar_id IN (' . implode(',', $configIds) . ')'
+                );
+                $statement->bindValue(':is_enabled', $status, PDO::PARAM_STR);
+                $statement->execute();
+            }
+        }
+    }
+
+    /**
+     * Get list of servers from resource id
+     *
+     * @param int $arId Auth resource id
+     * @return array<int, array<string, mixed>>
+     */
+    public function getServersFromResId($arId): array
+    {
+        $statement = $this->db->prepare(
+            "SELECT host_address, host_port, use_ssl, use_tls
+            FROM auth_ressource_host
+            WHERE auth_ressource_id = :id
+            ORDER BY host_order"
+        );
+        $statement->bindValue(':id', $arId, PDO::PARAM_INT);
+        $statement->execute();
+        $arr = [];
+        $i = 0;
+        while ($row = $statement->fetch()) {
+            $arr[$i]['address_#index#'] = $row['host_address'];
+            $arr[$i]['port_#index#'] = $row['host_port'];
+            if ($row['use_ssl']) {
+                $arr[$i]['ssl_#index#'] = $row['use_ssl'];
+            }
+            if ($row['use_tls']) {
+                $arr[$i]['tls_#index#'] = $row['use_tls'];
+            }
+            $i++;
+        }
+        return $arr;
+    }
+
+    /**
+     * Remove contact passwords if password storage is disabled
+     *
+     * @param int $arId Auth resource id
+     * @return void
+     */
+    private function manageContactPasswords($arId): void
+    {
+        $statement = $this->db->prepare(
+            'SELECT ari_value 
+            FROM auth_ressource_info 
+            WHERE ar_id = :id
+            AND ari_name = "ldap_store_password"'
+        );
+        $statement->bindValue(':id', $arId, PDO::PARAM_INT);
+        $statement->execute();
+        if ($row = $statement->fetch()) {
+            if ($row['ari_value'] === '0') {
+                $statement2 = $this->db->prepare("SELECT contact_id FROM contact WHERE ar_id = :arId");
+                $statement2->bindValue(':arId', $arId, \PDO::PARAM_INT);
+                $statement2->execute();
+                $ldapContactIdList = [];
+                while ($row2 = $statement2->fetch()) {
+                    $ldapContactIdList[] = (int) $row2['contact_id'];
+                }
+                if (!empty($ldapContactIdList)) {
+                    $contactIds = implode(', ', $ldapContactIdList);
+                    $this->db->query(
+                        "DELETE FROM contact_password WHERE contact_id IN ($contactIds)"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/centreon/www/class/centreon-clapi/centreonLDAP.class.php
+++ b/centreon/www/class/centreon-clapi/centreonLDAP.class.php
@@ -79,6 +79,7 @@ class CentreonLDAP extends CentreonObject
             'ldap_contact_tmpl' => '',
             'ldap_default_cg' => '',
             'ldap_dns_use_domain' => '',
+            'ldap_connection_timeout' => '',
             'ldap_search_limit' => '',
             'ldap_search_timeout' => '',
             'ldap_srv_dns' => '',

--- a/centreon/www/include/Administration/parameters/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/DB-Func.php
@@ -491,6 +491,13 @@ function updateLdapConfigData($gopt_id = null)
     );
     updateOption(
         $pearDB,
+        "ldap_connection_timeout",
+        !empty($ret["ldap_connection_timeout"])
+            ? htmlentities($ret["ldap_connection_timeout"], ENT_QUOTES, "UTF-8")
+            : "NULL"
+    );
+    updateOption(
+        $pearDB,
         "ldap_search_timeout",
         isset($ret["ldap_search_timeout"]) && $ret["ldap_search_timeout"] != null
             ? htmlentities($ret["ldap_search_timeout"], ENT_QUOTES, "UTF-8") : "NULL"

--- a/centreon/www/include/Administration/parameters/ldap/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/ldap/DB-Func.php
@@ -51,3 +51,13 @@ function minimalValue(int $value): bool
 
     return false;
 }
+
+/**
+ * @param string $filterValue
+ * @return bool
+ */
+function checkLdapFilterSyntax(string $filterValue): bool
+{
+    return preg_match('/=%s\)/', $filterValue)
+        && preg_match('/^(\s*\((?:[&|](?1)+|(?:!(?1))|[a-zA-Z][a-zA-Z0-9-]*[<>~]?=[^()]*)\s*\)\s*)$/', $filterValue);
+}

--- a/centreon/www/include/Administration/parameters/ldap/form.ihtml
+++ b/centreon/www/include/Administration/parameters/ldap/form.ihtml
@@ -12,6 +12,7 @@
 		<td class="FormRowField"><img class="helpTooltip" name="ldap_auto_import" /><span>{$form.ldap_auto_import.label}</span></td>
 		<td class="FormRowValue">{$form.ldap_auto_import.html}&nbsp;&nbsp;<input type="button" onClick="javascript:location.href='./main.get.php?p=60301&o=li'" class="btc bt_info" value='{$manualImport}'></td>
 	</tr>
+	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="ldap_connection_timeout" /><span>{$form.ldap_connection_timeout.label}</span></td><td class="FormRowValue">{$form.ldap_connection_timeout.html}</td></tr>
 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ldap_search_limit" /><span>{$form.ldap_search_limit.label}</span></td><td class="FormRowValue">{$form.ldap_search_limit.html}</td></tr>
 	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="ldap_search_timeout" /><span>{$form.ldap_search_timeout.label}</span></td><td class="FormRowValue">{$form.ldap_search_timeout.html}</td></tr>
 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="ldap_contact_tmpl" /><span>{$form.ldap_contact_tmpl.label}</span></td><td class="FormRowValue">{$form.ldap_contact_tmpl.html}{if $o != 'w'}&nbsp;

--- a/centreon/www/include/Administration/parameters/ldap/form.php
+++ b/centreon/www/include/Administration/parameters/ldap/form.php
@@ -97,6 +97,7 @@ $form->addGroup($ldapUseDns, 'ldap_srv_dns', _("Use service DNS"), '&nbsp;');
 
 $form->addElement('text', 'ldap_dns_use_domain', _("Alternative domain for ldap"), $attrsText);
 
+$form->addElement('text', 'ldap_connection_timeout', _('LDAP connection timeout'), $attrsText2);
 $form->addElement('text', 'ldap_search_limit', _('LDAP search size limit'), $attrsText2);
 $form->addElement('text', 'ldap_search_timeout', _('LDAP search timeout'), $attrsText2);
 
@@ -176,9 +177,11 @@ $form->addElement(
     array('0' => "", 'Active Directory' => _("Active Directory"), 'Okta' => _("Okta"), 'Posix' => _("Posix")),
     array('id' => 'ldap_template', 'onchange' => 'applyTemplate(this.value);')
 );
+$form->registerRule('checkLdapFilter', 'callback', 'checkLdapFilterSyntax');
 $form->addElement('text', 'user_base_search', _("Search user base DN"), $attrsText);
 $form->addElement('text', 'group_base_search', _("Search group base DN"), $attrsText);
 $form->addElement('text', 'user_filter', _("User filter"), $attrsText);
+$form->addRule('user_filter', _("Incorrect LDAP filter syntax"), 'checkLdapFilter');
 $form->addElement('text', 'alias', _("Login attribute"), $attrsText);
 $form->addElement('text', 'user_group', _("User group attribute"), $attrsText);
 $form->addElement('text', 'user_name', _("User displayname attribute"), $attrsText);
@@ -187,6 +190,7 @@ $form->addElement('text', 'user_lastname', _("User lastname attribute"), $attrsT
 $form->addElement('text', 'user_email', _("User email attribute"), $attrsText);
 $form->addElement('text', 'user_pager', _("User pager attribute"), $attrsText);
 $form->addElement('text', 'group_filter', _("Group filter"), $attrsText);
+$form->addRule('group_filter', _("Incorrect LDAP filter syntax"), 'checkLdapFilter');
 $form->addElement('text', 'group_name', _("Group attribute"), $attrsText);
 $form->addElement('text', 'group_member', _("Group member attribute"), $attrsText);
 
@@ -216,6 +220,7 @@ $defaultOpt = array(
     'ldap_dns_use_tls' => '0',
     'ldap_contact_tmpl' => '0',
     'ldap_default_cg' => '0',
+    'ldap_connection_timeout' => '5',
     'ldap_search_limit' => '60',
     'ldap_auto_sync' => '1', // synchronization on user's login is enabled by default
     'ldap_sync_interval' => '1', // minimal value of the interval between two LDAP synchronizations

--- a/centreon/www/include/Administration/parameters/ldap/help.php
+++ b/centreon/www/include/Administration/parameters/ldap/help.php
@@ -23,6 +23,7 @@ $help['ldap_srv_dns'] = dgettext('help', 'Use the DNS service for get LDAP host'
 $help['ldap_srv_dns_ssl'] = dgettext('help', 'Enable SSL connection');
 $help['ldap_srv_dns_tls'] = dgettext('help', 'Enable TLS connection');
 $help['ldap_dns_use_domain'] = dgettext('help', 'Set the domain for search the service');
+$help['ldap_connection_timeout'] = dgettext('help', 'Connection timeout');
 $help['ldap_search_limit'] = dgettext('help', 'Search size limit');
 $help['ldap_search_timeout'] = dgettext('help', 'Search timeout');
 $help['ldapConf'] = dgettext(

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -72,6 +72,7 @@ INSERT INTO `options` (`key`, `value`) VALUES
 ('ldap_auth_enable', '0'),
 ('ldap_auto_import', '0'),
 ('ldap_srv_dns', '0'),
+('ldap_connection_timeout','5'),
 ('ldap_dns_use_domain', ''),
 ('ldap_search_timeout','60'),
 ('ldap_search_limit','60'),

--- a/centreon/www/install/php/Update-21.10.10.php
+++ b/centreon/www/install/php/Update-21.10.10.php
@@ -44,6 +44,18 @@ try {
             ON DELETE CASCADE"
         );
     }
+
+    // check if entry ldap_connection_timeout exist
+    $query = $pearDB->query("SELECT * FROM auth_ressource_info WHERE ari_name = 'ldap_connection_timeout'");
+    $ldapResult = $query->fetchAll(PDO::FETCH_ASSOC);
+    // insert entry ldap_connection_timeout  with default value
+    if (! $ldapResult) {
+        $errorMessage = "Unable to add default ldap connection timeout";
+        $pearDB->query(
+            "INSERT INTO auth_ressource_info (ar_id, ari_name, ari_value)
+                        (SELECT ar_id, 'ldap_connection_timeout', '' FROM auth_ressource)"
+        );
+    }
 } catch (\Exception $e) {
     $centreonLog->insertLog(
         4,

--- a/centreon/www/install/php/Update-21.10.14.php
+++ b/centreon/www/install/php/Update-21.10.14.php
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
## Description

add default connection-timeout value to avoid infinit loop

Also the hard coded timeout should be a parameter that can be defined in the LDAP form

**Fixes** # MON-3511

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Go to ‘Administration > Parameters > LDAP’
2. Add an incorrect LDAP configuration (host or port) but enable it with timeout value (5 for example)
3. Check /var/log/centreon/ldap.log
4. Try to connect with login/user
5. Check in log that a timeout is this defined (5 seconds)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-3511]: https://centreon.atlassian.net/browse/MON-3511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ