### PR TITLE
fix(web): fix force check in host/service details tab

### DIFF
--- a/centreon/www/include/monitoring/objectDetails/xml/hostSendCommand.php
+++ b/centreon/www/include/monitoring/objectDetails/xml/hostSendCommand.php
@@ -43,6 +43,7 @@ require_once _CENTREON_PATH_ . "/www/class/centreonSession.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonUtils.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreon.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonXML.class.php";
+require_once _CENTREON_PATH_ . '/www/class/HtmlAnalyzer.php';
 
 CentreonSession::start(1);
 $centreon = $_SESSION["centreon"];

--- a/centreon/www/include/monitoring/objectDetails/xml/serviceSendCommand.php
+++ b/centreon/www/include/monitoring/objectDetails/xml/serviceSendCommand.php
@@ -47,6 +47,7 @@ require_once _CENTREON_PATH_ . "/www/class/centreonSession.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonUtils.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreon.class.php";
 require_once _CENTREON_PATH_ . "/www/class/centreonXML.class.php";
+require_once _CENTREON_PATH_ . '/www/class/HtmlAnalyzer.php';
 
 CentreonSession::start(1);
 $centreon = $_SESSION["centreon"];


### PR DESCRIPTION
## Description

Users were unable to send check/force check command from the host/service details tab.
The file missed the HtmlAnalyser.php file path

**Fixes** MON-16289

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)
