### PR TITLE
[enh](ldap): add ldap connection timeout to avoid infinite connection dev21.10-fix

### DIFF
--- a/centreon/www/install/php/Update-21.10.10.php
+++ b/centreon/www/install/php/Update-21.10.10.php
@@ -45,17 +45,6 @@ try {
         );
     }
 
-    // check if entry ldap_connection_timeout exist
-    $query = $pearDB->query("SELECT * FROM auth_ressource_info WHERE ari_name = 'ldap_connection_timeout'");
-    $ldapResult = $query->fetchAll(PDO::FETCH_ASSOC);
-    // insert entry ldap_connection_timeout  with default value
-    if (! $ldapResult) {
-        $errorMessage = "Unable to add default ldap connection timeout";
-        $pearDB->query(
-            "INSERT INTO auth_ressource_info (ar_id, ari_name, ari_value)
-                        (SELECT ar_id, 'ldap_connection_timeout', '' FROM auth_ressource)"
-        );
-    }
 } catch (\Exception $e) {
     $centreonLog->insertLog(
         4,

--- a/centreon/www/install/php/Update-21.10.14.php
+++ b/centreon/www/install/php/Update-21.10.14.php
@@ -36,6 +36,17 @@ try {
     // Transactional queries
     $pearDB->beginTransaction();
 
+    // check if entry ldap_connection_timeout exist
+    $query = $pearDB->query("SELECT * FROM auth_ressource_info WHERE ari_name = 'ldap_connection_timeout'");
+    $ldapResult = $query->fetchAll(PDO::FETCH_ASSOC);
+    // insert entry ldap_connection_timeout  with default value
+    if (! $ldapResult) {
+        $errorMessage = "Unable to add default ldap connection timeout";
+        $pearDB->query(
+            "INSERT INTO auth_ressource_info (ar_id, ari_name, ari_value)
+                        (SELECT ar_id, 'ldap_connection_timeout', '' FROM auth_ressource)"
+        );
+    }
     $errorMessage = 'Unable to update illegal characters fields from engine configuration of pollers';
     decodeIllegalCharactersNagios($pearDB);
 


### PR DESCRIPTION
## Description

This pull request is a fix to move the code from centreon\www\install\php\Update-21.10.10.php to centreon\www\install\php\Update-21.10.14.php
**Fixes** # MON-3511

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
