### PR TITLE
enh (RT): Optimisation of SQL queries to reduce callbacks on the legacy services monitoring page

### DIFF
--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -375,25 +375,15 @@ class CentreonHost
      */
     public function getHostName($hostId)
     {
-        static $hosts = null;
-
         if (!isset($hostId) || !$hostId) {
             return null;
         }
 
-        if (is_null($hosts)) {
-            $hosts = array();
-            $query = 'SELECT host_id, host_name FROM host';
-            $res = $this->db->query($query);
-            if (!$res) {
-                throw new \Exception("An error occured");
-            }
-            while ($row = $res->fetch()) {
-                $hosts[$row['host_id']] = $row['host_name'];
-            }
-        }
-        if (isset($hosts[$hostId])) {
-            return $hosts[$hostId];
+        $statement = $this->db->prepare('SELECT host_name FROM host WHERE host_id = :host_id');
+        $statement->bindValue(':host_id', (int) $hostId, \PDO::PARAM_INT);
+        $statement->execute();
+        if ($hostName = $statement->fetchColumn()) {
+            return $hostName;
         }
         return null;
     }
@@ -683,16 +673,30 @@ class CentreonHost
      */
     public function replaceMacroInString($hostParam, $string, $antiLoop = null)
     {
+        if (! preg_match('/\$[0-9a-zA-Z_-]+\$/', $string)) {
+            return $string;
+        }
         if (is_numeric($hostParam)) {
-            $hostId = $hostParam;
+            $query = 'SELECT host_id, ns.nagios_server_id, host_register, host_address, host_name, host_alias
+              FROM host
+              LEFT JOIN ns_host_relation ns
+                ON ns.host_host_id = host.host_id
+              WHERE host_id = :hostId 
+              LIMIT 1';
+            $stmt = $this->db->prepare($query);
+            $stmt->bindParam(':hostId', (int) $hostParam, \PDO::PARAM_INT);
         } elseif (is_string($hostParam)) {
-            $hostId = $this->getHostId($hostParam);
+            $query = 'SELECT host_id, ns.nagios_server_id, host_register, host_address, host_name, host_alias
+              FROM host
+              LEFT JOIN ns_host_relation ns
+                ON ns.host_host_id = host.host_id
+              WHERE host_name = :hostName
+              LIMIT 1';
+            $stmt = $this->db->prepare($query);
+            $stmt->bindParam(':hostName', $hostParam);
         } else {
             return $string;
         }
-        $query = 'SELECT host_register FROM host WHERE host_id = :hostId LIMIT 1';
-        $stmt = $this->db->prepare($query);
-        $stmt->bindParam(':hostId', $hostId, PDO::PARAM_INT);
         $dbResult = $stmt->execute();
         if (!$dbResult) {
             throw new \Exception("An error occured");
@@ -702,31 +706,36 @@ class CentreonHost
             return $string;
         }
         $row = $stmt->fetch();
+        $hostId = (int) $row['host_id'];
 
         /*
          * replace if not template
          */
         if ($row['host_register'] == 1) {
-            if (strpos($string, "\$HOSTADDRESS$")) {
-                $string = str_replace("\$HOSTADDRESS\$", $this->getHostAddress($hostId), $string);
+            if (strpos($string, '$HOSTADDRESS$') !== false) {
+                $string = str_replace('$HOSTADDRESS$', $row['host_address'], $string);
             }
-            if (strpos($string, "\$HOSTNAME$")) {
-                $string = str_replace("\$HOSTNAME\$", $this->getHostName($hostId), $string);
+            if (strpos($string, '$HOSTNAME$') !== false) {
+                $string = str_replace('$HOSTNAME$', $row['host_name'], $string);
             }
-            if (strpos($string, "\$HOSTALIAS$")) {
-                $string = str_replace("\$HOSTALIAS\$", $this->getHostAlias($hostId), $string);
+            if (strpos($string, '$HOSTALIAS$') !== false) {
+                $string = str_replace('$HOSTALIAS$', $row['host_alias'], $string);
             }
-            if (preg_match("\$INSTANCENAME\$", $string)) {
+            if (strpos($string, '$INSTANCENAME$') !== false) {
+                $pollerId = $row['nagios_server_id'] ?? $this->getHostPollerId($hostId);
                 $string = str_replace(
-                    "\$INSTANCENAME\$",
-                    $this->instanceObj->getParam($this->getHostPollerId($hostId), 'name'),
+                    '$INSTANCENAME$',
+                    $this->instanceObj->getParam((int) $pollerId, 'name'),
                     $string
                 );
             }
-            if (preg_match("\$INSTANCEADDRESS\$", $string)) {
+            if (strpos($string, '$INSTANCEADDRESS$') !== false) {
+                if (!isset($pollerId)) {
+                    $pollerId = $row['nagios_server_id'] ?? $this->getHostPollerId($hostId);
+                }
                 $string = str_replace(
-                    "\$INSTANCEADDRESS\$",
-                    $this->instanceObj->getParam($this->getHostPollerId($hostId), 'ns_ip_address'),
+                    '$INSTANCEADDRESS$',
+                    $this->instanceObj->getParam($pollerId, 'ns_ip_address'),
                     $string
                 );
             }

--- a/centreon/www/class/centreonService.class.php
+++ b/centreon/www/class/centreonService.class.php
@@ -325,19 +325,29 @@ class CentreonService
      */
     public function replaceMacroInString($svc_id, $string, $antiLoop = null, $instanceId = null)
     {
-        $rq = "SELECT service_register FROM service WHERE service_id = '" . $svc_id . "' LIMIT 1";
-        $DBRES = $this->db->query($rq);
-        if (!$DBRES->rowCount()) {
+        if (! preg_match('/\$[0-9a-zA-Z_-]+\$/', $string)) {
             return $string;
         }
-        $row = $DBRES->fetchRow();
+        $query = <<<SQL
+          SELECT service_register, service_description
+          FROM service
+          WHERE service_id = :service_id LIMIT 1
+        SQL;
+        $statement = $this->db->prepare($query);
+        $statement->bindValue(':service_id', (int) $svc_id, \PDO::PARAM_INT);
+        $statement->execute();
+
+        if (!$statement->rowCount()) {
+            return $string;
+        }
+        $row = $statement->fetchRow();
 
         /*
          * replace if not template
          */
         if ($row['service_register'] == 1) {
             if (preg_match('/\$SERVICEDESC\$/', $string)) {
-                $string = str_replace("\$SERVICEDESC\$", $this->getServiceDesc($svc_id), $string);
+                $string = str_replace("\$SERVICEDESC\$", $row['service_description'], $string);
             }
             if (!is_null($instanceId) && preg_match("\$INSTANCENAME\$", $string)) {
                 $string = str_replace("\$INSTANCENAME\$", $this->instanceObj->getParam($instanceId, 'name'), $string);

--- a/centreon/www/include/monitoring/status/Services/xsl/service.xsl
+++ b/centreon/www/include/monitoring/status/Services/xsl/service.xsl
@@ -294,7 +294,7 @@
             </xsl:if>
         </td>
         <td class="ListColRight">
-            <xsl:if test="svc_index &gt; 0">
+            <xsl:if test="hasGraph &gt; 0">
                 <xsl:element name="a">
                     <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/>;<xsl:value-of select="sdl"/></xsl:attribute>
                     <xsl:element name="span">


### PR DESCRIPTION
## Description

Backport of this PR https://github.com/centreon/centreon/pull/728

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Deactivate the broker
2. Connect to the Centreon platform and access the http://lcentreon_ip/centreon/main.php?p=20201 page (Legacy Services Monitoring page)
3. Copy/paste the url called by Centreon to retrieve the real time services in a new browser tab (url: centreon/include/monitoring/status/Services/xml/serviceXML.php ?....)
5. Close the Centreon main page
6. Check the number of queries in the database: `show status like 'Queries';``
7. Refresh the tab where the serviceXML.php url is located.
8. Check the number of queries in the database again: show status like 'Queries'.

Do the subtraction.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
