### PR TITLE
Fix(ui): fix padding in the listing header

### DIFF
--- a/centreon/package.json
+++ b/centreon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "centreon",
-  "version": "23.4.19",
+  "version": "23.4.0",
   "description": "centreon web package",
   "scripts": {
     "build": "webpack --mode production --config ./webpack.config.prod.js",

--- a/centreon/package.json
+++ b/centreon/package.json
@@ -1,6 +1,6 @@
 {
   "name": "centreon",
-  "version": "23.4.0",
+  "version": "23.4.19",
   "description": "centreon web package",
   "scripts": {
     "build": "webpack --mode production --config ./webpack.config.prod.js",

--- a/centreon/packages/ui/package.json
+++ b/centreon/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centreon/ui",
-  "version": "23.4.18",
+  "version": "23.4.19",
   "description": "Centreon UI Components",
   "main": "src/index.ts",
   "scripts": {

--- a/centreon/packages/ui/src/Listing/Cell/DataCell.tsx
+++ b/centreon/packages/ui/src/Listing/Cell/DataCell.tsx
@@ -3,7 +3,7 @@ import { memo } from 'react';
 import { equals, props } from 'ramda';
 import { makeStyles } from 'tss-react/mui';
 
-import { Tooltip } from '@mui/material';
+import { Tooltip, useTheme } from '@mui/material';
 
 import { ListingVariant } from '@centreon/ui-context';
 
@@ -68,6 +68,7 @@ const DataCell = ({
   getHighlightRowCondition,
   areColumnsEditable
 }: Props): JSX.Element | null => {
+  const theme = useTheme();
   const { dataStyle } = useStyleTable({ viewMode });
   const { classes } = useStyles();
 
@@ -103,7 +104,10 @@ const DataCell = ({
       return (
         <Cell
           isRowHighlighted={isRowHighlighted}
-          style={{ gridColumn }}
+          style={{
+            gridColumn,
+            paddingLeft: theme.spacing(1.5)
+          }}
           viewMode={viewMode}
           {...commonCellProps}
         >
@@ -132,6 +136,9 @@ const DataCell = ({
       return (
         <Cell
           isRowHighlighted={isRowHighlighted}
+          style={{
+            paddingLeft: theme.spacing(1.5)
+          }}
           viewMode={viewMode}
           onClick={(e): void => {
             if (!clickable) {

--- a/centreon/packages/ui/src/Listing/Cell/DataCell.tsx
+++ b/centreon/packages/ui/src/Listing/Cell/DataCell.tsx
@@ -3,7 +3,7 @@ import { memo } from 'react';
 import { equals, props } from 'ramda';
 import { makeStyles } from 'tss-react/mui';
 
-import { Tooltip, useTheme } from '@mui/material';
+import { Tooltip } from '@mui/material';
 
 import { ListingVariant } from '@centreon/ui-context';
 
@@ -47,6 +47,9 @@ const useStyles = makeStyles()((theme) => ({
   headerCell: {
     padding: theme.spacing(0, 0, 0, 1)
   },
+  item: {
+    paddingLeft: theme.spacing(1.5)
+  },
   rowNotHovered: {
     color: theme.palette.text.secondary
   },
@@ -68,7 +71,6 @@ const DataCell = ({
   getHighlightRowCondition,
   areColumnsEditable
 }: Props): JSX.Element | null => {
-  const theme = useTheme();
   const { dataStyle } = useStyleTable({ viewMode });
   const { classes } = useStyles();
 
@@ -103,10 +105,10 @@ const DataCell = ({
 
       return (
         <Cell
+          className={classes.item}
           isRowHighlighted={isRowHighlighted}
           style={{
-            gridColumn,
-            paddingLeft: theme.spacing(1.5)
+            gridColumn
           }}
           viewMode={viewMode}
           {...commonCellProps}
@@ -135,10 +137,8 @@ const DataCell = ({
 
       return (
         <Cell
+          className={classes.item}
           isRowHighlighted={isRowHighlighted}
-          style={{
-            paddingLeft: theme.spacing(1.5)
-          }}
           viewMode={viewMode}
           onClick={(e): void => {
             if (!clickable) {

--- a/centreon/packages/ui/src/Listing/Header/Label.tsx
+++ b/centreon/packages/ui/src/Listing/Header/Label.tsx
@@ -4,9 +4,10 @@ import { makeStyles } from 'tss-react/mui';
 
 import { Typography, TypographyProps } from '@mui/material';
 
-const useStyles = makeStyles()(() => ({
+const useStyles = makeStyles()((theme) => ({
   root: {
-    fontWeight: 'bold'
+    fontWeight: 'bold',
+    paddingLeft: theme.spacing(1.5)
   }
 }));
 


### PR DESCRIPTION
## Description

the padding-left same to be lost in the header of our listing component

preview of the fix : 

https://user-images.githubusercontent.com/109956462/215766570-beb15dfb-d3b1-4fd1-993c-795dd89407bf.mp4


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>


#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
