### PR TITLE
enh(api): Remove possibility of updating Vault configuration and storage name

### DIFF
--- a/centreon/doc/API/centreon-api-v23.04.yaml
+++ b/centreon/doc/API/centreon-api-v23.04.yaml
@@ -4447,7 +4447,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Administration.Vault.Configuration.Write'
+              $ref: '#/components/schemas/Administration.Vault.Configuration.Update'
       responses:
         '204':
           description: "OK"

--- a/centreon/doc/API/centreon-api-v23.04.yaml
+++ b/centreon/doc/API/centreon-api-v23.04.yaml
@@ -7969,7 +7969,7 @@ components:
           example: "0"
     Administration.Vault.Configuration.Write:
       type: object
-      required: [name, address, port, storage, role_id, secret_id]
+      required: [name, address, port, root_path, role_id, secret_id]
       description: "Vault configuration"
       properties:
         name:
@@ -7984,9 +7984,9 @@ components:
           type: integer
           description: "Vault Port"
           example: 8200
-        storage:
+        root_path:
           type: string
-          description: "Vault storage name"
+          description: "Vault root storage path"
           example: "centreon"
         role_id:
           type: string
@@ -8037,9 +8037,9 @@ components:
           type: integer
           description: "Vault Port"
           example: 8200
-        storage:
+        root_path:
           type: string
-          description: "Vault storage name"
+          description: "Vault root storage path"
           example: "centreon"
         role_id:
           type: string

--- a/centreon/doc/API/centreon-api-v23.04.yaml
+++ b/centreon/doc/API/centreon-api-v23.04.yaml
@@ -7994,6 +7994,25 @@ components:
         secret_id:
           type: string
           description: "Vault secret id"
+    Administration.Vault.Configuration.Update:
+      type: object
+      required: [address, port, role_id, secret_id]
+      description: "Vault configuration"
+      properties:
+        address:
+          type: string
+          description: "Vault URL or IP"
+          example: "127.0.0.1"
+        port:
+          type: integer
+          description: "Vault Port"
+          example: 8200
+        role_id:
+          type: string
+          description: "Vault role id"
+        secret_id:
+          type: string
+          description: "Vault secret id"
     Administration.Vault.Configuration.Read:
       type: object
       description: "Vault configuration"

--- a/centreon/lib/Centreon/Object/Host/Host.php
+++ b/centreon/lib/Centreon/Object/Host/Host.php
@@ -160,7 +160,7 @@ class Centreon_Object_Host extends Centreon_Object
         CentreonRestHttp $httpClient
     ): array {
         $url = $vaultConfiguration->getAddress() . ':' . $vaultConfiguration->getPort() . '/v1/'
-            . $vaultConfiguration->getStorage() . '/monitoring/hosts/' . $hostId;
+            . $vaultConfiguration->getRootPath() . '/monitoring/hosts/' . $hostId;
             $logger->info(sprintf("Search Host %d secrets at: %s", $hostId, $url));
         try {
             $content = $httpClient->call($url, 'GET', null, ['X-Vault-Token: ' . $clientToken]);
@@ -200,7 +200,7 @@ class Centreon_Object_Host extends Centreon_Object
     ): void {
         try {
             $url = $vaultConfiguration->getAddress() . ':' . $vaultConfiguration->getPort()
-                . '/v1/' . $vaultConfiguration->getStorage()
+                . '/v1/' . $vaultConfiguration->getRootPath()
                 . '/monitoring/hosts/' . $hostId;
                 $logger->info(
                     "Writing Host Secrets at : " . $url,
@@ -237,7 +237,7 @@ class Centreon_Object_Host extends Centreon_Object
         int $hostId,
         \CentreonDB $pearDB
     ): void {
-        $path = "secret::" . $vaultConfiguration->getId() . "::" . $vaultConfiguration->getStorage()
+        $path = "secret::" . $vaultConfiguration->getId() . "::" . $vaultConfiguration->getRootPath()
             . "/monitoring/hosts/" . $hostId;
 
         $statementUpdateHost = $pearDB->prepare(

--- a/centreon/src/Core/Security/Vault/Application/Repository/ReadVaultConfigurationRepositoryInterface.php
+++ b/centreon/src/Core/Security/Vault/Application/Repository/ReadVaultConfigurationRepositoryInterface.php
@@ -39,18 +39,18 @@ interface ReadVaultConfigurationRepositoryInterface
     /**
      * @param string $address
      * @param integer $port
-     * @param string $storage
+     * @param string $rootPath
      *
      * @throws \Throwable
      *
      * @return boolean
      */
-    public function existsSameConfiguration(string $address, int $port, string $storage): bool;
+    public function existsSameConfiguration(string $address, int $port, string $rootPath): bool;
 
     /**
      * @param string $address
      * @param int $port
-     * @param string $storage
+     * @param string $rootPath
      *
      * @throws \Throwable
      *
@@ -59,7 +59,7 @@ interface ReadVaultConfigurationRepositoryInterface
     public function findByAddressAndPortAndStorage(
         string $address,
         int $port,
-        string $storage
+        string $rootPath
     ): ?VaultConfiguration;
 
     /**

--- a/centreon/src/Core/Security/Vault/Application/Repository/ReadVaultConfigurationRepositoryInterface.php
+++ b/centreon/src/Core/Security/Vault/Application/Repository/ReadVaultConfigurationRepositoryInterface.php
@@ -56,7 +56,7 @@ interface ReadVaultConfigurationRepositoryInterface
      *
      * @return VaultConfiguration|null
      */
-    public function findByAddressAndPortAndStorage(
+    public function findByAddressAndPortAndRootPath(
         string $address,
         int $port,
         string $rootPath

--- a/centreon/src/Core/Security/Vault/Application/Repository/ReadVaultRepositoryInterface.php
+++ b/centreon/src/Core/Security/Vault/Application/Repository/ReadVaultRepositoryInterface.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace Core\Security\Vault\Application\Repository;
 
 use Core\Security\Vault\Domain\Model\Vault;
-use Core\Security\Vault\Infrastructure\Repository\DbReadVaultRepository;
 
 interface ReadVaultRepositoryInterface
 {

--- a/centreon/src/Core/Security/Vault/Application/UseCase/CreateVaultConfiguration/CreateVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/CreateVaultConfiguration/CreateVaultConfiguration.php
@@ -81,7 +81,7 @@ final class CreateVaultConfiguration
                 $this->readVaultConfigurationRepository->existsSameConfiguration(
                     $createVaultConfigurationRequest->address,
                     $createVaultConfigurationRequest->port,
-                    $createVaultConfigurationRequest->storage,
+                    $createVaultConfigurationRequest->rootPath,
                 )
             ) {
                 $this->error(
@@ -89,7 +89,7 @@ final class CreateVaultConfiguration
                     [
                         'address' => $createVaultConfigurationRequest->address,
                         'port' => $createVaultConfigurationRequest->port,
-                        'storage' => $createVaultConfigurationRequest->storage,
+                        'rootPath' => $createVaultConfigurationRequest->rootPath,
                     ]
                 );
                 $presenter->setResponseStatus(

--- a/centreon/src/Core/Security/Vault/Application/UseCase/CreateVaultConfiguration/CreateVaultConfigurationRequest.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/CreateVaultConfiguration/CreateVaultConfigurationRequest.php
@@ -38,7 +38,7 @@ final class CreateVaultConfigurationRequest
     public int $port = 0;
 
     /** @var string */
-    public string $storage = '';
+    public string $rootPath = '';
 
     /** @var string */
     public string $roleId = '';

--- a/centreon/src/Core/Security/Vault/Application/UseCase/CreateVaultConfiguration/NewVaultConfigurationFactory.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/CreateVaultConfiguration/NewVaultConfigurationFactory.php
@@ -67,7 +67,7 @@ class NewVaultConfigurationFactory
             $vault,
             $request->address,
             $request->port,
-            $request->storage,
+            $request->rootPath,
             $request->roleId,
             $request->secretId
         );

--- a/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfiguration.php
@@ -124,7 +124,7 @@ final class FindVaultConfiguration
         $findVaultConfigurationResponse->vaultConfiguration['vault_id'] = $vaultConfiguration->getVault()->getId();
         $findVaultConfigurationResponse->vaultConfiguration['url'] = $vaultConfiguration->getAddress();
         $findVaultConfigurationResponse->vaultConfiguration['port'] = $vaultConfiguration->getPort();
-        $findVaultConfigurationResponse->vaultConfiguration['storage'] = $vaultConfiguration->getStorage();
+        $findVaultConfigurationResponse->vaultConfiguration['rooth_path'] = $vaultConfiguration->getRootPath();
 
         return $findVaultConfigurationResponse;
     }

--- a/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfiguration.php
@@ -124,7 +124,7 @@ final class FindVaultConfiguration
         $findVaultConfigurationResponse->vaultConfiguration['vault_id'] = $vaultConfiguration->getVault()->getId();
         $findVaultConfigurationResponse->vaultConfiguration['url'] = $vaultConfiguration->getAddress();
         $findVaultConfigurationResponse->vaultConfiguration['port'] = $vaultConfiguration->getPort();
-        $findVaultConfigurationResponse->vaultConfiguration['rooth_path'] = $vaultConfiguration->getRootPath();
+        $findVaultConfigurationResponse->vaultConfiguration['root_path'] = $vaultConfiguration->getRootPath();
 
         return $findVaultConfigurationResponse;
     }

--- a/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfigurationResponse.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfigurationResponse.php
@@ -32,7 +32,7 @@ final class FindVaultConfigurationResponse
      *  vault_id: int,
      *  url: string,
      *  port: int,
-     *  storage: string
+     *  root_path: string
      * }
      */
     public array $vaultConfiguration;

--- a/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfigurations/FindVaultConfigurations.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfigurations/FindVaultConfigurations.php
@@ -105,7 +105,7 @@ final class FindVaultConfigurations
                 'vault_id' => $vaultConfiguration->getVault()->getId(),
                 'url' => $vaultConfiguration->getAddress(),
                 'port' => $vaultConfiguration->getPort(),
-                'storage' => $vaultConfiguration->getStorage()
+                'root_path' => $vaultConfiguration->getRootPath()
             ],
             $vaultConfigurations
         );

--- a/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfigurations/FindVaultConfigurationsResponse.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfigurations/FindVaultConfigurationsResponse.php
@@ -32,7 +32,7 @@ final class FindVaultConfigurationsResponse
      *  vault_id: int,
      *  url: string,
      *  port: int,
-     *  storage: string
+     *  root_path: string
      * }>
      */
     public array $vaultConfigurations;

--- a/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfiguration.php
@@ -103,13 +103,13 @@ final class UpdateVaultConfiguration
                 return;
             }
 
-            if ($this->isVaultConfigurationAlreadyExists($request, $vaultConfiguration->getStorage())) {
+            if ($this->isVaultConfigurationAlreadyExists($request, $vaultConfiguration->getRootPath())) {
                 $this->error(
                     'Vault configuration with these properties already exists for same provider',
                     [
                         'address' => $request->address,
                         'port' => $request->port,
-                        'storage' => $vaultConfiguration->getStorage()
+                        'root_path' => $vaultConfiguration->getRootPath()
                     ]
                 );
                 $presenter->setResponseStatus(
@@ -145,17 +145,17 @@ final class UpdateVaultConfiguration
 
     /**
      * @param UpdateVaultConfigurationRequest $request
-     *
+     * @param string $rootPath
      * @throws \Throwable
      *
      * @return boolean
      */
-    private function isVaultConfigurationAlreadyExists(UpdateVaultConfigurationRequest $request, string $storage): bool
+    private function isVaultConfigurationAlreadyExists(UpdateVaultConfigurationRequest $request, string $rootPath): bool
     {
         $existingVaultConfiguration = $this->readVaultConfigurationRepository->findByAddressAndPortAndStorage(
             $request->address,
             $request->port,
-            $storage
+            $rootPath
         );
 
         return $existingVaultConfiguration !== null

--- a/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfiguration.php
@@ -102,13 +102,13 @@ final class UpdateVaultConfiguration
                 return;
             }
 
-            if ($this->isVaultConfigurationAlreadyExists($request)) {
+            if ($this->isVaultConfigurationAlreadyExists($request, $vaultConfiguration->getStorage())) {
                 $this->error(
                     'Vault configuration with these properties already exists for same provider',
                     [
                         'address' => $request->address,
                         'port' => $request->port,
-                        'storage' => $request->storage,
+                        'storage' => $vaultConfiguration->getStorage()
                     ]
                 );
                 $presenter->setResponseStatus(
@@ -149,12 +149,12 @@ final class UpdateVaultConfiguration
      *
      * @return boolean
      */
-    private function isVaultConfigurationAlreadyExists(UpdateVaultConfigurationRequest $request): bool
+    private function isVaultConfigurationAlreadyExists(UpdateVaultConfigurationRequest $request, string $storage): bool
     {
         $existingVaultConfiguration = $this->readVaultConfigurationRepository->findByAddressAndPortAndStorage(
             $request->address,
             $request->port,
-            $request->storage
+            $storage
         );
 
         return $existingVaultConfiguration !== null
@@ -170,9 +170,7 @@ final class UpdateVaultConfiguration
         UpdateVaultConfigurationRequest $request,
         VaultConfiguration $vaultConfiguration
     ): void {
-        $vaultConfiguration->setName($request->name);
         $vaultConfiguration->setAddress($request->address);
-        $vaultConfiguration->setStorage($request->storage);
         $vaultConfiguration->setPort($request->port);
         $vaultConfiguration->setNewRoleId($request->roleId);
         $vaultConfiguration->setNewSecretId($request->secretId);

--- a/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfiguration.php
@@ -152,7 +152,7 @@ final class UpdateVaultConfiguration
      */
     private function isVaultConfigurationAlreadyExists(UpdateVaultConfigurationRequest $request, string $rootPath): bool
     {
-        $existingVaultConfiguration = $this->readVaultConfigurationRepository->findByAddressAndPortAndStorage(
+        $existingVaultConfiguration = $this->readVaultConfigurationRepository->findByAddressAndPortAndRootPath(
             $request->address,
             $request->port,
             $rootPath

--- a/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfiguration.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Core\Security\Vault\Application\UseCase\UpdateVaultConfiguration;
 
 use Assert\InvalidArgumentException;
+use Centreon\Domain\Common\Assertion\AssertionException;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Core\Application\Common\UseCase\{
@@ -122,7 +123,7 @@ final class UpdateVaultConfiguration
 
             $this->writeVaultConfigurationRepository->update($vaultConfiguration);
             $presenter->setResponseStatus(new NoContentResponse());
-        } catch (InvalidArgumentException $ex) {
+        } catch (InvalidArgumentException | AssertionException $ex) {
             $this->error('Some parameters are not valid', ['trace' => $ex->getTraceAsString()]);
             $presenter->setResponseStatus(
                 new InvalidArgumentResponse($ex->getMessage())

--- a/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationRequest.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationRequest.php
@@ -28,9 +28,6 @@ final class UpdateVaultConfigurationRequest
     /** @var int */
     public int $vaultConfigurationId = 0;
 
-    /** @var string */
-    public string $name = '';
-
     /** @var int */
     public int $typeId = 0;
 
@@ -39,9 +36,6 @@ final class UpdateVaultConfigurationRequest
 
     /** @var int */
     public int $port = 0;
-
-    /** @var string */
-    public string $storage = '';
 
     /** @var string */
     public string $roleId = '';

--- a/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
@@ -34,9 +34,11 @@ class NewVaultConfiguration
 {
     public const MIN_LENGTH = 1;
     public const MAX_LENGTH = 255;
+    public const NAME_MAX_LENGTH = 50;
     public const MIN_PORT_VALUE = 1;
     public const MAX_PORT_VALUE = 65535;
     public const SALT_LENGTH = 128;
+    public const NAME_VALIDATION_REGEX = '[a-zA-Z0-9_-/]';
 
     protected string $encryptedSecretId;
 
@@ -68,13 +70,13 @@ class NewVaultConfiguration
         string $unencryptedSecretId
     ) {
         Assertion::minLength($name, self::MIN_LENGTH, 'NewVaultConfiguration::name');
-        Assertion::maxLength($name, self::MAX_LENGTH, 'NewVaultConfiguration::name');
+        Assertion::maxLength($name, self::MAX_NAME_LENGTH, 'NewVaultConfiguration::name');
         Assertion::minLength($address, self::MIN_LENGTH, 'NewVaultConfiguration::address');
         Assertion::ipOrDomain($address, 'NewVaultConfiguration::address');
         Assertion::max($port, self::MAX_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::min($port, self::MIN_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::minLength($storage, self::MIN_LENGTH, 'NewVaultConfiguration::storage');
-        Assertion::maxLength($storage, self::MAX_LENGTH, 'NewVaultConfiguration::storage');
+        Assertion::maxLength($storage, self::MAX_NAME_LENGTH, 'NewVaultConfiguration::storage');
         Assertion::minLength($unencryptedRoleId, self::MIN_LENGTH, 'NewVaultConfiguration::roleId');
         Assertion::maxLength($unencryptedRoleId, self::MAX_LENGTH, 'NewVaultConfiguration::roleId');
         Assertion::minLength($unencryptedSecretId, self::MIN_LENGTH, 'NewVaultConfiguration::secretId');

--- a/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
@@ -38,7 +38,7 @@ class NewVaultConfiguration
     public const MIN_PORT_VALUE = 1;
     public const MAX_PORT_VALUE = 65535;
     public const SALT_LENGTH = 128;
-    public const NAME_VALIDATION_REGEX = '[a-zA-Z0-9_-/]';
+    public const NAME_VALIDATION_REGEX = '/^[\w+\-_\/]*$/';
 
     protected string $encryptedSecretId;
 
@@ -71,12 +71,14 @@ class NewVaultConfiguration
     ) {
         Assertion::minLength($name, self::MIN_LENGTH, 'NewVaultConfiguration::name');
         Assertion::maxLength($name, self::NAME_MAX_LENGTH, 'NewVaultConfiguration::name');
+        Assertion::regex($name, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::name');
         Assertion::minLength($address, self::MIN_LENGTH, 'NewVaultConfiguration::address');
         Assertion::ipOrDomain($address, 'NewVaultConfiguration::address');
         Assertion::max($port, self::MAX_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::min($port, self::MIN_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::minLength($storage, self::MIN_LENGTH, 'NewVaultConfiguration::storage');
         Assertion::maxLength($storage, self::NAME_MAX_LENGTH, 'NewVaultConfiguration::storage');
+        Assertion::regex($storage, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::name');
         Assertion::minLength($unencryptedRoleId, self::MIN_LENGTH, 'NewVaultConfiguration::roleId');
         Assertion::maxLength($unencryptedRoleId, self::MAX_LENGTH, 'NewVaultConfiguration::roleId');
         Assertion::minLength($unencryptedSecretId, self::MIN_LENGTH, 'NewVaultConfiguration::secretId');

--- a/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
@@ -70,13 +70,13 @@ class NewVaultConfiguration
         string $unencryptedSecretId
     ) {
         Assertion::minLength($name, self::MIN_LENGTH, 'NewVaultConfiguration::name');
-        Assertion::maxLength($name, self::MAX_NAME_LENGTH, 'NewVaultConfiguration::name');
+        Assertion::maxLength($name, self::NAME_MAX_LENGTH, 'NewVaultConfiguration::name');
         Assertion::minLength($address, self::MIN_LENGTH, 'NewVaultConfiguration::address');
         Assertion::ipOrDomain($address, 'NewVaultConfiguration::address');
         Assertion::max($port, self::MAX_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::min($port, self::MIN_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::minLength($storage, self::MIN_LENGTH, 'NewVaultConfiguration::storage');
-        Assertion::maxLength($storage, self::MAX_NAME_LENGTH, 'NewVaultConfiguration::storage');
+        Assertion::maxLength($storage, self::NAME_MAX_LENGTH, 'NewVaultConfiguration::storage');
         Assertion::minLength($unencryptedRoleId, self::MIN_LENGTH, 'NewVaultConfiguration::roleId');
         Assertion::maxLength($unencryptedRoleId, self::MAX_LENGTH, 'NewVaultConfiguration::roleId');
         Assertion::minLength($unencryptedSecretId, self::MIN_LENGTH, 'NewVaultConfiguration::secretId');

--- a/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
@@ -52,7 +52,7 @@ class NewVaultConfiguration
      * @param Vault $vault
      * @param string $address
      * @param int $port
-     * @param string $storage
+     * @param string $rootPath
      * @param string $unencryptedRoleId
      * @param string $unencryptedSecretId
      *
@@ -65,7 +65,7 @@ class NewVaultConfiguration
         protected Vault $vault,
         protected string $address,
         protected int $port,
-        protected string $storage,
+        protected string $rootPath,
         string $unencryptedRoleId,
         string $unencryptedSecretId
     ) {
@@ -76,9 +76,9 @@ class NewVaultConfiguration
         Assertion::ipOrDomain($address, 'NewVaultConfiguration::address');
         Assertion::max($port, self::MAX_PORT_VALUE, 'NewVaultConfiguration::port');
         Assertion::min($port, self::MIN_PORT_VALUE, 'NewVaultConfiguration::port');
-        Assertion::minLength($storage, self::MIN_LENGTH, 'NewVaultConfiguration::storage');
-        Assertion::maxLength($storage, self::NAME_MAX_LENGTH, 'NewVaultConfiguration::storage');
-        Assertion::regex($storage, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::name');
+        Assertion::minLength($rootPath, self::MIN_LENGTH, 'NewVaultConfiguration::rootPath');
+        Assertion::maxLength($rootPath, self::NAME_MAX_LENGTH, 'NewVaultConfiguration::rootPath');
+        Assertion::regex($rootPath, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::name');
         Assertion::minLength($unencryptedRoleId, self::MIN_LENGTH, 'NewVaultConfiguration::roleId');
         Assertion::maxLength($unencryptedRoleId, self::MAX_LENGTH, 'NewVaultConfiguration::roleId');
         Assertion::minLength($unencryptedSecretId, self::MIN_LENGTH, 'NewVaultConfiguration::secretId');
@@ -123,9 +123,9 @@ class NewVaultConfiguration
     /**
      * @return string
      */
-    public function getStorage(): string
+    public function getRootPath(): string
     {
-        return $this->storage;
+        return $this->rootPath;
     }
 
     /**

--- a/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/NewVaultConfiguration.php
@@ -38,7 +38,7 @@ class NewVaultConfiguration
     public const MIN_PORT_VALUE = 1;
     public const MAX_PORT_VALUE = 65535;
     public const SALT_LENGTH = 128;
-    public const NAME_VALIDATION_REGEX = '/^[\w+\-_\/]*$/';
+    public const NAME_VALIDATION_REGEX = '/^[\w+\-\/]+$/';
 
     protected string $encryptedSecretId;
 

--- a/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
@@ -37,7 +37,7 @@ class VaultConfiguration
     public const MIN_PORT_VALUE = 1;
     public const MAX_PORT_VALUE = 65535;
     public const SALT_LENGTH = 128;
-    public const NAME_VALIDATION_REGEX = '/^[\w+\-_\/]*$/';
+    public const NAME_VALIDATION_REGEX = NewVaultConfiguration::NAME_VALIDATION_REGEX;
 
     private ?string $secretId;
     private ?string $roleId;

--- a/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
@@ -37,7 +37,7 @@ class VaultConfiguration
     public const MIN_PORT_VALUE = 1;
     public const MAX_PORT_VALUE = 65535;
     public const SALT_LENGTH = 128;
-    public const NAME_VALIDATION_REGEX = '^[a-zA-Z0-9_-/]$';
+    public const NAME_VALIDATION_REGEX = '/^[\w+\-_\/]*$/';
 
     private ?string $secretId;
     private ?string $roleId;
@@ -198,6 +198,7 @@ class VaultConfiguration
     {
         Assertion::minLength($storage, self::MIN_LENGTH, 'VaultConfiguration::storage');
         Assertion::maxLength($storage, self::NAME_MAX_LENGTH, 'VaultConfiguration::storage');
+        Assertion::regex($storage, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::name');
         $this->storage = $storage;
     }
 

--- a/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
@@ -33,9 +33,11 @@ class VaultConfiguration
 {
     public const MIN_LENGTH = 1;
     public const MAX_LENGTH = 255;
+    public const NAME_MAX_LENGTH = 50;
     public const MIN_PORT_VALUE = 1;
     public const MAX_PORT_VALUE = 65535;
     public const SALT_LENGTH = 128;
+    public const NAME_VALIDATION_REGEX = '[a-zA-Z0-9_-/]';
 
     private ?string $secretId;
     private ?string $roleId;
@@ -164,7 +166,8 @@ class VaultConfiguration
     public function setName(string $name): void
     {
         Assertion::minLength($name, self::MIN_LENGTH, 'VaultConfiguration::name');
-        Assertion::maxLength($name, self::MAX_LENGTH, 'VaultConfiguration::name');
+        Assertion::maxLength($name, self::MAX_NAME_LENGTH, 'VaultConfiguration::name');
+        Assertion::regex($name, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::name');
         $this->name = $name;
     }
 
@@ -194,7 +197,7 @@ class VaultConfiguration
     public function setStorage(string $storage): void
     {
         Assertion::minLength($storage, self::MIN_LENGTH, 'VaultConfiguration::storage');
-        Assertion::maxLength($storage, self::MAX_LENGTH, 'VaultConfiguration::storage');
+        Assertion::maxLength($storage, self::MAX_NAME_LENGTH, 'VaultConfiguration::storage');
         $this->storage = $storage;
     }
 

--- a/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
@@ -49,7 +49,7 @@ class VaultConfiguration
      * @param Vault $vault
      * @param string $address
      * @param integer $port
-     * @param string $storage
+     * @param string $rootPath
      * @param string $encryptedRoleId
      * @param string $encryptedSecretId
      * @param string $salt
@@ -63,7 +63,7 @@ class VaultConfiguration
         private Vault $vault,
         private string $address,
         private int $port,
-        private string $storage,
+        private string $rootPath,
         private string $encryptedRoleId,
         private string $encryptedSecretId,
         private string $salt
@@ -71,7 +71,7 @@ class VaultConfiguration
         $this->setName($name);
         $this->setAddress($address);
         $this->setPort($port);
-        $this->setStorage($storage);
+        $this->setRootPath($rootPath);
     }
 
     /**
@@ -117,9 +117,9 @@ class VaultConfiguration
     /**
      * @return string
      */
-    public function getStorage(): string
+    public function getRootPath(): string
     {
-        return $this->storage;
+        return $this->rootPath;
     }
 
     /**
@@ -192,14 +192,14 @@ class VaultConfiguration
     }
 
     /**
-     * @param string $storage
+     * @param string $rootPath
      */
-    public function setStorage(string $storage): void
+    public function setRootPath(string $rootPath): void
     {
-        Assertion::minLength($storage, self::MIN_LENGTH, 'VaultConfiguration::storage');
-        Assertion::maxLength($storage, self::NAME_MAX_LENGTH, 'VaultConfiguration::storage');
-        Assertion::regex($storage, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::name');
-        $this->storage = $storage;
+        Assertion::minLength($rootPath, self::MIN_LENGTH, 'VaultConfiguration::rootPath');
+        Assertion::maxLength($rootPath, self::NAME_MAX_LENGTH, 'VaultConfiguration::rootPath');
+        Assertion::regex($rootPath, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::rootPath');
+        $this->rootPath = $rootPath;
     }
 
     /**

--- a/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
@@ -37,7 +37,7 @@ class VaultConfiguration
     public const MIN_PORT_VALUE = 1;
     public const MAX_PORT_VALUE = 65535;
     public const SALT_LENGTH = 128;
-    public const NAME_VALIDATION_REGEX = '[a-zA-Z0-9_-/]';
+    public const NAME_VALIDATION_REGEX = '^[a-zA-Z0-9_-/]$';
 
     private ?string $secretId;
     private ?string $roleId;
@@ -166,7 +166,7 @@ class VaultConfiguration
     public function setName(string $name): void
     {
         Assertion::minLength($name, self::MIN_LENGTH, 'VaultConfiguration::name');
-        Assertion::maxLength($name, self::MAX_NAME_LENGTH, 'VaultConfiguration::name');
+        Assertion::maxLength($name, self::NAME_MAX_LENGTH, 'VaultConfiguration::name');
         Assertion::regex($name, self::NAME_VALIDATION_REGEX, 'VaultConfiguration::name');
         $this->name = $name;
     }
@@ -197,7 +197,7 @@ class VaultConfiguration
     public function setStorage(string $storage): void
     {
         Assertion::minLength($storage, self::MIN_LENGTH, 'VaultConfiguration::storage');
-        Assertion::maxLength($storage, self::MAX_NAME_LENGTH, 'VaultConfiguration::storage');
+        Assertion::maxLength($storage, self::NAME_MAX_LENGTH, 'VaultConfiguration::storage');
         $this->storage = $storage;
     }
 

--- a/centreon/src/Core/Security/Vault/Infrastructure/API/CreateVaultConfiguration/CreateVaultConfigurationController.php
+++ b/centreon/src/Core/Security/Vault/Infrastructure/API/CreateVaultConfiguration/CreateVaultConfigurationController.php
@@ -54,7 +54,7 @@ final class CreateVaultConfigurationController extends AbstractController
          *  "name": string,
          *  "address": string,
          *  "port": integer,
-         *  "storage": string,
+         *  "root_path": string,
          *  "role_id": string,
          *  "secret_id": string
          * } $decodedRequest
@@ -77,7 +77,7 @@ final class CreateVaultConfigurationController extends AbstractController
      *  "name": string,
      *  "address": string,
      *  "port": integer,
-     *  "storage": string,
+     *  "root_path": string,
      *  "role_id": string,
      *  "secret_id": string
      * } $decodedRequest
@@ -93,7 +93,7 @@ final class CreateVaultConfigurationController extends AbstractController
         $createVaultConfigurationRequest->typeId = $vaultId;
         $createVaultConfigurationRequest->address = $decodedRequest['address'];
         $createVaultConfigurationRequest->port = $decodedRequest['port'];
-        $createVaultConfigurationRequest->storage = $decodedRequest['storage'];
+        $createVaultConfigurationRequest->rootPath = $decodedRequest['root_path'];
         $createVaultConfigurationRequest->roleId = $decodedRequest['role_id'];
         $createVaultConfigurationRequest->secretId = $decodedRequest['secret_id'];
 

--- a/centreon/src/Core/Security/Vault/Infrastructure/API/CreateVaultConfiguration/CreateVaultConfigurationSchema.json
+++ b/centreon/src/Core/Security/Vault/Infrastructure/API/CreateVaultConfiguration/CreateVaultConfigurationSchema.json
@@ -6,7 +6,7 @@
         "name",
         "address",
         "port",
-        "storage",
+        "root_path",
         "role_id",
         "secret_id"
     ],
@@ -21,7 +21,7 @@
         "port": {
             "type": "integer"
         },
-        "storage": {
+        "root_path": {
             "type": "string"
         },
         "role_id": {

--- a/centreon/src/Core/Security/Vault/Infrastructure/API/UpdateVaultConfiguration/UpdateVaultConfigurationController.php
+++ b/centreon/src/Core/Security/Vault/Infrastructure/API/UpdateVaultConfiguration/UpdateVaultConfigurationController.php
@@ -53,10 +53,8 @@ final class UpdateVaultConfigurationController extends AbstractController
 
         /**
          * @var array{
-         *  "name": string,
          *  "address": string,
          *  "port": integer,
-         *  "storage": string,
          *  "role_id": string,
          *  "secret_id": string
          * } $decodedRequest
@@ -81,10 +79,8 @@ final class UpdateVaultConfigurationController extends AbstractController
      * @param int $vaultId
      * @param int $vaultConfigurationId
      * @param array{
-     *  "name": string,
      *  "address": string,
      *  "port": integer,
-     *  "storage": string,
      *  "role_id": string,
      *  "secret_id": string
      * } $decodedRequest
@@ -98,11 +94,9 @@ final class UpdateVaultConfigurationController extends AbstractController
     ): UpdateVaultConfigurationRequest {
         $updateVaultConfigurationRequest = new UpdateVaultConfigurationRequest();
         $updateVaultConfigurationRequest->vaultConfigurationId = $vaultConfigurationId;
-        $updateVaultConfigurationRequest->name = $decodedRequest['name'];
         $updateVaultConfigurationRequest->typeId = $vaultId;
         $updateVaultConfigurationRequest->address = $decodedRequest['address'];
         $updateVaultConfigurationRequest->port = $decodedRequest['port'];
-        $updateVaultConfigurationRequest->storage = $decodedRequest['storage'];
         $updateVaultConfigurationRequest->roleId = $decodedRequest['role_id'];
         $updateVaultConfigurationRequest->secretId = $decodedRequest['secret_id'];
 

--- a/centreon/src/Core/Security/Vault/Infrastructure/API/UpdateVaultConfiguration/UpdateVaultConfigurationSchema.json
+++ b/centreon/src/Core/Security/Vault/Infrastructure/API/UpdateVaultConfiguration/UpdateVaultConfigurationSchema.json
@@ -3,26 +3,18 @@
     "title": "Update Vault Configuration",
     "type": "object",
     "required": [
-        "name",
         "address",
         "port",
-        "storage",
         "role_id",
         "secret_id"
     ],
     "additionalProperties": false,
     "properties": {
-        "name": {
-            "type": "string"
-        },
         "address": {
             "type": "string"
         },
         "port": {
             "type": "integer"
-        },
-        "storage": {
-            "type": "string"
         },
         "role_id": {
             "type": "string"

--- a/centreon/src/Core/Security/Vault/Infrastructure/Repository/DbReadVaultConfigurationRepository.php
+++ b/centreon/src/Core/Security/Vault/Infrastructure/Repository/DbReadVaultConfigurationRepository.php
@@ -47,7 +47,7 @@ class DbReadVaultConfigurationRepository extends AbstractRepositoryDRB implement
     /**
      * @inheritDoc
      */
-    public function findByAddressAndPortAndStorage(
+    public function findByAddressAndPortAndRootPath(
         string $address,
         int $port,
         string $rootPath

--- a/centreon/src/Core/Security/Vault/Infrastructure/Repository/DbReadVaultConfigurationRepository.php
+++ b/centreon/src/Core/Security/Vault/Infrastructure/Repository/DbReadVaultConfigurationRepository.php
@@ -50,9 +50,9 @@ class DbReadVaultConfigurationRepository extends AbstractRepositoryDRB implement
     public function findByAddressAndPortAndStorage(
         string $address,
         int $port,
-        string $storage
+        string $rootPath
     ): ?VaultConfiguration {
-        $this->info('Getting existing vault configuration by address, port and storage');
+        $this->info('Getting existing vault configuration by address, port and rootPath');
 
         $statement = $this->db->prepare(
             $this->translateDbName(
@@ -61,13 +61,13 @@ class DbReadVaultConfigurationRepository extends AbstractRepositoryDRB implement
                     FROM `:db`.`vault_configuration` conf
                     INNER JOIN `:db`.`vault`
                       ON vault.id = conf.vault_id
-                    WHERE `url`=:address AND `port`=:port AND `storage`=:storage
+                    WHERE `url`=:address AND `port`=:port AND `root_path`=:rootPath
                 SQL
             )
         );
         $statement->bindValue(':address', $address, \PDO::PARAM_STR);
         $statement->bindValue(':port', $port, \PDO::PARAM_INT);
-        $statement->bindValue(':storage', $storage, \PDO::PARAM_STR);
+        $statement->bindValue(':rootPath', $rootPath, \PDO::PARAM_STR);
         $statement->execute();
 
         if (! ($record = $statement->fetch(\PDO::FETCH_ASSOC))) {
@@ -81,7 +81,7 @@ class DbReadVaultConfigurationRepository extends AbstractRepositoryDRB implement
          *  vault_name: string,
          *  url: string,
          *  port: int,
-         *  storage: string,
+         *  root_path: string,
          *  role_id: string,
          *  secret_id: string,
          *  salt: string
@@ -108,20 +108,20 @@ class DbReadVaultConfigurationRepository extends AbstractRepositoryDRB implement
     /**
      * @param string $address
      * @param integer $port
-     * @param string $storage
+     * @param string $rootPath
      *
      * @throws \Throwable
      *
      * @return boolean
      */
-    public function existsSameConfiguration(string $address, int $port, string $storage): bool
+    public function existsSameConfiguration(string $address, int $port, string $rootPath): bool
     {
         $this->info(
             'Check if same vault configuration exists',
             [
                 'address' => $address,
                 'port' => $port,
-                'storage' => $storage
+                'root_path' => $rootPath
             ]
         );
 
@@ -132,13 +132,13 @@ class DbReadVaultConfigurationRepository extends AbstractRepositoryDRB implement
                     FROM `:db`.`vault_configuration` conf
                     INNER JOIN `:db`.`vault`
                       ON vault.id = conf.vault_id
-                    WHERE `url`=:address AND `port`=:port AND `storage`=:storage
+                    WHERE `url`=:address AND `port`=:port AND `root_path`=:rootPath
                 SQL
             )
         );
         $statement->bindValue(':address', $address, \PDO::PARAM_STR);
         $statement->bindValue(':port', $port, \PDO::PARAM_INT);
-        $statement->bindValue(':storage', $storage, \PDO::PARAM_STR);
+        $statement->bindValue(':rootPath', $rootPath, \PDO::PARAM_STR);
         $statement->execute();
 
         return ! empty($statement->fetch(\PDO::FETCH_ASSOC));
@@ -176,7 +176,7 @@ class DbReadVaultConfigurationRepository extends AbstractRepositoryDRB implement
          *  vault_name: string,
          *  url: string,
          *  port: int,
-         *  storage: string,
+         *  root_path: string,
          *  role_id: string,
          *  secret_id: string,
          *  salt: string
@@ -216,7 +216,7 @@ class DbReadVaultConfigurationRepository extends AbstractRepositoryDRB implement
              *  vault_name: string,
              *  url: string,
              *  port: int,
-             *  storage: string,
+             *  root_path: string,
              *  role_id: string,
              *  secret_id: string,
              *  salt: string
@@ -257,7 +257,7 @@ class DbReadVaultConfigurationRepository extends AbstractRepositoryDRB implement
          *  vault_name: string,
          *  url: string,
          *  port: int,
-         *  storage: string,
+         *  root_path: string,
          *  role_id: string,
          *  secret_id: string,
          *  salt: string

--- a/centreon/src/Core/Security/Vault/Infrastructure/Repository/DbVaultConfigurationFactory.php
+++ b/centreon/src/Core/Security/Vault/Infrastructure/Repository/DbVaultConfigurationFactory.php
@@ -45,7 +45,7 @@ class DbVaultConfigurationFactory
      *  vault_name: string,
      *  url: string,
      *  port: int,
-     *  storage: string,
+     *  root_path: string,
      *  role_id: string,
      *  secret_id: string,
      *  salt: string
@@ -65,7 +65,7 @@ class DbVaultConfigurationFactory
             new Vault($recordData['vault_id'], $recordData['vault_name']),
             (string) $recordData['url'],
             (int) $recordData['port'],
-            (string) $recordData['storage'],
+            (string) $recordData['root_path'],
             (string) $recordData['role_id'],
             (string) $recordData['secret_id'],
             (string) $recordData['salt']

--- a/centreon/src/Core/Security/Vault/Infrastructure/Repository/DbWriteVaultConfigurationRepository.php
+++ b/centreon/src/Core/Security/Vault/Infrastructure/Repository/DbWriteVaultConfigurationRepository.php
@@ -64,7 +64,7 @@ class DbWriteVaultConfigurationRepository extends AbstractRepositoryDRB implemen
         $statement->bindValue(':vault_id', $vaultConfiguration->getVault()->getId(), \PDO::PARAM_INT);
         $statement->bindValue(':url', $vaultConfiguration->getAddress(), \PDO::PARAM_STR);
         $statement->bindValue(':port', $vaultConfiguration->getPort(), \PDO::PARAM_INT);
-        $statement->bindValue(':storage', $vaultConfiguration->getStorage(), \PDO::PARAM_STR);
+        $statement->bindValue(':storage', $vaultConfiguration->getRootPath(), \PDO::PARAM_STR);
         $statement->bindValue(':role_id', $vaultConfiguration->getEncryptedRoleId(), \PDO::PARAM_STR);
         $statement->bindValue(':secret_id', $vaultConfiguration->getEncryptedSecretId(), \PDO::PARAM_STR);
         $statement->bindValue(':salt', $vaultConfiguration->getSalt(), \PDO::PARAM_STR);
@@ -100,7 +100,7 @@ class DbWriteVaultConfigurationRepository extends AbstractRepositoryDRB implemen
         $statement->bindValue(':vault_id', $vaultConfiguration->getVault()->getId(), \PDO::PARAM_INT);
         $statement->bindValue(':url', $vaultConfiguration->getAddress(), \PDO::PARAM_STR);
         $statement->bindValue(':port', $vaultConfiguration->getPort(), \PDO::PARAM_INT);
-        $statement->bindValue(':storage', $vaultConfiguration->getStorage(), \PDO::PARAM_STR);
+        $statement->bindValue(':storage', $vaultConfiguration->getRootPath(), \PDO::PARAM_STR);
         $statement->bindValue(':role_id', $vaultConfiguration->getEncryptedRoleId(), \PDO::PARAM_STR);
         $statement->bindValue(':secret_id', $vaultConfiguration->getEncryptedSecretId(), \PDO::PARAM_STR);
 

--- a/centreon/src/Core/Security/Vault/Infrastructure/Repository/DbWriteVaultConfigurationRepository.php
+++ b/centreon/src/Core/Security/Vault/Infrastructure/Repository/DbWriteVaultConfigurationRepository.php
@@ -55,8 +55,8 @@ class DbWriteVaultConfigurationRepository extends AbstractRepositoryDRB implemen
             $this->translateDbName(
                 <<<'SQL'
                     INSERT INTO `:db`.`vault_configuration`
-                    (`name`, `vault_id`, `url`, `port`, `storage`, `role_id`, `secret_id`, `salt`)
-                    VALUES (:name, :vault_id, :url, :port, :storage, :role_id, :secret_id, :salt)
+                    (`name`, `vault_id`, `url`, `port`, `root_path`, `role_id`, `secret_id`, `salt`)
+                    VALUES (:name, :vault_id, :url, :port, :rootPath, :role_id, :secret_id, :salt)
                     SQL
             )
         );
@@ -64,7 +64,7 @@ class DbWriteVaultConfigurationRepository extends AbstractRepositoryDRB implemen
         $statement->bindValue(':vault_id', $vaultConfiguration->getVault()->getId(), \PDO::PARAM_INT);
         $statement->bindValue(':url', $vaultConfiguration->getAddress(), \PDO::PARAM_STR);
         $statement->bindValue(':port', $vaultConfiguration->getPort(), \PDO::PARAM_INT);
-        $statement->bindValue(':storage', $vaultConfiguration->getRootPath(), \PDO::PARAM_STR);
+        $statement->bindValue(':rootPath', $vaultConfiguration->getRootPath(), \PDO::PARAM_STR);
         $statement->bindValue(':role_id', $vaultConfiguration->getEncryptedRoleId(), \PDO::PARAM_STR);
         $statement->bindValue(':secret_id', $vaultConfiguration->getEncryptedSecretId(), \PDO::PARAM_STR);
         $statement->bindValue(':salt', $vaultConfiguration->getSalt(), \PDO::PARAM_STR);
@@ -87,7 +87,7 @@ class DbWriteVaultConfigurationRepository extends AbstractRepositoryDRB implemen
                         `vault_id`=:vault_id,
                         `url`=:url,
                         `port`=:port,
-                        `storage`=:storage,
+                        `root_path`=:rootPath,
                         `role_id`=:role_id,
                         `secret_id`=:secret_id
                     WHERE `id`=:id
@@ -100,7 +100,7 @@ class DbWriteVaultConfigurationRepository extends AbstractRepositoryDRB implemen
         $statement->bindValue(':vault_id', $vaultConfiguration->getVault()->getId(), \PDO::PARAM_INT);
         $statement->bindValue(':url', $vaultConfiguration->getAddress(), \PDO::PARAM_STR);
         $statement->bindValue(':port', $vaultConfiguration->getPort(), \PDO::PARAM_INT);
-        $statement->bindValue(':storage', $vaultConfiguration->getRootPath(), \PDO::PARAM_STR);
+        $statement->bindValue(':rootPath', $vaultConfiguration->getRootPath(), \PDO::PARAM_STR);
         $statement->bindValue(':role_id', $vaultConfiguration->getEncryptedRoleId(), \PDO::PARAM_STR);
         $statement->bindValue(':secret_id', $vaultConfiguration->getEncryptedSecretId(), \PDO::PARAM_STR);
 

--- a/centreon/src/Utility/Interfaces/UUIDGeneratorInterface.php
+++ b/centreon/src/Utility/Interfaces/UUIDGeneratorInterface.php
@@ -30,6 +30,6 @@ interface UUIDGeneratorInterface
      *
      * @return string
      */
-    public function generateUUIDV4(): string;
+    public function generateV4(): string;
 }
 

--- a/centreon/src/Utility/UUIDGenerator.php
+++ b/centreon/src/Utility/UUIDGenerator.php
@@ -31,7 +31,7 @@ class UUIDGenerator implements UUIDGeneratorInterface
     /**
      * @inheritDoc
      */
-    public function generateUUIDV4(): string
+    public function generateV4(): string
     {
         return (string) Uuid::v4();
     }

--- a/centreon/tests/api/features/VaultConfiguration.feature
+++ b/centreon/tests/api/features/VaultConfiguration.feature
@@ -147,7 +147,7 @@ Feature: Vault Configuration API
     """
       {
         "address": "127.0.0.1",
-        "port": 8200,
+        "port": 8201,
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -195,7 +195,7 @@ Feature: Vault Configuration API
     When I send a PUT request to '/api/latest/administration/vaults/1/configurations/1' with body:
     """
       {
-        "address": "127.0.0.2",
+        "address": "127.0.0.3",
         "port": 8201,
         "role_id": "myRoleId",
         "secret_id": "mySecretId"

--- a/centreon/tests/api/features/VaultConfiguration.feature
+++ b/centreon/tests/api/features/VaultConfiguration.feature
@@ -186,7 +186,7 @@ Feature: Vault Configuration API
         "name": "myAnotherVaultConfiguration",
         "address": "127.0.0.2",
         "port": 8201,
-        "root_path": "myAnotherStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myAnotherRoleId",
         "secret_id": "myAnotherSecretId"
       }

--- a/centreon/tests/api/features/VaultConfiguration.feature
+++ b/centreon/tests/api/features/VaultConfiguration.feature
@@ -195,7 +195,7 @@ Feature: Vault Configuration API
     When I send a PUT request to '/api/latest/administration/vaults/1/configurations/1' with body:
     """
       {
-        "address": "127.0.0.3",
+        "address": "127.0.0.2",
         "port": 8201,
         "role_id": "myRoleId",
         "secret_id": "mySecretId"

--- a/centreon/tests/api/features/VaultConfiguration.feature
+++ b/centreon/tests/api/features/VaultConfiguration.feature
@@ -15,7 +15,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -31,7 +31,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -52,7 +52,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -80,7 +80,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -95,7 +95,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -107,7 +107,7 @@ Feature: Vault Configuration API
         "name": "myAnotherVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myAnotherRoleId",
         "secret_id": "myAnotherSecretId"
       }
@@ -122,7 +122,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -137,7 +137,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -146,10 +146,8 @@ Feature: Vault Configuration API
     When I send a PUT request to '/api/latest/administration/vaults/1/configurations/1' with body:
     """
       {
-        "name": "myNewVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -161,17 +159,15 @@ Feature: Vault Configuration API
     When I send a PUT request to '/api/latest/administration/vaults/1/configurations/1' with body:
     """
       {
-        "name": "myNewVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
     """
     Then the response code should be "404"
 
-  Scenario: Update vault configuration as an admin user by setting address, port and storage to be the same as in another existing one
+  Scenario: Update vault configuration as an admin user by setting address, port and root_path to be the same as in another existing one
     Given I am logged in
     And I send a POST request to '/api/latest/administration/vaults/1/configurations' with body:
     """
@@ -179,7 +175,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -190,7 +186,7 @@ Feature: Vault Configuration API
         "name": "myAnotherVaultConfiguration",
         "address": "127.0.0.2",
         "port": 8201,
-        "storage": "myAnotherStorageFolder",
+        "root_path": "myAnotherStorageFolder",
         "role_id": "myAnotherRoleId",
         "secret_id": "myAnotherSecretId"
       }
@@ -199,10 +195,8 @@ Feature: Vault Configuration API
     When I send a PUT request to '/api/latest/administration/vaults/1/configurations/1' with body:
     """
       {
-        "name": "myNewVaultConfiguration",
         "address": "127.0.0.2",
         "port": 8201,
-        "storage": "myAnotherStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -217,7 +211,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -234,7 +228,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -257,7 +251,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -274,7 +268,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -291,7 +285,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -309,7 +303,7 @@ Feature: Vault Configuration API
             "vault_id": 1,
             "url": "127.0.0.1",
             "port": 8200,
-            "storage": "myStorageFolder"
+            "root_path": "myStorageFolder"
           }
         ],
         "meta": {
@@ -330,7 +324,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -353,7 +347,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -370,7 +364,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -387,7 +381,7 @@ Feature: Vault Configuration API
           "vault_id": 1,
           "url": "127.0.0.1",
           "port": 8200,
-          "storage": "myStorageFolder"
+          "root_path": "myStorageFolder"
         }
       }
     """
@@ -400,7 +394,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -423,7 +417,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }
@@ -440,7 +434,7 @@ Feature: Vault Configuration API
         "name": "myVaultConfiguration",
         "address": "127.0.0.1",
         "port": 8200,
-        "storage": "myStorageFolder",
+        "root_path": "myStorageFolder",
         "role_id": "myRoleId",
         "secret_id": "mySecretId"
       }

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/CreateVaultConfiguration/CreateVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/CreateVaultConfiguration/CreateVaultConfigurationTest.php
@@ -148,7 +148,7 @@ it('should present InvalidArgumentResponse when one parameter is not valid', fun
     $createVaultConfigurationRequest->typeId = 1;
     $createVaultConfigurationRequest->address = '127.0.0.1';
     $createVaultConfigurationRequest->port = 8200;
-    $createVaultConfigurationRequest->storage = 'myStorage';
+    $createVaultConfigurationRequest->rootPath = 'myStorage';
     $createVaultConfigurationRequest->roleId = 'myRole';
     $createVaultConfigurationRequest->secretId = 'mySecretId';
 
@@ -211,7 +211,7 @@ it('should present NotFoundResponse when vault provider does not exist', functio
     $createVaultConfigurationRequest->typeId = 3;
     $createVaultConfigurationRequest->address = '127.0.0.1';
     $createVaultConfigurationRequest->port = 8200;
-    $createVaultConfigurationRequest->storage = 'myStorage';
+    $createVaultConfigurationRequest->rootPath = 'myStorage';
     $createVaultConfigurationRequest->roleId = 'myRole';
     $createVaultConfigurationRequest->secretId = 'mySecretId';
 
@@ -284,7 +284,7 @@ it('should present CreatedResponse when vault configuration is created with succ
     $createVaultConfigurationRequest->typeId = $vault->getId();
     $createVaultConfigurationRequest->address = '127.0.0.1';
     $createVaultConfigurationRequest->port = 8200;
-    $createVaultConfigurationRequest->storage = 'myStorage';
+    $createVaultConfigurationRequest->rootPath = 'myStorage';
     $createVaultConfigurationRequest->roleId = 'myRoleId';
     $createVaultConfigurationRequest->secretId = 'mySecretId';
 

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/CreateVaultConfiguration/NewVaultConfigurationFactoryTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/CreateVaultConfiguration/NewVaultConfigurationFactoryTest.php
@@ -54,7 +54,7 @@ it(
         $createVaultConfigurationRequest->typeId = 1;
         $createVaultConfigurationRequest->address = '127.0.0.1';
         $createVaultConfigurationRequest->port = 8200;
-        $createVaultConfigurationRequest->storage = 'myStorage';
+        $createVaultConfigurationRequest->rootPath = 'myStorage';
         $createVaultConfigurationRequest->roleId = 'myRoleId';
         $createVaultConfigurationRequest->secretId = 'mySecretId';
 
@@ -80,7 +80,7 @@ it('should encrypt roleId and secretId correctly', function (): void {
     $createVaultConfigurationRequest->typeId = 1;
     $createVaultConfigurationRequest->address = '127.0.0.1';
     $createVaultConfigurationRequest->port = 8200;
-    $createVaultConfigurationRequest->storage = 'myStorage';
+    $createVaultConfigurationRequest->rootPath = 'myStorage';
     $createVaultConfigurationRequest->roleId = 'myRoleId';
     $createVaultConfigurationRequest->secretId = 'mySecretId';
 

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfigurationTest.php
@@ -215,7 +215,7 @@ it('should present FindVaultConfigurationResponse', function () {
         'vault_id' => $vaultConfiguration->getVault()->getId(),
         'url' => $vaultConfiguration->getAddress(),
         'port' => $vaultConfiguration->getPort(),
-        'storage' => $vaultConfiguration->getStorage()
+        'storage' => $vaultConfiguration->getRootPath()
     ];
 
     $useCase($presenter, $findVaultConfigurationRequest);

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfigurationTest.php
@@ -215,7 +215,7 @@ it('should present FindVaultConfigurationResponse', function () {
         'vault_id' => $vaultConfiguration->getVault()->getId(),
         'url' => $vaultConfiguration->getAddress(),
         'port' => $vaultConfiguration->getPort(),
-        'storage' => $vaultConfiguration->getRootPath()
+        'root_path' => $vaultConfiguration->getRootPath()
     ];
 
     $useCase($presenter, $findVaultConfigurationRequest);

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/FindVaultConfigurations/FindVaultConfigurationsTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/FindVaultConfigurations/FindVaultConfigurationsTest.php
@@ -33,7 +33,6 @@ use Core\Security\Vault\Application\Repository\{
 };
 use Core\Security\Vault\Application\UseCase\FindVaultConfigurations\{
     FindVaultConfigurations,
-    FindVaultConfigurationsRequest,
     FindVaultConfigurationsResponse
 };
 use Core\Security\Vault\Domain\Model\{Vault, VaultConfiguration};
@@ -172,7 +171,7 @@ it('should present FindVaultConfigurationsResponse', function () {
             'vault_id' => $vault->getId(),
             'url' => $vaultConfiguration->getAddress(),
             'port' => $vaultConfiguration->getPort(),
-            'storage' => $vaultConfiguration->getStorage()
+            'storage' => $vaultConfiguration->getRootPath()
         ]
     ];
 

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/FindVaultConfigurations/FindVaultConfigurationsTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/FindVaultConfigurations/FindVaultConfigurationsTest.php
@@ -171,7 +171,7 @@ it('should present FindVaultConfigurationsResponse', function () {
             'vault_id' => $vault->getId(),
             'url' => $vaultConfiguration->getAddress(),
             'port' => $vaultConfiguration->getPort(),
-            'storage' => $vaultConfiguration->getRootPath()
+            'root_path' => $vaultConfiguration->getRootPath()
         ]
     ];
 

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
@@ -197,12 +197,11 @@ it('should present InvalidArgumentResponse when one parameter is not valid', fun
         $this->user
     );
 
-    $invalidName = '';
-
+    $invalidAddress = '._@';
     $updateVaultConfigurationRequest = new UpdateVaultConfigurationRequest();
     $updateVaultConfigurationRequest->vaultConfigurationId = 1;
     $updateVaultConfigurationRequest->typeId = 1;
-    $updateVaultConfigurationRequest->address = '127.0.0.1';
+    $updateVaultConfigurationRequest->address = $invalidAddress;
     $updateVaultConfigurationRequest->port = 8200;
     $updateVaultConfigurationRequest->roleId = 'myRole';
     $updateVaultConfigurationRequest->secretId = 'mySecretId';
@@ -211,11 +210,9 @@ it('should present InvalidArgumentResponse when one parameter is not valid', fun
 
     expect($presenter->getResponseStatus())->toBeInstanceOf(InvalidArgumentResponse::class);
     expect($presenter->getResponseStatus()?->getMessage())->toBe(
-        AssertionException::minLength(
-            $invalidName,
-            strlen($invalidName),
-            VaultConfiguration::MIN_LENGTH,
-            'VaultConfiguration::name'
+        AssertionException::ipOrDomain(
+            $invalidAddress,
+            'VaultConfiguration::address'
         )->getMessage()
     );
 });

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
@@ -272,7 +272,7 @@ it(
 
         $this->readVaultConfigurationRepository
             ->expects($this->once())
-            ->method('findByAddressAndPortAndStorage')
+            ->method('findByAddressAndPortAndRootPath')
             ->willReturn($existingVaultConfiguration);
 
         $updateVaultConfigurationRequest = new UpdateVaultConfigurationRequest();
@@ -363,7 +363,7 @@ it('should present NoContentResponse when vault configuration is created with su
 
     $this->readVaultConfigurationRepository
         ->expects($this->once())
-        ->method('findByAddressAndPortAndStorage')
+        ->method('findByAddressAndPortAndRootPath')
         ->willReturn(null);
 
     $presenter = new UpdateVaultConfigurationPresenterStub($this->presenterFormatter);
@@ -384,7 +384,7 @@ it('should present NoContentResponse when vault configuration is created with su
 
     $this->readVaultConfigurationRepository
         ->expects($this->once())
-        ->method('findByAddressAndPortAndStorage')
+        ->method('findByAddressAndPortAndRootPath')
         ->willReturn(null);
 
     $useCase($presenter, $updateVaultConfigurationRequest);

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/UpdateVaultConfiguration/UpdateVaultConfigurationTest.php
@@ -102,11 +102,9 @@ it('should present NotFoundResponse when vault provider does not exist', functio
 
     $updateVaultConfigurationRequest = new UpdateVaultConfigurationRequest();
     $updateVaultConfigurationRequest->vaultConfigurationId = 1;
-    $updateVaultConfigurationRequest->name = 'myVault';
     $updateVaultConfigurationRequest->typeId = 3;
     $updateVaultConfigurationRequest->address = '127.0.0.1';
     $updateVaultConfigurationRequest->port = 8200;
-    $updateVaultConfigurationRequest->storage = 'myStorage';
     $updateVaultConfigurationRequest->roleId = 'myRole';
     $updateVaultConfigurationRequest->secretId = 'mySecretId';
 
@@ -144,11 +142,9 @@ it('should present NotFoundResponse when vault configuration does not exist for 
 
     $updateVaultConfigurationRequest = new UpdateVaultConfigurationRequest();
     $updateVaultConfigurationRequest->vaultConfigurationId = 1;
-    $updateVaultConfigurationRequest->name = 'myVault';
     $updateVaultConfigurationRequest->typeId = 3;
     $updateVaultConfigurationRequest->address = '127.0.0.1';
     $updateVaultConfigurationRequest->port = 8200;
-    $updateVaultConfigurationRequest->storage = 'myStorage';
     $updateVaultConfigurationRequest->roleId = 'myRole';
     $updateVaultConfigurationRequest->secretId = 'mySecretId';
 
@@ -205,11 +201,9 @@ it('should present InvalidArgumentResponse when one parameter is not valid', fun
 
     $updateVaultConfigurationRequest = new UpdateVaultConfigurationRequest();
     $updateVaultConfigurationRequest->vaultConfigurationId = 1;
-    $updateVaultConfigurationRequest->name = $invalidName;
     $updateVaultConfigurationRequest->typeId = 1;
     $updateVaultConfigurationRequest->address = '127.0.0.1';
     $updateVaultConfigurationRequest->port = 8200;
-    $updateVaultConfigurationRequest->storage = 'myStorage';
     $updateVaultConfigurationRequest->roleId = 'myRole';
     $updateVaultConfigurationRequest->secretId = 'mySecretId';
 
@@ -286,11 +280,9 @@ it(
 
         $updateVaultConfigurationRequest = new UpdateVaultConfigurationRequest();
         $updateVaultConfigurationRequest->vaultConfigurationId = $vaultConfiguration->getId();
-        $updateVaultConfigurationRequest->name = $vaultConfiguration->getName();
         $updateVaultConfigurationRequest->typeId = $vault->getId();
         $updateVaultConfigurationRequest->address = $existingVaultConfiguration->getAddress();
         $updateVaultConfigurationRequest->port = $existingVaultConfiguration->getPort();
-        $updateVaultConfigurationRequest->storage = $existingVaultConfiguration->getStorage();
         $updateVaultConfigurationRequest->roleId = $vaultConfiguration->getEncryptedRoleId();
         $updateVaultConfigurationRequest->secretId = $vaultConfiguration->getEncryptedSecretId();
 
@@ -387,11 +379,9 @@ it('should present NoContentResponse when vault configuration is created with su
 
     $updateVaultConfigurationRequest = new UpdateVaultConfigurationRequest();
     $updateVaultConfigurationRequest->vaultConfigurationId = 1;
-    $updateVaultConfigurationRequest->name = 'myVaultConfigurationName';
     $updateVaultConfigurationRequest->typeId = 1;
     $updateVaultConfigurationRequest->address = '127.0.0.1';
     $updateVaultConfigurationRequest->port = 8200;
-    $updateVaultConfigurationRequest->storage = 'myStorage';
     $updateVaultConfigurationRequest->roleId = 'myRole';
     $updateVaultConfigurationRequest->secretId = 'mySecretId';
 

--- a/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
@@ -337,6 +337,6 @@ it(
         expect($newVaultConfiguration->getVault())->toBeInstanceOf(Vault::class);
         expect($newVaultConfiguration->getAddress())->toBe('127.0.0.1');
         expect($newVaultConfiguration->getPort())->toBe(8200);
-        expect($newVaultConfiguration->getStorage())->toBe('myStorage');
+        expect($newVaultConfiguration->getRootPath())->toBe('myStorage');
     }
 );

--- a/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
@@ -176,7 +176,7 @@ it('should throw InvalidArgumentException when vault configuration port exceeds 
 );
 
 it(
-    'should throw InvalidArgumentException when vault configuration storage is empty',
+    'should throw InvalidArgumentException when vault configuration rootPath is empty',
     function () use ($invalidMinLengthString): void {
         new NewVaultConfiguration(
             $this->encryption,
@@ -195,12 +195,12 @@ it(
         $invalidMinLengthString,
         strlen($invalidMinLengthString),
         NewVaultConfiguration::MIN_LENGTH,
-        'NewVaultConfiguration::storage'
+        'NewVaultConfiguration::rootPath'
     )->getMessage()
 );
 
 it(
-    'should throw InvalidArgumentException when vault configuration storage exceeds allowed max length',
+    'should throw InvalidArgumentException when vault configuration rootPath exceeds allowed max length',
     function () use ($invalidNameMaxLengthString): void {
         new NewVaultConfiguration(
             $this->encryption,
@@ -219,7 +219,7 @@ it(
         $invalidNameMaxLengthString,
         strlen($invalidNameMaxLengthString),
         NewVaultConfiguration::NAME_MAX_LENGTH,
-        'NewVaultConfiguration::storage'
+        'NewVaultConfiguration::rootPath'
     )->getMessage()
 );
 

--- a/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
@@ -87,7 +87,7 @@ it(
     AssertionException::maxLength(
         $invalidNameMaxLengthString,
         strlen($invalidNameMaxLengthString),
-        NewVaultConfiguration::MAX_LENGTH,
+        NewVaultConfiguration::NAME_MAX_LENGTH,
         'NewVaultConfiguration::name'
     )->getMessage()
 );
@@ -218,7 +218,7 @@ it(
     AssertionException::maxLength(
         $invalidNameMaxLengthString,
         strlen($invalidNameMaxLengthString),
-        NewVaultConfiguration::MAX_LENGTH,
+        NewVaultConfiguration::NAME_MAX_LENGTH,
         'NewVaultConfiguration::storage'
     )->getMessage()
 );

--- a/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
@@ -34,10 +34,7 @@ $invalidMaxLengthString = '';
 for ($index = 0; $index <= NewVaultConfiguration::MAX_LENGTH; $index++) {
     $invalidMaxLengthString .= 'a';
 }
-$invalidNameMaxLengthString = '';
-for ($index = 0; $index <= NewVaultConfiguration::NAME_MAX_LENGTH; $index++) {
-    $invalidNameMaxLengthString .= 'a';
-}
+$invalidNameMaxLengthString = str_repeat('a', NewVaultConfiguration::NAME_MAX_LENGTH + 1);
 beforeEach(function (): void {
     $this->vault = new Vault(1, 'myVaultProvider');
     $this->encryption = new Encryption();

--- a/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Domain/Model/NewVaultConfigurationTest.php
@@ -34,7 +34,10 @@ $invalidMaxLengthString = '';
 for ($index = 0; $index <= NewVaultConfiguration::MAX_LENGTH; $index++) {
     $invalidMaxLengthString .= 'a';
 }
-
+$invalidNameMaxLengthString = '';
+for ($index = 0; $index <= NewVaultConfiguration::NAME_MAX_LENGTH; $index++) {
+    $invalidNameMaxLengthString .= 'a';
+}
 beforeEach(function (): void {
     $this->vault = new Vault(1, 'myVaultProvider');
     $this->encryption = new Encryption();
@@ -67,10 +70,10 @@ it(
 
 it(
     'should throw InvalidArgumentException when vault configuration name exceeds allowed max length',
-    function () use ($invalidMaxLengthString): void {
+    function () use ($invalidNameMaxLengthString): void {
         new NewVaultConfiguration(
             $this->encryption,
-            $invalidMaxLengthString,
+            $invalidNameMaxLengthString,
             $this->vault,
             '127.0.0.1',
             8200,
@@ -82,8 +85,8 @@ it(
 )->throws(
     InvalidArgumentException::class,
     AssertionException::maxLength(
-        $invalidMaxLengthString,
-        strlen($invalidMaxLengthString),
+        $invalidNameMaxLengthString,
+        strlen($invalidNameMaxLengthString),
         NewVaultConfiguration::MAX_LENGTH,
         'NewVaultConfiguration::name'
     )->getMessage()
@@ -197,15 +200,15 @@ it(
 );
 
 it(
-    'should throw InvalidArgumentException when vault configuration storage exeeds allowed max length',
-    function () use ($invalidMaxLengthString): void {
+    'should throw InvalidArgumentException when vault configuration storage exceeds allowed max length',
+    function () use ($invalidNameMaxLengthString): void {
         new NewVaultConfiguration(
             $this->encryption,
             'myVault',
             $this->vault,
             '127.0.0.1',
             8200,
-            $invalidMaxLengthString,
+            $invalidNameMaxLengthString,
             'myRoleId',
             'mySecretId'
         );
@@ -213,8 +216,8 @@ it(
 )->throws(
     InvalidArgumentException::class,
     AssertionException::maxLength(
-        $invalidMaxLengthString,
-        strlen($invalidMaxLengthString),
+        $invalidNameMaxLengthString,
+        strlen($invalidNameMaxLengthString),
         NewVaultConfiguration::MAX_LENGTH,
         'NewVaultConfiguration::storage'
     )->getMessage()
@@ -245,7 +248,7 @@ it(
 );
 
 it(
-    'should throw InvalidArgumentException when vault configuration role id exeeds allowed max length',
+    'should throw InvalidArgumentException when vault configuration role id exceeds allowed max length',
     function () use ($invalidMaxLengthString): void {
         new NewVaultConfiguration(
             $this->encryption,
@@ -293,7 +296,7 @@ it(
 );
 
 it(
-    'should throw InvalidArgumentException when vault configuration secret id exeeds allowed max length',
+    'should throw InvalidArgumentException when vault configuration secret id exceeds allowed max length',
     function () use ($invalidMaxLengthString): void {
         new NewVaultConfiguration(
             $this->encryption,

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -732,7 +732,7 @@ function multipleHostInDB($hosts = array(), $nbrDup = array())
                                         $httpClient
                                     );
                                     $hostPath = "secret::" . $vaultConfiguration->getId() . "::"
-                                        . $vaultConfiguration->getStorage()
+                                        . $vaultConfiguration->getRootPath()
                                         . "/monitoring/hosts/" . $maxId['MAX(host_id)'];
                                     //Store vault path for SNMP Community
                                     if (array_key_exists(SNMP_COMMUNITY_MACRO_NAME, $hostSecretsFromVault)){
@@ -1199,7 +1199,7 @@ function insertHost($ret, $macro_on_demand = null, $server_id = null)
                     $logger,
                     $httpClient
                 );
-                $hostPath = "secret::" . $vaultConfiguration->getId() . "::" . $vaultConfiguration->getStorage()
+                $hostPath = "secret::" . $vaultConfiguration->getId() . "::" . $vaultConfiguration->getRootPath()
                     . "/monitoring/hosts/" . $host_id['MAX(host_id)'];
 
                 //Store vault path for SNMP Community
@@ -1665,7 +1665,7 @@ function updateHost($hostId = null, $from_MC = false, $cfg = null)
                     $httpClient
                 );
                 $hostPath = "secret::" . $vaultConfiguration->getId() . "::"
-                    . $vaultConfiguration->getStorage()
+                    . $vaultConfiguration->getRootPath()
                     . "/monitoring/hosts/" . $hostId;
                 //Store vault path for SNMP Community
                 if (array_key_exists(SNMP_COMMUNITY_MACRO_NAME, $updateHostPayload)){
@@ -1826,7 +1826,7 @@ function updateHost_MC($hostId = null)
                     $httpClient
                 );
                 $hostPath = "secret::" . $vaultConfiguration->getId() . "::"
-                    . $vaultConfiguration->getStorage()
+                    . $vaultConfiguration->getRootPath()
                     . "/monitoring/hosts/" . $hostId;
                 //Store vault path for SNMP Community
                 if (array_key_exists(SNMP_COMMUNITY_MACRO_NAME, $updateHostPayload)){
@@ -3066,7 +3066,7 @@ function writeSecretsInVault(
 ): void {
     try {
         $url = $vaultConfiguration->getAddress() . ':' . $vaultConfiguration->getPort()
-            . '/v1/' . $vaultConfiguration->getStorage()
+            . '/v1/' . $vaultConfiguration->getRootPath()
             . '/monitoring/hosts/' . $hostId;
         $logger->info(
             "Writing Host Secrets at : " . $url,
@@ -3156,7 +3156,7 @@ function getHostSecretsFromVault(
     CentreonRestHttp $httpClient
 ): array {
     $url = $vaultConfiguration->getAddress() . ':' . $vaultConfiguration->getPort() . '/v1/'
-        . $vaultConfiguration->getStorage() . '/monitoring/hosts/' . $hostId;
+        . $vaultConfiguration->getRootPath() . '/monitoring/hosts/' . $hostId;
     $logger->info(sprintf("Search Host %d secrets at: %s", $hostId, $url));
     $hostSecrets = [];
     try {
@@ -3194,7 +3194,7 @@ function deleteHostFromVault(
     CentreonRestHttp $httpClient
 ): void {
     $url = $vaultConfiguration->getAddress() . ':' . $vaultConfiguration->getPort() . '/v1/'
-        . $vaultConfiguration->getStorage() . '/monitoring/hosts/' . $hostId;
+        . $vaultConfiguration->getRootPath() . '/monitoring/hosts/' . $hostId;
     $logger->info(sprintf("Deleting Host: %d", $hostId));
     try {
         $httpClient->call($url, 'DELETE', null, ['X-Vault-Token: ' . $clientToken]);

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2461,12 +2461,12 @@ CREATE TABLE IF NOT EXISTS `vault_configuration` (
   `vault_id` INT UNSIGNED NOT NULL,
   `url` VARCHAR(1024) NOT NULL,
   `port` SMALLINT UNSIGNED NOT NULL,
-  `storage` VARCHAR(50) NOT NULL,
+  `root_path` VARCHAR(50) NOT NULL,
   `role_id` VARCHAR(255) NOT NULL,
   `secret_id` VARCHAR(255) NOT NULL,
   `salt` CHAR(128) NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unique_vault_configuration` (`url`, `port`, `storage`),
+  UNIQUE KEY `unique_vault_configuration` (`url`, `port`, `root_path`),
   CONSTRAINT `vault_configuration_vault_id`
     FOREIGN KEY (`vault_id`)
     REFERENCES `vault` (`id`) ON DELETE CASCADE

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2457,11 +2457,11 @@ INSERT INTO `vault` (`name`) VALUES ('hashicorp');
 
 CREATE TABLE IF NOT EXISTS `vault_configuration` (
   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
-  `name` VARCHAR(255) NOT NULL,
+  `name` VARCHAR(50) NOT NULL,
   `vault_id` INT UNSIGNED NOT NULL,
   `url` VARCHAR(1024) NOT NULL,
   `port` SMALLINT UNSIGNED NOT NULL,
-  `storage` VARCHAR(255) NOT NULL,
+  `storage` VARCHAR(50) NOT NULL,
   `role_id` VARCHAR(255) NOT NULL,
   `secret_id` VARCHAR(255) NOT NULL,
   `salt` CHAR(128) NOT NULL,

--- a/centreon/www/install/sql/centreon/Update-DB-23.04.0-beta.1.sql
+++ b/centreon/www/install/sql/centreon/Update-DB-23.04.0-beta.1.sql
@@ -10,11 +10,11 @@ INSERT INTO `vault` (`name`) VALUES ('hashicorp');
 
 CREATE TABLE IF NOT EXISTS `vault_configuration` (
   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
-  `name` VARCHAR(255) NOT NULL,
+  `name` VARCHAR(50) NOT NULL,
   `vault_id` INT UNSIGNED NOT NULL,
   `url` VARCHAR(1024) NOT NULL,
   `port` SMALLINT UNSIGNED NOT NULL,
-  `storage` VARCHAR(255) NOT NULL,
+  `storage` VARCHAR(50) NOT NULL,
   `role_id` VARCHAR(255) NOT NULL,
   `secret_id` VARCHAR(255) NOT NULL,
   `salt` CHAR(128) NOT NULL,

--- a/centreon/www/install/sql/centreon/Update-DB-23.04.0-beta.1.sql
+++ b/centreon/www/install/sql/centreon/Update-DB-23.04.0-beta.1.sql
@@ -14,12 +14,12 @@ CREATE TABLE IF NOT EXISTS `vault_configuration` (
   `vault_id` INT UNSIGNED NOT NULL,
   `url` VARCHAR(1024) NOT NULL,
   `port` SMALLINT UNSIGNED NOT NULL,
-  `storage` VARCHAR(50) NOT NULL,
+  `root_path` VARCHAR(50) NOT NULL,
   `role_id` VARCHAR(255) NOT NULL,
   `secret_id` VARCHAR(255) NOT NULL,
   `salt` CHAR(128) NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unique_vault_configuration` (`url`, `port`, `storage`),
+  UNIQUE KEY `unique_vault_configuration` (`url`, `port`, `root_path`),
   CONSTRAINT `vault_configuration_vault_id`
     FOREIGN KEY (`vault_id`)
     REFERENCES `vault` (`id`) ON DELETE CASCADE


### PR DESCRIPTION
## Description

This PR intends to remove the possibility of updating Vault configuration and storage name

**Fixes** # MON-16974

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
