### PR TITLE
fix: reordering of eventually wrong indexed object keys

### DIFF
--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -204,6 +204,8 @@ class Broker extends AbstractObjectJSON
             $logs = $this->cacheLogValue[$object['broker_id']];
             $object['log']['loggers'] = $logs;
 
+            $reindexedObjectKeys = [];
+
             // Flow parameters
             foreach ($resultParameters as $key => $value) {
                 // We search the BlockId
@@ -307,7 +309,8 @@ class Broker extends AbstractObjectJSON
                             array_values($object[$key][$configGroupId][$subValue]);
                     }
                 }
-                $object[$key] = array_values($object[$key]);
+
+                $reindexedObjectKeys[] = $key;
             }
 
             // Stats parameters
@@ -337,6 +340,12 @@ class Broker extends AbstractObjectJSON
                 'port' => 51000 + (int) $row['config_id']
             ];
 
+            // Force as list-array eventually wrong indexed object keys (input, output)
+            foreach ($reindexedObjectKeys as $key) {
+                if (is_array($object[$key])) {
+                    $object[$key] = array_values($object[$key]);
+                }
+            }
 
             // Generate file
             $this->generateFile($object);


### PR DESCRIPTION
## Description

**Backport of 🏷️ #824** 

Jira: MON-16221

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [X] 22.04.x
- [X] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

cf. Jira ticket.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
