### PR TITLE
fix(clapi) do not encode CLAPI variables

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -805,11 +805,7 @@ class CentreonAPI
                 if (strlen(trim($string)) != 0 && !preg_match('/^\{OBJECT_TYPE\}/', $string)) {
                     $this->object = htmlspecialchars(trim($tab[0]), ENT_QUOTES, 'UTF-8');
                     $this->action = htmlspecialchars(trim($tab[1]), ENT_QUOTES, 'UTF-8');
-                    $this->variables = htmlspecialchars(
-                        trim(substr($string, strlen($tab[0] . ";" . $tab[1] . ";"))),
-                        ENT_QUOTES,
-                        'UTF-8'
-                    );
+                    $this->variables = trim(substr($string, strlen($tab[0] . ";" . $tab[1] . ";")));
                     if ($this->debug == 1) {
                         print "Object : " . $this->object . "\n";
                         print "Action : " . $this->action . "\n";


### PR DESCRIPTION
## Description

We don't have to encode CLAPI variables because they can contain characters like " & < > and we should keep them like that.
Without this fix we have these translations:
```
& ==> &amp;
" ==> &quot;
< ==> &lt;
> ==> &gt;
```
The semi-colon (;) is a variable separator so it doesn't work.

**Fixes** MON-16762

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)
