### PR TITLE
fix(UI): popup on services page

### DIFF
--- a/centreon/www/include/monitoring/status/Services/xsl/service.xsl
+++ b/centreon/www/include/monitoring/status/Services/xsl/service.xsl
@@ -298,7 +298,8 @@
                 <xsl:element name="a">
                     <xsl:attribute name="href">main.php?p=204&amp;mode=0&amp;svc_id=<xsl:value-of select="hnl"/>;<xsl:value-of select="sdl"/></xsl:attribute>
                     <xsl:element name="span">
-                        <xsl:attribute name="class">svgs</xsl:attribute>
+                        <xsl:attribute name="class">svgs graph-volant</xsl:attribute>
+                        <xsl:attribute name="id"><xsl:value-of select="hid"/>-<xsl:value-of select="svc_id"/></xsl:attribute>
                         <xsl:value-of select="chartIcon" disable-output-escaping="yes"/>
                     </xsl:element>
                 </xsl:element>


### PR DESCRIPTION
## Description

This PR fixes mouseover issue on deprecated Monitoring => Status Details => Services page

**Fixes** # (issue)
MON-1509

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (develop)

<h2> How this pull request can be tested ? </h2>

On deprecated Monitoring => Status Details => Services page hover to chart icon. A popup with graph prevision should appear.

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
