### PR TITLE
fix(packaging): add missing symfony cache clear

### DIFF
--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -628,6 +628,13 @@ systemctl try-restart httpd || :
 %endif
 systemctl try-restart php-fpm || :
 
+%posttrans web
+
+# rebuild symfony cache on upgrade
+if [ -f %{_sysconfdir}/centreon/centreon.conf.php ] ; then
+  su - apache -s /bin/bash -c "%{_datadir}/centreon/bin/console cache:clear --no-warmup"
+fi
+
 #%preun web
 #setsebool -P httpd_unified off 2>/dev/null || :
 #setsebool -P httpd_can_network_connect off 2>/dev/null || :


### PR DESCRIPTION
## Description

This PR intends to re add the symfony cache clear for 22.10.x

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
