### PR TITLE
enh (RT): Optimisation of SQL queries to reduce callbacks on the legacy service grid monitoring page

### DIFF
--- a/centreon/www/class/centreonMonitoring.class.php
+++ b/centreon/www/class/centreonMonitoring.class.php
@@ -128,53 +128,69 @@ class CentreonMonitoring
      */
     public function getServiceStatus($hostList, $objXMLBG, $o, $instance, $hostgroups)
     {
-        if ($hostList == "") {
-            return array();
+        if ($hostList === '') {
+            return [];
         }
 
-        $rq = "SELECT h.name, s.description as service_name, s.state, s.service_id, "
-            . " (case s.state when 0 then 3 when 2 then 0 when 3 then 2  when 3 then 2 else s.state END) as tri "
-            . "FROM hosts h, services s ";
+        $rq = <<<SQL
+            SELECT
+                h.name, s.description AS service_name, s.state, s.service_id,
+                (CASE s.state
+                    WHEN 0 THEN 3
+                    WHEN 2 THEN 0
+                    WHEN 3 THEN 2
+                    WHEN 3 THEN 2
+                    ELSE s.state
+                END) AS tri
+            FROM hosts h
+            INNER JOIN services s
+                ON s.host_id = h.host_id
+            SQL;
 
         if (!$objXMLBG->is_admin) {
-            $rq .= ", centreon_acl ";
+            $grouplistStr = $objXMLBG->access->getAccessGroupsString();
+            $rq .= <<<SQL
+                
+                INNER JOIN centreon_acl
+                    ON centreon_acl.host_id = h.host_id
+                    AND centreon_acl.service_id = s.service_id
+                    AND centreon_acl.group_id IN ({$grouplistStr})
+                SQL;
         }
-            $rq .= "WHERE h.host_id = s.host_id "
-                . "AND s.enabled = '1' "
-                . "AND h.enabled = '1' "
-                . "AND h.name NOT LIKE '\_Module\_%' ";
+        $rq .= <<<SQL
 
-        if ($o == "svcgrid_pb" || $o == "svcOV_pb") {
-            $rq .= "AND s.state != 0 ";
-        } elseif ($o == "svcgrid_ack_0" || $o == "svcOV_ack_0") {
-            $rq .= "AND s.acknowledged = 0 AND s.state != 0 ";
-        } elseif ($o == "svcgrid_ack_1" || $o == "svcOV_ack_1") {
-            $rq .= "AND s.acknowledged = 1 ";
+            WHERE s.enabled = '1'
+                AND h.enabled = '1'
+                AND h.name NOT LIKE '\_Module\_%'
+            SQL;
+
+        if ($o === "svcgrid_pb" || $o === "svcOV_pb") {
+            $rq .= " AND s.state != 0 ";
+        } elseif ($o === "svcgrid_ack_0" || $o === "svcOV_ack_0") {
+            $rq .= " AND s.acknowledged = 0 AND s.state != 0 ";
+        } elseif ($o === "svcgrid_ack_1" || $o === "svcOV_ack_1") {
+            $rq .= " AND s.acknowledged = 1 ";
         }
 
-        $rq .= "AND h.name IN (" . $hostList . ") ";
+        $rq .= " AND h.name IN (" . $hostList . ") ";
 
         # Instance filter
-        if ($instance != -1) {
-            $rq .=  "AND h.instance_id = " . $instance . " ";
+        if ($instance !== -1) {
+            $rq .=  " AND h.instance_id = " . $instance . " ";
         }
 
-        $grouplistStr = $objXMLBG->access->getAccessGroupsString();
-        if (!$objXMLBG->is_admin) {
-            $rq .= "AND h.host_id = centreon_acl.host_id AND s.service_id = centreon_acl.service_id "
-                . $objXMLBG->access->queryBuilder("AND", "centreon_acl.group_id", $grouplistStr)
-                . " ";
-        }
+        $rq .= " ORDER BY tri ASC, service_name";
 
-        $rq .= " order by tri asc, service_name";
-
-        $tab = array();
+        $tab = [];
         $DBRESULT = $objXMLBG->DBC->query($rq);
         while ($svc = $DBRESULT->fetchRow()) {
             if (!isset($tab[$svc["name"]])) {
-                $tab[$svc["name"]] = array();
+                $tab[$svc["name"]] = [];
             }
-            $tab[$svc["name"]][$svc["service_name"]] = $svc["state"];
+            $tab[$svc["name"]][$svc["service_name"]] = [
+                'state' => $svc["state"],
+                'service_id' => $svc['service_id']
+            ];
         }
         $DBRESULT->closeCursor();
 

--- a/centreon/www/class/centreonMonitoring.class.php
+++ b/centreon/www/class/centreonMonitoring.class.php
@@ -118,13 +118,11 @@ class CentreonMonitoring
     }
 
     /**
-     *
-     * Proxy function
-     * @param unknown_type $hostList
-     * @param unknown_type $objXMLBG
-     * @param unknown_type $o
-     * @param unknown_type $instance
-     * @param unknown_type $hostgroups
+     * @param string $hostList
+     * @param CentreonXMLBGRequest $objXMLBG
+     * @param string $o
+     * @param false|int $instance
+     * @param false|int $hostgroups
      */
     public function getServiceStatus($hostList, $objXMLBG, $o, $instance, $hostgroups)
     {
@@ -138,7 +136,6 @@ class CentreonMonitoring
                 (CASE s.state
                     WHEN 0 THEN 3
                     WHEN 2 THEN 0
-                    WHEN 3 THEN 2
                     WHEN 3 THEN 2
                     ELSE s.state
                 END) AS tri


### PR DESCRIPTION
## Description

The aim is to reduce the number of requests on the service grid monitoring page.
In a typical case, reduction:
- As admin: 40 to 10 queries
- As non admin: 89 to 25 queries

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Deactivate the broker
2. Connect to the Centreon platform and access the http://lcentreon_ip/centreon/main.php?p=20204 page (Legacy service grid Monitoring page)
3. Copy/paste the url called by Centreon to retrieve the real time services in a new browser tab (url: centreon/include/monitoring/status/Services/xml/serviceGridXML.php?....)
5. Close the Centreon main page
6. Check the number of queries in the database: `show status like 'Queries';``
7. Refresh the tab where the serviceGridXML.php url is located.
8. Check the number of queries in the database again: show status like 'Queries'.

Do the subtraction.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
