### PR TITLE
fix(ci): missing delivery of web to el9

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -419,7 +419,7 @@ jobs:
     if: ${{ !cancelled() && contains(fromJson('["stable", "testing", "unstable"]'), needs.get-version.outputs.stability) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
     strategy:
       matrix:
-        distrib: [el7, el8]
+        distrib: [el7, el8, el9]
 
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Description

missing delivery of web to el9

**Fixes** MON-16456

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)