### PR TITLE
fix(openTicket): missing centreon_path when using smarty function in ticket body

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/centreon-open-tickets.conf.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/centreon-open-tickets.conf.php
@@ -19,7 +19,11 @@
  * limitations under the License.
  */
 
-require_once realpath(__DIR__ . '/../../../bootstrap.php');
+require_once dirname(__DIR__, 3) . '/bootstrap.php';
+
+if (empty($centreon_path)) {
+    $centreon_path = dirname(__DIR__, 3) . '/';
+}
 
 require_once $centreon_path . 'www/modules/centreon-open-tickets/class/request.php';
 require_once $centreon_path . 'www/modules/centreon-open-tickets/class/rule.php';


### PR DESCRIPTION
## Description

when you want to use the automatic ticketing feature of open tickets, if you are using a smarty function such as {host_get_macro_value_in_config} then it will fails with an error 500. 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

first of all you need to have a working open ticket rule (on my side i'm using a glpi server for my tests). By working, I mean that you must be able to open tickets from the web interface. 

then you need to be able to open a ticket using the webservice. On my side, i've simplified my glpi rule in order to have an easy command line. And by simplified, I mean that I have removed everything but the entity part
![image](https://user-images.githubusercontent.com/7352865/216645010-f7dbd634-e359-4309-859f-5b0036541355.png)

this leads me to a command line such as this one (you need to clone the centreon-plugins repository first)

```bash
/tmp/centreon-plugins/src/centreon_plugins.pl --plugin=notification::centreon::opentickets::api::plugin --mode=open-service --service-id=7 --host-name='test-host' --service-description='test-service' --host-id=9 --select='glpi_entity=1' --rule-name=glpi --service-output='marche po' --api-username=admin --api-password=centreon --service-state='CRITICAL' --api-hostname=127.0.0.1
```

when your command line works, you are ready to test the bug. 

to do so, add a custom macro called DATACENTER on the host that is linked to the service on which you want to open a ticket.
then, in your rule configuration add the following line in the `{if $service_selected` part `DATACENTER: {host_get_macro_value_in_config host_id=$service.host_id macro_name='DATACENTER'}{$host_get_macro_value_in_config_result}`

with my glpi rule, it gives me the following body: 

```smarty

{$user.alias} open ticket at {$smarty.now|date_format:"%d/%m/%y %H:%M:%S"}

{$custom_message}

{include file="file:$centreon_open_tickets_path/providers/Abstract/templates/display_selected_lists.ihtml" separator=""}

{if $host_selected|@count gt 0}
{foreach from=$host_selected item=host}
Host: {$host.name}
State: {$host.state_str}
Duration: {$host.last_hard_state_change_duration}
Output: {$host.output|substr:0:1024}

{/foreach}
{/if}

{if $service_selected|@count gt 0}
{foreach from=$service_selected item=service}
Host: {$service.host_name}
Service: {$service.description}
State: {$service.state_str}
Duration: {$service.last_hard_state_change_duration}
Output: {$service.output|substr:0:1024}
DATACENTER: {host_get_macro_value_in_config host_id=$service.host_id macro_name='DATACENTER'}{$host_get_macro_value_in_config_result}
{/foreach}
{/if}
```

when done, you should be able to open a ticket from the web interface but not from the command line anymore.


apply the patch and it should work from the command line and the web interface. 

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
