### PR TITLE
Fix(security): Sanitizing queries in serviceDetails.php  (dev-22.10.x)

### DIFF
--- a/centreon/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -109,7 +109,7 @@ if (
 }
 
 // Check if host is found
-$host_id = getMyHostID($host_name);
+$host_id = (int) getMyHostID($host_name);
 
 if (!is_null($host_id)) {
     $can_display = 1;
@@ -139,19 +139,19 @@ if (!is_null($host_id)) {
     } else {
         // Get Hostgroup List
 
-        $DBRESULT = $pearDB->query(
-            "SELECT DISTINCT hostgroup_hg_id FROM hostgroup_relation " .
-            "WHERE host_host_id = '" . $host_id . "' " .
+        $hgrStatement = $pearDB->prepare("SELECT DISTINCT hostgroup_hg_id FROM hostgroup_relation " .
+            "WHERE host_host_id = :hostId " .
             $centreon->user->access->queryBuilder(
                 "AND",
                 "host_host_id",
                 $centreon->user->access->getHostsString("ID", $pearDBO)
-            )
-        );
-        for ($i = 0; $hg = $DBRESULT->fetchRow(); $i++) {
+            ));
+        $hgrStatement->bindValue(":hostId", (int) $host_id, \PDO::PARAM_INT);
+        $hgrStatement->execute();
+
+        for ($i = 0; $hg = $hgrStatement->fetch(\PDO::FETCH_ASSOC); $i++) {
             $hostGroups[] = getMyHostGroupName($hg["hostgroup_hg_id"]);
         }
-        $DBRESULT->closeCursor();
 
         if (isset($service_id) && $service_id) {
             $proc_warning = getMyServiceMacro($service_id, "PROC_WARNING");
@@ -164,19 +164,20 @@ if (!is_null($host_id)) {
         $contactGroups = $retrievedNotificationsInfos['contactGroups'];
         // Get servicegroups list
         if (isset($service_id) && isset($host_id)) {
-            $query = "SELECT DISTINCT sg.sg_name FROM servicegroup sg, servicegroup_relation sgr " .
-                "WHERE sgr.servicegroup_sg_id = sg.sg_id AND sgr.host_host_id = " . $host_id .
-                " AND sgr.service_service_id = " . $service_id . " " .
+            $sgStatement = $pearDB->prepare("SELECT DISTINCT sg.sg_name FROM servicegroup sg, servicegroup_relation sgr " .
+                "WHERE sgr.servicegroup_sg_id = sg.sg_id AND sgr.host_host_id = :hostId " .
+                " AND sgr.service_service_id = :serviceId " .
                 $centreon->user->access->queryBuilder(
                     "AND",
                     "sgr.host_host_id",
                     $centreon->user->access->getHostsString("ID", $pearDBO)
-                );
-            $DBRESULT = $pearDB->query($query);
-            while ($row = $DBRESULT->fetchRow()) {
+                ));
+            $sgStatement->bindValue(":hostId", (int) $host_id, \PDO::PARAM_INT);
+            $sgStatement->bindValue(":serviceId", (int) $service_id, \PDO::PARAM_INT);
+            $sgStatement->execute();
+            while ($row = $sgStatement->fetch(\PDO::FETCH_ASSOC)) {
                 $serviceGroups[] = $row['sg_name'];
             }
-            $DBRESULT->closeCursor();
         }
 
         // Get service category
@@ -232,13 +233,15 @@ if (!is_null($host_id)) {
             " i.name as instance_name " .
             " FROM services s, hosts h, instances i " .
             " WHERE h.host_id = s.host_id " .
-            " AND h.host_id LIKE '" . $pearDB->escape($host_id) . "'" .
-            " AND s.service_id LIKE '" . $pearDB->escape($service_id) . "'" .
-            " AND h.instance_id = i.instance_id " .
+            " AND h.host_id LIKE :hostId " .
+            " AND s.service_id LIKE :serviceId " .
+            " AND h.instance_id = i.instance_id" .
             " AND h.enabled = 1 " .
             " AND s.enabled = 1 ";
-        $DBRESULT = $pearDBO->query($rq);
-
+        $shiStatement = $pearDBO->prepare($rq);
+        $shiStatement->bindValue(":hostId", (int) $host_id, \PDO::PARAM_INT);
+        $shiStatement->bindValue(":serviceId", (int) $service_id, \PDO::PARAM_INT);
+        $shiStatement->execute();
         $tab_status_service = array(0 => "OK", 1 => "WARNING", 2 => "CRITICAL", "3" => "UNKNOWN", "4" => "PENDING");
         $tab_class_service = array(
             "ok" => 'service_ok',
@@ -297,7 +300,7 @@ if (!is_null($host_id)) {
             "duration" => ""
         ];
 
-        while ($data = $DBRESULT->fetchRow()) {
+        while ($data = $shiStatement->fetch(\PDO::FETCH_ASSOC)) {
             if (isset($data['performance_data'])) {
                 $data['performance_data'] = $data['performance_data'];
             }
@@ -309,7 +312,6 @@ if (!is_null($host_id)) {
             }
             $tab_status[$tab_status_service[$data["current_state"]]]++;
         }
-        $DBRESULT->closeCursor();
 
         if ($is_admin || isset($authorized_actions['service_display_command'])) {
             $commandLine = '';
@@ -345,9 +347,11 @@ if (!is_null($host_id)) {
         }
 
         // Get Host informations
-        $DBRESULT = $pearDB->query("SELECT * FROM host WHERE host_id = " . $pearDB->escape($host_id));
-        $host = $DBRESULT->fetchrow();
-        $DBRESULT->closeCursor();
+        $hStatement = $pearDB->prepare("SELECT * FROM host WHERE host_id = :hostId");
+        $hStatement->bindValue(":hostId", (int)$host_id, \PDO::PARAM_INT);
+        $hStatement->execute();
+        $host = $hStatement->fetch(\PDO::FETCH_ASSOC);
+
 
         if ($isMetaservice == 'true') {
             $metaParameters = $metaObj->getParameters($meta_id, array('max_check_attempts'));
@@ -970,7 +974,7 @@ if (!is_null($host_id)) {
         );
 
         function display_deprecated_banner() {
-            const url = "<?php echo $redirectionUrl; ?>";
+            const url = "<?php echo htmlspecialchars($redirectionUrl); ?>";
             const message = "<?php echo $deprecationMessage; ?>";
             const label = "<?php echo $resourcesStatusLabel; ?>";
             jQuery('.pathway').append(

--- a/centreon/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -109,7 +109,7 @@ if (
 }
 
 // Check if host is found
-$host_id = (int) getMyHostID($host_name);
+$host_id = getMyHostID($host_name);
 
 if (!is_null($host_id)) {
     $can_display = 1;


### PR DESCRIPTION
## Description

Fixed SQLi and XXS on legacy service details page

**Fixes** # MON-16601

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

See jira ticket

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
