### PR TITLE
enh (RT): Optimisation of SQL queries to reduce callbacks on the legacy service grid monitoring page

### DIFF
--- a/centreon/package-lock.json
+++ b/centreon/package-lock.json
@@ -40840,7 +40840,7 @@
     },
     "packages/ui": {
       "name": "@centreon/ui",
-      "version": "22.10.10",
+      "version": "22.10.11-MON-16851-22.10.x.0",
       "license": "GPL-2.0",
       "dependencies": {
         "@centreon/ui-context": "file:../ui-context",

--- a/centreon/packages/ui/package.json
+++ b/centreon/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centreon/ui",
-  "version": "22.10.10",
+  "version": "22.10.11-MON-16851-22.10.x.0",
   "description": "Centreon UI Components",
   "main": "src",
   "scripts": {

--- a/centreon/packages/ui/src/Listing/Row.tsx
+++ b/centreon/packages/ui/src/Listing/Row.tsx
@@ -153,16 +153,21 @@ const Row = memo<RowProps>(
       return false;
     }
 
-    if (not(nextIsInViewport) && lt(nextLimit, 60)) {
-      return equals(prevProps.isSelected, nextProps.isSelected);
-    }
-
     const previousRowColors = previousRowColorConditions?.map(({ condition }) =>
       condition(previousRow),
     );
     const nextRowColors = nextRowColorConditions?.map(({ condition }) =>
       condition(nextRow),
     );
+
+    if (not(nextIsInViewport) && lt(nextLimit, 60)) {
+      return (
+        equals(prevProps.isSelected, nextProps.isSelected) &&
+        equals(prevProps.row, nextProps.row) &&
+        equals(previousRowColors, nextRowColors) &&
+        equals(prevProps.className, nextProps.className)
+      );
+    }
 
     return (
       equals(prevProps.isSelected, nextProps.isSelected) &&


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/850

The aim is to reduce the number of requests on the service grid monitoring page.
In a typical case, reduction:
- As admin: 40 to 10 queries
- As non admin: 89 to 25 queries

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Deactivate the broker
2. Connect to the Centreon platform and access the http://lcentreon_ip/centreon/main.php?p=20204 page (Legacy service grid Monitoring page)
3. Copy/paste the url called by Centreon to retrieve the real time services in a new browser tab (url: centreon/include/monitoring/status/Services/xml/serviceGridXML.php?....)
5. Close the Centreon main page
6. Check the number of queries in the database: `show status like 'Queries';``
7. Refresh the tab where the serviceGridXML.php url is located.
8. Check the number of queries in the database again: show status like 'Queries'.

Do the subtraction.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
