### PR TITLE
enh(API) change comments for comment in HostCategory and HostSeverity APIs

### DIFF
--- a/centreon/doc/API/centreon-api-v23.04.yaml
+++ b/centreon/doc/API/centreon-api-v23.04.yaml
@@ -5921,10 +5921,10 @@ components:
           type: boolean
           description: is active or not (enable/disable)
           example: true
-        comments:
+        comment:
           type: string
           nullable: true
-          description: "some comments"
+          description: "some comment"
     Configuration.Service.Category:
       type: object
       properties:
@@ -5959,10 +5959,10 @@ components:
           type: boolean
           description: is active or not (enable/disable)
           example: true
-        comments:
+        comment:
           type: string
           nullable: true
-          description: "some comments"
+          description: "some comment"
     Configuration.Service.Category.Add:
       type: object
       properties:
@@ -6001,9 +6001,9 @@ components:
           type: integer
           description: "Define the image ID associated with this severity"
           example: 1
-        comments:
+        comment:
           type: string
-          description: "Host severity comments"
+          description: "Host severity comment"
           nullable: true
         is_activated:
           type: boolean

--- a/centreon/src/Core/HostCategory/Infrastructure/API/AddHostCategory/AddHostCategoryController.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/API/AddHostCategory/AddHostCategoryController.php
@@ -51,7 +51,7 @@ final class AddHostCategoryController extends AbstractController
         $this->denyAccessUnlessGrantedForApiConfiguration();
 
         try {
-            /** @var array{name:string,alias:string,is_activated?:bool,comments?:string|null} $data */
+            /** @var array{name:string,alias:string,is_activated?:bool,comment?:string|null} $data */
             $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/AddHostCategorySchema.json');
 
             $hostCategoryRequest = $this->createRequestDto($data);
@@ -70,7 +70,7 @@ final class AddHostCategoryController extends AbstractController
     }
 
     /**
-     * @param array{name:string,alias:string,is_activated?:bool,comments:string|null} $data
+     * @param array{name:string,alias:string,is_activated?:bool,comment:string|null} $data
      *
      * @return AddHostCategoryRequest
      */
@@ -80,7 +80,7 @@ final class AddHostCategoryController extends AbstractController
         $hostCategoryRequest->name = $data['name'];
         $hostCategoryRequest->alias = $data['alias'];
         $hostCategoryRequest->isActivated = $data['is_activated'] ?? true;
-        $hostCategoryRequest->comment = $data['comments'] ?? null;
+        $hostCategoryRequest->comment = $data['comment'] ?? null;
 
         return $hostCategoryRequest;
     }

--- a/centreon/src/Core/HostCategory/Infrastructure/API/AddHostCategory/AddHostCategoryPresenter.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/API/AddHostCategory/AddHostCategoryPresenter.php
@@ -57,7 +57,7 @@ class AddHostCategoryPresenter extends AbstractPresenter
                 'name' => $payload->name,
                 'alias' => $payload->alias,
                 'is_activated' => $payload->isActivated,
-                'comments' => $payload->comment,
+                'comment' => $payload->comment,
             ]);
 
             // NOT setting location as required route does not currently exist

--- a/centreon/src/Core/HostCategory/Infrastructure/API/AddHostCategory/AddHostCategorySchema.json
+++ b/centreon/src/Core/HostCategory/Infrastructure/API/AddHostCategory/AddHostCategorySchema.json
@@ -17,7 +17,7 @@
         "is_activated": {
             "type": "boolean"
         },
-        "comments": {
+        "comment": {
             "type": ["string","null"]
         }
     }

--- a/centreon/src/Core/HostCategory/Infrastructure/API/FindHostCategories/FindHostCategoriesPresenter.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/API/FindHostCategories/FindHostCategoriesPresenter.php
@@ -53,7 +53,7 @@ class FindHostCategoriesPresenter extends AbstractPresenter
                 'name' => $hostCategory['name'],
                 'alias' => $hostCategory['alias'],
                 'is_activated' => $hostCategory['is_activated'],
-                'comments' => $hostCategory['comment'],
+                'comment' => $hostCategory['comment'],
             ];
         }
 

--- a/centreon/src/Core/HostSeverity/Infrastructure/API/AddHostSeverity/AddHostSeverityController.php
+++ b/centreon/src/Core/HostSeverity/Infrastructure/API/AddHostSeverity/AddHostSeverityController.php
@@ -59,7 +59,7 @@ final class AddHostSeverityController extends AbstractController
              *     level: int,
              *     icon_id: positive-int,
              *     is_activated?: bool,
-             *     comments?: string|null
+             *     comment?: string|null
              * } $data
              */
             $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/AddHostSeveritySchema.json');
@@ -83,7 +83,7 @@ final class AddHostSeverityController extends AbstractController
      *     level: int,
      *     icon_id: positive-int,
      *     is_activated?: bool,
-     *     comments?: string|null
+     *     comment?: string|null
      * } $data
      *
      * @return AddHostSeverityRequest
@@ -96,7 +96,7 @@ final class AddHostSeverityController extends AbstractController
         $hostSeverityRequest->level = $data['level'];
         $hostSeverityRequest->iconId = $data['icon_id'];
         $hostSeverityRequest->isActivated = $data['is_activated'] ?? true;
-        $hostSeverityRequest->comment = $data['comments'] ?? null;
+        $hostSeverityRequest->comment = $data['comment'] ?? null;
 
         return $hostSeverityRequest;
     }

--- a/centreon/src/Core/HostSeverity/Infrastructure/API/AddHostSeverity/AddHostSeverityPresenter.php
+++ b/centreon/src/Core/HostSeverity/Infrastructure/API/AddHostSeverity/AddHostSeverityPresenter.php
@@ -59,7 +59,7 @@ class AddHostSeverityPresenter extends AbstractPresenter
                 'level' => $payload->level,
                 'icon_id' => $payload->iconId,
                 'is_activated' => $payload->isActivated,
-                'comments' => $payload->comment,
+                'comment' => $payload->comment,
             ]);
 
             // NOT setting location as required route does not currently exist

--- a/centreon/src/Core/HostSeverity/Infrastructure/API/AddHostSeverity/AddHostSeveritySchema.json
+++ b/centreon/src/Core/HostSeverity/Infrastructure/API/AddHostSeverity/AddHostSeveritySchema.json
@@ -25,7 +25,7 @@
         "is_activated": {
             "type": "boolean"
         },
-        "comments": {
+        "comment": {
             "type": ["string","null"]
         }
     }

--- a/centreon/src/Core/HostSeverity/Infrastructure/API/FindHostSeverities/FindHostSeveritiesPresenter.php
+++ b/centreon/src/Core/HostSeverity/Infrastructure/API/FindHostSeverities/FindHostSeveritiesPresenter.php
@@ -56,7 +56,7 @@ class FindHostSeveritiesPresenter extends AbstractPresenter
                 'level' => $hostSeverity['level'],
                 'icon_id' => $hostSeverity['iconId'],
                 'is_activated' => $hostSeverity['isActivated'],
-                'comments' => $hostSeverity['comment'],
+                'comment' => $hostSeverity['comment'],
             ];
         }
 

--- a/centreon/tests/api/features/HostCategory.feature
+++ b/centreon/tests/api/features/HostCategory.feature
@@ -25,7 +25,7 @@ Feature:
                 "name": "host-cat1",
                 "alias": "host-cat1-alias",
                 "is_activated": true,
-                "comments": null
+                "comment": null
             }
         ],
         "meta": {
@@ -67,7 +67,7 @@ Feature:
                 "name": "host-cat2",
                 "alias": "host-cat2-alias",
                 "is_activated": true,
-                "comments": null
+                "comment": null
             }
         ],
         "meta": {
@@ -108,14 +108,14 @@ Feature:
                 "name": "host-cat1",
                 "alias": "host-cat1-alias",
                 "is_activated": true,
-                "comments": null
+                "comment": null
             },
             {
                 "id": 2,
                 "name": "host-cat2",
                 "alias": "host-cat2-alias",
                 "is_activated": true,
-                "comments": null
+                "comment": null
             }
         ],
         "meta": {
@@ -228,7 +228,7 @@ Feature:
     {
         "name": "  host-cat-name  ",
         "alias": "  host-cat-alias  ",
-        "comments": "blablabla"
+        "comment": "blablabla"
     }
     """
     Then the response code should be "201"
@@ -239,7 +239,7 @@ Feature:
         "name": "host-cat-name",
         "alias": "host-cat-alias",
         "is_activated": true,
-        "comments": "blablabla"
+        "comment": "blablabla"
     }
     """
     When I send a POST request to '/api/latest/configuration/hosts/categories' with body:
@@ -247,7 +247,7 @@ Feature:
     {
         "name": "host-cat-name",
         "alias": "host-cat-alias",
-        "comments": "blablabla"
+        "comment": "blablabla"
     }
     """
     Then the response code should be "409"

--- a/centreon/tests/api/features/HostSeverity.feature
+++ b/centreon/tests/api/features/HostSeverity.feature
@@ -30,7 +30,7 @@ Feature:
                 "level": 42,
                 "icon_id": 1,
                 "is_activated": true,
-                "comments": "blabla bla"
+                "comment": "blabla bla"
             }
         ],
         "meta": {
@@ -76,7 +76,7 @@ Feature:
                 "level": 2,
                 "icon_id": 1,
                 "is_activated": true,
-                "comments": null
+                "comment": null
             }
         ],
         "meta": {
@@ -121,7 +121,7 @@ Feature:
                 "level": 1,
                 "icon_id": 1,
                 "is_activated": true,
-                "comments": null
+                "comment": null
             },
             {
                 "id": 2,
@@ -130,7 +130,7 @@ Feature:
                 "level": 2,
                 "icon_id": 1,
                 "is_activated": true,
-                "comments": null
+                "comment": null
             }
         ],
         "meta": {
@@ -247,7 +247,7 @@ Feature:
         "alias": "  host-sev-alias  ",
         "level": 2,
         "icon_id": 1,
-        "comments": "blablabla"
+        "comment": "blablabla"
     }
     """
     Then the response code should be "201"
@@ -260,7 +260,7 @@ Feature:
         "level": 2,
         "icon_id": 1,
         "is_activated": true,
-        "comments": "blablabla"
+        "comment": "blablabla"
     }
     """
 
@@ -273,7 +273,7 @@ Feature:
         "level": 2,
         "icon_id": 1,
         "is_activated": true,
-        "comments": "blablabla"
+        "comment": "blablabla"
     }
     """
     Then the response code should be "409"
@@ -287,7 +287,7 @@ Feature:
         "level": 2,
         "icon_id": 1,
         "is_activated": true,
-        "comments": "blablabla"
+        "comment": "blablabla"
     }
     """
     Then the response code should be "409"


### PR DESCRIPTION
## Description

Some of the new API endpoints have `comment` field and some others have `comments`
To unify them, all bodies and responses are now changed to receive/return `comment` singular only 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
