### PR TITLE
fix(clapi): remove string encoding (dev-22.04.x)

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -716,7 +716,7 @@ class CentreonAPI
      */
     public function launchAction($exit = true)
     {
-        $action = htmlspecialchars(strtoupper($this->action), ENT_QUOTES, 'UTF-8');
+        $action = strtoupper($this->action);
 
         /**
          * Debug
@@ -803,13 +803,9 @@ class CentreonAPI
                 $i++;
                 $tab = preg_split('/;/', $string);
                 if (strlen(trim($string)) != 0 && !preg_match('/^\{OBJECT_TYPE\}/', $string)) {
-                    $this->object = htmlspecialchars(trim($tab[0]), ENT_QUOTES, 'UTF-8');
-                    $this->action = htmlspecialchars(trim($tab[1]), ENT_QUOTES, 'UTF-8');
-                    $this->variables = htmlspecialchars(
-                        trim(substr($string, strlen($tab[0] . ";" . $tab[1] . ";"))),
-                        ENT_QUOTES,
-                        'UTF-8'
-                    );
+                    $this->object = trim($tab[0]);
+                    $this->action = trim($tab[1]);
+                    $this->variables = trim(substr($string, strlen($tab[0] . ";" . $tab[1] . ";")));
                     if ($this->debug == 1) {
                         print "Object : " . $this->object . "\n";
                         print "Action : " . $this->action . "\n";
@@ -834,7 +830,7 @@ class CentreonAPI
 
     public function launchActionForImport()
     {
-        $action = htmlspecialchars(strtoupper($this->action), ENT_QUOTES, 'UTF-8');
+        $action = strtoupper($this->action);
         /**
          * Debug
          */


### PR DESCRIPTION
## Description

We don't have to encode CLAPI variables because they can contain characters like " & < > and we should keep them like that.
**Fixes** # MON-15378

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)
 


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
