### PR TITLE
fix(upgrade): Fix Upgrade 22.04.0-beta.1 MySQL8 Compatibility

### DIFF
--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2358,7 +2358,6 @@ CREATE TABLE `security_token` (
   `creation_date` bigint UNSIGNED NOT NULL,
   `expiration_date` bigint UNSIGNED DEFAULT NULL,
   PRIMARY KEY (`id`),
-  INDEX `token_index` (`token`),
   INDEX `expiration_index` (`expiration_date`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 

--- a/centreon/www/install/php/Update-22.04.0-beta.1.php
+++ b/centreon/www/install/php/Update-22.04.0-beta.1.php
@@ -428,12 +428,11 @@ function addNewUnifiedSqlOutput(CentreonDB $pearDB): void
     // Add form fields for 'unified_sql' output
     $inputs = [];
     $statement = $pearDB->query(
-        "SELECT DISTINCT(tfr.cb_field_id), tfr.order_display tfr.is_required FROM cb_type_field_relation tfr, cb_type t, cb_field f
+        "SELECT DISTINCT(tfr.cb_field_id), tfr.is_required FROM cb_type_field_relation tfr, cb_type t, cb_field f
         WHERE tfr.cb_type_id = t.cb_type_id
         AND t.type_shortname in ('sql', 'storage')
         AND tfr.cb_field_id = f.cb_field_id
-        AND f.fieldname NOT LIKE 'db_type'
-        ORDER BY tfr.order_display"
+        AND f.fieldname NOT LIKE 'db_type'"
     );
     $inputs = $statement->fetchAll();
     if (empty($inputs)) {

--- a/centreon/www/install/php/Update-22.04.0-beta.1.php
+++ b/centreon/www/install/php/Update-22.04.0-beta.1.php
@@ -103,7 +103,7 @@ try {
         $pearDB->query(
             <<<'SQL'
             DROP INDEX token_index
-                ON security_token;
+                ON security_token
             SQL
         );
     }
@@ -165,7 +165,7 @@ try {
         WHERE type_shortname = 'sql'"
     );
 
-    $errorMessage = "Unable to add 'unifed_sql' broker configuration output";
+    $errorMessage = "Unable to add 'unified_sql' broker configuration output";
     addNewUnifiedSqlOutput($pearDB);
     $errorMessage = "Unable to migrate broker config to unified_sql";
     migrateBrokerConfigOutputsToUnifiedSql($pearDB);
@@ -428,7 +428,7 @@ function addNewUnifiedSqlOutput(CentreonDB $pearDB): void
     // Add form fields for 'unified_sql' output
     $inputs = [];
     $statement = $pearDB->query(
-        "SELECT DISTINCT(tfr.cb_field_id), tfr.is_required FROM cb_type_field_relation tfr, cb_type t, cb_field f
+        "SELECT DISTINCT(tfr.cb_field_id), tfr.order_display tfr.is_required FROM cb_type_field_relation tfr, cb_type t, cb_field f
         WHERE tfr.cb_type_id = t.cb_type_id
         AND t.type_shortname in ('sql', 'storage')
         AND tfr.cb_field_id = f.cb_field_id

--- a/centreon/www/install/php/Update-22.04.0-beta.1.php
+++ b/centreon/www/install/php/Update-22.04.0-beta.1.php
@@ -99,9 +99,17 @@ try {
         SQL
     );
     if ($tokenIndexKeyExistsStatement->fetch() !== false) {
-        $errorMessage = "Unable to alter table security_token";
-        $pearDB->query("ALTER TABLE `security_token` MODIFY `token` varchar(4096)");
+        $errorMessage = "Unable to remove key token_index from security_token";
+        $pearDB->query(
+            <<<'SQL'
+            DROP INDEX token_index
+                ON security_token;
+            SQL
+        );
     }
+
+    $errorMessage = "Unable to alter table security_token";
+    $pearDB->query("ALTER TABLE `security_token` MODIFY `token` varchar(4096)");
 
     if ($pearDB->isColumnExist('provider_configuration', 'custom_configuration') !== 1) {
         // Add custom_configuration to provider configurations

--- a/centreon/www/install/php/Update-22.04.0-beta.1.php
+++ b/centreon/www/install/php/Update-22.04.0-beta.1.php
@@ -90,8 +90,18 @@ try {
         $pearDB->query("ALTER TABLE `security_token` DROP INDEX `unique_token`");
     }
 
-    $errorMessage = "Unable to alter table security_token";
-    $pearDB->query("ALTER TABLE `security_token` MODIFY `token` varchar(4096)");
+    $errorMessage = "Unable to find key token_index from security_token";
+    $tokenIndexKeyExistsStatement = $pearDB->query(
+        <<<'SQL'
+        SHOW indexes
+            FROM security_token
+            WHERE Key_name='token_index'
+        SQL
+    );
+    if ($tokenIndexKeyExistsStatement->fetch() !== false) {
+        $errorMessage = "Unable to alter table security_token";
+        $pearDB->query("ALTER TABLE `security_token` MODIFY `token` varchar(4096)");
+    }
 
     if ($pearDB->isColumnExist('provider_configuration', 'custom_configuration') !== 1) {
         // Add custom_configuration to provider configurations


### PR DESCRIPTION
## Description

This PR Intends to fix(upgrade): Fix Upgrade 22.04.0-beta.1 MySQL8 Compatibility

Upgrade was broken due to a default bytes length set by MySQL for token_index. this default length is too short for the varchar(4096) set later in the upgrade. This index is not useful it is remove.

Also, the SELECT DISTINCT request is not valid with MySQL as the order by should be select. the order by is not relevant so it has been also removed.

**Fixes** # MON-16673

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Upgrade form 21.10 to >= 22.04.x with MySQL 8 compatibility

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
