### PR TITLE
fix: assertion messages and tests

### DIFF
--- a/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
+++ b/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,16 +18,13 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
 namespace Centreon\Domain\Common\Assertion;
 
-use Assert\Assertion as Assert;
-
 /**
  * This class is designed to allow the translation of error messages and provide them with a unique format.
- *
- * @package Centreon\Domain\Common\Assertion
  */
 class Assertion
 {
@@ -37,28 +34,15 @@ class Assertion
      * @param string $value Value to test
      * @param int $maxLength Maximum length of the expected value in characters
      * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
      * @throws \Assert\AssertionFailedException
      */
-    public static function maxLength(string $value, int $maxLength, string $propertyPath = null): void
+    public static function maxLength(string $value, int $maxLength, ?string $propertyPath = null): void
     {
-        Assert::maxLength(
-            $value,
-            $maxLength,
-            function (array $parameters) {
-                return AssertionException::maxLength(
-                    $parameters['value'],
-                    self::calculateStringLengthOrFails(
-                        $parameters['value'],
-                        $parameters['encoding'],
-                        $parameters['propertyPath']
-                    ),
-                    $parameters['maxLength'],
-                    $parameters['propertyPath']
-                )->getMessage();
-            },
-            $propertyPath,
-            'UTF-8'
-        );
+        $length = \mb_strlen($value, 'utf8');
+        if ($length > $maxLength) {
+            throw AssertionException::maxLength($value, $length, $maxLength, $propertyPath);
+        }
     }
 
     /**
@@ -67,34 +51,21 @@ class Assertion
      * @param string $value Value to test
      * @param int $minLength Minimum length of the expected value in characters
      * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
      * @throws \Assert\AssertionFailedException
      */
-    public static function minLength(string $value, int $minLength, string $propertyPath = null): void
+    public static function minLength(string $value, int $minLength, ?string $propertyPath = null): void
     {
-        Assert::minLength(
-            $value,
-            $minLength,
-            function (array $parameters) {
-                return AssertionException::minLength(
-                    $parameters['value'],
-                    self::calculateStringLengthOrFails(
-                        $parameters['value'],
-                        $parameters['encoding'],
-                        $parameters['propertyPath']
-                    ),
-                    $parameters['minLength'],
-                    $parameters['propertyPath']
-                )->getMessage();
-            },
-            $propertyPath,
-            'UTF-8'
-        );
+        $length = \mb_strlen($value, 'utf8');
+        if ($length < $minLength) {
+            throw AssertionException::minLength($value, $length, $minLength, $propertyPath);
+        }
     }
 
     /**
      * Assert that a value is at least an integer > 0.
      *
-     * @param positive-int $value Value to test
+     * @param int $value Value to test
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
      *
      * @throws \Assert\AssertionFailedException
@@ -107,25 +78,19 @@ class Assertion
     /**
      * Assert that a value is at least as big as a given limit.
      *
+     * Same as {@see self::greaterOrEqualThan()} but with a different message.
+     *
      * @param int $value Value to test
      * @param int $minValue Minimum value
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     *
      * @throws \Assert\AssertionFailedException
      */
-    public static function min(int $value, int $minValue, string $propertyPath = null): void
+    public static function min(int $value, int $minValue, ?string $propertyPath = null): void
     {
-        Assert::min(
-            $value,
-            $minValue,
-            function (array $parameters) {
-                return AssertionException::min(
-                    $parameters['value'],
-                    $parameters['minValue'],
-                    $parameters['propertyPath']
-                )->getMessage();
-            },
-            $propertyPath
-        );
+        if ($value < $minValue) {
+            throw AssertionException::min($value, $minValue, $propertyPath);
+        }
     }
 
     /**
@@ -134,22 +99,14 @@ class Assertion
      * @param int $value Value to test
      * @param int $maxValue Maximum value
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     *
      * @throws \Assert\AssertionFailedException
      */
-    public static function max(int $value, int $maxValue, string $propertyPath = null): void
+    public static function max(int $value, int $maxValue, ?string $propertyPath = null): void
     {
-        Assert::max(
-            $value,
-            $maxValue,
-            function (array $parameters) {
-                return AssertionException::max(
-                    $parameters['value'],
-                    $parameters['maxValue'],
-                    $parameters['propertyPath']
-                )->getMessage();
-            },
-            $propertyPath
-        );
+        if ($value > $maxValue) {
+            throw AssertionException::max($value, $maxValue, $propertyPath);
+        }
     }
 
     /**
@@ -157,32 +114,30 @@ class Assertion
      *
      * @param string $value Value to test
      * @param string|null $propertyPath Property's path (ex: User::email)
+     *
      * @throws \Assert\AssertionFailedException
      */
-    public static function email(string $value, string $propertyPath = null): void
+    public static function email(string $value, ?string $propertyPath = null): void
     {
-        Assert::email(
-            $value,
-            function (array $parameters) {
-                return AssertionException::email(
-                    $parameters['value'],
-                    $parameters['propertyPath']
-                )->getMessage();
-            },
-            $propertyPath
-        );
+        if (! \filter_var($value, FILTER_VALIDATE_EMAIL)) {
+            throw AssertionException::email($value, $propertyPath);
+        }
     }
 
     /**
      * Assert that a date is smaller as a given limit.
      *
-     * @param \DateTime $value
-     * @param \DateTime $maxDate
+     * @param \DateTimeInterface $value
+     * @param \DateTimeInterface $maxDate
      * @param string|null $propertyPath
-     * @throws AssertionException
+     *
+     * @throws \Assert\AssertionFailedException
      */
-    public static function maxDate(\DateTime $value, \DateTime $maxDate, string $propertyPath = null): void
-    {
+    public static function maxDate(
+        \DateTimeInterface $value,
+        \DateTimeInterface $maxDate,
+        ?string $propertyPath = null
+    ): void {
         if ($value->getTimestamp() > $maxDate->getTimestamp()) {
             throw AssertionException::maxDate($value, $maxDate, $propertyPath);
         }
@@ -191,43 +146,55 @@ class Assertion
     /**
      * Determines if the value is greater or equal than given limit.
      *
+     * Same as {@see self::min()} but with a different message.
+     *
      * @param int $value Value to test
      * @param int $limit Limit value (>=)
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     *
      * @throws \Assert\AssertionFailedException
      */
-    public static function greaterOrEqualThan(int $value, int $limit, string $propertyPath = null): void
+    public static function greaterOrEqualThan(int $value, int $limit, ?string $propertyPath = null): void
     {
-        Assert::greaterOrEqualThan(
-            $value,
-            $limit,
-            function (array $parameters) {
-                return AssertionException::greaterOrEqualThan(
-                    $parameters['value'],
-                    $parameters['limit'],
-                    $parameters['propertyPath']
-                )->getMessage();
-            },
-            $propertyPath
-        );
+        if ($value < $limit) {
+            throw AssertionException::greaterOrEqualThan($value, $limit, $propertyPath);
+        }
     }
 
     /**
      * Assert that value is not empty.
      *
+     * This is bound to the native php {@see https://www.php.net/manual/en/function.empty.php} function.
+     *
+     * Use it carefully for strings as '0' is considered empty by PHP !
+     *
      * @param mixed $value Value to test
      * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
      * @throws \Assert\AssertionFailedException
      */
-    public static function notEmpty($value, string $propertyPath = null): void
+    public static function notEmpty(mixed $value, ?string $propertyPath = null): void
     {
-        Assert::notEmpty(
-            $value,
-            function (array $parameters) {
-                return AssertionException::notEmpty($parameters['propertyPath']);
-            },
-            $propertyPath
-        );
+        if (empty($value)) {
+            throw AssertionException::notEmpty($propertyPath);
+        }
+    }
+
+    /**
+     * Assert that a string is not NULL or an empty string ''.
+     *
+     * This method is specifically done for strings to manage the php case `empty('0')` which is `TRUE`.
+     *
+     * @param ?string $value Value to test
+     * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function notEmptyString(?string $value, ?string $propertyPath = null): void
+    {
+        if ($value === null || $value === '') {
+            throw AssertionException::notEmptyString($propertyPath);
+        }
     }
 
     /**
@@ -235,105 +202,112 @@ class Assertion
      *
      * @param mixed $value Value to test
      * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
      * @throws \Assert\AssertionFailedException
      */
-    public static function notNull($value, string $propertyPath = null): void
+    public static function notNull(mixed $value, ?string $propertyPath = null): void
     {
-        Assert::notNull(
-            $value,
-            function (array $parameters) {
-                return AssertionException::notNull($parameters['propertyPath']);
-            },
-            $propertyPath
-        );
-    }
-
-    /**
-     * Calculates the string length or fails.
-     *
-     * @param string $value Value for which we have to calculate the length
-     * @param string $encoding Encoding used for calculation
-     * @param string $propertyPath Property's path (ex: Host::name)
-     * @return int Calculated length
-     */
-    private static function calculateStringLengthOrFails(string $value, string $encoding, string $propertyPath): int
-    {
-        $length = \mb_strlen($value, $encoding);
-        if ($length === false) {
-            throw new \RuntimeException(
-                sprintf(
-                    _('[%s] Error when calculating string length of "%s" in %s'),
-                    $propertyPath,
-                    $value,
-                    $encoding
-                )
-            );
+        if (null === $value) {
+            throw AssertionException::notNull($propertyPath);
         }
-        return $length;
     }
 
     /**
-     * Assert that value is in array
+     * Assert that value is in array.
      *
      * @param mixed $value
      * @param mixed[] $choices
      * @param string|null $propertyPath
+     *
      * @throws \Assert\AssertionFailedException
-     * @return void
      */
-    public static function inArray($value, array $choices, string $propertyPath = null): void
+    public static function inArray(mixed $value, array $choices, ?string $propertyPath = null): void
     {
-        Assert::inArray(
-            $value,
-            $choices,
-            function (array $parameters) {
-                return AssertionException::inArray(
-                    $parameters['value'],
-                    $parameters['choices'],
-                    $parameters['propertyPath']
-                );
-            },
-            $propertyPath
-        );
+        if (! \in_array($value, $choices, true)) {
+            throw AssertionException::inArray($value, $choices, $propertyPath);
+        }
     }
 
     /**
-     * Assert that a value match a regex
+     * Assert that a value match a regex.
      *
      * @param mixed $value
      * @param string $pattern
      * @param string|null $propertyPath
-     * @return void
+     *
+     * @throws \Assert\AssertionFailedException
      */
-    public static function regex(mixed $value, string $pattern, string $propertyPath = null): void
+    public static function regex(mixed $value, string $pattern, ?string $propertyPath = null): void
     {
-        Assert::regex(
-            $value,
-            $pattern,
-            function (array $parameters) {
-                return AssertionException::matchRegex(
-                    $parameters['value'],
-                    $parameters['pattern'],
-                    $parameters['propertyPath']
-                )->getMessage();
-            },
-            $propertyPath
-        );
+        if (! \is_string($value) || ! \preg_match($pattern, $value)) {
+            throw AssertionException::matchRegex(self::stringify($value), $pattern, $propertyPath);
+        }
     }
 
     /**
-     * Assert that value is a valid IP or Domain name
+     * Assert that value is a valid IP or Domain name.
      *
      * @param string $value
      * @param string|null $propertyPath
+     *
+     * @throws \Assert\AssertionFailedException
      */
-    public static function ipOrDomain(string $value, string $propertyPath = null): void
+    public static function ipOrDomain(string $value, ?string $propertyPath = null): void
     {
         if (
-            filter_var($value, FILTER_VALIDATE_IP) === false
-            && filter_var($value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false
+            false === filter_var($value, FILTER_VALIDATE_IP)
+            && false === filter_var($value, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME)
         ) {
             throw AssertionException::ipOrDomain($value, $propertyPath);
         }
+    }
+
+    /**
+     * Assert that value is a valid IP.
+     *
+     * @param mixed $value
+     * @param string|null $propertyPath
+     *
+     * @throws \Assert\AssertionFailedException
+     */
+    public static function ipAddress(mixed $value, ?string $propertyPath = null): void
+    {
+        if (! \is_string($value) || false === filter_var($value, FILTER_VALIDATE_IP)) {
+            throw AssertionException::ipAddressNotValid(self::stringify($value), $propertyPath);
+        }
+    }
+
+    /**
+     * Make a string version of a value.
+     *
+     * Copied from {@see \Assert\Assertion::stringify()}.
+     *
+     * @param mixed $value
+     */
+    private static function stringify(mixed $value): string
+    {
+        $result = \gettype($value);
+
+        if (\is_bool($value)) {
+            $result = $value ? '<TRUE>' : '<FALSE>';
+        } elseif (\is_scalar($value)) {
+            $val = (string) $value;
+
+            if (\mb_strlen($val) > 100) {
+                $val = \mb_substr($val, 0, 97) . '...';
+            }
+
+            $result = $val;
+        } elseif (\is_array($value)) {
+            $result = '<ARRAY>';
+        } elseif (\is_object($value)) {
+            $result = $value::class;
+        } elseif (\is_resource($value)) {
+            $result = \get_resource_type($value);
+        } elseif (null === $value) {
+            $result = '<NULL>';
+        }
+
+        return $result;
     }
 }

--- a/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
+++ b/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
@@ -301,7 +301,7 @@ class Assertion
         } elseif (\is_array($value)) {
             $result = '<ARRAY>';
         } elseif (\is_object($value)) {
-            $result = $value::class;
+            $result = \get_debug_type($value);
         } elseif (\is_resource($value)) {
             $result = \get_resource_type($value);
         } elseif (null === $value) {

--- a/centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+++ b/centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,17 +18,42 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
 namespace Centreon\Domain\Common\Assertion;
 
+use Assert\Assertion as Assert;
+
 /**
- * This class is designed to contain all assertion exceptions
- *
- * @package Centreon\Domain\Common\Assertion
+ * This class is designed to contain all assertion exceptions.
  */
-class AssertionException extends \InvalidArgumentException
+class AssertionException extends \Assert\InvalidArgumentException
 {
+    public const INVALID_EMAIL = Assert::INVALID_EMAIL;
+    public const INVALID_GREATER_OR_EQUAL = Assert::INVALID_GREATER_OR_EQUAL;
+    public const INVALID_IP = Assert::INVALID_IP;
+    public const INVALID_IP_OR_DOMAIN = 1002;
+    public const INVALID_MAX = Assert::INVALID_MAX;
+    public const INVALID_MAX_DATE = 1001;
+    public const INVALID_MAX_LENGTH = Assert::INVALID_MAX_LENGTH;
+    public const INVALID_MIN = Assert::INVALID_MIN;
+    public const INVALID_MIN_LENGTH = Assert::INVALID_MIN_LENGTH;
+    public const INVALID_REGEX = Assert::INVALID_REGEX;
+    public const INVALID_CHOICE = Assert::INVALID_CHOICE;
+    public const VALUE_EMPTY = Assert::VALUE_EMPTY;
+    public const VALUE_NULL = Assert::VALUE_NULL;
+
+    public function __construct(
+        $message,
+        int $code = 0,
+        ?string $propertyPath = null,
+        mixed $value = null,
+        array $constraints = []
+    ) {
+        parent::__construct($message, $code, $propertyPath, $value, $constraints);
+    }
+
     /**
      * Exception when the value of the string is longer than the expected number of characters.
      *
@@ -36,10 +61,15 @@ class AssertionException extends \InvalidArgumentException
      * @param int $valueLength Length of the tested value
      * @param int $maxLength Maximum length of the expected value in characters
      * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
      * @return self
      */
-    public static function maxLength(string $value, int $valueLength, int $maxLength, string $propertyPath = null): self
-    {
+    public static function maxLength(
+        string $value,
+        int $valueLength,
+        int $maxLength,
+        ?string $propertyPath = null
+    ): self {
         return new self(
             sprintf(
                 _(
@@ -50,7 +80,10 @@ class AssertionException extends \InvalidArgumentException
                 $value,
                 $maxLength,
                 $valueLength
-            )
+            ),
+            self::INVALID_MAX_LENGTH,
+            $propertyPath,
+            $value
         );
     }
 
@@ -61,10 +94,15 @@ class AssertionException extends \InvalidArgumentException
      * @param int $valueLength Length of the tested value
      * @param int $minLength Minimum length of the expected value in characters
      * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
      * @return self
      */
-    public static function minLength(string $value, int $valueLength, int $minLength, string $propertyPath = null): self
-    {
+    public static function minLength(
+        string $value,
+        int $valueLength,
+        int $minLength,
+        ?string $propertyPath = null
+    ): self {
         return new self(
             sprintf(
                 _(
@@ -75,7 +113,10 @@ class AssertionException extends \InvalidArgumentException
                 $value,
                 $minLength,
                 $valueLength
-            )
+            ),
+            self::INVALID_MIN_LENGTH,
+            $propertyPath,
+            $value
         );
     }
 
@@ -95,12 +136,15 @@ class AssertionException extends \InvalidArgumentException
     /**
      * Exception when the value of the integer is less than the expected value.
      *
+     * Same as {@see self::greaterOrEqualThan()} but with a different message.
+     *
      * @param int $value Tested value
      * @param int $minValue Minimum value
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     *
      * @return self
      */
-    public static function min(int $value, int $minValue, string $propertyPath = null): self
+    public static function min(int $value, int $minValue, ?string $propertyPath = null): self
     {
         return new self(
             sprintf(
@@ -108,7 +152,10 @@ class AssertionException extends \InvalidArgumentException
                 $propertyPath,
                 $value,
                 $minValue
-            )
+            ),
+            self::INVALID_MIN,
+            $propertyPath,
+            $value
         );
     }
 
@@ -118,9 +165,10 @@ class AssertionException extends \InvalidArgumentException
      * @param int $value Tested value
      * @param int $maxValue Maximum value
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     *
      * @return self
      */
-    public static function max(int $value, int $maxValue, string $propertyPath = null): self
+    public static function max(int $value, int $maxValue, ?string $propertyPath = null): self
     {
         return new self(
             sprintf(
@@ -128,7 +176,10 @@ class AssertionException extends \InvalidArgumentException
                 $propertyPath,
                 $value,
                 $maxValue
-            )
+            ),
+            self::INVALID_MAX,
+            $propertyPath,
+            $value
         );
     }
 
@@ -137,48 +188,64 @@ class AssertionException extends \InvalidArgumentException
      *
      * @param string $value Tested value
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     *
      * @return self
      */
-    public static function email(string $value, string $propertyPath = null): self
+    public static function email(string $value, ?string $propertyPath = null): self
     {
         return new self(
             sprintf(
                 _('[%s] The value "%s" was expected to be a valid e-mail address'),
                 $propertyPath,
                 $value
-            )
+            ),
+            self::INVALID_EMAIL,
+            $propertyPath,
+            $value
         );
     }
 
     /**
      * Exception when the value of the date is higher than the expected date.
      *
-     * @param \DateTime $date Tested date
-     * @param \DateTime $maxDate Maximum date
+     * @param \DateTimeInterface $date Tested date
+     * @param \DateTimeInterface $maxDate Maximum date
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     *
      * @return self
      */
-    public static function maxDate(\DateTime $date, \DateTime $maxDate, string $propertyPath = null): self
-    {
+    public static function maxDate(
+        \DateTimeInterface $date,
+        \DateTimeInterface $maxDate,
+        ?string $propertyPath = null
+    ): self {
+        $value = $date->format('c');
+
         return new self(
             sprintf(
                 _('[%s] The date "%s" was expected to be at most %s'),
                 $propertyPath,
-                $date->format('c'),
+                $value,
                 $maxDate->format('c')
-            )
+            ),
+            self::INVALID_MAX_DATE,
+            $propertyPath,
+            $value
         );
     }
 
     /**
      * Exception when the value of the integer is less than the expected value.
      *
+     * Same as {@see self::min()} but with a different message.
+     *
      * @param int $value Tested value
      * @param int $limit Limit value
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     *
      * @return self
      */
-    public static function greaterOrEqualThan(int $value, int $limit, string $propertyPath = null): self
+    public static function greaterOrEqualThan(int $value, int $limit, ?string $propertyPath = null): self
     {
         return new self(
             sprintf(
@@ -186,7 +253,10 @@ class AssertionException extends \InvalidArgumentException
                 $propertyPath,
                 $value,
                 $limit
-            )
+            ),
+            self::INVALID_GREATER_OR_EQUAL,
+            $propertyPath,
+            $value
         );
     }
 
@@ -194,15 +264,37 @@ class AssertionException extends \InvalidArgumentException
      * Exception when the value is empty.
      *
      * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
      * @return self
      */
-    public static function notEmpty(string $propertyPath = null): self
+    public static function notEmpty(?string $propertyPath = null): self
     {
         return new self(
             sprintf(
                 _('[%s] The value is empty, but non empty value was expected'),
                 $propertyPath
-            )
+            ),
+            self::VALUE_EMPTY,
+            $propertyPath
+        );
+    }
+
+    /**
+     * Exception when the string is empty.
+     *
+     * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
+     * @return self
+     */
+    public static function notEmptyString(?string $propertyPath = null): self
+    {
+        return new self(
+            sprintf(
+                _('[%s] The string is empty, but non empty string was expected'),
+                $propertyPath
+            ),
+            self::VALUE_EMPTY,
+            $propertyPath
         );
     }
 
@@ -210,15 +302,18 @@ class AssertionException extends \InvalidArgumentException
      * Exception when the value is null.
      *
      * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
      * @return self
      */
-    public static function notNull(string $propertyPath = null): self
+    public static function notNull(?string $propertyPath = null): self
     {
         return new self(
             sprintf(
                 _('[%s] The value is null, but non null value was expected'),
                 $propertyPath
-            )
+            ),
+            self::VALUE_NULL,
+            $propertyPath
         );
     }
 
@@ -228,9 +323,10 @@ class AssertionException extends \InvalidArgumentException
      * @param mixed $value
      * @param mixed[] $expectedValues
      * @param string|null $propertyPath Property's path (ex: Host::name)
+     *
      * @return self
      */
-    public static function inArray($value, array $expectedValues, string $propertyPath = null): self
+    public static function inArray(mixed $value, array $expectedValues, ?string $propertyPath = null): self
     {
         return new self(
             sprintf(
@@ -238,7 +334,10 @@ class AssertionException extends \InvalidArgumentException
                 $propertyPath,
                 $value,
                 implode('|', $expectedValues)
-            )
+            ),
+            self::INVALID_CHOICE,
+            $propertyPath,
+            $value
         );
     }
 
@@ -247,16 +346,20 @@ class AssertionException extends \InvalidArgumentException
      *
      * @param string $value Tested value
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     *
      * @return self
      */
-    public static function ipOrDomain(string $value, string $propertyPath = null): self
+    public static function ipOrDomain(string $value, ?string $propertyPath = null): self
     {
         return new self(
             sprintf(
                 _('[%s] The value "%s" was expected to be a valid ip address or domain name'),
                 $propertyPath,
                 $value
-            )
+            ),
+            self::INVALID_IP_OR_DOMAIN,
+            $propertyPath,
+            $value
         );
     }
 
@@ -266,17 +369,21 @@ class AssertionException extends \InvalidArgumentException
      * @param string $value
      * @param string $pattern
      * @param string|null $propertyPath
+     *
      * @return self
      */
-    public static function matchRegex(string $value, string $pattern, string $propertyPath = null): self
+    public static function matchRegex(string $value, string $pattern, ?string $propertyPath = null): self
     {
         return new self(
             sprintf(
-                _('[%s] The value (%s) doesn\'t match the regex \'%s\''),
+                _("[%s] The value (%s) doesn't match the regex '%s'"),
                 $propertyPath,
                 $value,
                 $pattern
-            )
+            ),
+            self::INVALID_REGEX,
+            $propertyPath,
+            $value
         );
     }
 
@@ -285,16 +392,20 @@ class AssertionException extends \InvalidArgumentException
      *
      * @param string $value Tested value
      * @param string|null $propertyPath Property's path (ex: Host::maxCheckAttempts)
+     *
      * @return self
      */
-    public static function ipAddressNotValid(string $value, string $propertyPath = null): self
+    public static function ipAddressNotValid(string $value, ?string $propertyPath = null): self
     {
         return new self(
             sprintf(
-                _('[%s] The value \'%s\' was expected to be a valid ip address'),
+                _("[%s] The value '%s' was expected to be a valid ip address"),
                 $propertyPath,
                 $value
-            )
+            ),
+            self::INVALID_IP,
+            $propertyPath,
+            $value
         );
     }
 }

--- a/centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
+++ b/centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
@@ -44,8 +44,18 @@ class AssertionException extends \Assert\InvalidArgumentException
     public const VALUE_EMPTY = Assert::VALUE_EMPTY;
     public const VALUE_NULL = Assert::VALUE_NULL;
 
+    /**
+     * The extended constructor is here only to enforce the types used
+     * and set a default `int $code = 0` for child classes.
+     *
+     * @param string $message
+     * @param int $code
+     * @param string|null $propertyPath
+     * @param mixed|null $value
+     * @param array<string, mixed> $constraints
+     */
     public function __construct(
-        $message,
+        string $message,
         int $code = 0,
         ?string $propertyPath = null,
         mixed $value = null,

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/OpenId/Model/AuthenticationConditions.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/OpenId/Model/AuthenticationConditions.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\ProviderConfiguration\Domain\OpenId\Model;
 
+use Centreon\Domain\Common\Assertion\Assertion;
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\Security\ProviderConfiguration\Domain\Model\Endpoint;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Exceptions\OpenIdConfigurationException;
@@ -127,7 +128,7 @@ class AuthenticationConditions
     /**
      * @param string[] $trustedClientAddresses
      * @return self
-     * @throws AssertionException
+     * @throws \Assert\AssertionFailedException
      */
     public function setTrustedClientAddresses(array $trustedClientAddresses): self
     {
@@ -142,7 +143,7 @@ class AuthenticationConditions
     /**
      * @param string $trustedClientAddress
      * @return self
-     * @throws AssertionException
+     * @throws \Assert\AssertionFailedException
      */
     public function addTrustedClientAddress(string $trustedClientAddress): self
     {
@@ -155,7 +156,7 @@ class AuthenticationConditions
     /**
      * @param string[] $blacklistClientAddresses
      * @return self
-     * @throws AssertionException
+     * @throws \Assert\AssertionFailedException
      */
     public function setBlacklistClientAddresses(array $blacklistClientAddresses): self
     {
@@ -170,7 +171,7 @@ class AuthenticationConditions
     /**
      * @param string $blacklistClientAddress
      * @return self
-     * @throws AssertionException
+     * @throws \Assert\AssertionFailedException
      */
     public function addBlacklistClientAddress(string $blacklistClientAddress): self
     {
@@ -183,19 +184,11 @@ class AuthenticationConditions
     /**
      * @param string $clientAddress
      * @param string $fieldName
-     * @throws AssertionException
+     * @throws \Assert\AssertionFailedException
      */
     private function validateClientAddressOrFail(string $clientAddress, string $fieldName): void
     {
-        if (
-            filter_var($clientAddress, FILTER_VALIDATE_IP) === false
-            && filter_var($clientAddress, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false
-        ) {
-            throw AssertionException::ipOrDomain(
-                $clientAddress,
-                'AuthenticationConditions::' . $fieldName
-            );
-        }
+        Assertion::ipOrDomain($clientAddress, 'AuthenticationConditions::' . $fieldName);
     }
 
     /**

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/WebSSO/Model/CustomConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/WebSSO/Model/CustomConfiguration.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\ProviderConfiguration\Domain\WebSSO\Model;
 
-use Centreon\Domain\Common\Assertion\AssertionException;
+use Centreon\Domain\Common\Assertion\Assertion;
 use Core\Security\ProviderConfiguration\Domain\CustomConfigurationInterface;
 use Core\Security\ProviderConfiguration\Domain\Local\Model\SecurityPolicy;
 use Security\Domain\Authentication\Interfaces\ProviderConfigurationInterface;
@@ -93,20 +93,10 @@ final class CustomConfiguration implements CustomConfigurationInterface, Provide
     private function guard(): void
     {
         foreach ($this->getTrustedClientAddresses() as $trustedClientAddress) {
-            if (filter_var($trustedClientAddress, FILTER_VALIDATE_IP) === false) {
-                throw AssertionException::ipAddressNotValid(
-                    $trustedClientAddress,
-                    'WebSSOConfiguration::trustedClientAddresses'
-                );
-            }
+            Assertion::ipAddress($trustedClientAddress, 'WebSSOConfiguration::trustedClientAddresses');
         }
         foreach ($this->getBlackListClientAddresses() as $blacklistClientAddress) {
-            if (filter_var($blacklistClientAddress, FILTER_VALIDATE_IP) === false) {
-                throw AssertionException::ipAddressNotValid(
-                    $blacklistClientAddress,
-                    'WebSSOConfiguration::blacklistClientAddresses'
-                );
-            }
+            Assertion::ipAddress($blacklistClientAddress, 'WebSSOConfiguration::blacklistClientAddresses');
         }
     }
 }

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/WebSSO/Model/WebSSOConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/WebSSO/Model/WebSSOConfiguration.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\ProviderConfiguration\Domain\WebSSO\Model;
 
-use Centreon\Domain\Common\Assertion\AssertionException;
+use Centreon\Domain\Common\Assertion\Assertion;
 use Security\Domain\Authentication\Interfaces\ProviderConfigurationInterface;
 
 class WebSSOConfiguration implements ProviderConfigurationInterface
@@ -54,20 +54,10 @@ class WebSSOConfiguration implements ProviderConfigurationInterface
         private ?string $patternReplaceLogin
     ) {
         foreach ($trustedClientAddresses as $trustedClientAddress) {
-            if (filter_var($trustedClientAddress, FILTER_VALIDATE_IP) === false) {
-                throw AssertionException::ipAddressNotValid(
-                    $trustedClientAddress,
-                    'WebSSOConfiguration::trustedClientAddresses'
-                );
-            }
+            Assertion::ipAddress($trustedClientAddress, 'WebSSOConfiguration::trustedClientAddresses');
         }
         foreach ($blacklistClientAddresses as $blacklistClientAddress) {
-            if (filter_var($blacklistClientAddress, FILTER_VALIDATE_IP) === false) {
-                throw AssertionException::ipAddressNotValid(
-                    $blacklistClientAddress,
-                    'WebSSOConfiguration::blacklistClientAddresses'
-                );
-            }
+            Assertion::ipAddress($blacklistClientAddress, 'WebSSOConfiguration::blacklistClientAddresses');
         }
     }
 

--- a/centreon/tests/php/Centreon/Domain/Common/AssertionTest.php
+++ b/centreon/tests/php/Centreon/Domain/Common/AssertionTest.php
@@ -176,7 +176,7 @@ $failDataProvider = [
     ],
 ];
 
-// We use a custom data provider with a loop, because pest auto-evaluate the closure from the dataset.
+// We use a custom data provider with a loop to avoid pest from auto-evaluating the closure from the dataset.
 foreach ($failDataProvider as $name => [$failAssertion, $failMessage, $failCode]) {
     it(
         'should throw an exception for ' . $name,
@@ -281,7 +281,7 @@ $successDataProvider = [
     ],
 ];
 
-// We use a custom data provider with a loop, because pest auto-evaluate the closure from the dataset.
+// We use a custom data provider with a loop to avoid pest from auto-evaluating the closure from the dataset.
 foreach ($successDataProvider as $name => [$successAssertion]) {
     it(
         'should NOT throw an exception for ' . $name,

--- a/centreon/tests/php/Centreon/Domain/Common/AssertionTest.php
+++ b/centreon/tests/php/Centreon/Domain/Common/AssertionTest.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2020 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,215 +18,280 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
 namespace Tests\Centreon\Domain\Common;
 
-use Centreon\Domain\Common\Assertion\AssertionException;
-use PHPUnit\Framework\TestCase;
+use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
+use Centreon\Domain\Common\Assertion\AssertionException;
 
-/**
- * @package Tests\Centreon\Domain\Common
- */
-class AssertionTest extends TestCase
-{
-    /**
-     * @var string
-     */
-    private $propertyName;
+$propertyPath = 'Class::property';
 
-    protected function setUp(): void
-    {
-        $this->propertyName = 'Class::property';
-    }
+// ────────────────────────────── FAILURES tests ──────────────────────────────
+$failDataProvider = [
+    'maxLength("oooX", 3)' => [
+        fn() => Assertion::maxLength('oooX', 3, $propertyPath),
+        AssertionException::maxLength('oooX', 4, 3, $propertyPath)->getMessage(),
+        AssertionException::INVALID_MAX_LENGTH,
+    ],
+    'maxLength("utf8: éà", 7)' => [
+        fn() => Assertion::maxLength('utf8: éà', 7, $propertyPath),
+        AssertionException::maxLength('utf8: éà', 8, 7, $propertyPath)->getMessage(),
+        AssertionException::INVALID_MAX_LENGTH,
+    ],
+    'minLength("", 1)' => [
+        fn() => Assertion::minLength('', 1, $propertyPath),
+        AssertionException::minLength('', 0, 1, $propertyPath)->getMessage(),
+        AssertionException::INVALID_MIN_LENGTH,
+    ],
+    'minLength("utf8: éà", 9)' => [
+        fn() => Assertion::minLength('utf8: éà', 9, $propertyPath),
+        AssertionException::minLength('utf8: éà', 8, 9, $propertyPath)->getMessage(),
+        AssertionException::INVALID_MIN_LENGTH,
+    ],
+    'email("not-an-email")' => [
+        fn() => Assertion::email('not-an-email', $propertyPath),
+        AssertionException::email('not-an-email', $propertyPath)->getMessage(),
+        AssertionException::INVALID_EMAIL,
+    ],
+    'positiveInt(0)' => [
+        fn() => Assertion::positiveInt(0, $propertyPath),
+        AssertionException::positiveInt(0, $propertyPath)->getMessage(),
+        AssertionException::INVALID_MIN,
+    ],
+    'min(0, 1)' => [
+        fn() => Assertion::min(0, 1, $propertyPath),
+        AssertionException::min(0, 1, $propertyPath)->getMessage(),
+        AssertionException::INVALID_MIN,
+    ],
+    'max(43, 42)' => [
+        fn() => Assertion::max(43, 42, $propertyPath),
+        AssertionException::max(43, 42, $propertyPath)->getMessage(),
+        AssertionException::INVALID_MAX,
+    ],
+    'greaterOrEqualThan(41, 42)' => [
+        fn() => Assertion::greaterOrEqualThan(41, 42, $propertyPath),
+        AssertionException::greaterOrEqualThan(41, 42, $propertyPath)->getMessage(),
+        AssertionException::INVALID_GREATER_OR_EQUAL,
+    ],
+    'notEmpty(NULL)' => [
+        fn() => Assertion::notEmpty(null, $propertyPath),
+        AssertionException::notEmpty($propertyPath)->getMessage(),
+        AssertionException::VALUE_EMPTY,
+    ],
+    'notEmpty(false)' => [
+        fn() => Assertion::notEmpty(false, $propertyPath),
+        AssertionException::notEmpty($propertyPath)->getMessage(),
+        AssertionException::VALUE_EMPTY,
+    ],
+    'notEmpty(0)' => [
+        fn() => Assertion::notEmpty(0, $propertyPath),
+        AssertionException::notEmpty($propertyPath)->getMessage(),
+        AssertionException::VALUE_EMPTY,
+    ],
+    'notEmpty(0.0)' => [
+        fn() => Assertion::notEmpty(0.0, $propertyPath),
+        AssertionException::notEmpty($propertyPath)->getMessage(),
+        AssertionException::VALUE_EMPTY,
+    ],
+    'notEmpty("")' => [
+        fn() => Assertion::notEmpty('', $propertyPath),
+        AssertionException::notEmpty($propertyPath)->getMessage(),
+        AssertionException::VALUE_EMPTY,
+    ],
+    'notEmpty("0")' => [
+        fn() => Assertion::notEmpty('0', $propertyPath),
+        AssertionException::notEmpty($propertyPath)->getMessage(),
+        AssertionException::VALUE_EMPTY,
+    ],
+    'notEmpty([])' => [
+        fn() => Assertion::notEmpty([], $propertyPath),
+        AssertionException::notEmpty($propertyPath)->getMessage(),
+        AssertionException::VALUE_EMPTY,
+    ],
+    'notEmptyString(NULL)' => [
+        fn() => Assertion::notEmptyString(null, $propertyPath),
+        AssertionException::notEmptyString($propertyPath)->getMessage(),
+        AssertionException::VALUE_EMPTY,
+    ],
+    'notEmptyString("")' => [
+        fn() => Assertion::notEmptyString('', $propertyPath),
+        AssertionException::notEmptyString($propertyPath)->getMessage(),
+        AssertionException::VALUE_EMPTY,
+    ],
+    'notNull(NULL)' => [
+        fn() => Assertion::notNull(null, $propertyPath),
+        AssertionException::notNull($propertyPath)->getMessage(),
+        AssertionException::VALUE_NULL,
+    ],
+    'inArray(2, [1, "a", NULL])' => [
+        fn() => Assertion::inArray(2, [1, 'a', null], $propertyPath),
+        AssertionException::inArray(2, [1, 'a', null], $propertyPath)->getMessage(),
+        AssertionException::INVALID_CHOICE,
+    ],
+    'regex("abc123", "/^\d+$/")' => [
+        fn() => Assertion::regex('abc123', '/^\d+$/', $propertyPath),
+        AssertionException::matchRegex('abc123', '/^\d+$/', $propertyPath)->getMessage(),
+        AssertionException::INVALID_REGEX,
+    ],
+    'regex(1234, "/^\d+$/")' => [
+        fn() => Assertion::regex(1234, '/^\d+$/', $propertyPath),
+        AssertionException::matchRegex('1234', '/^\d+$/', $propertyPath)->getMessage(),
+        AssertionException::INVALID_REGEX,
+    ],
+    'ipOrDomain("")' => [
+        fn() => Assertion::ipOrDomain('', $propertyPath),
+        AssertionException::ipOrDomain('', $propertyPath)->getMessage(),
+        AssertionException::INVALID_IP_OR_DOMAIN,
+    ],
+    'ipOrDomain("not:valid")' => [
+        fn() => Assertion::ipOrDomain('not:valid', $propertyPath),
+        AssertionException::ipOrDomain('not:valid', $propertyPath)->getMessage(),
+        AssertionException::INVALID_IP_OR_DOMAIN,
+    ],
+    'ipAddress("any-hostname")' => [
+        fn() => Assertion::ipAddress('any-hostname', $propertyPath),
+        AssertionException::ipAddressNotValid('any-hostname', $propertyPath)->getMessage(),
+        AssertionException::INVALID_IP,
+    ],
+    'ipAddress(1234)' => [
+        fn() => Assertion::ipAddress(1234, $propertyPath),
+        AssertionException::ipAddressNotValid('1234', $propertyPath)->getMessage(),
+        AssertionException::INVALID_IP,
+    ],
+    'maxDate(new DateTime("2023-02-08 16:00:01"), new DateTime("2023-02-08 16:00:00"))' => [
+        fn() => Assertion::maxDate(
+            new \DateTime('2023-02-08 16:00:01'),
+            new \DateTime('2023-02-08 16:00:00'),
+            $propertyPath
+        ),
+        AssertionException::maxDate(
+            new \DateTime('2023-02-08 16:00:01'),
+            new \DateTime('2023-02-08 16:00:00'),
+            $propertyPath
+        )->getMessage(),
+        AssertionException::INVALID_MAX_DATE,
+    ],
+];
 
-    /**
-     * Test the maxLength assertion
-     */
-    public function testMaxLengthException(): void
-    {
-        $propertyValue = 'test_value_too_long';
-        $maxLength = strlen($propertyValue) - 1;
-        $expectedExceptionMessage = AssertionException::maxLength(
-            $propertyValue,
-            mb_strlen($propertyValue, 'UTF-8'),
-            $maxLength,
-            $this->propertyName
-        )->getMessage();
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-        Assertion::maxLength($propertyValue, $maxLength, $this->propertyName);
-    }
+// We use a custom data provider with a loop, because pest auto-evaluate the closure from the dataset.
+foreach ($failDataProvider as $name => [$failAssertion, $failMessage, $failCode]) {
+    it(
+        'should throw an exception for ' . $name,
+        function () use ($propertyPath, $failAssertion, $failMessage, $failCode): void {
+            try {
+                $failAssertion();
+                $this->fail('This SHALL NOT pass.');
+            } catch (\Throwable $e) {
+                // expected class + message + propertyPath + code
+                expect($e)->toBeInstanceOf(AssertionFailedException::class)
+                    ->and($e->getMessage())->toBe($failMessage)
+                    ->and($e->getPropertyPath())->toBe($propertyPath)
+                    ->and($e->getCode())->toBe($failCode);
+            }
+        }
+    );
+}
 
-    /**
-     * Test no exception on maxLength assertion
-     */
-    public function testNoExceptionMaxLength(): void
-    {
-        $propertyValue = 'test_value_too_long';
-        Assertion::maxLength($propertyValue, strlen($propertyValue), $this->propertyName);
-        $this->expectNotToPerformAssertions();
-    }
+// ────────────────────────────── SUCCESS tests ──────────────────────────────
+$successDataProvider = [
+    'maxLength("ooo", 3)' => [
+        fn() => Assertion::maxLength('ooo', 3, $propertyPath),
+    ],
+    'maxLength("utf8: éà", 8)' => [
+        fn() => Assertion::maxLength('utf8: éà', 8, $propertyPath),
+    ],
+    'minLength("o", 1)' => [
+        fn() => Assertion::minLength('o', 1, $propertyPath),
+    ],
+    'minLength("utf8: éà", 8)' => [
+        fn() => Assertion::minLength('utf8: éà', 8, $propertyPath),
+    ],
+    'email("ok@centreon.com")' => [
+        fn() => Assertion::email('ok@centreon.com', $propertyPath),
+    ],
+    'positiveInt(1)' => [
+        fn() => Assertion::positiveInt(1, $propertyPath),
+    ],
+    'min(1, 1)' => [
+        fn() => Assertion::min(1, 1, $propertyPath),
+    ],
+    'max(42, 42)' => [
+        fn() => Assertion::max(42, 42, $propertyPath),
+    ],
+    'greaterOrEqualThan(42, 42)' => [
+        fn() => Assertion::greaterOrEqualThan(42, 42, $propertyPath),
+    ],
+    'notEmpty(true)' => [
+        fn() => Assertion::notEmpty(true, $propertyPath),
+    ],
+    'notEmpty(1)' => [
+        fn() => Assertion::notEmpty(1, $propertyPath),
+    ],
+    'notEmpty(1.5)' => [
+        fn() => Assertion::notEmpty(1, $propertyPath),
+    ],
+    'notEmpty("abc")' => [
+        fn() => Assertion::notEmpty('abc', $propertyPath),
+    ],
+    'notEmpty([42])' => [
+        fn() => Assertion::notEmpty([42], $propertyPath),
+    ],
+    'notEmptyString("0")' => [
+        fn() => Assertion::notEmptyString('0', $propertyPath),
+    ],
+    'notEmptyString("abc")' => [
+        fn() => Assertion::notEmptyString('abc', $propertyPath),
+    ],
+    'notNull(0)' => [
+        fn() => Assertion::notNull(0, $propertyPath),
+    ],
+    'notNull(0.0)' => [
+        fn() => Assertion::notNull(0.0, $propertyPath),
+    ],
+    'notNull("")' => [
+        fn() => Assertion::notNull('', $propertyPath),
+    ],
+    'notNull([])' => [
+        fn() => Assertion::notNull([], $propertyPath),
+    ],
+    'inArray(NULL, [1, "a", NULL])' => [
+        fn() => Assertion::inArray(null, [1, 'a', null], $propertyPath),
+    ],
+    'regex("1234", "/^\d+$/")' => [
+        fn() => Assertion::regex('1234', '/^\d+$/', $propertyPath),
+    ],
+    'ipOrDomain("1.2.3.4")' => [
+        fn() => Assertion::ipOrDomain('1.2.3.4', $propertyPath),
+    ],
+    'ipOrDomain("any-hostname")' => [
+        fn() => Assertion::ipOrDomain('any-hostname', $propertyPath),
+    ],
+    'ipAddress("2.3.4.5")' => [
+        fn() => Assertion::ipAddress('2.3.4.5', $propertyPath),
+    ],
+    'maxDate(new DateTime("2023-02-08 16:00:00"), new DateTime("2023-02-08 16:00:00"))' => [
+        fn() => Assertion::maxDate(
+            new \DateTime('2023-02-08 16:00:00'),
+            new \DateTime('2023-02-08 16:00:00'),
+            $propertyPath
+        ),
+    ],
+];
 
-    /**
-     * Test the minLength assertion
-     */
-    public function testMinLengthException(): void
-    {
-        $propertyValue = 'test_value_too_short';
-        $minLength = strlen($propertyValue) + 1;
-        $expectedExceptionMessage = AssertionException::minLength(
-            $propertyValue,
-            mb_strlen($propertyValue, 'UTF-8'),
-            $minLength,
-            $this->propertyName
-        )->getMessage();
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-        Assertion::minLength($propertyValue, $minLength, $this->propertyName);
-    }
-
-    /**
-     * Test no exception on minLength assertion
-     */
-    public function testNoExceptionMinLength(): void
-    {
-        $propertyValue = 'test_value_too_long';
-        Assertion::minLength($propertyValue, strlen($propertyValue), $this->propertyName);
-        $this->expectNotToPerformAssertions();
-    }
-
-    /**
-     * Test the min assertion
-     */
-    public function testMinException(): void
-    {
-        $propertyValue = 49;
-        $minLength = $propertyValue + 1;
-        $expectedExceptionMessage = AssertionException::min(
-            $propertyValue,
-            $minLength,
-            $this->propertyName
-        )->getMessage();
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-        Assertion::min($propertyValue, $minLength, $this->propertyName);
-    }
-
-    /**
-     * Test no exception on min assertion
-     */
-    public function testNoExceptionMin(): void
-    {
-        $propertyValue = 49;
-        $minLength = $propertyValue;
-        Assertion::min($propertyValue, $minLength, $this->propertyName);
-        $this->expectNotToPerformAssertions();
-    }
-
-    /**
-     * Test the max assertion
-     */
-    public function testMaxException(): void
-    {
-        $propertyValue = 49;
-        $minLength = $propertyValue - 1;
-        $expectedExceptionMessage = AssertionException::max(
-            $propertyValue,
-            $minLength,
-            $this->propertyName
-        )->getMessage();
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-        Assertion::max($propertyValue, $minLength, $this->propertyName);
-    }
-
-    /**
-     * Test no exception on max assertion
-     */
-    public function testNoExceptionMax(): void
-    {
-        $propertyValue = 49;
-        $minLength = $propertyValue;
-        Assertion::max($propertyValue, $minLength, $this->propertyName);
-        $this->expectNotToPerformAssertions();
-    }
-
-    /**
-     * Test the greaterOrEqualThan exception
-     */
-    public function testGreaterOrEqualThan(): void
-    {
-        $propertyValue = 1;
-        $minLength = $propertyValue + 1;
-        $expectedExceptionMessage = sprintf(
-            _('[%s] The value "%d" is not greater or equal than %d'),
-            $this->propertyName,
-            $propertyValue,
-            $minLength
-        );
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-        Assertion::greaterOrEqualThan($propertyValue, $minLength, $this->propertyName);
-    }
-
-    /**
-     * Test no exception on greaterOrEqualThan assertion
-     */
-    public function testNoExceptionGreaterOrEqualThan(): void
-    {
-        $propertyValue = 49;
-        $minLength = $propertyValue;
-        Assertion::greaterOrEqualThan($propertyValue, $minLength, $this->propertyName);
-        $this->expectNotToPerformAssertions();
-    }
-
-    /**
-     * Test the notEmpty assertion
-     */
-    public function testNotEmptyException(): void
-    {
-        $propertyValue = '';
-        $expectedExceptionMessage = AssertionException::notEmpty(
-            $this->propertyName
-        )->getMessage();
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-        Assertion::notEmpty($propertyValue, $this->propertyName);
-    }
-
-    /**
-     * Test no exception on notEmpty assertion
-     */
-    public function testNoExceptionNotEmpty(): void
-    {
-        $propertyValue = 'test_value_too_long';
-        Assertion::notEmpty($propertyValue, $this->propertyName);
-        $this->expectNotToPerformAssertions();
-    }
-
-    /**
-     * Test the notNull assertion
-     */
-    public function testNotNullException(): void
-    {
-        $propertyValue = null;
-        $expectedExceptionMessage = AssertionException::notNull(
-            $this->propertyName
-        )->getMessage();
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage($expectedExceptionMessage);
-        Assertion::notNull($propertyValue, $this->propertyName);
-    }
-
-    /**
-     * Test no exception on notNull assertion
-     */
-    public function testNoExceptionNotNull(): void
-    {
-        $propertyValue = 'test_value_too_long';
-        Assertion::notNull($propertyValue, $this->propertyName);
-        $this->expectNotToPerformAssertions();
-    }
+// We use a custom data provider with a loop, because pest auto-evaluate the closure from the dataset.
+foreach ($successDataProvider as $name => [$successAssertion]) {
+    it(
+        'should NOT throw an exception for ' . $name,
+        function () use ($successAssertion): void {
+            try {
+                $successAssertion();
+                expect(true)->toBeTrue();
+            } catch (\Throwable) {
+                $this->fail('This SHALL NOT fail.');
+            }
+        }
+    );
 }


### PR DESCRIPTION
## Description

* refactor: the inheritance tree around Assertion and its exceptions for a more consistant catch logic
* refactor: removed the direct use of Beberlei for custom messages to ease a future decoupling
* refactor: move tests to pest
* fix: messages where sometime exceptions message contained the stack trace (notEmpty, notNull, inArray)
* fix: missing consistent error codes for AssertionException
* fix: missing important and edge case tests (ie: mixed values, utf8, empty behaviour, ...)
* fix: missing asserts to match the assert exceptions
* fix: use of mixed non-string in regex assert caused a message factory error
* fix: various phpstan messages
* style: php-cs-fixer was passed over the classes

Jira: 🏷️ **MON-16872**

## The inheritance refactor

![image](https://user-images.githubusercontent.com/114949454/218994626-cbe73ad0-c013-4c7d-9b47-c04a2d3bf5e4.png)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

The pest tests.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
