### PR TITLE
enh(openid): retrieve conditions and mapping from token

### DIFF
--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -281,6 +281,9 @@ class OpenIdProvider implements OpenIdProviderInterface
 
         $this->sendRequestForConnectionTokenOrFail($authorizationCode);
         $this->createAuthenticationTokens();
+        if (array_key_exists("id_token", $this->connectionTokenResponseContent)) {
+            $this->idTokenPayload = $this->extractTokenPayload($this->connectionTokenResponseContent["id_token"]);
+        }
         $this->verifyThatClientIsAllowedToConnectOrFail($clientIp);
         if ($this->providerToken->isExpired() && $this->refreshToken->isExpired()) {
             throw SSOAuthenticationException::tokensExpired($this->configuration->getName());
@@ -289,9 +292,6 @@ class OpenIdProvider implements OpenIdProviderInterface
             $this->getUserInformationFromIntrospectionEndpoint();
         }
 
-        if (array_key_exists("id_token", $this->connectionTokenResponseContent)) {
-            $this->idTokenPayload = $this->extractTokenPayload($this->connectionTokenResponseContent["id_token"]);
-        }
         $this->username = $this->getUsernameFromLoginClaim();
     }
 
@@ -1019,6 +1019,9 @@ class OpenIdProvider implements OpenIdProviderInterface
             if (array_key_exists($attribute, $conditions)) {
                 $providerAuthenticationConditions = $conditions[$attribute];
                 $conditions = $conditions[$attribute];
+            } elseif (array_key_exists($attribute, $this->idTokenPayload)) {
+                $providerAuthenticationConditions = $this->idTokenPayload[$attribute];
+                $conditions = $this->idTokenPayload[$attribute];
             } else {
                 break;
             }
@@ -1157,11 +1160,15 @@ class OpenIdProvider implements OpenIdProviderInterface
 
         $conditions = $this->getAclConditionsFromProvider($customConfiguration);
         $attributePath = explode(".", $aclConditions->getAttributePath());
+        $this->info("CONNECTION TOKEN BIPBOUP", $this->idTokenPayload);
         foreach ($attributePath as $attribute) {
             $providerConditions = [];
             if (array_key_exists($attribute, $conditions)) {
                 $providerConditions = $conditions[$attribute];
                 $conditions = $conditions[$attribute];
+            } elseif (array_key_exists($attribute, $this->idTokenPayload)) {
+                $providerConditions = $this->idTokenPayload[$attribute];
+                $conditions = $this->idTokenPayload[$attribute];
             } else {
                 break;
             }
@@ -1319,6 +1326,9 @@ class OpenIdProvider implements OpenIdProviderInterface
             if (array_key_exists($attribute, $groups)) {
                 $providerGroups = $groups[$attribute];
                 $groups = $groups[$attribute];
+            } elseif (array_key_exists($attribute, $this->idTokenPayload)) {
+                $providerGroups = $this->idTokenPayload[$attribute];
+                $groups = $this->idTokenPayload[$attribute];
             } else {
                 break;
             }

--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -1160,7 +1160,6 @@ class OpenIdProvider implements OpenIdProviderInterface
 
         $conditions = $this->getAclConditionsFromProvider($customConfiguration);
         $attributePath = explode(".", $aclConditions->getAttributePath());
-        $this->info("CONNECTION TOKEN BIPBOUP", $this->idTokenPayload);
         foreach ($attributePath as $attribute) {
             $providerConditions = [];
             if (array_key_exists($attribute, $conditions)) {


### PR DESCRIPTION
## Description

This PR intends to retrieve Authentication Condition / Roles Mapping / Groups Mapping from JWT Connection Token if they haven't been found in the configured endpoints

**Fixes** # MON-16165

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
