### PR TITLE
enh (RT): Optimisation of SQL queries to reduce callbacks on the legacy hosts monitoring page

### DIFF
--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -63,15 +63,13 @@ class CentreonHost
     protected $serviceObj;
 
     /**
-     * Constructor
-     *
      * @param CentreonDB $db
-     * @return void
+     * @throws PDOException
      */
-    public function __construct($db)
+    public function __construct(CentreonDB $db)
     {
         $this->db = $db;
-        $this->instanceObj = new CentreonInstance($db);
+        $this->instanceObj = CentreonInstance::getInstance($db);
         $this->serviceObj = new CentreonService($db);
     }
 
@@ -684,7 +682,7 @@ class CentreonHost
               WHERE host_id = :hostId 
               LIMIT 1';
             $stmt = $this->db->prepare($query);
-            $stmt->bindParam(':hostId', (int) $hostParam, \PDO::PARAM_INT);
+            $stmt->bindValue(':hostId', (int) $hostParam, \PDO::PARAM_INT);
         } elseif (is_string($hostParam)) {
             $query = 'SELECT host_id, ns.nagios_server_id, host_register, host_address, host_name, host_alias
               FROM host
@@ -693,7 +691,7 @@ class CentreonHost
               WHERE host_name = :hostName
               LIMIT 1';
             $stmt = $this->db->prepare($query);
-            $stmt->bindParam(':hostName', $hostParam);
+            $stmt->bindValue(':hostName', $hostParam);
         } else {
             return $string;
         }
@@ -752,7 +750,7 @@ class CentreonHost
                 'WHERE host_host_id = :hostId ' .
                 'AND host_macro_name LIKE :macro';
             $stmt = $this->db->prepare($query);
-            $stmt->bindParam(':hostId', $hostId, PDO::PARAM_INT);
+            $stmt->bindValue(':hostId', $hostId, PDO::PARAM_INT);
             $stmt->bindParam(':macro', $matches[1][$i], PDO::PARAM_STR);
             $dbResult = $stmt->execute();
             if (!$dbResult) {
@@ -766,7 +764,7 @@ class CentreonHost
         if ($i) {
             $query2 = 'SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = :host ORDER BY `order`';
             $stmt2 = $this->db->prepare($query2);
-            $stmt2->bindParam(':host', $hostId, PDO::PARAM_INT);
+            $stmt2->bindValue(':host', $hostId, PDO::PARAM_INT);
             $dbResult = $stmt2->execute();
             if (!$dbResult) {
                 throw new \Exception("An error occured");

--- a/centreon/www/class/centreonInstance.class.php
+++ b/centreon/www/class/centreonInstance.class.php
@@ -42,6 +42,10 @@ class CentreonInstance
     protected $dbo;
     protected $params;
     protected $instances;
+    /**
+     * @var CentreonInstance|null $staticInstance
+     */
+    private static ?CentreonInstance $staticInstance = null;
 
     /**
      * Constructor
@@ -57,6 +61,17 @@ class CentreonInstance
         }
         $this->instances = array();
         $this->initParams();
+    }
+
+    /**
+     * @param CentreonDB $db
+     * @param CentreonDB|null $dbo
+     * @return CentreonInstance
+     * @throws PDOException
+     */
+    public static function getInstance(CentreonDB $db, ?CentreonDB $dbo = null): CentreonInstance
+    {
+        return self::$staticInstance ??= new self($db, $dbo);
     }
 
     /**

--- a/centreon/www/class/centreonService.class.php
+++ b/centreon/www/class/centreonService.class.php
@@ -75,7 +75,7 @@ class CentreonService
             $this->dbMon = $dbMon;
         }
 
-        $this->instanceObj = new CentreonInstance($db);
+        $this->instanceObj = CentreonInstance::getInstance($db, $dbMon);
     }
 
     /**

--- a/centreon/www/class/centreonXMLBGRequest.class.php
+++ b/centreon/www/class/centreonXMLBGRequest.class.php
@@ -141,7 +141,7 @@ class CentreonXMLBGRequest
          * Init Objects
          */
         $this->hostObj = new CentreonHost($this->DB);
-        $this->serviceObj = new CentreonService($this->DB);
+        $this->serviceObj = new CentreonService($this->DB, $this->DBC);
 
         /*
          * Init Object Monitoring


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/788

The aim is to reduce the number of requests when monitoring hosts.
In a typical case, reduction:
- As admin: 74 to 11 queries
- As non admin: 89 to 26 queries

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Deactivate the broker
2. Connect to the Centreon platform and access the http://lcentreon_ip/centreon/main.php?p=20202 page (Legacy Hosts Monitoring page)
3. Copy/paste the url called by Centreon to retrieve the real time hosts in a new browser tab (url: centreon/include/monitoring/status/Hosts/xml/hostXML.php ?....)
5. Close the Centreon main page
6. Check the number of queries in the database: `show status like 'Queries';``
7. Refresh the tab where the hostXML.php url is located.
8. Check the number of queries in the database again: show status like 'Queries'.

Do the subtraction.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
