### PR TITLE
fix(web): update query to get right acl groups and generate graph (22.04)

### DIFF
--- a/centreon/www/include/views/graphs/generateGraphs/generateImage.php
+++ b/centreon/www/include/views/graphs/generateGraphs/generateImage.php
@@ -200,7 +200,7 @@ if (!$isAdmin) {
 
     $aclGroupsQueryBinds = [];
     foreach ($aclGroupsExploded as $key => $value) {
-        $aclGroupsQueryBinds[':acl_group_' . $key] = $value;
+        $aclGroupsQueryBinds[':acl_group_' . $key] = str_replace("'","",$value);
     }
     $aclGroupBinds = implode(',', array_keys($aclGroupsQueryBinds));
     $sql = "SELECT service_id FROM centreon_acl WHERE host_id = :host_id AND service_id = :service_id


### PR DESCRIPTION
## Description

The previous query didn't get the right ACL groups and the non-admin user can't generate PNG from the Graph page.
I tested it with one and more groups.

**Fixes** MON-16467

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)