### PR TITLE
fix(clapi) update the updated column when poller reload/restart

### DIFF
--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -288,7 +288,7 @@ class CentreonConfigPoller
         $msg_restart = _("OK: A restart signal has been sent to '" . $host["name"] . "'");
         print $msg_restart . "\n";
         $statement = $this->DB->prepare(
-            "UPDATE `nagios_server` SET `last_restart` = :last_restart, `updated` = '0'  WHERE `id` = :poller_id LIMIT 1"
+            "UPDATE `nagios_server` SET `last_restart` = :last_restart, `updated` = '0' WHERE `id` = :poller_id LIMIT 1"
         );
         $statement->bindValue(':last_restart', time(), \PDO::PARAM_INT);
         $statement->bindValue(':poller_id', (int) $poller_id, \PDO::PARAM_INT);

--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -210,7 +210,7 @@ class CentreonConfigPoller
         $msg_restart = _("OK: A reload signal has been sent to '" . $host["name"] . "'");
         print $msg_restart . "\n";
         $statement = $this->DB->prepare(
-            "UPDATE `nagios_server` SET `last_restart` = :last_restart WHERE `id` = :poller_id LIMIT 1"
+            "UPDATE `nagios_server` SET `last_restart` = :last_restart, `updated` = '0' WHERE `id` = :poller_id LIMIT 1"
         );
         $statement->bindValue(':last_restart', time(), \PDO::PARAM_INT);
         $statement->bindValue(':poller_id', (int) $poller_id, \PDO::PARAM_INT);
@@ -288,7 +288,7 @@ class CentreonConfigPoller
         $msg_restart = _("OK: A restart signal has been sent to '" . $host["name"] . "'");
         print $msg_restart . "\n";
         $statement = $this->DB->prepare(
-            "UPDATE `nagios_server` SET `last_restart` = :last_restart WHERE `id` = :poller_id LIMIT 1"
+            "UPDATE `nagios_server` SET `last_restart` = :last_restart, `updated` = '0'  WHERE `id` = :poller_id LIMIT 1"
         );
         $statement->bindValue(':last_restart', time(), \PDO::PARAM_INT);
         $statement->bindValue(':poller_id', (int) $poller_id, \PDO::PARAM_INT);


### PR DESCRIPTION
## Description

The "updated" column of nagios_server was updated when we reload/restart threw the GUI but not from CLAPI.

**Fixes** MON-12216

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)