### PR TITLE
fix(security): rebuild query Service groups widget (dev-21.10.x)

### DIFF
--- a/widgets/centreon-widget-servicegroup-monitoring/servicegroup-monitoring/src/export.php
+++ b/widgets/centreon-widget-servicegroup-monitoring/servicegroup-monitoring/src/export.php
@@ -133,41 +133,49 @@ $serviceStateLabels = array(
 );
 
 $query = "SELECT SQL_CALC_FOUND_ROWS DISTINCT name FROM servicegroups ";
+$whereConditions = [];
+$whereParams = [];
+
 if (isset($preferences['sg_name_search']) && $preferences['sg_name_search'] != "") {
     $tab = explode(" ", $preferences['sg_name_search']);
-    $op = $tab[0];
-    if (isset($tab[1])) {
-        $search = $tab[1];
+    $operand = CentreonUtils::operandToMysqlFormat($tab[0]);
+    $searchString = $tab[1];
+
+    if ($operand && $searchString) {
+        $whereConditions[] = "name $operand :search_string";
+        $whereParams[':search_string'] = $searchString;
     }
-    if ($op && isset($search) && $search != "") {
-        $query = CentreonUtils::conditionBuilder(
-            $query,
-            "name " . CentreonUtils::operandToMysqlFormat($op) . " '" . $dbb->escape($search) . "' "
-        );
-    }
-}
-if (!$centreon->user->admin) {
-    $query = CentreonUtils::conditionBuilder(
-        $query,
-        "name IN (" . $aclObj->getServiceGroupsString("NAME") . ")"
-    );
 }
 
-$orderby = "name ASC";
+if (! $centreon->user->admin) {
+    $whereConditions[] = "name IN (" . $aclObj->getServiceGroupsString("NAME") . ")";
+
+}
+
+if ($whereConditions) {
+    $query .= " WHERE " . implode(" AND ", $whereConditions);
+}
+
+$orderBy = "name ASC";
 if (isset($preferences['order_by']) && $preferences['order_by'] != "") {
-    $orderby = $preferences['order_by'];
+    $orderBy = $preferences['order_by'];
 }
-$query .= "ORDER BY $orderby";
-file_put_contents("/tmp/log", $query);
 
-$res = $dbb->query($query);
-$nbRows = $res->rowCount();
+$query .= " ORDER BY $orderBy";
+
+$stmt = $dbb->prepare($query);
+// bind params
+foreach ($whereParams as $key => $value) {
+    $stmt->bindValue($key, $value, \PDO::PARAM_STR);
+}
+$stmt->execute();
+$nbRows = $stmt->rowCount();
 $data = array();
 $detailMode = false;
 if (isset($preferences['enable_detailed_mode']) && $preferences['enable_detailed_mode']) {
     $detailMode = true;
 }
-while ($row = $res->fetch()) {
+while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
     foreach ($row as $key => $value) {
         $data[$row['name']][$key] = $value;
         $data[$row['name']]['host_state'] = $sgMonObj->getHostStates(


### PR DESCRIPTION
## Description

Rebuild query
 

**Fixes** # MON-16606

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Configure services linked to SG
2. Export configuration
3. Add servicegroups-monitoring widget to a view
4. Edit widget and
5. Select a SG using “Servicegroup Name Search” filter
6. Enable “Enable pagination and more actions” option
7. Click on “Export button”
8. Validate that you download the CSV file and that this one contains correct values displayed in the widget (servicegroups name, and correct hosts and services status)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
