### PR TITLE
fix(oidc) call the legacy generateFile api through OIDC

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -176,6 +176,9 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
 
     /**
      * @inheritDoc
+     *
+     * Check if token is present in security_authentication_tokens (session token)
+     * and on top of that in security_token (JWT, OAuth access token...)
      */
     public function findByAuthenticationToken(string $token): ?Contact
     {
@@ -192,7 +195,9 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
                     ON t.topology_page = contact.default_page
                 INNER JOIN `:db`.security_authentication_tokens sat
                     ON sat.user_id = contact.contact_id
-                WHERE sat.token = :token
+                INNER JOIN `:db`.security_token st
+                    ON st.id = sat.provider_token_id
+                WHERE (sat.token = :token OR st.token = :token)
                 ORDER BY cp.creation_date DESC LIMIT 1"
             )
         );


### PR DESCRIPTION
## Description

When a user try export configuration through an oidc authentication on the top bar, we have an error.
![image](https://user-images.githubusercontent.com/110023866/218698279-2a612270-6ad4-413a-952c-19a59808a51b.png)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Authenticate a user with OpenID and try to export the configuration through the top bar
![image](https://user-images.githubusercontent.com/110023866/218698279-2a612270-6ad4-413a-952c-19a59808a51b.png)


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
