### PR TITLE
fix(recurrentDowntime): unable to edit a recurrent downtime (dev-22.04.x)

### DIFF
--- a/centreon/www/class/centreonDowntime.class.php
+++ b/centreon/www/class/centreonDowntime.class.php
@@ -268,7 +268,7 @@ class CentreonDowntime
      * Intends to return hosts, hostgroups, services, servicesgroups linked to the recurrent downtime
      *
      * @param integer $downtimeId
-     * @return array
+     * @return array<string, array<int, array{id: string, activated: '0'|'1'}>>
      */
     public function getRelations(int $downtimeId): array
     {

--- a/centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+++ b/centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
@@ -254,16 +254,17 @@ $form->setRequiredNote("<i class='red'>*</i>&nbsp;" . _("Required fields"));
 if ($o == "c" || $o == 'w') {
     $infos = $downtime->getInfos($id);
     $relations = $downtime->getRelations((int) $id);
-    $default_dt = array(
+    $extractRelationId = static fn(array $item): string => (string) ($item['id'] ?? '');
+    $default_dt = [
         'dt_id' => $id,
         'downtime_name' => $infos['name'],
         'downtime_description' => $infos['description'],
         'downtime_activate' => $infos['activate'],
-        'host_relations' => $relations['hosts'],
-        'hostgroup_relations' => $relations['hostgroups'],
-        'service_relations' => $relations['services'],
-        'servicegroup_relations' => $relations['servicegroups']
-    );
+        'host_relation' => array_map($extractRelationId, $relations['hosts']),
+        'hostgroup_relation' => array_map($extractRelationId, $relations['hostgroups']),
+        'svc_relation' => array_map($extractRelationId, $relations['services']),
+        'svcgroup_relation' => array_map($extractRelationId, $relations['servicegroups']),
+    ];
 }
 
 
@@ -301,9 +302,9 @@ if ($o == "w") {
         $userAcl = new CentreonACL($userId, $userIsAdmin);
 
         if (
-            ! checkResourcesRelations($userAcl, $default_dt['host_relations'], 'hosts')
-            || ! checkResourcesRelations($userAcl, $default_dt['hostgroup_relations'], 'hostgroups')
-            || ! checkResourcesRelations($userAcl, $default_dt['servicegroup_relations'], 'servicegroups')
+            ! checkResourcesRelations($userAcl, $default_dt['host_relation'], 'hosts')
+            || ! checkResourcesRelations($userAcl, $default_dt['hostgroup_relation'], 'hostgroups')
+            || ! checkResourcesRelations($userAcl, $default_dt['svcgroup_relation'], 'servicegroups')
         ) {
             $form->addElement('text', 'msgacl', _("error"), 'error');
             $form->freeze();


### PR DESCRIPTION
## Description

ℹ️ Backport of #958 

> Since #320 we cannot edit a recurrent downtime.
> This PR fixes that.

Jira: 🏷️ **MON-16971**

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [X] 22.04.x
- [X] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

The Jira ticket contains all the informations about testing.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
