### PR TITLE
enh(export) update key name to tag_name and severity_name in export files (tags.cfg and severities.cfg)

### DIFF
--- a/centreon/www/class/config-generate/hostcategory.class.php
+++ b/centreon/www/class/config-generate/hostcategory.class.php
@@ -53,7 +53,7 @@ final class HostCategory extends AbstractObject
         $this->generate_filename = 'tags.cfg';
         $this->attributes_write =  [
             'id',
-            'name',
+            'tag_name',
             'type',
         ];
     }
@@ -65,7 +65,7 @@ final class HostCategory extends AbstractObject
     private function addHostCategoryToList(int $hostCategoryId): self
     {
         $stmt = $this->backend_instance->db->prepare(
-            "SELECT hc_id as id, hc_name as name
+            "SELECT hc_id as id, hc_name as tag_name
             FROM hostcategories
             WHERE hc_id = :hc_id
             AND level IS NULL

--- a/centreon/www/class/config-generate/hostgroup.class.php
+++ b/centreon/www/class/config-generate/hostgroup.class.php
@@ -135,7 +135,7 @@ class Hostgroup extends AbstractObject
         $this->object_name = self::TAG_OBJECT_NAME;
         $this->attributes_write = [
             'id',
-            'name',
+            'tag_name',
             'type',
         ];
         $this->attributes_array = [];
@@ -150,7 +150,7 @@ class Hostgroup extends AbstractObject
 
             $tag = [
                 'id' => $value['hostgroup_id'],
-                'name' => $value['hostgroup_name'],
+                'tag_name' => $value['hostgroup_name'],
                 'type' => self::TAG_TYPE,
             ];
 

--- a/centreon/www/class/config-generate/servicecategory.class.php
+++ b/centreon/www/class/config-generate/servicecategory.class.php
@@ -54,7 +54,7 @@ final class ServiceCategory extends AbstractObject
         $this->generate_filename = 'tags.cfg';
         $this->attributes_write =  [
             'id',
-            'name',
+            'tag_name',
             'type',
         ];
     }
@@ -102,7 +102,7 @@ final class ServiceCategory extends AbstractObject
     private function addServiceCategoryToList(int $serviceCategoryId): self
     {
         $stmt = $this->backend_instance->db->prepare(
-            "SELECT sc_id as id, sc_name as name
+            "SELECT sc_id as id, sc_name as tag_name
             FROM service_categories
             WHERE sc_id = :serviceCategoryId AND level IS NULL AND sc_activate = '1'"
         );

--- a/centreon/www/class/config-generate/servicegroup.class.php
+++ b/centreon/www/class/config-generate/servicegroup.class.php
@@ -228,7 +228,7 @@ class Servicegroup extends AbstractObject
         $this->object_name = self::TAG_OBJECT_NAME;
         $this->attributes_write = [
             'id',
-            'name',
+            'tag_name',
             'type',
         ];
         $this->attributes_array = [];
@@ -243,7 +243,7 @@ class Servicegroup extends AbstractObject
 
             $tag = [
                 'id' => $value['servicegroup_id'],
-                'name' => $value['servicegroup_name'],
+                'tag_name' => $value['servicegroup_name'],
                 'type' => self::TAG_TYPE,
             ];
 

--- a/centreon/www/class/config-generate/severity.class.php
+++ b/centreon/www/class/config-generate/severity.class.php
@@ -55,19 +55,19 @@ class Severity extends AbstractObject
     protected $object_name = 'severity';
     protected $attributesSelectHost = [
         'hc_id' => 'id',
-        'hc_name' => 'name',
+        'hc_name' => 'severity_name',
         'level' => 'level',
         'icon_id' => 'icon_id',
     ];
     protected $attributesSelectService = [
         'sc_id' => 'id',
-        'sc_name' => 'name',
+        'sc_name' => 'severity_name',
         'level' => 'level',
         'icon_id' => 'icon_id',
     ];
     protected $attributes_write = [
         'id',
-        'name',
+        'severity_name',
         'level',
         'icon_id',
         'type',


### PR DESCRIPTION
## Description

Change property 'name' to 'tag_name' in tags.cfg file and 'severity_name' in severities.cfg file

```
define tag {
    id                             1
    tag_name                       Centreon
    type                           hostgroup
}

define tag {
    id                             1
    tag_name                       Ping
    type                           servicecategory
}
```
and 

```
define severity {
    id                             5
    severity_name                  P1
    level                          1
    icon_id                        3
    type                           service
}
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>
Create:

- At least one host group
- At least one host category
- At least one host severity
- At least one service group
- At least one service category
- At least one service severity

And make sure there is at least one host/service linked to each one (to make sure they will be exported).

Export and reload the configuration. Files should follow the naming example above

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
