### PR TITLE
fix(conf) allow to update service group without name change

### DIFF
--- a/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
@@ -52,7 +52,7 @@ function testServiceGroupExistence($name = null)
     $statement->bindValue(':sg_name', $sgName, \PDO::PARAM_STR);
     $statement->execute();
     $sg = $statement->fetch();
-    if ($statement->rowCount() >= 1 && $sg["sg_id"] !== $id) {
+    if ($statement->rowCount() >= 1 && $sg["sg_id"] !== (int) $id) {
         return false;
     } else {
         return true;


### PR DESCRIPTION
## Description

Trying to edit a service group without changing the name result in the error message “Name already in use”  and won't allow you to save unless you change the service group name

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
