### PR TITLE
fix(conf) allow to update escalation without name change

### DIFF
--- a/centreon/www/include/configuration/configObject/escalation/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/escalation/DB-Func.php
@@ -59,7 +59,7 @@ function testExistence(?string $name = null): bool
 
     $escalation = $stmt->fetch();
 
-    return ! ($stmt->rowCount() >= 1 && $escalation["esc_id"] !== $id);
+    return ! ($stmt->rowCount() >= 1 && $escalation["esc_id"] !== (int) $id);
 }
 
 /**


### PR DESCRIPTION
## Description

Trying to edit an existing Escalation without changing its name result in the error message “Name already in use”  and won't allow you to save your modification unlesss you change hte name as well

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
