### PR TITLE
fix(centreon): Fix list host categories with database contains hyphen

### DIFF
--- a/centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+++ b/centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
@@ -151,7 +151,7 @@ for ($i = 0; $hc = $statement->fetch(\PDO::FETCH_ASSOC); $i++) {
     $aclFrom = "";
     $aclCond = "";
     if (!$centreon->user->admin) {
-        $aclFrom = ", $aclDbName.centreon_acl acl ";
+        $aclFrom = ", `$aclDbName`.centreon_acl acl ";
         $aclCond = " AND h.host_id = acl.host_id AND acl.group_id IN (" . $acl->getAccessGroupsString() . ") ";
     }
     $hcStatement = $pearDB->prepare("SELECT h.host_id, h.host_activate " .


### PR DESCRIPTION
## Description

> The dabase name should be enclosed into backticks `` `db-name` `` to avoid a SQL error when the name contains non-standard characters like hyphen `-`.

Jira : 🏷️ **MON-15864**

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
