### PR TITLE
[enh]: configure mariadb with utf8mb4 by default

### DIFF
--- a/centreon/src/Centreon/Infrastructure/DatabaseConnection.php
+++ b/centreon/src/Centreon/Infrastructure/DatabaseConnection.php
@@ -53,7 +53,7 @@ class DatabaseConnection extends \PDO
     {
         $dsn = "mysql:dbname={$basename};host={$host};port={$port}";
         $options = array(
-            \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
+            \PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
             \PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION,
             \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC,
         );

--- a/centreon/tools/convert_db_charset_to_utfmb4.php
+++ b/centreon/tools/convert_db_charset_to_utfmb4.php
@@ -49,7 +49,7 @@ function convertCharset($dbName, $db, $excluded_table = "")
             $tableName = $table["table_name"];
             $tableType = $table["table_type"];
 
-            // Check if the table is a view, and skip it if it is
+            // Skip the table if it is a view or an explicitly excluded table
             if ($tableName === $excluded_table || $tableType !== "BASE TABLE") {
                 continue;
             }

--- a/centreon/tools/convert_db_charset_to_utfmb4.php
+++ b/centreon/tools/convert_db_charset_to_utfmb4.php
@@ -56,7 +56,7 @@ function convertCharset($dbName, $db, $excluded_table = "")
 
             $errorMessage = "Couldn't change charset for table: " . $tableName . "\n";
             // Create a query to alter the table and change the character set to utf8mb4
-            $query = 'ALTER TABLE ' . $tableName . ' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci';
+            $query = 'ALTER TABLE `' . $tableName . '` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci';
             $stmt = $db->prepare($query);
             $stmt->execute();
 
@@ -65,9 +65,6 @@ function convertCharset($dbName, $db, $excluded_table = "")
         echo "All tables of " . $dbName . " have had their charset converted.\n";
     } catch (\PDOException $e) {
 
-        if ($db->inTransaction()) {
-            $db->rollBack();
-        }
         throw new \Exception($errorMessage, (int)$e->getCode(), $e);
     }
 }

--- a/centreon/tools/convert_db_charset_to_utfmb4.php
+++ b/centreon/tools/convert_db_charset_to_utfmb4.php
@@ -1,0 +1,75 @@
+<?php
+
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+
+require_once(__DIR__ . '/../bootstrap.php');
+$pearDB = new CentreonDB("centreon");
+$pearDBO = new CentreonDB("centstorage");
+
+convertCharset("centreon", $pearDB, "security_token");
+
+convertCharset("centreon_storage", $pearDBO);
+
+
+function convertCharset($dbName, $db, $excluded_table = "")
+{
+
+    try {
+
+        $errorMessage = "";
+
+        // Get the list of tables in the database
+        $query = "SELECT table_name, table_type FROM information_schema.tables WHERE table_schema = :database";
+        $stmt = $db->prepare($query);
+        $stmt->execute(array (":database" => $dbName));
+        $tables = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+
+        // Loop through the tables and convert them to utf8mb4
+        foreach ($tables as $table) {
+            $tableName = $table["table_name"];
+            $tableType = $table["table_type"];
+
+            // Check if the table is a view, and skip it if it is
+            if ($tableName === $excluded_table || $tableType !== "BASE TABLE") {
+                continue;
+            }
+
+            $errorMessage = "Couldn't change charset for table: " . $tableName;
+            // Create a query to alter the table and change the character set to utf8mb4
+            $query = 'ALTER TABLE ' . $tableName . ' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci';
+            $stmt = $db->prepare($query);
+            $stmt->execute();
+
+        }
+
+        echo "all tables of " . $dbName . " has charset converted \n";
+    } catch (\PDOException $e) {
+
+        if ($db->inTransaction()) {
+            $db->rollBack();
+        }
+        throw new \Exception($errorMessage, (int)$e->getCode(), $e);
+    }
+}
+
+

--- a/centreon/tools/convert_db_charset_to_utfmb4.php
+++ b/centreon/tools/convert_db_charset_to_utfmb4.php
@@ -40,7 +40,7 @@ function convertCharset($dbName, $db, $excluded_table = "")
         // Get the list of tables in the database
         $query = "SELECT table_name, table_type FROM information_schema.tables WHERE table_schema = :database";
         $stmt = $db->prepare($query);
-        $stmt->execute(array (":database" => $dbName));
+        $stmt->execute([":database" => $dbName]);
         $tables = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 
@@ -54,7 +54,7 @@ function convertCharset($dbName, $db, $excluded_table = "")
                 continue;
             }
 
-            $errorMessage = "Couldn't change charset for table: " . $tableName;
+            $errorMessage = "Couldn't change charset for table: " . $tableName . "\n";
             // Create a query to alter the table and change the character set to utf8mb4
             $query = 'ALTER TABLE ' . $tableName . ' CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci';
             $stmt = $db->prepare($query);
@@ -62,7 +62,7 @@ function convertCharset($dbName, $db, $excluded_table = "")
 
         }
 
-        echo "all tables of " . $dbName . " has charset converted \n";
+        echo "All tables of " . $dbName . " have had their charset converted.\n";
     } catch (\PDOException $e) {
 
         if ($db->inTransaction()) {

--- a/centreon/tools/convert_db_charset_to_utfmb4.php
+++ b/centreon/tools/convert_db_charset_to_utfmb4.php
@@ -62,7 +62,7 @@ function convertCharset($dbName, $db, $excluded_table = "")
 
         }
 
-        echo "All tables of " . $dbName . " have had their charset converted.\n";
+        echo "All tables of " . $dbName . " had their charset converted.\n";
     } catch (\PDOException $e) {
 
         throw new \Exception($errorMessage, (int)$e->getCode(), $e);

--- a/centreon/www/class/centreonDB.class.php
+++ b/centreon/www/class/centreonDB.class.php
@@ -158,7 +158,7 @@ class CentreonDB extends \PDO
                     CentreonDBStatement::class,
                     [$this->log],
                 ],
-                PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8',
+                PDO::MYSQL_ATTR_INIT_COMMAND => 'SET NAMES utf8mb4',
                 PDO::MYSQL_ATTR_LOCAL_INFILE => true,
                 PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION
             ];

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -17,7 +17,7 @@ CREATE TABLE `acl_actions` (
   `acl_action_description` varchar(255) DEFAULT NULL,
   `acl_action_activate` enum('0','1','2') DEFAULT NULL,
   PRIMARY KEY (`acl_action_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -28,7 +28,7 @@ CREATE TABLE `acl_actions_rules` (
   PRIMARY KEY (`aar_id`),
   KEY `acl_action_rule_id` (`acl_action_rule_id`),
   CONSTRAINT `acl_actions_rules_ibfk_1` FOREIGN KEY (`acl_action_rule_id`) REFERENCES `acl_actions` (`acl_action_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -37,7 +37,7 @@ CREATE TABLE `acl_group_actions_relations` (
   `acl_group_id` int(11) DEFAULT NULL,
   KEY `acl_action_id` (`acl_action_id`),
   KEY `acl_group_id` (`acl_group_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -48,7 +48,7 @@ CREATE TABLE `acl_group_contactgroups_relations` (
   KEY `acl_group_id` (`acl_group_id`),
   CONSTRAINT `acl_group_contactgroups_relations_ibfk_2` FOREIGN KEY (`acl_group_id`) REFERENCES `acl_groups` (`acl_group_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_group_contactgroups_relations_ibfk_1` FOREIGN KEY (`cg_cg_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -59,7 +59,7 @@ CREATE TABLE `acl_group_contacts_relations` (
   KEY `acl_group_id` (`acl_group_id`),
   CONSTRAINT `acl_group_contacts_relations_ibfk_1` FOREIGN KEY (`contact_contact_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_group_contacts_relations_ibfk_2` FOREIGN KEY (`acl_group_id`) REFERENCES `acl_groups` (`acl_group_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -70,7 +70,7 @@ CREATE TABLE `acl_group_topology_relations` (
   KEY `acl_topology_id` (`acl_topology_id`),
   CONSTRAINT `acl_group_topology_relations_ibfk_1` FOREIGN KEY (`acl_group_id`) REFERENCES `acl_groups` (`acl_group_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_group_topology_relations_ibfk_2` FOREIGN KEY (`acl_topology_id`) REFERENCES `acl_topology` (`acl_topo_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -81,7 +81,7 @@ CREATE TABLE `acl_groups` (
   `acl_group_changed` int(11) NOT NULL DEFAULT 1,
   `acl_group_activate` enum('0','1','2') DEFAULT NULL,
   PRIMARY KEY (`acl_group_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -92,7 +92,7 @@ CREATE TABLE `acl_res_group_relations` (
   KEY `acl_group_id` (`acl_group_id`),
   CONSTRAINT `acl_res_group_relations_ibfk_1` FOREIGN KEY (`acl_res_id`) REFERENCES `acl_resources` (`acl_res_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_res_group_relations_ibfk_2` FOREIGN KEY (`acl_group_id`) REFERENCES `acl_groups` (`acl_group_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -109,7 +109,7 @@ CREATE TABLE `acl_resources` (
   `changed` int(11) DEFAULT NULL,
   `locked` tinyint(1) NOT NULL DEFAULT 0,
   PRIMARY KEY (`acl_res_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -120,7 +120,7 @@ CREATE TABLE `acl_resources_hc_relations` (
   KEY `acl_res_id` (`acl_res_id`),
   CONSTRAINT `acl_resources_hc_relations_ibfk_1` FOREIGN KEY (`hc_id`) REFERENCES `hostcategories` (`hc_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_resources_hc_relations_ibfk_2` FOREIGN KEY (`acl_res_id`) REFERENCES `acl_resources` (`acl_res_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -132,7 +132,7 @@ CREATE TABLE `acl_resources_hg_relations` (
   KEY `hg_hg_id_2` (`hg_hg_id`,`acl_res_id`),
   CONSTRAINT `acl_resources_hg_relations_ibfk_2` FOREIGN KEY (`acl_res_id`) REFERENCES `acl_resources` (`acl_res_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_resources_hg_relations_ibfk_1` FOREIGN KEY (`hg_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -143,7 +143,7 @@ CREATE TABLE `acl_resources_host_relations` (
   KEY `acl_res_id` (`acl_res_id`),
   CONSTRAINT `acl_resources_host_relations_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_resources_host_relations_ibfk_2` FOREIGN KEY (`acl_res_id`) REFERENCES `acl_resources` (`acl_res_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -154,7 +154,7 @@ CREATE TABLE `acl_resources_hostex_relations` (
   KEY `acl_res_id` (`acl_res_id`),
   CONSTRAINT `acl_resources_hostex_relations_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_resources_hostex_relations_ibfk_2` FOREIGN KEY (`acl_res_id`) REFERENCES `acl_resources` (`acl_res_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -165,7 +165,7 @@ CREATE TABLE `acl_resources_meta_relations` (
   KEY `acl_res_id` (`acl_res_id`),
   CONSTRAINT `acl_resources_meta_relations_ibfk_2` FOREIGN KEY (`acl_res_id`) REFERENCES `acl_resources` (`acl_res_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_resources_meta_relations_ibfk_1` FOREIGN KEY (`meta_id`) REFERENCES `meta_service` (`meta_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -176,7 +176,7 @@ CREATE TABLE `acl_resources_poller_relations` (
   KEY `acl_res_id` (`acl_res_id`),
   CONSTRAINT `acl_resources_poller_relations_ibfk_1` FOREIGN KEY (`poller_id`) REFERENCES `nagios_server` (`id`) ON DELETE CASCADE,
   CONSTRAINT `acl_resources_poller_relations_ibfk_2` FOREIGN KEY (`acl_res_id`) REFERENCES `acl_resources` (`acl_res_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -187,7 +187,7 @@ CREATE TABLE `acl_resources_sc_relations` (
   KEY `acl_res_id` (`acl_res_id`),
   CONSTRAINT `acl_resources_sc_relations_ibfk_1` FOREIGN KEY (`sc_id`) REFERENCES `service_categories` (`sc_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_resources_sc_relations_ibfk_2` FOREIGN KEY (`acl_res_id`) REFERENCES `acl_resources` (`acl_res_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -198,7 +198,7 @@ CREATE TABLE `acl_resources_service_relations` (
   KEY `acl_group_id` (`acl_group_id`),
   CONSTRAINT `acl_resources_service_relations_ibfk_1` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_resources_service_relations_ibfk_2` FOREIGN KEY (`acl_group_id`) REFERENCES `acl_groups` (`acl_group_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -210,7 +210,7 @@ CREATE TABLE `acl_resources_sg_relations` (
   KEY `sg_id_2` (`sg_id`,`acl_res_id`),
   CONSTRAINT `acl_resources_sg_relations_ibfk_2` FOREIGN KEY (`acl_res_id`) REFERENCES `acl_resources` (`acl_res_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_resources_sg_relations_ibfk_1` FOREIGN KEY (`sg_id`) REFERENCES `servicegroup` (`sg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -222,7 +222,7 @@ CREATE TABLE `acl_topology` (
   `acl_topo_activate` enum('0','1') DEFAULT NULL,
   PRIMARY KEY (`acl_topo_id`),
   KEY `acl_topo_id` (`acl_topo_id`,`acl_topo_activate`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -234,7 +234,7 @@ CREATE TABLE `acl_topology_relations` (
   KEY `acl_topo_id` (`acl_topo_id`),
   CONSTRAINT `acl_topology_relations_ibfk_2` FOREIGN KEY (`topology_topology_id`) REFERENCES `topology` (`topology_id`) ON DELETE CASCADE,
   CONSTRAINT `acl_topology_relations_ibfk_3` FOREIGN KEY (`acl_topo_id`) REFERENCES `acl_topology` (`acl_topo_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -246,7 +246,7 @@ CREATE TABLE `auth_ressource` (
   `ar_enable` enum('0','1') DEFAULT '0',
   `ar_sync_base_date` int(11) DEFAULT 0,
   PRIMARY KEY (`ar_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -261,7 +261,7 @@ CREATE TABLE `auth_ressource_host` (
   PRIMARY KEY (`ldap_host_id`),
   KEY `fk_auth_ressource_id` (`auth_ressource_id`),
   CONSTRAINT `fk_auth_ressource_id` FOREIGN KEY (`auth_ressource_id`) REFERENCES `auth_ressource` (`ar_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -271,7 +271,7 @@ CREATE TABLE `auth_ressource_info` (
   `ari_value` varchar(1024) NOT NULL,
   PRIMARY KEY (`ar_id`,`ari_name`),
   CONSTRAINT `auth_ressource_info_ibfk_1` FOREIGN KEY (`ar_id`) REFERENCES `auth_ressource` (`ar_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -279,7 +279,7 @@ CREATE TABLE `cb_fieldset` (
   `cb_fieldset_id` INT NOT NULL,
   `fieldset_name` VARCHAR(255) NOT NULL,
   PRIMARY KEY(`cb_fieldset_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -291,7 +291,7 @@ CREATE TABLE `cb_fieldgroup` (
   `group_parent_id` INT DEFAULT NULL,
   PRIMARY KEY(`cb_fieldgroup_id`),
   FOREIGN KEY(`group_parent_id`) REFERENCES `cb_fieldgroup` (`cb_fieldgroup_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -455,7 +455,7 @@ CREATE TABLE `cfg_centreonbroker` (
   `pool_size` int(11) DEFAULT NULL,
   `bbdo_version` varchar(50) DEFAULT '3.0.0',
   PRIMARY KEY (`config_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -472,7 +472,7 @@ CREATE TABLE `cfg_centreonbroker_info` (
   KEY `cfg_centreonbroker_info_idx01` (`config_id`),
   KEY `cfg_centreonbroker_info_idx02` (`config_id`,`config_group`),
   CONSTRAINT `cfg_centreonbroker_info_ibfk_01` FOREIGN KEY (`config_id`) REFERENCES `cfg_centreonbroker` (`config_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -574,7 +574,7 @@ CREATE TABLE `cfg_nagios` (
   CONSTRAINT `cfg_nagios_ibfk_19` FOREIGN KEY (`global_service_event_handler`) REFERENCES `command` (`command_id`) ON DELETE SET NULL,
   CONSTRAINT `cfg_nagios_ibfk_26` FOREIGN KEY (`nagios_server_id`) REFERENCES `nagios_server` (`id`) ON DELETE CASCADE,
   CONSTRAINT `cfg_nagios_ibfk_27` FOREIGN KEY (`use_timezone`) REFERENCES `timezone` (`timezone_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -585,7 +585,7 @@ CREATE TABLE `cfg_nagios_broker_module` (
   PRIMARY KEY (`bk_mod_id`),
   KEY `fk_nagios_cfg` (`cfg_nagios_id`),
   CONSTRAINT `fk_nagios_cfg` FOREIGN KEY (`cfg_nagios_id`) REFERENCES `cfg_nagios` (`nagios_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -596,7 +596,7 @@ CREATE TABLE `cfg_resource` (
   `resource_comment` varchar(255) DEFAULT NULL,
   `resource_activate` enum('0','1') DEFAULT NULL,
   PRIMARY KEY (`resource_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -607,7 +607,7 @@ CREATE TABLE `cfg_resource_instance_relations` (
   KEY `fk_crir_ins_id` (`instance_id`),
   CONSTRAINT `fk_crir_res_id` FOREIGN KEY (`resource_id`) REFERENCES `cfg_resource` (`resource_id`) ON DELETE CASCADE,
   CONSTRAINT `fk_crir_ins_id` FOREIGN KEY (`instance_id`) REFERENCES `nagios_server` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -627,7 +627,7 @@ CREATE TABLE `command` (
   PRIMARY KEY (`command_id`),
   KEY `connector_id` (`connector_id`),
   CONSTRAINT `command_ibfk_1` FOREIGN KEY (`connector_id`) REFERENCES `connector` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -637,7 +637,7 @@ CREATE TABLE `command_arg_description` (
   `macro_description` varchar(255) NOT NULL,
   KEY `command_arg_description_ibfk_1` (`cmd_id`),
   CONSTRAINT `command_arg_description_ibfk_1` FOREIGN KEY (`cmd_id`) REFERENCES `command` (`command_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -647,14 +647,14 @@ CREATE TABLE `command_categories` (
   `category_alias` varchar(255) NOT NULL,
   `category_order` int(11) NOT NULL,
   PRIMARY KEY (`cmd_category_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `command_categories_relation` (
   `category_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -669,7 +669,7 @@ CREATE TABLE `connector` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `name` (`name`),
   KEY `enabled` (`enabled`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -726,7 +726,7 @@ CREATE TABLE `contact` (
   CONSTRAINT `contact_ibfk_2` FOREIGN KEY (`timeperiod_tp_id2`) REFERENCES `timeperiod` (`tp_id`) ON DELETE SET NULL,
   CONSTRAINT `contact_ibfk_3` FOREIGN KEY (`contact_template_id`) REFERENCES `contact` (`contact_id`) ON DELETE SET NULL,
   CONSTRAINT `fk_ar_id` FOREIGN KEY (`ar_id`) REFERENCES `auth_ressource` (`ar_id`) ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -737,7 +737,7 @@ CREATE TABLE `contact_host_relation` (
   KEY `contact_id` (`contact_id`),
   CONSTRAINT `contact_host_relation_ibfk_2` FOREIGN KEY (`contact_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
   CONSTRAINT `contact_host_relation_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -748,7 +748,7 @@ CREATE TABLE `contact_hostcommands_relation` (
   KEY `command_index` (`command_command_id`),
   CONSTRAINT `contact_hostcommands_relation_ibfk_1` FOREIGN KEY (`contact_contact_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
   CONSTRAINT `contact_hostcommands_relation_ibfk_2` FOREIGN KEY (`command_command_id`) REFERENCES `command` (`command_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -760,7 +760,7 @@ CREATE TABLE `contact_param` (
   PRIMARY KEY (`id`),
   KEY `contact_id` (`cp_contact_id`),
   CONSTRAINT `contact_param_ibfk_1` FOREIGN KEY (`cp_contact_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -771,7 +771,7 @@ CREATE TABLE `contact_service_relation` (
   KEY `contact_id` (`contact_id`),
   CONSTRAINT `contact_service_relation_ibfk_2` FOREIGN KEY (`contact_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
   CONSTRAINT `contact_service_relation_ibfk_1` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -782,7 +782,7 @@ CREATE TABLE `contact_servicecommands_relation` (
   KEY `command_index` (`command_command_id`),
   CONSTRAINT `contact_servicecommands_relation_ibfk_1` FOREIGN KEY (`contact_contact_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
   CONSTRAINT `contact_servicecommands_relation_ibfk_2` FOREIGN KEY (`command_command_id`) REFERENCES `command` (`command_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -798,7 +798,7 @@ CREATE TABLE `contactgroup` (
   PRIMARY KEY (`cg_id`),
   KEY `name_index` (`cg_name`),
   KEY `alias_index` (`cg_alias`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -809,7 +809,7 @@ CREATE TABLE `contactgroup_contact_relation` (
   KEY `contactgroup_index` (`contactgroup_cg_id`),
   CONSTRAINT `contactgroup_contact_relation_ibfk_1` FOREIGN KEY (`contact_contact_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
   CONSTRAINT `contactgroup_contact_relation_ibfk_2` FOREIGN KEY (`contactgroup_cg_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -820,7 +820,7 @@ CREATE TABLE `contactgroup_host_relation` (
   KEY `contactgroup_index` (`contactgroup_cg_id`),
   CONSTRAINT `contactgroup_host_relation_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `contactgroup_host_relation_ibfk_2` FOREIGN KEY (`contactgroup_cg_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -831,7 +831,7 @@ CREATE TABLE `contactgroup_hostgroup_relation` (
   KEY `hostgroup_index` (`hostgroup_hg_id`),
   CONSTRAINT `contactgroup_hostgroup_relation_ibfk_1` FOREIGN KEY (`contactgroup_cg_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE,
   CONSTRAINT `contactgroup_hostgroup_relation_ibfk_2` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -842,7 +842,7 @@ CREATE TABLE `contactgroup_service_relation` (
   KEY `service_index` (`service_service_id`),
   CONSTRAINT `contactgroup_service_relation_ibfk_1` FOREIGN KEY (`contactgroup_cg_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE,
   CONSTRAINT `contactgroup_service_relation_ibfk_2` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -853,7 +853,7 @@ CREATE TABLE `contactgroup_servicegroup_relation` (
   KEY `contactgroup_index` (`contactgroup_cg_id`),
   CONSTRAINT `contactgroup_servicegroup_relation_ibfk_1` FOREIGN KEY (`contactgroup_cg_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE,
   CONSTRAINT `contactgroup_servicegroup_relation_ibfk_2` FOREIGN KEY (`servicegroup_sg_id`) REFERENCES `servicegroup` (`sg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -870,7 +870,7 @@ CREATE TABLE `cron_operation` (
   `last_execution_time` int(11) NOT NULL DEFAULT '0',
   `activate` enum('0','1') DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -879,7 +879,7 @@ CREATE TABLE `css_color_menu` (
   `menu_nb` int(11) DEFAULT NULL,
   `css_name` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id_css_color_menu`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -890,7 +890,7 @@ CREATE TABLE `custom_view_default` (
   KEY `fk_custom_view_default_cv_id` (`custom_view_id`),
   CONSTRAINT `fk_custom_view_default_user_id` FOREIGN KEY (`user_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
   CONSTRAINT `fk_custom_view_default_cv_id` FOREIGN KEY (`custom_view_id`) REFERENCES `custom_views` (`custom_view_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -909,7 +909,7 @@ CREATE TABLE `custom_view_user_relation` (
   CONSTRAINT `fk_custom_views_user_id` FOREIGN KEY (`user_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
   CONSTRAINT `fk_custom_views_usergroup_id` FOREIGN KEY (`usergroup_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE,
   CONSTRAINT `fk_custom_view_user_id` FOREIGN KEY (`custom_view_id`) REFERENCES `custom_views` (`custom_view_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -919,7 +919,7 @@ CREATE TABLE `custom_views` (
   `layout` varchar(255) NOT NULL,
   `public` tinyint(6) null default 0,
   PRIMARY KEY (`custom_view_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -932,7 +932,7 @@ CREATE TABLE `dependency` (
   `notification_failure_criteria` varchar(255) DEFAULT NULL,
   `dep_comment` text,
   PRIMARY KEY (`dep_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -944,7 +944,7 @@ CREATE TABLE `dependency_hostChild_relation` (
   UNIQUE (`dependency_dep_id`, `host_host_id`),
   CONSTRAINT `dependency_hostChild_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_hostChild_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -956,7 +956,7 @@ CREATE TABLE `dependency_hostParent_relation` (
   UNIQUE (`dependency_dep_id`, `host_host_id`),
   CONSTRAINT `dependency_hostParent_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_hostParent_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -968,7 +968,7 @@ CREATE TABLE `dependency_hostgroupChild_relation` (
   UNIQUE (`dependency_dep_id`, `hostgroup_hg_id`),
   CONSTRAINT `dependency_hostgroupChild_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_hostgroupChild_relation_ibfk_2` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -980,7 +980,7 @@ CREATE TABLE `dependency_hostgroupParent_relation` (
   UNIQUE (`dependency_dep_id`, `hostgroup_hg_id`),
   CONSTRAINT `dependency_hostgroupParent_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_hostgroupParent_relation_ibfk_2` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -992,7 +992,7 @@ CREATE TABLE `dependency_metaserviceChild_relation` (
   UNIQUE (`dependency_dep_id`, `meta_service_meta_id`),
   CONSTRAINT `dependency_metaserviceChild_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_metaserviceChild_relation_ibfk_2` FOREIGN KEY (`meta_service_meta_id`) REFERENCES `meta_service` (`meta_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1004,7 +1004,7 @@ CREATE TABLE `dependency_metaserviceParent_relation` (
   UNIQUE (`dependency_dep_id`, `meta_service_meta_id`),
   CONSTRAINT `dependency_metaserviceParent_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_metaserviceParent_relation_ibfk_2` FOREIGN KEY (`meta_service_meta_id`) REFERENCES `meta_service` (`meta_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1019,7 +1019,7 @@ CREATE TABLE `dependency_serviceChild_relation` (
   CONSTRAINT `dependency_serviceChild_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_serviceChild_relation_ibfk_2` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_serviceChild_relation_ibfk_3` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1034,7 +1034,7 @@ CREATE TABLE `dependency_serviceParent_relation` (
   CONSTRAINT `dependency_serviceParent_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_serviceParent_relation_ibfk_2` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_serviceParent_relation_ibfk_3` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1046,7 +1046,7 @@ CREATE TABLE `dependency_servicegroupChild_relation` (
   UNIQUE (`dependency_dep_id`, `servicegroup_sg_id`),
   CONSTRAINT `dependency_servicegroupChild_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_servicegroupChild_relation_ibfk_2` FOREIGN KEY (`servicegroup_sg_id`) REFERENCES `servicegroup` (`sg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1058,7 +1058,7 @@ CREATE TABLE `dependency_servicegroupParent_relation` (
   UNIQUE (`dependency_dep_id`, `servicegroup_sg_id`),
   CONSTRAINT `dependency_servicegroupParent_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_servicegroupParent_relation_ibfk_2` FOREIGN KEY (`servicegroup_sg_id`) REFERENCES `servicegroup` (`sg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1070,7 +1070,7 @@ CREATE TABLE `downtime` (
   PRIMARY KEY (`dt_id`),
   UNIQUE KEY `downtime_idx02` (`dt_name`),
   KEY `downtime_idx01` (`dt_id`,`dt_activate`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1081,7 +1081,7 @@ CREATE TABLE `downtime_host_relation` (
   KEY `downtime_host_relation_ibfk_1` (`host_host_id`),
   CONSTRAINT `downtime_host_relation_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `downtime_host_relation_ibfk_2` FOREIGN KEY (`dt_id`) REFERENCES `downtime` (`dt_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1092,7 +1092,7 @@ CREATE TABLE `downtime_hostgroup_relation` (
   KEY `downtime_hostgroup_relation_ibfk_1` (`hg_hg_id`),
   CONSTRAINT `downtime_hostgroup_relation_ibfk_1` FOREIGN KEY (`hg_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE,
   CONSTRAINT `downtime_hostgroup_relation_ibfk_2` FOREIGN KEY (`dt_id`) REFERENCES `downtime` (`dt_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1109,7 +1109,7 @@ CREATE TABLE `downtime_period` (
   `dtp_activate` enum('0','1') DEFAULT '1',
   KEY `downtime_period_idx01` (`dt_id`,`dtp_activate`),
   CONSTRAINT `downtime_period_ibfk_1` FOREIGN KEY (`dt_id`) REFERENCES `downtime` (`dt_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1123,7 +1123,7 @@ CREATE TABLE `downtime_service_relation` (
   CONSTRAINT `downtime_service_relation_ibfk_1` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE,
   CONSTRAINT `downtime_service_relation_ibfk_3` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `downtime_service_relation_ibfk_2` FOREIGN KEY (`dt_id`) REFERENCES `downtime` (`dt_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1134,7 +1134,7 @@ CREATE TABLE `downtime_servicegroup_relation` (
   KEY `downtime_servicegroup_relation_ibfk_1` (`sg_sg_id`),
   CONSTRAINT `downtime_servicegroup_relation_ibfk_1` FOREIGN KEY (`sg_sg_id`) REFERENCES `servicegroup` (`sg_id`) ON DELETE CASCADE,
   CONSTRAINT `downtime_servicegroup_relation_ibfk_2` FOREIGN KEY (`dt_id`) REFERENCES `downtime` (`dt_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1154,7 +1154,7 @@ CREATE TABLE `escalation` (
   PRIMARY KEY (`esc_id`),
   KEY `period_index` (`escalation_period`),
   CONSTRAINT `escalation_ibfk_1` FOREIGN KEY (`escalation_period`) REFERENCES `timeperiod` (`tp_id`) ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1165,7 +1165,7 @@ CREATE TABLE `escalation_contactgroup_relation` (
   KEY `cg_index` (`contactgroup_cg_id`),
   CONSTRAINT `escalation_contactgroup_relation_ibfk_1` FOREIGN KEY (`escalation_esc_id`) REFERENCES `escalation` (`esc_id`) ON DELETE CASCADE,
   CONSTRAINT `escalation_contactgroup_relation_ibfk_2` FOREIGN KEY (`contactgroup_cg_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1176,7 +1176,7 @@ CREATE TABLE `escalation_host_relation` (
   KEY `host_index` (`host_host_id`),
   CONSTRAINT `escalation_host_relation_ibfk_1` FOREIGN KEY (`escalation_esc_id`) REFERENCES `escalation` (`esc_id`) ON DELETE CASCADE,
   CONSTRAINT `escalation_host_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1187,7 +1187,7 @@ CREATE TABLE `escalation_hostgroup_relation` (
   KEY `hg_index` (`hostgroup_hg_id`),
   CONSTRAINT `escalation_hostgroup_relation_ibfk_1` FOREIGN KEY (`escalation_esc_id`) REFERENCES `escalation` (`esc_id`) ON DELETE CASCADE,
   CONSTRAINT `escalation_hostgroup_relation_ibfk_2` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1198,7 +1198,7 @@ CREATE TABLE `escalation_meta_service_relation` (
   KEY `meta_service_index` (`meta_service_meta_id`),
   CONSTRAINT `escalation_meta_service_relation_ibfk_1` FOREIGN KEY (`escalation_esc_id`) REFERENCES `escalation` (`esc_id`) ON DELETE CASCADE,
   CONSTRAINT `escalation_meta_service_relation_ibfk_2` FOREIGN KEY (`meta_service_meta_id`) REFERENCES `meta_service` (`meta_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1212,7 +1212,7 @@ CREATE TABLE `escalation_service_relation` (
   CONSTRAINT `escalation_service_relation_ibfk_1` FOREIGN KEY (`escalation_esc_id`) REFERENCES `escalation` (`esc_id`) ON DELETE CASCADE,
   CONSTRAINT `escalation_service_relation_ibfk_2` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE,
   CONSTRAINT `escalation_service_relation_ibfk_3` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1223,7 +1223,7 @@ CREATE TABLE `escalation_servicegroup_relation` (
   KEY `sg_index` (`servicegroup_sg_id`),
   CONSTRAINT `escalation_servicegroup_relation_ibfk_1` FOREIGN KEY (`escalation_esc_id`) REFERENCES `escalation` (`esc_id`) ON DELETE CASCADE,
   CONSTRAINT `escalation_servicegroup_relation_ibfk_2` FOREIGN KEY (`servicegroup_sg_id`) REFERENCES `servicegroup` (`sg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1247,7 +1247,7 @@ CREATE TABLE `extended_host_information` (
   CONSTRAINT `extended_host_information_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `extended_host_information_ibfk_2` FOREIGN KEY (`ehi_icon_image`) REFERENCES `view_img` (`img_id`) ON DELETE SET NULL,
   CONSTRAINT `extended_host_information_ibfk_4` FOREIGN KEY (`ehi_statusmap_image`) REFERENCES `view_img` (`img_id`) ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1267,7 +1267,7 @@ CREATE TABLE `extended_service_information` (
   CONSTRAINT `extended_service_information_ibfk_1` FOREIGN KEY (`graph_id`) REFERENCES `giv_graphs_template` (`graph_id`) ON DELETE SET NULL,
   CONSTRAINT `extended_service_information_ibfk_2` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE,
   CONSTRAINT `extended_service_information_ibfk_3` FOREIGN KEY (`esi_icon_image`) REFERENCES `view_img` (`img_id`) ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1300,7 +1300,7 @@ CREATE TABLE `giv_components_template` (
   `default_tpl1` enum('0','1') DEFAULT NULL,
   `comment` text,
   PRIMARY KEY (`compo_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1320,7 +1320,7 @@ CREATE TABLE `giv_graphs_template` (
   `scaled` enum('0','1') DEFAULT '1',
   `comment` text,
   PRIMARY KEY (`graph_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1386,7 +1386,7 @@ CREATE TABLE `host` (
   CONSTRAINT `host_ibfk_2` FOREIGN KEY (`command_command_id2`) REFERENCES `command` (`command_id`) ON DELETE SET NULL,
   CONSTRAINT `host_ibfk_3` FOREIGN KEY (`timeperiod_tp_id`) REFERENCES `timeperiod` (`tp_id`) ON DELETE SET NULL,
   CONSTRAINT `host_ibfk_4` FOREIGN KEY (`timeperiod_tp_id2`) REFERENCES `timeperiod` (`tp_id`) ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1397,7 +1397,7 @@ CREATE TABLE `host_hostparent_relation` (
   KEY `host2_index` (`host_host_id`),
   CONSTRAINT `host_hostparent_relation_ibfk_1` FOREIGN KEY (`host_parent_hp_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `host_hostparent_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1417,7 +1417,7 @@ CREATE TABLE `host_service_relation` (
   CONSTRAINT `host_service_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `host_service_relation_ibfk_3` FOREIGN KEY (`servicegroup_sg_id`) REFERENCES `servicegroup` (`sg_id`) ON DELETE CASCADE,
   CONSTRAINT `host_service_relation_ibfk_4` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1429,7 +1429,7 @@ CREATE TABLE `host_template_relation` (
   KEY `host_tpl_id` (`host_tpl_id`),
   CONSTRAINT `host_template_relation_ibfk_2` FOREIGN KEY (`host_tpl_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `host_template_relation_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1444,7 +1444,7 @@ CREATE TABLE `hostcategories` (
   PRIMARY KEY (`hc_id`),
   KEY `name_index` (`hc_name`),
   KEY `alias_index` (`hc_alias`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1455,7 +1455,7 @@ CREATE TABLE `hostcategories_relation` (
   KEY `host_index` (`host_host_id`),
   CONSTRAINT `hostcategories_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `hostcategories_relation_ibfk_1` FOREIGN KEY (`hostcategories_hc_id`) REFERENCES `hostcategories` (`hc_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1475,7 +1475,7 @@ CREATE TABLE `hostgroup` (
   PRIMARY KEY (`hg_id`),
   KEY `name_index` (`hg_name`),
   KEY `alias_index` (`hg_alias`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1486,7 +1486,7 @@ CREATE TABLE `hostgroup_hg_relation` (
   KEY `hg_child_id` (`hg_child_id`),
   CONSTRAINT `hostgroup_hg_relation_ibfk_2` FOREIGN KEY (`hg_child_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE,
   CONSTRAINT `hostgroup_hg_relation_ibfk_1` FOREIGN KEY (`hg_parent_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1499,14 +1499,14 @@ CREATE TABLE `hostgroup_relation` (
   KEY `host_index` (`host_host_id`),
   CONSTRAINT `hostgroup_relation_ibfk_1` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE,
   CONSTRAINT `hostgroup_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `informations` (
   `key` varchar(25) DEFAULT NULL,
   `value` varchar(1024) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1517,7 +1517,7 @@ CREATE TABLE `meta_contactgroup_relation` (
   KEY `cg_index` (`cg_cg_id`),
   CONSTRAINT `meta_contactgroup_relation_ibfk_1` FOREIGN KEY (`meta_id`) REFERENCES `meta_service` (`meta_id`) ON DELETE CASCADE,
   CONSTRAINT `meta_contactgroup_relation_ibfk_2` FOREIGN KEY (`cg_cg_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1552,7 +1552,7 @@ CREATE TABLE `meta_service` (
   CONSTRAINT `meta_service_ibfk_1` FOREIGN KEY (`check_period`) REFERENCES `timeperiod` (`tp_id`) ON DELETE SET NULL,
   CONSTRAINT `meta_service_ibfk_2` FOREIGN KEY (`notification_period`) REFERENCES `timeperiod` (`tp_id`) ON DELETE SET NULL,
   CONSTRAINT `meta_service_ibfk_3` FOREIGN KEY (`graph_id`) REFERENCES `giv_graphs_template` (`graph_id`) ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1569,7 +1569,7 @@ CREATE TABLE `meta_service_relation` (
   KEY `host_index` (`host_id`),
   CONSTRAINT `meta_service_relation_ibfk_1` FOREIGN KEY (`host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `meta_service_relation_ibfk_2` FOREIGN KEY (`meta_id`) REFERENCES `meta_service` (`meta_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1584,7 +1584,7 @@ CREATE TABLE `modules_informations` (
   `svc_tools` enum('0','1') DEFAULT NULL,
   `host_tools` enum('0','1') DEFAULT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1592,7 +1592,7 @@ CREATE TABLE `nagios_macro` (
   `macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `macro_name` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`macro_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1629,7 +1629,7 @@ CREATE TABLE `nagios_server` (
   `updated` enum('1','0') NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   CONSTRAINT `nagios_server_remote_id_id` FOREIGN KEY (`remote_id`) REFERENCES `nagios_server` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1641,7 +1641,7 @@ CREATE TABLE `ns_host_relation` (
   KEY `nagios_server_id` (`nagios_server_id`),
   CONSTRAINT `ns_host_relation_ibfk_2` FOREIGN KEY (`nagios_server_id`) REFERENCES `nagios_server` (`id`) ON DELETE CASCADE,
   CONSTRAINT `ns_host_relation_ibfk_3` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation Table For centreon Servers and hosts ';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Relation Table For centreon Servers and hosts ';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1655,7 +1655,7 @@ CREATE TABLE `ods_view_details` (
   PRIMARY KEY (`dv_id`),
   KEY `index_id` (`index_id`),
   KEY `contact_index` (`contact_id`, `index_id`) USING BTREE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1670,7 +1670,7 @@ CREATE TABLE `on_demand_macro_host` (
   PRIMARY KEY (`host_macro_id`),
   KEY `host_host_id` (`host_host_id`),
   CONSTRAINT `on_demand_macro_host_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1685,14 +1685,14 @@ CREATE TABLE `on_demand_macro_service` (
   PRIMARY KEY (`svc_macro_id`),
   KEY `svc_svc_id` (`svc_svc_id`),
   CONSTRAINT `on_demand_macro_service_ibfk_1` FOREIGN KEY (`svc_svc_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `options` (
   `key` varchar(255) DEFAULT NULL,
   `value` varchar(255) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1704,7 +1704,7 @@ CREATE TABLE `poller_command_relations` (
   KEY `command_id` (`command_id`),
   CONSTRAINT `poller_command_relations_fk_1` FOREIGN KEY (`poller_id`) REFERENCES `nagios_server` (`id`) ON DELETE CASCADE,
   CONSTRAINT `poller_command_relations_fk_2` FOREIGN KEY (`command_id`) REFERENCES `command` (`command_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1765,7 +1765,7 @@ CREATE TABLE `service` (
   CONSTRAINT `service_ibfk_2` FOREIGN KEY (`command_command_id2`) REFERENCES `command` (`command_id`) ON DELETE SET NULL,
   CONSTRAINT `service_ibfk_3` FOREIGN KEY (`timeperiod_tp_id`) REFERENCES `timeperiod` (`tp_id`) ON DELETE SET NULL,
   CONSTRAINT `service_ibfk_4` FOREIGN KEY (`timeperiod_tp_id2`) REFERENCES `timeperiod` (`tp_id`) ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1777,7 +1777,7 @@ CREATE TABLE `service_categories` (
   `icon_id` INT(11) DEFAULT NULL,
   `sc_activate` enum('0','1') DEFAULT NULL,
   PRIMARY KEY (`sc_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Services Catygories For best Reporting';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Services Catygories For best Reporting';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1790,7 +1790,7 @@ CREATE TABLE `service_categories_relation` (
   KEY `sc_id` (`sc_id`),
   CONSTRAINT `service_categories_relation_ibfk_1` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE,
   CONSTRAINT `service_categories_relation_ibfk_2` FOREIGN KEY (`sc_id`) REFERENCES `service_categories` (`sc_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1804,7 +1804,7 @@ CREATE TABLE `servicegroup` (
   PRIMARY KEY (`sg_id`),
   KEY `name_index` (`sg_name`),
   KEY `alias_index` (`sg_alias`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1823,7 +1823,7 @@ CREATE TABLE `servicegroup_relation` (
   CONSTRAINT `servicegroup_relation_ibfk_7` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `servicegroup_relation_ibfk_8` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE,
   CONSTRAINT `servicegroup_relation_ibfk_9` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1848,7 +1848,7 @@ CREATE TABLE `session` (
   KEY `session_id` (`session_id`(255)),
   KEY `user_id` (`user_id`),
   CONSTRAINT `session_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1864,7 +1864,7 @@ CREATE TABLE `timeperiod` (
   `tp_friday` varchar(2048) DEFAULT NULL,
   `tp_saturday` varchar(2048) DEFAULT NULL,
   PRIMARY KEY (`tp_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1876,7 +1876,7 @@ CREATE TABLE `timeperiod_exceptions` (
   PRIMARY KEY (`exception_id`),
   KEY `timeperiod_exceptions_relation_ibfk_1` (`timeperiod_id`),
   CONSTRAINT `timeperiod_exceptions_relation_ibfk_1` FOREIGN KEY (`timeperiod_id`) REFERENCES `timeperiod` (`tp_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1887,7 +1887,7 @@ CREATE TABLE `timeperiod_exclude_relations` (
   FOREIGN KEY (`timeperiod_id`) REFERENCES `timeperiod` (`tp_id`) ON DELETE CASCADE,
   FOREIGN KEY (`timeperiod_exclude_id`) REFERENCES `timeperiod` (`tp_id`) ON DELETE CASCADE,
   PRIMARY KEY (`exclude_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1898,7 +1898,7 @@ CREATE TABLE `timeperiod_include_relations` (
   FOREIGN KEY (`timeperiod_id`) REFERENCES `timeperiod` (`tp_id`) ON DELETE CASCADE,
   FOREIGN KEY (`timeperiod_include_id`) REFERENCES `timeperiod` (`tp_id`) ON DELETE CASCADE,
   PRIMARY KEY (`include_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1925,7 +1925,7 @@ CREATE TABLE `topology` (
   KEY `topology_parent` (`topology_parent`),
   KEY `topology_order` (`topology_order`),
   KEY `topology_group` (`topology_group`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1939,7 +1939,7 @@ CREATE TABLE `topology_JS` (
   KEY `id_page` (`id_page`),
   KEY `id_page_2` (`id_page`,`o`),
   CONSTRAINT `topology_JS_ibfk_1` FOREIGN KEY (`id_page`) REFERENCES `topology` (`topology_page`) ON DELETE CASCADE ON UPDATE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1976,7 +1976,7 @@ CREATE TABLE `traps` (
   KEY `traps_ibfk_2` (`severity_id`),
   CONSTRAINT `traps_ibfk_1` FOREIGN KEY (`manufacturer_id`) REFERENCES `traps_vendor` (`id`) ON DELETE CASCADE,
   CONSTRAINT `traps_ibfk_2` FOREIGN KEY (`severity_id`) REFERENCES `service_categories` (`sc_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1992,7 +1992,7 @@ CREATE TABLE `traps_matching_properties` (
   KEY `trap_id` (`trap_id`),
   CONSTRAINT `traps_matching_properties_ibfk_1` FOREIGN KEY (`trap_id`) REFERENCES `traps` (`traps_id`) ON DELETE CASCADE,
   CONSTRAINT `traps_matching_properties_ibfk_2` FOREIGN KEY (`severity_id`) REFERENCES `service_categories` (`sc_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2002,7 +2002,7 @@ CREATE TABLE `traps_preexec` (
   `tpe_string` varchar(512) DEFAULT NULL,
   KEY `trap_id` (`trap_id`),
   CONSTRAINT `traps_preexec_ibfk_1` FOREIGN KEY (`trap_id`) REFERENCES `traps` (`traps_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2013,7 +2013,7 @@ CREATE TABLE `traps_service_relation` (
   KEY `traps_index` (`traps_id`),
   CONSTRAINT `traps_service_relation_ibfk_2` FOREIGN KEY (`service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE,
   CONSTRAINT `traps_service_relation_ibfk_3` FOREIGN KEY (`traps_id`) REFERENCES `traps` (`traps_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2021,7 +2021,7 @@ CREATE TABLE `traps_group` (
   `traps_group_id` int(11) NOT NULL AUTO_INCREMENT,
   `traps_group_name` varchar(255) NOT NULL,
   PRIMARY KEY (`traps_group_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2032,7 +2032,7 @@ CREATE TABLE `traps_group_relation` (
   KEY `traps_id` (`traps_id`),
   CONSTRAINT `traps_group_relation_ibfk_1` FOREIGN KEY (`traps_id`) REFERENCES `traps` (`traps_id`) ON DELETE CASCADE,
   CONSTRAINT `traps_group_relation_ibfk_2` FOREIGN KEY (`traps_group_id`) REFERENCES `traps_group` (`traps_group_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2042,7 +2042,7 @@ CREATE TABLE `traps_vendor` (
   `alias` varchar(254) DEFAULT NULL,
   `description` text,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2052,7 +2052,7 @@ CREATE TABLE `view_img` (
   `img_path` varchar(255) DEFAULT NULL,
   `img_comment` text,
   PRIMARY KEY (`img_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2062,7 +2062,7 @@ CREATE TABLE `view_img_dir` (
   `dir_alias` varchar(255) DEFAULT NULL,
   `dir_comment` text,
   PRIMARY KEY (`dir_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2073,7 +2073,7 @@ CREATE TABLE `view_img_dir_relation` (
   PRIMARY KEY (`vidr_id`),
   KEY `directory_parent_index` (`dir_dir_parent_id`),
   KEY `image_index` (`img_img_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2091,7 +2091,7 @@ CREATE TABLE `virtual_metrics` (
   `vmetric_activate` enum('0','1') DEFAULT NULL,
   `ck_state` enum('0','1','2') DEFAULT NULL,
   PRIMARY KEY (`vmetric_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2110,7 +2110,7 @@ CREATE TABLE `widget_models` (
   `thumbnail` varchar(255) DEFAULT NULL,
   `autoRefresh` int(11) DEFAULT NULL,
   PRIMARY KEY (`widget_model_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2129,7 +2129,7 @@ CREATE TABLE `widget_parameters` (
   KEY `fk_widget_field_type_id` (`field_type_id`),
   CONSTRAINT `fk_widget_param_widget_id` FOREIGN KEY (`widget_model_id`) REFERENCES `widget_models` (`widget_model_id`) ON DELETE CASCADE,
   CONSTRAINT `fk_widget_field_type_id` FOREIGN KEY (`field_type_id`) REFERENCES `widget_parameters_field_type` (`field_type_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2138,7 +2138,7 @@ CREATE TABLE `widget_parameters_field_type` (
   `ft_typename` varchar(50) NOT NULL,
   `is_connector` tinyint(6) NOT NULL DEFAULT '0',
   PRIMARY KEY (`field_type_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2148,7 +2148,7 @@ CREATE TABLE `widget_parameters_multiple_options` (
   `option_value` varchar(255) NOT NULL,
   KEY `fk_option_parameter_id` (`parameter_id`),
   CONSTRAINT `fk_option_parameter_id` FOREIGN KEY (`parameter_id`) REFERENCES `widget_parameters` (`parameter_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2159,7 +2159,7 @@ CREATE TABLE `widget_parameters_range` (
   `step` int(11) NOT NULL,
   KEY `fk_option_range_id` (`parameter_id`),
   CONSTRAINT `fk_option_range_id` FOREIGN KEY (`parameter_id`) REFERENCES `widget_parameters` (`parameter_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2172,7 +2172,7 @@ CREATE TABLE `widget_preferences` (
   KEY `fk_widget_parameter_id` (`parameter_id`),
   CONSTRAINT `fk_widget_parameter_id` FOREIGN KEY (`parameter_id`) REFERENCES `widget_parameters` (`parameter_id`) ON DELETE CASCADE,
   CONSTRAINT `fk_widget_view_id` FOREIGN KEY (`widget_view_id`) REFERENCES `widget_views` (`widget_view_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2186,7 +2186,7 @@ CREATE TABLE `widget_views` (
   KEY `fk_widget_id` (`widget_id`),
   CONSTRAINT `fk_custom_view_id` FOREIGN KEY (`custom_view_id`) REFERENCES `custom_views` (`custom_view_id`) ON DELETE CASCADE,
   CONSTRAINT `fk_widget_id` FOREIGN KEY (`widget_id`) REFERENCES `widgets` (`widget_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -2197,7 +2197,7 @@ CREATE TABLE `widgets` (
   PRIMARY KEY (`widget_id`),
   KEY `fk_wdg_model_id` (`widget_model_id`),
   CONSTRAINT `fk_wdg_model_id` FOREIGN KEY (`widget_model_id`) REFERENCES `widget_models` (`widget_model_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
@@ -2209,7 +2209,7 @@ CREATE TABLE `meta_contact` (
   PRIMARY KEY (`meta_id`, `contact_id`),
   FOREIGN KEY (`meta_id`) REFERENCES `meta_service` (`meta_id`) ON DELETE CASCADE,
   FOREIGN KEY (`contact_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 
 CREATE TABLE `on_demand_macro_command` (
@@ -2221,7 +2221,7 @@ CREATE TABLE `on_demand_macro_command` (
   PRIMARY KEY (`command_macro_id`),
   KEY `command_command_id` (`command_command_id`),
   CONSTRAINT `on_demand_macro_command_ibfk_1` FOREIGN KEY (`command_command_id`) REFERENCES `command` (`command_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `timezone` (
   `timezone_id` int(11) unsigned NOT NULL AUTO_INCREMENT,
@@ -2231,7 +2231,7 @@ CREATE TABLE `timezone` (
   `timezone_description` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`timezone_id`),
   UNIQUE KEY `name` (`timezone_name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `locale` (
   `locale_id` int(11) NOT NULL AUTO_INCREMENT,
@@ -2239,7 +2239,7 @@ CREATE TABLE IF NOT EXISTS `locale` (
   `locale_short_name` varchar(3) NOT NULL,
   `locale_long_name` varchar(255) NOT NULL,
   `locale_img` varchar(255) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- Create downtime cache table for recurrent downtimes
 CREATE TABLE IF NOT EXISTS `downtime_cache` (
@@ -2255,7 +2255,7 @@ CREATE TABLE IF NOT EXISTS `downtime_cache` (
   CONSTRAINT `downtime_cache_ibfk_1` FOREIGN KEY (`downtime_id`) REFERENCES `downtime` (`dt_id`) ON DELETE CASCADE,
   CONSTRAINT `downtime_cache_ibfk_2` FOREIGN KEY (`host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `downtime_cache_ibfk_3` FOREIGN KEY (`service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- Manage new feature proposal
 CREATE TABLE IF NOT EXISTS contact_feature (
@@ -2265,7 +2265,7 @@ CREATE TABLE IF NOT EXISTS contact_feature (
   feature_enabled TINYINT DEFAULT 0,
   PRIMARY KEY (contact_id, feature, feature_version),
   FOREIGN KEY (contact_id) REFERENCES contact (contact_id) ON DELETE CASCADE
-) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB  DEFAULT CHARSET=utf8mb4;
 
 -- Create remote servers table for keeping track of remote instances
 CREATE TABLE IF NOT EXISTS `remote_servers` (
@@ -2282,14 +2282,14 @@ CREATE TABLE IF NOT EXISTS `remote_servers` (
   `no_proxy` enum('0','1') NOT NULL DEFAULT '0',
   `server_id` int(11) NOT NULL,
   CONSTRAINT `remote_server_nagios_server_ibfk_1` FOREIGN KEY(`server_id`) REFERENCES `nagios_server` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- Create rs_poller_relation for the additional relationship between poller and remote servers
 CREATE TABLE IF NOT EXISTS `rs_poller_relation` (
   `remote_server_id` int(11) NOT NULL,
   `poller_server_id` int(11) NOT NULL,
   KEY `remote_server_id` (`remote_server_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation Table For centreon pollers and remote servers';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Relation Table For centreon pollers and remote servers';
 
 -- Create tasks table
 CREATE TABLE IF NOT EXISTS `task` (
@@ -2299,7 +2299,7 @@ CREATE TABLE IF NOT EXISTS `task` (
   `parent_id` INT(11) NULL,
   `params` BLOB NULL,
   `created_at` TIMESTAMP NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- Create user_filter table
 CREATE TABLE `user_filter` (
@@ -2311,7 +2311,7 @@ CREATE TABLE `user_filter` (
     `order` int(11) NOT NULL,
     PRIMARY KEY (`id`),
     CONSTRAINT `filter_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- Create platform_topology table
 CREATE TABLE `platform_topology` (
@@ -2326,7 +2326,7 @@ CREATE TABLE `platform_topology` (
     PRIMARY KEY (`id`),
     CONSTRAINT `platform_topology_ibfk_1` FOREIGN KEY (`server_id`) REFERENCES `nagios_server` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
     CONSTRAINT `platform_topology_ibfk_2` FOREIGN KEY (`parent_id`) REFERENCES `platform_topology` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
 COMMENT='Registration and parent relation Table used to set the platform topology';
 
 -- Create authentication tables
@@ -2340,7 +2340,7 @@ CREATE TABLE `provider_configuration` (
   `is_forced` BOOLEAN NOT NULL DEFAULT 0,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unique_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `password_expiration_excluded_users` (
   `provider_configuration_id` int(11) NOT NULL,
@@ -2350,7 +2350,7 @@ CREATE TABLE `password_expiration_excluded_users` (
   REFERENCES `provider_configuration` (`id`) ON DELETE CASCADE,
   CONSTRAINT `password_expiration_excluded_users_provider_user_id_fk` FOREIGN KEY (`user_id`)
   REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `security_token` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
@@ -2381,7 +2381,7 @@ CREATE TABLE `security_authentication_tokens` (
   REFERENCES `security_token` (`id`) ON DELETE SET NULL,
   CONSTRAINT `security_authentication_tokens_user_id_fk` FOREIGN KEY (`user_id`)
   REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `contact_password` (
   `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -2393,7 +2393,7 @@ CREATE TABLE `contact_password` (
   INDEX `creation_date_index` (`creation_date`),
   CONSTRAINT `contact_password_contact_id_fk` FOREIGN KEY (`contact_id`)
   REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `cfg_nagios_logger` (
   `id` int(11) UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -2416,7 +2416,7 @@ CREATE TABLE `cfg_nagios_logger` (
   CONSTRAINT `cfg_nagios_logger_cfg_nagios_id_fk`
     FOREIGN KEY (`cfg_nagios_id`)
     REFERENCES `cfg_nagios` (`nagios_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `security_provider_access_group_relation` (
   `claim_value` VARCHAR(255) NOT NULL,
@@ -2430,7 +2430,7 @@ CREATE TABLE `security_provider_access_group_relation` (
   CONSTRAINT `security_provider_provider_configuration_id`
     FOREIGN KEY (`provider_configuration_id`)
     REFERENCES `provider_configuration` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE `security_provider_contact_group_relation` (
   `claim_value` VARCHAR(255) NOT NULL,
@@ -2443,14 +2443,14 @@ CREATE TABLE `security_provider_contact_group_relation` (
   CONSTRAINT `security_provider_configuration_provider_id`
     FOREIGN KEY (`provider_configuration_id`)
     REFERENCES `provider_configuration` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 CREATE TABLE IF NOT EXISTS `vault` (
   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unique_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO `vault` (`name`) VALUES ('hashicorp');
 
@@ -2469,7 +2469,7 @@ CREATE TABLE IF NOT EXISTS `vault_configuration` (
   CONSTRAINT `vault_configuration_vault_id`
     FOREIGN KEY (`vault_id`)
     REFERENCES `vault` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -10,7 +10,7 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_actions` (
   `acl_action_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_action_name` varchar(255) DEFAULT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE `acl_actions` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_actions_rules` (
   `aar_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_action_rule_id` int(11) DEFAULT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE `acl_actions_rules` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_actions_relations` (
   `acl_action_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -40,7 +40,7 @@ CREATE TABLE `acl_group_actions_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_contactgroups_relations` (
   `cg_cg_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -51,7 +51,7 @@ CREATE TABLE `acl_group_contactgroups_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_contacts_relations` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -62,7 +62,7 @@ CREATE TABLE `acl_group_contacts_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_topology_relations` (
   `acl_group_id` int(11) DEFAULT NULL,
   `acl_topology_id` int(11) DEFAULT NULL,
@@ -73,7 +73,7 @@ CREATE TABLE `acl_group_topology_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_groups` (
   `acl_group_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_group_name` varchar(255) DEFAULT NULL,
@@ -84,7 +84,7 @@ CREATE TABLE `acl_groups` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_res_group_relations` (
   `acl_res_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -95,7 +95,7 @@ CREATE TABLE `acl_res_group_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources` (
   `acl_res_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_res_name` varchar(255) DEFAULT NULL,
@@ -112,7 +112,7 @@ CREATE TABLE `acl_resources` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hc_relations` (
   `hc_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -123,7 +123,7 @@ CREATE TABLE `acl_resources_hc_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hg_relations` (
   `hg_hg_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -135,7 +135,7 @@ CREATE TABLE `acl_resources_hg_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_host_relations` (
   `host_host_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -146,7 +146,7 @@ CREATE TABLE `acl_resources_host_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hostex_relations` (
   `host_host_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -157,7 +157,7 @@ CREATE TABLE `acl_resources_hostex_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_meta_relations` (
   `meta_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -168,7 +168,7 @@ CREATE TABLE `acl_resources_meta_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_poller_relations` (
   `poller_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -179,7 +179,7 @@ CREATE TABLE `acl_resources_poller_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_sc_relations` (
   `sc_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -190,7 +190,7 @@ CREATE TABLE `acl_resources_sc_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_service_relations` (
   `service_service_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -201,7 +201,7 @@ CREATE TABLE `acl_resources_service_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_sg_relations` (
   `sg_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -213,7 +213,7 @@ CREATE TABLE `acl_resources_sg_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_topology` (
   `acl_topo_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_topo_name` varchar(255) DEFAULT NULL,
@@ -225,7 +225,7 @@ CREATE TABLE `acl_topology` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_topology_relations` (
   `topology_topology_id` int(11) DEFAULT NULL,
   `acl_topo_id` int(11) DEFAULT NULL,
@@ -237,7 +237,7 @@ CREATE TABLE `acl_topology_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource` (
   `ar_id` int(11) NOT NULL AUTO_INCREMENT,
   `ar_name` varchar(255) NOT NULL DEFAULT 'Default',
@@ -249,7 +249,7 @@ CREATE TABLE `auth_ressource` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource_host` (
   `ldap_host_id` int(11) NOT NULL AUTO_INCREMENT,
   `auth_ressource_id` int(11) NOT NULL,
@@ -264,7 +264,7 @@ CREATE TABLE `auth_ressource_host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource_info` (
   `ar_id` int(11) NOT NULL,
   `ari_name` varchar(100) NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `auth_ressource_info` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_fieldset` (
   `cb_fieldset_id` INT NOT NULL,
   `fieldset_name` VARCHAR(255) NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `cb_fieldset` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_fieldgroup` (
   `cb_fieldgroup_id` INT NOT NULL AUTO_INCREMENT,
   `groupname` VARCHAR(100) NOT NULL,
@@ -294,7 +294,7 @@ CREATE TABLE `cb_fieldgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_field` (
   `cb_field_id` int(11) NOT NULL AUTO_INCREMENT,
   `fieldname` varchar(100) NOT NULL,
@@ -307,7 +307,7 @@ CREATE TABLE `cb_field` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_list` (
   `cb_list_id` int(11) NOT NULL,
   `cb_field_id` int(11) NOT NULL,
@@ -319,7 +319,7 @@ CREATE TABLE `cb_list` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_list_values` (
   `cb_list_id` int(11) NOT NULL,
   `value_name` varchar(255) NOT NULL,
@@ -330,7 +330,7 @@ CREATE TABLE `cb_list_values` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_module` (
   `cb_module_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL,
@@ -344,7 +344,7 @@ CREATE TABLE `cb_module` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_module_relation` (
   `cb_module_id` int(11) NOT NULL,
   `module_depend_id` int(11) NOT NULL,
@@ -357,7 +357,7 @@ CREATE TABLE `cb_module_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_tag` (
   `cb_tag_id` int(11) NOT NULL AUTO_INCREMENT,
   `tagname` varchar(50) NOT NULL,
@@ -366,7 +366,7 @@ CREATE TABLE `cb_tag` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_tag_type_relation` (
   `cb_tag_id` int(11) NOT NULL,
   `cb_type_id` int(11) NOT NULL,
@@ -379,7 +379,7 @@ CREATE TABLE `cb_tag_type_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_type` (
   `cb_type_id` int(11) NOT NULL AUTO_INCREMENT,
   `type_name` varchar(50) NOT NULL,
@@ -391,7 +391,7 @@ CREATE TABLE `cb_type` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_type_field_relation` (
   `cb_type_id` int(11) NOT NULL,
   `cb_field_id` int(11) NOT NULL,
@@ -408,7 +408,7 @@ CREATE TABLE `cb_type_field_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
@@ -416,7 +416,7 @@ CREATE TABLE `cb_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_log_level` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
@@ -424,7 +424,7 @@ CREATE TABLE `cb_log_level` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `id_centreonbroker` int(11) NOT NULL,
@@ -434,7 +434,7 @@ CREATE TABLE `cfg_centreonbroker_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker` (
   `config_id` int(11) NOT NULL AUTO_INCREMENT,
   `config_name` varchar(100) NOT NULL,
@@ -458,7 +458,7 @@ CREATE TABLE `cfg_centreonbroker` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker_info` (
   `config_id` int(11) NOT NULL,
   `config_key` varchar(50) NOT NULL,
@@ -475,7 +475,7 @@ CREATE TABLE `cfg_centreonbroker_info` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_nagios` (
   `nagios_id` int(11) NOT NULL AUTO_INCREMENT,
   `nagios_name` varchar(255) DEFAULT NULL,
@@ -577,7 +577,7 @@ CREATE TABLE `cfg_nagios` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_nagios_broker_module` (
   `bk_mod_id` int(11) NOT NULL AUTO_INCREMENT,
   `cfg_nagios_id` int(11) DEFAULT NULL,
@@ -588,7 +588,7 @@ CREATE TABLE `cfg_nagios_broker_module` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_resource` (
   `resource_id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_name` varchar(255) DEFAULT NULL,
@@ -599,7 +599,7 @@ CREATE TABLE `cfg_resource` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_resource_instance_relations` (
   `resource_id` int(11) NOT NULL,
   `instance_id` int(11) NOT NULL,
@@ -610,7 +610,7 @@ CREATE TABLE `cfg_resource_instance_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `command` (
   `command_id` int(11) NOT NULL AUTO_INCREMENT,
   `connector_id` int(10) unsigned DEFAULT NULL,
@@ -630,7 +630,7 @@ CREATE TABLE `command` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `command_arg_description` (
   `cmd_id` int(11) NOT NULL,
   `macro_name` varchar(255) NOT NULL,
@@ -640,7 +640,7 @@ CREATE TABLE `command_arg_description` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `command_categories` (
   `cmd_category_id` int(11) NOT NULL AUTO_INCREMENT,
   `category_name` varchar(255) NOT NULL,
@@ -650,14 +650,14 @@ CREATE TABLE `command_categories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `command_categories_relation` (
   `category_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `connector` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
@@ -672,7 +672,7 @@ CREATE TABLE `connector` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact` (
   `contact_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_tp_id` int(11) DEFAULT NULL,
@@ -729,7 +729,7 @@ CREATE TABLE `contact` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact_host_relation` (
   `host_host_id` int(11) DEFAULT NULL,
   `contact_id` int(11) DEFAULT NULL,
@@ -740,7 +740,7 @@ CREATE TABLE `contact_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact_hostcommands_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL,
@@ -751,7 +751,7 @@ CREATE TABLE `contact_hostcommands_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact_param` (
   `id` int(4) NOT NULL AUTO_INCREMENT,
   `cp_key` varchar(255) NOT NULL,
@@ -763,7 +763,7 @@ CREATE TABLE `contact_param` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact_service_relation` (
   `service_service_id` int(11) DEFAULT NULL,
   `contact_id` int(11) DEFAULT NULL,
@@ -774,7 +774,7 @@ CREATE TABLE `contact_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact_servicecommands_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL,
@@ -785,7 +785,7 @@ CREATE TABLE `contact_servicecommands_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup` (
   `cg_id` int(11) NOT NULL AUTO_INCREMENT,
   `cg_name` varchar(200) DEFAULT NULL,
@@ -801,7 +801,7 @@ CREATE TABLE `contactgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_contact_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -812,7 +812,7 @@ CREATE TABLE `contactgroup_contact_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_host_relation` (
   `host_host_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -823,7 +823,7 @@ CREATE TABLE `contactgroup_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_hostgroup_relation` (
   `contactgroup_cg_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -834,7 +834,7 @@ CREATE TABLE `contactgroup_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_service_relation` (
   `contactgroup_cg_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -845,7 +845,7 @@ CREATE TABLE `contactgroup_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_servicegroup_relation` (
   `servicegroup_sg_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -856,7 +856,7 @@ CREATE TABLE `contactgroup_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `cron_operation` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(254) DEFAULT NULL,
@@ -873,7 +873,7 @@ CREATE TABLE `cron_operation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `css_color_menu` (
   `id_css_color_menu` int(11) NOT NULL AUTO_INCREMENT,
   `menu_nb` int(11) DEFAULT NULL,
@@ -882,7 +882,7 @@ CREATE TABLE `css_color_menu` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `custom_view_default` (
   `user_id` int(11) NOT NULL,
   `custom_view_id` int(11) NOT NULL,
@@ -893,7 +893,7 @@ CREATE TABLE `custom_view_default` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `custom_view_user_relation` (
   `custom_view_id` int(11) NOT NULL,
   `user_id` int(11) DEFAULT NULL,
@@ -912,7 +912,7 @@ CREATE TABLE `custom_view_user_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `custom_views` (
   `custom_view_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
@@ -922,7 +922,7 @@ CREATE TABLE `custom_views` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency` (
   `dep_id` int(11) NOT NULL AUTO_INCREMENT,
   `dep_name` varchar(255) DEFAULT NULL,
@@ -935,7 +935,7 @@ CREATE TABLE `dependency` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -947,7 +947,7 @@ CREATE TABLE `dependency_hostChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -959,7 +959,7 @@ CREATE TABLE `dependency_hostParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostgroupChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -971,7 +971,7 @@ CREATE TABLE `dependency_hostgroupChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostgroupParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -983,7 +983,7 @@ CREATE TABLE `dependency_hostgroupParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_metaserviceChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -995,7 +995,7 @@ CREATE TABLE `dependency_metaserviceChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_metaserviceParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -1007,7 +1007,7 @@ CREATE TABLE `dependency_metaserviceParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_serviceChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1022,7 +1022,7 @@ CREATE TABLE `dependency_serviceChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_serviceParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1037,7 +1037,7 @@ CREATE TABLE `dependency_serviceParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_servicegroupChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1049,7 +1049,7 @@ CREATE TABLE `dependency_servicegroupChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_servicegroupParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1061,7 +1061,7 @@ CREATE TABLE `dependency_servicegroupParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime` (
   `dt_id` int(11) NOT NULL AUTO_INCREMENT,
   `dt_name` varchar(100) NOT NULL,
@@ -1073,7 +1073,7 @@ CREATE TABLE `downtime` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_host_relation` (
   `dt_id` int(11) NOT NULL,
   `host_host_id` int(11) NOT NULL,
@@ -1084,7 +1084,7 @@ CREATE TABLE `downtime_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_hostgroup_relation` (
   `dt_id` int(11) NOT NULL,
   `hg_hg_id` int(11) NOT NULL,
@@ -1095,7 +1095,7 @@ CREATE TABLE `downtime_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_period` (
   `dt_id` int(11) NOT NULL,
   `dtp_start_time` time NOT NULL,
@@ -1112,7 +1112,7 @@ CREATE TABLE `downtime_period` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_service_relation` (
   `dt_id` int(11) NOT NULL,
   `host_host_id` int(11) NOT NULL,
@@ -1126,7 +1126,7 @@ CREATE TABLE `downtime_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_servicegroup_relation` (
   `dt_id` int(11) NOT NULL,
   `sg_sg_id` int(11) NOT NULL,
@@ -1137,7 +1137,7 @@ CREATE TABLE `downtime_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation` (
   `esc_id` int(11) NOT NULL AUTO_INCREMENT,
   `esc_name` varchar(255) DEFAULT NULL,
@@ -1157,7 +1157,7 @@ CREATE TABLE `escalation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_contactgroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -1168,7 +1168,7 @@ CREATE TABLE `escalation_contactgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_host_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1179,7 +1179,7 @@ CREATE TABLE `escalation_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_hostgroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1190,7 +1190,7 @@ CREATE TABLE `escalation_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_meta_service_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -1201,7 +1201,7 @@ CREATE TABLE `escalation_meta_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_service_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1215,7 +1215,7 @@ CREATE TABLE `escalation_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_servicegroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1226,7 +1226,7 @@ CREATE TABLE `escalation_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `extended_host_information` (
   `ehi_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1250,7 +1250,7 @@ CREATE TABLE `extended_host_information` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `extended_service_information` (
   `esi_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1270,7 +1270,7 @@ CREATE TABLE `extended_service_information` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `giv_components_template` (
   `compo_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_id` int(11) DEFAULT NULL,
@@ -1303,7 +1303,7 @@ CREATE TABLE `giv_components_template` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `giv_graphs_template` (
   `graph_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(200) DEFAULT NULL,
@@ -1323,7 +1323,7 @@ CREATE TABLE `giv_graphs_template` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `host` (
   `host_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_template_model_htm_id` int(11) DEFAULT NULL,
@@ -1389,7 +1389,7 @@ CREATE TABLE `host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_hostparent_relation` (
   `host_parent_hp_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1400,7 +1400,7 @@ CREATE TABLE `host_hostparent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_service_relation` (
   `hsr_id` int(11) NOT NULL AUTO_INCREMENT,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1420,7 +1420,7 @@ CREATE TABLE `host_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_template_relation` (
   `host_host_id` int(11) NOT NULL DEFAULT '0',
   `host_tpl_id` int(11) NOT NULL DEFAULT '0',
@@ -1432,7 +1432,7 @@ CREATE TABLE `host_template_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `hostcategories` (
   `hc_id` int(11) NOT NULL AUTO_INCREMENT,
   `hc_name` varchar(200) DEFAULT NULL,
@@ -1447,7 +1447,7 @@ CREATE TABLE `hostcategories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `hostcategories_relation` (
   `hostcategories_hc_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1458,7 +1458,7 @@ CREATE TABLE `hostcategories_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup` (
   `hg_id` int(11) NOT NULL AUTO_INCREMENT,
   `hg_name` varchar(200) DEFAULT NULL,
@@ -1478,7 +1478,7 @@ CREATE TABLE `hostgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup_hg_relation` (
   `hg_parent_id` int(11) DEFAULT NULL,
   `hg_child_id` int(11) DEFAULT NULL,
@@ -1489,7 +1489,7 @@ CREATE TABLE `hostgroup_hg_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup_relation` (
   `hgr_id` int(11) NOT NULL AUTO_INCREMENT,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1502,14 +1502,14 @@ CREATE TABLE `hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `informations` (
   `key` varchar(25) DEFAULT NULL,
   `value` varchar(1024) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `meta_contactgroup_relation` (
   `meta_id` int(11) DEFAULT NULL,
   `cg_cg_id` int(11) DEFAULT NULL,
@@ -1520,7 +1520,7 @@ CREATE TABLE `meta_contactgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `meta_service` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `meta_name` varchar(254) DEFAULT NULL,
@@ -1555,7 +1555,7 @@ CREATE TABLE `meta_service` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `meta_service_relation` (
   `msr_id` int(11) NOT NULL AUTO_INCREMENT,
   `meta_id` int(11) DEFAULT NULL,
@@ -1572,7 +1572,7 @@ CREATE TABLE `meta_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `modules_informations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
@@ -1587,7 +1587,7 @@ CREATE TABLE `modules_informations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `nagios_macro` (
   `macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `macro_name` varchar(255) DEFAULT NULL,
@@ -1595,7 +1595,7 @@ CREATE TABLE `nagios_macro` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `nagios_server` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(40) DEFAULT NULL,
@@ -1632,7 +1632,7 @@ CREATE TABLE `nagios_server` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ns_host_relation` (
   `nagios_server_id` int(11) NOT NULL DEFAULT '0',
   `host_host_id` int(11) NOT NULL DEFAULT '0',
@@ -1644,7 +1644,7 @@ CREATE TABLE `ns_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Relation Table For centreon Servers and hosts ';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `ods_view_details` (
   `dv_id` int(11) NOT NULL AUTO_INCREMENT,
   `index_id` BIGINT UNSIGNED DEFAULT NULL,
@@ -1658,7 +1658,7 @@ CREATE TABLE `ods_view_details` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `on_demand_macro_host` (
   `host_macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_macro_name` varchar(255) NOT NULL,
@@ -1673,7 +1673,7 @@ CREATE TABLE `on_demand_macro_host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `on_demand_macro_service` (
   `svc_macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `svc_macro_name` varchar(255) NOT NULL,
@@ -1688,14 +1688,14 @@ CREATE TABLE `on_demand_macro_service` (
 ) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `options` (
   `key` varchar(255) DEFAULT NULL,
   `value` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `poller_command_relations` (
   `poller_id` int(11) NOT NULL,
   `command_id` int(11) NOT NULL,
@@ -1707,7 +1707,7 @@ CREATE TABLE `poller_command_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `service` (
   `service_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_template_model_stm_id` int(11) DEFAULT NULL,
@@ -1768,7 +1768,7 @@ CREATE TABLE `service` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `service_categories` (
   `sc_id` int(11) NOT NULL AUTO_INCREMENT,
   `sc_name` varchar(255) DEFAULT NULL,
@@ -1780,7 +1780,7 @@ CREATE TABLE `service_categories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Services Catygories For best Reporting';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `service_categories_relation` (
   `scr_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1793,7 +1793,7 @@ CREATE TABLE `service_categories_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `servicegroup` (
   `sg_id` int(11) NOT NULL AUTO_INCREMENT,
   `sg_name` varchar(200) DEFAULT NULL,
@@ -1807,7 +1807,7 @@ CREATE TABLE `servicegroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `servicegroup_relation` (
   `sgr_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1826,7 +1826,7 @@ CREATE TABLE `servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `session` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `session_id` varchar(256) DEFAULT NULL,
@@ -1851,7 +1851,7 @@ CREATE TABLE `session` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod` (
   `tp_id` int(11) NOT NULL AUTO_INCREMENT,
   `tp_name` varchar(200) DEFAULT NULL,
@@ -1867,7 +1867,7 @@ CREATE TABLE `timeperiod` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_exceptions` (
   `exception_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1879,7 +1879,7 @@ CREATE TABLE `timeperiod_exceptions` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_exclude_relations` (
   `exclude_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1890,7 +1890,7 @@ CREATE TABLE `timeperiod_exclude_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_include_relations` (
   `include_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1901,7 +1901,7 @@ CREATE TABLE `timeperiod_include_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `topology` (
   `topology_id` int(11) NOT NULL AUTO_INCREMENT,
   `topology_name` varchar(255) DEFAULT NULL,
@@ -1928,7 +1928,7 @@ CREATE TABLE `topology` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `topology_JS` (
   `id_t_js` int(11) NOT NULL AUTO_INCREMENT,
   `id_page` int(11) DEFAULT NULL,
@@ -1942,7 +1942,7 @@ CREATE TABLE `topology_JS` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps` (
   `traps_id` int(11) NOT NULL AUTO_INCREMENT,
   `traps_name` varchar(255) DEFAULT NULL,
@@ -1979,7 +1979,7 @@ CREATE TABLE `traps` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_matching_properties` (
   `tmo_id` int(11) NOT NULL AUTO_INCREMENT,
   `trap_id` int(11) DEFAULT NULL,
@@ -1995,7 +1995,7 @@ CREATE TABLE `traps_matching_properties` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_preexec` (
   `trap_id` int(11) DEFAULT NULL,
   `tpe_order` int(11) DEFAULT NULL,
@@ -2005,7 +2005,7 @@ CREATE TABLE `traps_preexec` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_service_relation` (
   `traps_id` int(11) DEFAULT NULL,
   `service_id` int(11) DEFAULT NULL,
@@ -2016,7 +2016,7 @@ CREATE TABLE `traps_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_group` (
   `traps_group_id` int(11) NOT NULL AUTO_INCREMENT,
   `traps_group_name` varchar(255) NOT NULL,
@@ -2024,7 +2024,7 @@ CREATE TABLE `traps_group` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_group_relation` (
   `traps_group_id` int(11) NOT NULL,
   `traps_id` int(11) NOT NULL,
@@ -2035,7 +2035,7 @@ CREATE TABLE `traps_group_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_vendor` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(254) DEFAULT NULL,
@@ -2045,7 +2045,7 @@ CREATE TABLE `traps_vendor` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `view_img` (
   `img_id` int(11) NOT NULL AUTO_INCREMENT,
   `img_name` varchar(255) DEFAULT NULL,
@@ -2055,7 +2055,7 @@ CREATE TABLE `view_img` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `view_img_dir` (
   `dir_id` int(11) NOT NULL AUTO_INCREMENT,
   `dir_name` varchar(255) DEFAULT NULL,
@@ -2065,7 +2065,7 @@ CREATE TABLE `view_img_dir` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `view_img_dir_relation` (
   `vidr_id` int(11) NOT NULL AUTO_INCREMENT,
   `dir_dir_parent_id` int(11) DEFAULT NULL,
@@ -2076,7 +2076,7 @@ CREATE TABLE `view_img_dir_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `virtual_metrics` (
   `vmetric_id` int(11) NOT NULL AUTO_INCREMENT,
   `index_id` BIGINT UNSIGNED DEFAULT NULL,
@@ -2094,7 +2094,7 @@ CREATE TABLE `virtual_metrics` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_models` (
   `widget_model_id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(255) NOT NULL,
@@ -2113,7 +2113,7 @@ CREATE TABLE `widget_models` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters` (
   `parameter_id` int(11) NOT NULL AUTO_INCREMENT,
   `parameter_name` varchar(255) NOT NULL,
@@ -2132,7 +2132,7 @@ CREATE TABLE `widget_parameters` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_field_type` (
   `field_type_id` int(11) NOT NULL AUTO_INCREMENT,
   `ft_typename` varchar(50) NOT NULL,
@@ -2141,7 +2141,7 @@ CREATE TABLE `widget_parameters_field_type` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_multiple_options` (
   `parameter_id` int(11) NOT NULL,
   `option_name` varchar(255) NOT NULL,
@@ -2151,7 +2151,7 @@ CREATE TABLE `widget_parameters_multiple_options` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_range` (
   `parameter_id` int(11) NOT NULL,
   `min_range` int(11) NOT NULL,
@@ -2162,7 +2162,7 @@ CREATE TABLE `widget_parameters_range` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_preferences` (
   `widget_view_id` int(11) NOT NULL,
   `parameter_id` int(11) NOT NULL,
@@ -2175,7 +2175,7 @@ CREATE TABLE `widget_preferences` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_views` (
   `widget_view_id` int(11) NOT NULL AUTO_INCREMENT,
   `custom_view_id` int(11) NOT NULL,
@@ -2189,7 +2189,7 @@ CREATE TABLE `widget_views` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SETcharacter_set_client = utf8mb4 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `widgets` (
   `widget_id` int(11) NOT NULL AUTO_INCREMENT,
   `widget_model_id` int(11) NOT NULL,

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -10,7 +10,7 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_actions` (
   `acl_action_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_action_name` varchar(255) DEFAULT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE `acl_actions` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_actions_rules` (
   `aar_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_action_rule_id` int(11) DEFAULT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE `acl_actions_rules` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_actions_relations` (
   `acl_action_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -40,7 +40,7 @@ CREATE TABLE `acl_group_actions_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_contactgroups_relations` (
   `cg_cg_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -51,7 +51,7 @@ CREATE TABLE `acl_group_contactgroups_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_contacts_relations` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -62,7 +62,7 @@ CREATE TABLE `acl_group_contacts_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_topology_relations` (
   `acl_group_id` int(11) DEFAULT NULL,
   `acl_topology_id` int(11) DEFAULT NULL,
@@ -73,7 +73,7 @@ CREATE TABLE `acl_group_topology_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_groups` (
   `acl_group_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_group_name` varchar(255) DEFAULT NULL,
@@ -84,7 +84,7 @@ CREATE TABLE `acl_groups` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_res_group_relations` (
   `acl_res_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -95,7 +95,7 @@ CREATE TABLE `acl_res_group_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources` (
   `acl_res_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_res_name` varchar(255) DEFAULT NULL,
@@ -112,7 +112,7 @@ CREATE TABLE `acl_resources` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hc_relations` (
   `hc_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -123,7 +123,7 @@ CREATE TABLE `acl_resources_hc_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hg_relations` (
   `hg_hg_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -135,7 +135,7 @@ CREATE TABLE `acl_resources_hg_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_host_relations` (
   `host_host_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -146,7 +146,7 @@ CREATE TABLE `acl_resources_host_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hostex_relations` (
   `host_host_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -157,7 +157,7 @@ CREATE TABLE `acl_resources_hostex_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_meta_relations` (
   `meta_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -168,7 +168,7 @@ CREATE TABLE `acl_resources_meta_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_poller_relations` (
   `poller_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -179,7 +179,7 @@ CREATE TABLE `acl_resources_poller_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_sc_relations` (
   `sc_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -190,7 +190,7 @@ CREATE TABLE `acl_resources_sc_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_service_relations` (
   `service_service_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -201,7 +201,7 @@ CREATE TABLE `acl_resources_service_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_sg_relations` (
   `sg_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -213,7 +213,7 @@ CREATE TABLE `acl_resources_sg_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_topology` (
   `acl_topo_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_topo_name` varchar(255) DEFAULT NULL,
@@ -225,7 +225,7 @@ CREATE TABLE `acl_topology` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `acl_topology_relations` (
   `topology_topology_id` int(11) DEFAULT NULL,
   `acl_topo_id` int(11) DEFAULT NULL,
@@ -237,7 +237,7 @@ CREATE TABLE `acl_topology_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource` (
   `ar_id` int(11) NOT NULL AUTO_INCREMENT,
   `ar_name` varchar(255) NOT NULL DEFAULT 'Default',
@@ -249,7 +249,7 @@ CREATE TABLE `auth_ressource` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource_host` (
   `ldap_host_id` int(11) NOT NULL AUTO_INCREMENT,
   `auth_ressource_id` int(11) NOT NULL,
@@ -264,7 +264,7 @@ CREATE TABLE `auth_ressource_host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource_info` (
   `ar_id` int(11) NOT NULL,
   `ari_name` varchar(100) NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `auth_ressource_info` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_fieldset` (
   `cb_fieldset_id` INT NOT NULL,
   `fieldset_name` VARCHAR(255) NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `cb_fieldset` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_fieldgroup` (
   `cb_fieldgroup_id` INT NOT NULL AUTO_INCREMENT,
   `groupname` VARCHAR(100) NOT NULL,
@@ -294,7 +294,7 @@ CREATE TABLE `cb_fieldgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_field` (
   `cb_field_id` int(11) NOT NULL AUTO_INCREMENT,
   `fieldname` varchar(100) NOT NULL,
@@ -307,7 +307,7 @@ CREATE TABLE `cb_field` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_list` (
   `cb_list_id` int(11) NOT NULL,
   `cb_field_id` int(11) NOT NULL,
@@ -319,7 +319,7 @@ CREATE TABLE `cb_list` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_list_values` (
   `cb_list_id` int(11) NOT NULL,
   `value_name` varchar(255) NOT NULL,
@@ -330,7 +330,7 @@ CREATE TABLE `cb_list_values` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_module` (
   `cb_module_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL,
@@ -344,7 +344,7 @@ CREATE TABLE `cb_module` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_module_relation` (
   `cb_module_id` int(11) NOT NULL,
   `module_depend_id` int(11) NOT NULL,
@@ -357,7 +357,7 @@ CREATE TABLE `cb_module_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_tag` (
   `cb_tag_id` int(11) NOT NULL AUTO_INCREMENT,
   `tagname` varchar(50) NOT NULL,
@@ -366,7 +366,7 @@ CREATE TABLE `cb_tag` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_tag_type_relation` (
   `cb_tag_id` int(11) NOT NULL,
   `cb_type_id` int(11) NOT NULL,
@@ -379,7 +379,7 @@ CREATE TABLE `cb_tag_type_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_type` (
   `cb_type_id` int(11) NOT NULL AUTO_INCREMENT,
   `type_name` varchar(50) NOT NULL,
@@ -391,7 +391,7 @@ CREATE TABLE `cb_type` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_type_field_relation` (
   `cb_type_id` int(11) NOT NULL,
   `cb_field_id` int(11) NOT NULL,
@@ -408,7 +408,7 @@ CREATE TABLE `cb_type_field_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
@@ -416,7 +416,7 @@ CREATE TABLE `cb_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cb_log_level` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
@@ -424,7 +424,7 @@ CREATE TABLE `cb_log_level` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `id_centreonbroker` int(11) NOT NULL,
@@ -434,7 +434,7 @@ CREATE TABLE `cfg_centreonbroker_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker` (
   `config_id` int(11) NOT NULL AUTO_INCREMENT,
   `config_name` varchar(100) NOT NULL,
@@ -458,7 +458,7 @@ CREATE TABLE `cfg_centreonbroker` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker_info` (
   `config_id` int(11) NOT NULL,
   `config_key` varchar(50) NOT NULL,
@@ -475,7 +475,7 @@ CREATE TABLE `cfg_centreonbroker_info` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_nagios` (
   `nagios_id` int(11) NOT NULL AUTO_INCREMENT,
   `nagios_name` varchar(255) DEFAULT NULL,
@@ -577,7 +577,7 @@ CREATE TABLE `cfg_nagios` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_nagios_broker_module` (
   `bk_mod_id` int(11) NOT NULL AUTO_INCREMENT,
   `cfg_nagios_id` int(11) DEFAULT NULL,
@@ -588,7 +588,7 @@ CREATE TABLE `cfg_nagios_broker_module` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_resource` (
   `resource_id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_name` varchar(255) DEFAULT NULL,
@@ -599,7 +599,7 @@ CREATE TABLE `cfg_resource` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_resource_instance_relations` (
   `resource_id` int(11) NOT NULL,
   `instance_id` int(11) NOT NULL,
@@ -610,7 +610,7 @@ CREATE TABLE `cfg_resource_instance_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `command` (
   `command_id` int(11) NOT NULL AUTO_INCREMENT,
   `connector_id` int(10) unsigned DEFAULT NULL,
@@ -630,7 +630,7 @@ CREATE TABLE `command` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `command_arg_description` (
   `cmd_id` int(11) NOT NULL,
   `macro_name` varchar(255) NOT NULL,
@@ -640,7 +640,7 @@ CREATE TABLE `command_arg_description` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `command_categories` (
   `cmd_category_id` int(11) NOT NULL AUTO_INCREMENT,
   `category_name` varchar(255) NOT NULL,
@@ -650,14 +650,14 @@ CREATE TABLE `command_categories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `command_categories_relation` (
   `category_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `connector` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
@@ -672,7 +672,7 @@ CREATE TABLE `connector` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contact` (
   `contact_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_tp_id` int(11) DEFAULT NULL,
@@ -729,7 +729,7 @@ CREATE TABLE `contact` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contact_host_relation` (
   `host_host_id` int(11) DEFAULT NULL,
   `contact_id` int(11) DEFAULT NULL,
@@ -740,7 +740,7 @@ CREATE TABLE `contact_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contact_hostcommands_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL,
@@ -751,7 +751,7 @@ CREATE TABLE `contact_hostcommands_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contact_param` (
   `id` int(4) NOT NULL AUTO_INCREMENT,
   `cp_key` varchar(255) NOT NULL,
@@ -763,7 +763,7 @@ CREATE TABLE `contact_param` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contact_service_relation` (
   `service_service_id` int(11) DEFAULT NULL,
   `contact_id` int(11) DEFAULT NULL,
@@ -774,7 +774,7 @@ CREATE TABLE `contact_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contact_servicecommands_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL,
@@ -785,7 +785,7 @@ CREATE TABLE `contact_servicecommands_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup` (
   `cg_id` int(11) NOT NULL AUTO_INCREMENT,
   `cg_name` varchar(200) DEFAULT NULL,
@@ -801,7 +801,7 @@ CREATE TABLE `contactgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_contact_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -812,7 +812,7 @@ CREATE TABLE `contactgroup_contact_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_host_relation` (
   `host_host_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -823,7 +823,7 @@ CREATE TABLE `contactgroup_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_hostgroup_relation` (
   `contactgroup_cg_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -834,7 +834,7 @@ CREATE TABLE `contactgroup_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_service_relation` (
   `contactgroup_cg_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -845,7 +845,7 @@ CREATE TABLE `contactgroup_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_servicegroup_relation` (
   `servicegroup_sg_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -856,7 +856,7 @@ CREATE TABLE `contactgroup_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `cron_operation` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(254) DEFAULT NULL,
@@ -873,7 +873,7 @@ CREATE TABLE `cron_operation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `css_color_menu` (
   `id_css_color_menu` int(11) NOT NULL AUTO_INCREMENT,
   `menu_nb` int(11) DEFAULT NULL,
@@ -882,7 +882,7 @@ CREATE TABLE `css_color_menu` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `custom_view_default` (
   `user_id` int(11) NOT NULL,
   `custom_view_id` int(11) NOT NULL,
@@ -893,7 +893,7 @@ CREATE TABLE `custom_view_default` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `custom_view_user_relation` (
   `custom_view_id` int(11) NOT NULL,
   `user_id` int(11) DEFAULT NULL,
@@ -912,7 +912,7 @@ CREATE TABLE `custom_view_user_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `custom_views` (
   `custom_view_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
@@ -922,7 +922,7 @@ CREATE TABLE `custom_views` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency` (
   `dep_id` int(11) NOT NULL AUTO_INCREMENT,
   `dep_name` varchar(255) DEFAULT NULL,
@@ -935,7 +935,7 @@ CREATE TABLE `dependency` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -947,7 +947,7 @@ CREATE TABLE `dependency_hostChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -959,7 +959,7 @@ CREATE TABLE `dependency_hostParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostgroupChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -971,7 +971,7 @@ CREATE TABLE `dependency_hostgroupChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostgroupParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -983,7 +983,7 @@ CREATE TABLE `dependency_hostgroupParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_metaserviceChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -995,7 +995,7 @@ CREATE TABLE `dependency_metaserviceChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_metaserviceParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -1007,7 +1007,7 @@ CREATE TABLE `dependency_metaserviceParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_serviceChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1022,7 +1022,7 @@ CREATE TABLE `dependency_serviceChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_serviceParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1037,7 +1037,7 @@ CREATE TABLE `dependency_serviceParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_servicegroupChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1049,7 +1049,7 @@ CREATE TABLE `dependency_servicegroupChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_servicegroupParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1061,7 +1061,7 @@ CREATE TABLE `dependency_servicegroupParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `downtime` (
   `dt_id` int(11) NOT NULL AUTO_INCREMENT,
   `dt_name` varchar(100) NOT NULL,
@@ -1073,7 +1073,7 @@ CREATE TABLE `downtime` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_host_relation` (
   `dt_id` int(11) NOT NULL,
   `host_host_id` int(11) NOT NULL,
@@ -1084,7 +1084,7 @@ CREATE TABLE `downtime_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_hostgroup_relation` (
   `dt_id` int(11) NOT NULL,
   `hg_hg_id` int(11) NOT NULL,
@@ -1095,7 +1095,7 @@ CREATE TABLE `downtime_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_period` (
   `dt_id` int(11) NOT NULL,
   `dtp_start_time` time NOT NULL,
@@ -1112,7 +1112,7 @@ CREATE TABLE `downtime_period` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_service_relation` (
   `dt_id` int(11) NOT NULL,
   `host_host_id` int(11) NOT NULL,
@@ -1126,7 +1126,7 @@ CREATE TABLE `downtime_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_servicegroup_relation` (
   `dt_id` int(11) NOT NULL,
   `sg_sg_id` int(11) NOT NULL,
@@ -1137,7 +1137,7 @@ CREATE TABLE `downtime_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `escalation` (
   `esc_id` int(11) NOT NULL AUTO_INCREMENT,
   `esc_name` varchar(255) DEFAULT NULL,
@@ -1157,7 +1157,7 @@ CREATE TABLE `escalation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_contactgroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -1168,7 +1168,7 @@ CREATE TABLE `escalation_contactgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_host_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1179,7 +1179,7 @@ CREATE TABLE `escalation_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_hostgroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1190,7 +1190,7 @@ CREATE TABLE `escalation_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_meta_service_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -1201,7 +1201,7 @@ CREATE TABLE `escalation_meta_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_service_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1215,7 +1215,7 @@ CREATE TABLE `escalation_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_servicegroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1226,7 +1226,7 @@ CREATE TABLE `escalation_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `extended_host_information` (
   `ehi_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1250,7 +1250,7 @@ CREATE TABLE `extended_host_information` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `extended_service_information` (
   `esi_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1270,7 +1270,7 @@ CREATE TABLE `extended_service_information` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `giv_components_template` (
   `compo_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_id` int(11) DEFAULT NULL,
@@ -1303,7 +1303,7 @@ CREATE TABLE `giv_components_template` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `giv_graphs_template` (
   `graph_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(200) DEFAULT NULL,
@@ -1323,7 +1323,7 @@ CREATE TABLE `giv_graphs_template` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `host` (
   `host_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_template_model_htm_id` int(11) DEFAULT NULL,
@@ -1389,7 +1389,7 @@ CREATE TABLE `host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `host_hostparent_relation` (
   `host_parent_hp_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1400,7 +1400,7 @@ CREATE TABLE `host_hostparent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `host_service_relation` (
   `hsr_id` int(11) NOT NULL AUTO_INCREMENT,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1420,7 +1420,7 @@ CREATE TABLE `host_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `host_template_relation` (
   `host_host_id` int(11) NOT NULL DEFAULT '0',
   `host_tpl_id` int(11) NOT NULL DEFAULT '0',
@@ -1432,7 +1432,7 @@ CREATE TABLE `host_template_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `hostcategories` (
   `hc_id` int(11) NOT NULL AUTO_INCREMENT,
   `hc_name` varchar(200) DEFAULT NULL,
@@ -1447,7 +1447,7 @@ CREATE TABLE `hostcategories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `hostcategories_relation` (
   `hostcategories_hc_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1458,7 +1458,7 @@ CREATE TABLE `hostcategories_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup` (
   `hg_id` int(11) NOT NULL AUTO_INCREMENT,
   `hg_name` varchar(200) DEFAULT NULL,
@@ -1478,7 +1478,7 @@ CREATE TABLE `hostgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup_hg_relation` (
   `hg_parent_id` int(11) DEFAULT NULL,
   `hg_child_id` int(11) DEFAULT NULL,
@@ -1489,7 +1489,7 @@ CREATE TABLE `hostgroup_hg_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup_relation` (
   `hgr_id` int(11) NOT NULL AUTO_INCREMENT,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1502,14 +1502,14 @@ CREATE TABLE `hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `informations` (
   `key` varchar(25) DEFAULT NULL,
   `value` varchar(1024) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `meta_contactgroup_relation` (
   `meta_id` int(11) DEFAULT NULL,
   `cg_cg_id` int(11) DEFAULT NULL,
@@ -1520,7 +1520,7 @@ CREATE TABLE `meta_contactgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `meta_service` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `meta_name` varchar(254) DEFAULT NULL,
@@ -1555,7 +1555,7 @@ CREATE TABLE `meta_service` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `meta_service_relation` (
   `msr_id` int(11) NOT NULL AUTO_INCREMENT,
   `meta_id` int(11) DEFAULT NULL,
@@ -1572,7 +1572,7 @@ CREATE TABLE `meta_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `modules_informations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
@@ -1587,7 +1587,7 @@ CREATE TABLE `modules_informations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `nagios_macro` (
   `macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `macro_name` varchar(255) DEFAULT NULL,
@@ -1595,7 +1595,7 @@ CREATE TABLE `nagios_macro` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `nagios_server` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(40) DEFAULT NULL,
@@ -1632,7 +1632,7 @@ CREATE TABLE `nagios_server` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `ns_host_relation` (
   `nagios_server_id` int(11) NOT NULL DEFAULT '0',
   `host_host_id` int(11) NOT NULL DEFAULT '0',
@@ -1644,7 +1644,7 @@ CREATE TABLE `ns_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Relation Table For centreon Servers and hosts ';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `ods_view_details` (
   `dv_id` int(11) NOT NULL AUTO_INCREMENT,
   `index_id` BIGINT UNSIGNED DEFAULT NULL,
@@ -1658,7 +1658,7 @@ CREATE TABLE `ods_view_details` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `on_demand_macro_host` (
   `host_macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_macro_name` varchar(255) NOT NULL,
@@ -1673,7 +1673,7 @@ CREATE TABLE `on_demand_macro_host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `on_demand_macro_service` (
   `svc_macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `svc_macro_name` varchar(255) NOT NULL,
@@ -1688,14 +1688,14 @@ CREATE TABLE `on_demand_macro_service` (
 ) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `options` (
   `key` varchar(255) DEFAULT NULL,
   `value` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `poller_command_relations` (
   `poller_id` int(11) NOT NULL,
   `command_id` int(11) NOT NULL,
@@ -1707,7 +1707,7 @@ CREATE TABLE `poller_command_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `service` (
   `service_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_template_model_stm_id` int(11) DEFAULT NULL,
@@ -1768,7 +1768,7 @@ CREATE TABLE `service` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `service_categories` (
   `sc_id` int(11) NOT NULL AUTO_INCREMENT,
   `sc_name` varchar(255) DEFAULT NULL,
@@ -1780,7 +1780,7 @@ CREATE TABLE `service_categories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Services Catygories For best Reporting';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `service_categories_relation` (
   `scr_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1793,7 +1793,7 @@ CREATE TABLE `service_categories_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `servicegroup` (
   `sg_id` int(11) NOT NULL AUTO_INCREMENT,
   `sg_name` varchar(200) DEFAULT NULL,
@@ -1807,7 +1807,7 @@ CREATE TABLE `servicegroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `servicegroup_relation` (
   `sgr_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1826,7 +1826,7 @@ CREATE TABLE `servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `session` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `session_id` varchar(256) DEFAULT NULL,
@@ -1851,7 +1851,7 @@ CREATE TABLE `session` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod` (
   `tp_id` int(11) NOT NULL AUTO_INCREMENT,
   `tp_name` varchar(200) DEFAULT NULL,
@@ -1867,7 +1867,7 @@ CREATE TABLE `timeperiod` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_exceptions` (
   `exception_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1879,7 +1879,7 @@ CREATE TABLE `timeperiod_exceptions` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_exclude_relations` (
   `exclude_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1890,7 +1890,7 @@ CREATE TABLE `timeperiod_exclude_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_include_relations` (
   `include_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1901,7 +1901,7 @@ CREATE TABLE `timeperiod_include_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `topology` (
   `topology_id` int(11) NOT NULL AUTO_INCREMENT,
   `topology_name` varchar(255) DEFAULT NULL,
@@ -1928,7 +1928,7 @@ CREATE TABLE `topology` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `topology_JS` (
   `id_t_js` int(11) NOT NULL AUTO_INCREMENT,
   `id_page` int(11) DEFAULT NULL,
@@ -1942,7 +1942,7 @@ CREATE TABLE `topology_JS` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `traps` (
   `traps_id` int(11) NOT NULL AUTO_INCREMENT,
   `traps_name` varchar(255) DEFAULT NULL,
@@ -1979,7 +1979,7 @@ CREATE TABLE `traps` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `traps_matching_properties` (
   `tmo_id` int(11) NOT NULL AUTO_INCREMENT,
   `trap_id` int(11) DEFAULT NULL,
@@ -1995,7 +1995,7 @@ CREATE TABLE `traps_matching_properties` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `traps_preexec` (
   `trap_id` int(11) DEFAULT NULL,
   `tpe_order` int(11) DEFAULT NULL,
@@ -2005,7 +2005,7 @@ CREATE TABLE `traps_preexec` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `traps_service_relation` (
   `traps_id` int(11) DEFAULT NULL,
   `service_id` int(11) DEFAULT NULL,
@@ -2016,7 +2016,7 @@ CREATE TABLE `traps_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `traps_group` (
   `traps_group_id` int(11) NOT NULL AUTO_INCREMENT,
   `traps_group_name` varchar(255) NOT NULL,
@@ -2024,7 +2024,7 @@ CREATE TABLE `traps_group` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `traps_group_relation` (
   `traps_group_id` int(11) NOT NULL,
   `traps_id` int(11) NOT NULL,
@@ -2035,7 +2035,7 @@ CREATE TABLE `traps_group_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `traps_vendor` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(254) DEFAULT NULL,
@@ -2045,7 +2045,7 @@ CREATE TABLE `traps_vendor` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `view_img` (
   `img_id` int(11) NOT NULL AUTO_INCREMENT,
   `img_name` varchar(255) DEFAULT NULL,
@@ -2055,7 +2055,7 @@ CREATE TABLE `view_img` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `view_img_dir` (
   `dir_id` int(11) NOT NULL AUTO_INCREMENT,
   `dir_name` varchar(255) DEFAULT NULL,
@@ -2065,7 +2065,7 @@ CREATE TABLE `view_img_dir` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `view_img_dir_relation` (
   `vidr_id` int(11) NOT NULL AUTO_INCREMENT,
   `dir_dir_parent_id` int(11) DEFAULT NULL,
@@ -2076,7 +2076,7 @@ CREATE TABLE `view_img_dir_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `virtual_metrics` (
   `vmetric_id` int(11) NOT NULL AUTO_INCREMENT,
   `index_id` BIGINT UNSIGNED DEFAULT NULL,
@@ -2094,7 +2094,7 @@ CREATE TABLE `virtual_metrics` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `widget_models` (
   `widget_model_id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(255) NOT NULL,
@@ -2113,7 +2113,7 @@ CREATE TABLE `widget_models` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters` (
   `parameter_id` int(11) NOT NULL AUTO_INCREMENT,
   `parameter_name` varchar(255) NOT NULL,
@@ -2132,7 +2132,7 @@ CREATE TABLE `widget_parameters` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_field_type` (
   `field_type_id` int(11) NOT NULL AUTO_INCREMENT,
   `ft_typename` varchar(50) NOT NULL,
@@ -2141,7 +2141,7 @@ CREATE TABLE `widget_parameters_field_type` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_multiple_options` (
   `parameter_id` int(11) NOT NULL,
   `option_name` varchar(255) NOT NULL,
@@ -2151,7 +2151,7 @@ CREATE TABLE `widget_parameters_multiple_options` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_range` (
   `parameter_id` int(11) NOT NULL,
   `min_range` int(11) NOT NULL,
@@ -2162,7 +2162,7 @@ CREATE TABLE `widget_parameters_range` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `widget_preferences` (
   `widget_view_id` int(11) NOT NULL,
   `parameter_id` int(11) NOT NULL,
@@ -2175,7 +2175,7 @@ CREATE TABLE `widget_preferences` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `widget_views` (
   `widget_view_id` int(11) NOT NULL AUTO_INCREMENT,
   `custom_view_id` int(11) NOT NULL,
@@ -2189,7 +2189,7 @@ CREATE TABLE `widget_views` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET SET character_set_client = utf8mb4 */;
+/*!40101 SET  character_set_client = utf8mb4 */;
 CREATE TABLE `widgets` (
   `widget_id` int(11) NOT NULL AUTO_INCREMENT,
   `widget_model_id` int(11) NOT NULL,

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -10,7 +10,7 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_actions` (
   `acl_action_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_action_name` varchar(255) DEFAULT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE `acl_actions` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_actions_rules` (
   `aar_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_action_rule_id` int(11) DEFAULT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE `acl_actions_rules` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_actions_relations` (
   `acl_action_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -40,7 +40,7 @@ CREATE TABLE `acl_group_actions_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_contactgroups_relations` (
   `cg_cg_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -51,7 +51,7 @@ CREATE TABLE `acl_group_contactgroups_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_contacts_relations` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -62,7 +62,7 @@ CREATE TABLE `acl_group_contacts_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_topology_relations` (
   `acl_group_id` int(11) DEFAULT NULL,
   `acl_topology_id` int(11) DEFAULT NULL,
@@ -73,7 +73,7 @@ CREATE TABLE `acl_group_topology_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_groups` (
   `acl_group_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_group_name` varchar(255) DEFAULT NULL,
@@ -84,7 +84,7 @@ CREATE TABLE `acl_groups` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_res_group_relations` (
   `acl_res_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -95,7 +95,7 @@ CREATE TABLE `acl_res_group_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources` (
   `acl_res_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_res_name` varchar(255) DEFAULT NULL,
@@ -112,7 +112,7 @@ CREATE TABLE `acl_resources` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hc_relations` (
   `hc_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -123,7 +123,7 @@ CREATE TABLE `acl_resources_hc_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hg_relations` (
   `hg_hg_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -135,7 +135,7 @@ CREATE TABLE `acl_resources_hg_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_host_relations` (
   `host_host_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -146,7 +146,7 @@ CREATE TABLE `acl_resources_host_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hostex_relations` (
   `host_host_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -157,7 +157,7 @@ CREATE TABLE `acl_resources_hostex_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_meta_relations` (
   `meta_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -168,7 +168,7 @@ CREATE TABLE `acl_resources_meta_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_poller_relations` (
   `poller_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -179,7 +179,7 @@ CREATE TABLE `acl_resources_poller_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_sc_relations` (
   `sc_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -190,7 +190,7 @@ CREATE TABLE `acl_resources_sc_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_service_relations` (
   `service_service_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -201,7 +201,7 @@ CREATE TABLE `acl_resources_service_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_sg_relations` (
   `sg_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -213,7 +213,7 @@ CREATE TABLE `acl_resources_sg_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_topology` (
   `acl_topo_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_topo_name` varchar(255) DEFAULT NULL,
@@ -225,7 +225,7 @@ CREATE TABLE `acl_topology` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `acl_topology_relations` (
   `topology_topology_id` int(11) DEFAULT NULL,
   `acl_topo_id` int(11) DEFAULT NULL,
@@ -237,7 +237,7 @@ CREATE TABLE `acl_topology_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource` (
   `ar_id` int(11) NOT NULL AUTO_INCREMENT,
   `ar_name` varchar(255) NOT NULL DEFAULT 'Default',
@@ -249,7 +249,7 @@ CREATE TABLE `auth_ressource` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource_host` (
   `ldap_host_id` int(11) NOT NULL AUTO_INCREMENT,
   `auth_ressource_id` int(11) NOT NULL,
@@ -264,7 +264,7 @@ CREATE TABLE `auth_ressource_host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource_info` (
   `ar_id` int(11) NOT NULL,
   `ari_name` varchar(100) NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `auth_ressource_info` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_fieldset` (
   `cb_fieldset_id` INT NOT NULL,
   `fieldset_name` VARCHAR(255) NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `cb_fieldset` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_fieldgroup` (
   `cb_fieldgroup_id` INT NOT NULL AUTO_INCREMENT,
   `groupname` VARCHAR(100) NOT NULL,
@@ -294,7 +294,7 @@ CREATE TABLE `cb_fieldgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_field` (
   `cb_field_id` int(11) NOT NULL AUTO_INCREMENT,
   `fieldname` varchar(100) NOT NULL,
@@ -307,7 +307,7 @@ CREATE TABLE `cb_field` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_list` (
   `cb_list_id` int(11) NOT NULL,
   `cb_field_id` int(11) NOT NULL,
@@ -319,7 +319,7 @@ CREATE TABLE `cb_list` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_list_values` (
   `cb_list_id` int(11) NOT NULL,
   `value_name` varchar(255) NOT NULL,
@@ -330,7 +330,7 @@ CREATE TABLE `cb_list_values` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_module` (
   `cb_module_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL,
@@ -344,7 +344,7 @@ CREATE TABLE `cb_module` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_module_relation` (
   `cb_module_id` int(11) NOT NULL,
   `module_depend_id` int(11) NOT NULL,
@@ -357,7 +357,7 @@ CREATE TABLE `cb_module_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_tag` (
   `cb_tag_id` int(11) NOT NULL AUTO_INCREMENT,
   `tagname` varchar(50) NOT NULL,
@@ -366,7 +366,7 @@ CREATE TABLE `cb_tag` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_tag_type_relation` (
   `cb_tag_id` int(11) NOT NULL,
   `cb_type_id` int(11) NOT NULL,
@@ -379,7 +379,7 @@ CREATE TABLE `cb_tag_type_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_type` (
   `cb_type_id` int(11) NOT NULL AUTO_INCREMENT,
   `type_name` varchar(50) NOT NULL,
@@ -391,7 +391,7 @@ CREATE TABLE `cb_type` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_type_field_relation` (
   `cb_type_id` int(11) NOT NULL,
   `cb_field_id` int(11) NOT NULL,
@@ -408,7 +408,7 @@ CREATE TABLE `cb_type_field_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
@@ -416,7 +416,7 @@ CREATE TABLE `cb_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cb_log_level` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
@@ -424,7 +424,7 @@ CREATE TABLE `cb_log_level` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `id_centreonbroker` int(11) NOT NULL,
@@ -434,7 +434,7 @@ CREATE TABLE `cfg_centreonbroker_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker` (
   `config_id` int(11) NOT NULL AUTO_INCREMENT,
   `config_name` varchar(100) NOT NULL,
@@ -458,7 +458,7 @@ CREATE TABLE `cfg_centreonbroker` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker_info` (
   `config_id` int(11) NOT NULL,
   `config_key` varchar(50) NOT NULL,
@@ -475,7 +475,7 @@ CREATE TABLE `cfg_centreonbroker_info` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_nagios` (
   `nagios_id` int(11) NOT NULL AUTO_INCREMENT,
   `nagios_name` varchar(255) DEFAULT NULL,
@@ -577,7 +577,7 @@ CREATE TABLE `cfg_nagios` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_nagios_broker_module` (
   `bk_mod_id` int(11) NOT NULL AUTO_INCREMENT,
   `cfg_nagios_id` int(11) DEFAULT NULL,
@@ -588,7 +588,7 @@ CREATE TABLE `cfg_nagios_broker_module` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_resource` (
   `resource_id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_name` varchar(255) DEFAULT NULL,
@@ -599,7 +599,7 @@ CREATE TABLE `cfg_resource` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cfg_resource_instance_relations` (
   `resource_id` int(11) NOT NULL,
   `instance_id` int(11) NOT NULL,
@@ -610,7 +610,7 @@ CREATE TABLE `cfg_resource_instance_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `command` (
   `command_id` int(11) NOT NULL AUTO_INCREMENT,
   `connector_id` int(10) unsigned DEFAULT NULL,
@@ -630,7 +630,7 @@ CREATE TABLE `command` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `command_arg_description` (
   `cmd_id` int(11) NOT NULL,
   `macro_name` varchar(255) NOT NULL,
@@ -640,7 +640,7 @@ CREATE TABLE `command_arg_description` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `command_categories` (
   `cmd_category_id` int(11) NOT NULL AUTO_INCREMENT,
   `category_name` varchar(255) NOT NULL,
@@ -650,14 +650,14 @@ CREATE TABLE `command_categories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `command_categories_relation` (
   `category_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `connector` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
@@ -672,7 +672,7 @@ CREATE TABLE `connector` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact` (
   `contact_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_tp_id` int(11) DEFAULT NULL,
@@ -729,7 +729,7 @@ CREATE TABLE `contact` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact_host_relation` (
   `host_host_id` int(11) DEFAULT NULL,
   `contact_id` int(11) DEFAULT NULL,
@@ -740,7 +740,7 @@ CREATE TABLE `contact_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact_hostcommands_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL,
@@ -751,7 +751,7 @@ CREATE TABLE `contact_hostcommands_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact_param` (
   `id` int(4) NOT NULL AUTO_INCREMENT,
   `cp_key` varchar(255) NOT NULL,
@@ -763,7 +763,7 @@ CREATE TABLE `contact_param` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact_service_relation` (
   `service_service_id` int(11) DEFAULT NULL,
   `contact_id` int(11) DEFAULT NULL,
@@ -774,7 +774,7 @@ CREATE TABLE `contact_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contact_servicecommands_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL,
@@ -785,7 +785,7 @@ CREATE TABLE `contact_servicecommands_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup` (
   `cg_id` int(11) NOT NULL AUTO_INCREMENT,
   `cg_name` varchar(200) DEFAULT NULL,
@@ -801,7 +801,7 @@ CREATE TABLE `contactgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_contact_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -812,7 +812,7 @@ CREATE TABLE `contactgroup_contact_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_host_relation` (
   `host_host_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -823,7 +823,7 @@ CREATE TABLE `contactgroup_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_hostgroup_relation` (
   `contactgroup_cg_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -834,7 +834,7 @@ CREATE TABLE `contactgroup_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_service_relation` (
   `contactgroup_cg_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -845,7 +845,7 @@ CREATE TABLE `contactgroup_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_servicegroup_relation` (
   `servicegroup_sg_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -856,7 +856,7 @@ CREATE TABLE `contactgroup_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `cron_operation` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(254) DEFAULT NULL,
@@ -873,7 +873,7 @@ CREATE TABLE `cron_operation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `css_color_menu` (
   `id_css_color_menu` int(11) NOT NULL AUTO_INCREMENT,
   `menu_nb` int(11) DEFAULT NULL,
@@ -882,7 +882,7 @@ CREATE TABLE `css_color_menu` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `custom_view_default` (
   `user_id` int(11) NOT NULL,
   `custom_view_id` int(11) NOT NULL,
@@ -893,7 +893,7 @@ CREATE TABLE `custom_view_default` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `custom_view_user_relation` (
   `custom_view_id` int(11) NOT NULL,
   `user_id` int(11) DEFAULT NULL,
@@ -912,7 +912,7 @@ CREATE TABLE `custom_view_user_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `custom_views` (
   `custom_view_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
@@ -922,7 +922,7 @@ CREATE TABLE `custom_views` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency` (
   `dep_id` int(11) NOT NULL AUTO_INCREMENT,
   `dep_name` varchar(255) DEFAULT NULL,
@@ -935,7 +935,7 @@ CREATE TABLE `dependency` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -947,7 +947,7 @@ CREATE TABLE `dependency_hostChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -959,7 +959,7 @@ CREATE TABLE `dependency_hostParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostgroupChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -971,7 +971,7 @@ CREATE TABLE `dependency_hostgroupChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostgroupParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -983,7 +983,7 @@ CREATE TABLE `dependency_hostgroupParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_metaserviceChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -995,7 +995,7 @@ CREATE TABLE `dependency_metaserviceChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_metaserviceParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -1007,7 +1007,7 @@ CREATE TABLE `dependency_metaserviceParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_serviceChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1022,7 +1022,7 @@ CREATE TABLE `dependency_serviceChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_serviceParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1037,7 +1037,7 @@ CREATE TABLE `dependency_serviceParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_servicegroupChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1049,7 +1049,7 @@ CREATE TABLE `dependency_servicegroupChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `dependency_servicegroupParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1061,7 +1061,7 @@ CREATE TABLE `dependency_servicegroupParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime` (
   `dt_id` int(11) NOT NULL AUTO_INCREMENT,
   `dt_name` varchar(100) NOT NULL,
@@ -1073,7 +1073,7 @@ CREATE TABLE `downtime` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_host_relation` (
   `dt_id` int(11) NOT NULL,
   `host_host_id` int(11) NOT NULL,
@@ -1084,7 +1084,7 @@ CREATE TABLE `downtime_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_hostgroup_relation` (
   `dt_id` int(11) NOT NULL,
   `hg_hg_id` int(11) NOT NULL,
@@ -1095,7 +1095,7 @@ CREATE TABLE `downtime_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_period` (
   `dt_id` int(11) NOT NULL,
   `dtp_start_time` time NOT NULL,
@@ -1112,7 +1112,7 @@ CREATE TABLE `downtime_period` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_service_relation` (
   `dt_id` int(11) NOT NULL,
   `host_host_id` int(11) NOT NULL,
@@ -1126,7 +1126,7 @@ CREATE TABLE `downtime_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `downtime_servicegroup_relation` (
   `dt_id` int(11) NOT NULL,
   `sg_sg_id` int(11) NOT NULL,
@@ -1137,7 +1137,7 @@ CREATE TABLE `downtime_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation` (
   `esc_id` int(11) NOT NULL AUTO_INCREMENT,
   `esc_name` varchar(255) DEFAULT NULL,
@@ -1157,7 +1157,7 @@ CREATE TABLE `escalation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_contactgroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -1168,7 +1168,7 @@ CREATE TABLE `escalation_contactgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_host_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1179,7 +1179,7 @@ CREATE TABLE `escalation_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_hostgroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1190,7 +1190,7 @@ CREATE TABLE `escalation_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_meta_service_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -1201,7 +1201,7 @@ CREATE TABLE `escalation_meta_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_service_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1215,7 +1215,7 @@ CREATE TABLE `escalation_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `escalation_servicegroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1226,7 +1226,7 @@ CREATE TABLE `escalation_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `extended_host_information` (
   `ehi_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1250,7 +1250,7 @@ CREATE TABLE `extended_host_information` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `extended_service_information` (
   `esi_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1270,7 +1270,7 @@ CREATE TABLE `extended_service_information` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `giv_components_template` (
   `compo_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_id` int(11) DEFAULT NULL,
@@ -1303,7 +1303,7 @@ CREATE TABLE `giv_components_template` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `giv_graphs_template` (
   `graph_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(200) DEFAULT NULL,
@@ -1323,7 +1323,7 @@ CREATE TABLE `giv_graphs_template` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `host` (
   `host_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_template_model_htm_id` int(11) DEFAULT NULL,
@@ -1389,7 +1389,7 @@ CREATE TABLE `host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_hostparent_relation` (
   `host_parent_hp_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1400,7 +1400,7 @@ CREATE TABLE `host_hostparent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_service_relation` (
   `hsr_id` int(11) NOT NULL AUTO_INCREMENT,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1420,7 +1420,7 @@ CREATE TABLE `host_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `host_template_relation` (
   `host_host_id` int(11) NOT NULL DEFAULT '0',
   `host_tpl_id` int(11) NOT NULL DEFAULT '0',
@@ -1432,7 +1432,7 @@ CREATE TABLE `host_template_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `hostcategories` (
   `hc_id` int(11) NOT NULL AUTO_INCREMENT,
   `hc_name` varchar(200) DEFAULT NULL,
@@ -1447,7 +1447,7 @@ CREATE TABLE `hostcategories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `hostcategories_relation` (
   `hostcategories_hc_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1458,7 +1458,7 @@ CREATE TABLE `hostcategories_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup` (
   `hg_id` int(11) NOT NULL AUTO_INCREMENT,
   `hg_name` varchar(200) DEFAULT NULL,
@@ -1478,7 +1478,7 @@ CREATE TABLE `hostgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup_hg_relation` (
   `hg_parent_id` int(11) DEFAULT NULL,
   `hg_child_id` int(11) DEFAULT NULL,
@@ -1489,7 +1489,7 @@ CREATE TABLE `hostgroup_hg_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup_relation` (
   `hgr_id` int(11) NOT NULL AUTO_INCREMENT,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1502,14 +1502,14 @@ CREATE TABLE `hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `informations` (
   `key` varchar(25) DEFAULT NULL,
   `value` varchar(1024) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `meta_contactgroup_relation` (
   `meta_id` int(11) DEFAULT NULL,
   `cg_cg_id` int(11) DEFAULT NULL,
@@ -1520,7 +1520,7 @@ CREATE TABLE `meta_contactgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `meta_service` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `meta_name` varchar(254) DEFAULT NULL,
@@ -1555,7 +1555,7 @@ CREATE TABLE `meta_service` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `meta_service_relation` (
   `msr_id` int(11) NOT NULL AUTO_INCREMENT,
   `meta_id` int(11) DEFAULT NULL,
@@ -1572,7 +1572,7 @@ CREATE TABLE `meta_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `modules_informations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
@@ -1587,7 +1587,7 @@ CREATE TABLE `modules_informations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `nagios_macro` (
   `macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `macro_name` varchar(255) DEFAULT NULL,
@@ -1595,7 +1595,7 @@ CREATE TABLE `nagios_macro` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `nagios_server` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(40) DEFAULT NULL,
@@ -1632,7 +1632,7 @@ CREATE TABLE `nagios_server` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `ns_host_relation` (
   `nagios_server_id` int(11) NOT NULL DEFAULT '0',
   `host_host_id` int(11) NOT NULL DEFAULT '0',
@@ -1644,7 +1644,7 @@ CREATE TABLE `ns_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Relation Table For centreon Servers and hosts ';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `ods_view_details` (
   `dv_id` int(11) NOT NULL AUTO_INCREMENT,
   `index_id` BIGINT UNSIGNED DEFAULT NULL,
@@ -1658,7 +1658,7 @@ CREATE TABLE `ods_view_details` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `on_demand_macro_host` (
   `host_macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_macro_name` varchar(255) NOT NULL,
@@ -1673,7 +1673,7 @@ CREATE TABLE `on_demand_macro_host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `on_demand_macro_service` (
   `svc_macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `svc_macro_name` varchar(255) NOT NULL,
@@ -1688,14 +1688,14 @@ CREATE TABLE `on_demand_macro_service` (
 ) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `options` (
   `key` varchar(255) DEFAULT NULL,
   `value` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `poller_command_relations` (
   `poller_id` int(11) NOT NULL,
   `command_id` int(11) NOT NULL,
@@ -1707,7 +1707,7 @@ CREATE TABLE `poller_command_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `service` (
   `service_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_template_model_stm_id` int(11) DEFAULT NULL,
@@ -1768,7 +1768,7 @@ CREATE TABLE `service` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `service_categories` (
   `sc_id` int(11) NOT NULL AUTO_INCREMENT,
   `sc_name` varchar(255) DEFAULT NULL,
@@ -1780,7 +1780,7 @@ CREATE TABLE `service_categories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Services Catygories For best Reporting';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `service_categories_relation` (
   `scr_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1793,7 +1793,7 @@ CREATE TABLE `service_categories_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `servicegroup` (
   `sg_id` int(11) NOT NULL AUTO_INCREMENT,
   `sg_name` varchar(200) DEFAULT NULL,
@@ -1807,7 +1807,7 @@ CREATE TABLE `servicegroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `servicegroup_relation` (
   `sgr_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1826,7 +1826,7 @@ CREATE TABLE `servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `session` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `session_id` varchar(256) DEFAULT NULL,
@@ -1851,7 +1851,7 @@ CREATE TABLE `session` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod` (
   `tp_id` int(11) NOT NULL AUTO_INCREMENT,
   `tp_name` varchar(200) DEFAULT NULL,
@@ -1867,7 +1867,7 @@ CREATE TABLE `timeperiod` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_exceptions` (
   `exception_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1879,7 +1879,7 @@ CREATE TABLE `timeperiod_exceptions` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_exclude_relations` (
   `exclude_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1890,7 +1890,7 @@ CREATE TABLE `timeperiod_exclude_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_include_relations` (
   `include_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1901,7 +1901,7 @@ CREATE TABLE `timeperiod_include_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `topology` (
   `topology_id` int(11) NOT NULL AUTO_INCREMENT,
   `topology_name` varchar(255) DEFAULT NULL,
@@ -1928,7 +1928,7 @@ CREATE TABLE `topology` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `topology_JS` (
   `id_t_js` int(11) NOT NULL AUTO_INCREMENT,
   `id_page` int(11) DEFAULT NULL,
@@ -1942,7 +1942,7 @@ CREATE TABLE `topology_JS` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps` (
   `traps_id` int(11) NOT NULL AUTO_INCREMENT,
   `traps_name` varchar(255) DEFAULT NULL,
@@ -1979,7 +1979,7 @@ CREATE TABLE `traps` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_matching_properties` (
   `tmo_id` int(11) NOT NULL AUTO_INCREMENT,
   `trap_id` int(11) DEFAULT NULL,
@@ -1995,7 +1995,7 @@ CREATE TABLE `traps_matching_properties` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_preexec` (
   `trap_id` int(11) DEFAULT NULL,
   `tpe_order` int(11) DEFAULT NULL,
@@ -2005,7 +2005,7 @@ CREATE TABLE `traps_preexec` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_service_relation` (
   `traps_id` int(11) DEFAULT NULL,
   `service_id` int(11) DEFAULT NULL,
@@ -2016,7 +2016,7 @@ CREATE TABLE `traps_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_group` (
   `traps_group_id` int(11) NOT NULL AUTO_INCREMENT,
   `traps_group_name` varchar(255) NOT NULL,
@@ -2024,7 +2024,7 @@ CREATE TABLE `traps_group` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_group_relation` (
   `traps_group_id` int(11) NOT NULL,
   `traps_id` int(11) NOT NULL,
@@ -2035,7 +2035,7 @@ CREATE TABLE `traps_group_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `traps_vendor` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(254) DEFAULT NULL,
@@ -2045,7 +2045,7 @@ CREATE TABLE `traps_vendor` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `view_img` (
   `img_id` int(11) NOT NULL AUTO_INCREMENT,
   `img_name` varchar(255) DEFAULT NULL,
@@ -2055,7 +2055,7 @@ CREATE TABLE `view_img` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `view_img_dir` (
   `dir_id` int(11) NOT NULL AUTO_INCREMENT,
   `dir_name` varchar(255) DEFAULT NULL,
@@ -2065,7 +2065,7 @@ CREATE TABLE `view_img_dir` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `view_img_dir_relation` (
   `vidr_id` int(11) NOT NULL AUTO_INCREMENT,
   `dir_dir_parent_id` int(11) DEFAULT NULL,
@@ -2076,7 +2076,7 @@ CREATE TABLE `view_img_dir_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `virtual_metrics` (
   `vmetric_id` int(11) NOT NULL AUTO_INCREMENT,
   `index_id` BIGINT UNSIGNED DEFAULT NULL,
@@ -2094,7 +2094,7 @@ CREATE TABLE `virtual_metrics` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_models` (
   `widget_model_id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(255) NOT NULL,
@@ -2113,7 +2113,7 @@ CREATE TABLE `widget_models` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters` (
   `parameter_id` int(11) NOT NULL AUTO_INCREMENT,
   `parameter_name` varchar(255) NOT NULL,
@@ -2132,7 +2132,7 @@ CREATE TABLE `widget_parameters` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_field_type` (
   `field_type_id` int(11) NOT NULL AUTO_INCREMENT,
   `ft_typename` varchar(50) NOT NULL,
@@ -2141,7 +2141,7 @@ CREATE TABLE `widget_parameters_field_type` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_multiple_options` (
   `parameter_id` int(11) NOT NULL,
   `option_name` varchar(255) NOT NULL,
@@ -2151,7 +2151,7 @@ CREATE TABLE `widget_parameters_multiple_options` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_range` (
   `parameter_id` int(11) NOT NULL,
   `min_range` int(11) NOT NULL,
@@ -2162,7 +2162,7 @@ CREATE TABLE `widget_parameters_range` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_preferences` (
   `widget_view_id` int(11) NOT NULL,
   `parameter_id` int(11) NOT NULL,
@@ -2175,7 +2175,7 @@ CREATE TABLE `widget_preferences` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `widget_views` (
   `widget_view_id` int(11) NOT NULL AUTO_INCREMENT,
   `custom_view_id` int(11) NOT NULL,
@@ -2189,7 +2189,7 @@ CREATE TABLE `widget_views` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET SET character_set_client = utf8mb4 */;
 CREATE TABLE `widgets` (
   `widget_id` int(11) NOT NULL AUTO_INCREMENT,
   `widget_model_id` int(11) NOT NULL,

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -10,7 +10,7 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_actions` (
   `acl_action_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_action_name` varchar(255) DEFAULT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE `acl_actions` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_actions_rules` (
   `aar_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_action_rule_id` int(11) DEFAULT NULL,
@@ -31,7 +31,7 @@ CREATE TABLE `acl_actions_rules` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_actions_relations` (
   `acl_action_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -40,7 +40,7 @@ CREATE TABLE `acl_group_actions_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_contactgroups_relations` (
   `cg_cg_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -51,7 +51,7 @@ CREATE TABLE `acl_group_contactgroups_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_contacts_relations` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -62,7 +62,7 @@ CREATE TABLE `acl_group_contacts_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_group_topology_relations` (
   `acl_group_id` int(11) DEFAULT NULL,
   `acl_topology_id` int(11) DEFAULT NULL,
@@ -73,7 +73,7 @@ CREATE TABLE `acl_group_topology_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_groups` (
   `acl_group_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_group_name` varchar(255) DEFAULT NULL,
@@ -84,7 +84,7 @@ CREATE TABLE `acl_groups` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_res_group_relations` (
   `acl_res_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -95,7 +95,7 @@ CREATE TABLE `acl_res_group_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources` (
   `acl_res_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_res_name` varchar(255) DEFAULT NULL,
@@ -112,7 +112,7 @@ CREATE TABLE `acl_resources` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hc_relations` (
   `hc_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -123,7 +123,7 @@ CREATE TABLE `acl_resources_hc_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hg_relations` (
   `hg_hg_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -135,7 +135,7 @@ CREATE TABLE `acl_resources_hg_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_host_relations` (
   `host_host_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -146,7 +146,7 @@ CREATE TABLE `acl_resources_host_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_hostex_relations` (
   `host_host_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -157,7 +157,7 @@ CREATE TABLE `acl_resources_hostex_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_meta_relations` (
   `meta_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -168,7 +168,7 @@ CREATE TABLE `acl_resources_meta_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_poller_relations` (
   `poller_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -179,7 +179,7 @@ CREATE TABLE `acl_resources_poller_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_sc_relations` (
   `sc_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -190,7 +190,7 @@ CREATE TABLE `acl_resources_sc_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_service_relations` (
   `service_service_id` int(11) DEFAULT NULL,
   `acl_group_id` int(11) DEFAULT NULL,
@@ -201,7 +201,7 @@ CREATE TABLE `acl_resources_service_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_resources_sg_relations` (
   `sg_id` int(11) DEFAULT NULL,
   `acl_res_id` int(11) DEFAULT NULL,
@@ -213,7 +213,7 @@ CREATE TABLE `acl_resources_sg_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_topology` (
   `acl_topo_id` int(11) NOT NULL AUTO_INCREMENT,
   `acl_topo_name` varchar(255) DEFAULT NULL,
@@ -225,7 +225,7 @@ CREATE TABLE `acl_topology` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `acl_topology_relations` (
   `topology_topology_id` int(11) DEFAULT NULL,
   `acl_topo_id` int(11) DEFAULT NULL,
@@ -237,7 +237,7 @@ CREATE TABLE `acl_topology_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource` (
   `ar_id` int(11) NOT NULL AUTO_INCREMENT,
   `ar_name` varchar(255) NOT NULL DEFAULT 'Default',
@@ -249,7 +249,7 @@ CREATE TABLE `auth_ressource` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource_host` (
   `ldap_host_id` int(11) NOT NULL AUTO_INCREMENT,
   `auth_ressource_id` int(11) NOT NULL,
@@ -264,7 +264,7 @@ CREATE TABLE `auth_ressource_host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `auth_ressource_info` (
   `ar_id` int(11) NOT NULL,
   `ari_name` varchar(100) NOT NULL,
@@ -274,7 +274,7 @@ CREATE TABLE `auth_ressource_info` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_fieldset` (
   `cb_fieldset_id` INT NOT NULL,
   `fieldset_name` VARCHAR(255) NOT NULL,
@@ -282,7 +282,7 @@ CREATE TABLE `cb_fieldset` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_fieldgroup` (
   `cb_fieldgroup_id` INT NOT NULL AUTO_INCREMENT,
   `groupname` VARCHAR(100) NOT NULL,
@@ -294,7 +294,7 @@ CREATE TABLE `cb_fieldgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_field` (
   `cb_field_id` int(11) NOT NULL AUTO_INCREMENT,
   `fieldname` varchar(100) NOT NULL,
@@ -307,7 +307,7 @@ CREATE TABLE `cb_field` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_list` (
   `cb_list_id` int(11) NOT NULL,
   `cb_field_id` int(11) NOT NULL,
@@ -319,7 +319,7 @@ CREATE TABLE `cb_list` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_list_values` (
   `cb_list_id` int(11) NOT NULL,
   `value_name` varchar(255) NOT NULL,
@@ -330,7 +330,7 @@ CREATE TABLE `cb_list_values` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_module` (
   `cb_module_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(50) NOT NULL,
@@ -344,7 +344,7 @@ CREATE TABLE `cb_module` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_module_relation` (
   `cb_module_id` int(11) NOT NULL,
   `module_depend_id` int(11) NOT NULL,
@@ -357,7 +357,7 @@ CREATE TABLE `cb_module_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_tag` (
   `cb_tag_id` int(11) NOT NULL AUTO_INCREMENT,
   `tagname` varchar(50) NOT NULL,
@@ -366,7 +366,7 @@ CREATE TABLE `cb_tag` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_tag_type_relation` (
   `cb_tag_id` int(11) NOT NULL,
   `cb_type_id` int(11) NOT NULL,
@@ -379,7 +379,7 @@ CREATE TABLE `cb_tag_type_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_type` (
   `cb_type_id` int(11) NOT NULL AUTO_INCREMENT,
   `type_name` varchar(50) NOT NULL,
@@ -391,7 +391,7 @@ CREATE TABLE `cb_type` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_type_field_relation` (
   `cb_type_id` int(11) NOT NULL,
   `cb_field_id` int(11) NOT NULL,
@@ -408,7 +408,7 @@ CREATE TABLE `cb_type_field_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
@@ -416,7 +416,7 @@ CREATE TABLE `cb_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cb_log_level` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
@@ -424,7 +424,7 @@ CREATE TABLE `cb_log_level` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker_log` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `id_centreonbroker` int(11) NOT NULL,
@@ -434,7 +434,7 @@ CREATE TABLE `cfg_centreonbroker_log` (
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker` (
   `config_id` int(11) NOT NULL AUTO_INCREMENT,
   `config_name` varchar(100) NOT NULL,
@@ -458,7 +458,7 @@ CREATE TABLE `cfg_centreonbroker` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cfg_centreonbroker_info` (
   `config_id` int(11) NOT NULL,
   `config_key` varchar(50) NOT NULL,
@@ -475,7 +475,7 @@ CREATE TABLE `cfg_centreonbroker_info` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cfg_nagios` (
   `nagios_id` int(11) NOT NULL AUTO_INCREMENT,
   `nagios_name` varchar(255) DEFAULT NULL,
@@ -577,7 +577,7 @@ CREATE TABLE `cfg_nagios` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cfg_nagios_broker_module` (
   `bk_mod_id` int(11) NOT NULL AUTO_INCREMENT,
   `cfg_nagios_id` int(11) DEFAULT NULL,
@@ -588,7 +588,7 @@ CREATE TABLE `cfg_nagios_broker_module` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cfg_resource` (
   `resource_id` int(11) NOT NULL AUTO_INCREMENT,
   `resource_name` varchar(255) DEFAULT NULL,
@@ -599,7 +599,7 @@ CREATE TABLE `cfg_resource` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cfg_resource_instance_relations` (
   `resource_id` int(11) NOT NULL,
   `instance_id` int(11) NOT NULL,
@@ -610,7 +610,7 @@ CREATE TABLE `cfg_resource_instance_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `command` (
   `command_id` int(11) NOT NULL AUTO_INCREMENT,
   `connector_id` int(10) unsigned DEFAULT NULL,
@@ -630,7 +630,7 @@ CREATE TABLE `command` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `command_arg_description` (
   `cmd_id` int(11) NOT NULL,
   `macro_name` varchar(255) NOT NULL,
@@ -640,7 +640,7 @@ CREATE TABLE `command_arg_description` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `command_categories` (
   `cmd_category_id` int(11) NOT NULL AUTO_INCREMENT,
   `category_name` varchar(255) NOT NULL,
@@ -650,14 +650,14 @@ CREATE TABLE `command_categories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `command_categories_relation` (
   `category_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `connector` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
@@ -672,7 +672,7 @@ CREATE TABLE `connector` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contact` (
   `contact_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_tp_id` int(11) DEFAULT NULL,
@@ -729,7 +729,7 @@ CREATE TABLE `contact` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contact_host_relation` (
   `host_host_id` int(11) DEFAULT NULL,
   `contact_id` int(11) DEFAULT NULL,
@@ -740,7 +740,7 @@ CREATE TABLE `contact_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contact_hostcommands_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL,
@@ -751,7 +751,7 @@ CREATE TABLE `contact_hostcommands_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contact_param` (
   `id` int(4) NOT NULL AUTO_INCREMENT,
   `cp_key` varchar(255) NOT NULL,
@@ -763,7 +763,7 @@ CREATE TABLE `contact_param` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contact_service_relation` (
   `service_service_id` int(11) DEFAULT NULL,
   `contact_id` int(11) DEFAULT NULL,
@@ -774,7 +774,7 @@ CREATE TABLE `contact_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contact_servicecommands_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `command_command_id` int(11) DEFAULT NULL,
@@ -785,7 +785,7 @@ CREATE TABLE `contact_servicecommands_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup` (
   `cg_id` int(11) NOT NULL AUTO_INCREMENT,
   `cg_name` varchar(200) DEFAULT NULL,
@@ -801,7 +801,7 @@ CREATE TABLE `contactgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_contact_relation` (
   `contact_contact_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -812,7 +812,7 @@ CREATE TABLE `contactgroup_contact_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_host_relation` (
   `host_host_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -823,7 +823,7 @@ CREATE TABLE `contactgroup_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_hostgroup_relation` (
   `contactgroup_cg_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -834,7 +834,7 @@ CREATE TABLE `contactgroup_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_service_relation` (
   `contactgroup_cg_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -845,7 +845,7 @@ CREATE TABLE `contactgroup_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `contactgroup_servicegroup_relation` (
   `servicegroup_sg_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -856,7 +856,7 @@ CREATE TABLE `contactgroup_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `cron_operation` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(254) DEFAULT NULL,
@@ -873,7 +873,7 @@ CREATE TABLE `cron_operation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `css_color_menu` (
   `id_css_color_menu` int(11) NOT NULL AUTO_INCREMENT,
   `menu_nb` int(11) DEFAULT NULL,
@@ -882,7 +882,7 @@ CREATE TABLE `css_color_menu` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `custom_view_default` (
   `user_id` int(11) NOT NULL,
   `custom_view_id` int(11) NOT NULL,
@@ -893,7 +893,7 @@ CREATE TABLE `custom_view_default` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `custom_view_user_relation` (
   `custom_view_id` int(11) NOT NULL,
   `user_id` int(11) DEFAULT NULL,
@@ -912,7 +912,7 @@ CREATE TABLE `custom_view_user_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `custom_views` (
   `custom_view_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
@@ -922,7 +922,7 @@ CREATE TABLE `custom_views` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency` (
   `dep_id` int(11) NOT NULL AUTO_INCREMENT,
   `dep_name` varchar(255) DEFAULT NULL,
@@ -935,7 +935,7 @@ CREATE TABLE `dependency` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -947,7 +947,7 @@ CREATE TABLE `dependency_hostChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -959,7 +959,7 @@ CREATE TABLE `dependency_hostParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostgroupChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -971,7 +971,7 @@ CREATE TABLE `dependency_hostgroupChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency_hostgroupParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -983,7 +983,7 @@ CREATE TABLE `dependency_hostgroupParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency_metaserviceChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -995,7 +995,7 @@ CREATE TABLE `dependency_metaserviceChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency_metaserviceParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -1007,7 +1007,7 @@ CREATE TABLE `dependency_metaserviceParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency_serviceChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1022,7 +1022,7 @@ CREATE TABLE `dependency_serviceChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency_serviceParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1037,7 +1037,7 @@ CREATE TABLE `dependency_serviceParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency_servicegroupChild_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1049,7 +1049,7 @@ CREATE TABLE `dependency_servicegroupChild_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `dependency_servicegroupParent_relation` (
   `dependency_dep_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1061,7 +1061,7 @@ CREATE TABLE `dependency_servicegroupParent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `downtime` (
   `dt_id` int(11) NOT NULL AUTO_INCREMENT,
   `dt_name` varchar(100) NOT NULL,
@@ -1073,7 +1073,7 @@ CREATE TABLE `downtime` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `downtime_host_relation` (
   `dt_id` int(11) NOT NULL,
   `host_host_id` int(11) NOT NULL,
@@ -1084,7 +1084,7 @@ CREATE TABLE `downtime_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `downtime_hostgroup_relation` (
   `dt_id` int(11) NOT NULL,
   `hg_hg_id` int(11) NOT NULL,
@@ -1095,7 +1095,7 @@ CREATE TABLE `downtime_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `downtime_period` (
   `dt_id` int(11) NOT NULL,
   `dtp_start_time` time NOT NULL,
@@ -1112,7 +1112,7 @@ CREATE TABLE `downtime_period` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `downtime_service_relation` (
   `dt_id` int(11) NOT NULL,
   `host_host_id` int(11) NOT NULL,
@@ -1126,7 +1126,7 @@ CREATE TABLE `downtime_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `downtime_servicegroup_relation` (
   `dt_id` int(11) NOT NULL,
   `sg_sg_id` int(11) NOT NULL,
@@ -1137,7 +1137,7 @@ CREATE TABLE `downtime_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `escalation` (
   `esc_id` int(11) NOT NULL AUTO_INCREMENT,
   `esc_name` varchar(255) DEFAULT NULL,
@@ -1157,7 +1157,7 @@ CREATE TABLE `escalation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `escalation_contactgroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `contactgroup_cg_id` int(11) DEFAULT NULL,
@@ -1168,7 +1168,7 @@ CREATE TABLE `escalation_contactgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `escalation_host_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1179,7 +1179,7 @@ CREATE TABLE `escalation_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `escalation_hostgroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1190,7 +1190,7 @@ CREATE TABLE `escalation_hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `escalation_meta_service_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `meta_service_meta_id` int(11) DEFAULT NULL,
@@ -1201,7 +1201,7 @@ CREATE TABLE `escalation_meta_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `escalation_service_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1215,7 +1215,7 @@ CREATE TABLE `escalation_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `escalation_servicegroup_relation` (
   `escalation_esc_id` int(11) DEFAULT NULL,
   `servicegroup_sg_id` int(11) DEFAULT NULL,
@@ -1226,7 +1226,7 @@ CREATE TABLE `escalation_servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `extended_host_information` (
   `ehi_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1250,7 +1250,7 @@ CREATE TABLE `extended_host_information` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `extended_service_information` (
   `esi_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1270,7 +1270,7 @@ CREATE TABLE `extended_service_information` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `giv_components_template` (
   `compo_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_id` int(11) DEFAULT NULL,
@@ -1303,7 +1303,7 @@ CREATE TABLE `giv_components_template` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `giv_graphs_template` (
   `graph_id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(200) DEFAULT NULL,
@@ -1323,7 +1323,7 @@ CREATE TABLE `giv_graphs_template` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `host` (
   `host_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_template_model_htm_id` int(11) DEFAULT NULL,
@@ -1389,7 +1389,7 @@ CREATE TABLE `host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `host_hostparent_relation` (
   `host_parent_hp_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1400,7 +1400,7 @@ CREATE TABLE `host_hostparent_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `host_service_relation` (
   `hsr_id` int(11) NOT NULL AUTO_INCREMENT,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1420,7 +1420,7 @@ CREATE TABLE `host_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `host_template_relation` (
   `host_host_id` int(11) NOT NULL DEFAULT '0',
   `host_tpl_id` int(11) NOT NULL DEFAULT '0',
@@ -1432,7 +1432,7 @@ CREATE TABLE `host_template_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `hostcategories` (
   `hc_id` int(11) NOT NULL AUTO_INCREMENT,
   `hc_name` varchar(200) DEFAULT NULL,
@@ -1447,7 +1447,7 @@ CREATE TABLE `hostcategories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `hostcategories_relation` (
   `hostcategories_hc_id` int(11) DEFAULT NULL,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1458,7 +1458,7 @@ CREATE TABLE `hostcategories_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup` (
   `hg_id` int(11) NOT NULL AUTO_INCREMENT,
   `hg_name` varchar(200) DEFAULT NULL,
@@ -1478,7 +1478,7 @@ CREATE TABLE `hostgroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup_hg_relation` (
   `hg_parent_id` int(11) DEFAULT NULL,
   `hg_child_id` int(11) DEFAULT NULL,
@@ -1489,7 +1489,7 @@ CREATE TABLE `hostgroup_hg_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `hostgroup_relation` (
   `hgr_id` int(11) NOT NULL AUTO_INCREMENT,
   `hostgroup_hg_id` int(11) DEFAULT NULL,
@@ -1502,14 +1502,14 @@ CREATE TABLE `hostgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `informations` (
   `key` varchar(25) DEFAULT NULL,
   `value` varchar(1024) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `meta_contactgroup_relation` (
   `meta_id` int(11) DEFAULT NULL,
   `cg_cg_id` int(11) DEFAULT NULL,
@@ -1520,7 +1520,7 @@ CREATE TABLE `meta_contactgroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `meta_service` (
   `meta_id` int(11) NOT NULL AUTO_INCREMENT,
   `meta_name` varchar(254) DEFAULT NULL,
@@ -1555,7 +1555,7 @@ CREATE TABLE `meta_service` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `meta_service_relation` (
   `msr_id` int(11) NOT NULL AUTO_INCREMENT,
   `meta_id` int(11) DEFAULT NULL,
@@ -1572,7 +1572,7 @@ CREATE TABLE `meta_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `modules_informations` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(255) DEFAULT NULL,
@@ -1587,7 +1587,7 @@ CREATE TABLE `modules_informations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `nagios_macro` (
   `macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `macro_name` varchar(255) DEFAULT NULL,
@@ -1595,7 +1595,7 @@ CREATE TABLE `nagios_macro` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `nagios_server` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(40) DEFAULT NULL,
@@ -1632,7 +1632,7 @@ CREATE TABLE `nagios_server` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `ns_host_relation` (
   `nagios_server_id` int(11) NOT NULL DEFAULT '0',
   `host_host_id` int(11) NOT NULL DEFAULT '0',
@@ -1644,7 +1644,7 @@ CREATE TABLE `ns_host_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Relation Table For centreon Servers and hosts ';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `ods_view_details` (
   `dv_id` int(11) NOT NULL AUTO_INCREMENT,
   `index_id` BIGINT UNSIGNED DEFAULT NULL,
@@ -1658,7 +1658,7 @@ CREATE TABLE `ods_view_details` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `on_demand_macro_host` (
   `host_macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_macro_name` varchar(255) NOT NULL,
@@ -1673,7 +1673,7 @@ CREATE TABLE `on_demand_macro_host` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `on_demand_macro_service` (
   `svc_macro_id` int(11) NOT NULL AUTO_INCREMENT,
   `svc_macro_name` varchar(255) NOT NULL,
@@ -1688,14 +1688,14 @@ CREATE TABLE `on_demand_macro_service` (
 ) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `options` (
   `key` varchar(255) DEFAULT NULL,
   `value` varchar(255) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `poller_command_relations` (
   `poller_id` int(11) NOT NULL,
   `command_id` int(11) NOT NULL,
@@ -1707,7 +1707,7 @@ CREATE TABLE `poller_command_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `service` (
   `service_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_template_model_stm_id` int(11) DEFAULT NULL,
@@ -1768,7 +1768,7 @@ CREATE TABLE `service` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `service_categories` (
   `sc_id` int(11) NOT NULL AUTO_INCREMENT,
   `sc_name` varchar(255) DEFAULT NULL,
@@ -1780,7 +1780,7 @@ CREATE TABLE `service_categories` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='Services Catygories For best Reporting';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `service_categories_relation` (
   `scr_id` int(11) NOT NULL AUTO_INCREMENT,
   `service_service_id` int(11) DEFAULT NULL,
@@ -1793,7 +1793,7 @@ CREATE TABLE `service_categories_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `servicegroup` (
   `sg_id` int(11) NOT NULL AUTO_INCREMENT,
   `sg_name` varchar(200) DEFAULT NULL,
@@ -1807,7 +1807,7 @@ CREATE TABLE `servicegroup` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `servicegroup_relation` (
   `sgr_id` int(11) NOT NULL AUTO_INCREMENT,
   `host_host_id` int(11) DEFAULT NULL,
@@ -1826,7 +1826,7 @@ CREATE TABLE `servicegroup_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `session` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `session_id` varchar(256) DEFAULT NULL,
@@ -1851,7 +1851,7 @@ CREATE TABLE `session` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod` (
   `tp_id` int(11) NOT NULL AUTO_INCREMENT,
   `tp_name` varchar(200) DEFAULT NULL,
@@ -1867,7 +1867,7 @@ CREATE TABLE `timeperiod` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_exceptions` (
   `exception_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1879,7 +1879,7 @@ CREATE TABLE `timeperiod_exceptions` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_exclude_relations` (
   `exclude_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1890,7 +1890,7 @@ CREATE TABLE `timeperiod_exclude_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `timeperiod_include_relations` (
   `include_id` int(11) NOT NULL AUTO_INCREMENT,
   `timeperiod_id` int(11) NOT NULL,
@@ -1901,7 +1901,7 @@ CREATE TABLE `timeperiod_include_relations` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `topology` (
   `topology_id` int(11) NOT NULL AUTO_INCREMENT,
   `topology_name` varchar(255) DEFAULT NULL,
@@ -1928,7 +1928,7 @@ CREATE TABLE `topology` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `topology_JS` (
   `id_t_js` int(11) NOT NULL AUTO_INCREMENT,
   `id_page` int(11) DEFAULT NULL,
@@ -1942,7 +1942,7 @@ CREATE TABLE `topology_JS` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `traps` (
   `traps_id` int(11) NOT NULL AUTO_INCREMENT,
   `traps_name` varchar(255) DEFAULT NULL,
@@ -1979,7 +1979,7 @@ CREATE TABLE `traps` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `traps_matching_properties` (
   `tmo_id` int(11) NOT NULL AUTO_INCREMENT,
   `trap_id` int(11) DEFAULT NULL,
@@ -1995,7 +1995,7 @@ CREATE TABLE `traps_matching_properties` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `traps_preexec` (
   `trap_id` int(11) DEFAULT NULL,
   `tpe_order` int(11) DEFAULT NULL,
@@ -2005,7 +2005,7 @@ CREATE TABLE `traps_preexec` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `traps_service_relation` (
   `traps_id` int(11) DEFAULT NULL,
   `service_id` int(11) DEFAULT NULL,
@@ -2016,7 +2016,7 @@ CREATE TABLE `traps_service_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `traps_group` (
   `traps_group_id` int(11) NOT NULL AUTO_INCREMENT,
   `traps_group_name` varchar(255) NOT NULL,
@@ -2024,7 +2024,7 @@ CREATE TABLE `traps_group` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `traps_group_relation` (
   `traps_group_id` int(11) NOT NULL,
   `traps_id` int(11) NOT NULL,
@@ -2035,7 +2035,7 @@ CREATE TABLE `traps_group_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `traps_vendor` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(254) DEFAULT NULL,
@@ -2045,7 +2045,7 @@ CREATE TABLE `traps_vendor` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `view_img` (
   `img_id` int(11) NOT NULL AUTO_INCREMENT,
   `img_name` varchar(255) DEFAULT NULL,
@@ -2055,7 +2055,7 @@ CREATE TABLE `view_img` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `view_img_dir` (
   `dir_id` int(11) NOT NULL AUTO_INCREMENT,
   `dir_name` varchar(255) DEFAULT NULL,
@@ -2065,7 +2065,7 @@ CREATE TABLE `view_img_dir` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `view_img_dir_relation` (
   `vidr_id` int(11) NOT NULL AUTO_INCREMENT,
   `dir_dir_parent_id` int(11) DEFAULT NULL,
@@ -2076,7 +2076,7 @@ CREATE TABLE `view_img_dir_relation` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `virtual_metrics` (
   `vmetric_id` int(11) NOT NULL AUTO_INCREMENT,
   `index_id` BIGINT UNSIGNED DEFAULT NULL,
@@ -2094,7 +2094,7 @@ CREATE TABLE `virtual_metrics` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `widget_models` (
   `widget_model_id` int(11) NOT NULL AUTO_INCREMENT,
   `title` varchar(255) NOT NULL,
@@ -2113,7 +2113,7 @@ CREATE TABLE `widget_models` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters` (
   `parameter_id` int(11) NOT NULL AUTO_INCREMENT,
   `parameter_name` varchar(255) NOT NULL,
@@ -2132,7 +2132,7 @@ CREATE TABLE `widget_parameters` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_field_type` (
   `field_type_id` int(11) NOT NULL AUTO_INCREMENT,
   `ft_typename` varchar(50) NOT NULL,
@@ -2141,7 +2141,7 @@ CREATE TABLE `widget_parameters_field_type` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_multiple_options` (
   `parameter_id` int(11) NOT NULL,
   `option_name` varchar(255) NOT NULL,
@@ -2151,7 +2151,7 @@ CREATE TABLE `widget_parameters_multiple_options` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `widget_parameters_range` (
   `parameter_id` int(11) NOT NULL,
   `min_range` int(11) NOT NULL,
@@ -2162,7 +2162,7 @@ CREATE TABLE `widget_parameters_range` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `widget_preferences` (
   `widget_view_id` int(11) NOT NULL,
   `parameter_id` int(11) NOT NULL,
@@ -2175,7 +2175,7 @@ CREATE TABLE `widget_preferences` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `widget_views` (
   `widget_view_id` int(11) NOT NULL AUTO_INCREMENT,
   `custom_view_id` int(11) NOT NULL,
@@ -2189,7 +2189,7 @@ CREATE TABLE `widget_views` (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET  character_set_client = utf8mb4 */;
+/*!40101 SETcharacter_set_client = utf8mb4 */;
 CREATE TABLE `widgets` (
   `widget_id` int(11) NOT NULL AUTO_INCREMENT,
   `widget_model_id` int(11) NOT NULL,

--- a/centreon/www/install/createTablesCentstorage.sql
+++ b/centreon/www/install/createTablesCentstorage.sql
@@ -17,7 +17,7 @@ CREATE TABLE `centreon_acl` (
   `service_id` int(11) DEFAULT NULL,
   UNIQUE KEY (`group_id`,`host_id`,`service_id`),
   KEY `index1` (`host_id`,`service_id`,`group_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `centreon_acl` WRITE;
@@ -48,7 +48,7 @@ CREATE TABLE `config` (
   `len_storage_comments` int(11) DEFAULT NULL,
   `audit_log_retention` int(11) DEFAULT 0,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `config` WRITE;
@@ -68,7 +68,7 @@ CREATE TABLE `data_stats_daily` (
   `day_time` int(11) DEFAULT NULL,
   PRIMARY KEY (`data_stats_daily_id`),
   KEY `metric_id` (`metric_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `data_stats_daily` WRITE;
@@ -87,7 +87,7 @@ CREATE TABLE `data_stats_monthly` (
   `month_time` int(11) DEFAULT NULL,
   PRIMARY KEY (`data_stats_monthly_id`),
   KEY `metric_id` (`metric_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `data_stats_monthly` WRITE;
@@ -106,7 +106,7 @@ CREATE TABLE `data_stats_yearly` (
   `year_time` int(11) DEFAULT NULL,
   PRIMARY KEY (`data_stats_yearly_id`),
   KEY `metric_id` (`metric_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `data_stats_yearly` WRITE;
@@ -138,7 +138,7 @@ CREATE TABLE `index_data` (
   KEY `service_id` (`service_id`),
   KEY `must_be_rebuild` (`must_be_rebuild`),
   KEY `trashed` (`trashed`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `index_data` WRITE;
@@ -159,7 +159,7 @@ CREATE TABLE `log_action` (
   KEY `log_contact_id` (`log_contact_id`),
   KEY `action_log_date` (`action_log_date`),
   KEY `action_object_date` (`object_type`,`action_log_date`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `log_action` WRITE;
@@ -175,7 +175,7 @@ CREATE TABLE `log_action_modification` (
   `action_log_id` int(11) NOT NULL,
   PRIMARY KEY (`modification_id`),
   KEY `action_log_id` (`action_log_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `log_action_modification` WRITE;
@@ -191,7 +191,7 @@ CREATE TABLE `log_archive_last_status` (
   `service_description` varchar(255) DEFAULT NULL,
   `status` varchar(255) DEFAULT NULL,
   `ctime` int(11) DEFAULT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `log_archive_last_status` WRITE;
@@ -221,7 +221,7 @@ CREATE TABLE `metrics` (
   PRIMARY KEY (`metric_id`),
   UNIQUE KEY `index_id` (`index_id`,`metric_name`),
   KEY `index` (`index_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `metrics` WRITE;
@@ -235,7 +235,7 @@ CREATE TABLE `nagios_stats` (
   `stat_key` varchar(255) NOT NULL,
   `stat_value` varchar(255) NOT NULL,
   `stat_label` varchar(255) NOT NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `nagios_stats` WRITE;
@@ -262,7 +262,7 @@ CREATE TABLE `log_traps` (
   `output_message` varchar(2048) DEFAULT NULL,
   KEY `trap_id` (`trap_id`),
   KEY `trap_time` (`trap_time`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `log_traps` WRITE;
@@ -279,7 +279,7 @@ CREATE TABLE `log_traps_args` (
   `arg_value` varchar(255) DEFAULT NULL,
   `trap_time` int(11) DEFAULT NULL,
   KEY `fk_log_traps` (`fk_log_traps`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 LOCK TABLES `log_traps_args` WRITE;

--- a/centreon/www/install/createTablesCentstorage.sql
+++ b/centreon/www/install/createTablesCentstorage.sql
@@ -10,7 +10,7 @@
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `centreon_acl` (
   `group_id` int(11) NOT NULL,
   `host_id` int(11) NOT NULL,
@@ -25,7 +25,7 @@ LOCK TABLES `centreon_acl` WRITE;
 /*!40000 ALTER TABLE `centreon_acl` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `config` (
   `id` int(11) NOT NULL AUTO_INCREMENT,
   `RRDdatabase_path` varchar(255) DEFAULT NULL,
@@ -57,7 +57,7 @@ INSERT INTO `config` VALUES (1,'@centreon_varlib@/metrics/','@centreon_varlib@/s
 /*!40000 ALTER TABLE `config` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `data_stats_daily` (
   `data_stats_daily_id` int(11) NOT NULL AUTO_INCREMENT,
   `metric_id` int(11) DEFAULT NULL,
@@ -76,7 +76,7 @@ LOCK TABLES `data_stats_daily` WRITE;
 /*!40000 ALTER TABLE `data_stats_daily` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `data_stats_monthly` (
   `data_stats_monthly_id` int(11) NOT NULL AUTO_INCREMENT,
   `metric_id` int(11) DEFAULT NULL,
@@ -95,7 +95,7 @@ LOCK TABLES `data_stats_monthly` WRITE;
 /*!40000 ALTER TABLE `data_stats_monthly` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `data_stats_yearly` (
   `data_stats_yearly_id` int(11) NOT NULL AUTO_INCREMENT,
   `metric_id` int(11) DEFAULT NULL,
@@ -114,7 +114,7 @@ LOCK TABLES `data_stats_yearly` WRITE;
 /*!40000 ALTER TABLE `data_stats_yearly` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `index_data` (
   `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
   `host_name` varchar(255) DEFAULT NULL,
@@ -146,7 +146,7 @@ LOCK TABLES `index_data` WRITE;
 /*!40000 ALTER TABLE `index_data` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `log_action` (
   `action_log_id` int(11) NOT NULL AUTO_INCREMENT,
   `action_log_date` int(11) NOT NULL,
@@ -167,7 +167,7 @@ LOCK TABLES `log_action` WRITE;
 /*!40000 ALTER TABLE `log_action` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `log_action_modification` (
   `modification_id` int(11) NOT NULL AUTO_INCREMENT,
   `field_name` varchar(255) NOT NULL,
@@ -183,7 +183,7 @@ LOCK TABLES `log_action_modification` WRITE;
 /*!40000 ALTER TABLE `log_action_modification` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `log_archive_last_status` (
   `host_id` int(11) DEFAULT NULL,
   `service_id` int(11) DEFAULT NULL,
@@ -199,7 +199,7 @@ LOCK TABLES `log_archive_last_status` WRITE;
 /*!40000 ALTER TABLE `log_archive_last_status` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `metrics` (
   `metric_id` int(11) NOT NULL AUTO_INCREMENT,
   `index_id` BIGINT UNSIGNED DEFAULT NULL,
@@ -229,7 +229,7 @@ LOCK TABLES `metrics` WRITE;
 /*!40000 ALTER TABLE `metrics` ENABLE KEYS */;
 UNLOCK TABLES;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `nagios_stats` (
   `instance_id` int(11) NOT NULL,
   `stat_key` varchar(255) NOT NULL,
@@ -244,7 +244,7 @@ LOCK TABLES `nagios_stats` WRITE;
 UNLOCK TABLES;
 
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `log_traps` (
   `trap_id` int(11) NOT NULL AUTO_INCREMENT,
   `trap_time` int(11) DEFAULT NULL,
@@ -271,7 +271,7 @@ LOCK TABLES `log_traps` WRITE;
 UNLOCK TABLES;
 
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
-/*!40101 SET character_set_client = utf8 */;
+/*!40101 SET character_set_client = utf8mb4 */;
 CREATE TABLE `log_traps_args` (
   `fk_log_traps` int(11) NOT NULL,
   `arg_number` int(11) DEFAULT NULL,


### PR DESCRIPTION
## Description

In order to manage emoji, Mariadb and Mysql have a 4 bytes encoded UTF8 charset called utf8mb4.

Modern monitoring tools should  allows to use emoji to spread messages to anyone and anywhere.

 set the database charset by default at utf8mb4 at install.

- Only change database charset for new installation

- Develop a script to perform update manually (in centreon/tools/)

 
**Fixes** # MON-7025

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Install a new Centreon 23.04 platform
2. Add emoji in host / service / Meta / BA name
3. Export configuration
4. Check that resources name are correctly displayed in Resource Status pages
5. Install a Centreon platform < 23.04
6. Run manually database script update (DEV to put script name)
7. Add emoji in host / service / Meta / BA name
8. Export configuration
9. Check that resources name are correctly displayed in Resource Status pages

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
