### PR TITLE
fix(web): handle properly poller status api returning an empty array 

### DIFF
--- a/centreon/www/front_src/src/Header/api/decoders.ts
+++ b/centreon/www/front_src/src/Header/api/decoders.ts
@@ -79,9 +79,13 @@ const issuesDecoder = JsonDecoder.object(
   'issues'
 );
 
+const noIssuesDecoder = JsonDecoder.array(JsonDecoder.string, 'Empty issues');
+
 export const pollerIssuesDecoder = JsonDecoder.object<PollersIssuesList>(
   {
-    issues: issuesDecoder,
+    issues: JsonDecoder.oneOf<
+      FromDecoder<typeof noIssuesDecoder> | FromDecoder<typeof issuesDecoder>
+    >([noIssuesDecoder, issuesDecoder], 'empty array | issues'),
     refreshTime: JsonDecoder.number,
     total: JsonDecoder.number
   },

--- a/centreon/www/front_src/src/Header/api/models.ts
+++ b/centreon/www/front_src/src/Header/api/models.ts
@@ -13,12 +13,22 @@ export interface Alert {
   warning?: AlertDetails;
 }
 
+// api inconsistency return an empty array when there is no issues
+// but decoders don't allow empty array as a valid type,
+// the real signature would be :
+// issues: {
+//   database?: Alert;
+//   latency?: Alert;
+//   stability?: Alert;
+// } | [];
+
+export interface NonNullIssues {
+  database?: Alert;
+  latency?: Alert;
+  stability?: Alert;
+}
 export interface PollersIssuesList {
-  issues: {
-    database?: Alert;
-    latency?: Alert;
-    stability?: Alert;
-  };
+  issues: NonNullIssues | Array<string>;
   refreshTime: number;
   total: number;
 }

--- a/centreon/www/front_src/src/Header/specs/Header.Poller.ts
+++ b/centreon/www/front_src/src/Header/specs/Header.Poller.ts
@@ -95,6 +95,25 @@ export default (): void =>
     });
 
     describe('top status indicators', () => {
+      it('displays green indicators when no issues where detected', () => {
+        initialize({
+          pollersListIssues: {
+            issues: []
+          }
+        });
+        getElements();
+
+        cy.get('@databaseIndicator').should(
+          'contain.text',
+          labelDatabaseUpdateAndActive
+        );
+
+        cy.get('@latencyIndicator').should(
+          'contain.text',
+          labelNoLatencyDetected
+        );
+      });
+
       describe('database', () => {
         it('alert user about database critical issues', () => {
           initialize({


### PR DESCRIPTION
## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** 

https://centreon.atlassian.net/browse/MON-15815

modify decoders and api response types to handle the case where poster status API return an empty array.  
this can happen when restarting the engines, and no data is available

see conversation here : 
https://centreon.atlassian.net/browse/MON-15815?focusedCommentId=66261

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

run : 
```
systemctl restart cbd centengine
systemctl restart gorgoned
systemctl start snmptrapd centreontrapd
systemctl start snmpd
```

and check that the poller menu is not disappearing and that there is no error in the snack-bar

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
