### PR TITLE
fix(exportServices): add missing severity field

### DIFF
--- a/centreon/www/class/config-generate/service.class.php
+++ b/centreon/www/class/config-generate/service.class.php
@@ -419,6 +419,7 @@ class Service extends AbstractService
         if (!is_null($severity)) {
             $this->service_cache[$serviceIdArg]['macros']['_CRITICALITY_LEVEL'] = $severity['level'];
             $this->service_cache[$serviceIdArg]['macros']['_CRITICALITY_ID'] = $severity['sc_id'];
+            $this->service_cache[$serviceIdArg]['macros']['severity'] = $severity['sc_id'];
             return;
         }
 
@@ -472,6 +473,7 @@ class Service extends AbstractService
                 if (!is_null($serviceSeverity)) {
                     $this->service_cache[$serviceId]['macros']['_CRITICALITY_LEVEL'] = $serviceSeverity['level'];
                     $this->service_cache[$serviceId]['macros']['_CRITICALITY_ID'] = $serviceSeverity['sc_id'];
+                    $this->service_cache[$serviceId]['macros']['severity'] = $serviceSeverity['sc_id'];
                 }
             }
         }
@@ -482,6 +484,7 @@ class Service extends AbstractService
         if ($service['severity_from_host'] == 1) {
             unset($service['macros']['_CRITICALITY_LEVEL']);
             unset($service['macros']['_CRITICALITY_ID']);
+            unset($service['macros']['severity']);
         }
     }
 


### PR DESCRIPTION
## Description

Backport of #1029 

> There is a missing field in the `services.cfg` exported file.
> This PR aim to fix that.

Jira: 🏷️ **MON-16846**

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Add a service seveirty to a service
- Export the conf
- Check the added field `severity`  from `/var/cache/centreon/config/engine/<ID>/services.cfg`

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
