### PR TITLE
fix(acl): SQL queries with not escaped dbname (ex: hyphen) [22.10.next]

### DIFF
--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -2098,10 +2098,10 @@ class CentreonACL
         $where_acl = "";
         if (!$this->admin) {
             $groupIds = array_keys($this->accessGroups);
-            $from_acl = ", $db_name_acl.centreon_acl ";
-            $where_acl = " AND $db_name_acl.centreon_acl.group_id IN (" . implode(',', $groupIds) . ") "
-                . "AND $db_name_acl.centreon_acl.host_id = host.host_id "
-                . "AND $db_name_acl.centreon_acl.service_id = service.service_id ";
+            $from_acl = ", `$db_name_acl`.centreon_acl ";
+            $where_acl = " AND `$db_name_acl`.centreon_acl.group_id IN (" . implode(',', $groupIds) . ") "
+                . "AND `$db_name_acl`.centreon_acl.host_id = host.host_id "
+                . "AND `$db_name_acl`.centreon_acl.service_id = service.service_id ";
         }
 
         // Making sure that the id provided is a real int
@@ -2119,7 +2119,7 @@ class CentreonACL
         $query = $request['select'] . $request['simpleFields'] . " "
             . "FROM ( "
             . "SELECT " . $request['fields'] . " "
-            . "FROM " . $db_name_acl . ".services_servicegroups, service, host" . $from_acl . " "
+            . "FROM `$db_name_acl`.services_servicegroups, service, host" . $from_acl . " "
             . "WHERE servicegroup_id = " . $sgId . " "
             . "AND host.host_id = services_servicegroups.host_id "
             . "AND service.service_id = services_servicegroups.service_id "
@@ -2193,13 +2193,13 @@ class CentreonACL
         } else {
             $groupIds = array_keys($this->accessGroups);
             if ($host_empty) {
-                $emptyJoin .= "AND $db_name_acl.centreon_acl.service_id IS NOT NULL ";
+                $emptyJoin .= "AND `$db_name_acl`.centreon_acl.service_id IS NOT NULL ";
             }
             $query = $request['select'] . $request['fields'] . " "
                 . "FROM host "
-                . "JOIN $db_name_acl.centreon_acl "
-                . "ON $db_name_acl.centreon_acl.host_id = host.host_id "
-                . "AND $db_name_acl.centreon_acl.group_id IN (" . implode(',', $groupIds) . ") "
+                . "JOIN `$db_name_acl`.centreon_acl "
+                . "ON `$db_name_acl`.centreon_acl.host_id = host.host_id "
+                . "AND `$db_name_acl`.centreon_acl.group_id IN (" . implode(',', $groupIds) . ") "
                 . $emptyJoin
                 . "WHERE host.host_register = '1' "
                 //. "AND host.host_activate = '1' "
@@ -2258,31 +2258,31 @@ class CentreonACL
                 . ") as t ";
         } else {
             $query = "SELECT " . $request['fields'] . " "
-                . "FROM host_service_relation hsr, host h, service s, $db_name_acl.centreon_acl "
+                . "FROM host_service_relation hsr, host h, service s, `$db_name_acl`.centreon_acl "
                 . "WHERE h.host_id = '" . CentreonDB::escape($host_id) . "' "
                 . "AND h.host_activate = '1' "
                 . "AND h.host_register = '1' "
                 . "AND h.host_id = hsr.host_host_id "
                 . "AND hsr.service_service_id = s.service_id "
                 . "AND s.service_activate = '1' "
-                . "AND $db_name_acl.centreon_acl.host_id = h.host_id "
-                . "AND $db_name_acl.centreon_acl.service_id IS NOT NULL "
-                . "AND $db_name_acl.centreon_acl.service_id = s.service_id "
-                . "AND $db_name_acl.centreon_acl.group_id IN (" . $this->getAccessGroupsString() . ") "
+                . "AND `$db_name_acl`.centreon_acl.host_id = h.host_id "
+                . "AND `$db_name_acl`.centreon_acl.service_id IS NOT NULL "
+                . "AND `$db_name_acl`.centreon_acl.service_id = s.service_id "
+                . "AND `$db_name_acl`.centreon_acl.group_id IN (" . $this->getAccessGroupsString() . ") "
                 . "UNION "
                 . "SELECT " . $request['fields'] . " "
                 . "FROM host h, hostgroup_relation hgr, "
-                . "service s, host_service_relation hsr, $db_name_acl.centreon_acl "
+                . "service s, host_service_relation hsr, `$db_name_acl`.centreon_acl "
                 . "WHERE h.host_id = '" . CentreonDB::escape($host_id) . "' "
                 . "AND h.host_activate = '1' "
                 . "AND h.host_register = '1' "
                 . "AND h.host_id = hgr.host_host_id "
                 . "AND hgr.hostgroup_hg_id = hsr.hostgroup_hg_id "
                 . "AND hsr.service_service_id = s.service_id "
-                . "AND $db_name_acl.centreon_acl.host_id = h.host_id "
-                . "AND $db_name_acl.centreon_acl.service_id IS NOT NULL "
-                . "AND $db_name_acl.centreon_acl.service_id = s.service_id "
-                . "AND $db_name_acl.centreon_acl.group_id IN (" . $this->getAccessGroupsString() . ") ";
+                . "AND `$db_name_acl`.centreon_acl.host_id = h.host_id "
+                . "AND `$db_name_acl`.centreon_acl.service_id IS NOT NULL "
+                . "AND `$db_name_acl`.centreon_acl.service_id = s.service_id "
+                . "AND `$db_name_acl`.centreon_acl.group_id IN (" . $this->getAccessGroupsString() . ") ";
         }
 
         $query .= $request['order'] . $request['pages'];

--- a/centreon/www/include/configuration/configObject/escalation/listEscalation.php
+++ b/centreon/www/include/configuration/configObject/escalation/listEscalation.php
@@ -66,7 +66,7 @@ $aclCond = array(
     'ms' => ''
 );
 if (!$centreon->user->admin) {
-    $aclFrom = ", $dbmon.centreon_acl acl ";
+    $aclFrom = ", `$dbmon`.centreon_acl acl ";
     $aclCond['h'] = " AND ehr.host_host_id = acl.host_id
                       AND acl.group_id IN (" . $acl->getAccessGroupsString() . ") ";
     $aclCond['sv'] = " AND esr.host_host_id = acl.host_id

--- a/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+++ b/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
@@ -59,7 +59,7 @@ if (isset($_POST['searchHD']) || isset($_GET['searchHD'])) {
 $aclFrom = "";
 $aclCond = "";
 if (!$centreon->user->admin) {
-    $aclFrom = ", $dbmon.centreon_acl acl ";
+    $aclFrom = ", `$dbmon`.centreon_acl acl ";
     $aclCond = " AND dhpr.host_host_id = acl.host_id 
                      AND acl.group_id IN (" . $acl->getAccessGroupsString() . ") ";
 }

--- a/centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
@@ -146,7 +146,7 @@ for ($i = 0; $hg = $dbResult->fetch(); $i++) {
     $aclFrom = "";
     $aclCond = "";
     if (!$centreon->user->admin) {
-        $aclFrom = ", $aclDbName.centreon_acl acl ";
+        $aclFrom = ", `$aclDbName`.centreon_acl acl ";
         $aclCond = " AND h.host_id = acl.host_id AND acl.group_id IN (" . $acl->getAccessGroupsString() . ") ";
     }
     $rq = "SELECT h.host_id, h.host_activate

--- a/centreon/www/include/configuration/configObject/meta_service/listMetric.php
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetric.php
@@ -80,7 +80,7 @@ $tpl->assign("headerMenu_options", _("Options"));
 $aclFrom = "";
 $aclCond = "";
 if (!$oreon->user->admin) {
-    $aclFrom = ", $aclDbName.centreon_acl acl ";
+    $aclFrom = ", `$aclDbName`.centreon_acl acl ";
     $aclCond = " AND acl.host_id = msr.host_id
                  AND acl.group_id IN (" . $acl->getAccessGroupsString() . ") ";
 }

--- a/centreon/www/include/configuration/configObject/service/formService.php
+++ b/centreon/www/include/configuration/configObject/service/formService.php
@@ -65,7 +65,7 @@ function myDecodeService($arg)
 if (!$centreon->user->admin && is_numeric($service_id)) {
     $checkres = $pearDB->query(
         "SELECT service_id
-        FROM $aclDbName.centreon_acl
+        FROM `$aclDbName`.centreon_acl
         WHERE service_id = " . $pearDB->escape($service_id) . "
         AND group_id IN (" . $acl->getAccessGroupsString() . ")"
     );

--- a/centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+++ b/centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
@@ -101,7 +101,7 @@ if (!$centreon->user->admin) {
         $aclAccessGroupsParams[':access_' . $index] = str_replace("'", "", $accessGroupId);
     }
     $queryParams = implode(',', array_keys($aclAccessGroupsParams));
-    $aclFrom = ", $aclDbName.centreon_acl acl ";
+    $aclFrom = ", `$aclDbName`.centreon_acl acl ";
     $aclCond = " AND sv.service_id = acl.service_id
                  AND acl.group_id IN (" . $queryParams . ") ";
     $distinct = " DISTINCT ";

--- a/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+++ b/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
@@ -59,7 +59,7 @@ if (isset($_POST['searchSD']) || isset($_GET['searchSD'])) {
 $aclFrom = "";
 $aclCond = "";
 if (!$oreon->user->admin) {
-    $aclFrom = ", $dbmon.centreon_acl acl ";
+    $aclFrom = ", `$dbmon`.centreon_acl acl ";
     $aclCond = " AND dspr.host_host_id = acl.host_id 
                  AND acl.service_id = dspr.service_service_id 
                  AND acl.group_id IN (" . $acl->getAccessGroupsString() . ") ";


### PR DESCRIPTION
## Description

Backport of #1037 

> Fix sql queries which SHOULD escape dbname.

Jira: 🏷️ **MON-15864**

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [X] 22.10.x
- [X] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
