### PR TITLE
fix(abstractRepository): use correct typehint

### DIFF
--- a/centreon/src/Core/Common/Infrastructure/Repository/AbstractVaultRepository.php
+++ b/centreon/src/Core/Common/Infrastructure/Repository/AbstractVaultRepository.php
@@ -13,7 +13,7 @@ abstract class AbstractVaultRepository
 {
     use LoggerTrait;
 
-    protected VaultConfiguration $vaultConfiguration;
+    protected ?VaultConfiguration $vaultConfiguration;
 
     public function __construct(
         protected ReadVaultConfigurationRepositoryInterface $configurationRepository,


### PR DESCRIPTION
## Description

Typehint was incorrect so it cause repository constructor to fail if no vault configuration are returned

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
