### PR TITLE
fix(conf) allow removal of all notification options at contact update

### DIFF
--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -455,7 +455,7 @@ function multipleContactInDB($contacts = array(), $nbrDup = array())
                         "WHERE contact_contact_id = '" . (int)$key . "'";
                     $dbResult = $pearDB->query($query);
                     $fields["contact_svNotifCmds"] = "";
-                    $query = "INSERT INTO contact_servicecommands_relation 
+                    $query = "INSERT INTO contact_servicecommands_relation
                          VALUES (:contact_id, :command_command_id)";
                     $statement = $pearDB->prepare($query);
                     while ($serviceCmd = $dbResult->fetch()) {
@@ -1150,6 +1150,9 @@ function sanitizeFormContactParameters(array $ret): array
 {
     global $encryptType, $dependencyInjector;
     $bindParams = [];
+    $bindParams[':contact_host_notification_options'] = [\PDO::PARAM_STR => null];
+    $bindParams[':contact_service_notification_options'] = [\PDO::PARAM_STR => null];
+
     foreach ($ret as $inputName => $inputValue) {
         switch ($inputName) {
             case 'timeperiod_tp_id':
@@ -1177,19 +1180,13 @@ function sanitizeFormContactParameters(array $ret): array
                 break;
             case 'contact_hostNotifOpts':
                 $inputValue = \HtmlAnalyzer::sanitizeAndRemoveTags(implode(",", array_keys($inputValue)));
-                if (empty($inputValue)) {
-                    $bindParams[':contact_host_notification_options'] = [\PDO::PARAM_STR => null];
-                } else {
+                if (! empty($inputValue)) {
                     $bindParams[':contact_host_notification_options'] = [\PDO::PARAM_STR => $inputValue];
                 }
                 break;
             case 'contact_svNotifOpts':
-                $inputValue = \HtmlAnalyzer::sanitizeAndRemoveTags(
-                    implode(",", array_keys($inputValue))
-                );
-                if (empty($inputValue)) {
-                    $bindParams[':contact_service_notification_options'] = [\PDO::PARAM_STR => null];
-                } else {
+                $inputValue = \HtmlAnalyzer::sanitizeAndRemoveTags(implode(",", array_keys($inputValue)));
+                if (! empty($inputValue)) {
                     $bindParams[':contact_service_notification_options'] = [\PDO::PARAM_STR => $inputValue];
                 }
                 break;


### PR DESCRIPTION
## Description

For a contact with some notification options defined, unchecking all notification options during update result in a silent fail as previously checked options are kept.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Create a contact with some notification options
Edit contact and remove all notification options


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
