### PR TITLE
fix(export): check if poller is activated before conf export via API

### DIFF
--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15532,3 +15532,6 @@ msgstr "No ha guardado los cambios, ¿quiere continuar?"
 
 #  msgid "The service severity icon with id '%d' does not exist"
 #  msgstr ""
+
+#  msgid "Monitoring server disabled (#%d)"
+#  msgstr ""

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -16225,6 +16225,9 @@ msgstr "Erreur lors de la recherche d'un contact"
 msgid "Monitoring server not found (#%d)"
 msgstr "Serveur de supervision non trouvé (#%d)"
 
+msgid "Monitoring server disabled (#%d)"
+msgstr "Serveur de supervision désactivé (#%d)"
+
 msgid "Generation error on monitoring server #%d: %s"
 msgstr "Erreur de génération sur le serveur de supervision #%d : %s"
 

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -15993,3 +15993,6 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "The service severity icon with id '%d' does not exist"
 #  msgstr ""
+
+#  msgid "Monitoring server disabled (#%d)"
+#  msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -15983,3 +15983,6 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "The service severity icon with id '%d' does not exist"
 #  msgstr ""
+
+#  msgid "Monitoring server disabled (#%d)"
+#  msgstr ""

--- a/centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
@@ -44,6 +44,15 @@ class ConfigurationMonitoringServerException extends \Exception
 
     /**
      * @param int $monitoringServerId
+     * @return self
+     */
+    public static function disabled(int $monitoringServerId): self
+    {
+        return new self(sprintf(_('Monitoring server disabled (#%d)'), $monitoringServerId));
+    }
+
+    /**
+     * @param int $monitoringServerId
      * @param string $errorMessage
      * @return self
      */

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
@@ -80,7 +80,7 @@ class GenerateAllConfigurations
                     continue;
                 }
                 if ($monitoringServer->isActivate() === false) {
-                    $this->error('Monitoring server #' . $lastMonitoringServerId . 'is disabled');
+                    $this->error('Monitoring server #' . $lastMonitoringServerId . ' is disabled');
                     continue;
                 }
                 $this->info('Generate configuration files for monitoring server #' . $lastMonitoringServerId);

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
@@ -75,14 +75,18 @@ class GenerateAllConfigurations
         try {
             foreach ($monitoringServers as $monitoringServer) {
                 $lastMonitoringServerId = $monitoringServer->getId();
-                if ($lastMonitoringServerId !== null) {
-                    $this->info('Generate configuration files for monitoring server #' . $lastMonitoringServerId);
-                    $this->configurationRepository->generateConfiguration($lastMonitoringServerId);
-                    $this->info('Move configuration files for monitoring server #' . $lastMonitoringServerId);
-                    $this->configurationRepository->moveExportFiles($lastMonitoringServerId);
-                } else {
+                if ($lastMonitoringServerId === null) {
                     $this->error('Monitoring server id from repository is null');
+                    continue;
                 }
+                if ($monitoringServer->isActivate() === false) {
+                    $this->error('Monitoring server #' . $lastMonitoringServerId . 'is disabled');
+                    continue;
+                }
+                $this->info('Generate configuration files for monitoring server #' . $lastMonitoringServerId);
+                $this->configurationRepository->generateConfiguration($lastMonitoringServerId);
+                $this->info('Move configuration files for monitoring server #' . $lastMonitoringServerId);
+                $this->configurationRepository->moveExportFiles($lastMonitoringServerId);
             }
         } catch (TimeoutException $ex) {
             throw ConfigurationMonitoringServerException::timeout($lastMonitoringServerId, $ex->getMessage());

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
@@ -80,7 +80,7 @@ class GenerateAllConfigurations
                     continue;
                 }
                 if ($monitoringServer->isActivate() === false) {
-                    $this->error('Monitoring server #' . $lastMonitoringServerId . ' is disabled');
+                    $this->info('Monitoring server #' . $lastMonitoringServerId . ' is disabled');
                     continue;
                 }
                 $this->info('Generate configuration files for monitoring server #' . $lastMonitoringServerId);

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateConfiguration.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateConfiguration.php
@@ -73,6 +73,9 @@ class GenerateConfiguration
             if ($monitoringServer === null) {
                 throw ConfigurationMonitoringServerException::notFound($monitoringServerId);
             }
+            if ($monitoringServer->isActivate() === false) {
+                throw ConfigurationMonitoringServerException::disabled($monitoringServerId);
+            }
             $this->info('Generate configuration files for monitoring server #' . $monitoringServerId);
             $this->configurationRepository->generateConfiguration($monitoringServerId);
             $this->info('Move configuration files for monitoring server #' . $monitoringServerId);


### PR DESCRIPTION
## Description

Fix issue with disabled pollers when exporting configuration using top-banner export button

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Have a disabled poller
Click on the export configuration  button in the top banner
Export should resolve without error

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
