### PR TITLE
fix (repository): Update the defaut value of regexp

### DIFF
--- a/centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
+++ b/centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
@@ -292,12 +292,11 @@ class SqlRequestParametersTranslator
         ) {
             // We check the regex
             if ($searchOperator === RequestParameters::OPERATOR_REGEXP) {
-                try {
-                    preg_match('/' . $mixedValue . '/', '');
-                } catch (\Throwable $ex) {
-                    // No exception in prod environment
-                    throw new RequestParametersTranslatorException('Bad regex format \'' . $mixedValue . '\'', 0, $ex);
+                // For MySQL compatibility
+                if ($mixedValue === '') {
+                    $mixedValue = '.*';
                 }
+                preg_match('/' . $mixedValue . '/', '');
                 if (preg_last_error() !== PREG_NO_ERROR) {
                     throw new RequestParametersTranslatorException('Bad regex format \'' . $mixedValue . '\'', 0);
                 }


### PR DESCRIPTION
## Description

When a search parameter uses a regex expression with an empty value, the SQL syntax is not compatible with MySQL.
SELECT 
The purpose of this fix is to set a default value for the regex when the value is empty.
This fix will not change the current behaviour.

**MariaDB:**
SELECT 1 REGEXP ''
The result is "1".

**MySQL:**
SELECT 1 REGEXP ''
This will generate an error "Illegal argument to a regular expression"


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
