### PR TITLE
fix(web) : fix sidebar submenu and ressources filter overlap

### DIFF
--- a/centreon/packages/ui/src/PopoverMenu/index.tsx
+++ b/centreon/packages/ui/src/PopoverMenu/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 import { makeStyles } from 'tss-react/mui';
 
@@ -20,6 +20,7 @@ const useStyles = makeStyles()(() => ({
 }));
 
 interface Props {
+  canOpen?: boolean;
   children: (props?) => JSX.Element;
   className?: string;
   dataTestId?: string;
@@ -37,6 +38,7 @@ const PopoverMenu = ({
   popperPlacement,
   onOpen,
   onClose,
+  canOpen = true,
   className,
   dataTestId
 }: Props): JSX.Element => {
@@ -66,6 +68,12 @@ const PopoverMenu = ({
     onOpen?.();
     setAnchorEl(event.currentTarget);
   };
+
+  useEffect(() => {
+    if (!canOpen) {
+      close();
+    }
+  }, [canOpen]);
 
   return (
     <>

--- a/centreon/www/front_src/src/Resources/Filter/Criterias/index.tsx
+++ b/centreon/www/front_src/src/Resources/Filter/Criterias/index.tsx
@@ -72,7 +72,7 @@ const CriteriasContent = (): JSX.Element => {
 
   return (
     <PopoverMenu
-      canOpen={allowPopoverToOpen}
+      canOpen={canOpenPopover}
       icon={<TuneIcon fontSize="small" />}
       popperPlacement="bottom-start"
       title={t(labelSearchOptions) as string}

--- a/centreon/www/front_src/src/Resources/Filter/Criterias/index.tsx
+++ b/centreon/www/front_src/src/Resources/Filter/Criterias/index.tsx
@@ -39,8 +39,8 @@ const useStyles = makeStyles()((theme) => ({
 const CriteriasContent = (): JSX.Element => {
   const { classes } = useStyles();
   const { t } = useTranslation();
-  const openedItem = useAtomValue(hoveredNavigationItemsAtom);
-  const allowPopoverToOpen = isNil(openedItem);
+  const hoveredNavigationItem = useAtomValue(hoveredNavigationItemsAtom);
+  const canOpenPopover = isNil(hoveredNavigationItem);
 
   const { newCriteriaValueName, newSelectableCriterias } = useFilterByModule();
 

--- a/centreon/www/front_src/src/Resources/Filter/Criterias/index.tsx
+++ b/centreon/www/front_src/src/Resources/Filter/Criterias/index.tsx
@@ -9,6 +9,7 @@ import TuneIcon from '@mui/icons-material/Tune';
 import { PopoverMenu, useMemoComponent } from '@centreon/ui';
 import type { SelectEntry } from '@centreon/ui';
 
+import { hoveredNavigationItemsAtom } from '../../../Navigation/Sidebar/sideBarAtoms';
 import {
   labelClear,
   labelSearch,
@@ -37,8 +38,9 @@ const useStyles = makeStyles()((theme) => ({
 
 const CriteriasContent = (): JSX.Element => {
   const { classes } = useStyles();
-
   const { t } = useTranslation();
+  const openedItem = useAtomValue(hoveredNavigationItemsAtom);
+  const allowPopoverToOpen = isNil(openedItem);
 
   const { newCriteriaValueName, newSelectableCriterias } = useFilterByModule();
 
@@ -70,9 +72,10 @@ const CriteriasContent = (): JSX.Element => {
 
   return (
     <PopoverMenu
+      canOpen={allowPopoverToOpen}
       icon={<TuneIcon fontSize="small" />}
       popperPlacement="bottom-start"
-      title={t(labelSearchOptions)}
+      title={t(labelSearchOptions) as string}
       onClose={applyCurrentFilter}
     >
       {(): JSX.Element => (


### PR DESCRIPTION
## Description

detect when a sidebar submenu is open and force the filter tooltip to close. 

**Fixes** #[(issue)](https://centreon.atlassian.net/browse/MON-16269)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- go to /centreon/monitoring/resources 
- open the filter criteria tooltip
- open any sidebar submenu
- the criteria filters tooltip should disappear
- click again the filter criteria tooltip button
- the filter criteria tooltip should appear without problem


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
