### PR TITLE
enh(centreon): update the plugin packs term to monitoring connectors

### DIFF
--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2382,8 +2382,8 @@ msgid "Recurrent downtimes"
 msgstr "Tiempos de parada recurrentes"
 
 #: centreon-web/src/CentreonLegacy/Core/Menu/Menu.php:156
-msgid "Plugin Packs"
-msgstr "Packs de plugins"
+msgid "Monitoring Connectors"
+msgstr "Conectores de Supervisión"
 
 #: centreon-web/src/CentreonLegacy/Core/Menu/Menu.php:169
 msgid "Manager"
@@ -3056,8 +3056,8 @@ msgid "Performance Management"
 msgstr "Gestión de datos de rendimiento."
 
 #: centreon-web/www/install/menu_translation.php:121
-msgid "Plugin packs"
-msgstr "Packs de sondes"
+msgid "Monitoring connectors"
+msgstr "Conectores de supervisión"
 
 #: centreon-web/www/install/menu_translation.php:122
 msgid "Poller Statistics"

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -2383,7 +2383,7 @@ msgstr "Tiempos de parada recurrentes"
 
 #: centreon-web/src/CentreonLegacy/Core/Menu/Menu.php:156
 msgid "Monitoring Connectors"
-msgstr "Conectores de Supervisión"
+msgstr "Conectores de supervisión"
 
 #: centreon-web/src/CentreonLegacy/Core/Menu/Menu.php:169
 msgid "Manager"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2603,7 +2603,7 @@ msgstr "Plages de maintenance récurrentes"
 
 #: centreon-web/src/CentreonLegacy/Core/Menu/Menu.php:156
 msgid "Monitoring Connectors"
-msgstr "Connecteurs de Supervision"
+msgstr "Connecteurs de supervision"
 
 #: centreon-web/src/CentreonLegacy/Core/Menu/Menu.php:169
 msgid "Manager"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2602,8 +2602,8 @@ msgid "Recurrent downtimes"
 msgstr "Plages de maintenance récurrentes"
 
 #: centreon-web/src/CentreonLegacy/Core/Menu/Menu.php:156
-msgid "Plugin Packs"
-msgstr "Packs de plugins"
+msgid "Monitoring Connectors"
+msgstr "Connecteurs de Supervision"
 
 #: centreon-web/src/CentreonLegacy/Core/Menu/Menu.php:169
 msgid "Manager"
@@ -3322,8 +3322,8 @@ msgid "Performance Management"
 msgstr "Gestion des données de performance"
 
 #: centreon-web/www/install/menu_translation.php:121
-msgid "Plugin packs"
-msgstr "Packs de sondes"
+msgid "Monitoring connectors"
+msgstr "Connecteurs de supervision"
 
 #: centreon-web/www/install/menu_translation.php:122
 msgid "Poller Statistics"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -12255,8 +12255,8 @@ msgid "Performance Management"
 msgstr "Gerenciamento de Performance"
 
 #: centreon-web/www/install/menu_translation.php:121
-msgid "Plugin packs"
-msgstr "Pacotes de Plugin"
+msgid "Monitoring connectors"
+msgstr "Conectores de supervisão"
 
 #: centreon-web/www/install/menu_translation.php:122
 msgid "Poller Statistics"
@@ -12948,8 +12948,8 @@ msgstr "Mostrar Gráficos"
 msgid "Recurrent downtimes"
 msgstr "Manutenções recorrentes"
 
-msgid "Plugin Packs"
-msgstr "Pacote de Plugins"
+msgid "Monitoring Connectors"
+msgstr "Conectores de Supervisão"
 
 msgid "Manager"
 msgstr "Gerencia"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -12949,7 +12949,7 @@ msgid "Recurrent downtimes"
 msgstr "Manutenções recorrentes"
 
 msgid "Monitoring Connectors"
-msgstr "Conectores de Supervisão"
+msgstr "Conectores de supervisão"
 
 msgid "Manager"
 msgstr "Gerencia"

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -12268,8 +12268,8 @@ msgid "Performance Management"
 msgstr "Gerenciamento de Performance"
 
 #: centreon-web/www/install/menu_translation.php:121
-msgid "Plugin packs"
-msgstr "Pacotes de Plugin"
+msgid "Monitoring connectors"
+msgstr "Conectores de supervisão"
 
 #: centreon-web/www/install/menu_translation.php:122
 msgid "Poller Statistics"
@@ -12961,8 +12961,8 @@ msgstr "Mostrar Gráficos"
 msgid "Recurrent downtimes"
 msgstr "Manutenções recorrentes"
 
-msgid "Plugin Packs"
-msgstr "Pacote de Plugins"
+msgid "Monitoring Connectors"
+msgstr "Conectores de Supervisão"
 
 msgid "Manager"
 msgstr "Gerencia"

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -12962,7 +12962,7 @@ msgid "Recurrent downtimes"
 msgstr "Manutenções recorrentes"
 
 msgid "Monitoring Connectors"
-msgstr "Conectores de Supervisão"
+msgstr "Conectores de supervisão"
 
 msgid "Manager"
 msgstr "Gerencia"

--- a/centreon/www/install/menu_translation.php
+++ b/centreon/www/install/menu_translation.php
@@ -118,7 +118,7 @@ echo _("Overview");
 echo _("Parameters");
 echo _("Performance Management");
 echo _("Performances");
-echo _("Monitoring connectors");
+echo _("Monitoring Connectors Manager");
 echo _("Poller Statistics");
 echo _("Pollers");
 echo _("Reload ACL");

--- a/centreon/www/install/menu_translation.php
+++ b/centreon/www/install/menu_translation.php
@@ -118,7 +118,7 @@ echo _("Overview");
 echo _("Parameters");
 echo _("Performance Management");
 echo _("Performances");
-echo _("Plugin packs");
+echo _("Monitoring connectors");
 echo _("Poller Statistics");
 echo _("Pollers");
 echo _("Reload ACL");


### PR DESCRIPTION
## Description

🏷️ MON-16550

This PR intends to change the naming from "plugin packs" / "plugin pack manager" (only for the UI) to "Monitoring connectors" / "Monitoring Connectors Manager"

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
