### PR TITLE
fix(web): display hostname/service_desc in Logs after host deletion

### DIFF
--- a/centreon/www/class/centreonLogAction.class.php
+++ b/centreon/www/class/centreonLogAction.class.php
@@ -205,23 +205,27 @@ class CentreonLogAction
     {
         global $pearDB, $pearDBO;
 
-        $query = "SELECT host_name FROM host WHERE host_register = '1' AND host_id = " . $host_id;
-        $DBRESULT2 = $pearDB->query($query);
-        $info = $DBRESULT2->fetchRow();
+        $statement = $pearDB->prepare("SELECT host_name FROM host WHERE host_register = '1' AND host_id = :host_id");
+        $statement->bindValue(':host_id', $host_id, \PDO::PARAM_INT);
+        $statement->execute();
+        $info = $statement->fetchRow();
         if (isset($info['host_name'])) {
             return $info['host_name'];
         }
 
-        $query = "SELECT object_id, object_name FROM log_action WHERE object_type = 'service' AND object_id = " . $host_id;
-        $DBRESULT2 = $pearDBO->query($query);
-        $info = $DBRESULT2->fetchRow();
+        $statement = $pearDBO->prepare("SELECT object_id, object_name FROM log_action WHERE object_type = 'service' AND object_id = :host_id");
+        $statement->bindValue(':host_id', $host_id, \PDO::PARAM_INT);
+        $statement->execute();
+        $info = $statement->fetchRow();
         if (isset($info['object_name'])) {
             return $info['object_name'];
         }
-        
-        $query = "SELECT name FROM hosts WHERE host_id = " . $host_id;
-        $DBRESULT3 = $pearDBO->query($query);
-        $info = $DBRESULT3->fetchRow();
+
+        $statement = $pearDBO->prepare("SELECT name FROM hosts WHERE host_id = :host_id");
+        $statement->bindValue(':host_id', $host_id, \PDO::PARAM_INT);
+        $statement->execute();
+        $info = $statement->fetchRow();
+
         return $info['name'] ?? -1;
     }
 

--- a/centreon/www/include/Administration/configChangelog/viewLogs.php
+++ b/centreon/www/include/Administration/configChangelog/viewLogs.php
@@ -252,7 +252,7 @@ if ($prepareSelect->execute()) {
                             );
                             // If we can't find the host name in the DB, we can get it in the object name
                             if (
-                                $host_name === -1 && str_contains($objectName, '/')
+                                ((int) $host_name === -1 && str_contains($objectName, '/'))
                                 || str_contains($objectName, $host_name . '/')
                             ) {
                                 $objectValues = explode('/', $objectName, 2);


### PR DESCRIPTION
## Description

After a host deletion, all the related services were displayed with a negative value on the Administration > Logs page.
The "-1" was displayed because we didn't find the hostname in the database.

**Fixes** MON-14597

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)