### PR TITLE
fix(web): display hostname/service_desc in Logs after host deletion (22.04)

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -104,9 +104,8 @@ jobs:
 
       - uses: ./.github/actions/frontend-lint
         with:
-          frontend_directory: ${{ env.directory }}
-          installation_directory: ${{ env.centreon_directory }}
-          module_name: centreon-ui
+          frontend_directory: ${{ env.base_directory }}
+          module_name: centreon-web
 
   frontend-unit-test:
     runs-on: ubuntu-22.04

--- a/centreon/www/class/centreonLogAction.class.php
+++ b/centreon/www/class/centreonLogAction.class.php
@@ -222,11 +222,7 @@ class CentreonLogAction
         $query = "SELECT name FROM hosts WHERE host_id = " . $host_id;
         $DBRESULT3 = $pearDBO->query($query);
         $info = $DBRESULT3->fetchRow();
-        if (isset($info['name'])) {
-            return $info['name'];
-        }
-
-        return -1;
+        return $info['name'] ?? -1;
     }
 
     public function getHostGroupName($hg_id)

--- a/centreon/www/class/centreonLogAction.class.php
+++ b/centreon/www/class/centreonLogAction.class.php
@@ -212,12 +212,20 @@ class CentreonLogAction
             return $info['host_name'];
         }
 
-        $query = "SELECT object_id, object_name FROM log_action WHERE object_type = 'service' AND object_id = $host_id";
+        $query = "SELECT object_id, object_name FROM log_action WHERE object_type = 'service' AND object_id = " . $host_id;
         $DBRESULT2 = $pearDBO->query($query);
         $info = $DBRESULT2->fetchRow();
         if (isset($info['object_name'])) {
             return $info['object_name'];
         }
+        
+        $query = "SELECT name FROM hosts WHERE host_id = " . $host_id;
+        $DBRESULT3 = $pearDBO->query($query);
+        $info = $DBRESULT3->fetchRow();
+        if (isset($info['name'])) {
+            return $info['name'];
+        }
+
         return -1;
     }
 

--- a/centreon/www/class/centreonLogAction.class.php
+++ b/centreon/www/class/centreonLogAction.class.php
@@ -205,23 +205,27 @@ class CentreonLogAction
     {
         global $pearDB, $pearDBO;
 
-        $query = "SELECT host_name FROM host WHERE host_register = '1' AND host_id = " . $host_id;
-        $DBRESULT2 = $pearDB->query($query);
-        $info = $DBRESULT2->fetchRow();
+        $statement = $pearDB->prepare("SELECT host_name FROM host WHERE host_register = '1' AND host_id = :host_id");
+        $statement->bindValue(':host_id', $host_id, \PDO::PARAM_INT);
+        $statement->execute();
+        $info = $statement->fetchRow();
         if (isset($info['host_name'])) {
             return $info['host_name'];
         }
 
-        $query = "SELECT object_id, object_name FROM log_action WHERE object_type = 'service' AND object_id = " . $host_id;
-        $DBRESULT2 = $pearDBO->query($query);
-        $info = $DBRESULT2->fetchRow();
+        $statement = $pearDBO->prepare("SELECT object_id, object_name FROM log_action WHERE object_type = 'service' AND object_id = :host_id");
+        $statement->bindValue(':host_id', $host_id, \PDO::PARAM_INT);
+        $statement->execute();
+        $info = $statement->fetchRow();
         if (isset($info['object_name'])) {
             return $info['object_name'];
         }
-        
-        $query = "SELECT name FROM hosts WHERE host_id = " . $host_id;
-        $DBRESULT3 = $pearDBO->query($query);
-        $info = $DBRESULT3->fetchRow();
+
+        $statement = $pearDBO->prepare("SELECT name FROM hosts WHERE host_id = :host_id");
+        $statement->bindValue(':host_id', $host_id, \PDO::PARAM_INT);
+        $statement->execute();
+        $info = $statement->fetchRow();
+
         return $info['name'] ?? -1;
     }
 

--- a/centreon/www/include/Administration/configChangelog/viewLogs.php
+++ b/centreon/www/include/Administration/configChangelog/viewLogs.php
@@ -250,8 +250,11 @@ if ($prepareSelect->execute()) {
                                 $centreon->CentreonLogAction->getHostName($tmp2["h"]),
                                 CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
                             );
-                            ### If we can't find the host name in the DB, we can get it in the object name
-                            if (($host_name == -1 && str_contains($objectName, '/')) || (str_contains($objectName, $host_name.'/'))) {
+                            // If we can't find the host name in the DB, we can get it in the object name
+                            if (
+                                $host_name === -1 && str_contains($objectName, '/') 
+                                || str_contains($objectName, $host_name.'/')
+                            ) {
                                 $objectValues = explode('/', $objectName, 2);
                                 $host_name = $objectValues[0];
                                 $objectName = $objectValues[1];

--- a/centreon/www/include/Administration/configChangelog/viewLogs.php
+++ b/centreon/www/include/Administration/configChangelog/viewLogs.php
@@ -252,8 +252,8 @@ if ($prepareSelect->execute()) {
                             );
                             // If we can't find the host name in the DB, we can get it in the object name
                             if (
-                                $host_name === -1 && str_contains($objectName, '/') 
-                                || str_contains($objectName, $host_name.'/')
+                                ((int) $host_name === -1 && str_contains($objectName, '/'))
+                                || str_contains($objectName, $host_name . '/')
                             ) {
                                 $objectValues = explode('/', $objectName, 2);
                                 $host_name = $objectValues[0];

--- a/centreon/www/include/Administration/configChangelog/viewLogs.php
+++ b/centreon/www/include/Administration/configChangelog/viewLogs.php
@@ -250,6 +250,12 @@ if ($prepareSelect->execute()) {
                                 $centreon->CentreonLogAction->getHostName($tmp2["h"]),
                                 CentreonUtils::ESCAPE_ALL_EXCEPT_LINK
                             );
+                            ### If we can't find the host name in the DB, we can get it in the object name
+                            if (($host_name == -1 && str_contains($objectName, '/')) || (str_contains($objectName, $host_name.'/'))) {
+                                $objectValues = explode('/', $objectName, 2);
+                                $host_name = $objectValues[0];
+                                $objectName = $objectValues[1];
+                            }
                         } elseif (count($tabHost) > 1) {
                             $hosts = array();
                             foreach ($tabHost as $key => $value) {


### PR DESCRIPTION
## Description

After a host deletion, all the related services were displayed with a negative value on the Administration > Logs page.
The "-1" was displayed because we didn't find the hostname in the database.

**Fixes** MON-14597

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)