### PR TITLE
Fix[Installation]: error when accessing to installation wizard

### DIFF
--- a/centreon/www/front_src/src/Main/useMain.ts
+++ b/centreon/www/front_src/src/Main/useMain.ts
@@ -60,7 +60,9 @@ const useMain = (): void => {
       endpoint: platformInstallationStatusEndpoint
     }).then((retrievedPlatformInstallationStatus) => {
       setPlatformInstallationStatus(retrievedPlatformInstallationStatus);
-      getPlatformVersions();
+      if (retrievedPlatformInstallationStatus?.isInstalled || !retrievedPlatformInstallationStatus?.hasUpgradeAvailable) {
+         getPlatformVersions();
+      }
     });
   }, []);
 

--- a/centreon/www/front_src/src/Main/useMain.ts
+++ b/centreon/www/front_src/src/Main/useMain.ts
@@ -60,9 +60,13 @@ const useMain = (): void => {
       endpoint: platformInstallationStatusEndpoint
     }).then((retrievedPlatformInstallationStatus) => {
       setPlatformInstallationStatus(retrievedPlatformInstallationStatus);
-      if (retrievedPlatformInstallationStatus?.isInstalled || !retrievedPlatformInstallationStatus?.hasUpgradeAvailable) {
-         getPlatformVersions();
-      }
+
+    if (!retrievedPlatformInstallationStatus?.isInstalled && !retrievedPlatformInstallationStatus?.hasUpgradeAvailable){
+      return;
+    }
+    
+    getPlatformVersions();
+    
     });
   }, []);
 

--- a/centreon/www/front_src/src/Main/useMain.ts
+++ b/centreon/www/front_src/src/Main/useMain.ts
@@ -61,12 +61,14 @@ const useMain = (): void => {
     }).then((retrievedPlatformInstallationStatus) => {
       setPlatformInstallationStatus(retrievedPlatformInstallationStatus);
 
-    if (!retrievedPlatformInstallationStatus?.isInstalled && !retrievedPlatformInstallationStatus?.hasUpgradeAvailable){
-      return;
-    }
-    
-    getPlatformVersions();
-    
+      if (
+        !retrievedPlatformInstallationStatus?.isInstalled &&
+        !retrievedPlatformInstallationStatus?.hasUpgradeAvailable
+      ) {
+        return;
+      }
+
+      getPlatformVersions();
     });
   }, []);
 


### PR DESCRIPTION
## Description

 An error is appearing for like 5s when the wizard is shown up to continue the installation" Environment variable not found: hostCentreon "

**Fixes** # MON-15697

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>
Choose one of the os execute the commands of the installation for 22.10 after that go to complete the wizard so the login page will be appearing and check if the error  `Environment variable not found: "hostCentreon"` is not showing 

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
