### PR TITLE
enh(www): add pendo testid to ressource filters backport 22 10

### DIFF
--- a/centreon/packages/ui/src/InputField/Select/index.tsx
+++ b/centreon/packages/ui/src/InputField/Select/index.tsx
@@ -35,6 +35,7 @@ export interface SelectEntry {
   id: number | string;
   inputValue?: string;
   name: string;
+  testId?: string;
   type?: 'header';
   url?: string;
 }
@@ -101,7 +102,7 @@ const SelectField = ({
       >
         {options
           .filter(({ id }) => id !== '')
-          .map(({ id, name, color, type }) => {
+          .map(({ id, name, color, type, testId }) => {
             const key = `${id}-${name}`;
             if (type === 'header') {
               return [
@@ -111,7 +112,12 @@ const SelectField = ({
             }
 
             return (
-              <MenuItem key={key} style={{ backgroundColor: color }} value={id}>
+              <MenuItem
+                data-testid={testId}
+                key={key}
+                style={{ backgroundColor: color }}
+                value={id}
+              >
                 <Option>{name}</Option>
               </MenuItem>
             );

--- a/centreon/packages/ui/src/Listing/ActionBar/Pagination.tsx
+++ b/centreon/packages/ui/src/Listing/ActionBar/Pagination.tsx
@@ -15,7 +15,11 @@ const styles = {
 };
 
 const Pagination = (props): JSX.Element => (
-  <TablePagination component="div" {...props} />
+  <TablePagination
+    component="div"
+    data-testid="Listing Pagination"
+    {...props}
+  />
 );
 
 const MemoizedPagination = memo(

--- a/centreon/www/front_src/src/Resources/Actions/Refresh/index.tsx
+++ b/centreon/www/front_src/src/Resources/Actions/Refresh/index.tsx
@@ -37,6 +37,7 @@ const AutorefreshButton = ({
   return (
     <IconButton
       ariaLabel={t(label)}
+      data-testid="Disable autorefresh"
       size="small"
       title={t(label)}
       onClick={toggleAutorefresh}
@@ -67,7 +68,7 @@ const RefreshActions = ({ onRefresh }: Props): JSX.Element => {
       <Grid item>
         <IconButton
           ariaLabel={t(labelRefresh)}
-          data-testid={labelRefresh}
+          data-testid="Refresh"
           disabled={sending}
           size="small"
           title={t(labelRefresh)}

--- a/centreon/www/front_src/src/Resources/Actions/Resource/ActionMenuItem.tsx
+++ b/centreon/www/front_src/src/Resources/Actions/Resource/ActionMenuItem.tsx
@@ -7,12 +7,14 @@ import { labelActionNotPermitted } from '../../translatedLabels';
 type Props = {
   label: string;
   permitted: boolean;
+  testId: string;
 } & Pick<MenuItemProps, 'onClick' | 'disabled'>;
 
 const ActionMenuItem = ({
   permitted,
   label,
   onClick,
+  testId,
   disabled,
 }: Props): JSX.Element => {
   const { t } = useTranslation();
@@ -22,7 +24,7 @@ const ActionMenuItem = ({
   return (
     <Tooltip title={title}>
       <div>
-        <MenuItem disabled={disabled} onClick={onClick}>
+        <MenuItem data-testid={testId} disabled={disabled} onClick={onClick}>
           {t(label)}
         </MenuItem>
       </div>

--- a/centreon/www/front_src/src/Resources/Actions/Resource/ResourceActionButton.tsx
+++ b/centreon/www/front_src/src/Resources/Actions/Resource/ResourceActionButton.tsx
@@ -13,6 +13,7 @@ interface Props {
   label: string;
   onClick: () => void;
   permitted?: boolean;
+  testId: string;
 }
 
 const ResourceActionButton = ({
@@ -20,6 +21,7 @@ const ResourceActionButton = ({
   label,
   onClick,
   disabled,
+  testId,
   permitted = true,
 }: Props): JSX.Element => {
   const theme = useTheme();
@@ -33,7 +35,7 @@ const ResourceActionButton = ({
     return (
       <IconButton
         ariaLabel={t(label)}
-        data-testid={label}
+        data-testid={testId}
         disabled={disabled}
         size="large"
         title={title}
@@ -49,7 +51,7 @@ const ResourceActionButton = ({
       <span>
         <ActionButton
           aria-label={t(label)}
-          data-testid={label}
+          data-testid={testId}
           disabled={disabled}
           startIcon={icon}
           variant="contained"

--- a/centreon/www/front_src/src/Resources/Actions/Resource/index.tsx
+++ b/centreon/www/front_src/src/Resources/Actions/Resource/index.tsx
@@ -211,6 +211,7 @@ const ResourceActions = (): JSX.Element => {
             icon={<IconAcknowledge />}
             label={t(labelAcknowledge)}
             permitted={isAcknowledgePermitted}
+            testId="Multiple Acknowledge"
             onClick={prepareToAcknowledge}
           />
         </div>
@@ -220,6 +221,7 @@ const ResourceActions = (): JSX.Element => {
             icon={<IconDowntime />}
             label={t(labelSetDowntime)}
             permitted={isDowntimePermitted}
+            testId="Multiple Set Downtime"
             onClick={prepareToSetDowntime}
           />
         </div>
@@ -229,6 +231,7 @@ const ResourceActions = (): JSX.Element => {
             icon={<IconCheck />}
             label={t(labelCheck)}
             permitted={isCheckPermitted}
+            testId="Multiple Check"
             onClick={prepareToCheck}
           />
         </div>
@@ -280,6 +283,7 @@ const ResourceActions = (): JSX.Element => {
               disabled={disableDisacknowledge}
               label={labelDisacknowledge}
               permitted={isDisacknowledgePermitted}
+              testId="Multiple Disacknowledge"
               onClick={(): void => {
                 close();
                 prepareToDisacknowledge();
@@ -289,6 +293,7 @@ const ResourceActions = (): JSX.Element => {
               disabled={disableSubmitStatus}
               label={labelSubmitStatus}
               permitted={isSubmitStatusPermitted}
+              testId="Submit a status"
               onClick={(): void => {
                 close();
                 prepareToSubmitStatus();
@@ -299,6 +304,7 @@ const ResourceActions = (): JSX.Element => {
               disabled={disableAddComment}
               label={labelAddComment}
               permitted={isAddCommentPermitted}
+              testId="Add a comment"
               onClick={(): void => {
                 close();
                 prepareToAddComment();

--- a/centreon/www/front_src/src/Resources/Filter/Criterias/index.tsx
+++ b/centreon/www/front_src/src/Resources/Filter/Criterias/index.tsx
@@ -91,13 +91,19 @@ const CriteriasContent = (): JSX.Element => {
           })}
           <Grid container item className={classes.searchButton} spacing={1}>
             <Grid item data-testid={labelClear}>
-              <Button color="primary" size="small" onClick={clearFilter}>
+              <Button
+                color="primary"
+                data-testid="Filter Clear"
+                size="small"
+                onClick={clearFilter}
+              >
                 {t(labelClear)}
               </Button>
             </Grid>
             <Grid item data-testid={labelSearch}>
               <Button
                 color="primary"
+                data-testid="Filter Search"
                 size="small"
                 variant="contained"
                 onClick={applyCurrentFilter}

--- a/centreon/www/front_src/src/Resources/Filter/Save/index.tsx
+++ b/centreon/www/front_src/src/Resources/Filter/Save/index.tsx
@@ -174,18 +174,27 @@ const SaveFilterMenu = (): JSX.Element => {
         onClose={closeSaveFilterMenu}
       >
         <MenuItem
+          data-testid="Filter Save as new"
           disabled={!canSaveFilterAsNew}
           onClick={openCreateFilterDialog}
         >
           {t(labelSaveAsNew)}
         </MenuItem>
-        <MenuItem disabled={!canSaveFilter} onClick={updateFilter}>
+        <MenuItem
+          data-testid="Filter Save"
+          disabled={!canSaveFilter}
+          onClick={updateFilter}
+        >
           <div className={classes.save}>
             <span>{t(labelSave)}</span>
             {sendingUpdateFilterRequest && <CircularProgress size={15} />}
           </div>
         </MenuItem>
-        <MenuItem disabled={isEmpty(customFilters)} onClick={openEditPanel}>
+        <MenuItem
+          data-testid="Filter Edit filters"
+          disabled={isEmpty(customFilters)}
+          onClick={openEditPanel}
+        >
           {t(labelEditFilters)}
         </MenuItem>
       </Menu>

--- a/centreon/www/front_src/src/Resources/Filter/index.tsx
+++ b/centreon/www/front_src/src/Resources/Filter/index.tsx
@@ -50,6 +50,7 @@ import {
   getData,
   useRequest,
   LoadingSkeleton,
+  SelectEntry,
 } from '@centreon/ui';
 import { userAtom } from '@centreon/ui-context';
 
@@ -474,13 +475,13 @@ const Filter = (): JSX.Element => {
     applyFilter(updatedFilter);
   };
 
-  const translatedOptions = [
+  const translatedOptions: Array<SelectEntry> = [
     unhandledProblemsFilter,
     resourceProblemsFilter,
     allFilter,
-  ].map(({ id, name }) => ({ id, name: t(name) }));
+  ].map(({ id, name }) => ({ id, name: t(name), testId: `Filter ${name}` }));
 
-  const customFilterOptions = isEmpty(customFilters)
+  const customFilterOptions: Array<SelectEntry> = isEmpty(customFilters)
     ? []
     : [
         {
@@ -491,7 +492,7 @@ const Filter = (): JSX.Element => {
         ...customFilters,
       ];
 
-  const options = [
+  const options: Array<SelectEntry> = [
     { id: '', name: t(labelNewFilter) },
     ...translatedOptions,
     ...customFilterOptions,
@@ -550,7 +551,7 @@ const Filter = (): JSX.Element => {
             <Suspense fallback={<FilterLoadingSkeleton />}>
               <SelectFilter
                 ariaLabel={t(labelStateFilter)}
-                options={options.map(pick(['id', 'name', 'type']))}
+                options={options.map(pick(['id', 'name', 'type', 'testId']))}
                 selectedOptionId={
                   canDisplaySelectedFilter ? currentFilter.id : ''
                 }


### PR DESCRIPTION
## Description

backport pendo testids to v22.10

**Fixes** # [(issue)](https://centreon.atlassian.net/browse/MON-14835)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check that the testid list is applied correctly to the resources filters as described in the jira ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
