### PR TITLE
fix(clapi): service template macro name format

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php
+++ b/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php
@@ -590,6 +590,21 @@ class CentreonServiceTemplate extends CentreonObject
     }
 
     /**
+     * Extract macro name
+     *
+     * @param string $macroName
+     * @return string
+     */
+    protected function extractMacroName($macroName)
+    {
+        $strippedMacro = $macroName;
+        if (preg_match('/\$_SERVICE([a-zA-Z0-9_-]+)\$/', $strippedMacro, $matches)) {
+            $strippedMacro = $matches[1];
+        }
+        return $strippedMacro;
+    }
+
+    /**
      * Strip macro
      *
      * @param string $macroName
@@ -597,10 +612,7 @@ class CentreonServiceTemplate extends CentreonObject
      */
     protected function stripMacro($macroName)
     {
-        $strippedMacro = $macroName;
-        if (preg_match('/\$_SERVICE([a-zA-Z0-9_-]+)\$/', $strippedMacro, $matches)) {
-            $strippedMacro = $matches[1];
-        }
+        $strippedMacro = $this->extractMacroName($macroName);
         return strtolower($strippedMacro);
     }
 
@@ -653,7 +665,7 @@ class CentreonServiceTemplate extends CentreonObject
         echo "macro name;macro value;description;is_password\n";
         foreach ($macroList as $macro) {
             $password = !empty($macro['is_password']) ? (int)$macro['is_password'] : 0;
-            echo $macro['svc_macro_name'] . $this->delim
+            echo $this->extractMacroName($macro['svc_macro_name']) . $this->delim
             . $macro['svc_macro_value'] . $this->delim
             . $macro['description'] . $this->delim
             . $password . "\n";


### PR DESCRIPTION
## Description

Display macro names in the same way as for hosts, host templates, and services.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

With an API call to -o STPL -a getmacro -v "a-service-template"
