### PR TITLE
fix(install/upgrade): remove constraint on table vault_configuration

### DIFF
--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2465,7 +2465,6 @@ CREATE TABLE IF NOT EXISTS `vault_configuration` (
   `secret_id` VARCHAR(255) NOT NULL,
   `salt` CHAR(128) NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unique_vault_configuration` (`url`, `port`, `root_path`),
   CONSTRAINT `vault_configuration_vault_id`
     FOREIGN KEY (`vault_id`)
     REFERENCES `vault` (`id`) ON DELETE CASCADE

--- a/centreon/www/install/sql/centreon/Update-DB-23.04.0-beta.1.sql
+++ b/centreon/www/install/sql/centreon/Update-DB-23.04.0-beta.1.sql
@@ -1,10 +1,10 @@
---- CREATE TABLES FOR VAULT CONFIGURATION ---
+-- CREATE TABLES FOR VAULT CONFIGURATION --
 CREATE TABLE IF NOT EXISTS `vault` (
   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
   `name` VARCHAR(255) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `unique_name` (`name`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO `vault` (`name`) VALUES ('hashicorp');
 
@@ -19,10 +19,9 @@ CREATE TABLE IF NOT EXISTS `vault_configuration` (
   `secret_id` VARCHAR(255) NOT NULL,
   `salt` CHAR(128) NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `unique_vault_configuration` (`url`, `port`, `root_path`),
   CONSTRAINT `vault_configuration_vault_id`
     FOREIGN KEY (`vault_id`)
     REFERENCES `vault` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 INSERT INTO `options` (`key`, `value`) VALUES ('resource_status_view_mode', 'compact');


### PR DESCRIPTION
## Description

This PR intends to remove constraint on table vault_configuration. 

![image](https://user-images.githubusercontent.com/61694165/226869463-e27bfdcd-2210-480f-9345-5d942720630a.png)


**Fixes** # MON-17318

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Make a Fresh Install no errors should occur on step 7

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
