### PR TITLE
fix(install): Fail to read a file during centreon-web install

### DIFF
--- a/centreon/src/CentreonLegacy/Core/Install/Step/AbstractStep.php
+++ b/centreon/src/CentreonLegacy/Core/Install/Step/AbstractStep.php
@@ -60,8 +60,12 @@ abstract class AbstractStep implements StepInterface
     {
         if ($this->dependencyInjector['filesystem']->exists($file)) {
             $configuration = json_decode(file_get_contents($file), true);
-            foreach ($configuration as $key => $configurationValue) {
-                $configuration[$key] = htmlspecialchars($configurationValue, ENT_QUOTES);
+            if (is_array($configuration)) {
+                foreach ($configuration as $key => $configurationValue) {
+                    $configuration[$key] = htmlspecialchars($configurationValue, ENT_QUOTES);
+                }
+            } else {
+                $configuration = htmlspecialchars($configuration, ENT_QUOTES);
             }
         }
 


### PR DESCRIPTION
## Description

During centreon-web install, steps try to read files containing user provided information stored in json format.
There is one file that rises an error:

`[10-Mar-2023 14:59:56 UTC] PHP Warning:  foreach() argument must be of type array|object, string given in /usr/share/centreon/src/CentreonLegacy/Core/Install/Step/AbstractStep.php on line 63`

The fix is intended to fix this error.

**Fixes** # MON-17567

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- make fresh install
- check the php-fpm log, the mentioned error should not appear anymore

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
