### PR TITLE
fix (Authentication): PHP error on authentication APIs

### DIFF
--- a/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/Local/LoginController.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/Local/LoginController.php
@@ -58,8 +58,8 @@ class LoginController extends AbstractController
             ) : null;
 
         $request = LoginRequest::createForLocal(
-            $payload["login"] ?? null,
-            $payload["password"] ?? null,
+            (string) ($payload["login"] ?? ''),
+            (string) ($payload["password"] ?? ''),
             $request->getClientIp(),
             $referer
         );

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/OpenId/LoginController.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Api/Login/OpenId/LoginController.php
@@ -58,8 +58,8 @@ class LoginController extends AbstractController
         SessionInterface $session
     ): object {
         $request = LoginRequest::createForOpenId(
-            $request->getClientIp(),
-            $request->query->get("code")
+            $request->getClientIp() ?: '',
+            $request->query->get("code", '')
         );
 
         $useCase($request, $presenter);


### PR DESCRIPTION
## Description

Handling exception when sending null values

**Fixes** # MON-16742

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Execute previous authentication request and check that message correspond to 'Authentication failed'

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
