### PR TITLE
fix (Authentication): Make error messages generic (dev-2210)

### DIFF
--- a/centreon/src/Centreon/Application/Controller/AuthenticationController.php
+++ b/centreon/src/Centreon/Application/Controller/AuthenticationController.php
@@ -39,7 +39,7 @@ use Security\Infrastructure\Authentication\API\Model_2110\ApiAuthenticationFacto
  */
 class AuthenticationController extends AbstractController
 {
-    private const INVALID_CREDENTIALS_MESSAGE = 'Invalid credentials';
+    private const INVALID_CREDENTIALS_MESSAGE = 'Authentication failed';
 
     /**
      * Entry point used to identify yourself and retrieve an authentication token.

--- a/centreon/src/Core/Security/Authentication/Domain/Exception/AuthenticationException.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Exception/AuthenticationException.php
@@ -37,6 +37,6 @@ class AuthenticationException extends \Exception
      */
     public static function userBlocked(): self
     {
-        return new self(_('User is blocked'));
+        return new self(_('Authentication failed'));
     }
 }

--- a/centreon/tests/api/features/LocalAuthentication.feature
+++ b/centreon/tests/api/features/LocalAuthentication.feature
@@ -33,7 +33,7 @@ Feature:
     """
     {
         "code": 401,
-        "message": "User is blocked"
+        "message": "Authentication failed"
     }
     """
 
@@ -43,6 +43,6 @@ Feature:
     """
     {
         "code": 401,
-        "message": "User is blocked"
+        "message": "Authentication failed"
     }
     """

--- a/centreon/tests/php/Centreon/Application/Controller/AuthenticationControllerTest.php
+++ b/centreon/tests/php/Centreon/Application/Controller/AuthenticationControllerTest.php
@@ -154,7 +154,7 @@ class AuthenticationControllerTest extends TestCase
             View::create(
                 [
                     "code" => Response::HTTP_UNAUTHORIZED,
-                    "message" => 'Invalid credentials',
+                    "message" => 'Authentication failed',
                 ],
                 Response::HTTP_UNAUTHORIZED
             ),
@@ -208,7 +208,7 @@ class AuthenticationControllerTest extends TestCase
             View::create(
                 [
                     "code" => Response::HTTP_UNAUTHORIZED,
-                    "message" => 'Invalid credentials'
+                    "message" => 'Authentication failed'
                 ],
                 Response::HTTP_UNAUTHORIZED
             ),

--- a/centreon/www/api/index.php
+++ b/centreon/www/api/index.php
@@ -68,7 +68,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_GET['action']) && $_GET['ac
     try {
         $authenticateApiUseCase->execute($request, $response);
     } catch (AuthenticationException $ex) {
-        CentreonWebService::sendResult('Invalid credentials', 401);
+        CentreonWebService::sendResult('Authentication failed', 401);
     }
     $userAccessesStatement = $pearDB->prepare(
         "SELECT contact_admin, reach_api, reach_api_rt FROM contact WHERE contact_alias = :alias"

--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -547,7 +547,12 @@ class CentreonAPI
                         $row['blocking_time'] + $securityPolicy['blocking_duration']
                     );
                     $interval = (date_diff($now, $expirationDate))->format('%Dd %Hh %Im %Ss');
-                    print "Unable to login, max login attempts has been reached. $interval left\n";
+                    print "Authentication failed.\n";
+                    $CentreonLog = new \CentreonLog();
+                    $CentreonLog->insertLog(
+                        1, "Authentication failed for '" . $row['contact_alias'] . "',"
+                        . " max login attempts has been reached. $interval left\n"
+                    );
                     exit(1);
                 }
             }
@@ -609,7 +614,7 @@ class CentreonAPI
                 );
             }
         }
-        print "Invalid credentials.\n";
+        print "Authentication failed.\n";
         exit(1);
     }
 
@@ -1247,15 +1252,21 @@ class CentreonAPI
         int $securityPolicyAttempts,
         int $blockingDuration
     ): void {
+        $CentreonLog = new \CentreonLog();
         $loginAttempts = $this->incrementLoginAttempts($contactLoginAttempts);
         if ($loginAttempts === $securityPolicyAttempts) {
             $this->blockLoginForUser();
-            print "Invalid credentials. Max attempts has been reached, you can't login for "
-                . "$blockingDuration seconds. \n";
+            print "Authentication failed.\n";
+            $CentreonLog->insertLog(
+                1,
+                "Authentication failed. Max attempts has been reached, User can't login for "
+                . "$blockingDuration seconds."
+            );
             exit(1);
         }
         $attemptRemaining = $securityPolicyAttempts - $loginAttempts;
-        print "Invalid credentials. $attemptRemaining attempt(s) remaining \n";
+        print "Authentication failed.\n";
+        $CentreonLog->insertLog(1, "Authentication failed. $attemptRemaining attempt(s) remaining");
         exit(1);
     }
 


### PR DESCRIPTION
## Description

Change all authentication failed messages 

**Fixes** # MON-16740
## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

See example mapping in jira ticket

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
