### PR TITLE
fix(translations): monitoring connectors manager translation added fo…

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -2924,8 +2924,12 @@ msgid "Performance Management"
 msgstr "Leistungsverwaltung"
 
 #: centreon/www/install/menu_translation.php:121
-msgid "Plugin packs"
-msgstr "Plugin Pakete"
+msgid "Monitoring Connectors Manager"
+msgstr "Monitoring konnektoren manager"
+
+#: centreon/www/install/menu_translation.php:121
+msgid "Monitoring connectors"
+msgstr "Monitoring konnektoren"
 
 #: centreon/www/install/menu_translation.php:122
 msgid "Poller Statistics"

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -3059,6 +3059,10 @@ msgstr "Gestión de datos de rendimiento."
 msgid "Monitoring connectors"
 msgstr "Conectores de supervisión"
 
+# centreon-web/www/install/menu_translation.php:121
+msgid "Monitoring Connectors Manager"
+msgstr "Gestor de conectores de supervisión"
+
 #: centreon-web/www/install/menu_translation.php:122
 msgid "Poller Statistics"
 msgstr "Estadísticas de coleccionista"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2958,6 +2958,10 @@ msgstr "Activités métiers"
 msgid "Business Views"
 msgstr "Vues métiers"
 
+# centreon-web/www/install/menu_translation.php:121
+msgid "Monitoring Connectors Manager"
+msgstr "Gestionnaire de connecteurs de supervision"
+
 #: centreon-web/www/install/menu_translation.php:51
 msgid "By Host"
 msgstr "Par hôte"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -12258,6 +12258,10 @@ msgstr "Gerenciamento de Performance"
 msgid "Monitoring connectors"
 msgstr "Conectores de supervisão"
 
+#: centreon/www/install/menu_translation.php:121
+msgid "Monitoring Connectors Manager"
+msgstr "Gestor de conectores de supervisão"
+
 #: centreon-web/www/install/menu_translation.php:122
 msgid "Poller Statistics"
 msgstr "Estatisticas de Coleta"

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -12964,6 +12964,10 @@ msgstr "Manutenções recorrentes"
 msgid "Monitoring Connectors"
 msgstr "Conectores de supervisão"
 
+#: centreon/www/install/menu_translation.php:121
+msgid "Monitoring Connectors Manager"
+msgstr "Gestor de conectores de supervisão"
+
 msgid "Manager"
 msgstr "Gerencia"
 


### PR DESCRIPTION
…r menu

📎 MON-16550

This PR intends to add missing translation for "Monitoring Connectors Manager" menu entry that needs to be translated in centreon-web module and not ppm

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

See jira ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
