### PR TITLE
fix (Authentication): PHP error on authentication APIs (dev-2204)

### DIFF
--- a/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
+++ b/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
@@ -211,7 +211,7 @@ class Assertion
         Assert::notEmpty(
             $value,
             function (array $parameters) {
-                return AssertionException::notEmpty($parameters['propertyPath']);
+                return AssertionException::notEmpty($parameters['propertyPath'])->getMessage();
             },
             $propertyPath
         );
@@ -229,7 +229,7 @@ class Assertion
         Assert::notNull(
             $value,
             function (array $parameters) {
-                return AssertionException::notNull($parameters['propertyPath']);
+                return AssertionException::notNull($parameters['propertyPath'])->getMessage();
             },
             $propertyPath
         );
@@ -278,7 +278,7 @@ class Assertion
                     $parameters['value'],
                     $parameters['choices'],
                     $parameters['propertyPath']
-                );
+                )->getMessage();
             },
             $propertyPath
         );

--- a/centreon/src/Core/Security/Infrastructure/Api/LoginOpenIdSession/LoginOpenIdSessionController.php
+++ b/centreon/src/Core/Security/Infrastructure/Api/LoginOpenIdSession/LoginOpenIdSessionController.php
@@ -74,8 +74,8 @@ class LoginOpenIdSessionController extends AbstractController
     private function createLoginOpenIdSessionRequest(Request $request): LoginOpenIdSessionRequest
     {
         $loginOpenIdSessionRequest = new LoginOpenIdSessionRequest();
-        $loginOpenIdSessionRequest->authorizationCode = $request->query->get('code');
-        $loginOpenIdSessionRequest->clientIp = $request->getClientIp();
+        $loginOpenIdSessionRequest->authorizationCode = $request->query->get('code', '');
+        $loginOpenIdSessionRequest->clientIp = $request->getClientIp() ?: '';
 
         return $loginOpenIdSessionRequest;
     }

--- a/centreon/src/Core/Security/Infrastructure/Api/LoginSession/LoginSessionController.php
+++ b/centreon/src/Core/Security/Infrastructure/Api/LoginSession/LoginSessionController.php
@@ -74,8 +74,8 @@ class LoginSessionController extends AbstractController
         $requestData = json_decode((string) $request->getContent(), true);
 
         $loginSessionRequest = new LoginSessionRequest();
-        $loginSessionRequest->login = $requestData['login'];
-        $loginSessionRequest->password = $requestData['password'];
+        $loginSessionRequest->login =  (string) ($requestData['login']?? '');
+        $loginSessionRequest->password = (string) ($requestData['password']?? '');
         $loginSessionRequest->baseUri = $this->getBaseUri();
         $referer = $request->headers->get('referer');
         if ($referer !== null) {


### PR DESCRIPTION
## Description

Handling exception when sending null values

**Fixes** # MON-16742

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Execute previous authentication request and check that message correspond to 'Authentication failed'

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
