### PR TITLE
Fix (ux): Wrong timezone retrieved from current user parameter endpoint

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -391,6 +391,31 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
     }
 
     /**
+     * Get the default timezone.
+     *
+     * @return string
+     *   The timezone name.
+     */
+    private function getDefaultTimezone(): string
+    {
+        $query = "
+        SELECT timezone.timezone_name
+        FROM `:db`.timezone
+        JOIN `:db`.options ON timezone.timezone_id = options.value
+        WHERE options.key = 'gmt'
+    ";
+
+        $query = $this->translateDbName($query);
+
+        $statement = $this->db->prepare($query);
+        $statement->execute();
+
+        $result = $statement->fetch(\PDO::FETCH_ASSOC);
+
+        return $result['timezone_name'] ?? date_default_timezone_get();
+    }
+
+    /**
      * Create a contact based on the data.
      *
      * @param mixed[] $contact Array of values representing the contact information
@@ -400,7 +425,7 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
     {
         $contactTimezoneName = !empty($contact['timezone_name'])
             ? $contact['timezone_name']
-            : date_default_timezone_get();
+            : $this->getDefaultTimezone();
 
         $contactLocale = !empty($contact['contact_lang'])
             ? $this->parseLocaleFromContactLang($contact['contact_lang'])


### PR DESCRIPTION
## Description

When the user timezone is updated, after reloading the page, the user parameters endpoint return the wrong timezone.

## How to reproduce?

Login with any user

Go to Centreon UI page

Change the timezone to another timezone

Reload the page

The time in the clock is not updated
**Fixes** # MON-16910

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Login with any user
- Go to Centreon UI page
- Change the timezone to another timezone
- Reload the page

The time in the clock must be change regarding selected timezone
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
