### PR TITLE
fix(web): top counter qa fails (translation + responsive layout)

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -15315,3 +15315,7 @@ msgstr ""
 
 # msgid "OK status services"
 # msgstr ""
+
+#: centreon-bam/www/modules/centreon-bam-server/react/hooks/header/topCounter
+# msgid "B.Activities"
+# msgstr ""

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15614,3 +15614,8 @@ msgstr "No ha guardado los cambios, ¿quiere continuar?"
 
 # msgid "OK status services"
 # msgstr ""
+
+
+#: centreon-bam/www/modules/centreon-bam-server/react/hooks/header/topCounter
+# msgid "B.Activities"
+# msgstr ""

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17473,3 +17473,10 @@ msgstr "Services au statut Inconnu"
 
 msgid "OK status services"
 msgstr "Services au statut OK"
+
+
+#: centreon-bam/www/modules/centreon-bam-server/react/hooks/header/topCounter
+
+msgid "B.Activities"
+msgstr "A.Métier"
+

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -16078,3 +16078,7 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 
 # msgid "OK status services"
 # msgstr ""
+
+#: centreon-bam/www/modules/centreon-bam-server/react/hooks/header/topCounter
+# msgid "B.Activities"
+# msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -16068,3 +16068,8 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 
 # msgid "OK status services"
 # msgstr ""
+
+
+#: centreon-bam/www/modules/centreon-bam-server/react/hooks/header/topCounter
+# msgid "B.Activities"
+# msgstr ""

--- a/centreon/packages/ui/src/TopCounterElements/TopCounterLayout.tsx
+++ b/centreon/packages/ui/src/TopCounterElements/TopCounterLayout.tsx
@@ -72,11 +72,11 @@ const useStyles = makeStyles()((theme) => ({
     boxShadow: theme.shadows[3],
     boxSizing: 'border-box',
     left: 0,
+    minWidth: theme.spacing(20),
     position: 'absolute',
     textAlign: 'left',
     top: `calc(100% + ${theme.spacing(1.25)})`,
     visibility: 'hidden',
-    width: theme.spacing(20),
     zIndex: theme.zIndex.mobileStepper
   },
   subMenuOpen: {

--- a/centreon/www/front_src/src/Header/Poller/PollerSubMenu/PollerSubMenu.tsx
+++ b/centreon/www/front_src/src/Header/Poller/PollerSubMenu/PollerSubMenu.tsx
@@ -10,6 +10,7 @@ const useStyles = makeStyles()((theme) => ({
     textDecoration: 'none'
   },
   list: {
+    minWidth: theme.spacing(27),
     padding: 0
   },
   listItem: {

--- a/centreon/www/front_src/src/Header/Poller/getPollerPropsAdapter.ts
+++ b/centreon/www/front_src/src/Header/Poller/getPollerPropsAdapter.ts
@@ -14,7 +14,8 @@ import {
   labelLatencyDetected,
   labelNoLatencyDetected,
   labelAllPollers,
-  labelConfigurePollers
+  labelConfigurePollers,
+  labelPollers
 } from './translatedLabels';
 import type { PollerStatusIconProps } from './PollerStatusIcon';
 import type { PollerSubMenuProps } from './PollerSubMenu/PollerSubMenu';
@@ -56,6 +57,7 @@ interface GetPollerPropsAdapterProps {
 }
 
 export interface GetPollerPropsAdapterResult {
+  buttonLabel: string;
   iconSeverities: PollerStatusIconProps['iconSeverities'];
   subMenu: Omit<PollerSubMenuProps, 'closeSubMenu'>;
 }
@@ -101,6 +103,7 @@ export const getPollerPropsAdapter = ({
   };
 
   const result = {
+    buttonLabel: t(labelPollers),
     iconSeverities: topIconProps,
     subMenu: {
       allPollerLabel: t(labelAllPollers),
@@ -109,7 +112,7 @@ export const getPollerPropsAdapter = ({
       },
       issues: formatedIssues,
       pollerConfig: {
-        isAllowed: allowedPages?.includes(pollerConfigurationPageNumber),
+        isAllowed: !!allowedPages?.includes(pollerConfigurationPageNumber),
         label: t(labelConfigurePollers),
         redirect: (): void =>
           navigate(`/main.php?p=${pollerConfigurationPageNumber}`),

--- a/centreon/www/front_src/src/Header/Poller/index.tsx
+++ b/centreon/www/front_src/src/Header/Poller/index.tsx
@@ -5,7 +5,6 @@ import { MenuSkeleton, TopCounterLayout } from '@centreon/ui';
 import PollerStatusIcon from './PollerStatusIcon';
 import { PollerSubMenu } from './PollerSubMenu/PollerSubMenu';
 import { usePollerData } from './usePollerData';
-import { labelPollers } from './translatedLabels';
 
 const ServiceStatusCounter = (): JSX.Element | null => {
   const { isLoading, data, isAllowed } = usePollerData();
@@ -27,7 +26,7 @@ const ServiceStatusCounter = (): JSX.Element | null => {
       renderSubMenu={({ closeSubMenu }): JSX.Element => (
         <PollerSubMenu {...data.subMenu} closeSubMenu={closeSubMenu} />
       )}
-      title={labelPollers}
+      title={data.buttonLabel}
     />
   );
 };

--- a/centreon/www/front_src/src/Header/Resources/Host/getHostPropsAdapter.ts
+++ b/centreon/www/front_src/src/Header/Resources/Host/getHostPropsAdapter.ts
@@ -27,10 +27,12 @@ import {
   labelDown,
   labelPending,
   labelUnreachable,
-  labelUp
+  labelUp,
+  labelHosts
 } from './translatedLabels';
 
 export interface HostPropsAdapterOutput {
+  buttonLabel: string;
   counters: CounterProps['counters'];
   hasPending: boolean;
   items: SubMenuProps['items'];
@@ -168,6 +170,7 @@ const getHostPropsAdapter: GetHostPropsAdapter = ({
   };
 
   return {
+    buttonLabel: t(labelHosts),
     counters: ['down', 'unreachable', 'up'].map((statusName) => {
       const { to, shortCount, topCounterAriaLabel, onClick, severityCode } =
         config[statusName];

--- a/centreon/www/front_src/src/Header/Resources/Host/index.tsx
+++ b/centreon/www/front_src/src/Header/Resources/Host/index.tsx
@@ -14,7 +14,6 @@ import type { HostStatusResponse } from '../../api/decoders';
 
 import getHostPropsAdapter from './getHostPropsAdapter';
 import type { HostPropsAdapterOutput } from './getHostPropsAdapter';
-import { labelHosts } from './translatedLabels';
 
 const HostStatusCounter = (): JSX.Element | null => {
   const { isLoading, data, isAllowed } = useResourceCounters<
@@ -45,7 +44,7 @@ const HostStatusCounter = (): JSX.Element | null => {
         <TopCounterResourceSubMenu items={data.items} />
       )}
       showPendingBadge={data.hasPending}
-      title={labelHosts}
+      title={data.buttonLabel}
     />
   );
 };

--- a/centreon/www/front_src/src/Header/Resources/Service/getServicePropsAdapter.ts
+++ b/centreon/www/front_src/src/Header/Resources/Service/getServicePropsAdapter.ts
@@ -30,10 +30,12 @@ import {
   labelWarning,
   labelPending,
   labelUnknown,
-  labelOk
+  labelOk,
+  labelServices
 } from './translatedLabels';
 
 export interface ServicesPropsAdapterOutput {
+  buttonLabel: string;
   counters: CounterProps['counters'];
   hasPending: boolean;
   items: SubMenuProps['items'];
@@ -206,6 +208,7 @@ const getServicePropsAdapter: GetServicePropsAdapter = ({
   };
 
   return {
+    buttonLabel: t(labelServices),
     counters: ['critical', 'warning', 'unknown', 'ok'].map((statusName) => {
       const { to, shortCount, topCounterAriaLabel, onClick, severityCode } =
         config[statusName];

--- a/centreon/www/front_src/src/Header/Resources/Service/index.tsx
+++ b/centreon/www/front_src/src/Header/Resources/Service/index.tsx
@@ -14,7 +14,6 @@ import { serviceStatusEndpoint } from '../../api/endpoints';
 
 import type { ServicesPropsAdapterOutput } from './getServicePropsAdapter';
 import getServicePropsAdapter from './getServicePropsAdapter';
-import { labelServices } from './translatedLabels';
 
 const ServiceStatusCounter = (): JSX.Element | null => {
   const { isLoading, data, isAllowed } = useResourceCounters<
@@ -45,7 +44,7 @@ const ServiceStatusCounter = (): JSX.Element | null => {
         <TopCounterResourceSubMenu items={data.items} />
       )}
       showPendingBadge={data.hasPending}
-      title={labelServices}
+      title={data.buttonLabel}
     />
   );
 };

--- a/centreon/www/front_src/src/Header/index.tsx
+++ b/centreon/www/front_src/src/Header/index.tsx
@@ -30,16 +30,25 @@ const useStyles = makeStyles()((theme) => ({
     padding: `${theme.spacing(1)} ${theme.spacing(3)}`
   },
   item: {
+    '&:empty, &:last-of-type': {
+      marginRight: 0
+    },
     '&:first-of-type': {
       borderRight: `solid 1px ${theme.palette.common.white}`,
-      marginRight: theme.spacing(3),
-      paddingRight: theme.spacing(3)
+      marginRight: theme.spacing(3.5),
+      paddingRight: theme.spacing(3.5),
+
+      [theme.breakpoints.down(960)]: {
+        marginRight: theme.spacing(2.5),
+        paddingRight: theme.spacing(2.5)
+      }
     },
     flex: 'initial',
-    [theme.breakpoints.down(768)]: {
-      marginRight: theme.spacing(4)
-    },
-    marginRight: theme.spacing(4)
+    marginRight: theme.spacing(6),
+
+    [theme.breakpoints.down(960)]: {
+      marginRight: theme.spacing(3.5)
+    }
   },
   leftContainer: {
     alignItems: 'center',


### PR DESCRIPTION
## Description

- fix top counter chip layout bug when the device is between 668px and 773px wide
- fix translation of all top counter button labels
- fix the poller submenu button splitting in two different lines

**Fixes** # 
[(issue 1)](https://centreon.atlassian.net/browse/MON-15815) 
[(issue 2)](https://centreon.atlassian.net/browse/MON-17677)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
