### PR TITLE
enh(OpenID): Trim extra spaces and slashes in endpoint definition

### DIFF
--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/Model/Endpoint.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/Model/Endpoint.php
@@ -99,17 +99,36 @@ class Endpoint
      */
     private function guardUrl(): void
     {
-        if (
-            $this->type === self::CUSTOM &&
-            (
+        if ($this->type === self::CUSTOM) {
+            $this->url = $this->sanitizeEndpointValue($this->url);
+            if (
                 $this->url === null ||
                 (
                     !str_starts_with($this->url, '/') &&
                     filter_var($this->url, FILTER_VALIDATE_URL, FILTER_FLAG_PATH_REQUIRED) === false
                 )
-            )
-        ) {
-            throw InvalidEndpointException::invalidUrl();
+            ) {
+                throw InvalidEndpointException::invalidUrl();
+            }
         }
+    }
+
+    /**
+     * Trim unnecessary spaces and slashes in endpoint and return a valid endpoint value
+     *
+     * @param ?string $value
+     * @return ?string
+     */
+    private function sanitizeEndpointValue(?string $value): ?string
+    {
+        if ($value === null || strlen(trim($value, ' /')) === 0) {
+            return null;
+        }
+
+        if (str_contains($value, 'http://') || str_contains($value, 'https://')) {
+            return ltrim(rtrim($value, ' /'));
+        }
+
+        return '/' . trim($value, ' /');
     }
 }

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/OpenId/Model/CustomConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/OpenId/Model/CustomConfiguration.php
@@ -581,15 +581,15 @@ final class CustomConfiguration implements CustomConfigurationInterface, OpenIdC
         $this->setClientId($json['client_id']);
         $this->setAutoImportEnabled($json['auto_import']);
         $this->setClientSecret($json['client_secret']);
-        $this->setBaseUrl($json['base_url']);
-        $this->setAuthorizationEndpoint($json['authorization_endpoint']);
-        $this->setTokenEndpoint($json['token_endpoint']);
-        $this->setIntrospectionTokenEndpoint($json['introspection_token_endpoint']);
-        $this->setUserInformationEndpoint($json['userinfo_endpoint']);
+        $this->setBaseUrl($this->sanitizeEndpointValue($json['base_url']));
+        $this->setAuthorizationEndpoint($this->sanitizeEndpointValue($json['authorization_endpoint']));
+        $this->setTokenEndpoint($this->sanitizeEndpointValue($json['token_endpoint']));
+        $this->setIntrospectionTokenEndpoint($this->sanitizeEndpointValue($json['introspection_token_endpoint']));
+        $this->setUserInformationEndpoint($this->sanitizeEndpointValue($json['userinfo_endpoint']));
         $this->setContactTemplate($json['contact_template']);
         $this->setEmailBindAttribute($json['email_bind_attribute']);
         $this->setUserNameBindAttribute($json['fullname_bind_attribute']);
-        $this->setEndSessionEndpoint($json['endsession_endpoint']);
+        $this->setEndSessionEndpoint($this->sanitizeEndpointValue($json['endsession_endpoint']));
         $this->setConnectionScopes($json['connection_scopes']);
         $this->setLoginClaim($json['login_claim']);
         $this->setAuthenticationType($json['authentication_type']);
@@ -677,5 +677,24 @@ final class CustomConfiguration implements CustomConfigurationInterface, OpenIdC
                 $missingMandatoryParameters
             );
         }
+    }
+
+    /**
+     * Trim unnecessary spaces and slashes in endpoint and return a valid endpoint value
+     *
+     * @param ?string $value
+     * @return ?string
+     */
+    private function sanitizeEndpointValue(?string $value): ?string
+    {
+        if ($value === null || strlen(trim($value, ' /')) === 0) {
+            return null;
+        }
+
+        if (str_contains($value, 'http://') || str_contains($value, 'https://')) {
+            return ltrim(rtrim($value, ' /'));
+        }
+
+        return '/' . trim($value, ' /');
     }
 }

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Domain/Model/EndpointTest.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Domain/Model/EndpointTest.php
@@ -34,10 +34,6 @@ it('should throw an exception with a bad endpoint type', function () {
     (new Endpoint('bad_type', $this->custom_relative_url));
 })->throws(InvalidEndpointException::class, InvalidEndpointException::invalidType()->getMessage());
 
-it('should throw an exception with a bad relative URL', function () {
-    (new Endpoint(Endpoint::CUSTOM, 'bad_relative_url'));
-})->throws(InvalidEndpointException::class, InvalidEndpointException::invalidUrl()->getMessage());
-
 it('should return an EndpointCondition instance with a correct relative URL', function () {
     $endpointCondition = new Endpoint(Endpoint::CUSTOM, $this->custom_relative_url);
     expect($endpointCondition->getUrl())->toBe($this->custom_relative_url);

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Domain/Model/EndpointTest.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Domain/Model/EndpointTest.php
@@ -20,7 +20,7 @@
 
 declare(strict_types=1);
 
-namespace Tests\Core\Security\ProviderConfiguration\Application\WebSSO\UseCase\FindWebSSOConfiguration;
+namespace Tests\Core\Security\ProviderConfiguration\Domain\Model;
 
 use Core\Security\ProviderConfiguration\Domain\Model\Endpoint;
 use Core\Security\ProviderConfiguration\Domain\Exception\InvalidEndpointException;
@@ -62,4 +62,18 @@ it('should throw an exception with a null URL and a custom type', function () {
 
 it('should throw an exception with an empty URL and a custom type', function () {
     (new Endpoint(Endpoint::CUSTOM, ''));
+})->throws(InvalidEndpointException::class, InvalidEndpointException::invalidUrl()->getMessage());
+
+it(
+    'should return an EndpointCondition instance when an URL type is Custom and it contains additional slashes',
+    function () {
+        $urlWithAdditionalShlashes = '   //info/   ';
+        $sanitizedURL = '/info';
+        $endpointCondition = new Endpoint(Endpoint::CUSTOM, $urlWithAdditionalShlashes);
+        expect($endpointCondition->getUrl())->toBe($sanitizedURL);
+    }
+);
+
+it('should throw an exception when a custom type URL contains only spaces and/or slashes', function () {
+    (new Endpoint(Endpoint::CUSTOM, '    ///  '));
 })->throws(InvalidEndpointException::class, InvalidEndpointException::invalidUrl()->getMessage());

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Domain/OpenId/Model/CustomConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Domain/OpenId/Model/CustomConfigurationTest.php
@@ -24,10 +24,12 @@ namespace Tests\Core\Security\ProviderConfiguration\Domain\OpenId\Model;
 
 use Core\Contact\Domain\Model\ContactTemplate;
 use Core\Security\ProviderConfiguration\Domain\Model\Endpoint;
-use Core\Security\ProviderConfiguration\Domain\OpenId\Model\ACLConditions;
-use Core\Security\ProviderConfiguration\Domain\OpenId\Model\AuthenticationConditions;
-use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
-use Core\Security\ProviderConfiguration\Domain\OpenId\Model\GroupsMapping;
+use Core\Security\ProviderConfiguration\Domain\OpenId\Model\{
+    ACLConditions,
+    AuthenticationConditions,
+    CustomConfiguration,
+    GroupsMapping
+};
 
 it(
     'should sanitize URL/endpoint values when they contain additional slashes and/or spaces in the beginning and end',

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Domain/OpenId/Model/CustomConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Domain/OpenId/Model/CustomConfigurationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  For more information : contact@centreon.com
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\ProviderConfiguration\Domain\OpenId\Model;
+
+use Core\Contact\Domain\Model\ContactTemplate;
+use Core\Security\ProviderConfiguration\Domain\Model\Endpoint;
+use Core\Security\ProviderConfiguration\Domain\OpenId\Model\ACLConditions;
+use Core\Security\ProviderConfiguration\Domain\OpenId\Model\AuthenticationConditions;
+use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
+use Core\Security\ProviderConfiguration\Domain\OpenId\Model\GroupsMapping;
+
+it(
+    'should sanitize URL/endpoint values when they contain additional slashes and/or spaces in the beginning and end',
+    function () {
+        $json = [
+            'is_active' => true,
+            'is_forced' => false,
+            'base_url' => '   https://localhost:8080',
+            'authorization_endpoint' => '/authorize/ ',
+            'token_endpoint' => '/token  ',
+            'introspection_token_endpoint' => '// introspection/',
+            'userinfo_endpoint' => '//userinfo',
+            'endsession_endpoint' => '/ logout',
+            'connection_scopes' => ['openid', 'offline_access'],
+            'login_claim' => 'given_name',
+            'client_id' => 'user2',
+            'client_secret' => 'Centreon!2021',
+            'authentication_type' => 'client_secret_post',
+            'verify_peer' => false,
+            'auto_import' => true,
+            'contact_template' => (new ContactTemplate(19, 'contact_template')),
+            'email_bind_attribute' => 'email',
+            'fullname_bind_attribute' => 'given_name',
+            'authentication_conditions' => (
+                new AuthenticationConditions(
+                    true,
+                    'users.roles.info.status',
+                    (new Endpoint('custom_endpoint', '  /my/custom/endpoint')),
+                    ['status2']
+                )
+            ),
+            'roles_mapping' => (
+                new ACLConditions(
+                    false,
+                    false,
+                    'users.roles.info.status',
+                    (new Endpoint('custom_endpoint', '///my/custom/endpoint'))
+                )
+            ),
+            'groups_mapping' => (
+                new GroupsMapping(
+                    false,
+                    'users.roles.info.status',
+                    (new Endpoint('custom_endpoint', '/my/custom/endpoint//')),
+                    []
+                )
+            )
+        ];
+
+        $customConfiguration = new CustomConfiguration($json);
+
+        expect($customConfiguration->getBaseUrl())->toBe('https://localhost:8080');
+        expect($customConfiguration->getAuthorizationEndpoint())->toBe('/authorize');
+        expect($customConfiguration->getTokenEndpoint())->toBe('/token');
+        expect($customConfiguration->getIntrospectionTokenEndpoint())->toBe('/introspection');
+        expect($customConfiguration->getUserInformationEndpoint())->toBe('/userinfo');
+        expect($customConfiguration->getEndSessionEndpoint())->toBe('/logout');
+        expect($customConfiguration->getAuthenticationConditions()->getEndpoint()->getUrl())
+            ->toBe('/my/custom/endpoint');
+        expect($customConfiguration->getACLConditions()->getEndpoint()->getUrl())->toBe('/my/custom/endpoint');
+        expect($customConfiguration->getGroupsMapping()->getEndpoint()->getUrl())->toBe('/my/custom/endpoint');
+    }
+);


### PR DESCRIPTION
## Description

Removed extra spaces and slashes in endpoint definition

**Fixes** # MON-17274

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Configure OpenID Authentication
- For each endpoints add a slash before and after: “ /auth “ or “/endpoint///”
- Save the form
- Validate that extra slashes or spaces have been removed
- Try to connect

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
