### PR TITLE
Mon 17529 fix status chip display error

### DIFF
--- a/centreon/packages/ui/src/StatusChip/index.tsx
+++ b/centreon/packages/ui/src/StatusChip/index.tsx
@@ -5,54 +5,38 @@ import { makeStyles } from 'tss-react/mui';
 
 import { Chip, ChipProps } from '@mui/material';
 
-import useStyleTable from '../Listing/useStyleTable';
-import { TableStyleAtom } from '../Listing/models';
 import { getStatusColors, SeverityCode } from '../utils/statuses';
 
 export type Props = {
   clickable?: boolean;
   label?: string | ReactNode;
   severityCode: SeverityCode;
-  statusColumn?: boolean;
 } & ChipProps;
 
 interface StylesProps {
-  data: TableStyleAtom['statusColumnChip'];
   severityCode: SeverityCode;
 }
 
-const useStyles = makeStyles<StylesProps>()(
-  (theme, { severityCode, data }) => ({
-    chip: {
-      '&:hover': { ...getStatusColors({ severityCode, theme }) },
-      ...getStatusColors({ severityCode, theme }),
-      '& .MuiChip-label': {
-        alignItems: 'center',
-        display: 'flex',
-        height: '100%',
-        padding: 0
-      }
-    },
-    statusColumnContainer: {
-      fontWeight: 'bold',
-      height: data.height,
-      marginLeft: 1,
-      minWidth: theme.spacing((data.width - 1) / 8)
+const useStyles = makeStyles<StylesProps>()((theme, { severityCode }) => ({
+  chip: {
+    '&:hover': { ...getStatusColors({ severityCode, theme }) },
+    ...getStatusColors({ severityCode, theme }),
+    '& .MuiChip-label': {
+      alignItems: 'center',
+      display: 'flex',
+      height: '100%'
     }
-  })
-);
+  }
+}));
 
 const StatusChip = ({
   severityCode,
   label,
   clickable = false,
-  statusColumn = false,
   className,
   ...rest
 }: Props): JSX.Element => {
-  const { dataStyle } = useStyleTable({});
   const { classes, cx } = useStyles({
-    data: dataStyle.statusColumnChip,
     severityCode
   });
 
@@ -61,9 +45,7 @@ const StatusChip = ({
 
   return (
     <Chip
-      className={cx(classes.chip, className, {
-        [classes.statusColumnContainer]: statusColumn
-      })}
+      className={cx(classes.chip, className)}
       clickable={clickable}
       label={
         equals(typeof label, 'string') ? lowerLabel(label as string) : label

--- a/centreon/packages/ui/src/index.ts
+++ b/centreon/packages/ui/src/index.ts
@@ -27,6 +27,7 @@ export { default as SelectField } from './InputField/Select';
 export { default as IconPopoverMultiSelectField } from './InputField/Select/IconPopover';
 
 export { default as Listing, MemoizedListing } from './Listing';
+export { default as useStyleTable } from './Listing/useStyleTable';
 export type { Props as ListingProps } from './Listing';
 
 export { ColumnType } from './Listing/models';

--- a/centreon/www/front_src/src/Resources/Details/tabs/Timeline/Event.tsx
+++ b/centreon/www/front_src/src/Resources/Details/tabs/Timeline/Event.tsx
@@ -11,6 +11,7 @@ import FaceIcon from '@mui/icons-material/Face';
 
 import { useLocaleDateTimeFormat } from '@centreon/ui';
 
+import CompactStatusChip from '../CompactStatusChip';
 import {
   labelEvent,
   labelComment,
@@ -31,9 +32,6 @@ import {
 } from '../../../translatedLabels';
 import DowntimeChip from '../../../Chip/Downtime';
 import AcknowledgeChip from '../../../Chip/Acknowledge';
-import CompactStatusChip, {
-  useCompactStatusChipStyles
-} from '../CompactStatusChip';
 import OutputInformation from '../OutputInformation';
 
 import { TimelineEvent, Type } from './models';
@@ -70,6 +68,11 @@ const getTypeIds = (): Array<string> => {
 };
 
 const useStyles = makeStyles()((theme) => ({
+  author: {
+    borderRadius: theme.spacing(1.75),
+    height: theme.spacing(2.75),
+    paddingLeft: 0
+  },
   chip: {
     display: 'flex'
   },
@@ -81,11 +84,13 @@ const useStyles = makeStyles()((theme) => ({
     padding: theme.spacing(1)
   },
   eventTimeLineContainer: {
+    alignContent: 'center',
     alignItems: 'center',
+    columnGap: theme.spacing(2),
     display: 'flex',
     flexGrow: 0.5,
     flexWrap: 'wrap',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-start',
     marginBottom: theme.spacing(1),
     padding: theme.spacing(0, 1),
     rowGap: theme.spacing(1)
@@ -96,13 +101,11 @@ const useStyles = makeStyles()((theme) => ({
     gridGap: theme.spacing(1)
   },
   infoHeader: {
-    alignItems: 'start',
+    alignItems: 'center',
     display: 'grid',
     gridAutoFlow: 'column',
     gridGap: theme.spacing(2),
-    gridTemplateColumns: 'minmax(80px, auto) auto 1fr',
-    marginBottom: theme.spacing(1),
-    marginRight: theme.spacing(2)
+    gridTemplateColumns: 'minmax(80px, auto) auto 1fr'
   },
   outputContainer: {
     alignItems: 'center',
@@ -133,13 +136,12 @@ const Date = ({ event }: Props): JSX.Element => {
 };
 
 const Author = ({ event }: Props): JSX.Element => {
-  const classes = useCompactStatusChipStyles();
-
+  const { classes } = useStyles();
   const contactName = event.contact?.name || '';
 
   return (
     <Chip
-      className={classes.root}
+      className={classes.author}
       icon={<FaceIcon />}
       label={contactName}
       size="small"

--- a/centreon/www/front_src/src/Resources/Details/tabs/Timeline/Events/index.tsx
+++ b/centreon/www/front_src/src/Resources/Details/tabs/Timeline/Events/index.tsx
@@ -64,10 +64,9 @@ const useStyles = makeStyles()((theme) => ({
   },
   timelineDot: {
     alignItems: 'center',
+    boxSizing: 'content-box',
     display: 'grid',
-    height: theme.spacing(3),
-    justifyItems: 'center',
-    width: theme.spacing(3)
+    justifyItems: 'center'
   }
 }));
 

--- a/centreon/www/front_src/src/Resources/Listing/columns/Status.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/columns/Status.tsx
@@ -5,7 +5,12 @@ import { makeStyles } from 'tss-react/mui';
 import IconAcknowledge from '@mui/icons-material/Person';
 import IconCheck from '@mui/icons-material/Sync';
 
-import { SeverityCode, StatusChip, IconButton } from '@centreon/ui';
+import {
+  SeverityCode,
+  StatusChip,
+  IconButton,
+  useStyleTable
+} from '@centreon/ui';
 import type { ComponentColumnProps } from '@centreon/ui';
 
 import useAclQuery from '../../Actions/Resource/aclQuery';
@@ -20,7 +25,14 @@ import {
 
 import { ColumnProps } from '.';
 
-const useStyles = makeStyles()((theme) => ({
+interface StylesProps {
+  data: {
+    height: number;
+    width: number;
+  };
+}
+
+const useStyles = makeStyles<StylesProps>()((theme, { data }) => ({
   actions: {
     alignItems: 'center',
     display: 'flex',
@@ -31,6 +43,13 @@ const useStyles = makeStyles()((theme) => ({
   statusColumn: {
     alignItems: 'center',
     display: 'flex',
+    width: '100%'
+  },
+  statusColumnChip: {
+    fontWeight: 'bold',
+    height: data.height,
+    marginLeft: 1,
+    minWidth: theme.spacing((data.width - 1) / 8),
     width: '100%'
   }
 }));
@@ -43,7 +62,8 @@ const StatusColumnOnHover = ({
   actions,
   row
 }: StatusColumnProps): JSX.Element => {
-  const { classes } = useStyles();
+  const { dataStyle } = useStyleTable({});
+  const { classes } = useStyles({ data: dataStyle.statusColumnChip });
   const { t } = useTranslation();
 
   const { canAcknowledge, canDowntime, canCheck } = useAclQuery();
@@ -121,7 +141,10 @@ const StatusColumn = ({
   t
 }: ColumnProps): ((props: ComponentColumnProps) => JSX.Element) => {
   const Status = ({ row, isHovered }: ComponentColumnProps): JSX.Element => {
-    const { classes } = useStyles();
+    const { dataStyle } = useStyleTable({});
+    const { classes } = useStyles({
+      data: dataStyle.statusColumnChip
+    });
 
     const statusName = row.status.name;
 
@@ -131,7 +154,7 @@ const StatusColumn = ({
           <StatusColumnOnHover actions={actions} row={row} />
         ) : (
           <StatusChip
-            statusColumn
+            className={classes.statusColumnChip}
             label={t(statusName)}
             severityCode={row.status.severity_code}
           />


### PR DESCRIPTION
## Description

- add padding around status chips
- fix ressources table status chip layout issue (not centering and growing properly)
- fix ressource detail timeline tab left icon
- fix timeline Event layout
- fix timeline author chip layout

**Fixes** # [(issue)](https://centreon.atlassian.net/browse/MON-17529)

<img width="1034" alt="Capture d’écran 2023-03-27 à 15 44 50" src="https://user-images.githubusercontent.com/14542464/228187968-47442915-9ccf-4ca5-b85a-3e05041d05d6.png">
t/browse/MON-17529)

<img width="836" alt="Capture d’écran 2023-03-28 à 11 14 58" src="https://user-images.githubusercontent.com/14542464/228189299-739a5154-a2e6-47de-920c-6ab3a0d50f39.png">

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- check that any chips are displaying correctly in the resource detail panel
- check that the status chip in the ressource table are always the same width, regardless of there types or user language

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
