### PR TITLE
enh(OpenID): Trim extra spaces and slashes in endpoint definition - 22.04.x

### DIFF
--- a/centreon/src/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilder.php
+++ b/centreon/src/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilder.php
@@ -79,7 +79,7 @@ class ConfigurationBuilder
             ->setActive($request->isActive)
             ->setTrustedClientAddresses($request->trustedClientAddresses)
             ->setBlacklistClientAddresses($request->blacklistClientAddresses)
-            ->setEndSessionEndpoint($request->endSessionEndpoint)
+            ->setEndSessionEndpoint(self::sanitizeEndpointValue($request->endSessionEndpoint))
             ->setConnectionScopes($request->connectionScopes)
             ->setLoginClaim($request->loginClaim)
             ->setAuthenticationType($request->authenticationType)
@@ -87,11 +87,11 @@ class ConfigurationBuilder
             ->setAuthorizationRules($authorizationRules)
             ->setAutoImportEnabled($request->isAutoImportEnabled)
             ->setClientSecret($request->clientSecret)
-            ->setBaseUrl($request->baseUrl)
-            ->setAuthorizationEndpoint($request->authorizationEndpoint)
-            ->setTokenEndpoint($request->tokenEndpoint)
-            ->setIntrospectionTokenEndpoint($request->introspectionTokenEndpoint)
-            ->setUserInformationEndpoint($request->userInformationEndpoint)
+            ->setBaseUrl(self::sanitizeEndpointValue($request->baseUrl))
+            ->setAuthorizationEndpoint(self::sanitizeEndpointValue($request->authorizationEndpoint))
+            ->setTokenEndpoint(self::sanitizeEndpointValue($request->tokenEndpoint))
+            ->setIntrospectionTokenEndpoint(self::sanitizeEndpointValue($request->introspectionTokenEndpoint))
+            ->setUserInformationEndpoint(self::sanitizeEndpointValue($request->userInformationEndpoint))
             ->setContactTemplate($contactTemplate)
             ->setEmailBindAttribute($request->emailBindAttribute)
             ->setUserNameBindAttribute($request->userNameBindAttribute)
@@ -127,5 +127,24 @@ class ConfigurationBuilder
                 $missingMandatoryParameters
             );
         }
+    }
+
+    /**
+     * Trim unnecessary spaces and slashes in endpoint and return a valid endpoint value
+     *
+     * @param ?string $value
+     * @return ?string
+     */
+    private static function sanitizeEndpointValue(?string $value): ?string
+    {
+        if ($value === null || strlen(trim($value, ' /')) === 0) {
+            return null;
+        }
+
+        if (str_contains($value, 'http://') || str_contains($value, 'https://')) {
+            return ltrim(rtrim($value, ' /'));
+        }
+
+        return '/' . trim($value, ' /');
     }
 }

--- a/centreon/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilderTest.php
+++ b/centreon/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/Builder/ConfigurationBuilderTest.php
@@ -108,3 +108,29 @@ it('should return a Configuration when all mandatory parameters are present', fu
     $configuration = ConfigurationBuilder::create($request, $contactTemplate, $contactGroup, []);
     expect($configuration)->toBeInstanceOf(Configuration::class);
 });
+
+it('should sanitize endpoint definitions when they contain extra spaces and/or slashe', function () {
+    $request = new UpdateOpenIdConfigurationRequest();
+    $request->clientId = "clientId";
+    $request->clientSecret = "clientSecret";
+    $request->baseUrl = "   http://127.0.0.1/openid";
+    $request->authorizationEndpoint = "//authorize  ";
+    $request->tokenEndpoint = "  / token";
+    $request->isActive = true;
+    $request->introspectionTokenEndpoint = '/introspect /';
+    $request->isAutoImportEnabled = true;
+    $request->userNameBindAttribute = 'name';
+    $request->emailBindAttribute = 'email';
+    $request->endSessionEndpoint = ' // logout';
+    $request->userInformationEndpoint = '   userinfo';
+    $contactTemplate = new ContactTemplate(1, 'contact_template');
+    $contactGroup = new ContactGroup(1, 'contact_group');
+    $configuration = ConfigurationBuilder::create($request, $contactTemplate, $contactGroup, []);
+
+    expect($configuration->getBaseUrl())->toBe('http://127.0.0.1/openid');
+    expect($configuration->getAuthorizationEndpoint())->toBe('/authorize');
+    expect($configuration->getTokenEndpoint())->toBe('/token');
+    expect($configuration->getIntrospectionTokenEndpoint())->toBe('/introspect');
+    expect($configuration->getEndSessionEndpoint())->toBe('/logout');
+    expect($configuration->getUserInformationEndpoint())->toBe('/userinfo');
+});


### PR DESCRIPTION
## Description

Removed extra spaces and slashes in endpoint definition

**Fixes** # MON-17274

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Configure OpenID Authentication
- For each endpoints add a slash before and after: “ /auth “ or “/endpoint///”
- Save the form
- Validate that extra slashes or spaces have been removed
- Try to connect

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
