### PR TITLE
fix(auth) decode the contact_ldap_dn before the authentication (22.10)

### DIFF
--- a/centreon/www/class/centreonAuth.LDAP.class.php
+++ b/centreon/www/class/centreonAuth.LDAP.class.php
@@ -76,6 +76,9 @@ class CentreonAuthLDAP
          * Set contact Information
          */
         $this->contactInfos = $contactInfos;
+        if (!empty($this->contactInfos['contact_ldap_dn'])) {
+            $this->contactInfos['contact_ldap_dn'] = html_entity_decode($this->contactInfos['contact_ldap_dn']);
+        }
 
         /*
          * Keep password


### PR DESCRIPTION
## Description

When a LDAP contact is inserted in the DB, we encore some characters like simple quotes.
We have to decode them before contacting the LDAP server in order to give him good info.

**Fixes** MON-17685

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)
