### PR TITLE
enh(API): Modifies the CreateResponse ID so that it can handle different types.

### DIFF
--- a/centreon/src/Core/Application/Common/UseCase/CreatedResponse.php
+++ b/centreon/src/Core/Application/Common/UseCase/CreatedResponse.php
@@ -24,30 +24,34 @@ declare(strict_types=1);
 namespace Core\Application\Common\UseCase;
 
 /**
- * @template T
+ * @template R
+ * @template P
  */
 class CreatedResponse implements ResponseStatusInterface
 {
     /**
-     * @param int $resourceId
-     * @param T $payload
+     * @param R $resourceId
+     * @param P $payload
      */
     public function __construct(
-        readonly private int $resourceId,
+        readonly private mixed $resourceId,
         private mixed $payload
     ) {
     }
 
     /**
-     * @return int
+     * @return R
      */
-    public function getResourceId(): int
+    public function getResourceId(): mixed
     {
-        return $this->resourceId;
+        return match (gettype($this->resourceId)) {
+            'integer', 'string' => $this->resourceId,
+            default => (string) $this->resourceId,
+        };
     }
 
     /**
-     * @return T
+     * @return P
      */
     public function getPayload(): mixed
     {
@@ -55,7 +59,7 @@ class CreatedResponse implements ResponseStatusInterface
     }
 
     /**
-     * @param mixed $payload
+     * @param P $payload
      */
     public function setPayload(mixed $payload): void
     {


### PR DESCRIPTION
## Description

Modifies the CreateResponse ID so that it can handle different types.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
