### PR TITLE
fix(www): snackbar error when user does not have ACL for status counters

### DIFF
--- a/centreon/www/front_src/src/Header/Poller/usePollerData.ts
+++ b/centreon/www/front_src/src/Header/Poller/usePollerData.ts
@@ -17,7 +17,6 @@ import type { GetPollerPropsAdapterResult } from './getPollerPropsAdapter';
 
 interface UsePollerDataResult {
   data: GetPollerPropsAdapterResult | null;
-  error: unknown;
   isAllowed: boolean;
   isLoading: boolean;
 }
@@ -39,6 +38,7 @@ export const usePollerData = (): UsePollerDataResult => {
     decoder: pollerIssuesDecoder,
     getEndpoint: () => pollerListIssuesEndPoint,
     getQueryKey: () => [pollerListIssuesEndPoint, 'get-poller-status'],
+    httpCodesBypassErrorSnackbar: [401],
     queryOptions: {
       refetchInterval: refetchInterval * 1000
     }

--- a/centreon/www/front_src/src/Header/Resources/useResourceCounters.tsx
+++ b/centreon/www/front_src/src/Header/Resources/useResourceCounters.tsx
@@ -63,6 +63,7 @@ const useResourceCounters: UseRessourceCounters = ({
     decoder,
     getEndpoint: () => endPoint,
     getQueryKey: () => [endPoint, queryName],
+    httpCodesBypassErrorSnackbar: [401],
     queryOptions: {
       refetchInterval: refetchInterval * 1000
     }


### PR DESCRIPTION
## Description

**Fixes** # [(issue)](https://centreon.atlassian.net/browse/MON-17414)

When user does not have the access rights to see the top counters, we should not display a toaster error message. 


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

## Checklist

Create an user with ACLs that does not allow him to see the top counters
- user should not see a toaster with the "something went wrong message"

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
