### PR TITLE
fix (Authentication): PHP error on authentication APIs (dev-2204) 

### DIFF
--- a/centreon/src/Core/Security/Infrastructure/Api/LoginSession/LoginSessionController.php
+++ b/centreon/src/Core/Security/Infrastructure/Api/LoginSession/LoginSessionController.php
@@ -22,6 +22,10 @@ declare(strict_types=1);
 
 namespace Core\Security\Infrastructure\Api\LoginSession;
 
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Dropbox\Exception;
+use http\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Centreon\Application\Controller\AbstractController;
 use Core\Security\Application\UseCase\LoginSession\LoginSession;
@@ -45,7 +49,16 @@ class LoginSessionController extends AbstractController
         LoginSessionPresenterInterface $presenter,
         SessionInterface $session,
     ): object {
-        $this->validateDataSent($request, __DIR__ . '/LoginSessionSchema.json');
+
+        try {
+            $this->validateDataSent($request, __DIR__ . '/LoginSessionSchema.json');
+        } catch (\InvalidArgumentException $ex) {
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex->getMessage()));
+            return $presenter->show();
+        } catch (\Throwable $ex) {
+            $presenter->setResponseStatus(new ErrorResponse($ex->getMessage()));
+            return $presenter->show();
+        }
 
         $loginSessionRequest = $this->createLoginSessionRequest($request);
 

--- a/centreon/src/Core/Security/Infrastructure/Api/LoginSession/LoginSessionController.php
+++ b/centreon/src/Core/Security/Infrastructure/Api/LoginSession/LoginSessionController.php
@@ -24,8 +24,6 @@ namespace Core\Security\Infrastructure\Api\LoginSession;
 
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
-use Dropbox\Exception;
-use http\Exception\InvalidArgumentException;
 use Symfony\Component\HttpFoundation\Request;
 use Centreon\Application\Controller\AbstractController;
 use Core\Security\Application\UseCase\LoginSession\LoginSession;


### PR DESCRIPTION
## Description
handle the case when no content is sent in curl request

{"code":500,"message":"Error when decoding your sent data"}

**Fixes** # MON-16742

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- make a enthentication curl call without specifying login and password
-  curl -ski -X "POST" http://<ip-adress>/centreon/api/latest/authentication/providers/configurations/local
-  expected result
-  error says Error when decoding your sent data with 400 error bad request

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
