### PR TITLE
fix(www): timeline bubble for some miss-aligned icons

### DIFF
--- a/centreon/www/front_src/src/Resources/Details/tabs/Timeline/Events/index.tsx
+++ b/centreon/www/front_src/src/Resources/Details/tabs/Timeline/Events/index.tsx
@@ -63,10 +63,16 @@ const useStyles = makeStyles()((theme) => ({
     margin: 0
   },
   timelineDot: {
+    '> div, svg': {
+      height: theme.spacing(2.75),
+      width: theme.spacing(2.75)
+    },
     alignItems: 'center',
     boxSizing: 'content-box',
     display: 'grid',
-    justifyItems: 'center'
+    height: theme.spacing(3),
+    justifyItems: 'center',
+    width: theme.spacing(3)
   }
 }));
 


### PR DESCRIPTION
## Description

**Fixes** # [(issue)](https://centreon.atlassian.net/browse/MON-17529)

make a small (and a little dirty) fix in the timeline, to better align, center and size notification icons

### before : 
<img width="937" alt="Capture d’écran 2023-03-30 à 12 01 18" src="https://user-images.githubusercontent.com/14542464/228801829-7c5845b5-5045-46ff-9c41-2e0141a4f058.png">

### after : 
<img width="930" alt="Capture d’écran 2023-03-30 à 11 52 50" src="https://user-images.githubusercontent.com/14542464/228801082-692707be-e4d4-4fdd-a281-994deef51d68.png">


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

check that all icons are properly scaled and centered within the icon in front of every notification

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
