### PR TITLE
Fix[Installation]: error when accessing to installation wizard

### DIFF
--- a/centreon/www/front_src/src/Main/index.test.tsx
+++ b/centreon/www/front_src/src/Main/index.test.tsx
@@ -226,19 +226,12 @@ const mockNotConnectedGetRequests = (): void => {
 };
 
 const mockInstallGetRequests = (): void => {
-  mockedAxios.get
-    .mockResolvedValueOnce({
-      data: {
-        has_upgrade_available: false,
-        is_installed: false
-      }
-    })
-    .mockRejectedValueOnce({
-      response: { status: 403 }
-    })
-    .mockResolvedValueOnce({
-      data: retrievedWeb
-    });
+  mockedAxios.get.mockResolvedValueOnce({
+    data: {
+      has_upgrade_available: false,
+      is_installed: false
+    }
+  });
 };
 
 const mockUpgradeAndUserDisconnectedGetRequests = (): void => {
@@ -356,13 +349,6 @@ describe('Main', () => {
     await waitFor(() => {
       expect(mockedAxios.get).toHaveBeenCalledWith(
         platformInstallationStatusEndpoint,
-        cancelTokenRequestParam
-      );
-    });
-
-    await waitFor(() => {
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        userEndpoint,
         cancelTokenRequestParam
       );
     });

--- a/centreon/www/front_src/src/Main/useMain.ts
+++ b/centreon/www/front_src/src/Main/useMain.ts
@@ -30,12 +30,12 @@ const useMain = (): void => {
   const { getBrowserLocale, getInternalTranslation, i18next } =
     useInitializeTranslation();
 
-  const setPlatformInstallationStatus = useSetAtom(
-    platformInstallationStatusAtom
-  );
-  const user = useAtomValue(userAtom);
   const [areUserParametersLoaded, setAreUserParametersLoaded] = useAtom(
     areUserParametersLoadedAtom
+  );
+  const user = useAtomValue(userAtom);
+  const setPlatformInstallationStatus = useSetAtom(
+    platformInstallationStatusAtom
   );
 
   const loadUser = useUser();

--- a/centreon/www/front_src/src/Main/useMain.ts
+++ b/centreon/www/front_src/src/Main/useMain.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 
-import { useSetAtom } from 'jotai';
+import { useAtom, useSetAtom } from 'jotai';
 import { useAtomValue } from 'jotai/utils';
 import { and, includes, isEmpty, isNil, not, or } from 'ramda';
 import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
@@ -34,7 +34,9 @@ const useMain = (): void => {
     platformInstallationStatusAtom
   );
   const user = useAtomValue(userAtom);
-  const areUserParametersLoaded = useAtomValue(areUserParametersLoadedAtom);
+  const [areUserParametersLoaded, setAreUserParametersLoaded] = useAtom(
+    areUserParametersLoadedAtom
+  );
 
   const loadUser = useUser();
   const location = useLocation();
@@ -62,13 +64,14 @@ const useMain = (): void => {
       setPlatformInstallationStatus(retrievedPlatformInstallationStatus);
 
       if (!retrievedPlatformInstallationStatus?.isInstalled) {
+        setAreUserParametersLoaded(false);
+
         return;
       }
-      getPlatformVersions();
       loadUser();
+      getPlatformVersions();
     });
   }, []);
-
 
   useEffect((): void => {
     if (not(areUserParametersLoaded)) {

--- a/centreon/www/front_src/src/Main/useMain.ts
+++ b/centreon/www/front_src/src/Main/useMain.ts
@@ -61,20 +61,14 @@ const useMain = (): void => {
     }).then((retrievedPlatformInstallationStatus) => {
       setPlatformInstallationStatus(retrievedPlatformInstallationStatus);
 
-      if (
-        !retrievedPlatformInstallationStatus?.isInstalled &&
-        !retrievedPlatformInstallationStatus?.hasUpgradeAvailable
-      ) {
+      if (!retrievedPlatformInstallationStatus?.isInstalled) {
         return;
       }
-
       getPlatformVersions();
+      loadUser();
     });
   }, []);
 
-  useEffect((): void => {
-    loadUser();
-  }, []);
 
   useEffect((): void => {
     if (not(areUserParametersLoaded)) {


### PR DESCRIPTION
## Description

An error is appearing for like 5s when the wizard is shown up to continue the installation" Environment variable not found: hostCentreon "

Fixes # MON-15697

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Choose one of the os execute the commands of the installation for 22.10 after that go to complete the wizard so the login page will be appearing and check if the error `Environment variable not found: "hostCentreon"` is not showing

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
