### PR TITLE
fix(resource): error when opening detail panel of a resource in downtime

### DIFF
--- a/centreon/src/Core/Application/RealTime/Common/RealTimeResponseTrait.php
+++ b/centreon/src/Core/Application/RealTime/Common/RealTimeResponseTrait.php
@@ -78,6 +78,7 @@ trait RealTimeResponseTrait
                 'start_time' => $downtime->getStartTime(),
                 'end_time' => $downtime->getEndTime(),
                 'actual_start_time' => $downtime->getActualStartTime(),
+                'actual_end_time' => $downtime->getActualEndTime(),
                 'id' => $downtime->getId(),
                 'entry_time' => $downtime->getEntryTime(),
                 'author_id' => $downtime->getAuthorId(),


### PR DESCRIPTION
## Description

ℹ️ MON-18128

This PR intends to fix an issue when opening the detail panel of a resource that has been set in downtime

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

ℹ️ MON-18128

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
