### PR TITLE
enh(gorgone-svc-disco): can change macro before the service name crea…

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -578,6 +578,13 @@ sub service_response_parsing {
     foreach my $attributes (@{$xml->{label}}) {
         $discovery_svc->{service_name} = '';
         $discovery_svc->{attributes} = $attributes;
+
+        $self->custom_variables(
+            discovery_svc => $discovery_svc,
+            rule => $self->{discovery}->{rules}->{ $options{rule_id} },
+            logger_pre_message => $logger_pre_message
+        );
+
         gorgone::modules::centreon::autodiscovery::services::resources::change_vars(
             discovery_svc => $discovery_svc,
             rule => $self->{discovery}->{rules}->{ $options{rule_id} },
@@ -604,11 +611,7 @@ sub service_response_parsing {
                 logger_pre_message => $logger_pre_message
             )
         );
-        $self->custom_variables(
-            discovery_svc => $discovery_svc,
-            rule => $self->{discovery}->{rules}->{ $options{rule_id} },
-            logger_pre_message => $logger_pre_message
-        );
+
         my $macros = gorgone::modules::centreon::autodiscovery::services::resources::get_macros(
             discovery_svc => $discovery_svc,
             rule => $self->{discovery}->{rules}->{ $options{rule_id} }


### PR DESCRIPTION
…tion

## Description

In some cases the windows service discovery returns an empty display_name, so the service created is truncated "Service-".
The advanced options of custom variable do not allow to proceed to a change of the service name.

We should be able to make the following code effective if we consider that the service created is "Service-$display_name$":
```
if ($display_name$ eq "") {
    $display_name$ = $name$;
}
```

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

We should be able to make the following code effective if we consider that the service created is "Service-$display_name$":
```
if ($display_name$ eq "") {
    $display_name$ = $name$;
}
```

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
