### PR TITLE
fix(www): fr translations for problem to alert term in ressources status filter

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15442,7 +15442,7 @@ msgid "Type of resource"
 msgstr "Type de ressource"
 
 msgid "Unhandled alerts"
-msgstr "Alertes non traités"
+msgstr "Alertes non traitées"
 
 msgid "Unhandled"
 msgstr "Non traité"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -15370,7 +15370,7 @@ msgid "Resource name"
 msgstr "Nom de la ressource"
 
 msgid "All alerts"
-msgstr "Problèmes de ressources"
+msgstr "Toutes les alertes"
 
 msgid "Rows per page"
 msgstr "Lignes par page"
@@ -15442,7 +15442,7 @@ msgid "Type of resource"
 msgstr "Type de ressource"
 
 msgid "Unhandled alerts"
-msgstr "Problèmes non traités"
+msgstr "Alertes non traités"
 
 msgid "Unhandled"
 msgstr "Non traité"


### PR DESCRIPTION
## Description

un petit oubli de traduction en fr dans la drop down des filtres

**Fixes** # [(issue)](https://centreon.atlassian.net/browse/MON-16552)

<img width="473" alt="Capture d’écran 2023-03-30 à 16 27 30" src="https://user-images.githubusercontent.com/14542464/228868808-73dd4bdb-aa95-4e6d-8a31-fb13eaf2eb20.png">

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

check that the ressource filter drop down have the correct "Alerte" term instead of "problem" in French language

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
