### PR TITLE
fix(clapi): warnings when using parameters with clapi RT downtimes

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonRtDowntime.class.php
+++ b/centreon/www/class/centreon-clapi/centreonRtDowntime.class.php
@@ -190,7 +190,15 @@ class CentreonRtDowntime extends CentreonObject
      */
     private function parseShowParameters($parameters)
     {
-        list($type, $resource) = explode(';', $parameters);
+        $parameters = explode(';', $parameters);
+        if (count($parameters) === 1) {
+            $resource = '';
+        } elseif (count($parameters) === 2) {
+            $resource = $parameters[1];
+        } else {
+            throw new CentreonClapiException('Bad parameters');
+        }
+        $type = $parameters[0];
 
         return array(
             'type' => $type,


### PR DESCRIPTION
## Description

> Fix warnings when using malformed parameters in clapi RT downtimes

Jira: 🏷️ **MON-18152**

Comes from #384 

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Use clapi to show downtimes with a malformed parameters.

```
centreon -u admin -p 'centreon' -o RTDOWNTIME -a show -v "HOST"
centreon -u admin -p 'centreon' -o RTDOWNTIME -a show -v "HOST;generic-host;error"
```

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
