### PR TITLE
fix(firewall): add login_page to free firewall

### DIFF
--- a/centreon/config/packages/security.yaml
+++ b/centreon/config/packages/security.yaml
@@ -12,7 +12,7 @@ security:
     firewalls:
         free:
             stateless: true
-            pattern: ^.*/api/(?:latest|beta|v[0-9]+|v[0-9]+\.[0-9]+)/platform/(?:versions|installation/status)$
+            pattern: ^.*/api/(?:latest|beta|v[0-9]+|v[0-9]+\.[0-9]+)(/it-edition-extensions/login_page|/platform/(?:versions|installation/status))$
             security: false
         authentication:
             pattern: ^.*(?<!administration)/authentication/(providers/configurations|users)(.*)$


### PR DESCRIPTION
## Description

This PR intends to fix the missing pattern for /it-edition-extensions/login_page that could accessed publicly

**Fixes** # MON-13069

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Install Centreon IT Edition Extensions module, no "Invalid Credentials" error message should appears on login page

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
