### PR TITLE
fix(myAccount): remove theme selection from my account form

### DIFF
--- a/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
@@ -38,7 +38,6 @@
     		<tr class="list_two"><td class="FormRowField">{$form.contact_pager.label}</td><td class="FormRowValue">{$form.contact_pager.html}</td></tr>
             <tr class="list_one"><td class="FormRowField">{$form.contact_lang.label}</td><td class="FormRowValue">{$form.contact_lang.html}</td></tr>
             <tr class="list_two"><td class="FormRowField">{$form.contact_location.label}</td><td class="FormRowValue">{$form.contact_location.html}</td></tr>
-    		<tr class="list_one"><td class="FormRowField">{$form.contact_theme.label}</td><td class="FormRowValue">{$form.contact_theme.html}</td></tr>
             {if $cct.contact_auth_type != 'ldap'}
             <tr class="list_lvl_1">
                 <td class="ListColLvl1_name" colspan="2">

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -70,8 +70,7 @@ $encodedPasswordPolicy = json_encode($passwordSecurityPolicy);
 $cct = array();
 if ($o == "c") {
     $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager,
-        contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type,
-        contact_theme
+        contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type
         FROM contact WHERE contact_id = :id";
     $DBRESULT = $pearDB->prepare($query);
     $DBRESULT->bindValue(':id', $centreon->user->get_id(), \PDO::PARAM_INT);
@@ -115,11 +114,6 @@ if ($cct["contact_auth_type"] != 'ldap') {
 }
 $form->addElement('text', 'contact_email', _("Email"), $attrsText);
 $form->addElement('text', 'contact_pager', _("Pager"), $attrsText);
-
-$tab = array();
-$tab[] = $form->createElement('radio', 'contact_theme', null, _("Light"), 'light');
-$tab[] = $form->createElement('radio', 'contact_theme', null, _("Dark"), 'dark');
-$form->addGroup($tab, 'contact_theme', _("Front-end Theme"), '&nbsp;');
 
 if ($cct["contact_auth_type"] != 'ldap') {
     $form->addFormRule('validatePasswordModification');


### PR DESCRIPTION
## Description

This PR intends to Remove the Front-End Theme input from My Account form

**Fixes** # MON-17891

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x

<h2> How this pull request can be tested ? </h2>

Access to My Account form, the field Front-End Theme should not appears anymore

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
