### PR TITLE
fix(www:listing): change dark mode palette values (22.10.x)

### DIFF
--- a/centreon/packages/ui/src/ThemeProvider/palettes.ts
+++ b/centreon/packages/ui/src/ThemeProvider/palettes.ts
@@ -103,7 +103,7 @@ export const lightPalette: PaletteOptions = {
 export const darkPalette: PaletteOptions = {
   action: {
     acknowledged: '#67532C',
-    acknowledgedBackground: '#F5F1E9',
+    acknowledgedBackground: '#67532C',
     activatedOpacity: 0.3,
     active: '#B5B5B5',
     disabled: '#999999',
@@ -113,7 +113,7 @@ export const darkPalette: PaletteOptions = {
     hover: 'rgba(255, 255, 255, 0.16)',
     hoverOpacity: 0.16,
     inDowntime: '#4B2352',
-    inDowntimeBackground: '#F0E9F8',
+    inDowntimeBackground: '#4B2352',
     selected: 'rgba(255, 255, 255, 0.5)',
     selectedOpacity: 0.5,
   },
@@ -152,7 +152,7 @@ export const darkPalette: PaletteOptions = {
   text: {
     disabled: '#666666',
     primary: '#FFFFFF',
-    secondary: '#B5B5B5',
+    secondary: '#CCCCCC',
   },
   warning: {
     contrastText: '#fff',


### PR DESCRIPTION
## Description

Change dark mode palette, to handle ressource listing background

<img width="1277" alt="Capture d’écran 2023-04-05 à 11 21 50" src="https://user-images.githubusercontent.com/14542464/230039081-90d5896e-f72e-4338-96e0-23f7093faf38.png">

**Fixes** # [(issue)](https://centreon.atlassian.net/browse/MON-17335)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
