### PR TITLE
fix(web): do not erase relation with service by hostgroup (22.10)

### DIFF
--- a/centreon/www/class/centreonTraps.class.php
+++ b/centreon/www/class/centreonTraps.class.php
@@ -628,7 +628,12 @@ class CentreonTraps
                         SELECT s.service_id
                         FROM service s
                         WHERE s.service_register = '0'
-                        AND s.service_id = traps_service_relation.service_id)";
+                        AND s.service_id = traps_service_relation.service_id)
+                    AND NOT EXISTS (
+                        SELECT hsr.service_service_id
+                        FROM host_service_relation hsr
+                        WHERE hsr.hostgroup_hg_id IS NOT NULL
+                        AND hsr.service_service_id = traps_service_relation.service_id)";
 
             $statement = $this->db->prepare($query);
             $statement->bindValue(':trapId', $trapId, \PDO::PARAM_INT);


### PR DESCRIPTION
## Description

When we edit a SNMP trap and save the form, all the relations with Service by Hostgroup are lost.
We have to exclude them from the DELETE query.

**Fixes** MON-19161

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x (master)
