### PR TITLE
fix (monitoring): Improving the response time of real-time service monitoring

### DIFF
--- a/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -149,7 +149,7 @@ function analyseGraphs(array $hostServiceIds): void
     foreach ($hostServiceIds as $hostServiceId => $status) {
         list ($hostId, $serviceId) = explode('_', $hostServiceId);
         if (! empty($whereConditions)) {
-            $whereConditions .= ' || ';
+            $whereConditions .= ' OR ';
         }
         $whereConditions .= sprintf(' (host_id = :host_id_%d AND service_id = :service_id_%d)', $index, $index);
         $valuesToBind[$index] = ['host_id' => $hostId, 'service_id' => $serviceId];

--- a/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -134,6 +134,9 @@ $tabOrder["default"] = $tabOrder['criticality_id'];
  */
 function analyseGraphs(array $hostServiceIds): void
 {
+    if (empty($hostServiceIds)) {
+        return;
+    }
     global $obj, $graphs;
     $request = <<<SQL
         SELECT DISTINCT index_data.host_id, index_data.service_id
@@ -146,7 +149,7 @@ function analyseGraphs(array $hostServiceIds): void
     $whereConditions = null;
     $index = 0;
     $valuesToBind = [];
-    foreach ($hostServiceIds as $hostServiceId => $status) {
+    foreach ($hostServiceIds as $hostServiceId) {
         list ($hostId, $serviceId) = explode('_', $hostServiceId);
         if (! empty($whereConditions)) {
             $whereConditions .= ' OR ';
@@ -394,15 +397,17 @@ $flag = 0;
 
 if (!$sqlError) {
     $allResults = [];
+    $hostServiceIdsToAnalyse = [];
     // We get the host and service IDs to see if they have graphs or not
     while ($result = $dbResult->fetch()) {
         $hostId = (int) $result["host_id"];
         $serviceId = (int) $result["service_id"];
         $graphs[$hostId . '_' . $serviceId] = false;
+        $hostServiceIdsToAnalyse[] = $hostId . '_' . $serviceId;
         $allResults[] = $result;
     }
 
-    analyseGraphs($graphs);
+    analyseGraphs($hostServiceIdsToAnalyse);
 
     foreach ($allResults as $data) {
         $hostId = (int) $data["host_id"];

--- a/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -128,7 +128,7 @@ $tabOrder["output"] = " ORDER BY s.output " . $order . ", h.name, s.description"
 $tabOrder["default"] = $tabOrder['criticality_id'];
 
 /**
- * Analyse whether services have graphs by performing a single query.
+ * Analyse if services have graphs by performing a single query.
  *
  * @param array $hostServiceIds
  */


### PR DESCRIPTION
## Description

Improving the response time of real-time service monitoring.
On databases containing many services and metrics, the query time can take several seconds.
We have split the query into two.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
