### PR TITLE
fix(packaging): fix systemd configuration of centreontrapd and gorgone

### DIFF
--- a/centreon-gorgone/packaging/debian/rules
+++ b/centreon-gorgone/packaging/debian/rules
@@ -11,20 +11,5 @@ override_dh_gencontrol:
 override_dh_usrlocal:
 
 override_dh_auto_build:
-	sed -i 's#WEB_USER=apache#WEB_USER=www-data#g; s#WEB_GROUP=apache#WEB_GROUP=www-data#g' \
-		packaging/src/instCentWeb.conf \
-		packaging/src/instCentPlugins.conf
-	sed -i 's#"apache"#"www-data"#g' packaging/src/install.conf.php
-	sed -i "s#apache#www-data#g; s#@PHPFPM_LOGFILE@#/var/log/php8.1-fpm-centreon-error.log#g; s#/var/lib/php/session#/var/lib/php/sessions#g" \
-		packaging/src/php-fpm.conf
-	sed -i "s#@LIB_ARCH@#lib#g" \
-		packaging/src/centreon-macroreplacement.txt \
-		packaging/src/instCentWeb.conf \
-		packaging/src/instCentPlugins.conf \
-		packaging/src/install.conf.php
 	sed -i "s#/etc/sysconfig#/etc/default#g" \
-	    config/systemd/gorgoned-service
-	find . -type f -not -path "./vendor/*" | \
-		grep -v packaging/src/centreon-macroreplacement.txt | \
-		xargs -d '\n' sed -i -f packaging/src/centreon-macroreplacement.txt
-	mv config/centreon.config.php.template config/centreon.config.php
+		config/systemd/gorgoned-service

--- a/centreon-gorgone/packaging/debian/rules
+++ b/centreon-gorgone/packaging/debian/rules
@@ -9,3 +9,22 @@ override_dh_gencontrol:
 	dh_gencontrol -- -Tdebian/substvars
 
 override_dh_usrlocal:
+
+override_dh_auto_build:
+	sed -i 's#WEB_USER=apache#WEB_USER=www-data#g; s#WEB_GROUP=apache#WEB_GROUP=www-data#g' \
+		packaging/src/instCentWeb.conf \
+		packaging/src/instCentPlugins.conf
+	sed -i 's#"apache"#"www-data"#g' packaging/src/install.conf.php
+	sed -i "s#apache#www-data#g; s#@PHPFPM_LOGFILE@#/var/log/php8.1-fpm-centreon-error.log#g; s#/var/lib/php/session#/var/lib/php/sessions#g" \
+		packaging/src/php-fpm.conf
+	sed -i "s#@LIB_ARCH@#lib#g" \
+		packaging/src/centreon-macroreplacement.txt \
+		packaging/src/instCentWeb.conf \
+		packaging/src/instCentPlugins.conf \
+		packaging/src/install.conf.php
+	sed -i "s#/etc/sysconfig#/etc/default#g" \
+	    config/systemd/gorgoned-service
+	find . -type f -not -path "./vendor/*" | \
+		grep -v packaging/src/centreon-macroreplacement.txt | \
+		xargs -d '\n' sed -i -f packaging/src/centreon-macroreplacement.txt
+	mv config/centreon.config.php.template config/centreon.config.php

--- a/centreon/packaging/debian/rules
+++ b/centreon/packaging/debian/rules
@@ -22,6 +22,8 @@ override_dh_auto_build:
 		packaging/src/instCentWeb.conf \
 		packaging/src/instCentPlugins.conf \
 		packaging/src/install.conf.php
+	sed -i "s#/etc/sysconfig#/etc/default#g" \
+	    tmpl/install/systemd/centreontrapd.systemd
 	find . -type f -not -path "./vendor/*" | \
 		grep -v packaging/src/centreon-macroreplacement.txt | \
 		xargs -d '\n' sed -i -f packaging/src/centreon-macroreplacement.txt

--- a/centreon/packaging/debian/rules
+++ b/centreon/packaging/debian/rules
@@ -23,7 +23,7 @@ override_dh_auto_build:
 		packaging/src/instCentPlugins.conf \
 		packaging/src/install.conf.php
 	sed -i "s#/etc/sysconfig#/etc/default#g" \
-	    tmpl/install/systemd/centreontrapd.systemd
+		tmpl/install/systemd/centreontrapd.systemd
 	find . -type f -not -path "./vendor/*" | \
 		grep -v packaging/src/centreon-macroreplacement.txt | \
 		xargs -d '\n' sed -i -f packaging/src/centreon-macroreplacement.txt


### PR DESCRIPTION
## Description

fix(packaging): fix systemd configuration of centreontrapd and gorgone

**Fixes** MON-18006

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)