### PR TITLE
fix(gorgone): getlog ctime filter

### DIFF
--- a/centreon-gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/centreon-gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -272,6 +272,7 @@ sub routing {
             # We put the good time to get        
             my $ctime = $synctime_nodes->{$target}->{ctime};
             $options{frame}->setData({ ctime => $ctime });
+            $options{frame}->setRawData();
             $synctime_nodes->{$target}->{in_progress} = 1;
             $synctime_nodes->{$target}->{in_progress_time} = time();
         }


### PR DESCRIPTION
## Description

The gorgone configuration is not displayed for poller linked to remote

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>


## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
