### PR TITLE
fix(autodiscovery) : Fix TextField while debouncing value

### DIFF
--- a/centreon/packages/ui/src/InputField/Text/index.tsx
+++ b/centreon/packages/ui/src/InputField/Text/index.tsx
@@ -79,6 +79,7 @@ export type Props = {
   autoSizeDefaultWidth?: number;
   className?: string;
   dataTestId: string;
+  debounced?: boolean;
   displayErrorInTooltip?: boolean;
   error?: string;
   externalValueForAutoSize?: string;
@@ -102,6 +103,7 @@ const TextField = forwardRef(
       displayErrorInTooltip = false,
       className,
       autoSize = false,
+      debounced = false,
       autoSizeDefaultWidth = 0,
       externalValueForAutoSize,
       autoSizeCustomPadding,
@@ -123,7 +125,17 @@ const TextField = forwardRef(
 
     const tooltipTitle = displayErrorInTooltip && !isNil(error) ? error : '';
 
-    const valueProps = defaultValue ? { defaultValue } : { value: innerValue };
+    const getValueProps = (): object => {
+      if (debounced) {
+        return {};
+      }
+
+      if (defaultValue) {
+        return { defaultValue };
+      }
+
+      return { value: innerValue };
+    };
 
     return (
       <>
@@ -142,7 +154,7 @@ const TextField = forwardRef(
             ref={ref}
             size={size || 'small'}
             onChange={changeInputValue}
-            {...valueProps}
+            {...getValueProps()}
             {...rest}
             InputProps={{
               className: cx(

--- a/centreon/packages/ui/src/InputField/Text/index.tsx
+++ b/centreon/packages/ui/src/InputField/Text/index.tsx
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { forwardRef, useCallback } from 'react';
 
 import { isNil } from 'ramda';
 import { makeStyles } from 'tss-react/mui';
@@ -125,7 +125,7 @@ const TextField = forwardRef(
 
     const tooltipTitle = displayErrorInTooltip && !isNil(error) ? error : '';
 
-    const getValueProps = (): object => {
+    const getValueProps = useCallback((): object => {
       if (debounced) {
         return {};
       }
@@ -135,7 +135,7 @@ const TextField = forwardRef(
       }
 
       return { value: innerValue };
-    };
+    }, [innerValue, debounced, defaultValue]);
 
     return (
       <>


### PR DESCRIPTION
## Description

we can't type text in providers' filter search field 

the problem is that we shouldn't use the value property with debounced TextField

preview : 

https://user-images.githubusercontent.com/109956462/230473441-f359ef8c-77db-417b-b7ef-864f2055e608.mp4



**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>


#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
