### PR TITLE
fix(packaging): use www-data user for cron on debian

### DIFF
--- a/centreon/packaging/debian/rules
+++ b/centreon/packaging/debian/rules
@@ -17,6 +17,8 @@ override_dh_auto_build:
 	sed -i 's#"apache"#"www-data"#g' packaging/src/install.conf.php
 	sed -i "s#apache#www-data#g; s#@PHPFPM_LOGFILE@#/var/log/php8.1-fpm-centreon-error.log#g; s#/var/lib/php/session#/var/lib/php/sessions#g" \
 		packaging/src/php-fpm.conf
+	sed -i 's#apache#www-data#g' \
+		packaging/src/centreon-macroreplacement.txt
 	sed -i "s#@LIB_ARCH@#lib#g" \
 		packaging/src/centreon-macroreplacement.txt \
 		packaging/src/instCentWeb.conf \


### PR DESCRIPTION
## Description

User www-data user to run crons tasks instead  of apache for debian installations.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
