### PR TITLE
fix (monitoring): Improving the response time of real-time service monitoring

### DIFF
--- a/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+++ b/centreon/www/include/monitoring/status/Services/xml/serviceXML.php
@@ -127,6 +127,50 @@ $tabOrder["current_attempt"] = " ORDER BY s.check_attempt " . $order . ", h.name
 $tabOrder["output"] = " ORDER BY s.output " . $order . ", h.name, s.description";
 $tabOrder["default"] = $tabOrder['criticality_id'];
 
+/**
+ * Analyse if services have graphs by performing a single query.
+ *
+ * @param array $hostServiceIds
+ */
+function analyseGraphs(array $hostServiceIds): void
+{
+    if (empty($hostServiceIds)) {
+        return;
+    }
+    global $obj, $graphs;
+    $request = <<<SQL
+        SELECT DISTINCT index_data.host_id, index_data.service_id
+        FROM index_data
+        INNER JOIN metrics
+          ON metrics.index_id = index_data.id
+          AND index_data.hidden = '0'
+        WHERE
+        SQL;
+    $whereConditions = null;
+    $index = 0;
+    $valuesToBind = [];
+    foreach ($hostServiceIds as $hostServiceId) {
+        list ($hostId, $serviceId) = explode('_', $hostServiceId);
+        if (! empty($whereConditions)) {
+            $whereConditions .= ' OR ';
+        }
+        $whereConditions .= sprintf(' (host_id = :host_id_%d AND service_id = :service_id_%d)', $index, $index);
+        $valuesToBind[$index] = ['host_id' => $hostId, 'service_id' => $serviceId];
+        $index++;
+    }
+    $request .= $whereConditions;
+    $statement = $obj->DBC->prepare($request);
+    foreach ($valuesToBind as $index => $hostServiceId) {
+        $statement->bindValue(':host_id_' . $index, $hostServiceId['host_id'], PDO::PARAM_INT);
+        $statement->bindValue(':service_id_' . $index, $hostServiceId['service_id'], PDO::PARAM_INT);
+    }
+    $statement->execute();
+    while ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
+        $hostServiceId = $result['host_id'] . '_' . $result['service_id'];
+        $graphs[$hostServiceId] = true;
+    }
+}
+
 $request = <<<SQL
     SELECT SQL_CALC_FOUND_ROWS DISTINCT h.name, h.alias, h.address, h.host_id, s.description,
     s.service_id, s.notes, s.notes_url, s.action_url, s.max_check_attempts,
@@ -139,8 +183,7 @@ $request = <<<SQL
     h.icon_image AS h_icon_images, h.display_name AS h_display_name, h.action_url AS h_action_url,
     h.notes_url AS h_notes_url, h.notes AS h_notes, h.address,
     h.passive_checks AS h_passive_checks, h.active_checks AS h_active_checks,
-    i.name as instance_name, cv.value as criticality, cv.value IS NULL as isnull,
-    m.index_id IS NOT NULL as hasGraph
+    i.name as instance_name, cv.value as criticality, cv.value IS NULL as isnull
     FROM hosts h
     INNER JOIN instances i
       ON h.instance_id = i.instance_id
@@ -200,12 +243,6 @@ if ($criticalityId) {
 
 $request .= <<<SQL
 
-    LEFT JOIN index_data idx
-        ON idx.host_id = h.host_id
-        AND idx.service_id = s.service_id
-        AND idx.hidden = '0'
-    LEFT JOIN metrics m
-        ON m.index_id = idx.id
     LEFT JOIN customvariables cv
         ON (
             s.service_id = cv.service_id
@@ -359,7 +396,22 @@ $ct = 0;
 $flag = 0;
 
 if (!$sqlError) {
-    while ($data = $dbResult->fetch()) {
+    $allResults = [];
+    $hostServiceIdsToAnalyse = [];
+    // We get the host and service IDs to see if they have graphs or not
+    while ($result = $dbResult->fetch()) {
+        $hostId = (int) $result["host_id"];
+        $serviceId = (int) $result["service_id"];
+        $graphs[$hostId . '_' . $serviceId] = false;
+        $hostServiceIdsToAnalyse[] = $hostId . '_' . $serviceId;
+        $allResults[] = $result;
+    }
+
+    analyseGraphs($hostServiceIdsToAnalyse);
+
+    foreach ($allResults as $data) {
+        $hostId = (int) $data["host_id"];
+        $serviceId = (int) $data["service_id"];
         $passive = 0;
         $active = 1;
         $last_check = " ";
@@ -655,7 +707,7 @@ if (!$sqlError) {
         $obj->XML->writeElement("last_hard_state_change", $hard_duration);
 
         // Get Service Graph index
-        $obj->XML->writeElement("hasGraph", $data['hasGraph'] ? '1': '0');
+        $obj->XML->writeElement("hasGraph", $graphs[$hostId . '_' . $serviceId] ? '1' : '0');
         $obj->XML->writeElement("chartIcon", returnSvg("www/img/icons/chart.svg", "var(--icons-fill-color)", 18, 18));
         $obj->XML->endElement();
     }


### PR DESCRIPTION
## Description

Backport of: #1270 

Improving the response time of real-time service monitoring.
On databases containing many services and metrics, the query time can take several seconds.
We have split the query into two.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
