### PR TITLE
fix(UI): Fix row color condition memoization

### DIFF
--- a/.github/actions/npm-publish-package-beta/action.yml
+++ b/.github/actions/npm-publish-package-beta/action.yml
@@ -56,7 +56,7 @@ runs:
 
     - name: Bump NPM package version
       run: |
-        echo PREID=$(echo "${{ github.head_ref }}" | sed "s/\./_/g")
+        PREID=$(echo "${{ github.head_ref }}" | sed "s/\./_/g")
         npm version prerelease --preid $PREID --legacy-peer-deps
         VERSION=$(node -p "require('./package.json').version")
         rm ../../package-lock.json

--- a/centreon/packages/ui/src/Listing/Cell/DataCell.tsx
+++ b/centreon/packages/ui/src/Listing/Cell/DataCell.tsx
@@ -223,12 +223,20 @@ const MemoizedDataCell = memo<Props>(
     );
     const nextIsTruncated = nextProps.column.isTruncated;
 
-    const prevRowColors = prevProps.rowColorConditions?.map(({ condition }) =>
-      condition(prevProps.row)
+    const previousRowConditions = prevProps.rowColorConditions?.map(
+      ({ condition }) => condition(prevProps.row)
     );
-    const nextRowColors = nextProps.rowColorConditions?.map(({ condition }) =>
-      condition(nextProps.row)
+    const nextRowConditions = nextProps.rowColorConditions?.map(
+      ({ condition }) => condition(nextProps.row)
     );
+
+    const previousRowColors = prevProps.rowColorConditions?.map(
+      ({ color }) => color
+    );
+    const nextRowColors = nextProps.rowColorConditions?.map(
+      ({ color }) => color
+    );
+
     const nextIsRowHighlighted = nextProps.getHighlightRowCondition?.(
       nextProps.row
     );
@@ -265,7 +273,8 @@ const MemoizedDataCell = memo<Props>(
         previousFormattedString ?? previousRowProps,
         nextFormattedString ?? nextRowProps
       ) &&
-      equals(prevRowColors, nextRowColors) &&
+      equals(previousRowConditions, nextRowConditions) &&
+      equals(previousRowColors, nextRowColors) &&
       equals(
         prevProps.disableRowCondition(prevProps.row),
         nextProps.disableRowCondition(nextProps.row)

--- a/centreon/packages/ui/src/Listing/Row.tsx
+++ b/centreon/packages/ui/src/Listing/Row.tsx
@@ -158,17 +158,23 @@ const Row = memo<RowProps>(
       return false;
     }
 
-    const previousRowColors = previousRowColorConditions?.map(({ condition }) =>
-      condition(previousRow)
+    const previousRowConditions = previousRowColorConditions?.map(
+      ({ condition }) => condition(previousRow)
     );
-    const nextRowColors = nextRowColorConditions?.map(({ condition }) =>
+    const nextRowConditions = nextRowColorConditions?.map(({ condition }) =>
       condition(nextRow)
     );
+
+    const previousRowColors = previousRowColorConditions?.map(
+      ({ color }) => color
+    );
+    const nextRowColors = nextRowColorConditions?.map(({ color }) => color);
 
     if (not(nextIsInViewport) && lt(nextLimit, 60)) {
       return (
         equals(prevProps.isSelected, nextProps.isSelected) &&
         equals(prevProps.row, nextProps.row) &&
+        equals(previousRowConditions, nextRowConditions) &&
         equals(previousRowColors, nextRowColors) &&
         equals(prevProps.className, nextProps.className)
       );
@@ -178,6 +184,7 @@ const Row = memo<RowProps>(
       equals(prevProps.isSelected, nextProps.isSelected) &&
       equals(prevProps.row, nextProps.row) &&
       equals(prevProps.className, nextProps.className) &&
+      equals(previousRowConditions, nextRowConditions) &&
       equals(previousRowColors, nextRowColors) &&
       equals(prevProps.columnIds, nextProps.columnIds) &&
       equals(prevProps.columnConfiguration, nextProps.columnConfiguration) &&


### PR DESCRIPTION
## Description

This fixes the row color condition memoization.

https://user-images.githubusercontent.com/12515407/230605786-8b73235f-7075-4440-9c0c-ac8e419befbe.mov

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Go to Resource Status
- Set an acknowledgment or a downtime on a resource
- Wait for the resource line to be colored
- Change the theme
- -> The resource line is colored according to the theme

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
