### PR TITLE
enh(openid): Extend GET API to save redirect uri

### DIFF
--- a/centreon/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfiguration.php
+++ b/centreon/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfiguration.php
@@ -86,6 +86,7 @@ class FindOpenIdConfiguration
             : $findOpenIdConfigurationResponse::contactTemplateToArray($configuration->getContactTemplate());
         $findOpenIdConfigurationResponse->emailBindAttribute = $configuration->getEmailBindAttribute();
         $findOpenIdConfigurationResponse->userNameBindAttribute = $configuration->getUserNameBindAttribute();
+        $findOpenIdConfigurationResponse->redirectUrl = $configuration->getRedirectUrl();
         $findOpenIdConfigurationResponse->claimName = $configuration->getClaimName();
         $findOpenIdConfigurationResponse->contactGroup = $configuration->getContactGroup() === null
             ? null

--- a/centreon/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationResponse.php
+++ b/centreon/src/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationResponse.php
@@ -132,6 +132,11 @@ class FindOpenIdConfigurationResponse
     /**
      * @var string|null
      */
+    public ?string $redirectUrl = null;
+
+    /**
+     * @var string|null
+     */
     public ?string $claimName = null;
 
     /**

--- a/centreon/src/Core/Security/Application/UseCase/FindProviderConfigurations/ProviderResponse/OpenIdProviderResponse.php
+++ b/centreon/src/Core/Security/Application/UseCase/FindProviderConfigurations/ProviderResponse/OpenIdProviderResponse.php
@@ -62,6 +62,11 @@ class OpenIdProviderResponse implements ProviderResponseInterface
     public ?array $connectionScopes;
 
     /**
+     * @var string|null
+     */
+    public ?string $redirectUrl;
+
+    /**
      * @inheritDoc
      */
     public function getType(): string
@@ -82,6 +87,7 @@ class OpenIdProviderResponse implements ProviderResponseInterface
         $response->clientId = $configuration->getClientId();
         $response->id = $configuration->getId();
         $response->connectionScopes = $configuration->getConnectionScopes();
+        $response->redirectUrl = $configuration->getRedirectUrl();
 
         return $response;
     }

--- a/centreon/src/Core/Security/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenter.php
+++ b/centreon/src/Core/Security/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenter.php
@@ -52,12 +52,12 @@ class OpenIdProviderPresenter implements ProviderPresenterInterface
     {
         $redirectUri = $response->redirectUrl !== null
             ? $response->redirectUrl . $this->router->generate(
-                'centreon_security_authentication_login_openid',
+                'centreon_security_authentication_openid_login',
                 [],
                 UrlGeneratorInterface::ABSOLUTE_PATH
             )
             : $this->router->generate(
-                'centreon_security_authentication_login_openid',
+                'centreon_security_authentication_openid_login',
                 [],
                 UrlGeneratorInterface::ABSOLUTE_URL
             );

--- a/centreon/src/Core/Security/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenter.php
+++ b/centreon/src/Core/Security/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenter.php
@@ -50,11 +50,17 @@ class OpenIdProviderPresenter implements ProviderPresenterInterface
      */
     public function present(mixed $response): array
     {
-        $redirectUri = $this->router->generate(
-            'centreon_security_authentication_openid_login',
-            [],
-            UrlGeneratorInterface::ABSOLUTE_URL
-        );
+        $redirectUri = $response->redirectUrl !== null
+            ? $response->redirectUrl . $this->router->generate(
+                'centreon_security_authentication_login_openid',
+                [],
+                UrlGeneratorInterface::ABSOLUTE_PATH
+            )
+            : $this->router->generate(
+                'centreon_security_authentication_login_openid',
+                [],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            );
 
         return [
             'id' => $response->id,

--- a/centreon/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/FindOpenIdConfiguration/FindOpenIdConfigurationPresenter.php
+++ b/centreon/src/Core/Security/Infrastructure/ProviderConfiguration/OpenId/Api/FindOpenIdConfiguration/FindOpenIdConfigurationPresenter.php
@@ -58,6 +58,7 @@ class FindOpenIdConfigurationPresenter extends AbstractPresenter implements Find
             'contact_template' => $response->contactTemplate,
             'email_bind_attribute' => $response->emailBindAttribute,
             'fullname_bind_attribute' => $response->userNameBindAttribute,
+            'redirect_url' => $response->redirectUrl,
             'contact_group' => $response->contactGroup,
             'claim_name' => $response->claimName,
             'authorization_rules' => $response->authorizationRules

--- a/centreon/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/Application/ProviderConfiguration/OpenId/UseCase/FindOpenIdConfiguration/FindOpenIdConfigurationTest.php
@@ -60,7 +60,8 @@ it('should present a provider configuration', function () {
             ->setAuthenticationType('client_secret_post')
             ->setContactTemplate(new ContactTemplate(1, 'contact_template'))
             ->setAutoImportEnabled(false)
-            ->setContactGroup(new ContactGroup(1, 'contact_group'));
+            ->setContactGroup(new ContactGroup(1, 'contact_group'))
+            ->setRedirectUrl(null);
 
         $useCase = new FindOpenIdConfiguration($this->repository);
         $presenter = new FindOpenIdConfigurationPresenterStub($this->presenterFormatter);
@@ -97,6 +98,7 @@ it('should present a provider configuration', function () {
         expect($presenter->response->emailBindAttribute)->toBeNull();
         expect($presenter->response->userNameBindAttribute)->toBeNull();
         expect($presenter->response->contactGroup)->toBe(['id' => 1, 'name' => 'contact_group']);
+        expect($presenter->response->redirectUrl)->toBeNull();
 });
 
 it('should present a NotFoundReponse when no configuration is found', function () {

--- a/centreon/tests/php/Core/Security/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
+++ b/centreon/tests/php/Core/Security/Application/UseCase/LoginOpenIdSession/LoginOpenIdSessionTest.php
@@ -101,7 +101,8 @@ beforeEach(function () {
         ->setContactTemplate(new ContactTemplate(1, 'contact_template'))
         ->setAutoImportEnabled(false)
         ->setContactGroup($this->contactGroup)
-        ->setClaimName('groups');
+        ->setClaimName('groups')
+        ->setRedirectUrl(null);
 });
 
 it('expects to return an error message in presenter when no provider configuration are found', function () {

--- a/centreon/tests/php/Core/Security/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenterTest.php
+++ b/centreon/tests/php/Core/Security/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenterTest.php
@@ -39,6 +39,7 @@ beforeEach(function () {
     $this->openIdProviderResponse->clientId = 'client1';
     $this->openIdProviderResponse->isActive = true;
     $this->openIdProviderResponse->isForced = true;
+    $this->openIdProviderResponse->redirectUrl = null;
 
     $this->presenter = new OpenIdProviderPresenter($this->urlGenerator);
 });

--- a/centreon/www/install/php/Update-22.04.13.php
+++ b/centreon/www/install/php/Update-22.04.13.php
@@ -46,6 +46,7 @@ $updateOpenIdCustomConfiguration = function (CentreonDB $pearDB): void
             <<<SQL
                 UPDATE provider_configuration
                     SET custom_configuration = :encodedConfiguration
+                WHERE name = 'openid'
                 SQL
         );
         $statement->bindValue(':encodedConfiguration', $updatedCustomConfigurationEncoded, \PDO::PARAM_STR);


### PR DESCRIPTION
## Description

Added GET endpoint to save redirect URI for 22.04

Backport of https://github.com/centreon/centreon/pull/1200 to 22.04

**Fixes** # MON-18054

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
