### PR TITLE
fix(gorgone): add missing perl library for deb (#18238)

### DIFF
--- a/centreon-gorgone/packaging/debian/control
+++ b/centreon-gorgone/packaging/debian/control
@@ -14,6 +14,7 @@ Depends:
   centreon-common (>= ${centreon:version}~),
   centreon-common (<< ${centreon:versionThreshold}~),
   libdatetime-perl,
+  libtime-parsedate-perl,
   libtry-tiny-perl,
   libxml-simple-perl,
   libxml-libxml-simple-perl,


### PR DESCRIPTION
## Description

Fix an error when saving a scheduled host discovery

**Fixes** MON-18238

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)
