### PR TITLE
fix(nagios): bypass metadata usage for nagios server repository

### DIFF
--- a/centreon/src/Centreon/Domain/Entity/NagiosServer.php
+++ b/centreon/src/Centreon/Domain/Entity/NagiosServer.php
@@ -27,6 +27,8 @@ use PDO;
 
 class NagiosServer implements Mapping\MetadataInterface
 {
+    public const TABLE = 'nagios_server';
+    public const ENTITY_IDENTIFICATOR_COLUMN = 'id';
     public const SERIALIZER_GROUP_REMOTE_LIST = 'nagios-server-remote-list';
     public const SERIALIZER_GROUP_LIST = 'nagios-server-list';
 

--- a/centreon/src/Centreon/Domain/Repository/NagiosServerRepository.php
+++ b/centreon/src/Centreon/Domain/Repository/NagiosServerRepository.php
@@ -81,7 +81,7 @@ class NagiosServerRepository extends AbstractRepositoryRDB implements Pagination
      */
     public function checkListOfIds(array $ids): bool
     {
-        return $this->checkListOfIdsTrait($ids);
+        return $this->checkListOfIdsTrait($ids, NagiosServer::TABLE, NagiosServer::ENTITY_IDENTIFICATOR_COLUMN);
     }
 
     /**


### PR DESCRIPTION
This PR intends to fix an issue with the checkListIds since the migration of the the NagiosServerRepository inheritance (for BAM)

ℹ️ MON-18359

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>
See Jira

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
