### PR TITLE
enh(openid): Extend CEIP/telemetry to mesure redirect uri usage

### DIFF
--- a/centreon/www/class/centreonStatistics.class.php
+++ b/centreon/www/class/centreonStatistics.class.php
@@ -220,6 +220,7 @@ class CentreonStatistics
                         'authentication_type' => $customConfiguration['authentication_type'],
                         'verify_peer' => (bool)$customConfiguration['verify_peer'],
                         'auto_import' => (bool)$customConfiguration['auto_import'],
+                        'redirect_url' => $customConfiguration['redirect_url'] !== null,
                         'roles_mapping' => [
                             'relations' => $aclRelations
                         ]


### PR DESCRIPTION
## Description

Extend CEIP/telemetry to mesure redirect uri usage

This is a backport of https://github.com/centreon/centreon/pull/1200 to 22.04

**Fixes** # MON-18055

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
