### PR TITLE
fix(feature): Unblock users via GUI

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -15380,8 +15380,8 @@ msgstr ""
 # msgid "Groups mapping"
 # msgstr ""
 
-#: centreon-web/www/include/configuration/configObject/contact/listContact.php:281
-#msgid "Are you sure you want to unblock this contact ?"
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:280
+#msgid "Do you really want to unblock this user?"
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447

--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -15385,7 +15385,7 @@ msgstr ""
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
-#msgid "The user(s) will be unblocked. Do you confirm the request ?"
+#msgid "The user(s) will be unblocked. Do you confirm the request?"
 #msgstr ""
 
 # msgid "Error while retrieving a host group"

--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -15380,6 +15380,14 @@ msgstr ""
 # msgid "Groups mapping"
 # msgstr ""
 
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:281
+#msgid "Are you sure you want to unblock this contact ?"
+#msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+#msgstr ""
+
 # msgid "Error while retrieving a host group"
 # msgstr ""
 

--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -15385,7 +15385,7 @@ msgstr ""
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
-#msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+#msgid "The user(s) will be unblocked. Do you confirm the request ?"
 #msgstr ""
 
 # msgid "Error while retrieving a host group"

--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -15393,3 +15393,7 @@ msgstr ""
 
 #  msgid "Error while updating a host group"
 #  msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "Unblock"
+#msgstr ""

--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -15384,7 +15384,7 @@ msgstr ""
 #msgid "Do you really want to unblock this user?"
 #msgstr ""
 
-#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
 #msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
 #msgstr ""
 

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15697,6 +15697,14 @@ msgstr ""
 # msgid "Groups mapping"
 # msgstr ""
 
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:281
+#msgid "Are you sure you want to unblock this contact ?"
+#msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+#msgstr ""
+
 # msgid "Error while updating host severity"
 # msgstr ""
 

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15702,7 +15702,7 @@ msgstr ""
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
-#msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+#msgid "The user(s) will be unblocked. Do you confirm the request ?"
 #msgstr ""
 
 # msgid "Error while updating host severity"

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15701,7 +15701,7 @@ msgstr ""
 #msgid "Do you really want to unblock this user?"
 #msgstr ""
 
-#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
 #msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
 #msgstr ""
 

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15716,3 +15716,7 @@ msgstr ""
 
 #  msgid "Error while retrieving a host category"
 #  msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "Unblock"
+#msgstr ""

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15702,7 +15702,7 @@ msgstr ""
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
-#msgid "The user(s) will be unblocked. Do you confirm the request ?"
+#msgid "The user(s) will be unblocked. Do you confirm the request?"
 #msgstr ""
 
 # msgid "Error while updating host severity"

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15697,8 +15697,8 @@ msgstr ""
 # msgid "Groups mapping"
 # msgstr ""
 
-#: centreon-web/www/include/configuration/configObject/contact/listContact.php:281
-#msgid "Are you sure you want to unblock this contact ?"
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:280
+#msgid "Do you really want to unblock this user?"
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11289,8 +11289,8 @@ msgid "Do you really want to unblock this user?"
 msgstr "Voulez-vous vraiment débloquer cet utilisateur ?"
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
-msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
-msgstr "Les contacts choisis seront débloqués. Confirmez-vous l'action ?"
+msgid "The user(s) will be unblocked. Do you confirm the request ?"
+msgstr "Ces utilisateurs seront débloqués. Confirmez-vous l'action ?"
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
 msgid "Unblock"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11290,7 +11290,7 @@ msgstr "Voulez-vous vraiment débloquer cet utilisateur ?"
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
 msgid "The user(s) will be unblocked. Do you confirm the request?"
-msgstr "Ces utilisateurs seront débloqués. Confirmez-vous l'action?"
+msgstr "Ces utilisateurs seront débloqués. Confirmez-vous l'action ?"
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
 msgid "Unblock"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11289,8 +11289,8 @@ msgid "Do you really want to unblock this user?"
 msgstr "Voulez-vous vraiment débloquer cet utilisateur ?"
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
-msgid "The user(s) will be unblocked. Do you confirm the request ?"
-msgstr "Ces utilisateurs seront débloqués. Confirmez-vous l'action ?"
+msgid "The user(s) will be unblocked. Do you confirm the request?"
+msgstr "Ces utilisateurs seront débloqués. Confirmez-vous l'action?"
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
 msgid "Unblock"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11288,9 +11288,13 @@ msgstr "Afficher les notifications du contact"
 msgid "Are you sure you want to unblock this contact ?"
 msgstr "Êtes-vous sûr de vouloir débloquer ce contact ?"
 
-#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
 msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
 msgstr "Les contacts choisis seront débloqués. Confirmez-vous l'action ?"
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+msgid "Unblock"
+msgstr "Débloquer"
 
 #: centreon-web/www/include/configuration/configObject/escalation/ViewEscalation.php:103
 msgid "Escalations View"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11284,9 +11284,9 @@ msgstr "Ceci est un modèle de contact."
 msgid "View contact notifications"
 msgstr "Afficher les notifications du contact"
 
-#: centreon-web/www/include/configuration/configObject/contact/listContact.php:281
-msgid "Are you sure you want to unblock this contact ?"
-msgstr "Êtes-vous sûr de vouloir débloquer ce contact ?"
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:280
+msgid "Do you really want to unblock this user?"
+msgstr "Voulez-vous vraiment débloquer cet utilisateur ?"
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
 msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11284,6 +11284,14 @@ msgstr "Ceci est un modèle de contact."
 msgid "View contact notifications"
 msgstr "Afficher les notifications du contact"
 
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:281
+msgid "Are you sure you want to unblock this contact ?"
+msgstr "Êtes-vous sûr de vouloir débloquer ce contact ?"
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+msgstr "Les contacts choisis seront débloqués. Confirmez-vous l'action ?"
+
 #: centreon-web/www/include/configuration/configObject/escalation/ViewEscalation.php:103
 msgid "Escalations View"
 msgstr "Visualisation des escalades"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -16165,7 +16165,7 @@ msgstr ""
 #msgid "Do you really want to unblock this user?"
 #msgstr ""
 
-#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
 #msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
 #msgstr ""
 

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -16180,3 +16180,7 @@ msgstr ""
 
 #  msgid "Error while retrieving a host category"
 #  msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "Unblock"
+#msgstr ""

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -16166,7 +16166,7 @@ msgstr ""
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
-#msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+#msgid "The user(s) will be unblocked. Do you confirm the request ?"
 #msgstr ""
 
 # msgid "Error while updating host severity"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -16161,6 +16161,14 @@ msgstr ""
 # msgid "Groups mapping"
 # msgstr ""
 
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:281
+#msgid "Are you sure you want to unblock this contact ?"
+#msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+#msgstr ""
+
 # msgid "Error while updating host severity"
 # msgstr ""
 

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -16161,8 +16161,8 @@ msgstr ""
 # msgid "Groups mapping"
 # msgstr ""
 
-#: centreon-web/www/include/configuration/configObject/contact/listContact.php:281
-#msgid "Are you sure you want to unblock this contact ?"
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:280
+#msgid "Do you really want to unblock this user?"
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -16166,7 +16166,7 @@ msgstr ""
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
-#msgid "The user(s) will be unblocked. Do you confirm the request ?"
+#msgid "The user(s) will be unblocked. Do you confirm the request?"
 #msgstr ""
 
 # msgid "Error while updating host severity"

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -16167,6 +16167,10 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 #msgid "Do you really want to unblock this user?"
 #msgstr ""
 
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
+#msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+#msgstr ""
+
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
 #msgid "Unblock"
 #msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -16162,3 +16162,11 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "Error while retrieving a host category"
 #  msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:281
+#msgid "Are you sure you want to unblock this contact ?"
+#msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+#msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -16168,7 +16168,7 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
-#msgid "The user(s) will be unblocked. Do you confirm the request ?"
+#msgid "The user(s) will be unblocked. Do you confirm the request?"
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -16163,8 +16163,8 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 #  msgid "Error while retrieving a host category"
 #  msgstr ""
 
-#: centreon-web/www/include/configuration/configObject/contact/listContact.php:281
-#msgid "Are you sure you want to unblock this contact ?"
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:280
+#msgid "Do you really want to unblock this user?"
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -16168,5 +16168,5 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
-#msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+#msgid "Unblock"
 #msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -16168,7 +16168,7 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
-#msgid "The chosen contact(s) will be unblocked. Do you confirm the request ?"
+#msgid "The user(s) will be unblocked. Do you confirm the request ?"
 #msgstr ""
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -206,11 +206,11 @@ function unblockContactInDB(int|array|null $contact = null): void
 {
     global $pearDB, $centreon;
 
-    if (null === $contact) {
+    if (null === $contact || [] === $contact) {
         return;
     }
 
-    if (!is_array($contact)) {
+    if (is_int($contact)) {
         $contact = [$contact => "1"];
     }
 
@@ -223,11 +223,11 @@ function unblockContactInDB(int|array|null $contact = null): void
     $idPlaceholders = implode(', ', array_keys($bindContactIds));
 // retrieve the users and add log
     $updateQuery = "UPDATE contact SET blocking_time = null WHERE contact_id IN ($idPlaceholders)";
-    $statement = $pearDB->prepare($updateQuery);
+    $updateStatement = $pearDB->prepare($updateQuery);
     foreach ($bindContactIds as $token => $value) {
-        $statement->bindValue($token, $value, \PDO::PARAM_INT);
+        $updateStatement->bindValue($token, $value, \PDO::PARAM_INT);
     }
-    $statement->execute();
+    $updateStatement->execute();
 // retrieve the users and add log
     $selectQuery = "SELECT contact_id, contact_name FROM contact WHERE contact_id IN ($idPlaceholders)";
     $selectStatement = $pearDB->prepare($selectQuery);

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -200,7 +200,7 @@ function disableContactInDB($contact_id = null, $contact_arr = array())
 /**
  * Unblock contacts in the database
  *
- * @param int|array|null $contact Contact ID, array of contact IDs or null to unblock all contacts
+ * @param int|array<int, string>|null $contact Contact ID, array of contact IDs or null to unblock all contacts
  */
 function unblockContactInDB(int|array|null $contact = null): void
 {

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -198,6 +198,32 @@ function disableContactInDB($contact_id = null, $contact_arr = array())
 }
 
 /**
+ * Unblock contacts in the database
+ *
+ * @param int|array|null $contact Contact ID, array of contact IDs or null to unblock all contacts
+ */
+function unblockContactInDB($contact = null)
+{
+    global $pearDB, $centreon;
+
+    if (is_null($contact)) {
+        return;
+    }
+
+    if (!is_array($contact)) {
+        $contact = [$contact => "1"];
+    }
+
+    foreach ($contact as $key => $value) {
+        $pearDB->query("UPDATE contact SET blocking_time = null WHERE contact_id = '" . (int)$key . "'");
+        $query = "SELECT contact_name FROM `contact` WHERE `contact_id` = '" . (int)$key . "' LIMIT 1";
+        $dbResult2 = $pearDB->query($query);
+        $row = $dbResult2->fetch();
+
+        $centreon->CentreonLogAction->insertLog("contact", $key, $row['contact_name'], "unblock");
+    }
+}
+/**
  * Delete Contacts
  * @param array $contacts
  */

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -202,7 +202,7 @@ function disableContactInDB($contact_id = null, $contact_arr = array())
  *
  * @param int|array|null $contact Contact ID, array of contact IDs or null to unblock all contacts
  */
-function unblockContactInDB($contact = null)
+function unblockContactInDB(int|array|null $contact = null): void
 {
     global $pearDB, $centreon;
 

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -206,7 +206,7 @@ function unblockContactInDB($contact = null)
 {
     global $pearDB, $centreon;
 
-    if (is_null($contact)) {
+    if (null === $contact) {
         return;
     }
 

--- a/centreon/www/include/configuration/configObject/contact/contact.php
+++ b/centreon/www/include/configuration/configObject/contact/contact.php
@@ -276,6 +276,7 @@ switch ($o) {
         require_once($path . "listContact.php");
         break;
     case UNBLOCK_CONTACT:
+        purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
             unblockContactInDB($contactId);

--- a/centreon/www/include/configuration/configObject/contact/contact.php
+++ b/centreon/www/include/configuration/configObject/contact/contact.php
@@ -276,7 +276,12 @@ switch ($o) {
         require_once($path . "listContact.php");
         break;
     case UNBLOCK_CONTACT:
-        unblockContactInDB($contactId);
+        if (isCSRFTokenValid()) {
+            purgeCSRFToken();
+            unblockContactInDB($contactId);
+        } else {
+            unvalidFormMessage();
+        }
         require_once($path . "listContact.php");
         break;
     default:

--- a/centreon/www/include/configuration/configObject/contact/contact.php
+++ b/centreon/www/include/configuration/configObject/contact/contact.php
@@ -60,6 +60,8 @@ const MASSIVE_ACTIVATE_CONTACT = 'ms';
 const DEACTIVATE_CONTACT = 'u';
 // Massive deactivate on selected contacts
 const MASSIVE_DEACTIVATE_CONTACT = 'mu';
+// Massive Unblock on selected contacts
+const MASSIVE_UNBLOCK_CONTACT = 'mun';
 // Duplicate n contacts and notify it
 const DUPLICATE_CONTACTS = 'm';
 // Delete n contacts and notify it
@@ -68,6 +70,8 @@ const DELETE_CONTACTS = 'd';
 const DISPLAY_NOTIFICATION = 'dn';
 // Synchronize selected contacts with the LDAP
 const SYNC_LDAP_CONTACTS = 'sync';
+// Unblock contact
+const UNBLOCK_CONTACT = 'un';
 
 isset($_GET["contact_id"]) ? $cG = $_GET["contact_id"] : $cG = null;
 isset($_POST["contact_id"]) ? $cP = $_POST["contact_id"] : $cP = null;
@@ -213,6 +217,16 @@ switch ($o) {
         }
         require_once($path . "listContact.php");
         break;
+    case MASSIVE_UNBLOCK_CONTACT:
+        purgeOutdatedCSRFTokens();
+        if (isCSRFTokenValid()) {
+            purgeCSRFToken();
+            unblockContactInDB($select ?? []);
+        } else {
+            unvalidFormMessage();
+        }
+        require_once($path . "listContact.php");
+        break;
     case DUPLICATE_CONTACTS:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
@@ -259,6 +273,10 @@ switch ($o) {
         } else {
             unvalidFormMessage();
         }
+        require_once($path . "listContact.php");
+        break;
+    case UNBLOCK_CONTACT:
+        unblockContactInDB($contactId);
         require_once($path . "listContact.php");
         break;
     default:

--- a/centreon/www/include/configuration/configObject/contact/listContact.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/listContact.ihtml
@@ -55,6 +55,9 @@
             {if $isAdmin}
                 <td class="ListColHeaderCenter" title="{$headerMenu_refreshLdapTitleTooltip}">{$headerMenu_refreshLdap}</td>
             {/if}
+            {if $isAdmin && $blockedContactsCount}
+                <td class="ListColHeaderCenter">{$headerMenu_unblock}</td>
+            {/if}
             <td class="ListColHeaderCenter">{$headerMenu_status}</td>
             <td class="ListColHeaderRight">{$headerMenu_options}</td>
         </tr>
@@ -76,6 +79,9 @@
             <td class="ListColCenter">{$elemArr[elem].RowMenu_admin}</td>
             {if $isAdmin}
                 <td class="ListColCenter">{$elemArr[elem].RowMenu_refreshLdap}</td>
+            {/if}
+            {if $isAdmin && $blockedContactsCount}
+                <td class="ListColCenter">{$elemArr[elem].RowMenu_unblock}</td>
             {/if}
             <td class="ListColCenter">
                 <span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span>

--- a/centreon/www/include/configuration/configObject/contact/listContact.php
+++ b/centreon/www/include/configuration/configObject/contact/listContact.php
@@ -396,12 +396,9 @@ if ($row['count_ldap'] > 0) {
     $tpl->assign('ldap', '1');
 }
 
-
 ?>
-
 <script type="text/javascript">
-
-
+    
     function setO(_i) {
         document.forms['form'].elements['o'].value = _i;
     }

--- a/centreon/www/include/configuration/configObject/contact/listContact.php
+++ b/centreon/www/include/configuration/configObject/contact/listContact.php
@@ -134,7 +134,8 @@ $aclOptions = array(
         'contact_admin',
         'contact_register',
         'contact_auth_type',
-        'contact_ldap_required_sync'
+        'contact_ldap_required_sync',
+        'blocking_time'
     ),
     'keys' => array('contact_id'),
     'order' => array('contact_name'),
@@ -177,6 +178,7 @@ $tpl->assign("headerMenu_options", _("Options"));
 // header title displayed only to admins
 if ($centreon->user->admin) {
     $tpl->assign("headerMenu_refreshLdap", _("Refresh"));
+    $tpl->assign("headerMenu_unblock", _("Unblock"));
     $tpl->assign("headerMenu_refreshLdapTitleTooltip", _("To manually request a LDAP synchronization of a contact"));
 }
 
@@ -235,6 +237,9 @@ $refreshLdapBadge = array(0 => "");
 $elemArr = array();
 $centreonToken = createCSRFToken();
 
+// Get the count of blocked contacts
+$blockedContactsCount =  count(array_filter(array_column($contacts, 'blocking_time')));
+
 foreach ($contacts as $contact) {
     if ($centreon->user->get_id() == $contact['contact_id']) {
         $selectedElements = $form->addElement(
@@ -270,6 +275,12 @@ foreach ($contacts as $contact) {
         "event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) " .
         "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" .
         $contact['contact_id'] . "]' />";
+    $blocked_user_icon = "<a id='gui-unblock-contact' href='main.php?p=" . $p . "&contact_id=" .
+        $contact['contact_id'] . "&o=un&limit=" . $limit . "&num=" . $num . "&search=" . $searchContact .
+        "&centreon_token=" . $centreonToken .
+        "' onclick='return confirmUnblock(this) ;' >
+        <img src='img/icons/lock_closed.png' class='ico-22 margin_auto' border='0' alt='" .  _("Disabled") . "' >
+       </a>";
 
     $contact_type = 0;
     if ($contact["contact_register"]) {
@@ -353,11 +364,13 @@ foreach ($contacts as $contact) {
         "RowMenu_badge" => $contact["contact_activate"] ? "service_ok" : "service_critical",
         "RowMenu_refreshLdap" => $isLinkedToLdap ? $refreshLdapBadge[$isLinkedToLdap] : "",
         "RowMenu_refreshLdapHelp" => $isLinkedToLdap ? $refreshLdapHelp[$isLinkedToLdap] : "",
-        "RowMenu_options" => $moptions
+        "RowMenu_options" => $moptions,
+        "RowMenu_unblock" => $contact["blocking_time"] ? $blocked_user_icon : "-"
     );
     $style != "two" ? $style = "two" : $style = "one";
 }
 $tpl->assign("isAdmin", $centreon->user->admin);
+$tpl->assign("blockedContactsCount", $blockedContactsCount);
 $tpl->assign("elemArr", $elemArr);
 
 // Different messages we put in the template
@@ -385,6 +398,16 @@ if ($row['count_ldap'] > 0) {
 // Toolbar select
 ?>
 <script type="text/javascript">
+
+        function confirmUnblock(element) {
+        if (confirm("<?php echo _("Are you sure you want to unblock this contact?"); ?>")) {
+            var url = element.getAttribute("href");
+            window.location = url;
+            return true;
+    }
+        return false;
+    }
+
     function setO(_i) {
         document.forms['form'].elements['o'].value = _i;
     }
@@ -431,6 +454,10 @@ foreach (array('o1', 'o2') as $option) {
             _("The chosen contact(s) will be disconnected. Do you confirm the LDAP synchronization request ?") .
                 "')) {" .
                 "   setO(this.form.elements['" . $option . "'].value); submit();} " .
+            "else if (this.form.elements['" . $option . "'].selectedIndex == 7 && confirm('" .
+            _("The chosen contact(s) will be unblocked. Do you confirm the request ?") .
+            "')) {" .
+            "   setO(this.form.elements['" . $option . "'].value); submit();} " .
             "this.form.elements['" . $option . "'].selectedIndex = 0"
     );
 
@@ -445,6 +472,10 @@ foreach (array('o1', 'o2') as $option) {
     // adding a specific option available only for admin users
     if ($centreon->user->admin) {
         $formOptions["sync"] = _("Synchronize LDAP");
+    }
+    // adding a specific option available only for admin users and if at least one user is blocked
+    if ($centreon->user->admin && $blockedContactsCount) {
+        $formOptions["mun"] = _("Unblock");
     }
 
     $form->addElement(

--- a/centreon/www/include/configuration/configObject/contact/listContact.php
+++ b/centreon/www/include/configuration/configObject/contact/listContact.php
@@ -277,9 +277,11 @@ foreach ($contacts as $contact) {
         $contact['contact_id'] . "]' />";
 
     $blocked_user_icon = "
-  <a href='main.php?p=" . $p . "&o=un&contact_id=" . $contact['contact_id'] . "' onclick='return  confirm(\"Are you sure you want to unblock this contact ?\");event.preventDefault();  '>
-    <img src='img/icons/lock_closed.png' class='ico-22 margin_auto' border='0'>
-  </a>";
+    <a href='./main.get.php?p=" . $p . "&o=un&contact_id=" . $contact['contact_id'] . "&centreon_token=" . $centreonToken . "' onclick=\"if(confirm('" . _('Are you sure you want to unblock this contact?') . "')) {
+        window.location.href = this.href;
+    }\" >
+        <img src='img/icons/lock_closed.png' class='ico-22 margin_auto' border='0'>
+    </a>";
 
     $contact_type = 0;
     if ($contact["contact_register"]) {

--- a/centreon/www/include/configuration/configObject/contact/listContact.php
+++ b/centreon/www/include/configuration/configObject/contact/listContact.php
@@ -277,7 +277,7 @@ foreach ($contacts as $contact) {
         $contact['contact_id'] . "]' />";
 
     $blocked_user_icon = "
-    <a href='./main.get.php?p=" . $p . "&o=un&contact_id=" . $contact['contact_id'] . "&centreon_token=" . $centreonToken . "' onclick=\"if(confirm('" . _('Are you sure you want to unblock this contact?') . "')) {
+    <a href='./main.get.php?p=" . $p . "&o=un&contact_id=" . $contact['contact_id'] . "&centreon_token=" . $centreonToken . "' onclick=\"if(confirm('" . _('Do you really want to unblock this user?') . "')) {
         window.location.href = this.href;
     }\" >
         <img src='img/icons/lock_closed.png' class='ico-22 margin_auto' border='0'>
@@ -398,7 +398,7 @@ if ($row['count_ldap'] > 0) {
 
 ?>
 <script type="text/javascript">
-    
+
     function setO(_i) {
         document.forms['form'].elements['o'].value = _i;
     }

--- a/centreon/www/include/configuration/configObject/contact/listContact.php
+++ b/centreon/www/include/configuration/configObject/contact/listContact.php
@@ -275,11 +275,11 @@ foreach ($contacts as $contact) {
         "event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) " .
         "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" .
         $contact['contact_id'] . "]' />";
-    $blocked_user_icon = "<a id='gui-unblock-contact' href='main.php?p=" . $p . "&contact_id=" .
+    $blocked_user_icon = "<a href='#' onclick='return confirmUnblock(event) ;'  >   
+        <img href='main.php?p=" . $p . "&contact_id=" .
         $contact['contact_id'] . "&o=un&limit=" . $limit . "&num=" . $num . "&search=" . $searchContact .
         "&centreon_token=" . $centreonToken .
-        "' onclick='return confirmUnblock(this) ;' >
-        <img src='img/icons/lock_closed.png' class='ico-22 margin_auto' border='0' alt='" .  _("Disabled") . "' >
+        "' src='img/icons/lock_closed.png' class='ico-22 margin_auto' border='0' alt='" .  _("Blocked") . "' >
        </a>";
 
     $contact_type = 0;
@@ -395,17 +395,40 @@ if ($row['count_ldap'] > 0) {
     $tpl->assign('ldap', '1');
 }
 
-// Toolbar select
+
+$unblockContactMessagePrompt = "Are you sure you want to unblock this contact ?" ;
 ?>
+
 <script type="text/javascript">
 
-        function confirmUnblock(element) {
-        if (confirm("<?php echo _("Are you sure you want to unblock this contact?"); ?>")) {
-            var url = element.getAttribute("href");
-            window.location = url;
-            return true;
-    }
-        return false;
+    function confirmUnblock(event) {
+        event.preventDefault(); // Prevents the link from being followed immediately
+        // Display a confirmation dialog and check if user confirms
+        if (confirm('<?php echo $unblockContactMessagePrompt; ?>')) {
+            // Get the href attribute of the link and split it into the base URL and parameters
+            var href = event.target.getAttribute("href");
+            var baseUrl = href.split("?")[0];
+            var params = href.split("?")[1].split("&");
+            // Create a new form element
+            var form = document.createElement("form");
+            form.setAttribute("method", "post");
+            form.setAttribute("action", baseUrl);
+            // Add the parameters as hidden input fields to the form
+            for (var i = 0; i < params.length; i++) {
+                var parts = params[i].split("=");
+                var input = document.createElement("input");
+                input.setAttribute("type", "hidden");
+                input.setAttribute("name", parts[0]);
+                input.setAttribute("value", parts[1]);
+                form.appendChild(input);
+            }
+            // Append the form to the body and submit it
+            document.body.appendChild(form);
+
+       form.submit();
+        }
+
+        return false; // Prevents the link from being followed
     }
 
     function setO(_i) {

--- a/centreon/www/include/configuration/configObject/contact/listContact.php
+++ b/centreon/www/include/configuration/configObject/contact/listContact.php
@@ -275,12 +275,11 @@ foreach ($contacts as $contact) {
         "event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) " .
         "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" .
         $contact['contact_id'] . "]' />";
-    $blocked_user_icon = "<a href='#' onclick='return confirmUnblock(event) ;'  >   
-        <img href='main.php?p=" . $p . "&contact_id=" .
-        $contact['contact_id'] . "&o=un&limit=" . $limit . "&num=" . $num . "&search=" . $searchContact .
-        "&centreon_token=" . $centreonToken .
-        "' src='img/icons/lock_closed.png' class='ico-22 margin_auto' border='0' alt='" .  _("Blocked") . "' >
-       </a>";
+
+    $blocked_user_icon = "
+  <a href='main.php?p=" . $p . "&o=un&contact_id=" . $contact['contact_id'] . "' onclick='return  confirm(\"Are you sure you want to unblock this contact ?\");event.preventDefault();  '>
+    <img src='img/icons/lock_closed.png' class='ico-22 margin_auto' border='0'>
+  </a>";
 
     $contact_type = 0;
     if ($contact["contact_register"]) {
@@ -396,40 +395,10 @@ if ($row['count_ldap'] > 0) {
 }
 
 
-$unblockContactMessagePrompt = "Are you sure you want to unblock this contact ?" ;
 ?>
 
 <script type="text/javascript">
 
-    function confirmUnblock(event) {
-        event.preventDefault(); // Prevents the link from being followed immediately
-        // Display a confirmation dialog and check if user confirms
-        if (confirm('<?php echo $unblockContactMessagePrompt; ?>')) {
-            // Get the href attribute of the link and split it into the base URL and parameters
-            var href = event.target.getAttribute("href");
-            var baseUrl = href.split("?")[0];
-            var params = href.split("?")[1].split("&");
-            // Create a new form element
-            var form = document.createElement("form");
-            form.setAttribute("method", "post");
-            form.setAttribute("action", baseUrl);
-            // Add the parameters as hidden input fields to the form
-            for (var i = 0; i < params.length; i++) {
-                var parts = params[i].split("=");
-                var input = document.createElement("input");
-                input.setAttribute("type", "hidden");
-                input.setAttribute("name", parts[0]);
-                input.setAttribute("value", parts[1]);
-                form.appendChild(input);
-            }
-            // Append the form to the body and submit it
-            document.body.appendChild(form);
-
-       form.submit();
-        }
-
-        return false; // Prevents the link from being followed
-    }
 
     function setO(_i) {
         document.forms['form'].elements['o'].value = _i;

--- a/centreon/www/include/configuration/configObject/contact/listContact.php
+++ b/centreon/www/include/configuration/configObject/contact/listContact.php
@@ -276,7 +276,7 @@ foreach ($contacts as $contact) {
         "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" .
         $contact['contact_id'] . "]' />";
 
-    $blocked_user_icon = "
+    $blockedUserIcon = "
     <a href='./main.get.php?p=" . $p . "&o=un&contact_id=" . $contact['contact_id'] . "&centreon_token=" . $centreonToken . "' onclick=\"if(confirm('" . _('Do you really want to unblock this user?') . "')) {
         window.location.href = this.href;
     }\" >
@@ -366,7 +366,7 @@ foreach ($contacts as $contact) {
         "RowMenu_refreshLdap" => $isLinkedToLdap ? $refreshLdapBadge[$isLinkedToLdap] : "",
         "RowMenu_refreshLdapHelp" => $isLinkedToLdap ? $refreshLdapHelp[$isLinkedToLdap] : "",
         "RowMenu_options" => $moptions,
-        "RowMenu_unblock" => $contact["blocking_time"] ? $blocked_user_icon : "-"
+        "RowMenu_unblock" => $contact["blocking_time"] !== null ? $blockedUserIcon : "-"
     );
     $style != "two" ? $style = "two" : $style = "one";
 }
@@ -446,7 +446,7 @@ foreach (array('o1', 'o2') as $option) {
                 "')) {" .
                 "   setO(this.form.elements['" . $option . "'].value); submit();} " .
             "else if (this.form.elements['" . $option . "'].selectedIndex == 7 && confirm('" .
-            _("The chosen contact(s) will be unblocked. Do you confirm the request ?") .
+            _("The user(s) will be unblocked. Do you confirm the request ?") .
             "')) {" .
             "   setO(this.form.elements['" . $option . "'].value); submit();} " .
             "this.form.elements['" . $option . "'].selectedIndex = 0"

--- a/centreon/www/include/configuration/configObject/contact/listContact.php
+++ b/centreon/www/include/configuration/configObject/contact/listContact.php
@@ -238,7 +238,7 @@ $elemArr = array();
 $centreonToken = createCSRFToken();
 
 // Get the count of blocked contacts
-$blockedContactsCount =  count(array_filter(array_column($contacts, 'blocking_time')));
+$blockedContactsCount = count(array_filter(array_column($contacts, 'blocking_time')));
 
 foreach ($contacts as $contact) {
     if ($centreon->user->get_id() == $contact['contact_id']) {
@@ -446,7 +446,7 @@ foreach (array('o1', 'o2') as $option) {
                 "')) {" .
                 "   setO(this.form.elements['" . $option . "'].value); submit();} " .
             "else if (this.form.elements['" . $option . "'].selectedIndex == 7 && confirm('" .
-            _("The user(s) will be unblocked. Do you confirm the request ?") .
+            _("The user(s) will be unblocked. Do you confirm the request?") .
             "')) {" .
             "   setO(this.form.elements['" . $option . "'].value); submit();} " .
             "this.form.elements['" . $option . "'].selectedIndex = 0"

--- a/centreon/www/include/configuration/configObject/contact/listContact.php
+++ b/centreon/www/include/configuration/configObject/contact/listContact.php
@@ -277,7 +277,7 @@ foreach ($contacts as $contact) {
         $contact['contact_id'] . "]' />";
 
     $blockedUserIcon = "
-    <a href='./main.get.php?p=" . $p . "&o=un&contact_id=" . $contact['contact_id'] . "&centreon_token=" . $centreonToken . "' onclick=\"if(confirm('" . _('Do you really want to unblock this user?') . "')) {
+    <a href='./main.get.php?p=" . $p . "&o=un&contact_id=" . $contact['contact_id'] . "&centreon_token=" . $centreonToken . "' class='unblockUserLink' onclick=\"if(confirm('" . _('Do you really want to unblock this user?') . "')) {
         window.location.href = this.href;
     }\" >
         <img src='img/icons/lock_closed.png' class='ico-22 margin_auto' border='0'>


### PR DESCRIPTION
## Description

Since Centreon 22.04 with the password security policy and the option to block a user after several failed attempts, users find themselves blocked and the administrator must unlock them in the database via an SQL query before to wait configured windows range.

We would like to assist administrators to unblock accounts via the Centreon web interface.
A new column “Unblock” will be displayed if at least 1 account is blocked in list of accounts displayed.

Confirm text for action: Do you really want to unblock this user?

**Fixes** # MON-15409

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Configure local security policy to block user after 2 tentative for 30 minutes.
- Try to connect with a non admin user 2 times with incorrect password.
- Connect to Centreon with an administrator account.
- Go to “Configuration > Users > Contacts / Users” menu and click on unblock user button.
- Try to connect with previous simple user with correct password.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
