### PR TITLE
Fix (export): Fixed export of CSV graphics in the resource status page 

### DIFF
--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -99,7 +99,7 @@ services:
         class: Core\Infrastructure\Common\Presenter\DownloadPresenter
         arguments: ['@Core\Infrastructure\Common\Presenter\CsvFormatter']
 
-    Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetricPresenterInterface:
+    Core\Infrastructure\RealTime\Api\DownloadPerformanceMetrics\DownloadPerformanceMetricsPresenter:
         class: Core\Infrastructure\RealTime\Api\DownloadPerformanceMetrics\DownloadPerformanceMetricsPresenter
         arguments: ['@presenter.download.csv']
 

--- a/centreon/src/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetricPresenterInterface.php
+++ b/centreon/src/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetricPresenterInterface.php
@@ -26,6 +26,6 @@ namespace Core\Application\RealTime\UseCase\FindPerformanceMetrics;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Infrastructure\Common\Presenter\DownloadInterface;
 
-interface FindPerformanceMetricPresenterInterface extends PresenterInterface, DownloadInterface
+interface FindPerformanceMetricPresenterInterface extends PresenterInterface
 {
 }

--- a/centreon/src/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetricResponse.php
+++ b/centreon/src/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetricResponse.php
@@ -28,16 +28,19 @@ use Core\Domain\RealTime\Model\PerformanceMetric;
 class FindPerformanceMetricResponse
 {
     /**
-     * @var iterable<mixed>
+     * @var PerformanceMetric[]
      */
     public iterable $performanceMetrics = [];
+    public string $filename;
 
     /**
-     * @param iterable<PerformanceMetric> $performanceMetrics
+     * @param iterable $performanceMetrics
+     * @param string $filename
      */
-    public function __construct(iterable $performanceMetrics)
+    public function __construct(iterable $performanceMetrics, string $filename)
     {
         $this->performanceMetrics = $this->performanceMetricToArray($performanceMetrics);
+        $this->filename = $filename;
     }
 
     /**

--- a/centreon/src/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetrics.php
+++ b/centreon/src/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetrics.php
@@ -25,6 +25,7 @@ namespace Core\Application\RealTime\UseCase\FindPerformanceMetrics;
 
 use Centreon\Domain\Log\LoggerTrait;
 use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Application\RealTime\Repository\ReadPerformanceDataRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadIndexDataRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadMetricRepositoryInterface;
@@ -53,7 +54,7 @@ class FindPerformanceMetrics
      */
     public function __invoke(
         FindPerformanceMetricRequest $request,
-        FindPerformanceMetricPresenterInterface $presenter
+        PresenterInterface $presenter
     ): void {
         try {
             $this->debug(
@@ -75,8 +76,7 @@ class FindPerformanceMetrics
 
             $fileName = $this->generateDownloadFileNameByIndex($index);
             $this->info('Filename used to download metrics', ['filename' => $fileName]);
-            $presenter->setDownloadFileName($fileName);
-            $presenter->present(new FindPerformanceMetricResponse($performanceMetrics));
+            $presenter->present(new FindPerformanceMetricResponse($performanceMetrics, $fileName));
         } catch (\Throwable $ex) {
             $this->error(
                 'Impossible to retrieve performance metrics',

--- a/centreon/src/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetrics.php
+++ b/centreon/src/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetrics.php
@@ -100,7 +100,7 @@ class FindPerformanceMetrics
     {
         $indexData = $this->indexDataRepository->findHostNameAndServiceDescriptionByIndex($index);
 
-        if (!$indexData instanceof IndexData) {
+        if (! ($indexData instanceof IndexData)) {
             return (string) $index;
         }
 

--- a/centreon/src/Core/Infrastructure/RealTime/Api/DownloadPerformanceMetrics/DownloadPerformanceMetricsController.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Api/DownloadPerformanceMetrics/DownloadPerformanceMetricsController.php
@@ -46,7 +46,7 @@ class DownloadPerformanceMetricsController extends AbstractController
         int $serviceId,
         FindPerformanceMetrics $useCase,
         Request $request,
-        FindPerformanceMetricPresenterInterface $presenter
+        DownloadPerformanceMetricsPresenter $presenter
     ): Response {
         $this->denyAccessUnlessGrantedForApiRealtime();
 

--- a/centreon/src/Core/Infrastructure/RealTime/Api/DownloadPerformanceMetrics/DownloadPerformanceMetricsPresenter.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Api/DownloadPerformanceMetrics/DownloadPerformanceMetricsPresenter.php
@@ -28,7 +28,7 @@ use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetr
 use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetricResponse;
 use Core\Infrastructure\Common\Presenter\DownloadInterface;
 
-class DownloadPerformanceMetricsPresenter extends AbstractPresenter implements FindPerformanceMetricPresenterInterface
+class DownloadPerformanceMetricsPresenter extends AbstractPresenter
 {
     /**
      * {@inheritDoc}
@@ -36,18 +36,6 @@ class DownloadPerformanceMetricsPresenter extends AbstractPresenter implements F
      */
     public function present(mixed $data): void
     {
-        parent::present($data->performanceMetrics);
-    }
-
-    /**
-     * Sets download file name in presenter
-     *
-     * @inheritDoc
-     */
-    public function setDownloadFileName(string $fileName): void
-    {
-        if ($this->presenterFormatter instanceof DownloadInterface) {
-            $this->presenterFormatter->setDownloadFileName($fileName);
-        }
+        parent::present($data);
     }
 }

--- a/centreon/tests/php/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetricResponseTest.php
+++ b/centreon/tests/php/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetricResponseTest.php
@@ -63,8 +63,8 @@ function generateExpectedResponseData(string $date, float $rta, float $packetLos
 
 it(
     'response contains properly formatted performanceMetrics',
-    function (iterable $performanceMetrics, array $expectedResponseData) {
-        $response = new FindPerformanceMetricResponse($performanceMetrics);
+    function (iterable $performanceMetrics, array $expectedResponseData, string $filename) {
+        $response = new FindPerformanceMetricResponse($performanceMetrics, $filename);
 
         $this->assertTrue(property_exists($response, 'performanceMetrics'));
         $this->assertInstanceOf(\Generator::class, $response->performanceMetrics);
@@ -74,7 +74,7 @@ it(
     }
 )->with([
     [
-        [], []
+        [], [], 'filename'
     ],
     [
         [
@@ -82,7 +82,8 @@ it(
         ],
         [
             generateExpectedResponseData('2022-01-01', 0.039, 0, 0.108, 0.0049)
-        ]
+        ],
+        'filename'
     ],
     [
         [
@@ -92,6 +93,7 @@ it(
         [
             generateExpectedResponseData('2022-01-01', 0.039, 0, 0.108, 0.0049),
             generateExpectedResponseData('2022-01-01 11:00:05', 0.04, 0.1, 0.10, 0.006)
-        ]
+        ],
+        'filename'
     ]
 ]);

--- a/centreon/tests/php/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetricsTest.php
+++ b/centreon/tests/php/Core/Application/RealTime/UseCase/FindPerformanceMetrics/FindPerformanceMetricsTest.php
@@ -64,10 +64,6 @@ it(
         $metricRepository = $this->createMock(ReadMetricRepositoryInterface::class);
         $performanceDataRepository = $this->createMock(ReadPerformanceDataRepositoryInterface::class);
         $presenter = $this->createMock(FindPerformanceMetricPresenterInterface::class);
-        $presenter
-            ->expects($this->once())
-            ->method('setDownloadFileName')
-            ->with($this->equalTo($expectedFileName));
 
         $performanceMetricRequest = new FindPerformanceMetricRequest(
             $this->hostId,
@@ -117,7 +113,6 @@ it(
             ->method('present')
             ->with($this->equalTo($expectedResponse));
 
-
         $performanceMetricRequest = new FindPerformanceMetricRequest(
             $this->hostId,
             $this->serviceId,
@@ -126,7 +121,6 @@ it(
         );
 
         $sut = new FindPerformanceMetrics($indexDataRepository, $metricRepository, $performanceDataRepository);
-
         $sut($performanceMetricRequest, $presenter);
     }
 )->with([
@@ -138,7 +132,8 @@ it(
                     new DateTimeImmutable(),
                     [new MetricValue('rta', 0.001)]
                 )
-            ]
+            ],
+            '15'
         )
     ],
     [
@@ -152,7 +147,8 @@ it(
                         new MetricValue('pl', 0.002),
                     ]
                 ),
-            ]
+            ],
+            '15'
         )
     ]
 ]);


### PR DESCRIPTION
## Description

Fixed export of CSV graphics in the resource status page.

![export_csv](https://user-images.githubusercontent.com/1265083/231206989-5d1b943f-5610-493c-94b6-5033a539b020.jpg)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
