### PR TITLE
fix(upgrade): remove symfony cache folder before recreating it

### DIFF
--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -652,6 +652,7 @@ systemctl try-restart php-fpm || :
 
 # rebuild symfony cache on upgrade
 if [ -f %{_sysconfdir}/centreon/centreon.conf.php ] ; then
+  rm -rf /var/cache/centreon/symfony
   su - apache -s /bin/bash -c "%{_datadir}/centreon/bin/console cache:clear --no-warmup"
 fi
 

--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -653,7 +653,7 @@ systemctl try-restart php-fpm || :
 # rebuild symfony cache on upgrade
 if [ -f %{_sysconfdir}/centreon/centreon.conf.php ] ; then
   rm -rf /var/cache/centreon/symfony
-  su - apache -s /bin/bash -c "%{_datadir}/centreon/bin/console cache:clear --no-warmup"
+  su - apache -s /bin/bash -c "%{_datadir}/centreon/bin/console cache:clear"
 fi
 
 #%preun web


### PR DESCRIPTION
## Description

this PR intends to remove the symfony cache folder before recreating it, to avoid errors during upgrade

**Fixes** # MON-18434
## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
