### PR TITLE
fix(open-ticket) ticket creation from widget when priority is left empty

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/GlpiRestApi/GlpiRestApiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/GlpiRestApi/GlpiRestApiProvider.class.php
@@ -922,7 +922,7 @@ class GlpiRestApiProvider extends AbstractProvider
                 $tpl->assign('string', $value['Value']);
                 $resultString = $tpl->fetch('eval.ihtml');
                 if ($resultString == '') {
-                    $resultstring = null;
+                    $resultString = null;
                 }
                 $ticketArguments[$this->internal_arg_name[$value['Arg']]] = $resultString;
             }


### PR DESCRIPTION
## Description

Ticket creation from open-ticket widget was resulting in the following error
<img width="188" alt="image" src="https://user-images.githubusercontent.com/88387848/231512286-2ec6809d-03ca-4c79-bd74-29456c2bd97b.png">


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
