### PR TITLE
fix (Authentication): add log when user is blocked

### DIFF
--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/LoginLoggerInterface.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/LoginLoggerInterface.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Security\ProviderConfiguration\Domain;
+
+use Exception;
+
+/**
+ * This interface is used on authentication only
+ */
+interface LoginLoggerInterface
+{
+    /**
+     * @param string $scope
+     * @param string $message
+     * @param array<string,string> $content
+     * @return void
+     */
+    public function info(string $scope, string $message, array $content = []): void;
+
+    /**
+     * @param string $scope
+     * @param string $message
+     * @param array<string,string> $content
+     * @return void
+     */
+    public function debug(string $scope, string $message, array $content = []): void;
+
+    /**
+     * @param string $scope
+     * @param string $message
+     * @param array<string,string> $content
+     * @return void
+     */
+    public function error(string $scope, string $message, array $content = []): void;
+
+    /**
+     * @param string $scope
+     * @param string $message
+     * @param Exception $exception
+     * @return void
+     */
+    public function exception(string $scope, string $message, Exception $exception): void;
+}

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Logger/LoginLogger.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Logger/LoginLogger.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *  For more information : contact@centreon.com
+ */
+
+namespace Core\Security\ProviderConfiguration\Infrastructure\Logger;
+
+use CentreonUserLog;
+use Core\Security\ProviderConfiguration\Domain\LoginLoggerInterface;
+use Pimple\Container;
+
+class LoginLogger implements LoginLoggerInterface
+{
+    /**
+     * @var CentreonUserLog
+     */
+    private CentreonUserLog $logger;
+
+    /**
+     * @param Container $container
+     */
+    public function __construct(Container $container)
+    {
+        $pearDB = $container['configuration_db'];
+        $this->logger = new CentreonUserLog(-1, $pearDB);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function debug(string $scope, string $message, array $content = []): void
+    {
+        $this->logger->insertLog(
+            CentreonUserLog::TYPE_LOGIN,
+            "[$scope] [DEBUG] $message " . json_encode($content)
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function info(string $scope, string $message, array $content = []): void
+    {
+        $this->logger->insertLog(
+            CentreonUserLog::TYPE_LOGIN,
+            "[$scope] [INFO] $message " . json_encode($content)
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function error(string $scope, string $message, array $content = []): void
+    {
+        if (array_key_exists('error', $content)) {
+            $this->logger->insertLog(
+                CentreonUserLog::TYPE_LOGIN,
+                "[$scope] [Error] $message" . json_encode($content)
+            );
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function exception(string $scope, string $message, \Exception $exception): void
+    {
+        $this->logger->insertLog(
+            CentreonUserLog::TYPE_LOGIN,
+            sprintf(
+                "[$scope] [ERROR] $message",
+                get_class($exception),
+                $exception->getMessage()
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
## Description
Given a user performing a last authentication attempt with a valid user account
The error displayed in the interface must remain "Authentication failed" but the Centreon logs must indicate that the maximum number of authentications has been reached and that the user is blocked.
```
sh-4.2# tail -f var/log/centreon/login.log
2023-04-14 01:03:01|0|0|0|[local] [172.29.0.1] Authentication failed for 'admin' : invalid credentials
2023-04-14 01:03:01|-1|0|0|[local] [INFO] User is blocked: maximum number of authentication attempts was reached {"contact_alias":"admin"}
```
ui:
![image](https://user-images.githubusercontent.com/108519266/231903521-64e9242f-f2e5-457f-9df3-07d227a68c03.png)
api v2:
![image](https://user-images.githubusercontent.com/108519266/231904361-36d792b3-52ce-4f50-9565-e2d9d78babde.png)

api v1:
![image](https://user-images.githubusercontent.com/108519266/231904242-3c37f080-11df-4570-90c1-83f5f34ca1c9.png)


**Fixes** # MON-16740

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

  example mapping in jira ticket

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
