### PR TITLE
fix(ci): force install of cypress

### DIFF
--- a/.github/actions/cypress-e2e-testing/action.yml
+++ b/.github/actions/cypress-e2e-testing/action.yml
@@ -35,7 +35,9 @@ runs:
         cache-dependency-path: ${{ inputs.module }}
 
     - name: Install dependencies
-      run: pnpm install --frozen-lockfile
+      run: |
+        pnpm install --frozen-lockfile
+        pnpm cypress install --force
       working-directory: ${{ inputs.module }}
       shell: bash
 


### PR DESCRIPTION
## Description

force install of cypress to build properly cache directory

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)