### PR TITLE
use select2 in opt popup

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/Abstract/templates/group.ihtml
@@ -21,6 +21,9 @@
         {/if}
         {/foreach}
         </select>
+        <script>
+            jQuery('#select_{$groupId}').select2()
+        </script>
     {/if}
     </td>
 </tr>


### PR DESCRIPTION
## Description

replace old select lists in open ticket popup with a select2 select list
![image](https://user-images.githubusercontent.com/7352865/232428843-a01639be-f099-47e0-a307-76b0b4bd1f4f.png)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- have an open ticket rule that retrieves data from external software or add custom lists in the provider configuration
- try to open a ticket and select the desired values when the popup is displayed

with the patch, select lists now have a search field. When the ticket is created, the selected fields must be sent to the external software.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
