### PR TITLE
fix(ci): fix path to cache node dependencies

### DIFF
--- a/.github/actions/cypress-e2e-testing/action.yml
+++ b/.github/actions/cypress-e2e-testing/action.yml
@@ -32,13 +32,13 @@ runs:
       with:
         node-version: 18
         cache: pnpm
-        cache-dependency-path: ${{ inputs.module }}
+        cache-dependency-path: ${{ inputs.module }}/tests/e2e
 
     - name: Install dependencies
       run: |
         pnpm install --frozen-lockfile
         pnpm cypress install --force
-      working-directory: ${{ inputs.module }}
+      working-directory: ${{ inputs.module }}/tests/e2e
       shell: bash
 
     - name: Format feature file path


### PR DESCRIPTION
## Description

fix path to cache node dependencies

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)