### PR TITLE
Add poller filter to open ticket widget

### DIFF
--- a/centreon-open-tickets/widgets/open-tickets/configs.xml
+++ b/centreon-open-tickets/widgets/open-tickets/configs.xml
@@ -15,6 +15,7 @@
     <preference label="Opened Tickets" name="opened_tickets" defaultValue="0" type="boolean"/>
     <preference label="Host Name" name="host_name_search" defaultValue="" type="compare" header="Filters"/>
     <preference label="Service Description" name="service_description_search" defaultValue="" type="compare"/>
+    <preference label="Poller" name="poller" type="pollerMulti" defaultValue=""/>
     <preference label="Hide services with DOWN host" name="hide_down_host" defaultValue="0" type="boolean"/>
     <preference label="Hide services with UNREACHABLE host" name="hide_unreachable_host" defaultValue="0" type="boolean"/>
     <preference label="Hide hosts with disable notifications" name="hide_disable_notif_host" defaultValue="0" type="boolean"/>

--- a/centreon-open-tickets/widgets/open-tickets/src/export.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/export.php
@@ -159,6 +159,18 @@ if (isset($preferences['service_description_search']) && $preferences['service_d
         );
     }
 }
+
+if (!empty($preferences['poller'])) {
+    $pollers = [];
+    $pollerIds = explode(',', $preferences['poller']);
+    
+    foreach ($pollerIds as $pollerId) {
+        $pollers[] = (int) $pollerId;
+    }
+
+    $query .= " AND h.instance_id IN (" . implode(',', $pollers) . ")";
+}
+
 $stateTab = array();
 if (isset($preferences['svc_ok']) && $preferences['svc_ok']) {
     $stateTab[] = 0;

--- a/centreon-open-tickets/widgets/open-tickets/src/index.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/index.php
@@ -99,6 +99,7 @@ $stateLabels = array(
     3 => "Unknown",
     4 => "Pending"
 );
+
 // Build Query
 $query = "SELECT SQL_CALC_FOUND_ROWS h.host_id,
         h.name AS hostname,
@@ -173,6 +174,7 @@ $query = "SELECT SQL_CALC_FOUND_ROWS h.host_id,
 if (!$centreon->user->admin) {
     $query .= " , centreon_acl acl ";
 }
+
 $query .= " WHERE s.host_id = h.host_id
     AND h.enabled = 1 AND h.name NOT LIKE '_Module_%'
     AND s.enabled = 1 ";
@@ -189,6 +191,7 @@ if (isset($preferences['host_name_search']) && $preferences['host_name_search'] 
         );
     }
 }
+
 if (isset($preferences['service_description_search']) && $preferences['service_description_search'] != "") {
     $tab = explode(" ", $preferences['service_description_search']);
     $op = $tab[0];
@@ -202,6 +205,18 @@ if (isset($preferences['service_description_search']) && $preferences['service_d
         );
     }
 }
+
+if (!empty($preferences['poller'])) {
+    $pollers = [];
+    $pollerIds = explode(',', $preferences['poller']);
+    
+    foreach ($pollerIds as $pollerId) {
+        $pollers[] = (int) $pollerId;
+    }
+
+    $query .= " AND h.instance_id IN (" . implode(',', $pollers) . ")";
+}
+
 $stateTab = [];
 if (isset($preferences['svc_warning']) && $preferences['svc_warning']) {
     $stateTab[] = 1;


### PR DESCRIPTION
## Description

this PR brings the possibility to filter hosts/services depending on their monitoring poller

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

- change the version number in the configs.xml file for a higher value (/usr/share/centreon/www/widgets/open-tickets/configs.xml) 
- update your open ticket widget in the web interface in the extension menu
- in the custom view menu, edit your open ticket widget configuration. 

with the patch, you should have a new poller filter. You need to be able to filter on multiple pollers and the services displayed in the widget should match your new filters

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
