### PR TITLE
fix(upgrade): Error WebSSO during upgrade to 22.04

### DIFF
--- a/centreon/src/Security/WebSSOAuthenticator.php
+++ b/centreon/src/Security/WebSSOAuthenticator.php
@@ -30,7 +30,9 @@ use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Menu\MenuService;
 use Centreon\Domain\Menu\Model\Page;
 use Centreon\Domain\Option\Interfaces\OptionServiceInterface;
+use Centreon\Domain\Platform\Interfaces\PlatformRepositoryInterface;
 use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Centreon\Domain\VersionHelper;
 use Centreon\Infrastructure\Service\Exception\NotFoundException;
 use Core\Infrastructure\Common\Api\HttpUrlTrait;
 use Core\Security\Application\ProviderConfiguration\WebSSO\Repository\ReadWebSSOConfigurationRepositoryInterface;
@@ -67,6 +69,8 @@ class WebSSOAuthenticator extends AbstractAuthenticator
     use HttpUrlTrait;
     use LoggerTrait;
 
+    const MINIMUM_SUPPORTED_VERSION = "22.04";
+
     /**
      * @param Container $dependencyInjector
      * @param ReadWebSSOConfigurationRepositoryInterface $webSSOReadRepository
@@ -91,7 +95,8 @@ class WebSSOAuthenticator extends AbstractAuthenticator
         private OptionServiceInterface $optionService,
         private AuthenticationRepositoryInterface $authenticationRepository,
         private Security $security,
-        private MenuService $menuService
+        private MenuService $menuService,
+        private PlatformRepositoryInterface $platformRepository,
     ) {
 
     }
@@ -101,8 +106,12 @@ class WebSSOAuthenticator extends AbstractAuthenticator
      */
     public function supports(Request $request): bool
     {
+        $webVersion = $this->platformRepository->getWebVersion();
         // We skip all API calls
-        if ($request->headers->has('X-Auth-Token')) {
+        if (
+            $request->headers->has('X-Auth-Token')
+            || VersionHelper::compare($webVersion, self::MINIMUM_SUPPORTED_VERSION, VersionHelper::LT)
+        ) {
             return false;
         }
 

--- a/centreon/src/Security/WebSSOAuthenticator.php
+++ b/centreon/src/Security/WebSSOAuthenticator.php
@@ -69,7 +69,7 @@ class WebSSOAuthenticator extends AbstractAuthenticator
     use HttpUrlTrait;
     use LoggerTrait;
 
-    const MINIMUM_SUPPORTED_VERSION = "22.04";
+    private const MINIMUM_SUPPORTED_VERSION = "22.04";
 
     /**
      * @param Container $dependencyInjector


### PR DESCRIPTION
## Description

Fixed error during upgrade to 22.04

![image](https://user-images.githubusercontent.com/108675430/232469188-490294ee-ae33-49ea-b0b0-5c816af686cc.png)

**Fixes** # MON-17149

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
