### PR TITLE
fix(api): correctly display errors when failure on password renew

### DIFF
--- a/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
+++ b/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
@@ -28,14 +28,15 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Security\ProviderConfiguration\Application\Repository\ReadConfigurationRepositoryInterface;
 use Core\Security\ProviderConfiguration\Domain\Local\Model\Configuration;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
+use Core\Security\ProviderConfiguration\Infrastructure\Local\Api\Exception\ConfigurationException;
 use Core\Security\User\Domain\Exception\UserPasswordException;
 use Core\Security\User\Domain\Model\UserPasswordFactory;
 use Core\Application\Common\UseCase\UnauthorizedResponse;
 use Core\Security\User\Application\Repository\ReadUserRepositoryInterface;
 use Core\Security\User\Application\Repository\WriteUserRepositoryInterface;
-use Core\Security\ProviderConfiguration\Application\Repository\ReadConfigurationRepositoryInterface;
 
 class RenewPassword
 {
@@ -88,7 +89,7 @@ class RenewPassword
                 $user,
                 $providerConfiguration->getCustomConfiguration()->getSecurityPolicy()
             );
-        } catch(UserPasswordException $ex) {
+        } catch(UserPasswordException | ConfigurationException $ex) {
             $this->error("Unable to update password", ["trace" => (string) $ex]);
             $presenter->setResponseStatus(new InvalidArgumentResponse($ex->getMessage()));
 

--- a/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
+++ b/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
@@ -95,8 +95,8 @@ class RenewPassword
 
             return;
         }  catch(\Throwable $ex) {
-            $this->error("An error occured while updating password", ["trace" => (string) $ex]);
-            $presenter->setResponseStatus(new ErrorResponse("An error occured while updating password"));
+            $this->error('An error occured while updating password', ['trace' => (string) $ex]);
+            $presenter->setResponseStatus(new ErrorResponse('An error occured while updating password'));
 
             return;
         }

--- a/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
+++ b/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
@@ -90,7 +90,7 @@ class RenewPassword
                 $providerConfiguration->getCustomConfiguration()->getSecurityPolicy()
             );
         } catch(UserPasswordException | ConfigurationException $ex) {
-            $this->error("Unable to update password", ["trace" => (string) $ex]);
+            $this->error('Unable to update password', ['trace' => (string) $ex]);
             $presenter->setResponseStatus(new InvalidArgumentResponse($ex->getMessage()));
 
             return;

--- a/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
+++ b/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
@@ -40,7 +40,7 @@ class UserPasswordFactory
      * @param User $user
      * @param SecurityPolicy $securityPolicy
      * @return UserPassword
-     * @throws AssertionException|ConfigurationException
+     * @throws UserPasswordException|ConfigurationException
      */
     public static function create(string $password, User $user, SecurityPolicy $securityPolicy): UserPassword
     {
@@ -66,7 +66,7 @@ class UserPasswordFactory
                     'UserPassword::passwordValue'
                 );
             }
-        } catch (AssertionException $ex) {
+        } catch (AssertionException) {
             //Throw a generic user password exception to avoid returning a plain password in the AssertionException.
             throw UserPasswordException::passwordDoesnotMatchSecurityPolicy();
         }


### PR DESCRIPTION
## Description

This PR intends to correctly display errors when failure on password renew. 
Instead of non business logic messages we display a more coherent message:

```
{
  "code": 400,
  "message": "Your password doesn't match the security policy"
}
```

**Fixes** # MON-16507

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
