### PR TITLE
fix(ACL): adjust reload icon display

### DIFF
--- a/centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+++ b/centreon/www/include/options/accessLists/reloadACL/reloadACL.php
@@ -127,7 +127,7 @@ while ($r = $res->fetch()) {
         $session_data[$cpt]["current_page"] = $r["current_page"] . $rCP["topology_url_opt"];
         $session_data[$cpt]["topology_name"] = _($rCP["topology_name"]);
         $session_data[$cpt]["actions"] = "<a href='./main.php?p=" . $p . "&o=r'>" .
-            displaySvg(
+            returnSvg(
                 "www/img/icons/refresh.svg",
                 "var(--help-tool-tip-icon-fill-color)",
                 18,


### PR DESCRIPTION
## Description
Description
In GUI, ACL reload page will show extra "reload icon" based on number of users currenctly connected.

**Fixes** # MON-17579
**Recieved result**
![image](https://user-images.githubusercontent.com/108519266/232533529-b207f3a1-c1ce-4b59-9d2d-56053d412235.png)
**Expected result**
![image](https://user-images.githubusercontent.com/108519266/232537486-e6dba327-5697-4940-a5b1-aa79feff4360.png)
## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Install a Centreon platofrm
2. Create an ACL group
3. Add a user in this ACL group
4. Connect several time in private navigation with this user
5. Connect 1 time with an admin user
6. Go to “Administration > ACL > Reload ACL” and validate that “refresh icon” in in “Reload” column

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
