### PR TITLE
fix(hostgroup): correct the query to get hostgroup info

### DIFF
--- a/centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostGroupRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostGroupRepositoryRDB.php
@@ -221,8 +221,8 @@ class HostGroupRepositoryRDB extends AbstractRepositoryDRB implements
                         ON imapR.img_img_id = imap.img_id
                     LEFT JOIN `:db`.view_img_dir imapD
                         ON imapD.dir_id = imapR.dir_dir_parent_id
-                    INNER JOIN `:db`.acl_resources_hc_relations arhr
-                        ON hg.hg_id = arhr.hc_id
+                    INNER JOIN `:db`.acl_resources_hg_relations arhr
+                        ON hg.hg_id = arhr.hg_hg_id
                     INNER JOIN `:db`.acl_resources res
                         ON arhr.acl_res_id = res.acl_res_id
                     INNER JOIN `:db`.acl_res_group_relations argr


### PR DESCRIPTION
## Description

Fix the query to get hostgroup info for non-admin users

**Fixes** MON-18555

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)