### PR TITLE
fix(resource): return host when searching with h.name

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -70,7 +70,6 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         'alias' => 'resources.alias',
         'fqdn' => 'resources.address',
         'type' => 'resources.type',
-        // We know this trick breaks the EQUAL, but this is theoretically ONLY used as REGEX from the Resource status
         'h.name' => 'CASE type WHEN 1 THEN `resources.name` ELSE `resources.parent_name` END',
         'h.alias' => 'parent_resource.alias',
         'h.address' => 'parent_resource.address',

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -70,7 +70,8 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         'alias' => 'resources.alias',
         'fqdn' => 'resources.address',
         'type' => 'resources.type',
-        'h.name' => 'parent_resource.name',
+        // We know this trick breaks the EQUAL, but this is theoretically ONLY used as REGEX from the Resource status
+        'h.name' => 'CONCAT(resources.parent_name, resources.name)',
         'h.alias' => 'parent_resource.alias',
         'h.address' => 'parent_resource.address',
         's.description' => 'resources.type IN (0,2) AND resources.name',

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -71,7 +71,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         'fqdn' => 'resources.address',
         'type' => 'resources.type',
         // We know this trick breaks the EQUAL, but this is theoretically ONLY used as REGEX from the Resource status
-        'h.name' => 'CONCAT(resources.parent_name, resources.name)',
+        'h.name' => 'CASE type WHEN 1 THEN `resources.name` ELSE `resources.parent_name` END',
         'h.alias' => 'parent_resource.alias',
         'h.address' => 'parent_resource.address',
         's.description' => 'resources.type IN (0,2) AND resources.name',


### PR DESCRIPTION
ℹ️ MON-18040

This PR intends to return also the host when searching h.name:[search]
I've used CONCAT in the concordanceArray for the h.name which corresponds to `resources.name REGEXP [search] OR resources.parent_name REGEXP [search]`

Here is the difference between both types of requests. CONCAT here is only used with 2 columns which should not impact much performances (h.name filter is not used that much and should disappear with 23.10)

![image](https://user-images.githubusercontent.com/31647811/232598063-5a9c4363-1959-451d-b6a7-32567b19ec65.png)

// We know this trick breaks the EQUAL, but this is theorically ONLY used as REGEX from the Resource status


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

See MON-18040

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
