### PR TITLE
fix(api): correctly display errors when failure on password renew (22.10)

### DIFF
--- a/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
+++ b/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
@@ -285,27 +285,19 @@ class Assertion
     }
 
     /**
-     * Assert that a value match a regex
+     * Assert that a value match a regex.
      *
      * @param mixed $value
      * @param string $pattern
      * @param string|null $propertyPath
-     * @return void
+     *
+     * @throws \Assert\AssertionFailedException
      */
-    public static function regex(mixed $value, string $pattern, string $propertyPath = null): void
+    public static function regex(mixed $value, string $pattern, ?string $propertyPath = null): void
     {
-        Assert::regex(
-            $value,
-            $pattern,
-            function (array $parameters) {
-                return AssertionException::matchRegex(
-                    $parameters['value'],
-                    $parameters['pattern'],
-                    $parameters['propertyPath']
-                )->getMessage();
-            },
-            $propertyPath
-        );
+        if (! \is_string($value) || ! \preg_match($pattern, $value)) {
+            throw AssertionException::matchRegex(self::stringify($value), $pattern, $propertyPath);
+        }
     }
 
     /**
@@ -322,5 +314,39 @@ class Assertion
         ) {
             throw AssertionException::ipOrDomain($value, $propertyPath);
         }
+    }
+
+    /**
+     * Make a string version of a value.
+     *
+     * Copied from {@see \Assert\Assertion::stringify()}.
+     *
+     * @param mixed $value
+     */
+    private static function stringify(mixed $value): string
+    {
+        $result = \gettype($value);
+
+        if (\is_bool($value)) {
+            $result = $value ? '<TRUE>' : '<FALSE>';
+        } elseif (\is_scalar($value)) {
+            $val = (string) $value;
+
+            if (\mb_strlen($val) > 100) {
+                $val = \mb_substr($val, 0, 97) . '...';
+            }
+
+            $result = $val;
+        } elseif (\is_array($value)) {
+            $result = '<ARRAY>';
+        } elseif (\is_object($value)) {
+            $result = \get_debug_type($value);
+        } elseif (\is_resource($value)) {
+            $result = \get_resource_type($value);
+        } elseif (null === $value) {
+            $result = '<NULL>';
+        }
+
+        return $result;
     }
 }

--- a/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
+++ b/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
@@ -96,7 +96,7 @@ class RenewPassword
             return;
         }  catch(\Throwable $ex) {
             $this->error('An error occured while updating password', ['trace' => (string) $ex]);
-            $presenter->setResponseStatus(new ErrorResponse("An error occured while updating password"));
+            $presenter->setResponseStatus(new ErrorResponse('An error occured while updating password'));
 
             return;
         }

--- a/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
+++ b/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
@@ -82,7 +82,7 @@ class RenewPassword
 
         try {
             /** @var Configuration $providerConfiguration */
-            $providerConfiguration = $this->readConfigurationRepository->getConfigurationByType(Provider::LOCAL);
+            $providerConfiguration = $this->readConfigurationRepository->getConfigurationByName(Provider::LOCAL);
             $this->info('Validate password against security policy');
             $newPassword = UserPasswordFactory::create(
                 $renewPasswordRequest->newPassword,

--- a/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
+++ b/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
@@ -24,12 +24,16 @@ declare(strict_types=1);
 namespace Core\Security\User\Application\UseCase\RenewPassword;
 
 use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
-use Core\Security\ProviderConfiguration\Domain\Local\Model\Configuration;
-use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use Core\Security\User\Domain\Model\UserPasswordFactory;
 use Core\Application\Common\UseCase\UnauthorizedResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Security\ProviderConfiguration\Infrastructure\Local\Api\Exception\ConfigurationException;
+use Core\Security\ProviderConfiguration\Domain\Model\Provider;
+use Core\Security\User\Domain\Exception\UserPasswordException;
+use Core\Security\ProviderConfiguration\Domain\Local\Model\Configuration;
 use Core\Security\User\Application\Repository\ReadUserRepositoryInterface;
 use Core\Security\User\Application\Repository\WriteUserRepositoryInterface;
 use Core\Security\ProviderConfiguration\Application\Repository\ReadConfigurationRepositoryInterface;
@@ -76,17 +80,28 @@ class RenewPassword
             return;
         }
 
+        try {
+            /** @var Configuration $providerConfiguration */
+            $providerConfiguration = $this->readConfigurationRepository->getConfigurationByType(Provider::LOCAL);
+            $this->info('Validate password against security policy');
+            $newPassword = UserPasswordFactory::create(
+                $renewPasswordRequest->newPassword,
+                $user,
+                $providerConfiguration->getCustomConfiguration()->getSecurityPolicy()
+            );
+        } catch(UserPasswordException | ConfigurationException $ex) {
+            $this->error('Unable to update password', ['trace' => (string) $ex]);
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex->getMessage()));
 
-        /** @var Configuration $providerConfiguration */
-        $providerConfiguration = $this->readConfigurationRepository->getConfigurationByName(Provider::LOCAL);
-        $this->info('Validate password against security policy');
-        $newPassword = UserPasswordFactory::create(
-            $renewPasswordRequest->newPassword,
-            $user,
-            $providerConfiguration->getCustomConfiguration()->getSecurityPolicy()
-        );
+            return;
+        }  catch(\Throwable $ex) {
+            $this->error('An error occured while updating password', ['trace' => (string) $ex]);
+            $presenter->setResponseStatus(new ErrorResponse("An error occured while updating password"));
+
+            return;
+        }
+
         $user->setPassword($newPassword);
-
         $this->info('Updating user password', [
             'user_alias' => $user->getAlias()
         ]);

--- a/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
+++ b/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
@@ -89,12 +89,12 @@ class RenewPassword
                 $user,
                 $providerConfiguration->getCustomConfiguration()->getSecurityPolicy()
             );
-        } catch(UserPasswordException | ConfigurationException $ex) {
+        } catch (UserPasswordException | ConfigurationException $ex) {
             $this->error('Unable to update password', ['trace' => (string) $ex]);
             $presenter->setResponseStatus(new InvalidArgumentResponse($ex->getMessage()));
 
             return;
-        }  catch(\Throwable $ex) {
+        }  catch (\Throwable $ex) {
             $this->error('An error occured while updating password', ['trace' => (string) $ex]);
             $presenter->setResponseStatus(new ErrorResponse('An error occured while updating password'));
 

--- a/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
+++ b/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
@@ -63,7 +63,7 @@ class UserPasswordFactory
             if ($securityPolicy->hasSpecialCharacter()) {
                 Assertion::regex(
                     $password,
-                    '/[' . preg_quote(SecurityPolicy::SPECIAL_CHARACTERS_LIST) . ']/',
+                    '/[' . SecurityPolicy::SPECIAL_CHARACTERS_LIST . ']/',
                     'UserPassword::passwordValue'
                 );
             }

--- a/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
+++ b/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
@@ -63,11 +63,11 @@ class UserPasswordFactory
             if ($securityPolicy->hasSpecialCharacter()) {
                 Assertion::regex(
                     $password,
-                    '/[' . SecurityPolicy::SPECIAL_CHARACTERS_LIST . ']/',
+                    '/[' . preg_quote(SecurityPolicy::SPECIAL_CHARACTERS_LIST) . ']/',
                     'UserPassword::passwordValue'
                 );
             }
-        } catch (AssertionException | InvalidArgumentException) {
+        } catch (AssertionException | InvalidArgumentException | \ValueError) {
             //Throw a generic user password exception to avoid returning a plain password in the AssertionException.
             throw UserPasswordException::passwordDoesnotMatchSecurityPolicy();
         }

--- a/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
+++ b/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\User\Domain\Model;
 
+use Assert\InvalidArgumentException;
 use Core\Security\User\Domain\Model\User;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Core\Security\User\Domain\Model\UserPassword;
@@ -66,7 +67,7 @@ class UserPasswordFactory
                     'UserPassword::passwordValue'
                 );
             }
-        } catch (AssertionException $ex) {
+        } catch (AssertionException | InvalidArgumentException) {
             //Throw a generic user password exception to avoid returning a plain password in the AssertionException.
             throw UserPasswordException::passwordDoesnotMatchSecurityPolicy();
         }

--- a/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
+++ b/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
@@ -67,7 +67,7 @@ class UserPasswordFactory
                     'UserPassword::passwordValue'
                 );
             }
-        } catch (AssertionException | InvalidArgumentException | \ValueError) {
+        } catch (AssertionException | InvalidArgumentException) {
             //Throw a generic user password exception to avoid returning a plain password in the AssertionException.
             throw UserPasswordException::passwordDoesnotMatchSecurityPolicy();
         }


### PR DESCRIPTION
## Description

This PR intends to correctly display errors when failure on password renew. 
Instead of non business logic messages we display a more coherent message:

```
{
  "code": 400,
  "message": "Your password doesn't match the security policy"
}
```

**Fixes** # MON-16507

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
