### PR TITLE
fix(upgrade): Error WebSSO during upgrade to 22.10

### DIFF
--- a/centreon/src/Security/WebSSOAuthenticator.php
+++ b/centreon/src/Security/WebSSOAuthenticator.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 namespace Security;
 
-use Security\Domain\Authentication\Model\Session;
 use Centreon\Domain\Contact\Interfaces\{ContactInterface, ContactRepositoryInterface};
 use Centreon\Domain\Exception\ContactDisabledException;
 use Centreon\Domain\Log\LoggerTrait;
@@ -50,6 +49,7 @@ use DateInterval;
 use DateTimeImmutable;
 use FOS\RestBundle\View\View;
 use Security\Domain\Authentication\Interfaces\{AuthenticationServiceInterface, SessionRepositoryInterface};
+use Security\Domain\Authentication\Model\Session;
 use Symfony\Component\HttpFoundation\{Request, Response};
 use Symfony\Component\Security\Core\Exception\{
     AuthenticationException,

--- a/centreon/src/Security/WebSSOAuthenticator.php
+++ b/centreon/src/Security/WebSSOAuthenticator.php
@@ -22,49 +22,54 @@ declare(strict_types=1);
 
 namespace Security;
 
-use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use Centreon\Domain\Contact\Interfaces\ContactRepositoryInterface;
+use Security\Domain\Authentication\Model\Session;
+use Centreon\Domain\Contact\Interfaces\{ContactInterface, ContactRepositoryInterface};
 use Centreon\Domain\Exception\ContactDisabledException;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Menu\Interfaces\MenuServiceInterface;
 use Centreon\Domain\Menu\Model\Page;
 use Centreon\Domain\Option\Interfaces\OptionServiceInterface;
+use Centreon\Domain\Platform\Interfaces\PlatformRepositoryInterface;
 use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Centreon\Domain\VersionHelper;
 use Core\Infrastructure\Common\Api\HttpUrlTrait;
-use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
-use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
-use Core\Security\Authentication\Application\Repository\WriteSessionRepositoryInterface;
-use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
+use Core\Security\Authentication\Application\Provider\{
+    ProviderAuthenticationInterface,
+    ProviderAuthenticationFactoryInterface
+};
+use Core\Security\Authentication\Application\Repository\{
+    WriteTokenRepositoryInterface,
+    WriteSessionRepositoryInterface
+};
 use Core\Security\Authentication\Application\UseCase\Login\LoginRequest;
 use Core\Security\Authentication\Domain\Exception\SSOAuthenticationException;
-use Core\Security\Authentication\Domain\Model\NewProviderToken;
-use Core\Security\Authentication\Domain\Model\ProviderToken;
+use Core\Security\Authentication\Domain\Exception\AuthenticationException as CentreonAuthenticationException;
+use Core\Security\Authentication\Domain\Model\{NewProviderToken, ProviderToken};
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use DateInterval;
 use DateTimeImmutable;
 use FOS\RestBundle\View\View;
-use Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface;
-use Security\Domain\Authentication\Interfaces\SessionRepositoryInterface;
-use Security\Domain\Authentication\Model\Session;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpFoundation\Session\SessionInterface;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\AuthenticationException;
-use Symfony\Component\Security\Core\Exception\BadCredentialsException;
-use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
-use Symfony\Component\Security\Core\Exception\SessionUnavailableException;
-use Symfony\Component\Security\Core\Exception\UserNotFoundException;
+use Security\Domain\Authentication\Interfaces\{AuthenticationServiceInterface, SessionRepositoryInterface};
+use Symfony\Component\HttpFoundation\{Request, Response};
+use Symfony\Component\Security\Core\Exception\{
+    AuthenticationException,
+    BadCredentialsException,
+    CredentialsExpiredException,
+    SessionUnavailableException,
+    UserNotFoundException
+};
 use Symfony\Component\Security\Core\User\UserInterface;
 use Symfony\Component\Security\Http\Authenticator\AbstractAuthenticator;
 use Symfony\Component\Security\Http\Authenticator\Passport\Badge\UserBadge;
 use Symfony\Component\Security\Http\Authenticator\Passport\SelfValidatingPassport;
-use Core\Security\Authentication\Domain\Exception\AuthenticationException as CentreonAuthenticationException;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 
 class WebSSOAuthenticator extends AbstractAuthenticator
 {
     use HttpUrlTrait;
     use LoggerTrait;
+
+    private const MINIMUM_SUPPORTED_VERSION = "22.04";
 
     /**
      * @var ProviderAuthenticationInterface
@@ -91,9 +96,13 @@ class WebSSOAuthenticator extends AbstractAuthenticator
         private WriteSessionRepositoryInterface $writeSessionRepository,
         private ProviderAuthenticationFactoryInterface $providerFactory,
         private ContactRepositoryInterface $contactRepository,
-        private MenuServiceInterface $menuService
+        private MenuServiceInterface $menuService,
+        private PlatformRepositoryInterface $platformRepository
     ) {
-        $this->provider = $this->providerFactory->create(Provider::WEB_SSO);
+        $webVersion = $this->platformRepository->getWebVersion();
+        if (VersionHelper::compare($webVersion, self::MINIMUM_SUPPORTED_VERSION, VersionHelper::GE)) {
+            $this->provider = $this->providerFactory->create(Provider::WEB_SSO);
+        }
     }
 
     /**
@@ -101,13 +110,16 @@ class WebSSOAuthenticator extends AbstractAuthenticator
      */
     public function supports(Request $request): bool
     {
+        $webVersion = $this->platformRepository->getWebVersion();
         // We skip all API calls
-        if ($request->headers->has('X-Auth-Token')) {
+        if (
+            $request->headers->has('X-Auth-Token')
+            || VersionHelper::compare($webVersion, self::MINIMUM_SUPPORTED_VERSION, VersionHelper::LT)
+        ) {
             return false;
         }
 
-        $provider = $this->providerFactory->create(Provider::WEB_SSO);
-        $configuration = $provider->getConfiguration();
+        $configuration = $this->provider->getConfiguration();
 
         $sessionId = $request->getSession()->getId();
         $isValidToken = $this->authenticationService->isValidToken($sessionId);


### PR DESCRIPTION
## Description

Fixed error during upgrade to 22.10 from 21.10

This is a backport of https://github.com/centreon/centreon/pull/1329

**Fixes** # MON-17149

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
