### PR TITLE
fix(api): correctly display errors when failure on password renew (22.04)

### DIFF
--- a/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
+++ b/centreon/src/Centreon/Domain/Common/Assertion/Assertion.php
@@ -285,26 +285,52 @@ class Assertion
     }
 
     /**
-     * Assert that a value match a regex
+     * Assert that a value match a regex.
      *
      * @param mixed $value
      * @param string $pattern
      * @param string|null $propertyPath
-     * @return void
+     *
+     * @throws \Assert\AssertionFailedException
      */
-    public static function regex(mixed $value, string $pattern, string $propertyPath = null): void
+    public static function regex(mixed $value, string $pattern, ?string $propertyPath = null): void
     {
-        Assert::regex(
-            $value,
-            $pattern,
-            function (array $parameters) {
-                return AssertionException::matchRegex(
-                    $parameters['value'],
-                    $parameters['pattern'],
-                    $parameters['propertyPath']
-                )->getMessage();
-            },
-            $propertyPath
-        );
+        if (! \is_string($value) || ! \preg_match($pattern, $value)) {
+            throw AssertionException::matchRegex(self::stringify($value), $pattern, $propertyPath);
+        }
+    }
+
+    /**
+     * Make a string version of a value.
+     *
+     * Copied from {@see \Assert\Assertion::stringify()}.
+     *
+     * @param mixed $value
+     */
+    private static function stringify(mixed $value): string
+    {
+        $result = \gettype($value);
+
+        if (\is_bool($value)) {
+            $result = $value ? '<TRUE>' : '<FALSE>';
+        } elseif (\is_scalar($value)) {
+            $val = (string) $value;
+
+            if (\mb_strlen($val) > 100) {
+                $val = \mb_substr($val, 0, 97) . '...';
+            }
+
+            $result = $val;
+        } elseif (\is_array($value)) {
+            $result = '<ARRAY>';
+        } elseif (\is_object($value)) {
+            $result = \get_debug_type($value);
+        } elseif (\is_resource($value)) {
+            $result = \get_resource_type($value);
+        } elseif (null === $value) {
+            $result = '<NULL>';
+        }
+
+        return $result;
     }
 }

--- a/centreon/src/Core/Security/Domain/User/Model/UserPasswordFactory.php
+++ b/centreon/src/Core/Security/Domain/User/Model/UserPasswordFactory.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Security\Domain\User\Model;
 
+use Assert\InvalidArgumentException;
 use Core\Security\Domain\User\Model\User;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Core\Security\Domain\User\Model\UserPassword;
@@ -66,7 +67,7 @@ class UserPasswordFactory
                     'UserPassword::passwordValue'
                 );
             }
-        } catch (AssertionException $ex) {
+        } catch (AssertionException | InvalidArgumentException) {
             //Throw a generic user password exception to avoid returning a plain password in the AssertionException.
             throw UserPasswordException::passwordDoesnotMatchSecurityPolicy();
         }


### PR DESCRIPTION
## Description

This PR intends to correctly display errors when failure on password renew. 
Instead of non business logic messages we display a more coherent message:

```
{
  "code": 400,
  "message": "Your password doesn't match the security policy"
}
```

**Fixes** # MON-16507

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
