### PR TITLE
fix(install): Avoid centreon install to build gorgone config if not needed

### DIFF
--- a/centreon/www/install/steps/process/configFileSetup.php
+++ b/centreon/www/install/steps/process/configFileSetup.php
@@ -128,9 +128,11 @@ if (file_exists($apiConfigurationFile) && is_writable($apiConfigurationFile)) {
  * Gorgone daemon configuration file for a central
  */
 $gorgoneCoreFileForCentral = $centreonEtcPath . '/../centreon-gorgone/config.d/40-gorgoned.yaml';
-$contents = file_get_contents('../../var/gorgone/gorgoneCentralTemplate.yaml');
-$contents = str_replace(array_keys($macroReplacements), array_values($macroReplacements), $contents);
-file_put_contents($gorgoneCoreFileForCentral, $contents);
+if (file_exists($gorgoneCoreFileForCentral) && is_writable($gorgoneCoreFileForCentral)) {
+    $contents = file_get_contents('../../var/gorgone/gorgoneCentralTemplate.yaml');
+    $contents = str_replace(array_keys($macroReplacements), array_values($macroReplacements), $contents);
+    file_put_contents($gorgoneCoreFileForCentral, $contents);
+}
 
 $return['result'] = 0;
 echo json_encode($return);


### PR DESCRIPTION
## Description

Removed PHP warning during install wizard

**Fixes** # MON-17552

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
