### PR TITLE
fix(packaging): fix EnvironmentFile in dsmd service

### DIFF
--- a/centreon-dsm/packaging/debian/rules
+++ b/centreon-dsm/packaging/debian/rules
@@ -12,3 +12,5 @@ override_dh_auto_build:
 	find . -type f -not -path "./vendor/*" | \
 		grep -v packaging/src/centreon-macroreplacement.txt | \
 		xargs -d '\n' sed -i -f packaging/src/centreon-macroreplacement.txt
+	sed -i "s#/etc/sysconfig#/etc/default#g" \
+		libinstall/systemd/dsmd.systemd


### PR DESCRIPTION
## Description

Fix dsmd service configuration file for debian, to use correct EnvironmentFile path

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
