### PR TITLE
fix(web): users should not be able to add LDAP groups to a contact (2304)

### DIFF
--- a/centreon/www/api/class/centreon_configuration_contactgroup.class.php
+++ b/centreon/www/api/class/centreon_configuration_contactgroup.class.php
@@ -99,6 +99,10 @@ class CentreonConfigurationContactgroup extends CentreonConfigurationObjects
 
         $contactgroupList = array();
         foreach ($aclCgs['items'] as $id => $contactgroup) {
+            if (($this->arguments['type'] == 'local') && ($contactgroup['cg_type'] == 'ldap')) {
+                $aclCgs['total'] -= 1;
+                continue;
+            }
             $sText = $contactgroup['cg_name'];
             if ($contactgroup['cg_type'] == 'ldap') {
                 $sText .= " (LDAP : " . $contactgroup['ar_name'] . ")";
@@ -111,23 +115,25 @@ class CentreonConfigurationContactgroup extends CentreonConfigurationObjects
         }
 
         # get Ldap contactgroups
-        $ldapCgs = array();
-        if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
-            $maxItem = $this->arguments['page_limit'] * $this->arguments['page'];
-            if ($aclCgs['total'] <= $maxItem) {
+        if ($this->arguments['type'] != 'local') {
+            $ldapCgs = array();
+            if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
+                $maxItem = $this->arguments['page_limit'] * $this->arguments['page'];
+                if ($aclCgs['total'] <= $maxItem) {
+                    $ldapCgs = $cg->getLdapContactgroups($ldapFilter);
+                }
+            } else {
                 $ldapCgs = $cg->getLdapContactgroups($ldapFilter);
             }
-        } else {
-            $ldapCgs = $cg->getLdapContactgroups($ldapFilter);
-        }
 
-        foreach ($ldapCgs as $key => $value) {
-            $sTemp = $value;
-            if (!$this->uniqueKey($sTemp, $contactgroupList)) {
-                $contactgroupList[] = array(
-                    'id' => $key,
-                    'text' => $value
-                );
+            foreach ($ldapCgs as $key => $value) {
+                $sTemp = $value;
+                if (!$this->uniqueKey($sTemp, $contactgroupList)) {
+                    $contactgroupList[] = array(
+                        'id' => $key,
+                        'text' => $value
+                    );
+                }
             }
         }
 

--- a/centreon/www/api/class/centreon_configuration_contactgroup.class.php
+++ b/centreon/www/api/class/centreon_configuration_contactgroup.class.php
@@ -117,7 +117,7 @@ class CentreonConfigurationContactgroup extends CentreonConfigurationObjects
         # get Ldap contactgroups
         if ($this->arguments['type'] !== 'local') {
             $ldapCgs = array();
-            if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
+            if (isset($this->arguments['page_limit'], $this->arguments['page'])) {
                 $maxItem = $this->arguments['page_limit'] * $this->arguments['page'];
                 if ($aclCgs['total'] <= $maxItem) {
                     $ldapCgs = $cg->getLdapContactgroups($ldapFilter);

--- a/centreon/www/api/class/centreon_configuration_contactgroup.class.php
+++ b/centreon/www/api/class/centreon_configuration_contactgroup.class.php
@@ -99,7 +99,7 @@ class CentreonConfigurationContactgroup extends CentreonConfigurationObjects
 
         $contactgroupList = array();
         foreach ($aclCgs['items'] as $id => $contactgroup) {
-            if (($this->arguments['type'] == 'local') && ($contactgroup['cg_type'] == 'ldap')) {
+            if (($this->arguments['type'] === 'local') && ($contactgroup['cg_type'] === 'ldap')) {
                 $aclCgs['total'] -= 1;
                 continue;
             }

--- a/centreon/www/api/class/centreon_configuration_contactgroup.class.php
+++ b/centreon/www/api/class/centreon_configuration_contactgroup.class.php
@@ -99,6 +99,7 @@ class CentreonConfigurationContactgroup extends CentreonConfigurationObjects
 
         $contactgroupList = array();
         foreach ($aclCgs['items'] as $id => $contactgroup) {
+            // If we query local contactgroups and the contactgroup type is ldap, we skip it
             if (($this->arguments['type'] === 'local') && ($contactgroup['cg_type'] === 'ldap')) {
                 $aclCgs['total'] -= 1;
                 continue;
@@ -115,6 +116,7 @@ class CentreonConfigurationContactgroup extends CentreonConfigurationObjects
         }
 
         # get Ldap contactgroups
+        // If we don't query local contactgroups, we can return an array with ldap contactgroups
         if ($this->arguments['type'] !== 'local') {
             $ldapCgs = array();
             if (isset($this->arguments['page_limit'], $this->arguments['page'])) {

--- a/centreon/www/api/class/centreon_configuration_contactgroup.class.php
+++ b/centreon/www/api/class/centreon_configuration_contactgroup.class.php
@@ -115,7 +115,7 @@ class CentreonConfigurationContactgroup extends CentreonConfigurationObjects
         }
 
         # get Ldap contactgroups
-        if ($this->arguments['type'] != 'local') {
+        if ($this->arguments['type'] !== 'local') {
             $ldapCgs = array();
             if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
                 $maxItem = $this->arguments['page_limit'] * $this->arguments['page'];

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -225,7 +225,7 @@ $attrCommands = array(
     'multiple' => true,
     'linkedObject' => 'centreonCommand'
 );
-$contactRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_contactgroup&action=list';
+$contactRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_contactgroup&action=list&type=local';
 $attrContactgroups = array(
     'datasourceOrigin' => 'ajax',
     'availableDatasetRoute' => $contactRoute,


### PR DESCRIPTION
## Description

When we edit a contact, we shouldn't be able to add LDAP groups to a contact.
So in the SELECT2 box, we don't display LDAP groups.

**Fixes** MON-17965

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)