### PR TITLE
fix: hover menu timeout on mouse leave

### DIFF
--- a/centreon/www/front_src/src/Navigation/Sidebar/Menu/index.tsx
+++ b/centreon/www/front_src/src/Navigation/Sidebar/Menu/index.tsx
@@ -59,6 +59,9 @@ const NavigationMenu = ({
     number | undefined
   >(undefined);
   const [isDoubleClickedFromRoot, setIsDoubleClickedFromRoot] = useState(false);
+
+  const [isOverMenu, setIsOverMenu] = useState(false);
+
   const timeoutRef = useRef<null | NodeJS.Timeout>(null);
   const menuRef = useRef<HTMLUListElement>(null);
   const [selectedNavigationItems, setSelectedNavigationItems] = useAtom(
@@ -240,12 +243,18 @@ const NavigationMenu = ({
     });
   };
 
-  const closeMenu = (event): void => {
+  const moveMouse = (event): void => {
     const mouseOver = menuRef?.current?.contains(event.target);
-    if (!mouseOver) {
-      handleLeave();
-    }
+    setIsOverMenu(Boolean(mouseOver));
   };
+
+  useEffect(() => {
+    if (isOverMenu) {
+      return;
+    }
+
+    handleLeave();
+  }, [isOverMenu]);
 
   const visibilitychange = (): void => {
     if (equals(document.visibilityState, 'visible')) {
@@ -271,11 +280,11 @@ const NavigationMenu = ({
       iframe.addEventListener('load', () => {
         iframe.contentWindow?.document?.addEventListener(
           'mousemove',
-          closeMenu
+          moveMouse
         );
       });
     } else {
-      window.addEventListener('mousemove', closeMenu);
+      window.addEventListener('mousemove', moveMouse);
     }
   }, [pathname, search]);
 


### PR DESCRIPTION
## Description

fixes the menu timeout on mouse leave when mouse move still active

**Fixes** # 16728

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [x] 22.10.x

<h2> How this pull request can be tested ? </h2>

open side menu, on mouse out + continuous mouse move it should close the menu

