### PR TITLE
enh(pendo): Do not launch Pendo when browser not connected to Internet

### DIFF
--- a/centreon/www/include/common/javascript/pendo.js
+++ b/centreon/www/include/common/javascript/pendo.js
@@ -1,61 +1,100 @@
+//function that checks if pendo is reachable
+function checkConnection(url) {
+  return new Promise(function (resolve, reject) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('HEAD', url);
+    xhr.onload = function () {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve(true);
+      } else {
+        resolve(false);
+      }
+    };
+    xhr.onerror = function () {
+      resolve(false);
+    };
+      xhr.send();
+  });
+}
+const apiKey = 'b06b875d-4a10-4365-7edf-8efeaf53dfdd';
 // Pendo.io
-const initPendo = (data) => {
-  (function(apiKey, platformData){
-  (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=o._q||[];
-  v=['initialize','identify','updateOptions','pageLoad','track'];for(w=0,x=v.length;w<x;++w)(function(m){
-    o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-    y=e.createElement(n);y.async=!0;y.src='https://cdn.eu.pendo.io/agent/static/'+apiKey+'/pendo.js';
-    z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
+if (navigator.onLine ) {
+  checkConnection('https://cdn.eu.pendo.io/agent/static/'+apiKey+'/pendo.js').then(function(reachable) {
+    if (reachable) {
 
-    // Call this whenever information about your visitors becomes available
-    // Please use Strings, Numbers, or Bools for value types.
-    pendo.initialize(platformData);
-  })('b06b875d-4a10-4365-7edf-8efeaf53dfdd', data);
-};
+      const initPendo = (data) => {
+        (function (apiKey, platformData) {
+          (function (p, e, n, d, o) {
+            var v, w, x, y, z;
+            o = p[d] = p[d] || {};
+            o._q = o._q || [];
+            v = ['initialize', 'identify', 'updateOptions', 'pageLoad', 'track'];
+            for (w = 0, x = v.length; w < x; ++w) (function (m) {
+              o[m] = o[m] || function () {
+                o._q[m === v[0] ? 'unshift' : 'push']([m].concat([].slice.call(arguments, 0)));
+              };
+            })(v[w]);
+            y = e.createElement(n);
+            y.async = !0;
+            y.src = 'https://cdn.eu.pendo.io/agent/static/' + apiKey + '/pendo.js';
+            z = e.getElementsByTagName(n)[0];
+            z.parentNode.insertBefore(y, z);
+          })(window, document, 'script', 'pendo');
 
-if (window.fetch) {
-  let shouldGetCeipInfo = false;
+          // Call this whenever information about your visitors becomes available
+          // Please use Strings, Numbers, or Bools for value types.
+          pendo.initialize(platformData);
+        })(apiKey, data);
+      };
 
-  if (localStorage.getItem('centreonPlatformData') === null) {
-    shouldGetCeipInfo = true;
-  } else {
-    try {
-      let centreonPlatformData = JSON.parse(localStorage.getItem('centreonPlatformData'));
-      if ((centreonPlatformData.cacheGenerationDate + (24 * 60 * 60 * 1000)) < Date.now()) {
-        shouldGetCeipInfo = true;
-      } else if (centreonPlatformData.ceip === true) {
-        initPendo(centreonPlatformData);
-      }
-    } catch (e) {
-      shouldGetCeipInfo = true;
-    }
-  }
+      if (window.fetch) {
+        let shouldGetCeipInfo = false;
 
-  if (shouldGetCeipInfo) {
-    fetch(
-      './api/internal.php?object=centreon_ceip&action=ceipInfo',
-      { method: 'GET' }
-    ).then((response) => {
-      const contentType = response.headers.get('content-type');
-      if (contentType && contentType.indexOf("application/json") !== -1) {
-        response.json().then(function(data) {
-          if (data.ceip === true) {
-            initPendo(data);
-
-            // Create localStorage cache
-            const platformData = {
-              cacheGenerationDate: Date.now(),
-              visitor: data.visitor,
-              account: data.account,
-              excludeAllText: data.excludeAllText,
-              ceip: true
-            };
-            localStorage.setItem('centreonPlatformData', JSON.stringify(platformData));
-          } else {
-            localStorage.setItem('centreonPlatformData', JSON.stringify({ ceip: false }));
+        if (localStorage.getItem('centreonPlatformData') === null) {
+          shouldGetCeipInfo = true;
+        } else {
+          try {
+            let centreonPlatformData = JSON.parse(localStorage.getItem('centreonPlatformData'));
+            if ((centreonPlatformData.cacheGenerationDate + (24 * 60 * 60 * 1000)) < Date.now()) {
+              shouldGetCeipInfo = true;
+            } else if (centreonPlatformData.ceip === true) {
+              initPendo(centreonPlatformData);
+            }
+          } catch (e) {
+            shouldGetCeipInfo = true;
           }
-        });
+        }
+
+        if (shouldGetCeipInfo) {
+          fetch(
+              './api/internal.php?object=centreon_ceip&action=ceipInfo',
+              {method: 'GET'}
+          ).then((response) => {
+            const contentType = response.headers.get('content-type');
+            if (contentType && contentType.indexOf("application/json") !== -1) {
+              response.json().then(function (data) {
+                if (data.ceip === true) {
+                  initPendo(data);
+
+                  // Create localStorage cache
+                  const platformData = {
+                    cacheGenerationDate: Date.now(),
+                    visitor: data.visitor,
+                    account: data.account,
+                    excludeAllText: data.excludeAllText,
+                    ceip: true
+                  };
+                  localStorage.setItem('centreonPlatformData', JSON.stringify(platformData));
+                } else {
+                  localStorage.setItem('centreonPlatformData', JSON.stringify({ceip: false}));
+                }
+              });
+            }
+          });
+        }
       }
-    });
-  }
+    } else {
+      console.log("Offline mode: pendo is not loaded");
+    }
+  });
 }

--- a/centreon/www/include/common/javascript/pendo.js
+++ b/centreon/www/include/common/javascript/pendo.js
@@ -5,13 +5,13 @@ function checkConnection(url) {
     xhr.open('HEAD', url);
     xhr.onload = function () {
       if (xhr.status >= 200 && xhr.status < 300) {
-        resolve(true);
+        resolve();
       } else {
-        resolve(false);
+        reject();
       }
     };
     xhr.onerror = function () {
-      resolve(false);
+      reject();
     };
       xhr.send();
   });
@@ -19,8 +19,7 @@ function checkConnection(url) {
 const apiKey = 'b06b875d-4a10-4365-7edf-8efeaf53dfdd';
 // Pendo.io
 if (navigator.onLine ) {
-  checkConnection('https://cdn.eu.pendo.io/agent/static/'+apiKey+'/pendo.js').then(function(reachable) {
-    if (reachable) {
+  checkConnection('https://cdn.eu.pendo.io/agent/static/'+apiKey+'/pendo.js').then(function() {
 
       const initPendo = (data) => {
         (function (apiKey, platformData) {
@@ -93,8 +92,7 @@ if (navigator.onLine ) {
           });
         }
       }
-    } else {
-      console.log("Offline mode: pendo is not loaded");
-    }
+  }).catch(() => {
+    console.warn('Offline mode: pendo is not loaded');
   });
 }


### PR DESCRIPTION
## Description

Given a user accessing to Centreon UI without internet access
Pendo must not be loaded
To remove UI slowdown

**Fixes** # MON-15876

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x 
- [x] 23.10.x (develop)

<h2> How this pull request can be tested ? </h2>

Access to a Centreon with CIEP enabled (“Administration > Parameters > Centreon UI > Send anonymous statistics > On”)
Without access to Internet (maybe use a docker of a local VM)
Connect to Centreon
in “console” tab in developper mode:
You must have an answer that pendo is not loaded

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
