### PR TITLE
fix(web) button configure pollers in the top counter sometimes disappears

### DIFF
--- a/centreon/www/front_src/src/Header/Poller/getPollerPropsAdapter.ts
+++ b/centreon/www/front_src/src/Header/Poller/getPollerPropsAdapter.ts
@@ -1,4 +1,4 @@
-import { isNil, is, isEmpty } from 'ramda';
+import { isNil, is, isEmpty, flatten, includes } from 'ramda';
 import type { NavigateFunction } from 'react-router-dom';
 import type { TFunction } from 'react-i18next';
 
@@ -112,7 +112,9 @@ export const getPollerPropsAdapter = ({
       },
       issues: formatedIssues,
       pollerConfig: {
-        isAllowed: !!allowedPages?.includes(pollerConfigurationPageNumber),
+        isAllowed:
+          !!allowedPages &&
+          includes(pollerConfigurationPageNumber, flatten(allowedPages)),
         label: t(labelConfigurePollers),
         redirect: (): void =>
           navigate(`/main.php?p=${pollerConfigurationPageNumber}`),


### PR DESCRIPTION
## Description

In the poller top counter, the “Configure pollers” button sometimes disappears

How to reproduce
Refresh the page 

Open the poller header

Redo it until the button doesn’t appear

Received result
The button doesn’t appear

Expected result
The two buttons should appear each time

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)


#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
