### PR TITLE
fix(upgrade): remove symfony cache folder before recreating it (Debian)

### DIFF
--- a/centreon/packaging/debian/centreon-web.postinst
+++ b/centreon/packaging/debian/centreon-web.postinst
@@ -59,7 +59,8 @@ fi
 
 # rebuild symfony cache on upgrade
 if [ -n "$2" ]; then
-  su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear --no-warmup"
+  rm -rf /var/cache/centreon/symfony
+  su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear"
 fi
 
 # Try auto configure timezone for php


### PR DESCRIPTION
## Description

this PR intends to remove the symfony cache folder before recreating it, to avoid errors during upgrade

**Fixes** # MON-18768

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
