### PR TITLE
fix(web):  button configure pollers in the top counter sometimes disappears

### DIFF
--- a/centreon/www/front_src/src/Header/Poller/PollerSubMenu/PollerSubMenu.tsx
+++ b/centreon/www/front_src/src/Header/Poller/PollerSubMenu/PollerSubMenu.tsx
@@ -41,7 +41,6 @@ export interface PollerSubMenuProps {
     total: string;
   }>;
   pollerConfig: {
-    isAllowed: boolean;
     label: string;
     redirect: () => void;
     testId: string;

--- a/centreon/www/front_src/src/Header/Poller/PollerSubMenu/PollerSubMenu.tsx
+++ b/centreon/www/front_src/src/Header/Poller/PollerSubMenu/PollerSubMenu.tsx
@@ -31,6 +31,7 @@ const useStyles = makeStyles()((theme) => ({
 export interface PollerSubMenuProps {
   allPollerLabel: string;
   closeSubMenu: () => void;
+  displayPollerButton: boolean;
   exportConfig: {
     isExportButtonEnabled: boolean;
   };
@@ -54,7 +55,8 @@ export const PollerSubMenu = ({
   pollerCount,
   allPollerLabel,
   pollerConfig,
-  exportConfig
+  exportConfig,
+  displayPollerButton
 }: PollerSubMenuProps): JSX.Element => {
   const { classes, cx } = useStyles();
 
@@ -80,7 +82,7 @@ export const PollerSubMenu = ({
           <Typography variant="body2">{pollerCount as number}</Typography>
         </ListItem>
       )}
-      {pollerConfig.isAllowed && (
+      {displayPollerButton && (
         <ListItem className={classes.listItem}>
           <Button
             fullWidth

--- a/centreon/www/front_src/src/Header/Poller/getPollerPropsAdapter.ts
+++ b/centreon/www/front_src/src/Header/Poller/getPollerPropsAdapter.ts
@@ -1,4 +1,4 @@
-import { isNil, is, isEmpty, flatten, includes } from 'ramda';
+import { isNil, is, isEmpty } from 'ramda';
 import type { NavigateFunction } from 'react-router-dom';
 import type { TFunction } from 'react-i18next';
 

--- a/centreon/www/front_src/src/Header/Poller/getPollerPropsAdapter.ts
+++ b/centreon/www/front_src/src/Header/Poller/getPollerPropsAdapter.ts
@@ -1,4 +1,4 @@
-import { isNil, is, isEmpty, flatten, includes } from 'ramda';
+import { isNil, is, isEmpty } from 'ramda';
 import type { NavigateFunction } from 'react-router-dom';
 import type { TFunction } from 'react-i18next';
 
@@ -49,7 +49,6 @@ const getIssueSeverityCode = ({
 export const pollerConfigurationPageNumber = '60901';
 
 interface GetPollerPropsAdapterProps {
-  allowedPages: Array<string | Array<string>> | undefined;
   data: PollersIssuesList;
   isExportButtonEnabled: boolean;
   navigate: NavigateFunction;
@@ -65,7 +64,6 @@ export interface GetPollerPropsAdapterResult {
 export const getPollerPropsAdapter = ({
   data,
   t,
-  allowedPages,
   navigate,
   isExportButtonEnabled
 }: GetPollerPropsAdapterProps): GetPollerPropsAdapterResult => {
@@ -112,9 +110,6 @@ export const getPollerPropsAdapter = ({
       },
       issues: formatedIssues,
       pollerConfig: {
-        isAllowed:
-          !!allowedPages &&
-          includes(pollerConfigurationPageNumber, flatten(allowedPages)),
         label: t(labelConfigurePollers),
         redirect: (): void =>
           navigate(`/main.php?p=${pollerConfigurationPageNumber}`),

--- a/centreon/www/front_src/src/Header/Poller/getPollerPropsAdapter.ts
+++ b/centreon/www/front_src/src/Header/Poller/getPollerPropsAdapter.ts
@@ -1,4 +1,4 @@
-import { isNil, is, isEmpty } from 'ramda';
+import { isNil, is, isEmpty, flatten, includes } from 'ramda';
 import type { NavigateFunction } from 'react-router-dom';
 import type { TFunction } from 'react-i18next';
 
@@ -112,7 +112,9 @@ export const getPollerPropsAdapter = ({
       },
       issues: formatedIssues,
       pollerConfig: {
-        isAllowed: !!allowedPages?.includes(pollerConfigurationPageNumber),
+        isAllowed:
+          !!allowedPages &&
+          includes(pollerConfigurationPageNumber, flatten(allowedPages)),
         label: t(labelConfigurePollers),
         redirect: (): void =>
           navigate(`/main.php?p=${pollerConfigurationPageNumber}`),

--- a/centreon/www/front_src/src/Header/Poller/index.tsx
+++ b/centreon/www/front_src/src/Header/Poller/index.tsx
@@ -16,7 +16,7 @@ const ServiceStatusCounter = (): JSX.Element | null => {
   const { isLoading, data, isAllowed } = usePollerData();
   const { allowedPages } = useNavigation();
 
-  const showPollerButton =
+  const displayPollerButton =
     !!allowedPages &&
     includes(pollerConfigurationPageNumber, flatten(allowedPages));
 
@@ -38,7 +38,7 @@ const ServiceStatusCounter = (): JSX.Element | null => {
         <PollerSubMenu
           {...data.subMenu}
           closeSubMenu={closeSubMenu}
-          showPollerButton={showPollerButton}
+          displayPollerButton={displayPollerButton}
         />
       )}
       title={data.buttonLabel}

--- a/centreon/www/front_src/src/Header/Poller/index.tsx
+++ b/centreon/www/front_src/src/Header/Poller/index.tsx
@@ -1,13 +1,24 @@
+import { includes, flatten } from 'ramda';
+
 import PollerIcon from '@mui/icons-material/DeviceHub';
 
 import { MenuSkeleton, TopCounterLayout } from '@centreon/ui';
+
+import useNavigation from '../../Navigation/useNavigation';
 
 import PollerStatusIcon from './PollerStatusIcon';
 import { PollerSubMenu } from './PollerSubMenu/PollerSubMenu';
 import { usePollerData } from './usePollerData';
 
+export const pollerConfigurationPageNumber = '60901';
+
 const ServiceStatusCounter = (): JSX.Element | null => {
   const { isLoading, data, isAllowed } = usePollerData();
+  const { allowedPages } = useNavigation();
+
+  const showPollerButton =
+    !!allowedPages &&
+    includes(pollerConfigurationPageNumber, flatten(allowedPages));
 
   if (isLoading) {
     return <MenuSkeleton width={20} />;
@@ -24,7 +35,11 @@ const ServiceStatusCounter = (): JSX.Element | null => {
         <PollerStatusIcon iconSeverities={data.iconSeverities} />
       )}
       renderSubMenu={({ closeSubMenu }): JSX.Element => (
-        <PollerSubMenu {...data.subMenu} closeSubMenu={closeSubMenu} />
+        <PollerSubMenu
+          {...data.subMenu}
+          closeSubMenu={closeSubMenu}
+          showPollerButton={showPollerButton}
+        />
       )}
       title={data.buttonLabel}
     />

--- a/centreon/www/front_src/src/Header/Poller/usePollerData.ts
+++ b/centreon/www/front_src/src/Header/Poller/usePollerData.ts
@@ -24,7 +24,6 @@ interface UsePollerDataResult {
 export const usePollerData = (): UsePollerDataResult => {
   const navigate = useNavigate();
   const { t } = useTranslation();
-  const { allowedPages } = useNavigation();
   const [isAllowed, setIsAllowed] = useState<boolean>(true);
   const { isExportButtonEnabled } = useAtomValue(userAtom);
   const refetchInterval = useAtomValue(refreshIntervalAtom);
@@ -48,7 +47,6 @@ export const usePollerData = (): UsePollerDataResult => {
     () => ({
       data: !isNil(data)
         ? getPollerPropsAdapter({
-            allowedPages,
             data,
             isExportButtonEnabled,
             navigate,

--- a/centreon/www/front_src/src/Header/Poller/usePollerData.ts
+++ b/centreon/www/front_src/src/Header/Poller/usePollerData.ts
@@ -8,7 +8,6 @@ import { equals, isNil } from 'ramda';
 import { useFetchQuery } from '@centreon/ui';
 import { refreshIntervalAtom, userAtom } from '@centreon/ui-context';
 
-import useNavigation from '../../Navigation/useNavigation';
 import { pollerListIssuesEndPoint } from '../api/endpoints';
 import { pollerIssuesDecoder } from '../api/decoders';
 


### PR DESCRIPTION
## Description

The poller button doesn't show up in some case

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
