### PR TITLE
fix: missing perl dependencies on repos (el9)

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -121,7 +121,7 @@ jobs:
             image: packaging-bullseye
           - name: "BSON"
             build_deb: "false"
-            rpm_provides: "perl(BSON::Bytes) perl(BSON::Code) perl(BSON::DBRef) perl(BSON::OID) perl(BSON::Raw) perl(BSON::Regex) perl(BSON::Time) perl(BSON::Timestamp) perl(BSON::Types)"
+            rpm_provides: "perl(BSON::Bytes) perl(BSON::Code) perl(BSON::DBRef) perl(BSON::OID) perl(BSON::Raw) perl(BSON::Regex) perl(BSON::Time) perl(BSON::Timestamp) perl(BSON::Types) perl(BSON)"
           - name: "BSON::XS"
             build_deb: "false"
           - name: "Convert::Binary::C"

--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -450,7 +450,7 @@ touch %buildroot%{_sysconfdir}/centreon/centreon.conf.php
 # Sudoers files
 %{__install} -d %buildroot%{_sysconfdir}/sudoers.d/
 %{__cp} centreon/tmpl/install/sudoersCentreonEngine %buildroot%{_sysconfdir}/sudoers.d/centreon
-%{__cp} centreon/tmpl/install/sudoersCentreonPlugins %buildroot%{_sysconfdir}/sudoers.d/centreon-plugins
+%{__cp} centreon/packaging/src/sudoersCentreonPlugins %buildroot%{_sysconfdir}/sudoers.d/centreon-plugins
 
 # MySQL/MariaDB custom configuration
 %{__install} -d %buildroot%{_sysconfdir}/my.cnf.d/

--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -261,6 +261,17 @@ Obsoletes:  centreon-poller-centreon-engine
 This package add rights and default directories for a poller
 managed by Centreon. This includes the default central poller.
 
+%package plugins-sudoers
+Summary:    Sudoers configuration for centreon plugins
+Group:      Applications/System
+License:    Apache-2.0
+Provides:   centreon-cwrapper-perl
+Obsoletes:  centreon-cwrapper-perl
+
+%description plugins-sudoers
+%{COMMIT_HASH}
+Sudoers configuration for centreon plugins
+
 %prep
 %setup -q %{SOURCE0}
 %{__mkdir} additional
@@ -791,5 +802,14 @@ view centreon included .1.3.6.1" \
 access notConfigGroup \"\" any noauth exact centreon none none" \
                 /etc/snmp/snmpd.conf
 fi
+
+######################################################
+# Package centreon-plugins-sudoers
+######################################################
+
+%files plugins-sudoers
+
+%{__install} -d %buildroot%{_sysconfdir}/sudoers.d/
+%{__cp} centreon/tmpl/install/sudoersCentreonPlugins %buildroot%{_sysconfdir}/sudoers.d/centreon-plugins
 
 %changelog

--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -450,6 +450,7 @@ touch %buildroot%{_sysconfdir}/centreon/centreon.conf.php
 # Sudoers files
 %{__install} -d %buildroot%{_sysconfdir}/sudoers.d/
 %{__cp} centreon/tmpl/install/sudoersCentreonEngine %buildroot%{_sysconfdir}/sudoers.d/centreon
+%{__cp} centreon/tmpl/install/sudoersCentreonPlugins %buildroot%{_sysconfdir}/sudoers.d/centreon-plugins
 
 # MySQL/MariaDB custom configuration
 %{__install} -d %buildroot%{_sysconfdir}/my.cnf.d/
@@ -809,7 +810,7 @@ fi
 
 %files plugins-sudoers
 
-%{__install} -d %buildroot%{_sysconfdir}/sudoers.d/
-%{__cp} centreon/tmpl/install/sudoersCentreonPlugins %buildroot%{_sysconfdir}/sudoers.d/centreon-plugins
+%defattr(-,root,root,-)
+%attr(0600,root, root) %{_sysconfdir}/sudoers.d/centreon-plugins
 
 %changelog


### PR DESCRIPTION
## Description

Some Perl libraries are missing in our new repositories.

Fixes MON-18130 for el8

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x (master)

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
