### PR TITLE
fix(packaging): fix rights of centreon log dir on debian

### DIFF
--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -432,7 +432,7 @@ find . -type f -not -path "./vendor/*" | grep -v additional/centreon-macroreplac
 %{__install} -d -m 0775 %buildroot%{_localstatedir}/lib/centreon/centcore
 %{__install} -d -m 0775 %buildroot%{_localstatedir}/lib/centreon/perfdata
 
-%{__install} -d -m 0775 %buildroot%{_localstatedir}/log/centreon
+%{__install} -d -m 0774 %buildroot%{_localstatedir}/log/centreon
 %{__install} -d -m 0750 %buildroot%{_localstatedir}/run/centreon
 %{__install} -d -m 0750 %buildroot%{_localstatedir}/cache/centreon/backup
 
@@ -766,10 +766,12 @@ fi
 %{_datadir}/centreon/bin/registerServerTopology.sh
 %{_datadir}/centreon/bin/registerServerTopologyTemplate
 
+%defattr(-, centreon, centreon, 0774)
+%dir %{_localstatedir}/log/centreon
+
 %defattr(-, centreon, centreon, 0775)
 %dir %{_localstatedir}/lib/centreon
 %dir %{_localstatedir}/lib/centreon/centplugins
-%dir %{_localstatedir}/log/centreon
 %dir %{_localstatedir}/run/centreon
 
 %attr(0600,root, root) %{_sysconfdir}/sudoers.d/centreon

--- a/centreon/packaging/debian/centreon-poller-centreon-engine.postinst
+++ b/centreon/packaging/debian/centreon-poller-centreon-engine.postinst
@@ -2,6 +2,13 @@
 
 if [ "$1" = "configure" ]; then
 
+    chmod 0774 /var/log/centreon
+    chmod 0775 /var/run/centreon
+
+    if [ "$(getent passwd centreon)" ]; then
+        chown centreon:centreon /var/run/centreon
+    fi
+
     if [ "$(getent group nagios)" ]; then
         /usr/sbin/usermod -a -G centreon,nagios,centreon-broker centreon-engine
         /usr/sbin/usermod -a -G centreon,nagios centreon-broker

--- a/centreon/packaging/debian/centreon-web.postinst
+++ b/centreon/packaging/debian/centreon-web.postinst
@@ -11,9 +11,7 @@ if [ "$1" = "configure" ] ; then
     chmod 0775 \
       /usr/share/centreon/src \
       /usr/share/centreon/api
-    chmod -R 0775 \
-      /var/log/centreon \
-      /var/lib/centreon
+    chmod -R 0775 /var/lib/centreon
     chmod -R 0775 \
       /usr/share/centreon/www \
       /usr/share/centreon/GPL_LIB/SmartyCache


### PR DESCRIPTION
## Description

fix(packaging): fix rights of centreon log dir on debian

**Fixes** MON-18725

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)