### PR TITLE
fix(api): correctly display errors when failure on password renew (#1333)

### DIFF
--- a/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
+++ b/centreon/src/Core/Security/User/Application/UseCase/RenewPassword/RenewPassword.php
@@ -24,15 +24,19 @@ declare(strict_types=1);
 namespace Core\Security\User\Application\UseCase\RenewPassword;
 
 use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Security\ProviderConfiguration\Application\Repository\ReadConfigurationRepositoryInterface;
 use Core\Security\ProviderConfiguration\Domain\Local\Model\Configuration;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
+use Core\Security\ProviderConfiguration\Infrastructure\Local\Api\Exception\ConfigurationException;
+use Core\Security\User\Domain\Exception\UserPasswordException;
 use Core\Security\User\Domain\Model\UserPasswordFactory;
 use Core\Application\Common\UseCase\UnauthorizedResponse;
 use Core\Security\User\Application\Repository\ReadUserRepositoryInterface;
 use Core\Security\User\Application\Repository\WriteUserRepositoryInterface;
-use Core\Security\ProviderConfiguration\Application\Repository\ReadConfigurationRepositoryInterface;
 
 class RenewPassword
 {
@@ -76,15 +80,26 @@ class RenewPassword
             return;
         }
 
+        try {
+            /** @var Configuration $providerConfiguration */
+            $providerConfiguration = $this->readConfigurationRepository->getConfigurationByType(Provider::LOCAL);
+            $this->info('Validate password against security policy');
+            $newPassword = UserPasswordFactory::create(
+                $renewPasswordRequest->newPassword,
+                $user,
+                $providerConfiguration->getCustomConfiguration()->getSecurityPolicy()
+            );
+        } catch(UserPasswordException | ConfigurationException $ex) {
+            $this->error('Unable to update password', ['trace' => (string) $ex]);
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex->getMessage()));
 
-        /** @var Configuration $providerConfiguration */
-        $providerConfiguration = $this->readConfigurationRepository->getConfigurationByType(Provider::LOCAL);
-        $this->info('Validate password against security policy');
-        $newPassword = UserPasswordFactory::create(
-            $renewPasswordRequest->newPassword,
-            $user,
-            $providerConfiguration->getCustomConfiguration()->getSecurityPolicy()
-        );
+            return;
+        }  catch(\Throwable $ex) {
+            $this->error('An error occured while updating password', ['trace' => (string) $ex]);
+            $presenter->setResponseStatus(new ErrorResponse('An error occured while updating password'));
+
+            return;
+        }
         $user->setPassword($newPassword);
 
         $this->info('Updating user password', [

--- a/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
+++ b/centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
@@ -40,7 +40,7 @@ class UserPasswordFactory
      * @param User $user
      * @param SecurityPolicy $securityPolicy
      * @return UserPassword
-     * @throws AssertionException|ConfigurationException
+     * @throws UserPasswordException|ConfigurationException
      */
     public static function create(string $password, User $user, SecurityPolicy $securityPolicy): UserPassword
     {
@@ -66,7 +66,7 @@ class UserPasswordFactory
                     'UserPassword::passwordValue'
                 );
             }
-        } catch (AssertionException $ex) {
+        } catch (AssertionException) {
             //Throw a generic user password exception to avoid returning a plain password in the AssertionException.
             throw UserPasswordException::passwordDoesnotMatchSecurityPolicy();
         }


### PR DESCRIPTION
## Description

backport of #1333

**Fixes** # MON-16507

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
