### PR TITLE
chore(packaging): fix rights of centreon_traps dir on debian (#1428)

### DIFF
--- a/centreon/packaging/debian/centreon-trap.postinst
+++ b/centreon/packaging/debian/centreon-trap.postinst
@@ -17,6 +17,8 @@ EOF
     fi
 
     # Fix permissions
+    chmod 0775 /etc/snmp/centreon_traps
+    chown centreon:centreon /etc/snmp/centreon_traps
     chmod 0755 \
         /usr/share/centreon/bin/centreontrapd \
         /usr/share/centreon/bin/centreontrapdforward \


### PR DESCRIPTION
## Description

chore(packaging): fix rights of centreon_traps dir on debian (#1428)

**Fixes** MON-18710

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)