### PR TITLE
enh(gorgone-servicediscovery): use credentials from centreon vault for manual scan 23.04

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -846,6 +846,17 @@ sub launchdiscovery {
     }
     $self->{audit_user_id} = $user_id;
 
+    ##################
+    # get vault config
+    ##################
+    ($status, $message, my $vault_count) = gorgone::modules::centreon::autodiscovery::services::resources::get_vault_configured(
+        class_object_centreon => $self->{class_object_centreon}
+    );
+    if ($status < 0) {
+        $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);
+        return -1;
+    }
+
     ################
     # get rules
     ################
@@ -854,7 +865,8 @@ sub launchdiscovery {
     ($status, $message, my $rules) = gorgone::modules::centreon::autodiscovery::services::resources::get_rules(
         class_object_centreon => $self->{class_object_centreon},
         filter_rules => $data->{content}->{filter_rules},
-        force_rule => (defined($data->{content}->{force_rule}) && $data->{content}->{force_rule} =~ /^1$/) ? 1 : 0
+        force_rule => (defined($data->{content}->{force_rule}) && $data->{content}->{force_rule} =~ /^1$/) ? 1 : 0,
+		vault_count => $vault_count
     );
     if ($status < 0) {
         $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);
@@ -874,7 +886,8 @@ sub launchdiscovery {
             class_object_centreon => $self->{class_object_centreon},
             with_macro => 1,
             host_lookup => $data->{content}->{filter_hosts},
-            poller_lookup => $data->{content}->{filter_pollers}
+            poller_lookup => $data->{content}->{filter_pollers},
+		    vault_count => $vault_count
         );
         if ($status < 0) {
             $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -866,7 +866,7 @@ sub launchdiscovery {
         class_object_centreon => $self->{class_object_centreon},
         filter_rules => $data->{content}->{filter_rules},
         force_rule => (defined($data->{content}->{force_rule}) && $data->{content}->{force_rule} =~ /^1$/) ? 1 : 0,
-		vault_count => $vault_count
+        vault_count => $vault_count
     );
     if ($status < 0) {
         $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);
@@ -887,7 +887,7 @@ sub launchdiscovery {
             with_macro => 1,
             host_lookup => $data->{content}->{filter_hosts},
             poller_lookup => $data->{content}->{filter_pollers},
-		    vault_count => $vault_count
+            vault_count => $vault_count
         );
         if ($status < 0) {
             $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -750,7 +750,8 @@ sub service_execute_commands {
                 my $command = gorgone::modules::centreon::autodiscovery::services::resources::substitute_service_discovery_command(
                     command_line => $self->{discovery}->{rules}->{$rule_id}->{command_line},
                     host => $host,
-                    poller => $self->{service_pollers}->{$poller_id}
+                    poller => $self->{service_pollers}->{$poller_id},
+                    vault_count => $options{vault_count}
                 );
 
                 $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} [" .
@@ -865,8 +866,7 @@ sub launchdiscovery {
     ($status, $message, my $rules) = gorgone::modules::centreon::autodiscovery::services::resources::get_rules(
         class_object_centreon => $self->{class_object_centreon},
         filter_rules => $data->{content}->{filter_rules},
-        force_rule => (defined($data->{content}->{force_rule}) && $data->{content}->{force_rule} =~ /^1$/) ? 1 : 0,
-        vault_count => $vault_count
+        force_rule => (defined($data->{content}->{force_rule}) && $data->{content}->{force_rule} =~ /^1$/) ? 1 : 0
     );
     if ($status < 0) {
         $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);
@@ -934,7 +934,7 @@ sub launchdiscovery {
         pollers_reload => {}
     };
 
-    $self->service_execute_commands();
+    $self->service_execute_commands(vault_count => $vault_count);
 
     return 0;
 }

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -133,12 +133,10 @@ sub get_rules {
         $filter .= ') AND ';
     }
 
-    my $request = "SELECT rule_id, rule_alias, service_display_name, rule_disable, rule_update, ";
-    $request .= $options{vault_count} > 0 ? " CONCAT(command_line, ' --pass-manager=\"centreonvault\"') as command_line" : " command_line";
-    $request .= ", service_template_model_id, rule_scan_display_custom, rule_variable_custom";
-    $request .= " FROM mod_auto_disco_rule, command WHERE " . $filter . " mod_auto_disco_rule.command_command_id = command.command_id";
     my ($status, $rules) = $options{class_object_centreon}->custom_execute(
-        request => $request,
+        request =>
+            "SELECT rule_id, rule_alias, service_display_name, rule_disable, rule_update, command_line, service_template_model_id, rule_scan_display_custom, rule_variable_custom
+              FROM mod_auto_disco_rule, command WHERE " . $filter . " mod_auto_disco_rule.command_command_id = command.command_id",
         bind_values => \@bind_values,
         mode => 1,
         keys => 'rule_id'
@@ -499,6 +497,10 @@ sub substitute_service_discovery_command {
     
     $command =~ s/\$HOSTADDRESS\$/$options{host}->{host_address}/g;
     $command =~ s/\$HOSTNAME\$/$options{host}->{host_name}/g;
+
+    if ($options{vault_count} > 0) {
+        $command .= ' --pass-manager="centreonvault"';
+    }
     
     return $command;
 }

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -429,14 +429,18 @@ sub get_macros_host {
         }
 
         ($status, $datas) = $options{class_object_centreon}->custom_execute(
-            request => "SELECT host_macro_name, host_macro_value FROM on_demand_macro_host WHERE host_host_id = " . $lhost_id,
+            request => "SELECT host_macro_name, host_macro_value, is_password FROM on_demand_macro_host WHERE host_host_id = " . $lhost_id,
             mode => 2
         );
         if ($status == -1) {
             return (-1, 'get macro: cannot get on_demand_macro_host');
         }
         foreach (@$datas) {
-            set_macro(\%macros, $_->[0], $_->[1]);
+            if ($_->[2] == 1) {
+                set_macro(\%macros, $_->[0], "{$_->[0]::secret::$_->[1]}");
+            } else {
+                set_macro(\%macros, $_->[0], $_->[1]);
+            }
         }
 
         ($status, $datas) = $options{class_object_centreon}->custom_execute(

--- a/centreon/lib/perl/centreon/trapd/lib.pm
+++ b/centreon/lib/perl/centreon/trapd/lib.pm
@@ -392,10 +392,14 @@ sub get_macros_host {
             set_macro(\%macros, '$_HOSTSNMPVERSION$', $value->{host_snmp_version});
         }
     
-        ($dstatus, $sth) = $cdb->query("SELECT host_macro_name, host_macro_value FROM on_demand_macro_host WHERE host_host_id = " . $lhost_id);
+        ($dstatus, $sth) = $cdb->query("SELECT host_macro_name, host_macro_value, is_password FROM on_demand_macro_host WHERE host_host_id = " . $lhost_id);
         return -1 if ($dstatus == -1);
         while ($value = $sth->fetchrow_hashref()) {
-            set_macro(\%macros, $value->{host_macro_name}, $value->{host_macro_value});
+            if ($_->[2] == 1) {
+                set_macro(\%macros, $value->{host_macro_name}, "{$value->{host_macro_name}::secret::$value->{host_macro_value}}");
+            } else {
+                set_macro(\%macros, $value->{host_macro_name}, $value->{host_macro_value});
+            }
         }
     
         ($dstatus, $sth) = $cdb->query("SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = " . $lhost_id . " ORDER BY `order` DESC");

--- a/centreon/lib/perl/centreon/trapd/lib.pm
+++ b/centreon/lib/perl/centreon/trapd/lib.pm
@@ -392,14 +392,10 @@ sub get_macros_host {
             set_macro(\%macros, '$_HOSTSNMPVERSION$', $value->{host_snmp_version});
         }
     
-        ($dstatus, $sth) = $cdb->query("SELECT host_macro_name, host_macro_value, is_password FROM on_demand_macro_host WHERE host_host_id = " . $lhost_id);
+        ($dstatus, $sth) = $cdb->query("SELECT host_macro_name, host_macro_value FROM on_demand_macro_host WHERE host_host_id = " . $lhost_id);
         return -1 if ($dstatus == -1);
         while ($value = $sth->fetchrow_hashref()) {
-            if ($_->[2] == 1) {
-                set_macro(\%macros, $value->{host_macro_name}, "{$value->{host_macro_name}::secret::$value->{host_macro_value}}");
-            } else {
-                set_macro(\%macros, $value->{host_macro_name}, $value->{host_macro_value});
-            }
+            set_macro(\%macros, $value->{host_macro_name}, $value->{host_macro_value});
         }
     
         ($dstatus, $sth) = $cdb->query("SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = " . $lhost_id . " ORDER BY `order` DESC");


### PR DESCRIPTION
## Description

Use credentials from default Centreon vault for manual scan

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Update a macro in database to use "is_password" (=1)
Check the command generated by gorgone.
(see examples: https://centreon.atlassian.net/browse/MON-17186)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
