### PR TITLE
fix(web): Blank page in Extension Manager

### DIFF
--- a/centreon/src/Centreon/Application/DataRepresenter/Topology/NavigationList.php
+++ b/centreon/src/Centreon/Application/DataRepresenter/Topology/NavigationList.php
@@ -194,12 +194,6 @@ class NavigationList implements JsonSerializable
                 $levelOne = $matches[1];
                 $levelTwo = $matches[1] . $matches[2];
 
-                // level 3 items can be grouped for better display
-                // make sure we skip groups (we extracted them above)
-                if ($entity->getIsReact()) {
-                    continue;
-                }
-
                 // generate the array for the item
                 $levelThree = [
                     'page' => $topologyPage,


### PR DESCRIPTION
## Description

Fixed issue where "Extension Manager" page was not accessible through menu and displayed "Not Allowed" page when accessing directly via URL.

![image](https://github.com/centreon/centreon/assets/108675430/360834ab-9fa6-46b2-a3c0-1bb10c0353fd)

**Fixes** # MON-18979

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
