### PR TITLE
High web browser cpu usage and web interface crash when exporting configuration

### DIFF
--- a/centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+++ b/centreon/www/include/configuration/configGenerate/formGenerateFiles.php
@@ -504,8 +504,7 @@ $tpl->display("formGenerateFiles.ihtml");
         divErrors.style.visibility = 'hidden';
         tdEl2.appendChild(divErrors);
         for (var i = 0; i < errors.length; i++) {
-            divErrors.innerHTML += errors.get(i).firstChild.data;
-            divErrors.innerHTML += "<br/>";
+            divErrors.innerHTML += errors.get(i).firstChild.data + "<br/>";
         }
     }
 


### PR DESCRIPTION
## Description

When you export your configuration, you may suddenly have a huge web browser cpu usage that may lead to a crash of the webpage. 

This will happen as soon as you tick the “move export file” checkbox and click the export button”. This is because you may have thousands of warning messages such as 

```
Warningcopy(media/centreon-map/handshake_blue.png): Failed to open stream: No such file or directory
Warningmkdir(): No such file or directory
```


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

FInd a way to have thousands of above error messages

- Head over the poller export menu
- In my case, select all four checkboxes
- click the export button
- notice the cpu usage and the time it takes to finish the export (might not even be able to finish before the web browser crashes)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
