### PR TITLE
Fix(ui): Unify Button Size and Respect Spacing Between Them (dev-23.04.x)

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/list.ihtml
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/list.ihtml
@@ -18,7 +18,7 @@
         <tr class="ToolbarTR">
             <td>
                 {$form.o1.html}
-                <a class='btc bt_success' href="{$msg.addL}">{$msg.add}</a>
+                <a class='btc bt_success ml-1' href="{$msg.addL}">{$msg.add}</a>
             </td>
             <td class='toolbarPagination'>
                 {php}

--- a/centreon/www/Themes/Generic-theme/style.css
+++ b/centreon/www/Themes/Generic-theme/style.css
@@ -1684,7 +1684,7 @@ div.update_readme,div.update_output {background-color:var(--update-read-me-outpu
 .line_downtime td, .tab .line_downtime td,
 .list_unreachable td,.tab .list_unreachable td,
 .row_disabled td, .tab .row_disabled td {
-    border-bottom: 1px solid var(--listing-border-botom-color);    
+    border-bottom: 1px solid var(--listing-border-botom-color);
 }
 
 
@@ -1704,8 +1704,8 @@ div.update_readme,div.update_output {background-color:var(--update-read-me-outpu
     font-weight:700;
     height:18px;
     vertical-align:middle;
-    border-bottom: 1px solid var(--listing-border-botom-color); 
-} 
+    border-bottom: 1px solid var(--listing-border-botom-color);
+}
 .ListColHeaderPicker        {padding:1px 3px;text-align:center;vertical-align:middle;width:10px;}
 .ListColHeaderCenter        {padding:1px 3px;text-align:center;}
 .ListColHeaderLeft      {padding:1px 3px;text-align:left;}
@@ -1878,13 +1878,25 @@ span.show-disabled[disabled]::after {
 .ToolbarTR td:first-child {
     width: 50%;
 }
-.ToolbarTR a.btc { display: inline-block; font-size: 1rem; height: 28px; line-height: 28px; padding: 0 10px; }
+.ToolbarTR a.btc { display: inline-block; font-size: 1rem; height: 28px; line-height: 29px; padding: 0 10px; }
+
+.ToolbarTR input[type="submit"].btc {
+    font-size: 1rem;
+    height: 28px;
+    line-height: 29px;
+    padding: 0 10px;
+}
+
+#mail_to {
+    margin-right: 4px;
+}
 
 .Toolbar_TDSelectAction_Top {
     border: 1px solid var(--toolbar-td-select-top-action-border-color);
     border-radius: 4px;
     padding: 3px 2px;
     margin-left: 6px;
+    margin-right: 4px;
     overflow: hidden;
     float: left;
 }
@@ -2992,7 +3004,7 @@ ul.module_list {
 .bt-poller-action{
     line-height: 20px;
     font-size: 13.3333px;
-    margin: 4px 8px 0px 0px !important;
+    margin: 4px 16px 0px 0px !important;
 }
 
 .bt-poller-action:disabled {
@@ -3013,6 +3025,9 @@ ul.module_list {
 /* utilities */
 .ml-1 {
     margin-left: 8px;
+}
+.ml-2 {
+    margin-left: 16px;
 }
 .mr-1 {
     margin-right: 8px;

--- a/centreon/www/include/Administration/parameters/ldap/list.ihtml
+++ b/centreon/www/include/Administration/parameters/ldap/list.ihtml
@@ -17,7 +17,7 @@
 		<tr class="ToolbarTR">
 			<td>
 				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{php}
 			   include('./include/common/pagination.php');
@@ -60,7 +60,7 @@
 		<tr class="ToolbarTR">
 			<td>
 				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{php}
 			   include('./include/common/pagination.php');

--- a/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
+++ b/centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.ihtml
@@ -18,7 +18,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -60,7 +60,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/command/listCommand.ihtml
+++ b/centreon/www/include/configuration/configObject/command/listCommand.ihtml
@@ -24,7 +24,7 @@
 		<tr class="ToolbarTR">
 			{if $mode_access=='w'}
 				<td>
-					{$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+					{$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 				</td>
 			{else}
 				<td>&nbsp;</td>
@@ -80,7 +80,7 @@
 		<tr class="ToolbarTR">
 			{if $mode_access == 'w'}
 				<td>
-					{$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+					{$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 				</td>
 			{else}
 				<td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/connector/listConnector.ihtml
+++ b/centreon/www/include/configuration/configObject/connector/listConnector.ihtml
@@ -4,7 +4,7 @@
 		<tr class="ToolbarTR">
 			<td>
                 {if $mode_access == "w"}
-				{$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				{$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
                 {/if}
 			</td>
 			
@@ -50,7 +50,7 @@
 		<tr class="ToolbarTR">
 			<td>
                 {if $mode_access == "w"}
-				    {$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				    {$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			    {/if}
             </td>
 			

--- a/centreon/www/include/configuration/configObject/contact/listContact.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/listContact.ihtml
@@ -21,9 +21,9 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                {if isset($ldap) && $ldap == "1" }<a href="{$msg.ldap_importL}" class="btc bt_info ml-1">{$msg.ldap_importT}</a>{/if}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
-                <a href='#' class="btc bt_info ml-1"
+                {if isset($ldap) && $ldap == "1" }<a href="{$msg.ldap_importL}" class="btc bt_info ml-2">{$msg.ldap_importT}</a>{/if}
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
+                <a href='#' class="btc bt_info ml-2"
                    onclick="window.open('main.php?p=60301&o=dn&min=1', '', 'toolbar=no, location=no, directories=no, status=no, scrollbars=yes, resizable=yes, copyhistory=no, width=500, height=700');">
                    {$msg.view_notif}
                </a>
@@ -89,8 +89,8 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                {if isset($ldap) && $ldap == "1" }<a href="{$msg.ldap_importL}" class="btc bt_info ml-1">{$msg.ldap_importT}</a>{/if}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                {if isset($ldap) && $ldap == "1" }<a href="{$msg.ldap_importL}" class="btc bt_info ml-2">{$msg.ldap_importT}</a>{/if}
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.ihtml
@@ -18,7 +18,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -65,7 +65,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/contactgroup/listContactGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/contactgroup/listContactGroup.ihtml
@@ -18,8 +18,8 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
-                <a href='#' class="btc bt_info ml-1"
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
+                <a href='#' class="btc bt_info ml-2"
                    onclick="window.open('?p=60302&o=dn&min=1', '', 'toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=500, height=700');">{$msg.view_notif}</a>
             </td>
             { else }
@@ -61,7 +61,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
+++ b/centreon/www/include/configuration/configObject/escalation/listEscalation.ihtml
@@ -18,7 +18,7 @@
 		{if $mode_access == 'w'}
 		<td>
 			{$form.o1.html}
-			<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+			<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 		</td>
 		{else}
 		<td>&nbsp;</td>
@@ -54,7 +54,7 @@
 		{ if $mode_access == 'w' }
 		<td>
 			{$form.o2.html}
-			<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+			<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 		</td>
 		{ else }
 		<td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/host/listHost.ihtml
+++ b/centreon/www/include/configuration/configObject/host/listHost.ihtml
@@ -27,7 +27,7 @@
         <tr class="ToolbarTR">
             { if $mode_access == 'w' }
             <td>
-                 {$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                 {$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -95,7 +95,7 @@
         <tr class="ToolbarTR">
             { if $mode_access == 'w' }
             <td class="Toolbar_TDSelectAction_Bottom">
-                 {$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                 {$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/host_categories/listHostCategories.ihtml
+++ b/centreon/www/include/configuration/configObject/host_categories/listHostCategories.ihtml
@@ -18,7 +18,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -63,7 +63,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ms="1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/host_dependency/listHostDependency.ihtml
@@ -19,7 +19,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>
@@ -58,7 +58,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
@@ -27,7 +27,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>
@@ -80,7 +80,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/hostgroup/listHostGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/hostgroup/listHostGroup.ihtml
@@ -21,7 +21,7 @@
             {if $mode_access == 'w'}
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             {else}
             <td>&nbsp;</td>
@@ -73,7 +73,7 @@
             {if $mode_access == 'w'}
             <td class="Toolbar_TDSelectAction_Bottom">
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             {else}
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.ihtml
@@ -17,7 +17,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>
@@ -56,7 +56,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
+++ b/centreon/www/include/configuration/configObject/meta_service/listMetaService.ihtml
@@ -18,7 +18,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -60,7 +60,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.ihtml
@@ -19,7 +19,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>
@@ -58,7 +58,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/service/listService.ihtml
+++ b/centreon/www/include/configuration/configObject/service/listService.ihtml
@@ -45,7 +45,7 @@
 		<tr class="ToolbarTR">
 			{if $mode_access == 'w'}
 				<td>
-					{$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+					{$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 				</td>
 			{else}
 				<td>&nbsp;</td>
@@ -115,7 +115,7 @@
 			{if $mode_access == 'w'}
 				<td class="Toolbar_TDSelectAction_Bottom">
 					{$form.o2.html}
-					<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+					<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 				</td>
 			{else}
 				<td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.ihtml
@@ -18,8 +18,8 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                {if isset($ldap) && $ldap == "1" }<a href="{$msg.ldap_importL}" class="ml-1">{$msg.ldap_importT}</a>{/if}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                {if isset($ldap) && $ldap == "1" }<a href="{$msg.ldap_importL}" class="ml-2">{$msg.ldap_importT}</a>{/if}
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -64,7 +64,7 @@
             <td class="Toolbar_TDSelectAction_Bottom">
                 {$form.o2.html}
                 {if isset($ldap) && $ldap == "1" }<a href="{$msg.ldap_importL}" class="ml-1">{$msg.ldap_importT}</a>{/if}
-                <a href="{$msg.addL}" class="btc bt_success" class="ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2" >{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.ihtml
@@ -19,7 +19,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -57,7 +57,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
@@ -26,7 +26,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -75,7 +75,7 @@
             { if $mode_access == 'w' }
             <td class="Toolbar_TDSelectAction_Bottom">
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.ihtml
@@ -19,7 +19,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>
@@ -58,7 +58,7 @@
 			{ if $mode_access == 'w' }
 			<td class="Toolbar_TDSelectAction_Bottom">
 				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
+++ b/centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.ihtml
@@ -19,7 +19,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -57,7 +57,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
+++ b/centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.ihtml
@@ -19,7 +19,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -61,7 +61,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/traps-groups/listGroups.ihtml
+++ b/centreon/www/include/configuration/configObject/traps-groups/listGroups.ihtml
@@ -18,7 +18,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>
@@ -55,7 +55,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.ihtml
+++ b/centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.ihtml
@@ -18,7 +18,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -55,7 +55,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configObject/traps/listTraps.ihtml
+++ b/centreon/www/include/configuration/configObject/traps/listTraps.ihtml
@@ -23,7 +23,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>
@@ -66,7 +66,7 @@
             { if $mode_access == 'w' }
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             { else }
             <td>&nbsp;</td>

--- a/centreon/www/include/configuration/configResources/listResources.ihtml
+++ b/centreon/www/include/configuration/configResources/listResources.ihtml
@@ -19,8 +19,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o1.html}
-				&nbsp;&nbsp;&nbsp;
-				<a href="{$msg.addL}" class="btc bt_success">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>
@@ -62,8 +61,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o2.html}
-				&nbsp;&nbsp;&nbsp;
-				<a href="{$msg.addL}" class="btc bt_success">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>

--- a/centreon/www/include/configuration/configServers/listServers.ihtml
+++ b/centreon/www/include/configuration/configServers/listServers.ihtml
@@ -50,7 +50,7 @@
             <td>
                 {if !$isRemote}
                     {if $can_create_edit == 1}
-                        <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class}" isreact="true" target="_top">
+                        <a href="{$wizardAddBtn.link}" class="{$wizardAddBtn.class} " isreact="true" target="_top">
                             {$wizardAddBtn.icon} {$wizardAddBtn.text}
                         </a>
                         <a href="{$addBtn.link}" class="{$addBtn.class}">

--- a/centreon/www/include/monitoring/comments/template/comments.ihtml
+++ b/centreon/www/include/monitoring/comments/template/comments.ihtml
@@ -25,7 +25,7 @@
                     <td>
                         {if $msgs}<a href="{$msgs.addL}" class="btc bt_success">{$msgs.addT}</a>{/if}
                         {if $nb_comments_svc && $msgs}<input type="submit" name="submit2" value="{$delete}"
-                                                             class="btc bt_danger"
+                                                             class="btc bt_danger ml-2"
                                                              onclick="return confirm('{$msgs.delConfirm}')">{/if}
                     </td>
                     {php}
@@ -84,7 +84,7 @@
                         <td>
                             {if $msgs}<a href="{$msgs.addL}" class="btc bt_success">{$msgs.addT}</a>{/if}
                             {if $nb_comments_svc && $msgs}<input type="submit" name="submit2" value="{$delete}"
-                                                                 class="btc bt_danger"
+                                                                 class="btc bt_danger ml-2"
                                                                  onclick="return confirm('{$msgs.delConfirm}')">{/if}
                         </td>
                         {php}

--- a/centreon/www/include/monitoring/recurrentDowntime/listDowntime.html
+++ b/centreon/www/include/monitoring/recurrentDowntime/listDowntime.html
@@ -19,7 +19,7 @@
 	{ if $mode_access == 'w' }
 	<td>
 		{$form.o1.html}
-		<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+		<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 	</td>
 	{ else }
 	<td>&nbsp;</td>
@@ -59,7 +59,7 @@
 		{ if $mode_access == 'w' }
 		<td class="Toolbar_TDSelectAction_Bottom">
 			{$form.o2.html}
-			<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+			<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 		</td>
 		{ else }
 		<td>&nbsp;</td>

--- a/centreon/www/include/monitoring/status/Hosts/templates/host.ihtml
+++ b/centreon/www/include/monitoring/status/Hosts/templates/host.ihtml
@@ -46,7 +46,7 @@
 		<td>
         <span class="consol_button">{$form.o1.html}</span>
         
-        <div class="Toolbar_TDSelectAction_Top">
+        <div class="Toolbar_TDSelectAction_Top ml-2">
           <span class="consol_button"><div id="JS_monitoring_refresh" style="cursor:pointer" onclick="javascript:monitoring_refresh('');">{php}displaySvg("www/img/icons/refresh.svg", "var(--icons-fill-color)", 18, 18){/php}</div></span>
           <span class="consol_button"><div id="JS_monitoring_play" class="cachediv" style="cursor:pointer" onclick="javascript:monitoring_play('');">{php}displaySvg("www/img/icons/media_play.svg", "var(--icons-fill-color)", 20, 20){/php}</div></span>
           <span class="consol_button"><span id="JS_monitoring_play_gray">{php}displaySvg("www/img/icons/media_play.svg", "var(--icons-disabled-fill-color)", 18, 18){/php}</span></span>

--- a/centreon/www/include/monitoring/status/Services/templates/service.ihtml
+++ b/centreon/www/include/monitoring/status/Services/templates/service.ihtml
@@ -45,7 +45,7 @@
         <td>
         <span class="consol_button">{$form.o1.html}</span>
 
-        <div class="Toolbar_TDSelectAction_Top">
+        <div class="Toolbar_TDSelectAction_Top ml-2">
             <span class="consol_button">
                 <div id="JS_monitoring_refresh" style="cursor:pointer" onclick="javascript:monitoring_refresh('');">
                     <span title='Refresh'>

--- a/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
+++ b/centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.ihtml
@@ -16,7 +16,7 @@
     </table>
 	<table class="ToolbarTable table">
 		<tr class="ToolbarTR">
-			<td> {$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a></td>
+			<td> {$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a></td>
 			{php}
 			   include('./include/common/pagination.php');
 			{/php}
@@ -48,7 +48,7 @@
 	<table class="ToolbarTable table">
 		<tr class="ToolbarTR">
 			<td>
-				 {$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				 {$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{php}
 			   include('./include/common/pagination.php');

--- a/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
+++ b/centreon/www/include/options/accessLists/groupsACL/listGroupConfig.ihtml
@@ -18,7 +18,7 @@
         <tr class="ToolbarTR">
             <td>
                  {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             {php}
             include('./include/common/pagination.php');
@@ -57,7 +57,7 @@
         <tr class="ToolbarTR">
             <td>
                  {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             {php}
             include('./include/common/pagination.php');

--- a/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
+++ b/centreon/www/include/options/accessLists/menusACL/listsMenusAccess.ihtml
@@ -16,7 +16,7 @@
     </table>
 	<table class="ToolbarTable table">
 		<tr class="ToolbarTR">
-			<td> {$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a></td>
+			<td> {$form.o1.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a></td>
 			
 			{php}
 			   include('./include/common/pagination.php');
@@ -51,7 +51,7 @@
 	<table class="ToolbarTable table">
 		<tr class="ToolbarTR">
 			<td>
-				 {$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				 {$form.o2.html}<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			
 			{php}

--- a/centreon/www/include/options/media/images/listImg.ihtml
+++ b/centreon/www/include/options/media/images/listImg.ihtml
@@ -17,8 +17,8 @@
 		<tr class="ToolbarTR">
 			<td>
 				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
-				<a href='#' class="btc bt_info ml-1" onClick="window.open('./main.php?p={$p}&o=sd&min=1','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=350, height=250');">{$syncDir}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
+				<a href='#' class="btc bt_info ml-2 mr-1" onClick="window.open('./main.php?p={$p}&o=sd&min=1','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=350, height=250');">{$syncDir}</a>
 				<label >
 					{$availiableSpace} {$Available}
 				</label>
@@ -68,8 +68,8 @@
 		<tr class="ToolbarTR">
 			<td>
 				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>&nbsp;&nbsp;
-				<a href='#' class="btc bt_info ml-1" onClick="window.open('./main.php?p={$p}&o=sd&min=1','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=350, height=250');">{$syncDir}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
+				<a href='#' class="btc bt_info ml-2 mr-1" onClick="window.open('./main.php?p={$p}&o=sd&min=1','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=350, height=250');">{$syncDir}</a>
 				<a >
 					{$availiableSpace}  {$Available}
 				</a>

--- a/centreon/www/include/reporting/dashboard/initReport.php
+++ b/centreon/www/include/reporting/dashboard/initReport.php
@@ -383,7 +383,7 @@ $formPeriod->addElement(
         'class' => 'alternativeDate'
     )
 );
-$formPeriod->addElement('submit', 'button', _("Apply period"), array('class' => 'btc bt_success'));
+$formPeriod->addElement('submit', 'button', _("Apply period"), array('class' => 'btc bt_success ml-2'));
 $formPeriod->setDefaults(
     [
         'period' => $period,

--- a/centreon/www/include/views/componentTemplates/listComponentTemplates.ihtml
+++ b/centreon/www/include/views/componentTemplates/listComponentTemplates.ihtml
@@ -17,7 +17,7 @@
         <tr class="ToolbarTR">
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             {php}
                include('./include/common/pagination.php');
@@ -70,7 +70,7 @@
         <tr class="ToolbarTR">
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             {php}
                include('./include/common/pagination.php');

--- a/centreon/www/include/views/graphTemplates/listGraphTemplates.ihtml
+++ b/centreon/www/include/views/graphTemplates/listGraphTemplates.ihtml
@@ -17,7 +17,7 @@
         <tr class="ToolbarTR">
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             {php}
                 include('./include/common/pagination.php');
@@ -53,7 +53,7 @@
         <tr class="ToolbarTR">
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             {php}
                 include('./include/common/pagination.php');

--- a/centreon/www/include/views/graphs/graphs.html
+++ b/centreon/www/include/views/graphs/graphs.html
@@ -107,12 +107,12 @@ const templateGraph = ({ graphId, graphType, graphTitle, hostId, serviceId }) =>
                 <span>${graphTitle}</span>
                 {/literal}
                 {if $topologyAccess.2040101 || $admin == 1}
-                <a class="btc bt_info actions-simple mr-1" data-href="./main.get.php?p=2040101">
+                <a class="btc bt_info actions-simple ml-2" data-href="./main.get.php?p=2040101">
                     {t}Split chart{/t}
                 </a>
                 {/if}
                 {if $topologyAccess.2040102 || $admin == 1}
-                <a class="btc bt_info actions-simple" data-href="./main.get.php?p=2040102">
+                <a class="btc bt_info actions-simple ml-2" data-href="./main.get.php?p=2040102">
                     {t}Display multiple periods{/t}
                 </a>
                 {/if}

--- a/centreon/www/include/views/virtualMetrics/listVirtualMetrics.ihtml
+++ b/centreon/www/include/views/virtualMetrics/listVirtualMetrics.ihtml
@@ -17,7 +17,7 @@
         <tr class="ToolbarTR">
             <td>
                 {$form.o1.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             {php}
             include('./include/common/pagination.php');
@@ -85,7 +85,7 @@
         <tr class="ToolbarTR">
             <td>
                 {$form.o2.html}
-                <a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+                <a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
             </td>
             {php}
             include('./include/common/pagination.php');


### PR DESCRIPTION
## Description
 
Some action buttons on legacy pages doesn’t have the same size.

**The display after fix** 
after adding margin of 16px between action buttons

 
![acl](https://user-images.githubusercontent.com/108519266/236925089-fcfb976b-99cd-494c-b12b-b57ae99eacb1.PNG)
![host](https://user-images.githubusercontent.com/108519266/236925121-073a917a-160f-4808-baa2-b4ebca4b03d6.PNG)
![job](https://user-images.githubusercontent.com/108519266/236925152-fed5a435-b66a-4122-ae59-e95fdba8f6b4.PNG)
![jobGroupe](https://user-images.githubusercontent.com/108519266/236925165-3144abba-250a-4b0a-8462-90c33fe357d3.PNG)
![report design](https://user-images.githubusercontent.com/108519266/236925192-f7507747-3e69-4bab-be60-5b15999d960d.PNG)
![service](https://user-images.githubusercontent.com/108519266/236925206-47006aa5-cb56-4868-a037-c76fa1920fde.PNG)

**Fixes** # MON-18287

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] Develop

<h2> How this pull request can be tested ? </h2>

check buttons size in main.php?p=21002 and main.php?p=50221

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
