### PR TITLE
fix(api) check argument type before use

### DIFF
--- a/centreon/www/api/class/centreon_configuration_contactgroup.class.php
+++ b/centreon/www/api/class/centreon_configuration_contactgroup.class.php
@@ -100,7 +100,7 @@ class CentreonConfigurationContactgroup extends CentreonConfigurationObjects
         $contactgroupList = array();
         foreach ($aclCgs['items'] as $id => $contactgroup) {
             // If we query local contactgroups and the contactgroup type is ldap, we skip it
-            if (($this->arguments['type'] === 'local') && ($contactgroup['cg_type'] === 'ldap')) {
+            if (isset($this->arguments['type']) && ($this->arguments['type'] === 'local') && ($contactgroup['cg_type'] === 'ldap')) {
                 $aclCgs['total'] -= 1;
                 continue;
             }
@@ -117,7 +117,7 @@ class CentreonConfigurationContactgroup extends CentreonConfigurationObjects
 
         # get Ldap contactgroups
         // If we don't query local contactgroups, we can return an array with ldap contactgroups
-        if ($this->arguments['type'] !== 'local') {
+        if (! isset($this->arguments['type']) || $this->arguments['type'] !== 'local') {
             $ldapCgs = array();
             if (isset($this->arguments['page_limit'], $this->arguments['page'])) {
                 $maxItem = $this->arguments['page_limit'] * $this->arguments['page'];

--- a/centreon/www/api/class/centreon_configuration_contactgroup.class.php
+++ b/centreon/www/api/class/centreon_configuration_contactgroup.class.php
@@ -100,7 +100,11 @@ class CentreonConfigurationContactgroup extends CentreonConfigurationObjects
         $contactgroupList = array();
         foreach ($aclCgs['items'] as $id => $contactgroup) {
             // If we query local contactgroups and the contactgroup type is ldap, we skip it
-            if (isset($this->arguments['type']) && ($this->arguments['type'] === 'local') && ($contactgroup['cg_type'] === 'ldap')) {
+            if (
+                isset($this->arguments['type'])
+                && ($this->arguments['type'] === 'local')
+                && ($contactgroup['cg_type'] === 'ldap')
+            ) {
                 $aclCgs['total'] -= 1;
                 continue;
             }


### PR DESCRIPTION
## Description

Missing arguments verification causing tests to fail
Check that argument 'type' is set when querying contactgroups

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
