### PR TITLE
fix(feature): Unblock users via GUI (dev-23.04.x)

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -15385,3 +15385,21 @@ msgstr ""
 
 # msgid "Groups mapping"
 # msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:280
+#msgid "Do you really want to unblock this user?"
+#msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
+#msgid "The user(s) will be unblocked. Do you confirm the request?"
+#msgstr ""
+
+# msgid "Error while retrieving a host group"
+# msgstr ""
+
+#  msgid "Error while updating a host group"
+#  msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "Unblock"
+#msgstr ""

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15696,3 +15696,27 @@ msgstr ""
 
 # msgid "Groups mapping"
 # msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:280
+#msgid "Do you really want to unblock this user?"
+#msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
+#msgid "The user(s) will be unblocked. Do you confirm the request?"
+#msgstr ""
+
+# msgid "Error while updating host severity"
+# msgstr ""
+
+# msgid "Error when searching for the host severity #%d"
+# msgstr ""
+
+#  msgid "Error when searching for the host category #%d"
+#  msgstr ""
+
+#  msgid "Error while retrieving a host category"
+#  msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "Unblock"
+#msgstr ""

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11290,6 +11290,18 @@ msgstr "Ceci est un modèle de contact."
 msgid "View contact notifications"
 msgstr "Afficher les notifications du contact"
 
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:280
+msgid "Do you really want to unblock this user?"
+msgstr "Voulez-vous vraiment débloquer cet utilisateur ?"
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
+msgid "The user(s) will be unblocked. Do you confirm the request?"
+msgstr "Ces utilisateurs seront débloqués. Confirmez-vous l'action ?"
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+msgid "Unblock"
+msgstr "Débloquer"
+
 #: centreon-web/www/include/configuration/configObject/escalation/ViewEscalation.php:103
 msgid "Escalations View"
 msgstr "Visualisation des escalades"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -16160,3 +16160,27 @@ msgstr ""
 
 # msgid "Groups mapping"
 # msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:280
+#msgid "Do you really want to unblock this user?"
+#msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
+#msgid "The user(s) will be unblocked. Do you confirm the request?"
+#msgstr ""
+
+# msgid "Error while updating host severity"
+# msgstr ""
+
+# msgid "Error when searching for the host severity #%d"
+# msgstr ""
+
+#  msgid "Error when searching for the host category #%d"
+#  msgstr ""
+
+#  msgid "Error while retrieving a host category"
+#  msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "Unblock"
+#msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -16150,3 +16150,27 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 
 # msgid "Groups mapping"
 # msgstr ""
+
+# msgid "Error while updating host severity"
+# msgstr ""
+
+# msgid "Error when searching for the host severity #%d"
+# msgstr ""
+
+#  msgid "Error when searching for the host category #%d"
+#  msgstr ""
+
+#  msgid "Error while retrieving a host category"
+#  msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:280
+#msgid "Do you really want to unblock this user?"
+#msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
+#msgid "The user(s) will be unblocked. Do you confirm the request?"
+#msgstr ""
+
+#: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
+#msgid "Unblock"
+#msgstr ""

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -198,6 +198,49 @@ function disableContactInDB($contact_id = null, $contact_arr = array())
 }
 
 /**
+ * Unblock contacts in the database
+ *
+ * @param int|array<int, string>|null $contact Contact ID, array of contact IDs or null to unblock all contacts
+ */
+function unblockContactInDB(int|array|null $contact = null): void
+{
+    global $pearDB, $centreon;
+
+    if (null === $contact || [] === $contact) {
+        return;
+    }
+
+    if (is_int($contact)) {
+        $contact = [$contact => "1"];
+    }
+
+
+    $bindContactIds = [];
+    foreach (array_keys($contact) as $contactId) {
+        $bindContactIds[':contact_' . $contactId] = $contactId;
+    }
+//  implode ids for  IN() clause
+    $idPlaceholders = implode(', ', array_keys($bindContactIds));
+// retrieve the users and add log
+    $updateQuery = "UPDATE contact SET blocking_time = null WHERE contact_id IN ($idPlaceholders)";
+    $updateStatement = $pearDB->prepare($updateQuery);
+    foreach ($bindContactIds as $token => $value) {
+        $updateStatement->bindValue($token, $value, \PDO::PARAM_INT);
+    }
+    $updateStatement->execute();
+// retrieve the users and add log
+    $selectQuery = "SELECT contact_id, contact_name FROM contact WHERE contact_id IN ($idPlaceholders)";
+    $selectStatement = $pearDB->prepare($selectQuery);
+    foreach ($bindContactIds as $token => $value) {
+        $selectStatement->bindValue($token, $value, \PDO::PARAM_INT);
+    }
+    $selectStatement->execute();
+
+    while ($row = $selectStatement->fetch()) {
+        $centreon->CentreonLogAction->insertLog("contact", $row['contact_id'], $row['contact_name'], "unblock");
+    }
+}
+/**
  * Delete Contacts
  * @param array $contacts
  */

--- a/centreon/www/include/configuration/configObject/contact/contact.php
+++ b/centreon/www/include/configuration/configObject/contact/contact.php
@@ -60,6 +60,8 @@ const MASSIVE_ACTIVATE_CONTACT = 'ms';
 const DEACTIVATE_CONTACT = 'u';
 // Massive deactivate on selected contacts
 const MASSIVE_DEACTIVATE_CONTACT = 'mu';
+// Massive Unblock on selected contacts
+const MASSIVE_UNBLOCK_CONTACT = 'mun';
 // Duplicate n contacts and notify it
 const DUPLICATE_CONTACTS = 'm';
 // Delete n contacts and notify it
@@ -68,6 +70,8 @@ const DELETE_CONTACTS = 'd';
 const DISPLAY_NOTIFICATION = 'dn';
 // Synchronize selected contacts with the LDAP
 const SYNC_LDAP_CONTACTS = 'sync';
+// Unblock contact
+const UNBLOCK_CONTACT = 'un';
 
 isset($_GET["contact_id"]) ? $cG = $_GET["contact_id"] : $cG = null;
 isset($_POST["contact_id"]) ? $cP = $_POST["contact_id"] : $cP = null;
@@ -213,6 +217,16 @@ switch ($o) {
         }
         require_once($path . "listContact.php");
         break;
+    case MASSIVE_UNBLOCK_CONTACT:
+        purgeOutdatedCSRFTokens();
+        if (isCSRFTokenValid()) {
+            purgeCSRFToken();
+            unblockContactInDB($select ?? []);
+        } else {
+            unvalidFormMessage();
+        }
+        require_once($path . "listContact.php");
+        break;
     case DUPLICATE_CONTACTS:
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
@@ -256,6 +270,16 @@ switch ($o) {
                 EventDispatcher::EVENT_SYNCHRONIZE,
                 ['contact_ids' => $select]
             );
+        } else {
+            unvalidFormMessage();
+        }
+        require_once($path . "listContact.php");
+        break;
+    case UNBLOCK_CONTACT:
+        purgeOutdatedCSRFTokens();
+        if (isCSRFTokenValid()) {
+            purgeCSRFToken();
+            unblockContactInDB($contactId);
         } else {
             unvalidFormMessage();
         }

--- a/centreon/www/include/configuration/configObject/contact/listContact.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/listContact.ihtml
@@ -55,6 +55,9 @@
             {if $isAdmin}
                 <td class="ListColHeaderCenter" title="{$headerMenu_refreshLdapTitleTooltip}">{$headerMenu_refreshLdap}</td>
             {/if}
+            {if $isAdmin && $blockedContactsCount}
+                <td class="ListColHeaderCenter">{$headerMenu_unblock}</td>
+            {/if}
             <td class="ListColHeaderCenter">{$headerMenu_status}</td>
             <td class="ListColHeaderRight">{$headerMenu_options}</td>
         </tr>
@@ -76,6 +79,9 @@
             <td class="ListColCenter">{$elemArr[elem].RowMenu_admin}</td>
             {if $isAdmin}
                 <td class="ListColCenter">{$elemArr[elem].RowMenu_refreshLdap}</td>
+            {/if}
+            {if $isAdmin && $blockedContactsCount}
+                <td class="ListColCenter">{$elemArr[elem].RowMenu_unblock}</td>
             {/if}
             <td class="ListColCenter">
                 <span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span>


### PR DESCRIPTION
## Description

 a user after several failed attempts, users find themselves blocked and the administrator must unlock them in the database via an SQL query before to wait configured windows range.

We would like to assist administrators to unblock accounts via the Centreon web interface.
A new column “Unblock” will be displayed if at least 1 account is blocked in list of accounts displayed.

Confirm text for action: Do you really want to unblock this user?

**Fixes** # MON-15409

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x (master)
- [x] develop

<h2> How this pull request can be tested ? </h2>

- Configure local security policy to block user after 2 tentative for 30 minutes.
- Try to connect with a non admin user 2 times with incorrect password.
- Connect to Centreon with an administrator account.
- Go to “Configuration > Users > Contacts / Users” menu and click on unblock user button.
- Try to connect with previous simple user with correct password.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
