### PR TITLE
fix(clapi): gethosttemplate of service template

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php
+++ b/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php
@@ -913,11 +913,19 @@ class CentreonServiceTemplate extends CentreonObject
                 $relobj = new $relclass($this->dependencyInjector);
                 $obj = new $class($this->dependencyInjector);
                 if ($matches[1] == "get") {
-                    $tab = $relobj->getTargetIdFromSourceId(
-                        $relobj->getFirstKey(),
-                        $relobj->getSecondKey(),
-                        $serviceId
-                    );
+                    if ($matches[2] === 'hosttemplate') {
+                        $tab = $relobj->getTargetIdFromSourceId(
+                            $relobj->getSecondKey(),
+                            $relobj->getFirstKey(),
+                            $serviceId
+                        );
+                    } else {
+                        $tab = $relobj->getTargetIdFromSourceId(
+                            $relobj->getFirstKey(),
+                            $relobj->getSecondKey(),
+                            $serviceId
+                        );
+                    }
                     echo "id" . $this->delim . "name" . "\n";
                     foreach ($tab as $value) {
                         $tmp = $obj->getParameters($value, array($obj->getUniqueLabelField()));


### PR DESCRIPTION
gethosttemplate of service template has been broken by https://github.com/centreon/centreon/commit/512e624f756d9d6ac5e9522a636a87ae391250f1

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)
