### PR TITLE
fix(gorgone): Fix query to update mod_anomaly_service

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/anomalydetection/class.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/anomalydetection/class.pm
@@ -260,7 +260,7 @@ sub save_centreon_previous_register {
             ' saas_model_id = ?,' .
             ' saas_metric_id = ?,' .
             ' saas_creation_date = ?, ' .
-            ' saas_update_date = ?'
+            ' saas_update_date = ?' .
             ' WHERE `id` = ?';
         $query_append = ';';
         push @bind_values, $self->{unregister_metrics_centreon}->{$_}->{saas_model_id}, $self->{unregister_metrics_centreon}->{$_}->{saas_metric_id},
@@ -605,7 +605,7 @@ sub action_saasregister {
     }
 
     if ($self->save_centreon_previous_register()) {
-        $self->send_log(code => GORGONE_ACTION_FINISH_KO, token => $options{token}, data => { message => 'cannot save previsous register' });
+        $self->send_log(code => GORGONE_ACTION_FINISH_KO, token => $options{token}, data => { message => 'cannot save previous register' });
         return 1;
     }
 


### PR DESCRIPTION
## Description

This PR Intends to fix the query to update mod_anomaly_service.

While restarting gorgone after AD installation, their is an error in terminal.

`String found where operator expected at /usr/share/perl5/vendor_perl/gorgone/modules/centreon/anomalydetection/class.pm line 264, near "' WHERE `id` = ?'"
        (Missing semicolon on previous line?)`

This is due to a missing concatenation operator

**Fixes** # MON-19072

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Install Anomaly Detection, restart gorgone.
no errors should occurs

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
