### PR TITLE
fix(php): remove APP_DEBUG from logger (#1469)

### DIFF
--- a/.github/docker/Dockerfile.centreon-web-alma9
+++ b/.github/docker/Dockerfile.centreon-web-alma9
@@ -15,10 +15,6 @@ echo 'date.timezone = Europe/Paris' > /etc/php.d/centreon.ini
 touch /var/log/php-fpm/centreon-error.log
 chown apache:apache /var/log/php-fpm/centreon-error.log
 
-rm -f /usr/share/centreon/.env.local.php
-echo "APP_DEBUG=true" >> /usr/share/centreon/.env
-echo "DEBUG_LEVEL=300" >> /usr/share/centreon/.env
-
 dnf clean all --enablerepo=*
 
 EOF
@@ -48,9 +44,6 @@ mysql -e "GRANT ALL ON *.* to 'root'@'%' IDENTIFIED BY 'centreon' WITH GRANT OPT
 centreon -d -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1
 service mysql stop
 sed -i "5s/.*/    id: 1/" /etc/centreon-gorgone/config.d/40-gorgoned.yaml
-
-# CLAPI config generation creates prod cache with root user
-chown -R apache:apache /var/cache/centreon/symfony/*
 
 EOF
 

--- a/.github/docker/Dockerfile.centreon-web-bullseye
+++ b/.github/docker/Dockerfile.centreon-web-bullseye
@@ -55,10 +55,6 @@ apt update
 rm -f /tmp/debs-centreon/centreon-23.04*.deb /tmp/debs-centreon/centreon-central-23.04*.deb
 apt install -y /tmp/debs-centreon/centreon-*.deb
 
-rm -f /usr/share/centreon/.env.local.php
-echo "APP_DEBUG=true" >> /usr/share/centreon/.env
-echo "DEBUG_LEVEL=100" >> /usr/share/centreon/.env
-
 touch /var/log/php8.1-fpm-centreon-error.log
 chown www-data:www-data /var/log/php8.1-fpm-centreon-error.log
 
@@ -95,9 +91,6 @@ mysql -e "GRANT ALL ON *.* to 'root'@'%' IDENTIFIED BY 'centreon' WITH GRANT OPT
 centreon -d -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1
 service mysql stop
 sed -i "5s/.*/    id: 1/" /etc/centreon-gorgone/config.d/40-gorgoned.yaml
-
-# CLAPI config generation creates prod cache with root user
-chown -R www-data:www-data /var/cache/centreon/symfony/*
 
 EOF
 

--- a/centreon/bin/console
+++ b/centreon/bin/console
@@ -22,7 +22,11 @@
 use App\Kernel;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
-use Symfony\Component\Debug\Debug;
+use Symfony\Component\ErrorHandler\Debug;
+
+if (posix_getuid() === 0) {
+    throw new \RuntimeException('The console should not be invoked using root user.');
+}
 
 if (false === in_array(\PHP_SAPI, ['cli', 'phpdbg', 'embed'], true)) {
     echo 'Warning: The console should be invoked via the CLI version of PHP, not the '.\PHP_SAPI.' SAPI'.\PHP_EOL;

--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -17,7 +17,7 @@ parameters:
     api.header: "Api-Version"
     api.version.latest: "23.04"
     debug_log_file: '%log_path%/centreon-web.log'
-    env(DEBUG_LEVEL): !php/const Monolog\Logger::NOTICE
+    env(DEBUG_LEVEL): !php/const Monolog\Logger::WARNING
     curl.timeout: 60
     debug_level: "%env(int:DEBUG_LEVEL)%"
     env(DEBUG_CONTACT): null
@@ -430,7 +430,7 @@ services:
 
     monolog.debug.handler:
         class: Centreon\Domain\Log\DebugFileHandler
-        arguments: [ '@monolog.debug.formater', '%debug_log_file%', '%env(bool:APP_DEBUG)%', 664, '%debug_level%' ]
+        arguments: [ '@monolog.debug.formater', '%debug_log_file%', 664, '%debug_level%' ]
 
     Centreon\Domain\Log\ContactForDebug:
         class: Centreon\Domain\Log\ContactForDebug

--- a/centreon/logrotate/centreon
+++ b/centreon/logrotate/centreon
@@ -1,4 +1,4 @@
-@CENTREON_LOG@/centAcl.log @CENTREON_LOG@/centreon-backup.log @CENTREON_LOG@/centreon-partitioning.log @CENTREON_LOG@/centreon-purge.log @CENTREON_LOG@/dashboardBuilder.log @CENTREON_LOG@/downtimeManager.log @CENTREON_LOG@/eventReportBuilder.log @CENTREON_LOG@/knowledgebase.log @CENTREON_LOG@/ldap*.log @CENTREON_LOG@/login.log @CENTREON_LOG@/sql-error.log {
+@CENTREON_LOG@/centAcl.log @CENTREON_LOG@/centreon-backup.log @CENTREON_LOG@/centreon-web.log @CENTREON_LOG@/centreon-partitioning.log @CENTREON_LOG@/centreon-purge.log @CENTREON_LOG@/dashboardBuilder.log @CENTREON_LOG@/downtimeManager.log @CENTREON_LOG@/eventReportBuilder.log @CENTREON_LOG@/knowledgebase.log @CENTREON_LOG@/ldap*.log @CENTREON_LOG@/login.log @CENTREON_LOG@/sql-error.log {
     copytruncate
     weekly
     rotate 52

--- a/centreon/src/Centreon/Domain/Log/DebugFileHandler.php
+++ b/centreon/src/Centreon/Domain/Log/DebugFileHandler.php
@@ -34,11 +34,6 @@ use Monolog\Logger;
 class DebugFileHandler extends StreamHandler
 {
     /**
-     * @var bool Whether the messages can be processed
-     */
-    private $isActivate;
-
-    /**
      * @param FormatterInterface $formatter Monolog formatter
      * @param string|resource $stream Resource or Log filename
      * @param bool $isActivate Whether the messages can be processed
@@ -51,25 +46,12 @@ class DebugFileHandler extends StreamHandler
     public function __construct(
         FormatterInterface $formatter,
         $stream,
-        bool $isActivate = false,
         int $filePermission = null,
-        $level = Logger::DEBUG,
+        $level = Logger::EMERGENCY,
         bool $useLocking = false,
         bool $bubble = true
     ) {
         parent::__construct($stream, $level, $bubble, $filePermission, $useLocking);
         $this->setFormatter($formatter);
-        $this->isActivate = $isActivate;
-    }
-
-    /**
-     * {@inheritDoc}
-     * @throws \LogicException
-     */
-    protected function write(array $record): void
-    {
-        if ($this->isActivate) {
-            parent::write($record);
-        }
     }
 }


### PR DESCRIPTION
## Description

* remove APP_DEBUG from logger
* avoid to use root to use symfony console

**Fixes** MON-19153

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

* add `APP_DEBUG=true` to `.env` file
* rebuild symfony cache : `su - apache -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear`
* export configuration using clapi : `centreon -d -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1`
* list files in symfony cache directory : `ls /var/cache/centreon/symfony`
* ==> some files are owned by root user
