### PR TITLE
enh(configuration): remove nagios_path_img option

### DIFF
--- a/centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
@@ -619,9 +619,7 @@ class HostConfigurationRepositoryRDB extends AbstractRepositoryDRB implements Ho
                 LEFT JOIN `:db`.view_img smi
                     ON smi.img_id = ext.ehi_statusmap_image
                 LEFT JOIN `:db`.host_template_relation htr
-                    ON htr.host_host_id = h.host_id
-                LEFT JOIN `:db`.options AS opt
-                    ON opt.key = \'nagios_path_img\''
+                    ON htr.host_host_id = h.host_id'
             );
             // Search
             $searchRequest = $this->sqlRequestTranslator->translateSearchParameterToSql();

--- a/centreon/tests/rest_api/rest_api.postman_collection.json
+++ b/centreon/tests/rest_api/rest_api.postman_collection.json
@@ -63150,60 +63150,6 @@
 					"response": []
 				},
 				{
-					"name": "Setparam nagios_path_img",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"type": "text/javascript",
-								"exec": [
-									"tests[\"Status code is 200\"] = responseCode.code === 200;"
-								]
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							},
-							{
-								"key": "centreon-auth-token",
-								"value": "{{token}}"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"action\": \"setparam\",\n  \"object\": \"settings\",\n  \"values\": \"nagios_path_img;{{nagios_path_img}}\"\n}"
-						},
-						"url": {
-							"raw": "http://{{url}}/centreon/api/index.php?action=action&object=centreon_clapi",
-							"protocol": "http",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"centreon",
-								"api",
-								"index.php"
-							],
-							"query": [
-								{
-									"key": "action",
-									"value": "action"
-								},
-								{
-									"key": "object",
-									"value": "centreon_clapi"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
 					"name": "Setparam perl_library_path",
 					"event": [
 						{
@@ -63473,9 +63419,6 @@
 									"                break;",
 									"            case \"mailer_path_bin\":",
 									"                tests[\"Body contains the correct setting mailer_path_bin\"] = postman.getEnvironmentVariable(\"mailer_path_bin\") == exceptionData[i].value;",
-									"                break;",
-									"            case \"nagios_path_img\":",
-									"                tests[\"Body contains the correct setting nagios_path_img\"] = postman.getEnvironmentVariable(\"nagios_path_img\") == exceptionData[i].value;",
 									"                break;",
 									"            case \"perl_library_path\":",
 									"                tests[\"Body contains the correct setting perl_library_path\"] = postman.getEnvironmentVariable(\"perl_library_path\") == exceptionData[i].value;",

--- a/centreon/tests/rest_api/rest_api.postman_environment.json
+++ b/centreon/tests/rest_api/rest_api.postman_environment.json
@@ -1342,12 +1342,6 @@
     },
     {
       "enabled": true,
-      "key": "nagios_path_img",
-      "value": "my_nagios_image_path",
-      "type": "text"
-    },
-    {
-      "enabled": true,
       "key": "perl_library_path",
       "value": "my_perl_lib_path",
       "type": "text"

--- a/centreon/www/class/centreon-clapi/centreonSettings.class.php
+++ b/centreon/www/class/centreon-clapi/centreonSettings.class.php
@@ -82,7 +82,6 @@ class CentreonSettings extends CentreonObject
             'enable_autologin' => array('values' => array('0', '1')),
             'interval_length' => array('format' => self::ISNUM),
             'enable_gmt' => array('values' => array('0', '1')),
-            'nagios_path_img' => array('format' => self::ISSTRING),
         );
     }
 

--- a/centreon/www/class/centreonMedia.class.php
+++ b/centreon/www/class/centreonMedia.class.php
@@ -38,6 +38,8 @@
  */
 class CentreonMedia
 {
+    public const CENTREON_MEDIA_PATH = __DIR__ . '/../img/media/';
+
     /**
      *
      * @var \CentreonDB
@@ -73,29 +75,11 @@ class CentreonMedia
      */
     public function getMediaDirectory()
     {
-        $mediaDirectory = '';
         if (empty($this->mediadirectoryname)) {
-            $query = "SELECT options.value FROM options WHERE options.key = 'nagios_path_img'";
-            try {
-                $result = $this->db->query($query);
-            } catch (\PDOException $e) {
-                throw new \Exception('Error while getting media directory ');
-            }
-
-
-            if ($result->rowCount()) {
-                $row = $result->fetchRow();
-                $mediaDirectory = $row['value'];
-            }
-
-            if (trim($mediaDirectory) == '') {
-                throw new \Exception('Error while getting media directory ');
-            }
+            return self::CENTREON_MEDIA_PATH;
         } else {
-            $mediaDirectory .= $this->mediadirectoryname;
+            return $this->mediadirectoryname;
         }
-
-        return $mediaDirectory;
     }
 
     /**

--- a/centreon/www/class/config-generate-remote/Media.php
+++ b/centreon/www/class/config-generate-remote/Media.php
@@ -44,7 +44,7 @@ class Media extends AbstractObject
         'img_path',
         'img_comment',
     ];
-    protected $path_img = null;
+    protected $pathImg = null;
 
     /**
      * Get medias
@@ -62,10 +62,7 @@ class Media extends AbstractObject
         $stmt->execute();
         $this->medias = $stmt->fetchAll(PDO::FETCH_GROUP | PDO::FETCH_UNIQUE | PDO::FETCH_ASSOC);
 
-        $stmt = $this->backendInstance->db->prepare('SELECT * FROM options WHERE `key` = "nagios_path_img"');
-        $stmt->execute();
-        $row = $stmt->fetch(PDO::FETCH_ASSOC);
-        $this->pathImg = $row['value'];
+        $this->pathImg = \CentreonMedia::CENTREON_MEDIA_PATH;
     }
 
     /**

--- a/centreon/www/include/Administration/parameters/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/DB-Func.php
@@ -166,12 +166,6 @@ function updateNagiosConfigData($gopt_id = null)
 
     updateOption(
         $pearDB,
-        "nagios_path_img",
-        isset($ret["nagios_path_img"]) && $ret["nagios_path_img"] != null
-            ? $pearDB->escape($ret["nagios_path_img"]) : "NULL"
-    );
-    updateOption(
-        $pearDB,
         "nagios_path_plugins",
         isset($ret["nagios_path_plugins"]) && $ret["nagios_path_plugins"] != null
             ? $pearDB->escape($ret["nagios_path_plugins"]) : "NULL"

--- a/centreon/www/include/Administration/parameters/engine/form.ihtml
+++ b/centreon/www/include/Administration/parameters/engine/form.ihtml
@@ -13,8 +13,7 @@
           </td>
         </tr>
 		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="tip_interval_length">&nbsp;{$form.interval_length.label}</td><td class="FormRowValue">{$form.interval_length.html}&nbsp;{$seconds}</td></tr>
-		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="tip_images_directory">&nbsp;{$form.nagios_path_img.label}</td><td class="FormRowValue">{$form.nagios_path_img.html}</td></tr>
-		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="tip_plugins_directory">&nbsp;{$form.nagios_path_plugins.label}</td><td class="FormRowValue">{$form.nagios_path_plugins.html}</td></tr>
+		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="tip_plugins_directory">&nbsp;{$form.nagios_path_plugins.label}</td><td class="FormRowValue">{$form.nagios_path_plugins.html}</td></tr>
 
 		<tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="2">

--- a/centreon/www/include/Administration/parameters/engine/form.php
+++ b/centreon/www/include/Administration/parameters/engine/form.php
@@ -51,10 +51,6 @@ if (!isset($gopt["interval_length"])) {
     $gopt["interval_length"] = 60;
 }
 
-if (!isset($gopt["nagios_path_img"])) {
-    $gopt["nagios_path_img"] = _CENTREON_PATH_ . 'www/img/media/';
-}
-
 $attrsText = array("size" => "40");
 $attrsText2 = array("size" => "5");
 $attrsAdvSelect = null;
@@ -65,7 +61,6 @@ $form->addElement('header', 'title', _("Modify General Options"));
 
 // Nagios information
 $form->addElement('header', 'nagios', _("Monitoring Engine information"));
-$form->addElement('text', 'nagios_path_img', _("Images Directory"), $attrsText);
 $form->addElement('text', 'nagios_path_plugins', _("Plugins Directory"), $attrsText);
 $form->addElement('text', 'interval_length', _("Interval Length"), $attrsText2);
 $form->addElement('text', 'mailer_path_bin', _("Directory + Mailer Binary"), $attrsText);
@@ -105,7 +100,6 @@ $redirect->setValue($o);
 
 $form->applyFilter('__ALL__', 'myTrim');
 $form->applyFilter('nagios_path', 'slash');
-$form->applyFilter('nagios_path_img', 'slash');
 $form->applyFilter('nagios_path_plugins', 'slash');
 
 $form->registerRule('is_valid_path', 'callback', 'is_valid_path');

--- a/centreon/www/include/Administration/parameters/general/form.php
+++ b/centreon/www/include/Administration/parameters/general/form.php
@@ -224,7 +224,6 @@ $form->addElement('text', 'centreon_support_email', _("Centreon Support Email"),
 
 $form->applyFilter('__ALL__', 'myTrim');
 $form->applyFilter('nagios_path', 'slash');
-$form->applyFilter('nagios_path_img', 'slash');
 $form->applyFilter('nagios_path_plugins', 'slash');
 $form->applyFilter('oreon_path', 'slash');
 $form->applyFilter('debug_path', 'slash');

--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -240,34 +240,6 @@ try {
     # Centcore pipe path
     $centcore_pipe = _CENTREON_VARLIB_ . "/centcore.cmd";
 
-    /*
-     * Copying image in logos directory
-     */
-    if (isset($centreon->optGen["nagios_path_img"]) && $centreon->optGen["nagios_path_img"]) {
-        /**
-         * @var CentreonDBStatement $DBRESULT_imgs
-         */
-        $DBRESULT_imgs = $pearDB->query(
-            "SELECT `dir_alias`, `img_path` " .
-            "FROM `view_img`, `view_img_dir`, `view_img_dir_relation` " .
-            "WHERE dir_dir_parent_id = dir_id AND img_img_id = img_id"
-        );
-        $nagiosPathImg = basename($centreon->optGen["nagios_path_img"]);
-        while ($images = $DBRESULT_imgs->fetchrow()) {
-            $dirAlias = basename($images["dir_alias"]);
-            $imgName = basename($images["img_path"]);
-            if (!is_dir($nagiosPathImg . "/" . $dirAlias)) {
-                $mkdirResult = @mkdir($nagiosPathImg . "/" . $dirAlias);
-            }
-            if (file_exists(_CENTREON_PATH_ . "www/img/media/" . $dirAlias . "/" . $imgName)) {
-                $copyResult = @copy(
-                    _CENTREON_PATH_ . "www/img/media/" . $dirAlias . "/" . $imgName,
-                    $nagiosPathImg . "/" . $dirAlias . "/" . $imgName
-                );
-            }
-        }
-    }
-
     $tab_server = array();
     $tabs = $centreon->user->access->getPollerAclConf(array(
         'fields' => array('name', 'id', 'localhost'),

--- a/centreon/www/include/options/media/images/listImg.php
+++ b/centreon/www/include/options/media/images/listImg.php
@@ -150,12 +150,9 @@ for ($i = 0; $elem = $res->fetchRow(); $i++) {
 $tpl->assign("elemArr", $elemArr);
 
 /*
- * Calculate availiable disk's space
+ * Calculate available disk's space
  */
-
-$diskStmnt = $pearDB->query("SELECT value FROM options AS o WHERE  o.key = 'nagios_path_img'")->fetch();
-
-$bytes = disk_free_space($diskStmnt["value"]);
+$bytes = disk_free_space(\CentreonMedia::CENTREON_MEDIA_PATH);
 $units = ['B', 'KB', 'MB', 'GB', 'TB'];
 $class = min((int)log($bytes, 1024), count($units) - 1);
 $availiableSpace = sprintf('%1.2f', $bytes / pow(1024, $class)) . ' ' . $units[$class];

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -125,7 +125,6 @@ INSERT INTO `options` (`key`, `value`) VALUES
 ('tactical_refresh_interval', '20'),
 ('index_data', '1'),
 ('interval_length', '60'),
-('nagios_path_img','@centreon_dir@/www/img/media/'),
 ('selectPaginationSize', 60),
 ('display_downtime_chart','0'),
 ('display_comment_chart','0'),

--- a/centreon/www/install/php/Update-23.04.1.php
+++ b/centreon/www/install/php/Update-23.04.1.php
@@ -27,9 +27,9 @@ $versionOfTheUpgrade = 'UPGRADE - 23.04.1: ';
 $errorMessage = '';
 
 $removeNagiosPathImg = function(CentreonDB $pearDB) {
-    $selectStatement = $pearDB->query("SELECT 1 FROM option WHERE `key`='nagios_path_img'");
+    $selectStatement = $pearDB->query("SELECT 1 FROM options WHERE `key`='nagios_path_img'");
     if($selectStatement->rowCount() > 0) {
-        $pearDB->query("DELETE FROM option WHERE `key`='nagios_path_img'");
+        $pearDB->query("DELETE FROM options WHERE `key`='nagios_path_img'");
     }
 };
 


### PR DESCRIPTION
## Description

Since Centreon no longer supports Nagios, it is no longer useful to copy images from Centreon to a third-party folder.

This mechanism was half implemented that could occurs errors on pollers/remote conf export. (e.g moveFiles script try to recreate already existing images)

We choose to remove this option from Centreon and replace it by the media path of centreon.

**Fixes** # MON-19207

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Non-Regression on image upload, configuration export, create service / host with icons

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
