### PR TITLE
fix(openid): Authentication conditions not working when getting info from defined endpoints

### DIFF
--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -686,29 +686,44 @@ class OpenIdProvider implements OpenIdProviderInterface
 
         $this->conditions->validate(
             $this->configuration,
-            $this->idTokenPayload ?: $this->attributePathFetcher->fetch(
-                $accessToken,
-                $this->configuration,
-                $authenticationConditions->getEndpoint()
-            )
+            $authenticationConditions->isEnabled()
+                ? array_merge(
+                    $this->idTokenPayload,
+                    $this->attributePathFetcher->fetch(
+                        $accessToken,
+                        $this->configuration,
+                        $authenticationConditions->getEndpoint()
+                    )
+                )
+                : $this->idTokenPayload
         );
 
         $this->rolesMapping->validate(
             $this->configuration,
-            $this->idTokenPayload ?: $this->attributePathFetcher->fetch(
-                $accessToken,
-                $this->configuration,
-                $rolesMapping->getEndpoint()
-            )
+            $rolesMapping->isEnabled()
+                ? array_merge(
+                    $this->idTokenPayload,
+                    $this->attributePathFetcher->fetch(
+                        $accessToken,
+                        $this->configuration,
+                        $rolesMapping->getEndpoint()
+                    )
+                )
+                : $this->idTokenPayload
         );
 
         $this->groupsMapping->validate(
             $this->configuration,
-            $this->idTokenPayload ?: $this->attributePathFetcher->fetch(
-                $accessToken,
-                $this->configuration,
-                $groupsMapping->getEndpoint()
+            $groupsMapping->isEnabled()
+            ? array_merge(
+                $this->idTokenPayload,
+                $this->attributePathFetcher->fetch(
+                    $accessToken,
+                    $this->configuration,
+                    $groupsMapping->getEndpoint()
+                )
             )
+            : $this->idTokenPayload
         );
     }
 

--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -689,10 +689,13 @@ class OpenIdProvider implements OpenIdProviderInterface
             $authenticationConditions->isEnabled()
                 ? array_merge(
                     $this->idTokenPayload,
-                    $this->attributePathFetcher->fetch(
-                        $accessToken,
-                        $this->configuration,
-                        $authenticationConditions->getEndpoint()
+                    array_diff_key(
+                        $this->attributePathFetcher->fetch(
+                            $accessToken,
+                            $this->configuration,
+                            $authenticationConditions->getEndpoint()
+                        ),
+                        $this->idTokenPayload
                     )
                 )
                 : $this->idTokenPayload
@@ -703,10 +706,13 @@ class OpenIdProvider implements OpenIdProviderInterface
             $rolesMapping->isEnabled()
                 ? array_merge(
                     $this->idTokenPayload,
-                    $this->attributePathFetcher->fetch(
-                        $accessToken,
-                        $this->configuration,
-                        $rolesMapping->getEndpoint()
+                    array_diff_key(
+                        $this->attributePathFetcher->fetch(
+                            $accessToken,
+                            $this->configuration,
+                            $rolesMapping->getEndpoint()
+                        ),
+                        $this->idTokenPayload
                     )
                 )
                 : $this->idTokenPayload
@@ -717,10 +723,13 @@ class OpenIdProvider implements OpenIdProviderInterface
             $groupsMapping->isEnabled()
             ? array_merge(
                 $this->idTokenPayload,
-                $this->attributePathFetcher->fetch(
-                    $accessToken,
-                    $this->configuration,
-                    $groupsMapping->getEndpoint()
+                array_diff_key(
+                    $this->attributePathFetcher->fetch(
+                        $accessToken,
+                        $this->configuration,
+                        $groupsMapping->getEndpoint()
+                    ),
+                    $this->idTokenPayload
                 )
             )
             : $this->idTokenPayload

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/Conditions.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/Conditions.php
@@ -55,7 +55,7 @@ class Conditions implements SecurityAccessInterface
         $scope = $configuration->getType();
         $customConfiguration = $configuration->getCustomConfiguration();
         $authenticationConditions = $customConfiguration->getAuthenticationConditions();
-        if (!$authenticationConditions->isEnabled()) {
+        if (! $authenticationConditions->isEnabled()) {
             $this->loginLogger->info($scope, "Authentication conditions disabled");
             $this->info("Authentication conditions disabled");
             return;
@@ -64,13 +64,11 @@ class Conditions implements SecurityAccessInterface
         $this->loginLogger->info($scope, "Authentication conditions is enabled");
         $this->info("Authentication conditions is enabled");
 
-        $customConfiguration = $configuration->getCustomConfiguration();
-        $conditionsConfiguration = $customConfiguration->getAuthenticationConditions();
-        $localConditions = $conditionsConfiguration->getAuthorizedValues();
+        $localConditions = $authenticationConditions->getAuthorizedValues();
 
-        $authenticationAttributePath[] = $conditionsConfiguration->getAttributePath();
+        $authenticationAttributePath[] = $authenticationConditions->getAttributePath();
         if ($configuration->getType() === Provider::OPENID) {
-            $authenticationAttributePath = explode(".", $conditionsConfiguration->getAttributePath());
+            $authenticationAttributePath = explode(".", $authenticationConditions->getAttributePath());
         }
 
         $this->loginLogger->info($scope, "Configured attribute path found", $authenticationAttributePath);
@@ -113,7 +111,7 @@ class Conditions implements SecurityAccessInterface
             $this->error(
                 "Configured attribute value not found in conditions endpoint",
                 [
-                    "configured_authorized_values" => $conditionsConfiguration->getAuthorizedValues()
+                    "configured_authorized_values" => $authenticationConditions->getAuthorizedValues()
                 ]
             );
 

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
@@ -92,7 +92,7 @@ class HttpReadAttributePathRepository implements ReadAttributePathRepositoryInte
         $options = ["headers" => $headers, "body" => $body, "verify_peer" => $customConfiguration->verifyPeer()];
 
         try {
-            $response = $this->client->request("GET", $url, $options);
+            $response = $this->client->request("POST", $url, $options);
         } catch (Exception) {
             throw new InvalidResponseException();
         }

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
@@ -92,7 +92,7 @@ class HttpReadAttributePathRepository implements ReadAttributePathRepositoryInte
         $options = ["headers" => $headers, "body" => $body, "verify_peer" => $customConfiguration->verifyPeer()];
 
         try {
-            $response = $this->client->request("POST", $url, $options);
+            $response = $this->client->request("GET", $url, $options);
         } catch (Exception) {
             throw new InvalidResponseException();
         }


### PR DESCRIPTION
## Description

Fixed application access conditions (as well as roles mapping and group mapping) not working if the information comes from defined endpoints (introspection, userinfo or custom endpoint).

**Fixes** # MON-19027

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
