### PR TITLE
enh (service): Create new API endpoint to delete a service template

### DIFF
--- a/centreon/doc/API/Common/Response/NoContent.yaml
+++ b/centreon/doc/API/Common/Response/NoContent.yaml
@@ -1,1 +1,3 @@
-description: "Query executed"
+description: |
+  Indicates that the server has successfully fulfilled the request and that there is no additional content to send 
+  in the response payload body.

--- a/centreon/doc/API/Common/Response/NotFound.yaml
+++ b/centreon/doc/API/Common/Response/NotFound.yaml
@@ -1,0 +1,14 @@
+description: |
+  Indicates that the server did not find the target resource.
+content:
+  application/json:
+    schema:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int64
+          example: 404
+        message:
+          type: string
+          example: "Service not found"

--- a/centreon/doc/API/centreon-api-v23.10.yaml
+++ b/centreon/doc/API/centreon-api-v23.10.yaml
@@ -489,6 +489,8 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /configuration/services/templates:
     $ref: "./v23.10/Configuration/ServiceTemplate/ServiceTemplates.yaml"
+  /configuration/services/templates/{service_template_id}:
+    $ref: "v23.10/Configuration/ServiceTemplate/ServiceTemplate.yaml"
   /monitoring/services/categories:
     get:
       tags:

--- a/centreon/doc/API/v23.10/Common/Response/NotFound.yaml
+++ b/centreon/doc/API/v23.10/Common/Response/NotFound.yaml
@@ -1,0 +1,1 @@
+$ref: "../../../Common/Response/NotFound.yaml"

--- a/centreon/doc/API/v23.10/Configuration/ServiceTemplate/QueryParameter/ServiceTemplateId.yaml
+++ b/centreon/doc/API/v23.10/Configuration/ServiceTemplate/QueryParameter/ServiceTemplateId.yaml
@@ -1,0 +1,8 @@
+in: path
+name: service_template_id
+required: true
+description: "Service template ID"
+schema:
+  type: integer
+  minimum: 1
+  example: 1

--- a/centreon/doc/API/v23.10/Configuration/ServiceTemplate/ServiceTemplate.yaml
+++ b/centreon/doc/API/v23.10/Configuration/ServiceTemplate/ServiceTemplate.yaml
@@ -1,0 +1,16 @@
+delete:
+  tags:
+    - Service template
+  summary: "Delete a service template"
+  description: "Delete a service template configuration"
+  parameters:
+    - $ref: 'QueryParameter/ServiceTemplateId.yaml'
+  responses:
+    '204':
+      $ref: '../../Common/Response/NoContent.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'

--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -15403,3 +15403,12 @@ msgstr ""
 
 #  msgid "You are not allowed to access host templates"
 #  msgstr ""
+
+# msgid "The service template '%s' is locked and cannot be deleted"
+# msgstr ""
+
+# msgid "You are not allowed to delete this service template"
+# msgstr ""
+
+# msgid "Error while deleting the service template"
+# msgstr ""

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15738,3 +15738,12 @@ msgstr ""
 
 # msgid "[%s] (%s) was expected to be an instance of the class '%s'"
 # msgstr ""
+
+# msgid "The service template '%s' is locked and cannot be deleted"
+# msgstr ""
+
+# msgid "You are not allowed to delete this service template"
+# msgstr ""
+
+# msgid "Error while deleting the service template"
+# msgstr ""

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17591,3 +17591,12 @@ msgstr "Erreur lors de la recherche de modèles de services"
 
 msgid "[%s] (%s) was expected to be an instance of the class '%s'"
 msgstr "[%s] (%s) devait être une instance de la classe '%s'"
+
+msgid "The service template '%s' is locked and cannot be deleted"
+msgstr "Le modèle de service '%s' est verrouillé et ne peut pas être supprimé"
+
+msgid "You are not allowed to delete this service template"
+msgstr "Vous n'êtes pas autorisé à supprimer ce modèle de service"
+
+msgid "Error while deleting the service template"
+msgstr "Erreur lors de la suppression du modèle de service"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -16202,3 +16202,12 @@ msgstr ""
 
 # msgid "[%s] (%s) was expected to be an instance of the class '%s'"
 # msgstr ""
+
+# msgid "The service template '%s' is locked and cannot be deleted"
+# msgstr ""
+
+# msgid "You are not allowed to delete this service template"
+# msgstr ""
+
+# msgid "Error while deleting the service template"
+# msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -16192,3 +16192,12 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 
 # msgid "[%s] (%s) was expected to be an instance of the class '%s'"
 # msgstr ""
+
+# msgid "The service template '%s' is locked and cannot be deleted"
+# msgstr ""
+
+# msgid "You are not allowed to delete this service template"
+# msgstr ""
+
+# msgid "Error while deleting the service template"
+# msgstr ""

--- a/centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+++ b/centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
@@ -34,6 +34,39 @@ class ServiceTemplateException extends \Exception
     }
 
     /**
+     * @param string $serviceTemplateName
+     *
+     * @return self
+     */
+    public static function cannotBeDelete(string $serviceTemplateName): self
+    {
+        return new self(
+            sprintf(
+                _('The service template \'%s\' is locked and cannot be deleted'),
+                $serviceTemplateName
+            )
+        );
+    }
+
+    /**
+     * @return self
+     */
+    public static function deleteNotAllowed(): self
+    {
+        return new self(_('You are not allowed to delete this service template'));
+    }
+
+    /**
+     * @param \Throwable $ex
+     *
+     * @return self
+     */
+    public static function errorWhileDeleting(\Throwable $ex): self
+    {
+        return new self(_('Error while deleting the service template'), 0, $ex);
+    }
+
+    /**
      * @param \Throwable $ex
      *
      * @return self

--- a/centreon/src/Core/ServiceTemplate/Application/Repository/ReadServiceTemplateRepositoryInterface.php
+++ b/centreon/src/Core/ServiceTemplate/Application/Repository/ReadServiceTemplateRepositoryInterface.php
@@ -29,6 +29,17 @@ use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
 interface ReadServiceTemplateRepositoryInterface
 {
     /**
+     * Find one service template.
+     *
+     * @param int $serviceTemplateId
+     *
+     * @throws \Throwable
+     *
+     * @return ServiceTemplate|null
+     */
+    public function findById(int $serviceTemplateId): ?ServiceTemplate;
+
+    /**
      * Find all service templates.
      *
      * @param RequestParametersInterface $requestParameters
@@ -38,4 +49,15 @@ interface ReadServiceTemplateRepositoryInterface
      * @return ServiceTemplate[]
      */
     public function findByRequestParameter(RequestParametersInterface $requestParameters): array;
+
+    /**
+     * Check the existence of a service template.
+     *
+     * @param int $serviceTemplateId
+     *
+     * @throws \Throwable
+     *
+     * @return bool
+     */
+    public function exists(int $serviceTemplateId): bool;
 }

--- a/centreon/src/Core/ServiceTemplate/Application/Repository/ReadServiceTemplateRepositoryInterface.php
+++ b/centreon/src/Core/ServiceTemplate/Application/Repository/ReadServiceTemplateRepositoryInterface.php
@@ -49,15 +49,4 @@ interface ReadServiceTemplateRepositoryInterface
      * @return ServiceTemplate[]
      */
     public function findByRequestParameter(RequestParametersInterface $requestParameters): array;
-
-    /**
-     * Check the existence of a service template.
-     *
-     * @param int $serviceTemplateId
-     *
-     * @throws \Throwable
-     *
-     * @return bool
-     */
-    public function exists(int $serviceTemplateId): bool;
 }

--- a/centreon/src/Core/ServiceTemplate/Application/Repository/WriteServiceTemplateRepositoryInterface.php
+++ b/centreon/src/Core/ServiceTemplate/Application/Repository/WriteServiceTemplateRepositoryInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceTemplate\Application\Repository;
+
+interface WriteServiceTemplateRepositoryInterface
+{
+    /**
+     * Delete a service template by ID.
+     *
+     * @param int $serviceTemplateId
+     */
+    public function deleteById(int $serviceTemplateId): void;
+}

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplate.php
@@ -70,7 +70,7 @@ final class DeleteServiceTemplate
                 return;
             }
 
-            if (($serviceTemplate = $this->readRepository->findById($serviceTemplateId)) == null) {
+            if (($serviceTemplate = $this->readRepository->findById($serviceTemplateId)) === null) {
                 $this->error('Service template not found', ['service_template_id' => $serviceTemplateId]);
                 $presenter->setResponseStatus(new NotFoundResponse('Service template'));
 
@@ -93,6 +93,13 @@ final class DeleteServiceTemplate
 
             $this->writeRepository->deleteById($serviceTemplateId);
             $presenter->setResponseStatus(new NoContentResponse());
+            $this->info(
+                'Service template deleted',
+                [
+                    'service_template_id' => $serviceTemplateId,
+                    'user_id' => $this->user->getId(),
+                ]
+            );
         } catch (\Throwable $ex) {
             $presenter->setResponseStatus(new ErrorResponse(ServiceTemplateException::errorWhileDeleting($ex)));
             $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplate.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceTemplate\Application\UseCase\DeleteServiceTemplate;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\PresenterInterface;
+use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
+use Core\ServiceTemplate\Application\Repository\WriteServiceTemplateRepositoryInterface;
+
+final class DeleteServiceTemplate
+{
+    use LoggerTrait;
+
+    /**
+     * @param ReadServiceTemplateRepositoryInterface $readRepository
+     * @param WriteServiceTemplateRepositoryInterface $writeRepository
+     * @param ContactInterface $user
+     */
+    public function __construct(
+        private readonly ReadServiceTemplateRepositoryInterface $readRepository,
+        private readonly WriteServiceTemplateRepositoryInterface $writeRepository,
+        private readonly ContactInterface $user)
+    {
+    }
+
+    /**
+     * @param int $serviceTemplateId
+     * @param PresenterInterface $presenter
+     */
+    public function __invoke(int $serviceTemplateId, PresenterInterface $presenter): void
+    {
+        try {
+            if (! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_TEMPLATES_READ_WRITE)) {
+                $this->error(
+                    "User doesn't have sufficient rights to delete the service template",
+                    ['user_id' => $this->user->getId()]
+                );
+                $presenter->setResponseStatus(
+                    new ForbiddenResponse(ServiceTemplateException::deleteNotAllowed())
+                );
+
+                return;
+            }
+
+            if (! $serviceTemplate = $this->readRepository->findById($serviceTemplateId)) {
+                $this->error('Service template not found', ['service_template_id' => $serviceTemplateId]);
+                $presenter->setResponseStatus(new NotFoundResponse('Service template'));
+
+                return;
+            }
+
+            if ($serviceTemplate->isLocked()) {
+                $this->error(
+                    'The service template is locked and cannot be delete',
+                    ['service_template_id' => $serviceTemplateId]
+                );
+                $presenter->setResponseStatus(
+                    new ErrorResponse(
+                        ServiceTemplateException::cannotBeDelete($serviceTemplate->getName())->getMessage()
+                    )
+                );
+
+                return;
+            }
+
+            $this->writeRepository->deleteById($serviceTemplateId);
+            $presenter->setResponseStatus(new NoContentResponse());
+        } catch (\Throwable $ex) {
+            $presenter->setResponseStatus(new ErrorResponse(ServiceTemplateException::errorWhileDeleting($ex)));
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        }
+    }
+}

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplate.php
@@ -47,8 +47,8 @@ final class DeleteServiceTemplate
     public function __construct(
         private readonly ReadServiceTemplateRepositoryInterface $readRepository,
         private readonly WriteServiceTemplateRepositoryInterface $writeRepository,
-        private readonly ContactInterface $user)
-    {
+        private readonly ContactInterface $user
+    ) {
     }
 
     /**
@@ -70,7 +70,7 @@ final class DeleteServiceTemplate
                 return;
             }
 
-            if (! $serviceTemplate = $this->readRepository->findById($serviceTemplateId)) {
+            if (($serviceTemplate = $this->readRepository->findById($serviceTemplateId)) == null) {
                 $this->error('Service template not found', ['service_template_id' => $serviceTemplateId]);
                 $presenter->setResponseStatus(new NotFoundResponse('Service template'));
 

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/FindServiceTemplates.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/FindServiceTemplates.php
@@ -27,6 +27,7 @@ use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+use Centreon\Infrastructure\RequestParameters\RequestParametersTranslatorException;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
@@ -67,6 +68,9 @@ final class FindServiceTemplates
 
             $serviceTemplates = $this->repository->findByRequestParameter($this->requestParameters);
             $presenter->presentResponse($this->createResponse($serviceTemplates));
+        } catch (RequestParametersTranslatorException $ex) {
+            $presenter->presentResponse(new ErrorResponse($ex->getMessage()));
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
         } catch (\Throwable $ex) {
             $presenter->presentResponse(new ErrorResponse(ServiceTemplateException::errorWhileSearching($ex)));
             $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/DeleteServiceTemplate/DeleteServiceTemplateController.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/DeleteServiceTemplate/DeleteServiceTemplateController.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceTemplate\Infrastructure\API\DeleteServiceTemplate;
+
+use Centreon\Application\Controller\AbstractController;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\ServiceTemplate\Application\UseCase\DeleteServiceTemplate\DeleteServiceTemplate;
+use Symfony\Component\HttpFoundation\Response;
+
+final class DeleteServiceTemplateController extends AbstractController
+{
+    /**
+     * @param DeleteServiceTemplate $useCase
+     * @param DefaultPresenter $presenter
+     * @param int $serviceTemplateId
+     *
+     * @return Response
+     */
+    public function __invoke(
+        DeleteServiceTemplate $useCase,
+        DefaultPresenter $presenter,
+        int $serviceTemplateId
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        $useCase($serviceTemplateId, $presenter);
+
+        return $presenter->show();
+    }
+}

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/DeleteServiceTemplate/DeleteServiceTemplateController.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/DeleteServiceTemplate/DeleteServiceTemplateController.php
@@ -27,6 +27,7 @@ use Centreon\Application\Controller\AbstractController;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\ServiceTemplate\Application\UseCase\DeleteServiceTemplate\DeleteServiceTemplate;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 final class DeleteServiceTemplateController extends AbstractController
 {
@@ -34,6 +35,8 @@ final class DeleteServiceTemplateController extends AbstractController
      * @param DeleteServiceTemplate $useCase
      * @param DefaultPresenter $presenter
      * @param int $serviceTemplateId
+     *
+     * @throws AccessDeniedException
      *
      * @return Response
      */

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/DeleteServiceTemplate/DeleteServiceTemplateRoute.yaml
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/DeleteServiceTemplate/DeleteServiceTemplateRoute.yaml
@@ -1,0 +1,5 @@
+DeleteServiceTemplate:
+  methods: DELETE
+  path: /configuration/services/templates/{serviceTemplateId}
+  controller: 'Core\ServiceTemplate\Infrastructure\API\DeleteServiceTemplate\DeleteServiceTemplateController'
+  condition: "request.attributes.get('version') >= 23.10"

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbReadServiceTemplateRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbReadServiceTemplateRepository.php
@@ -165,6 +165,9 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
         return null;
     }
 
+    /**
+     * @inheritDoc
+     */
     public function findByRequestParameter(RequestParametersInterface $requestParameters): array
     {
         $this->info('Searching for service templates');
@@ -256,19 +259,6 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
     }
 
     /**
-     * @inheritDoc
-     */
-    public function exists(int $serviceTemplateId): bool
-    {
-        $request = $this->translateDbName('SELECT 1 FROM `:db`.service WHERE service_id = :id');
-        $statement = $this->db->prepare($request);
-        $statement->bindValue(':id', $serviceTemplateId, \PDO::PARAM_INT);
-        $statement->execute();
-
-        return (bool) $statement->fetchColumn();
-    }
-
-    /**
      * @param _ServiceTemplate $data
      *
      * @throws AssertionFailedException
@@ -333,6 +323,11 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
         );
     }
 
+    /**
+     * @param string $value
+     *
+     * @return YesNoDefault
+     */
     private function createYesNoDefault(string $value): YesNoDefault
     {
         return match ($value) {

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateRepository.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceTemplate\Infrastructure\Repository;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Infrastructure\DatabaseConnection;
+use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Core\ServiceTemplate\Application\Repository\WriteServiceTemplateRepositoryInterface;
+
+class DbWriteServiceTemplateRepository extends AbstractRepositoryRDB implements WriteServiceTemplateRepositoryInterface
+{
+    use LoggerTrait;
+
+    /**
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function deleteById(int $serviceTemplateId): void
+    {
+        $this->info('Delete service template by ID');
+        $request = $this->translateDbName('DELETE FROM `:db`.service WHERE service_id = :id');
+        $statement = $this->db->prepare($request);
+        $statement->bindValue(':id', $serviceTemplateId, \PDO::PARAM_INT);
+        $statement->execute();
+    }
+}

--- a/centreon/tests/api/features/ServiceTemplatesCloud.feature
+++ b/centreon/tests/api/features/ServiceTemplatesCloud.feature
@@ -12,6 +12,8 @@ Feature:
     And the following CLAPI import data:
     """
     STPL;ADD;service-name-1;service-alias-1;;;;
+    CONTACT;ADD;test;test;test@localhost.com;Centreon@2022;0;1;en_US;local
+    CONTACT;setparam;test;reach_api;1
     """
 
     When I send a GET request to '/api/latest/configuration/services/templates?search={"name": "service-name-1"}'
@@ -43,6 +45,34 @@ Feature:
             },
             "sort_by": {},
             "total": 1
+        }
+    }
+    """
+
+    Given I am logged in with "test"/"Centreon@2022"
+    When I send a DELETE request to '/api/v23.10/configuration/services/templates/27'
+    Then the response code should be "403"
+
+    When I am logged in
+    Then I send a DELETE request to '/api/v23.10/configuration/services/templates/27'
+    Then the response code should be "204"
+
+    When I send a GET request to '/api/v23.10/configuration/services/templates?search={"name": "service-name-1"}'
+    Then the response code should be "200"
+    And the JSON should be equal to:
+    """
+    {
+        "result": [],
+        "meta": {
+            "page": 1,
+            "limit": 10,
+            "search": {
+                "$and": {
+                    "name": "service-name-1"
+                }
+            },
+            "sort_by": {},
+            "total": 0
         }
     }
     """

--- a/centreon/tests/api/features/ServiceTemplatesOnPrem.feature
+++ b/centreon/tests/api/features/ServiceTemplatesOnPrem.feature
@@ -12,6 +12,8 @@ Feature:
     And the following CLAPI import data:
     """
     STPL;ADD;service-name-1;service-alias-1;;;;
+    CONTACT;ADD;test;test;test@localhost.com;Centreon@2022;0;1;en_US;local
+    CONTACT;setparam;test;reach_api;1
     """
 
     When I send a GET request to '/api/v23.10/configuration/services/templates?search={"name": "service-name-1"}'
@@ -73,6 +75,34 @@ Feature:
             },
             "sort_by": {},
             "total": 1
+        }
+    }
+    """
+
+    Given I am logged in with "test"/"Centreon@2022"
+    When I send a DELETE request to '/api/v23.10/configuration/services/templates/27'
+    Then the response code should be "403"
+
+    When I am logged in
+    Then I send a DELETE request to '/api/v23.10/configuration/services/templates/27'
+    Then the response code should be "204"
+
+    When I send a GET request to '/api/v23.10/configuration/services/templates?search={"name": "service-name-1"}'
+    Then the response code should be "200"
+    And the JSON should be equal to:
+    """
+    {
+        "result": [],
+        "meta": {
+            "page": 1,
+            "limit": 10,
+            "search": {
+                "$and": {
+                    "name": "service-name-1"
+                }
+            },
+            "sort_by": {},
+            "total": 0
         }
     }
     """

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/DeleteServiceTemplate/DeleteServiceTemplateTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
+use Core\ServiceTemplate\Application\Repository\WriteServiceTemplateRepositoryInterface;
+use Core\ServiceTemplate\Application\UseCase\DeleteServiceTemplate\DeleteServiceTemplate;
+use Tests\Core\ServiceTemplate\Infrastructure\API\DeleteServiceTemplate\DeleteServiceTemplatePresenterStub;
+use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
+
+beforeEach(closure: function (): void {
+    $this->readRepository = $this->createMock(ReadServiceTemplateRepositoryInterface::class);
+    $this->writeRepository = $this->createMock(WriteServiceTemplateRepositoryInterface::class);
+    $this->user = $this->createMock(ContactInterface::class);
+    $this->presenter = new DeleteServiceTemplatePresenterStub($this->createMock(PresenterFormatterInterface::class));
+    $this->useCase = new DeleteServiceTemplate($this->readRepository, $this->writeRepository, $this->user);
+    $this->serviceTemplateLockedFound = new ServiceTemplate(
+        1,
+        'fake_name',
+        'fake_alias',
+        ...['isLocked' => true]
+    );
+    $this->serviceTemplateNotLockedFound = new ServiceTemplate(
+        1,
+        'fake_name',
+        'fake_alias',
+        ...['isLocked' => false]
+    );
+});
+
+it('should present a ForbiddenResponse when the user has insufficient rights', function () {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturnMap(
+            [
+                [Contact::ROLE_CONFIGURATION_SERVICES_TEMPLATES_READ_WRITE, false],
+            ]
+        );
+
+    ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(ServiceTemplateException::deleteNotAllowed()->getMessage());
+});
+
+it('should present a NotFoundResponse when the service template is not found', function () {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->with(1)
+        ->willReturn(null);
+
+    ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(NotFoundResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe((new NotFoundResponse('Service template'))->getMessage());
+});
+
+it('should present an ErrorResponse when the service template is locked', function () {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->with($this->serviceTemplateLockedFound->getId())
+        ->willReturn($this->serviceTemplateLockedFound);
+
+    ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(ServiceTemplateException::cannotBeDelete($this->serviceTemplateLockedFound->getName())->getMessage());
+});
+
+it('should present a NoContentResponse when the service template has been deleted', function () {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->with($this->serviceTemplateNotLockedFound->getId())
+        ->willReturn($this->serviceTemplateNotLockedFound);
+
+    $this->writeRepository
+        ->expects($this->once())
+        ->method('deleteById')
+        ->with($this->serviceTemplateNotLockedFound->getId());
+
+    ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should present an ErrorResponse when an exception is thrown', function () {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willThrowException(new \Exception());
+
+    ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(ServiceTemplateException::errorWhileDeleting(new Exception())->getMessage());
+});

--- a/centreon/tests/php/Core/ServiceTemplate/Infrastructure/API/DeleteServiceTemplate/DeleteServiceTemplatePresenterStub.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Infrastructure/API/DeleteServiceTemplate/DeleteServiceTemplatePresenterStub.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * CENTREON
+ *
+ * Source Copyright 2005-2023 Centreon
+ *
+ * Unauthorized reproduction, copy and distribution are not allowed.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+declare(strict_types = 1);
+
+namespace Tests\Core\ServiceTemplate\Infrastructure\API\DeleteServiceTemplate;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+class DeleteServiceTemplatePresenterStub extends AbstractPresenter
+{
+    public ?ResponseStatusInterface $response;
+
+    public function setResponseStatus(?ResponseStatusInterface $responseStatus): void
+    {
+        $this->response = $responseStatus;
+    }
+}


### PR DESCRIPTION
## Description

Create a new API endpoint to delete a service template
```
GET /configuration/services/templates/{service_template_id}
```

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
