### PR TITLE
fix(open-tickets): Fix  SQL join on Custom Variables

### DIFF
--- a/centreon-open-tickets/widgets/open-tickets/src/index.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/index.php
@@ -159,7 +159,7 @@ $query = "SELECT SQL_CALC_FOUND_ROWS h.host_id,
         h.icon_image
     FROM hosts h
     LEFT JOIN customvariables cv5 ON (
-        h.host_id = cv5.host_id AND cv5.service_id IS NULL AND cv5.name = '" . $macro_tickets['ticket_id'] . "'
+        h.host_id = cv5.host_id AND (cv5.service_id IS NULL OR cv5.service_id = 0) AND cv5.name = '" . $macro_tickets['ticket_id'] . "'
     )
     LEFT JOIN mod_open_tickets mop1 ON (
         cv5.value = mop1.ticket_value AND (


### PR DESCRIPTION
## Description

when you open a ticket for a host with the open ticket widget. Even if the TICKET_ID custom macro is set up in the configuration, even if the whole workflow works fine, you'll never see your host in the widget that is supposed to display all currently opened tickets.


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

- have a working open ticket module and an open ticket widget to open ticket and one widget to display opened tickets
- open a ticket on a host

without the patch, the ticket will never appear
with it, it will.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
