### PR TITLE
fix(gorgone): add central id to gorgone configuration file

### DIFF
--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -667,7 +667,7 @@ if [ -f %{_sysconfdir}/centreon/centreon.conf.php ] ; then
 fi
 
 # make sure that gorgone configuration file has the central id set
-if [[ "$(sed '5,5!d' /etc/centreon-gorgone/config.d/40-gorgoned.yaml)" =~ ^.*id:.*$ ]]; then
+if [[ ! "$(sed '5,5!d' /etc/centreon-gorgone/config.d/40-gorgoned.yaml)" =~ ^.*id:.*$ ]]; then
     sed -i "5s/.*/    id: 1/" /etc/centreon-gorgone/config.d/40-gorgoned.yaml
 fi
 

--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -666,6 +666,11 @@ if [ -f %{_sysconfdir}/centreon/centreon.conf.php ] ; then
   su - apache -s /bin/bash -c "%{_datadir}/centreon/bin/console cache:clear"
 fi
 
+# make sure that gorgone configuration file has the central id set
+if [[ "$(sed '5,5!d' /etc/centreon-gorgone/config.d/40-gorgoned.yaml)" =~ ^.*id:.*$ ]]; then
+    sed -i "5s/.*/    id: 1/" /etc/centreon-gorgone/config.d/40-gorgoned.yaml
+fi
+
 #%preun web
 #setsebool -P httpd_unified off 2>/dev/null || :
 #setsebool -P httpd_can_network_connect off 2>/dev/null || :

--- a/centreon/packaging/debian/centreon-web.postinst
+++ b/centreon/packaging/debian/centreon-web.postinst
@@ -60,7 +60,7 @@ if [ -n "$2" ]; then
   rm -rf /var/cache/centreon/symfony
   su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear"
 
-  if [[ "$(sed '5,5!d' /etc/centreon-gorgone/config.d/40-gorgoned.yaml)" =~ ^.*id:.*$ ]]; then
+  if [[ ! "$(sed '5,5!d' /etc/centreon-gorgone/config.d/40-gorgoned.yaml)" =~ ^.*id:.*$ ]]; then
     sed -i "5s/.*/    id: 1/" /etc/centreon-gorgone/config.d/40-gorgoned.yaml
   fi
 fi

--- a/centreon/packaging/debian/centreon-web.postinst
+++ b/centreon/packaging/debian/centreon-web.postinst
@@ -59,6 +59,10 @@ fi
 if [ -n "$2" ]; then
   rm -rf /var/cache/centreon/symfony
   su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear"
+
+  if [[ "$(sed '5,5!d' /etc/centreon-gorgone/config.d/40-gorgoned.yaml)" =~ ^.*id:.*$ ]]; then
+    sed -i "5s/.*/    id: 1/" /etc/centreon-gorgone/config.d/40-gorgoned.yaml
+  fi
 fi
 
 # Try auto configure timezone for php

--- a/centreon/packaging/debian/centreon-web.postinst
+++ b/centreon/packaging/debian/centreon-web.postinst
@@ -60,7 +60,7 @@ if [ -n "$2" ]; then
   rm -rf /var/cache/centreon/symfony
   su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear"
 
-  if [[ ! "$(sed '5,5!d' /etc/centreon-gorgone/config.d/40-gorgoned.yaml)" =~ ^.*id:.*$ ]]; then
+  if ! echo "$(sed '5,5!d' /etc/centreon-gorgone/config.d/40-gorgoned.yaml)" | grep -Eq "^.*id:.*$"; then
     sed -i "5s/.*/    id: 1/" /etc/centreon-gorgone/config.d/40-gorgoned.yaml
   fi
 fi

--- a/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
+++ b/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
@@ -2,6 +2,7 @@ gorgone:
   gorgonecore:
     privkey: "--GORGONE_VARLIB--/.keys/rsakey.priv.pem"
     pubkey: "--GORGONE_VARLIB--/.keys/rsakey.pub.pem"
+    id: 1
 
   modules:
     - name: httpserver


### PR DESCRIPTION
## Description

ℹ️ MON-19087

This PR intends to make sure that the gorgone configuration file `/etc/centreon-gorgone/config.d/40-gorgoned.yaml` has always the central id set (1 by default).

For the update process of existing platform this will be handled through the packaging has apache user is not allowed to edit the files in /etc/centreon-gorgone/config.d/

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for testing information

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
