### PR TITLE
fix(openid): extractPayloadToken does not follow JWT standard 

### DIFF
--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -422,7 +422,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     {
         try {
             $tokenParts = explode(".", $token);
-            return json_decode(base64_decode(strtr($tokenParts[1], '-_', '+/')), true);
+            return json_decode($this->urlSafeTokenDecode($tokenParts[1]));
         } catch (Throwable $ex) {
             $this->error(
                 SSOAuthenticationException::unableToDecodeIdToken()->getMessage(),
@@ -963,5 +963,24 @@ class OpenIdProvider implements OpenIdProviderInterface
     public function getUserContactGroups(): array
     {
         return $this->groupsMapping->getUserContactGroups();
+    }
+
+    /**
+     * Decode using the RFC-4648 "URL and Filename safe" Base 64 Alphabet.
+     * @see https://www.ietf.org/rfc/rfc4648.txt
+     *
+     * @param string $token
+     * @return string
+     *
+     * @throws \ValueError
+     */
+    private function urlSafeTokenDecode(string $token): string
+    {
+        $decoded = base64_decode(str_replace(['-', '_'], ['+', '/'], $token), true);
+        if (false === $decoded) {
+            throw new \ValueError('The token cannot be base64 decoded');
+        }
+
+        return $decoded;
     }
 }

--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -422,7 +422,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     {
         try {
             $tokenParts = explode(".", $token);
-            return json_decode(base64_decode($tokenParts[1]), true);
+            return json_decode(base64_decode(strtr($tokenParts[1], '-_', '+/')), true);
         } catch (Throwable $ex) {
             $this->error(
                 SSOAuthenticationException::unableToDecodeIdToken()->getMessage(),


### PR DESCRIPTION
## Description

Fixed JWT token decoding to follow JWT standard

**Fixes** # MON-19064

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
