### PR TITLE
fix(resources status): protect the metric name in the query

### DIFF
--- a/centreon/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
@@ -79,7 +79,7 @@ class DbReadPerformanceDataRepository extends AbstractRepositoryDRB implements R
     {
         $metricIds = [];
         $subQueryColumns = [];
-        $subQueryPattern = 'AVG(CASE WHEN id_metric = %d THEN `value` end) AS %s';
+        $subQueryPattern = 'AVG(CASE WHEN id_metric = %d THEN `value` end) AS "%s"';
         foreach ($metrics as $metric) {
             $subQueryColumns[] = sprintf($subQueryPattern, $metric->getId(), $metric->getName());
             $metricIds[] = $metric->getId();

--- a/centreon/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
@@ -86,11 +86,11 @@ class DbReadPerformanceDataRepository extends AbstractRepositoryDRB implements R
         }
 
         $pattern = 'SELECT %s FROM `:dbstg`.data_bin WHERE ';
-        $pattern .= ' ctime >= :start AND ctime < :end AND id_metric IN (%s) GROUP BY time';
+        $pattern .= ' ctime >= :start AND ctime < :end AND id_metric IN (%s) GROUP BY ctime';
 
         return sprintf(
             $pattern,
-            join(', ', ['ctime AS time', ...$subQueryColumns]),
+            join(', ', ['ctime', ...$subQueryColumns]),
             join(',', $metricIds)
         );
     }
@@ -100,7 +100,7 @@ class DbReadPerformanceDataRepository extends AbstractRepositoryDRB implements R
      */
     private function createPerformanceMetricFromDataBin(array $dataBin): PerformanceMetric
     {
-        $time = (new \DateTimeImmutable())->setTimestamp((int) $dataBin['time']);
+        $time = (new \DateTimeImmutable())->setTimestamp((int) $dataBin['ctime']);
         $metricValues = $this->createMetricValues($dataBin);
 
         return new PerformanceMetric($time, $metricValues);
@@ -114,7 +114,7 @@ class DbReadPerformanceDataRepository extends AbstractRepositoryDRB implements R
     {
         $metricValues = [];
         foreach ($data as $columnName => $columnValue) {
-            if ($columnName !== 'time') {
+            if ($columnName !== 'ctime') {
                 $metricValues[] = new MetricValue($columnName, (float) $columnValue);
             }
         }


### PR DESCRIPTION
## Description

Protect the metric name in the query to avoid error for metric names beginning by underscore or a special charater.

**Fixes** MON-19475

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)
