### PR TITLE
fix(packaging): update rights of /var/log/centreon on debian (#1498)

### DIFF
--- a/centreon/packaging/debian/centreon-poller-centreon-engine.postinst
+++ b/centreon/packaging/debian/centreon-poller-centreon-engine.postinst
@@ -6,6 +6,7 @@ if [ "$1" = "configure" ]; then
     chmod 0775 /var/run/centreon
 
     if [ "$(getent passwd centreon)" ]; then
+        chown centreon:centreon /var/log/centreon
         chown centreon:centreon /var/run/centreon
     fi
 

--- a/centreon/packaging/debian/control
+++ b/centreon/packaging/debian/control
@@ -195,6 +195,8 @@ Architecture: all
 Depends:
     centreon-common (>= ${centreon:version}~),
     centreon-common (<< ${centreon:versionThreshold}~),
+    centreon-perl-libs (>= ${centreon:version}~),
+    centreon-perl-libs (<< ${centreon:versionThreshold}~),
     snmptrapd,
     snmpd,
     ${misc:Depends}


### PR DESCRIPTION
## Description

fix(packaging): update rights of /var/log/centreon on debian

**Fixes** MON-18725

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)