### PR TITLE
fix(resource status): Display the last acknowledgement into the details panel

### DIFF
--- a/centreon/src/Core/Infrastructure/RealTime/Repository/Acknowledgement/DbReadAcknowledgementRepository.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/Acknowledgement/DbReadAcknowledgementRepository.php
@@ -66,7 +66,7 @@ class DbReadAcknowledgementRepository extends AbstractRepositoryDRB implements R
                     FROM `:dbstg`.acknowledgements ack
                 LEFT JOIN `:db`.contact ON contact.contact_alias = ack.author
                 INNER JOIN (
-                    SELECT max(acknowledgement_id) as acknowledgement_id
+                    SELECT MAX(acknowledgement_id) AS acknowledgement_id
                     FROM `:dbstg`.acknowledgements ack
                     WHERE ack.host_id = :hostId
                     AND ack.service_id = :serviceId


### PR DESCRIPTION
## Description

This PR intends to Display the last acknowledgement into the details panel instead of the first one

**Fixes** # MON-16921

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Add an acknowledgements to a service. Wait for broker to process the command and populate the acknowledgements table.
- Add another acknowledgements to the same resource. 
- Display the panel
- In the Acknowledgement tile, the last acknowledgement details should be display

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
