### PR TITLE
chore(packaging): package perl-zmq-constants for el9/bullseye (#1499)

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -101,12 +101,12 @@ jobs:
             "XML::Filter::BufferText",
             "XML::LibXML::Simple",
             "XML::SAX::Writer",
+            "ZMQ::Constants",
             "ZMQ::FFI",
             "ZMQ::LibZMQ4"
           ]
         include:
-          - build_rpm: "true"
-          - build_deb: "true"
+          - build_distribs: "el8,el9,bullseye"
           - rpm_dependencies: ""
           - deb_dependencies: ""
           - rpm_provides: ""
@@ -123,26 +123,26 @@ jobs:
             package_extension: deb
             image: packaging-bullseye
           - name: "BSON"
-            build_deb: "false"
+            build_distribs: "el8,el9"
             rpm_provides: "perl(BSON::Bytes) perl(BSON::Code) perl(BSON::DBRef) perl(BSON::OID) perl(BSON::Raw) perl(BSON::Regex) perl(BSON::Time) perl(BSON::Timestamp) perl(BSON::Types) perl(BSON)"
           - name: "BSON::XS"
-            build_deb: "false"
+            build_distribs: "el8,el9"
           - name: "Convert::Binary::C"
-            build_deb: "false"
+            build_distribs: "el8,el9"
           - name: "DateTime::Format::Duration::ISO8601"
             rpm_provides: "perl(DateTime-Format-Duration-ISO8601)"
           - name: "DBD::Sybase"
-            build_deb: "false"
+            build_distribs: "el8,el9"
           - name: "Device::Modbus::RTU::Client"
             version: "0.022"
           - name: "Device::Modbus::TCP::Client"
             version: "0.026"
           - name: "EV"
-            build_deb: "false"
+            build_distribs: "el8,el9"
           - name: "FFI::CheckLib"
-            build_deb: "false"
+            build_distribs: "el8,el9"
           - name: "FFI::Platypus"
-            build_deb: "false"
+            build_distribs: "el8,el9"
             rpm_provides: "perl(FFI::Platypus::Buffer) perl(FFI::Platypus::Memory)"
           - name: "JSON::Path"
             version: "1.0.3"
@@ -155,12 +155,16 @@ jobs:
             version: "0.53"
           - name: "UUID"
             use_dh_make_perl: "false"
+          - name: "ZMQ::Constants"
+            build_distribs: "el9,bullseye"
           - name: "ZMQ::FFI"
-            build_deb: "false"
+            build_distribs: "el8,el9"
             rpm_dependencies: "zeromq"
           - name: "ZMQ::LibZMQ4"
             use_dh_make_perl: "false"
             version: "0.01"
+            rpm_dependencies: "zeromq"
+            deb_dependencies: "libzmq5"
     name: package ${{ matrix.distrib }} ${{ matrix.name }}
     container:
       image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-version.outputs.major_version }}
@@ -171,7 +175,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - if: ${{ matrix.build_rpm == 'true' && matrix.package_extension == 'rpm' }}
+      - if: ${{ contains(matrix.build_distribs, matrix.distrib) && matrix.package_extension == 'rpm' }}
         run: |
           yum install -y yum-utils epel-release git
           yum config-manager --set-enabled crb || true # alma 9
@@ -179,7 +183,7 @@ jobs:
           yum install -y cpanminus rpm-build libcurl-devel libssh-devel expat-devel gcc ruby libuuid-devel zeromq-devel libxml2-devel libffi-devel perl-DBI perl-Net-Pcap freetds freetds-devel
         shell: bash
 
-      - if: ${{ matrix.build_rpm == 'true' && matrix.package_extension == 'rpm' && matrix.spec_file == '' }}
+      - if: ${{ contains(matrix.build_distribs, matrix.distrib) && matrix.package_extension == 'rpm' && matrix.spec_file == '' }}
         run: |
           if [ -z "${{ matrix.version }}" ]; then
             PACKAGE_VERSION=""
@@ -212,7 +216,7 @@ jobs:
           fpm -s cpan -t ${{ matrix.package_extension }} --rpm-dist ${{ matrix.distrib }} --verbose --cpan-verbose --no-cpan-test$PACKAGE_DEPENDENCIES$PACKAGE_PROVIDES$PACKAGE_VERSION ${{ matrix.name }}
         shell: bash
 
-      - if: ${{ matrix.build_rpm == 'true' && matrix.package_extension == 'rpm' && matrix.spec_file != '' }}
+      - if: ${{ contains(matrix.build_distribs, matrix.distrib) && matrix.package_extension == 'rpm' && matrix.spec_file != '' }}
         run: |
           mkdir -p ~/rpmbuild/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
 
@@ -221,7 +225,7 @@ jobs:
           cp -r ~/rpmbuild/RPMS/noarch/*.rpm .
         shell: bash
 
-      - if: ${{ matrix.build_deb == 'true' && matrix.package_extension == 'deb' && matrix.use_dh_make_perl == 'false' }}
+      - if: ${{ contains(matrix.build_distribs, matrix.distrib) && matrix.package_extension == 'deb' && matrix.use_dh_make_perl == 'false' }}
         run: |
           apt update
           apt install -y cpanminus ruby libcurl4-openssl-dev libssh-dev uuid-dev libczmq-dev
@@ -248,7 +252,7 @@ jobs:
           fpm -s cpan -t ${{ matrix.package_extension }} --deb-dist ${{ matrix.distrib }} --verbose --cpan-verbose --no-cpan-test -n $PACKAGE_NAME$PACKAGE_DEPENDENCIES$PACKAGE_VERSION ${{ matrix.name }}
         shell: bash
 
-      - if: ${{ matrix.build_deb == 'true' && matrix.package_extension == 'deb' && matrix.use_dh_make_perl == 'true' }}
+      - if: ${{ contains(matrix.build_distribs, matrix.distrib) && matrix.package_extension == 'deb' && matrix.use_dh_make_perl == 'true' }}
         run: |
           apt update
           apt install -y cpanminus libcurl4-openssl-dev dh-make-perl libssh-dev uuid-dev libczmq-dev libmodule-install-perl


### PR DESCRIPTION
## Description

chore(packaging): package perl-zmq-constants for el9/bullseye

**Fixes** MON-19548

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)