### PR TITLE
fix(backup): check only if plugins dir exists

### DIFF
--- a/centreon/cron/centreon-backup.pl
+++ b/centreon/cron/centreon-backup.pl
@@ -769,8 +769,8 @@ sub monitoringengineBackup() {
         }
     }
     my $plugins_dir = "/usr/lib64/nagios/plugins";
-    if (-d $plugins_dir . "/*" ) {
-        `cp -pr $plugins_dir/* $TEMP_CENTRAL_DIR/plugins/`;
+    if (-d $plugins_dir) {
+        `cp -pr $plugins_dir $TEMP_CENTRAL_DIR/plugins/`;
         if ($? != 0) {
             print STDERR "Unable to copy plugins\n";
         }

--- a/centreon/cron/centreon-backup.pl
+++ b/centreon/cron/centreon-backup.pl
@@ -770,7 +770,7 @@ sub monitoringengineBackup() {
     }
     my $plugins_dir = "/usr/lib64/nagios/plugins";
     if (-d $plugins_dir) {
-        `cp -pr $plugins_dir $TEMP_CENTRAL_DIR/plugins/`;
+        `cp -pr $plugins_dir/* $TEMP_CENTRAL_DIR/plugins/`;
         if ($? != 0) {
             print STDERR "Unable to copy plugins\n";
         }


### PR DESCRIPTION
## Description

this PR intends to check only if plugins dir exists

**Fixes** # MON-19588

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
