### PR TITLE
enh(openid): Handle url parameters in authorization endpoint

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17650,4 +17650,4 @@ msgid "Host template #%d is locked (edition and deletion not allowed)"
 msgstr "Le modèle d'hôte #%d est verrouillé (édition et suppression interdites)"
 
 msgid "Unable to parse authorization url"
-msgstr "Impossible d'analyser l'url d'autorisation"
+msgstr "Impossible d'analyser l'URL d'autorisation"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17648,3 +17648,6 @@ msgstr "Error lors de la récupération d'un modèle d'hôtes"
 
 msgid "Host template #%d is locked (edition and deletion not allowed)"
 msgstr "Le modèle d'hôte #%d est verrouillé (édition et suppression interdites)"
+
+msgid "Unable to parse authorization url"
+msgstr "Impossible d'analyser l'url d'autorisation"

--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -287,7 +287,7 @@ class OpenIdProvider implements OpenIdProviderInterface
 
         $this->sendRequestForConnectionTokenOrFail($authorizationCode);
         $this->createAuthenticationTokens();
-        if (array_key_exists("id_token", $this->connectionTokenResponseContent)) {
+            if (array_key_exists("id_token", $this->connectionTokenResponseContent)) {
             $this->idTokenPayload = $this->extractTokenPayload($this->connectionTokenResponseContent["id_token"]);
         }
         $this->verifyThatClientIsAllowedToConnectOrFail($clientIp);
@@ -422,7 +422,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     {
         try {
             $tokenParts = explode(".", $token);
-            return json_decode($this->urlSafeTokenDecode($tokenParts[1]));
+            return json_decode($this->urlSafeTokenDecode($tokenParts[1]), true);
         } catch (Throwable $ex) {
             $this->error(
                 SSOAuthenticationException::unableToDecodeIdToken()->getMessage(),

--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -287,7 +287,7 @@ class OpenIdProvider implements OpenIdProviderInterface
 
         $this->sendRequestForConnectionTokenOrFail($authorizationCode);
         $this->createAuthenticationTokens();
-            if (array_key_exists("id_token", $this->connectionTokenResponseContent)) {
+        if (array_key_exists("id_token", $this->connectionTokenResponseContent)) {
             $this->idTokenPayload = $this->extractTokenPayload($this->connectionTokenResponseContent["id_token"]);
         }
         $this->verifyThatClientIsAllowedToConnectOrFail($clientIp);

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenter.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenter.php
@@ -68,31 +68,44 @@ class OpenIdProviderPresenter implements ProviderPresenterInterface
             'id' => $response->id,
             'type' => CustomConfiguration::TYPE,
             'name' => CustomConfiguration::NAME,
-            'authentication_uri' => $response->baseUrl . '/'
-                . $this->buildAuthenticationUriParameters(
+            'authentication_uri' => $this->buildAuthenticationUri(
+                    $response->baseUrl,
                     $response->clientId,
                     $response->authorizationEndpoint,
-                    $redirectUri
-                )
-                . (! empty($response->connectionScopes) ? '&scope=' . implode('%20', $response->connectionScopes) : ''),
+                    $redirectUri,
+                    $response->connectionScopes
+                ),
             'is_active' => $response->isActive,
             'is_forced' => $response->isForced,
         ];
     }
 
     /**
-     * Build Authentication Uri query parameters.
+     * Build authentication URI
      *
-     * @param string $clientId
-     * @param string $authorizationEndpoint
-     * @param string $redirectUri
+     * @param string|null $baseUrl
+     * @param string|null $clientId
+     * @param string|null $authorizationEndpoint
+     * @param string|null $redirectUri
+     * @param string[]|null $connectionScopes
+     *
      * @return string
      */
-    private function buildAuthenticationUriParameters(
-        string $clientId,
-        string $authorizationEndpoint,
-        string $redirectUri
+    private function buildAuthenticationUri(
+        ?string $baseUrl,
+        ?string $clientId,
+        ?string $authorizationEndpoint,
+        ?string $redirectUri,
+        ?array $connectionScopes
     ): string {
+        if ($baseUrl === null
+            || $clientId === null
+            || $authorizationEndpoint === null
+            || $redirectUri === null
+            || $connectionScopes === null
+        ) {
+            return '';
+        }
         $authenticationUriParts = [
             'client_id' => $clientId,
             'response_type' => 'code',
@@ -111,6 +124,7 @@ class OpenIdProviderPresenter implements ProviderPresenterInterface
             $queryParams .= '&' . $authorizationEndpointParts;
         }
 
-        return ltrim($authorizationEndpointBase ?? '', '/') . '?' . $queryParams;
+        return $baseUrl . '/' . ltrim($authorizationEndpointBase ?? '', '/') . '?' . $queryParams
+            . (! empty($connectionScopes) ? '&scope=' . implode('%20', $connectionScopes) : '');
     }
 }

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenter.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenter.php
@@ -79,7 +79,7 @@ class OpenIdProviderPresenter implements ProviderPresenterInterface
             $authorizationEndpointParts = parse_url($response->authorizationEndpoint, PHP_URL_QUERY);
 
             if ($authorizationEndpointBase === false || $authorizationEndpointParts === false) {
-                throw new \Exception(_('Unable to parse authorization url'));
+                throw new \ValueError(_('Unable to parse authorization url'));
             }
 
             $queryParams = http_build_query($authenticationUriParts);

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenter.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenter.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 
 namespace Core\Security\ProviderConfiguration\Infrastructure\Api\FindProviderConfigurations\ProviderPresenter;
 
-use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
-use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Core\Security\ProviderConfiguration\Application\UseCase\FindProviderConfigurations\ProviderResponse\{
     OpenIdProviderResponse
 };
+use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class OpenIdProviderPresenter implements ProviderPresenterInterface
 {
@@ -47,6 +47,7 @@ class OpenIdProviderPresenter implements ProviderPresenterInterface
 
     /**
      * @param OpenIdProviderResponse $response
+     *
      * @return array<string,mixed>
      */
     public function present(mixed $response): array
@@ -64,10 +65,10 @@ class OpenIdProviderPresenter implements ProviderPresenterInterface
             );
 
         $authenticationUriParts = [
-            "client_id" => $response->clientId,
-            "response_type" => "code",
-            "redirect_uri" => rtrim($redirectUri, '/'),
-            "state" => uniqid()
+            'client_id' => $response->clientId,
+            'response_type' => 'code',
+            'redirect_uri' => rtrim($redirectUri, '/'),
+            'state' => uniqid(),
         ];
 
         $authorizationEndpointBase = '';

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenterTest.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/ProviderPresenter/OpenIdProviderPresenterTest.php
@@ -46,6 +46,7 @@ beforeEach(function () {
     $this->openIdProviderResponse->isActive = true;
     $this->openIdProviderResponse->isForced = true;
     $this->openIdProviderResponse->redirectUrl = null;
+    $this->openIdProviderResponse->connectionScopes = ['openid', 'offline_access'];
 
     $this->presenter = new OpenIdProviderPresenter($this->urlGenerator);
 });
@@ -62,14 +63,14 @@ it('presents properly response data', function () {
     $this->urlGenerator
         ->expects($this->once())
         ->method('generate')
-        ->willReturn('/redirection_uri');
+        ->willReturn('redirection_uri');
 
     $presentedData = $this->presenter->present($this->openIdProviderResponse);
     expect($presentedData['id'])->toBe(1);
     expect($presentedData['type'])->toBe('openid');
     expect($presentedData['name'])->toBe('openid');
     expect($presentedData['authentication_uri'])->toMatch(
-        '/^\/oauth2\/authorization\?client_id=client1&response_type=code&redirect_uri=\/redirection_uri&state=/'
+        '/^\/oauth2\/authorization\?client_id=client1&response_type=code&redirect_uri=redirection_uri&state=/'
     );
     expect($presentedData['is_active'])->toBe(true);
     expect($presentedData['is_forced'])->toBe(true);


### PR DESCRIPTION
## Description

This PR intends to handle url parameters in authorization endpoint.
Some users could need to add url parameters to their authorization endpoint( e.g an audience parameter).
The query parameters will be generated in the authentication URI while listing the providers configuration:

```
https://login.microsoftonline.com/<application_id>/oauth2/v2.0/authorize
    ?client_id=<client_id>
    &response_type=code
    &redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcentreon%2Fauthentication%2Fproviders%2Fconfigurations%2Fopenid
    &state=647849c7c299d
    &audience=my-audience
    &scope=openid%20offline_access,
```

This also improve the authentication_uri presentation while no openid configuration are set.



**Fixes** # MON-19600

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

While configuring Open ID, add a query parameters when you fill the authorization endpoint field.
When you get the Provider configurations, for the OpenID Configuration, check that the "authentication_uri" is correctly formatted with your url parameters

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
