### PR TITLE
fix(openid): handle http method for custom endpoints

### DIFF
--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -422,7 +422,7 @@ class OpenIdProvider implements OpenIdProviderInterface
     {
         try {
             $tokenParts = explode(".", $token);
-            return json_decode($this->urlSafeTokenDecode($tokenParts[1]));
+            return json_decode($this->urlSafeTokenDecode($tokenParts[1]), true);
         } catch (Throwable $ex) {
             $this->error(
                 SSOAuthenticationException::unableToDecodeIdToken()->getMessage(),

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/Repository/ReadAttributePathRepositoryInterface.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/Repository/ReadAttributePathRepositoryInterface.php
@@ -34,7 +34,9 @@ interface ReadAttributePathRepositoryInterface
      * @param string $url
      * @param string $token
      * @param Configuration $configuration
+     * @param string $endpointType
+     * 
      * @return array
      */
-    public function getData(string $url, string $token, Configuration $configuration): array;
+    public function getData(string $url, string $token, Configuration $configuration, string $endpointType): array;
 }

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/AttributePath/HttpUrlFetcher.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/AttributePath/HttpUrlFetcher.php
@@ -59,7 +59,7 @@ class HttpUrlFetcher implements AttributePathFetcherInterface
             : $customEndpoint;
 
         try {
-            return $this->attributePathRepository->getData($url, $accessToken, $configuration);
+            return $this->attributePathRepository->getData($url, $accessToken, $configuration, $endpoint->getType());
         } catch (InvalidResponseException) {
             throw SSOAuthenticationException::requestOnCustomEndpointFailed();
         } catch (InvalidStatusCodeException $invalidStatusCodeException) {

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/AttributePath/IntrospectionFetcher.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/AttributePath/IntrospectionFetcher.php
@@ -58,7 +58,7 @@ class IntrospectionFetcher implements AttributePathFetcherInterface
             . ltrim($customConfiguration->getIntrospectionTokenEndpoint(), '/');
 
         try {
-            return $this->attributePathRepository->getData($url, $accessToken, $configuration);
+            return $this->attributePathRepository->getData($url, $accessToken, $configuration, $endpoint->getType());
         } catch (InvalidResponseException $invalidResponseException) {
             $this->loginLogger->exception(
                 $scope,

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/AttributePath/UserInformationFetcher.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/AttributePath/UserInformationFetcher.php
@@ -59,7 +59,7 @@ class UserInformationFetcher implements AttributePathFetcherInterface
 
 
         try {
-            return $this->attributePathRepository->getData($url, $accessToken, $configuration);
+            return $this->attributePathRepository->getData($url, $accessToken, $configuration, $endpoint->getType());
         } catch (InvalidResponseException) {
             throw SSOAuthenticationException::requestForUserInformationFail();
         } catch (InvalidStatusCodeException $invalidStatusCodeException) {

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
@@ -60,10 +60,10 @@ class HttpReadAttributePathRepository implements ReadAttributePathRepositoryInte
      * @throws ServerExceptionInterface
      * @throws TransportExceptionInterface
      */
-    public function getData(string $url, string $token, Configuration $configuration): array
+    public function getData(string $url, string $token, Configuration $configuration, string $endpointType): array
     {
         try {
-            $response = $this->getResponseOrFail($url, $token, $configuration);
+            $response = $this->getResponseOrFail($url, $token, $configuration, $endpointType);
             $this->statusCodeIsValidOrFail($response);
 
             return $this->getContentOrFail($response);


### PR DESCRIPTION
## Description

This PR intends to handle HTTP Methods for the custom endpoints in OpenID Configuration

The Custom Endpoint should be call in GET without body

**Fixes** # MON-19613

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
