### PR TITLE
fix(openid): Fixed headers not being set when custom endpoint is called - develop

### DIFF
--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
@@ -88,15 +88,14 @@ class HttpReadAttributePathRepository implements ReadAttributePathRepositoryInte
         string $endpointType
     ): ResponseInterface {
         $customConfiguration = $configuration->getCustomConfiguration();
-        $options = ["verify_peer" => $customConfiguration->verifyPeer()];
+        $headers = ["Authorization" => "Bearer " . trim($token)];
+        $options = ["verify_peer" => $customConfiguration->verifyPeer(), "headers" => $headers];
         if ($endpointType !== Endpoint::CUSTOM) {
-            $headers = ["Authorization" => "Bearer " . trim($token)];
             $body = [
                 "token" => $token,
                 "client_id" => $customConfiguration->getClientId(),
                 "client_secret" => $customConfiguration->getClientSecret()
             ];
-            $options['headers'] = $headers;
             $options['body'] = $body;
         }
 


### PR DESCRIPTION
## Description

Fixed headers not being set when custom endpoint is called
https://github.com/centreon/centreon/pull/1568

**Fixes** # MON-19688

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
