### PR TITLE
fix(modules): block install if module already installed (#1567)

### DIFF
--- a/centreon/src/CentreonModule/Infrastructure/Source/ModuleSource.php
+++ b/centreon/src/CentreonModule/Infrastructure/Source/ModuleSource.php
@@ -71,10 +71,25 @@ class ModuleSource extends SourceAbstract
      */
     public function install(string $id): ?Module
     {
+        /**
+         * Do not try to install the module if the package is not installed (deb or rpm)
+         */
+        if (($module = $this->getDetail($id)) === null) {
+            throw ModuleException::cannotFindModuleDetails($id);
+        }
+        /**
+         * Check if the module has dependencies
+         * if it does, then check if those dependencies are installed or need updates
+         * if not installed -> install the dependency
+         * if not up to date -> update the dependency
+         */
         $this->installOrUpdateDependencies($id);
 
-        return parent::install($id);
-    }
+        /**
+         * Do not execute the install process for the module if it is already installed
+         */
+        return $module->isInstalled() === false ? parent::install($id) : $module;
+  }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
ℹ️ Backport of https://github.com/centreon/centreon/pull/1567 for dev-23.04.x

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira for details

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
