### PR TITLE
fix(gorgone): proxy module is stuck after internal key rotate (MON-19742)

### DIFF
--- a/centreon-gorgone/gorgone/class/core.pm
+++ b/centreon-gorgone/gorgone/class/core.pm
@@ -620,7 +620,6 @@ sub broadcast_run {
             action => $options{action},
             logger => $self->{logger},
             frame => $options{frame},
-            data => $options{data},
             token => $options{token}
         );
     }
@@ -805,7 +804,7 @@ sub check_external_rotate_keys {
         }
         next if ($self->{identity_infos}->{$id}->{ctime} > ($time - $self->{config}->{configuration}->{gorgone}->{gorgonecore}->{external_com_rotation}));
 
-        $self->{logger}->writeLogDebug('[core] rotate external key for ' . $id);
+        $self->{logger}->writeLogDebug('[core] rotate external key for ' . pack('H*', $id));
 
         ($rv, $key) = gorgone::standard::library::generate_symkey(
             keysize => $self->{config}->{configuration}->{gorgone}->{gorgonecore}->{external_com_keysize}

--- a/centreon-gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/centreon-gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -496,7 +496,7 @@ sub broadcast {
         $options{gorgone}->send_internal_message(
             identity => 'gorgone-proxy-' . $pool_id,
             action => $options{action},
-            data => $options{data},
+            raw_data_ref => $options{frame}->getRawData(),
             token => $options{token}
         );
     }
@@ -505,7 +505,7 @@ sub broadcast {
         $options{gorgone}->send_internal_message(
             identity => 'gorgone-proxy-httpserver',
             action => $options{action},
-            data => $options{data},
+            raw_data_ref => $options{frame}->getRawData(),
             token => $options{token}
         );
     }

--- a/centreon-gorgone/gorgone/modules/plugins/newtest/hooks.pm
+++ b/centreon-gorgone/gorgone/modules/plugins/newtest/hooks.pm
@@ -180,7 +180,7 @@ sub broadcast {
         $options{gorgone}->send_internal_message(
             identity => 'gorgone-newtest-' . $container_id,
             action => $options{action},
-            data => $options{data},
+            raw_data_ref => $options{frame}->getRawData(),
             token => $options{token}
         );
     }

--- a/centreon-gorgone/gorgone/modules/plugins/scom/hooks.pm
+++ b/centreon-gorgone/gorgone/modules/plugins/scom/hooks.pm
@@ -179,7 +179,7 @@ sub broadcast {
         $options{gorgone}->send_internal_message(
             identity => 'gorgone-scom-' . $container_id,
             action => $options{action},
-            data => $options{data},
+            raw_data_ref => $options{frame}->getRawData(),
             token => $options{token}
         );
     }


### PR DESCRIPTION
## Description

Gorgone stops responding every 24-48 hrs 23.04

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x
- [X] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Add following option in ```/etc/centreon-gorgone/config.d/40-gorgoned.yaml``` file (avoid to wait 24h):
```
gorgone:
  gorgonecore:
    internal_com_rotation: 3
```

After 10 minutes, you should have that error:
```
2023-06-06 11:20:07 - ERROR - [proxy] container 1: decrypt issue: no message
```

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
