### PR TITLE
fix(clapi): exclude ldap user from password expiration

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -559,7 +559,8 @@ class CentreonAPI
 
             $passwordExpirationDelay = $securityPolicy['password_expiration']['expiration_delay'];
             if (
-                $passwordExpirationDelay !== null
+                $row['contact_auth_type'] !== \CentreonAuth::AUTH_TYPE_LDAP
+                && $passwordExpirationDelay !== null
                 && (int) $row['password_creation'] + (int) $passwordExpirationDelay < time()
                 // Do not check expiration for excluded users of local security policy
                 && !in_array($row['contact_alias'], $securityPolicy['password_expiration']['excluded_users'])


### PR DESCRIPTION
## Description

This PR intends to exclude ldap user from password expiration in CLAPI

**Fixes** # MON-19738

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
