### PR TITLE
(ui/legacy): fix spacing between buttons (#1569)

### DIFF
--- a/centreon/www/include/configuration/configNagios/listNagios.ihtml
+++ b/centreon/www/include/configuration/configNagios/listNagios.ihtml
@@ -19,7 +19,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>
@@ -60,7 +60,7 @@
 			{ if $mode_access == 'w' }
 			<td>
 				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 			</td>
 			{ else }
 			<td>&nbsp;</td>

--- a/centreon/www/include/monitoring/downtime/template/listDowntime.ihtml
+++ b/centreon/www/include/monitoring/downtime/template/listDowntime.ihtml
@@ -30,7 +30,7 @@
 	<tr class="ToolbarTR">
         <td>
             {if $msgs2}<a class="btc bt_success" href="{$msgs2.addL2}">{$msgs2.addT2}</a>{/if}
-            {if $nb_downtime_svc && $msgs2}<input type="submit" name="submit2" value="{$cancel}" class="btc bt_danger" onclick="doAction('select[name=\'o1\']', 'cs','{$msgs2.delConfirm}')">{/if}
+            {if $nb_downtime_svc && $msgs2}<input type="submit" name="submit2" value="{$cancel}" class="btc bt_danger ml-2" onclick="doAction('select[name=\'o1\']', 'cs','{$msgs2.delConfirm}')">{/if}
         </td>
         {php}
         include('./include/common/pagination.php');
@@ -105,7 +105,7 @@
     <tr class="ToolbarTR">
         <td>
             {if $msgs2}<a class="btc bt_success" href="{$msgs2.addL2}">{$msgs2.addT2}</a>{/if}
-            {if $nb_downtime_svc && $msgs2}<input type="submit" name="submit2" value="{$cancel}" class="btc bt_danger" onclick="doAction('select[name=\'o1\']', 'cs','{$msgs2.delConfirm}')">{/if}
+            {if $nb_downtime_svc && $msgs2}<input type="submit" name="submit2" value="{$cancel}" class="btc bt_danger ml-2" onclick="doAction('select[name=\'o1\']', 'cs','{$msgs2.delConfirm}')">{/if}
         </td>
 	{php}
 	   include('./include/common/pagination.php');

--- a/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
+++ b/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
@@ -18,8 +18,8 @@
 		<tr class="ToolbarTR">
 			<td> 
 				{$form.o1.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
-				<a href= '#' class="btc bt_info ml-1" onClick="window.open('{$msg.testL}','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=500, height=700');">{$msg.testT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
+				<a href= '#' class="btc bt_info ml-2" onClick="window.open('{$msg.testL}','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=500, height=700');">{$msg.testT}</a>
 			</td>
 			{php}
 			   include('./include/common/pagination.php');
@@ -59,7 +59,7 @@
 		<tr class="ToolbarTR">
 			<td> 
 				{$form.o2.html}
-				<a href="{$msg.addL}" class="btc bt_success ml-1">{$msg.addT}</a>
+				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
 				<a href= '#' class="btc bt_info ml-1" onClick="window.open('{$msg.testL}','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=500, height=700');">{$msg.testT}</a>
 			</td>
 			{php}

--- a/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
+++ b/centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.ihtml
@@ -60,7 +60,7 @@
 			<td> 
 				{$form.o2.html}
 				<a href="{$msg.addL}" class="btc bt_success ml-2">{$msg.addT}</a>
-				<a href= '#' class="btc bt_info ml-1" onClick="window.open('{$msg.testL}','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=500, height=700');">{$msg.testT}</a>
+				<a href= '#' class="btc bt_info ml-2" onClick="window.open('{$msg.testL}','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=500, height=700');">{$msg.testT}</a>
 			</td>
 			{php}
 			   include('./include/common/pagination.php');


### PR DESCRIPTION
## Description

Some action buttons on legacy pages doesn’t have the same space between

Exemple Monitoring → Downtime

![ScreenShot Tool -20230602155333](https://github.com/centreon/centreon/assets/134523914/5c633d9d-ddda-402a-8807-3d7ac572aca6)

**Fixes** # MON-19693

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

space between the add button and the others must be 16px in all legacy pages.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
