### PR TITLE
fix(packaging): fix php8.1 remaining references

### DIFF
--- a/centreon/packaging/debian/centreon-web.install
+++ b/centreon/packaging/debian/centreon-web.install
@@ -34,6 +34,6 @@ api/*                                           usr/share/centreon/api
 
 tmpl/install/centreon.cron => etc/cron.d/centreon
 tmpl/install/centstorage.cron => etc/cron.d/centstorage
-packaging/src/php-fpm.conf => etc/php/8.1/fpm/pool.d/centreon.conf
+packaging/src/php-fpm.conf => etc/php/8.0/fpm/pool.d/centreon.conf
 packaging/src/php-fpm-systemd.conf => etc/default/centreon.conf
-packaging/src/php.ini => etc/php/8.1/mods-available/centreon.ini
+packaging/src/php.ini => etc/php/8.0/mods-available/centreon.ini

--- a/centreon/packaging/debian/rules
+++ b/centreon/packaging/debian/rules
@@ -15,7 +15,7 @@ override_dh_auto_build:
 		packaging/src/instCentWeb.conf \
 		packaging/src/instCentPlugins.conf
 	sed -i 's#"apache"#"www-data"#g' packaging/src/install.conf.php
-	sed -i "s#apache#www-data#g; s#@PHPFPM_LOGFILE@#/var/log/php8.1-fpm-centreon-error.log#g; s#/var/lib/php/session#/var/lib/php/sessions#g" \
+	sed -i "s#apache#www-data#g; s#@PHPFPM_LOGFILE@#/var/log/php8.0-fpm-centreon-error.log#g; s#/var/lib/php/session#/var/lib/php/sessions#g" \
 		packaging/src/php-fpm.conf
 	sed -i "s#@LIB_ARCH@#lib#g" packaging/src/centreon-macroreplacement.txt
 	find . -type f -not -path "./vendor/*" | \


### PR DESCRIPTION
## Description

Replace php8.1 references by php8.0 in debian packaging to prevent php8.0-fpm to start with default php configuration instead of centreon custom configuration.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
