### PR TITLE
enh(api/conf) handle templates in AddHostTemplate endpoint

### DIFF
--- a/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
+++ b/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
@@ -253,3 +253,16 @@ properties:
        type: string
        description: "Define a host category name that is associated with this host template"
        example: 'host-category-name'
+  templates:
+    type: array
+    items:
+     type: object
+     properties:
+      id:
+       type: integer
+       description: "Define a parent host template ID that is associated with this host template"
+       example: 1
+      name:
+       type: string
+       description: "Define a parent host template name that is associated with this host template"
+       example: 'parent-template-name'

--- a/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/PostHostTemplateRequest.yaml
+++ b/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/PostHostTemplateRequest.yaml
@@ -236,5 +236,13 @@ properties:
     description: "Indicates whether the host template is activated or not"
   categories:
     type: array
+    items:
+      type: integer
     description: "Define the host category IDs that should be associated with this host template"
     example: [1, 15, 8]
+  templates:
+    type: array
+    items:
+      type: integer
+    description: "Define the parent host templates IDs that should be associated with this host template"
+    example: [3, 12]

--- a/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/PostHostTemplateRequest.yaml
+++ b/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/PostHostTemplateRequest.yaml
@@ -244,5 +244,7 @@ properties:
     type: array
     items:
       type: integer
-    description: "Define the parent host templates IDs that should be associated with this host template"
+    description: |
+      Define the parent host templates IDs that should be associated with this host template.
+      The order of the IDs determine the inheritance priority order.
     example: [3, 12]

--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -15508,3 +15508,6 @@ msgstr ""
 
 #  msgid "Host template #%d not found"
 #  msgstr ""
+
+#  msgid "Circular inheritance not allowed"
+#  msgstr ""

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -15843,3 +15843,6 @@ msgstr ""
 
 #  msgid "Host template #%d not found"
 #  msgstr ""
+
+#  msgid "Circular inheritance not allowed"
+#  msgstr ""

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -17810,3 +17810,6 @@ msgstr "Vous n'êtes pas autorisé à effectuer des actions d'écriture sur les 
 
 msgid "Host template #%d not found"
 msgstr "Modèle d'hôte #%d introuvable"
+
+msgid "Circular inheritance not allowed"
+msgstr "Héritage circulaire non autorisé"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -16307,3 +16307,6 @@ msgstr ""
 
 #  msgid "Host template #%d not found"
 #  msgstr ""
+
+#  msgid "Circular inheritance not allowed"
+#  msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -16297,3 +16297,6 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 
 #  msgid "Host template #%d not found"
 #  msgstr ""
+
+#  msgid "Circular inheritance not allowed"
+#  msgstr ""

--- a/centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+++ b/centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
@@ -148,7 +148,10 @@ class HostTemplateException extends \Exception
      */
     public static function nameAlreadyExists(string $formatedName, string $originalName = 'undefined'): self
     {
-        return new self(sprintf(_('The name %s (original name: %s) already exists'), $formatedName, $originalName), self::CODE_CONFLICT);
+        return new self(
+            sprintf(_('The name %s (original name: %s) already exists'), $formatedName, $originalName),
+            self::CODE_CONFLICT
+        );
     }
 
     /**
@@ -167,6 +170,14 @@ class HostTemplateException extends \Exception
     public static function hostIsLocked(int $hostTemplateId): self
     {
         return new self(sprintf(_('Host template #%d is locked (edition and deletion not allowed)'), $hostTemplateId));
+    }
+
+    /**
+     * @return self
+     */
+    public static function circularTemplateInheritance(): self
+    {
+        return new self(_('Circular template inheritance not allowed'), self::CODE_CONFLICT);
     }
 }
 

--- a/centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+++ b/centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
@@ -177,7 +177,7 @@ class HostTemplateException extends \Exception
      */
     public static function circularTemplateInheritance(): self
     {
-        return new self(_('Circular template inheritance not allowed'), self::CODE_CONFLICT);
+        return new self(_('Circular inheritance not allowed'), self::CODE_CONFLICT);
     }
 }
 

--- a/centreon/src/Core/HostTemplate/Application/Repository/ReadHostTemplateRepositoryInterface.php
+++ b/centreon/src/Core/HostTemplate/Application/Repository/ReadHostTemplateRepositoryInterface.php
@@ -67,15 +67,31 @@ interface ReadHostTemplateRepositoryInterface
      *
      * @param int $hostTemplateId
      *
+     * @throws \Throwable
+     *
      * @return bool
      */
     public function exists(int $hostTemplateId): bool;
+
+    /**
+     * Check existence of a list of host templates.
+     * Return the ids of the existing templates.
+     *
+     * @param int[] $hostTemplateIds
+     *
+     * @throws \Throwable
+     *
+     * @return int[]
+     */
+    public function exist(array $hostTemplateIds): array;
 
     /**
      * Determine if a host template exists by its name.
      * (include both host templates and hosts names).
      *
      * @param string $hostTemplateName
+     *
+     * @throws \Throwable
      *
      * @return bool
      */
@@ -87,7 +103,21 @@ interface ReadHostTemplateRepositoryInterface
      *
      * @param int $hostTemplateId
      *
+     * @throws \Throwable
+     *
      * @return bool
      */
     public function isLocked(int $hostTemplateId): bool;
+
+    /**
+     * Retrieve the name of a list of template ids.
+     * Return an array with ids as keys.
+     *
+     * @param int[] $templateIds
+     *
+     * @throws \Throwable
+     *
+     * @return array<int,string>
+     */
+    public function findNamesByIds(array $templateIds): array;
 }

--- a/centreon/src/Core/HostTemplate/Application/Repository/WriteHostTemplateRepositoryInterface.php
+++ b/centreon/src/Core/HostTemplate/Application/Repository/WriteHostTemplateRepositoryInterface.php
@@ -42,4 +42,15 @@ interface WriteHostTemplateRepositoryInterface
      * @return int
      */
     public function add(NewHostTemplate $hostTemplate): int;
+
+    /**
+     * Link a parent template to a child host(or another hostTemplate).
+     *
+     * @param int $childId host or host template to be linked as a child
+     * @param int $parentId host template to be linked as a parent
+     * @param int $order order of inheritance of the parent
+     *
+     * @throws \Throwable
+     */
+    public function addParent(int $childId, int $parentId, int $order): void;
 }

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplate.php
@@ -93,6 +93,7 @@ final class AddHostTemplate
                 $hostTemplateId = $this->createHostTemplate($request);
 
                 $this->linkHostCategories($request, $hostTemplateId);
+                $this->linkParentTemplates($request, $hostTemplateId);
 
                 $this->dataStorageEngine->commitTransaction();
             } catch (\Throwable $ex) {
@@ -115,8 +116,11 @@ final class AddHostTemplate
                     $accessGroups
                 );
             }
+            $parentTemplates = $this->findParentTemplates($request->templates);
 
-            $presenter->presentResponse(AddHostTemplateFactory::createResponse($hostTemplate, $hostCategories));
+            $presenter->presentResponse(
+                AddHostTemplateFactory::createResponse($hostTemplate, $hostCategories, $parentTemplates)
+            );
         } catch (AssertionFailedException|\ValueError $ex) {
             $presenter->presentResponse(new InvalidArgumentResponse($ex));
             $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
@@ -274,6 +278,28 @@ final class AddHostTemplate
     }
 
     /**
+     * Assert template IDs are valid.
+     *
+     * @param int[] $templateIds
+     * @param int $hostTemplateId
+     *
+     * @throws HostTemplateException
+     * @throws \Throwable
+     */
+    private function assertAreValidTemplates(array $templateIds, int $hostTemplateId): void
+    {
+        if (in_array($hostTemplateId, $templateIds, true)) {
+            throw HostTemplateException::circularTemplateInheritance();
+        }
+
+        $validTemplateIds = $this->readHostTemplateRepository->exist($templateIds);
+
+        if ([] !== ($invalidIds = array_diff($templateIds, $validTemplateIds))) {
+            throw HostTemplateException::idsDoNotExist('templates', $invalidIds);
+        }
+    }
+
+    /**
      * @param AddHostTemplateRequest $request
      *
      * @throws AssertionFailedException
@@ -299,7 +325,7 @@ final class AddHostTemplate
             : 0;
 
         $newHostTemplate = NewHostTemplateFactory::create($request, $inheritanceMode);
-        $hostTemplateId =  $this->writeHostTemplateRepository->add($newHostTemplate);
+        $hostTemplateId = $this->writeHostTemplateRepository->add($newHostTemplate);
 
         $this->info('AddHostTemplate: Adding new host template', ['host_template_id' => $hostTemplateId]);
 
@@ -316,6 +342,7 @@ final class AddHostTemplate
     private function linkHostCategories(AddHostTemplateRequest $dto, int $hostTemplateId): void
     {
         if ($dto->categories === []) {
+
             return;
         }
 
@@ -327,5 +354,54 @@ final class AddHostTemplate
         );
 
         $this->writeHostCategoryRepository->linkToHost($hostTemplateId, $dto->categories);
+    }
+
+    /**
+     * @param AddHostTemplateRequest $dto
+     * @param int $hostTemplateId
+     *
+     * @throws HostTemplateException
+     * @throws \Throwable
+     */
+    private function linkParentTemplates(AddHostTemplateRequest $dto, int $hostTemplateId): void
+    {
+        if ($dto->templates === []) {
+
+            return;
+        }
+
+        $this->assertAreValidTemplates($dto->templates, $hostTemplateId);
+
+        $this->info(
+            'AddHostTemplate: Linking parent templates',
+            ['host_template_id' => $hostTemplateId, 'template_ids' => $dto->templates]
+        );
+
+        foreach ($dto->templates as $order => $templateId) {
+            $this->writeHostTemplateRepository->addParent($hostTemplateId, $templateId, $order);
+        }
+    }
+
+    /**
+     * @param int[] $templateIds
+     *
+     * @throws HostTemplateException
+     * @throws \Throwable
+     *
+     * @return array<array{id:int,name:string}>
+     */
+    private function findParentTemplates(array $templateIds): array
+    {
+        $templateNames = $this->readHostTemplateRepository->findNamesByIds($templateIds);
+
+        $parentTemplates = [];
+        foreach ($templateIds as $templateId) {
+            $parentTemplates[] = [
+                'id' => $templateId,
+                'name' => $templateNames[$templateId],
+            ];
+        }
+
+        return $parentTemplates;
     }
 }

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplate.php
@@ -341,19 +341,20 @@ final class AddHostTemplate
      */
     private function linkHostCategories(AddHostTemplateRequest $dto, int $hostTemplateId): void
     {
-        if ($dto->categories === []) {
+        $categoryIds = array_unique($dto->categories);
+        if ($categoryIds === []) {
 
             return;
         }
 
-        $this->assertAreValidCategories($dto->categories);
+        $this->assertAreValidCategories($categoryIds);
 
         $this->info(
             'AddHostTemplate: Linking host categories',
-            ['host_template_id' => $hostTemplateId, 'category_ids' => $dto->categories]
+            ['host_template_id' => $hostTemplateId, 'category_ids' => $categoryIds]
         );
 
-        $this->writeHostCategoryRepository->linkToHost($hostTemplateId, $dto->categories);
+        $this->writeHostCategoryRepository->linkToHost($hostTemplateId, $categoryIds);
     }
 
     /**
@@ -365,19 +366,21 @@ final class AddHostTemplate
      */
     private function linkParentTemplates(AddHostTemplateRequest $dto, int $hostTemplateId): void
     {
-        if ($dto->templates === []) {
+        $parentTemplateIds = array_unique($dto->templates);
+
+        if ($parentTemplateIds === []) {
 
             return;
         }
 
-        $this->assertAreValidTemplates($dto->templates, $hostTemplateId);
+        $this->assertAreValidTemplates($parentTemplateIds, $hostTemplateId);
 
         $this->info(
             'AddHostTemplate: Linking parent templates',
-            ['host_template_id' => $hostTemplateId, 'template_ids' => $dto->templates]
+            ['host_template_id' => $hostTemplateId, 'template_ids' => $parentTemplateIds]
         );
 
-        foreach ($dto->templates as $order => $templateId) {
+        foreach ($parentTemplateIds as $order => $templateId) {
             $this->writeHostTemplateRepository->addParent($hostTemplateId, $templateId, $order);
         }
     }

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateFactory.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateFactory.php
@@ -33,13 +33,17 @@ final class AddHostTemplateFactory
     /**
      * @param HostTemplate $hostTemplate
      * @param HostCategory[] $hostCategories
+     * @param array<array{id:int,name:string}> $parentTemplates
      *
      * @throws \Throwable
      *
      * @return AddHostTemplateResponse
      */
-    public static function createResponse(HostTemplate $hostTemplate, array $hostCategories): AddHostTemplateResponse
-    {
+    public static function createResponse(
+        HostTemplate $hostTemplate,
+        array $hostCategories,
+        array $parentTemplates,
+    ): AddHostTemplateResponse {
         $dto = new AddHostTemplateResponse();
 
         $dto->id = $hostTemplate->getId();
@@ -86,6 +90,11 @@ final class AddHostTemplateFactory
         $dto->categories = array_map(
             fn(HostCategory $category) => ['id' => $category->getId(), 'name' => $category->getName()],
             $hostCategories
+        );
+
+        $dto->templates = array_map(
+            fn($template) => ['id' => $template['id'], 'name' => $template['name']],
+            $parentTemplates
         );
 
         return $dto;

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateRequest.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateRequest.php
@@ -105,4 +105,7 @@ final class AddHostTemplateRequest
 
     /** @var int[] */
     public array $categories = [];
+
+    /** @var int[] */
+    public array $templates = [];
 }

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateResponse.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateResponse.php
@@ -109,4 +109,7 @@ final class AddHostTemplateResponse
 
     /** @var array<array{id:int,name:string}> */
     public array $categories = [];
+
+    /** @var array<array{id:int,name:string}> */
+    public array $templates = [];
 }

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateController.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateController.php
@@ -119,7 +119,8 @@ final class AddHostTemplateController extends AbstractController
              *     icon_alternative?: string,
              *     comment?: string,
              *     is_activated?: bool,
-             *     categories?: int[]
+             *     categories?: int[],
+             *     templates?: int[]
              * } $data
              */
             $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/AddHostTemplateOnPremSchema.json');
@@ -164,6 +165,7 @@ final class AddHostTemplateController extends AbstractController
             $dto->comment = $data['comment'] ?? '';
             $dto->isActivated = $data['is_activated'] ?? true;
             $dto->categories = $data['categories'] ?? [];
+            $dto->templates = $data['templates'] ?? [];
 
             $useCase($dto, $presenter);
         } catch (\InvalidArgumentException $ex) {
@@ -204,7 +206,8 @@ final class AddHostTemplateController extends AbstractController
              *     note?: string,
              *     action_url?: string,
              *     is_activated?: bool,
-             *     categories?: int[]
+             *     categories?: int[],
+             *     templates?: int[]
              * } $data
              */
             $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/AddHostTemplateSaasSchema.json');
@@ -222,6 +225,7 @@ final class AddHostTemplateController extends AbstractController
             $dto->actionUrl = $data['action_url'] ?? '';
             $dto->isActivated = $data['is_activated'] ?? true;
             $dto->categories = $data['categories'] ?? [];
+            $dto->templates = $data['templates'] ?? [];
 
             $useCase($dto, $presenter);
         } catch (\InvalidArgumentException $ex) {

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateOnPremPresenter.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateOnPremPresenter.php
@@ -87,6 +87,7 @@ class AddHostTemplateOnPremPresenter extends AbstractPresenter implements AddHos
                         'is_activated' => $response->isActivated,
                         'is_locked' => $response->isLocked,
                         'categories' => $response->categories,
+                        'templates' => $response->templates,
                     ]
                 )
             );

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateOnPremSchema.json
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateOnPremSchema.json
@@ -277,6 +277,12 @@
             "items": {
                 "type": "integer"
             }
+        },
+        "templates": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
         }
     }
 }

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateSaasPresenter.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateSaasPresenter.php
@@ -60,6 +60,7 @@ class AddHostTemplateSaasPresenter extends AbstractPresenter implements AddHostT
                         'action_url' => $this->emptyStringAsNull($response->actionUrl),
                         'is_locked' => $response->isLocked,
                         'categories' => $response->categories,
+                        'templates' => $response->templates,
                     ]
                 )
             );

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateSaasSchema.json
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateSaasSchema.json
@@ -79,6 +79,12 @@
             "items": {
                 "type": "integer"
             }
+        },
+        "templates": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
         }
     }
 }

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
@@ -431,6 +431,9 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
         return (bool) $statement->fetchColumn();
     }
 
+    /**
+     * @inheritDoc
+     */
     public function findNamesByIds(array $hostTemplateIds): array
     {
         $this->info('Find names for host templates', ['host_template_ids' => $hostTemplateIds]);
@@ -458,8 +461,9 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
         $results = $statement->fetchAll(\PDO::FETCH_ASSOC);
         $nameById = [];
         foreach ($results as $row) {
-            $nameById[$row['host_id']] = $row['host_name'];
+            $nameById[(int) $row['host_id']] = $row['host_name'];
         }
+
         return $nameById;
     }
 

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
@@ -362,6 +362,36 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
     /**
      * @inheritDoc
      */
+    public function exist(array $hostTemplateIds): array
+    {
+        $this->info('Check existence of host templates', ['host_template_ids' => $hostTemplateIds]);
+
+        if ($hostTemplateIds === []) {
+            return [];
+        }
+
+        $concatenator = new SqlConcatenator();
+        $concatenator
+            ->defineSelect(
+                <<<'SQL'
+                    SELECT `host_id` FROM `:db`.`host`
+                    SQL
+            )
+            ->appendWhere('host_id IN (:host_template_ids)')
+            ->appendWhere('host_register = :hostTemplateType')
+            ->storeBindValueMultiple(':host_template_ids', $hostTemplateIds, \PDO::PARAM_INT)
+            ->storeBindValue(':hostTemplateType', HostType::Template->value, \PDO::PARAM_STR);
+
+        $statement = $this->db->prepare($this->translateDbName($concatenator->__toString()));
+        $concatenator->bindValuesToStatement($statement);
+        $statement->execute();
+
+        return $statement->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function existsByName(string $hostTemplateName): bool
     {
         $this->info('Check existence of host template with name #' . $hostTemplateName);
@@ -399,6 +429,38 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
         $statement->execute();
 
         return (bool) $statement->fetchColumn();
+    }
+
+    public function findNamesByIds(array $hostTemplateIds): array
+    {
+        $this->info('Find names for host templates', ['host_template_ids' => $hostTemplateIds]);
+
+        if ($hostTemplateIds === []) {
+            return [];
+        }
+
+        $concatenator = new SqlConcatenator();
+        $concatenator
+            ->defineSelect(
+                <<<'SQL'
+                    SELECT `host_id`, `host_name` FROM `:db`.`host`
+                    SQL
+            )
+            ->appendWhere('host_id IN (:host_template_ids)')
+            ->appendWhere('host_register = :hostTemplateType')
+            ->storeBindValueMultiple(':host_template_ids', $hostTemplateIds, \PDO::PARAM_INT)
+            ->storeBindValue(':hostTemplateType', HostType::Template->value, \PDO::PARAM_STR);
+
+        $statement = $this->db->prepare($this->translateDbName($concatenator->__toString()));
+        $concatenator->bindValuesToStatement($statement);
+        $statement->execute();
+
+        $results = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $nameById = [];
+        foreach ($results as $row) {
+            $nameById[$row['host_id']] = $row['host_name'];
+        }
+        return $nameById;
     }
 
     /**

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateRepository.php
@@ -104,6 +104,26 @@ class DbWriteHostTemplateRepository extends AbstractRepositoryRDB implements Wri
         }
     }
 
+    public function addParent(int $childId, int $parentId, int $order): void
+    {
+        $this->info('Add a parent tempalte to a host/host template', [
+            'child_id' => $childId, 'parent_id' => $parentId, 'order' => $order,
+        ]);
+
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<'SQL'
+                INSERT INTO `:db`.`host_template_relation` (`host_tpl_id`, `host_host_id`, `order`)
+                VALUES (:parent_id, :child_id, :order)
+                SQL
+        ));
+
+        $statement->bindValue(':child_id', $childId, \PDO::PARAM_INT);
+        $statement->bindValue(':parent_id', $parentId, \PDO::PARAM_INT);
+        $statement->bindValue(':order', $order, \PDO::PARAM_INT);
+
+        $statement->execute();
+    }
+
     private function addTemplateBasicInformations(NewHostTemplate $hostTemplate): int
     {
         $request = $this->translateDbName(

--- a/centreon/tests/api/features/CloudHostTemplate.feature
+++ b/centreon/tests/api/features/CloudHostTemplate.feature
@@ -94,7 +94,8 @@ Feature:
         "note_url": "noteUrl-value",
         "note": "note-value",
         "action_url": "actionUrl-value",
-        "categories": [2]
+        "categories": [2],
+        "templates": []
       }
       """
     Then the response code should be "201"
@@ -118,7 +119,8 @@ Feature:
             "id": 2,
             "name": "host-cat1"
           }
-        ]
+        ],
+        "templates": []
       }
       """
 
@@ -160,7 +162,27 @@ Feature:
         "note_url": "noteUrl-value",
         "note": "note-value",
         "action_url": "actionUrl-value",
-        "categories": [2]
+        "categories": [2],
+        "templates": []
+      }
+      """
+    Then the response code should be "409"
+
+    When I send a POST request to '/api/latest/configuration/hosts/templates' with body:
+      """
+      {
+        "name": "  host template name B  ",
+        "alias": "  host-template-alias  ",
+        "snmp_version": "2c",
+        "snmp_community": "   snmpCommunity-value",
+        "timezone_id": 1,
+        "severity_id": 1,
+        "check_timeperiod_id": 1,
+        "note_url": "noteUrl-value",
+        "note": "note-value",
+        "action_url": "actionUrl-value",
+        "categories": [],
+        "templates": [999]
       }
       """
     Then the response code should be "409"
@@ -184,14 +206,15 @@ Feature:
         "note_url": "noteUrl-value",
         "note": "note-value",
         "action_url": "actionUrl-value",
-        "categories": [2]
+        "categories": [2],
+        "templates": [15]
       }
       """
     Then the response code should be "201"
     And the JSON should be equal to:
       """
       {
-        "id": 17,
+        "id": 18,
         "name": "host_template_name_B",
         "alias": "host-template-alias",
         "snmp_version": "2c",
@@ -208,10 +231,15 @@ Feature:
             "id": 2,
             "name": "host-cat1"
           }
+        ],
+        "templates": [
+          {
+            "id": 15,
+            "name": "host_template_name_A"
+          }
         ]
       }
       """
-
   Scenario: Host template patching
     Given I am logged in
     And the following CLAPI import data:

--- a/centreon/tests/api/features/HostTemplate.feature
+++ b/centreon/tests/api/features/HostTemplate.feature
@@ -149,7 +149,8 @@ Feature:
         "icon_alternative": "iconAlternative-value",
         "comment": "comment-value",
         "is_activated": false,
-        "categories": [2]
+        "categories": [2],
+        "templates": []
       }
       """
     Then the response code should be "201"
@@ -201,7 +202,8 @@ Feature:
             "id": 2,
             "name": "host-cat1"
           }
-        ]
+        ],
+        "templates": []
       }
       """
 
@@ -271,7 +273,55 @@ Feature:
         "icon_alternative": "iconAlternative-value",
         "comment": "comment-value",
         "is_activated": false,
-        "categories": [2]
+        "categories": [2],
+        "templates": []
+      }
+      """
+    Then the response code should be "409"
+
+    When I send a POST request to '/api/latest/configuration/hosts/templates' with body:
+      """
+      {
+        "name": "  host template name B  ",
+        "alias": "  host-template-alias  ",
+        "snmp_version": "2c",
+        "snmp_community": "   snmpCommunity-value  ",
+        "timezone_id": 1,
+        "severity_id": 1,
+        "check_command_id": 1,
+        "check_command_args": [" this\nis\targ1 ", " arg2   "],
+        "check_timeperiod_id": 1,
+        "max_check_attempts": 5,
+        "normal_check_interval": 5,
+        "retry_check_interval": 5,
+        "active_check_enabled": 1,
+        "passive_check_enabled": 1,
+        "notification_enabled": 2,
+        "notification_options": 0,
+        "notification_interval": 5,
+        "notification_timeperiod_id": 2,
+        "add_inherited_contact_group": true,
+        "add_inherited_contact": true,
+        "first_notification_delay": 5,
+        "recovery_notification_delay": 5,
+        "acknowledgement_timeout": 5,
+        "freshness_checked": 2,
+        "freshness_threshold": 5,
+        "flap_detection_enabled": 2,
+        "low_flap_threshold": 5,
+        "high_flap_threshold": 5,
+        "event_handler_enabled": 2,
+        "event_handler_command_id": 2,
+        "event_handler_command_args": [" this\nis\targ3 ", " arg4   "],
+        "note_url": "noteUrl-value",
+        "note": "note-value",
+        "action_url": "actionUrl-value",
+        "icon_id": 1,
+        "icon_alternative": "iconAlternative-value",
+        "comment": "comment-value",
+        "is_activated": false,
+        "categories": [],
+        "templates": [999]
       }
       """
     Then the response code should be "409"
@@ -323,14 +373,15 @@ Feature:
         "icon_alternative": "iconAlternative-value",
         "comment": "comment-value",
         "is_activated": false,
-        "categories": [2]
+        "categories": [2],
+        "templates": [15]
       }
       """
     Then the response code should be "201"
     And the JSON should be equal to:
       """
       {
-        "id": 17,
+        "id": 18,
         "name": "host_template_name_B",
         "alias": "host-template-alias",
         "snmp_version": "2c",
@@ -374,6 +425,12 @@ Feature:
           {
             "id": 2,
             "name": "host-cat1"
+          }
+        ],
+        "templates": [
+          {
+            "id": 15,
+            "name": "host_template_name_A"
           }
         ]
       }


### PR DESCRIPTION
## Description

AddHostTemplate endpoint can now link the created host template to its parent templates

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
