### PR TITLE
(ui/legacy): fix size of images

### DIFF
--- a/centreon/www/Themes/Generic-theme/style.css
+++ b/centreon/www/Themes/Generic-theme/style.css
@@ -886,6 +886,14 @@ form#AjaxBankBasic {
     height: 12px;
 }
 
+.img_box {
+    margin: 0px;
+    padding: 0px;
+    width: 26px;
+    height: 26px;
+    position: absolute;
+}
+
 /* ------- END : Table -----------*/
 
 

--- a/centreon/www/include/configuration/configObject/host/formHost.ihtml
+++ b/centreon/www/include/configuration/configObject/host/formHost.ihtml
@@ -524,9 +524,9 @@
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="notes_url"> {$form.ehi_notes_url.label}</td><td class="FormRowValue">{$form.ehi_notes_url.html}</td></tr>
 		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="notes"> {$form.ehi_notes.label}</td><td class="FormRowValue">{$form.ehi_notes.html}</td></tr>
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="action_url"> {$form.ehi_action_url.label}</td><td class="FormRowValue">{$form.ehi_action_url.html}</td></tr>
-		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="icon_image"> {$form.ehi_icon_image.label}</td><td class="FormRowValue">{$form.ehi_icon_image.html}&nbsp;&nbsp;<img id='ehi_icon_image_img' src='./img/blank.gif'></td></tr>
+		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="icon_image"> {$form.ehi_icon_image.label}</td><td class="FormRowValue">{$form.ehi_icon_image.html}&nbsp;&nbsp;<img id='ehi_icon_image_img' class="img_box" src='./img/blank.gif'></td></tr>
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="icon_image_alt"> {$form.ehi_icon_image_alt.label}</td><td class="FormRowValue">{$form.ehi_icon_image_alt.html}</td></tr>
-		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="statusmap_image"> {$form.ehi_statusmap_image.label}</td><td class="FormRowValue">{$form.ehi_statusmap_image.html}&nbsp;&nbsp;<img id='ehi_statusmap_image_img' src='./img/blank.gif'></td></tr>
+		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="statusmap_image"> {$form.ehi_statusmap_image.label}</td><td class="FormRowValue">{$form.ehi_statusmap_image.html}&nbsp;&nbsp;<img id='ehi_statusmap_image_img' class="img_box" src='./img/blank.gif'></td></tr>
 		{if isset($form.geo_coords.label)}
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="geo_coords"> {$form.geo_coords.label}</td><td class="FormRowValue">{$form.geo_coords.html}</td></tr>
 		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="2d_coords"> {$form.ehi_2d_coords.label}</td><td class="FormRowValue">{$form.ehi_2d_coords.html}</td></tr>

--- a/centreon/www/include/configuration/configObject/hostgroup/formHostGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/hostgroup/formHostGroup.ihtml
@@ -72,7 +72,7 @@
             <tr class="list_two">
                 <td class="FormRowField"><img class="helpTooltip" name="icon_image"> {$form.hg_icon_image.label}</td>
                 <td class="FormRowValue"><p class="oreonbutton">{$form.hg_icon_image.html}&nbsp;&nbsp;<img
-                        id='hg_icon_image_img' src='./img/blank.gif'></p></td>
+                        id='hg_icon_image_img' src='./img/blank.gif' class="img_box" ></p></td>
             </tr>
             <tr class="list_one">
                 <td class="FormRowField"><img class="helpTooltip" name="statusmap_image">

--- a/centreon/www/include/configuration/configObject/service/formService.ihtml
+++ b/centreon/www/include/configuration/configObject/service/formService.ihtml
@@ -418,7 +418,7 @@
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="notes"> {$form.esi_notes.label}</td><td class="FormRowValue">{$form.esi_notes.html}</td></tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="action_url"> {$form.esi_action_url.label}</td><td class="FormRowValue">{$form.esi_action_url.html}</td></tr>
         {/if}
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="icon_image"> {$form.esi_icon_image.label}</td><td class="FormRowValue">{$form.esi_icon_image.html}&nbsp;&nbsp;<img id='esi_icon_image_img' src='./img/blank.gif'></td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="icon_image"> {$form.esi_icon_image.label}</td><td class="FormRowValue">{$form.esi_icon_image.html}&nbsp;&nbsp;<img id='esi_icon_image_img' src='./img/blank.gif' class="img_box" ></td></tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="icon_image_alt"> {$form.esi_icon_image_alt.label}</td><td class="FormRowValue">{$form.esi_icon_image_alt.html}</td></tr>
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="criticality_id"> {$form.criticality_id.label}</td><td class="FormRowValue">{$form.criticality_id.html}</td></tr>
         {if isset($form.geo_coords.label)}


### PR DESCRIPTION
## Description

set a size to prevent overblown size if image is bigger

![ScreenShot Tool -20230612130543](https://github.com/centreon/centreon/assets/134523914/b9a34da5-4d61-42cb-8664-e1c60e2d23e6)


**Fixes** #  MON-19872

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

fix the size of images to width 26px and height 26px in all legacy pages


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
