### PR TITLE
fix(test): clear all symfony caches

### DIFF
--- a/centreon/tests/api/Context/CloudPlatformContext.php
+++ b/centreon/tests/api/Context/CloudPlatformContext.php
@@ -89,7 +89,8 @@ class CloudPlatformContext extends FeatureFlagContext
 
         // Reload symfony cache to use updated environment variables
         $this->container->execute(
-            'su ' . $apacheUser . ' -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear"',
+            'su ' . $apacheUser
+                . ' -s /bin/bash -c "/usr/share/centreon/bin/console cache:pool:clear cache.global_clearer"',
             $this->webService
         );
     }


### PR DESCRIPTION
## Description

fix(test): clear all symfony caches

Problem appeared [here](https://github.com/centreon/centreon/actions/runs/5262614382/jobs/9512214566)

according to [symfony documentation](https://symfony.com/doc/5.4/cache.html#clearing-the-cache):
```
To clear the cache you can use the bin/console cache:pool:clear [pool] command.
That will remove all the entries from your storage and you will have to recalculate all the values.
You can also group your pools into "cache clearers".

There are 3 cache clearers by default:
* cache.global_clearer
* cache.system_clearer
* cache.app_clearer

The global clearer clears all the cache items in every pool.
The system cache clearer is used in the bin/console cache:clear command.
The app clearer is the default clearer.
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Check CI is green