### PR TITLE
Fix: override index.html base with the correct custom uri (dev-22.10.x)

### DIFF
--- a/centreon/www/index.php
+++ b/centreon/www/index.php
@@ -171,8 +171,14 @@ if (isset($_GET["autologin"]) && $_GET["autologin"]) {
 function updateCentreonBaseUri(): void
 {
     $requestUri = htmlspecialchars($_SERVER['REQUEST_URI']) ?: '/centreon/';
-    $basePath = '/' . trim(explode('index.php', $requestUri)[0], "/") . '/';
-    $basePath = str_replace('//', '/', $basePath);
+    // Regular expression pattern to match the string between slashes
+    $pattern = "/\/([^\/]+)\//";
+    preg_match($pattern, $requestUri, $matches);
+    if (isset($matches[0]) && $matches[0] !== '') {
+        $basePath = str_replace('//', '/', $matches[0]);
+    } else {
+        $basePath = '/centreon/';
+    }
     $indexHtmlPath = './index.html';
     $indexHtmlContent = file_get_contents($indexHtmlPath);
 


### PR DESCRIPTION
 
**Fixes** # MON-19919

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
