### PR TITLE
fix(upgrade): add missing column topology_url_substitute if not exists

### DIFF
--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -2,7 +2,7 @@
 -- Insert version
 --
 
-INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '23.04.3');
+INSERT INTO `informations` (`key` ,`value`) VALUES ('version', '23.04.4');
 
 --
 -- Contenu de la table `contact`

--- a/centreon/www/install/php/Update-23.04.4.php
+++ b/centreon/www/install/php/Update-23.04.4.php
@@ -24,7 +24,7 @@ $centreonLog = new CentreonLog();
 
 //error specific content
 $versionOfTheUpgrade = 'UPGRADE - 23.04.4: ';
-$errorMessage = '';
+$errorMessage = 'Unable to add column topology_url_substitute to topology';
 
 $addTopologyUrlSubstituteColumn = function(CentreonDB $pearDB) {
     if (! $pearDB->isColumnExist('topology', 'topology_url_substitute')) {

--- a/centreon/www/install/php/Update-23.04.4.php
+++ b/centreon/www/install/php/Update-23.04.4.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once __DIR__ . '/../../class/centreonLog.class.php';
+$centreonLog = new CentreonLog();
+
+//error specific content
+$versionOfTheUpgrade = 'UPGRADE - 23.04.4: ';
+$errorMessage = '';
+
+$addTopologyUrlSubstituteColumn = function(CentreonDB $pearDB) {
+    if (! $pearDB->isColumnExist('topology', 'topology_url_substitute')) {
+        $pearDB->query('ALTER TABLE topology ADD topology_url_substitute VARCHAR(255) NULL AFTER topology_url_opt');
+    }
+};
+
+try {
+    $addTopologyUrlSubstituteColumn($pearDB);
+    // Transactional queries
+} catch (\Exception $e) {
+    $centreonLog->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage
+        . ' - Code : ' . (int) $e->getCode()
+        . ' - Error : ' . $e->getMessage()
+        . ' - Trace : ' . $e->getTraceAsString()
+    );
+
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, (int) $e->getCode(), $e);
+}

--- a/centreon/www/install/php/Update-23.04.4.php
+++ b/centreon/www/install/php/Update-23.04.4.php
@@ -34,7 +34,6 @@ $addTopologyUrlSubstituteColumn = function(CentreonDB $pearDB) {
 
 try {
     $addTopologyUrlSubstituteColumn($pearDB);
-    // Transactional queries
 } catch (\Exception $e) {
     $centreonLog->insertLog(
         4,


### PR DESCRIPTION
## Description

This PR intends to add missing column topology_url_substitute if not exists

**Fixes** # MON-20067

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
