### PR TITLE
fix(chore): use scan action v1.0.8

### DIFF
--- a/.github/workflows/veracode-analysis.yml
+++ b/.github/workflows/veracode-analysis.yml
@@ -100,7 +100,8 @@ jobs:
           java-version: 8
 
       - name: Pipeline scan
-        uses: veracode/Veracode-pipeline-scan-action@v1.0.3
+        uses: veracode/Veracode-pipeline-scan-action@v1.0.8
+        continue-on-error: true
         with:
           vid: '${{ secrets.veracode_api_id }}'
           vkey: '${{ secrets.veracode_api_key }}'


### PR DESCRIPTION
## Description

Workaround to override veracode outage

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)
