### PR TITLE
fix(gorgone): external communication crash every 24h

### DIFF
--- a/centreon-gorgone/gorgone/class/core.pm
+++ b/centreon-gorgone/gorgone/class/core.pm
@@ -962,6 +962,7 @@ sub handshake {
 
         my $message = $options{frame}->getFrame();
         if ($rv == 0 && $$message =~ /^(?:[\[a-zA-Z-_]+?\]\s+\[.*?\]|[\[a-zA-Z-_]+?\]\s*$)/) {
+            $self->{identity_infos}->{ $options{identity} }->{mtime} = time();
             gorgone::standard::library::update_identity_mtime(dbh => $self->{db_gorgone}, identity => $options{identity});
             return (0, $cipher_infos);
         }

--- a/centreon-gorgone/gorgone/modules/core/proxy/hooks.pm
+++ b/centreon-gorgone/gorgone/modules/core/proxy/hooks.pm
@@ -567,17 +567,6 @@ sub pathway {
         }
 
         $first_target = $_ if (!defined($first_target));
-        if ($synctime_nodes->{$_}->{channel_read_stop} == 0) {
-            $synctime_nodes->{$_}->{channel_read_stop} = 1;
-            routing(
-                target => $_,
-                action => 'PROXYSTOPREADCHANNEL',
-                frame => gorgone::class::frame->new(data => { id => $_ }),
-                gorgone => $options{gorgone},
-                dbh => $options{dbh},
-                logger => $options{logger}
-            );
-        }
     }
 
     if (!defined($first_target)) {
@@ -1033,7 +1022,6 @@ sub register_nodes {
                 in_progress => 0,
                 in_progress_time => -1,
                 synctime_error => 0,
-                channel_read_stop => 0,
                 channel_ready => 0
             };
             get_sync_time(node_id => $node->{id}, dbh => $options{dbh});


### PR DESCRIPTION
## Description

On the poller side you have following errors:
```
[core] Decoding issue. Protocol not good: +igVmNw+Ciortk9LVbEKyg==
```

And on the central server:
```
[clientzmq] gorgone-proxy-1-2 - decrypt message issue: FATAL: cipher text length has to be multiple of 16 (8) at /us
```

Central reconnects after but only PING and GETLOG works.

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x
- [X] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Need to wait 24h after the gorgoned poller service restart. Or you can edit the file ```/usr/share/perl5/vendor_perl/gorgone/class/core.pm``` (change the 86400 by 300). Only need to wait 5minutes:
```
        if ($self->{identity_infos}->{$id}->{mtime} < ($time - 300)) {
            $self->{logger}->writeLogDebug('[core] clean external key for ' . $id);
            delete $self->{identity_infos}->{$id};
            next;
        }

```

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
