### PR TITLE
fix(chore): split veracode token for sandbox promotion

### DIFF
--- a/.github/workflows/veracode-analysis.yml
+++ b/.github/workflows/veracode-analysis.yml
@@ -17,6 +17,7 @@ on:
       stability:
         required: true
         type: string
+
     secrets:
       veracode_api_id:
         required: true
@@ -122,10 +123,15 @@ jobs:
         # only baseline files not generated from a development branch are saved
         if: needs.build.outputs.development_stage != 'Development'
         run: |
-          mv *results.json /tmp
-          BUCKET="s3://centreon-veracode-reports/${{ inputs.module_name }}/${{ github.base_ref || github.ref_name }}"
-          aws s3 cp "/tmp/filtered_results.json" "$BUCKET/filtered_results.json"
-          aws s3 cp "/tmp/results.json" "$BUCKET/results.json"
+          BRANCHES=(develop master dev-${{ inputs.major_version }}.x ${{ inputs.major_version }}.x)
+          for BRANCH in "${BRANCHES[@]}"; do
+            if [[ "${{ github.ref_name }}" == "$BRANCH" ]]; then
+              mv *results.json /tmp
+              BUCKET="s3://centreon-veracode-reports/${{ inputs.module_name }}/${{ github.base_ref || github.ref_name }}"
+              aws s3 cp "/tmp/filtered_results.json" "$BUCKET/filtered_results.json"
+              aws s3 cp "/tmp/results.json" "$BUCKET/results.json"
+            fi
+          done
 
   policy-scan:
     needs: [build]
@@ -165,7 +171,7 @@ jobs:
     needs: [build]
     name: Run a SCA scan
     # only stable and unstable maintenance branches will produce a report
-    if: needs.build.outputs.development_stage != 'Development'
+    if: github.ref_name == 'develop'
     runs-on: ubuntu-latest
     continue-on-error: true
 


### PR DESCRIPTION
## Description

Split Veracode tokens. This is required to be able to promote sandbox scans

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)
