### PR TITLE
fix(translation) escape simple quote for a listContact message (#1751)

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -11298,7 +11298,7 @@ msgstr "Voulez-vous vraiment débloquer cet utilisateur ?"
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:181
 msgid "The user(s) will be unblocked. Do you confirm the request?"
-msgstr "Ces utilisateurs seront débloqués. Confirmez-vous l'action ?"
+msgstr "Ces utilisateurs seront débloqués. Confirmez-vous l\\'action ?"
 
 #: centreon-web/www/include/configuration/configObject/contact/listContact.php:447
 msgid "Unblock"


### PR DESCRIPTION
ℹ️ dev-22.10.x backport of https://github.com/centreon/centreon/pull/1751