### PR TITLE
fix(api) fix and check location header in add endpoints

### DIFF
--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -6879,12 +6879,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "e39dd1c352748b7563b3aca8c5d7c786affe93a8"
+                "reference": "2e5568f2d2150a3fb218ce151f0d56b39acab0fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/e39dd1c352748b7563b3aca8c5d7c786affe93a8",
-                "reference": "e39dd1c352748b7563b3aca8c5d7c786affe93a8",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/2e5568f2d2150a3fb218ce151f0d56b39acab0fd",
+                "reference": "2e5568f2d2150a3fb218ce151f0d56b39acab0fd",
                 "shasum": ""
             },
             "require": {
@@ -6936,7 +6936,7 @@
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
                 "source": "https://github.com/centreon/centreon-test-lib/tree/master"
             },
-            "time": "2023-06-16T12:12:53+00:00"
+            "time": "2023-06-30T07:26:15+00:00"
         },
         {
             "name": "composer/pcre",

--- a/centreon/src/Core/HostCategory/Infrastructure/API/AddHostCategory/AddHostCategoryPresenter.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/API/AddHostCategory/AddHostCategoryPresenter.php
@@ -35,6 +35,8 @@ class AddHostCategoryPresenter extends AbstractPresenter
     use LoggerTrait;
     private const ROUTE_NAME = 'FindHostCategory';
 
+    private const ROUTE_HOST_CATEGORY_ID = 'hostCategoryId';
+
     public function __construct(
         protected PresenterFormatterInterface $presenterFormatter,
         readonly private Router $router
@@ -62,7 +64,7 @@ class AddHostCategoryPresenter extends AbstractPresenter
 
             try {
                 $this->setResponseHeaders([
-                    'Location' => $this->router->generate(self::ROUTE_NAME, ['id' => $payload->id]),
+                    'Location' => $this->router->generate(self::ROUTE_NAME, [self::ROUTE_HOST_CATEGORY_ID => $payload->id]),
                 ]);
             } catch (\Throwable $ex) {
                 $this->error('Impossible to generate the location header', [

--- a/centreon/src/Core/HostGroup/Infrastructure/API/AddHostGroup/AddHostGroupPresenterOnPrem.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/API/AddHostGroup/AddHostGroupPresenterOnPrem.php
@@ -38,6 +38,7 @@ class AddHostGroupPresenterOnPrem extends DefaultPresenter implements AddHostGro
     use PresenterTrait;
     use LoggerTrait;
     private const ROUTE_NAME = 'FindHostGroup';
+    private const ROUTE_HOST_GROUP_ID = 'hostGroupId';
 
     /**
      * @param PresenterFormatterInterface $presenterFormatter
@@ -78,7 +79,7 @@ class AddHostGroupPresenterOnPrem extends DefaultPresenter implements AddHostGro
 
             try {
                 $this->setResponseHeaders([
-                    'Location' => $this->router->generate(self::ROUTE_NAME, ['id' => $data->id]),
+                    'Location' => $this->router->generate(self::ROUTE_NAME, [self::ROUTE_HOST_GROUP_ID => $data->id]),
                 ]);
             } catch (\Throwable $ex) {
                 $this->error('Impossible to generate the location header', [

--- a/centreon/src/Core/HostGroup/Infrastructure/API/AddHostGroup/AddHostGroupPresenterSaas.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/API/AddHostGroup/AddHostGroupPresenterSaas.php
@@ -38,6 +38,7 @@ class AddHostGroupPresenterSaas extends DefaultPresenter implements AddHostGroup
     use PresenterTrait;
     use LoggerTrait;
     private const ROUTE_NAME = 'FindHostGroup';
+    private const ROUTE_HOST_GROUP_ID = 'hostGroupId';
 
     /**
      * @param PresenterFormatterInterface $presenterFormatter
@@ -72,7 +73,7 @@ class AddHostGroupPresenterSaas extends DefaultPresenter implements AddHostGroup
 
             try {
                 $this->setResponseHeaders([
-                    'Location' => $this->router->generate(self::ROUTE_NAME, ['id' => $data->id]),
+                    'Location' => $this->router->generate(self::ROUTE_NAME, [self::ROUTE_HOST_GROUP_ID => $data->id]),
                 ]);
             } catch (\Throwable $ex) {
                 $this->error('Impossible to generate the location header', [

--- a/centreon/src/Core/HostSeverity/Infrastructure/API/AddHostSeverity/AddHostSeverityPresenter.php
+++ b/centreon/src/Core/HostSeverity/Infrastructure/API/AddHostSeverity/AddHostSeverityPresenter.php
@@ -34,6 +34,8 @@ class AddHostSeverityPresenter extends AbstractPresenter
 {
     use LoggerTrait;
     private const ROUTE_NAME = 'FindHostSeverity';
+    private const ROUTE_HOST_SEVERITY_ID = 'hostSeverityId';
+
 
     public function __construct(
         PresenterFormatterInterface $presenterFormatter,
@@ -64,7 +66,7 @@ class AddHostSeverityPresenter extends AbstractPresenter
 
             try {
                 $this->setResponseHeaders([
-                    'Location' => $this->router->generate(self::ROUTE_NAME, ['id' => $payload->id]),
+                    'Location' => $this->router->generate(self::ROUTE_NAME, [self::ROUTE_HOST_SEVERITY_ID => $payload->id]),
                 ]);
             } catch (\Throwable $ex) {
                 $this->error('Impossible to generate the location header', [

--- a/centreon/src/Core/TimePeriod/Infrastructure/API/AddTimePeriod/AddTimePeriodsPresenter.php
+++ b/centreon/src/Core/TimePeriod/Infrastructure/API/AddTimePeriod/AddTimePeriodsPresenter.php
@@ -36,6 +36,8 @@ class AddTimePeriodsPresenter extends AbstractPresenter implements PresenterInte
     use LoggerTrait;
 
     private const ROUTE_NAME = 'FindTimePeriod';
+    private const ROUTE_TIME_PERIOD_ID = 'id';
+
 
     /**
      * @param PresenterFormatterInterface $presenterFormatter
@@ -67,7 +69,7 @@ class AddTimePeriodsPresenter extends AbstractPresenter implements PresenterInte
             ]);
             try {
                 $this->setResponseHeaders([
-                    'Location' => $this->router->generate(self::ROUTE_NAME, ['id' => $payload->id]),
+                    'Location' => $this->router->generate(self::ROUTE_NAME, [self::ROUTE_TIME_PERIOD_ID => $payload->id]),
                 ]);
             } catch (\Throwable $ex) {
                 $this->error('Impossible to generate the location header', [

--- a/centreon/tests/api/features/CloudHostGroup.feature
+++ b/centreon/tests/api/features/CloudHostGroup.feature
@@ -56,6 +56,7 @@ Feature:
       | name        | path |
       | hostGroupId | id   |
     Then the response code should be "201"
+    And the header location should be equal to '/centreon/api/latest/configuration/hosts/groups/<hostGroupId>'
     And the JSON should be equal to:
     """
     {

--- a/centreon/tests/api/features/HostCategory.feature
+++ b/centreon/tests/api/features/HostCategory.feature
@@ -328,6 +328,8 @@ Feature:
     }
     """
     Then the response code should be "201"
+    And the header location should be equal to '/centreon/api/latest/configuration/hosts/categories/1'
+
     And the JSON should be equal to:
     """
     {

--- a/centreon/tests/api/features/HostGroup.feature
+++ b/centreon/tests/api/features/HostGroup.feature
@@ -321,6 +321,7 @@ Feature:
     And I store response values in:
       | name        | path    |
       | hostGroupId | id      |
+    And the header location should be equal to '/centreon/api/latest/configuration/hosts/groups/<hostGroupId>'
 
     When I send a PUT request to '/api/latest/configuration/hosts/groups/<hostGroupId>' with body:
     """

--- a/centreon/tests/api/features/HostSeverity.feature
+++ b/centreon/tests/api/features/HostSeverity.feature
@@ -309,6 +309,7 @@ Feature:
     }
     """
     Then the response code should be "201"
+    And the header location should be equal to '/centreon/api/latest/configuration/hosts/severities/1'
     And the JSON should be equal to:
     """
     {


### PR DESCRIPTION
## Description

Fix the location header generation in : AddHostGroup, AddHostSeverity, AddHostCategory, AddTimePeriod
Add behat test on location header for each endpoint

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
