### PR TITLE
enh(ci): display github token usage

### DIFF
--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -24,7 +24,7 @@ jobs:
           display_token_usage () {
             echo "current token usage :"
             curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit | jq .rate
-            echo "\n"
+            echo ""
           }
 
           display_token_usage

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -21,6 +21,13 @@ jobs:
       - uses: actions/checkout@v3
 
       - run: |
+          display_token_usage () {
+            echo "current token usage :"
+            curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit | jq .rate
+            echo "\n"
+          }
+
+          display_token_usage
           sleep 30s
 
           ITERATIONS=1
@@ -50,7 +57,10 @@ jobs:
 
               if [ $ITERATIONS -lt 60 ]; then
                   echo "some jobs are still in progress, next try in 60 seconds... (tries: $ITERATIONS/60)"
-                  sleep 60s
+                  sleep 30s
+                  display_token_usage
+                  sleep 30s
+                  display_token_usage
               fi
 
               ITERATIONS=$((ITERATIONS+1))

--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -20,7 +20,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - run: |
+      - name: Check workflow statuses and display token usage
+        run: |
           display_token_usage () {
             echo "current token usage :"
             curl -s -H "Accept: application/vnd.github+json" -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" https://api.github.com/rate_limit | jq .rate


### PR DESCRIPTION
## Description

enh(ci): display github token usage

![image](https://github.com/centreon/centreon/assets/11978823/84b63e56-348f-4d49-971b-403abef308e4)


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

See check-status workflow