### PR TITLE
enh(ci): do not use personal access token for check status

### DIFF
--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -70,5 +70,3 @@ jobs:
           echo "Timeout : some jobs are still in progress"
           exit 1
         shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
## Description

do not use personal access token for check status

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)