### PR TITLE
fix(sql): remove mock widgets from database

### DIFF
--- a/centreon/package.json
+++ b/centreon/package.json
@@ -172,7 +172,6 @@
   "workspaces": [
     "packages/*"
   ],
-  
   "msw": {
     "workerDirectory": "www/front_src/public"
   }

--- a/centreon/package.json
+++ b/centreon/package.json
@@ -172,6 +172,7 @@
   "workspaces": [
     "packages/*"
   ],
+  
   "msw": {
     "workerDirectory": "www/front_src/public"
   }

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -1487,7 +1487,3 @@ VALUES (1, 4);
 
 INSERT INTO provider_configuration (`type`, `name`, `custom_configuration`, `is_active`, `is_forced`)
 VALUES ('saml', 'SAML', '{"remote_login_url":"","entity_id_url":"","certificate":"","user_id_attribute":"","logout_from":false,"logout_from_url":null,"auto_import":false,"contact_template_id":null,"email_bind_attribute":null,"fullname_bind_attribute":null,"authentication_conditions":{"is_enabled":false,"attribute_path":"","authorized_values":[]},"roles_mapping":{"is_enabled":false,"apply_only_first_role":false,"attribute_path":""},"groups_mapping":{"is_enabled":false,"attribute_path":""}}', 0, 0);
-
--- Add base widgets to the database
-INSERT INTO `widget_models` (`title`,`version`,`description`,`url`,`directory`,`author`) VALUES ('centreon-widget-text','23.10.0','This is a sample widget with text','http://centreon.com','centreon-widget-text','Centreon');
-INSERT INTO `widget_models` (`title`,`version`,`description`,`url`,`directory`,`author`) VALUES ('centreon-widget-input','23.10.0','This is a sample widget with text','http://centreon.com','centreon-widget-input','Centreon');

--- a/centreon/www/install/sql/centreon/Update-DB-23.10.0.sql
+++ b/centreon/www/install/sql/centreon/Update-DB-23.10.0.sql
@@ -4,9 +4,6 @@ INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`,
 INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_show`, `topology_feature_flag`) VALUES ('Creator', '/home/dashboards', '1', '0', 104, 10402, '0', 'dashboard');
 INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_show`, `topology_feature_flag`) VALUES ('Administrator', '/home/dashboards', '1', '0', 104, 10403, '0', 'dashboard');
 
-INSERT INTO `widget_models` (`title`,`version`,`description`,`url`,`directory`,`author`) VALUES ('centreon-widget-text','23.10.0','This is a sample widget with text','http://centreon.com','centreon-widget-text','Centreon');
-INSERT INTO `widget_models` (`title`,`version`,`description`,`url`,`directory`,`author`) VALUES ('centreon-widget-text2','23.10.0','This is a sample widget with text','http://centreon.com','centreon-widget-text2','Centreon');
-
 -- CREATE TABLES FOR DASHBOARD CONFIGURATION --
 
 CREATE TABLE IF NOT EXISTS `dashboard` (


### PR DESCRIPTION
## Description

fix(sql): remove mock widgets from database

Avoid broken install wizard
![image](https://github.com/centreon/centreon/assets/11978823/5a4b4374-7e87-4d91-98cb-dfb1f8ba1635)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Install centreon web using wizard