### PR TITLE
enh(notifications): handle contactgroup in user count for listing

### DIFF
--- a/centreon/tests/api/features/Notification.feature
+++ b/centreon/tests/api/features/Notification.feature
@@ -314,7 +314,7 @@ Feature:
         }
       ],
       "users": [20,21],
-      "contactgroups": [],
+      "contactgroups": [3,5],
       "is_activated": true
     }
     """
@@ -330,7 +330,7 @@ Feature:
           "id": 1,
           "is_activated": true,
           "name": "notification-name",
-          "user_count": 2,
+          "user_count": 4,
           "channels": [
             "Slack"
           ],
@@ -379,6 +379,7 @@ Feature:
     SG;ADD;service-grp2;service-grp2-alias
     CONTACT;ADD;user-name1;user-alias1;user1@mail.com;Centreon!2021;0;0;;local
     CONTACT;ADD;user-name2;user-alias2;user2@mail.com;Centreon!2021;0;0;;local
+    CG;addcontact;Guest;test-user;test-user
     """
     And I am logged in with "test-user"/"Centreon@2022"
     And a feature flag "notification" of bitmask 2
@@ -408,7 +409,7 @@ Feature:
           }
         ],
         "users": [20,21],
-        "contactgroups": [],
+        "contactgroups": [3],
         "is_activated": true
       }
       """
@@ -424,7 +425,7 @@ Feature:
           "id": 1,
           "is_activated": true,
           "name": "notification-name",
-          "user_count": 2,
+          "user_count": 3,
           "channels": [
             "Slack"
           ],
@@ -501,7 +502,7 @@ Feature:
           }
         ],
         "users": [20,21],
-        "contactgroups": [],
+        "contactgroups": [5],
         "is_activated": true
       }
       """

--- a/centreon/www/install/php/Update-22.10.11.php
+++ b/centreon/www/install/php/Update-22.10.11.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/../../class/centreonLog.class.php';
 $centreonLog = new CentreonLog();
 
 //error specific content
-$versionOfTheUpgrade = 'UPGRADE - 22.10.10: ';
+$versionOfTheUpgrade = 'UPGRADE - 22.10.11: ';
 $errorMessage = '';
 
 $alterMetricsTable = function(CentreonDB $pearDBO) {

--- a/centreon/www/install/php/Update-23.04.6.php
+++ b/centreon/www/install/php/Update-23.04.6.php
@@ -22,7 +22,7 @@ require_once __DIR__ . '/../../class/centreonLog.class.php';
 $centreonLog = new CentreonLog();
 
 //error specific content
-$versionOfTheUpgrade = 'UPGRADE - 23.04.5: ';
+$versionOfTheUpgrade = 'UPGRADE - 23.04.6: ';
 $errorMessage = '';
 
 $alterMetricsTable = function(CentreonDB $pearDBO) {


### PR DESCRIPTION
## Description

This PR intends to add contactgroup in user_count calculation for the notification listing

**Fixes** # MON-20373

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
