### PR TITLE
enh(ci): disable post release merge stable to dev

### DIFF
--- a/.github/actions/sync-branches/action.yml
+++ b/.github/actions/sync-branches/action.yml
@@ -14,9 +14,5 @@ runs:
     - name: Rebase branches
       id: rebase
       run: |
-        git config --global user.email "release@centreon.com"
-        git config --global user.name "Centreon"
-        git checkout ${{ inputs.dest_branch }}
-        git merge --strategy-option=theirs ${{ inputs.src_branch }}
-        git push origin ${{ inputs.dest_branch }}
+        echo "[DEBUG] - This action is disabled for safety reasons and has to be performed manually."
       shell: bash


### PR DESCRIPTION
## Description

1st step to prevent any potential damage that this sync may cause if left active
due to the use of merge strategy "theirs".

REF #MON-18839

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)
