### PR TITLE
fix(clapi) add missing broker parameters support (command_file, log_directory, log_filename)

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
+++ b/centreon/www/class/centreon-clapi/centreonCentbrokerCfg.class.php
@@ -123,6 +123,9 @@ class CentreonCentbrokerCfg extends CentreonObject
                     "stats_activate",
                     "daemon",
                     "pool_size",
+                    "command_file",
+                    "log_directory",
+                    "log_filename",
                 ];
                 if (!in_array($params[1], $parametersWithoutPrefix)) {
                     $params[1] = 'config_' . $params[1];


### PR DESCRIPTION
## Description

From external contribution: https://github.com/centreon/centreon/pull/885 

Fix broker configuration setting in CLAPI to support following parameters:
- command_file, 
- log_directory, 
- log_filename

Example:
`centreon -u admin -p 'Centreon!2021' -o CENTBROKERCFG -a setparam -v "my_broker_cfg;log_directory;some/path/to/my/log/"`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
