### PR TITLE
fix(packaging): fix rights of symfony log directory on debian

### DIFF
--- a/centreon/packaging/debian/centreon-web.postinst
+++ b/centreon/packaging/debian/centreon-web.postinst
@@ -8,6 +8,11 @@ if [ "$1" = "configure" ] ; then
       /usr/share/centreon \
       /var/log/centreon \
       /var/lib/centreon
+
+    if [ -d "/var/log/centreon/symfony" ]; then
+      chown -R www-data:www-data /var/log/centreon/symfony
+    fi
+
     chmod 0775 \
       /usr/share/centreon/src \
       /usr/share/centreon/api


### PR DESCRIPTION
## Description

fix(packaging): fix rights of symfony log directory on debian

**Fixes** MON-20449

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)