### PR TITLE
enh(clapi) ignore empty and commented lines in file import

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -798,9 +798,9 @@ class CentreonAPI
 
                 $string = trim($string);
                 if (
-                    strlen($string) === 0
-                    || substr($string, 0, 1)  === '#'
-                    || substr($string, 0, 13)  === '{OBJECT_TYPE}'
+                    $string === ''
+                    || str_starts_with($string, '#')
+                    || str_starts_with($string, '{OBJECT_TYPE}')
                 ) {
                     continue;
                 }

--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -793,28 +793,37 @@ class CentreonAPI
         $handle = fopen($filename, 'r');
         if ($handle) {
             $i = 0;
-            while ($string = fgets($handle)) {
+            while (($string = fgets($handle)) !== false) {
                 $i++;
-                $tab = preg_split('/;/', $string);
-                if (strlen(trim($string)) != 0 && !preg_match('/^\{OBJECT_TYPE\}/', $string)) {
-                    $this->object = trim($tab[0]);
-                    $this->action = trim($tab[1]);
-                    $this->variables = trim(substr($string, strlen($tab[0] . ";" . $tab[1] . ";")));
-                    if ($this->debug == 1) {
-                        print "Object : " . $this->object . "\n";
-                        print "Action : " . $this->action . "\n";
-                        print "VARIABLES : " . $this->variables . "\n\n";
-                    }
-                    try {
-                        $this->launchActionForImport();
-                    } catch (CentreonClapiException $e) {
-                        echo "Line $i : " . $e->getMessage() . "\n";
-                    } catch (\Exception $e) {
-                        echo "Line $i : " . $e->getMessage() . "\n";
-                    }
-                    if ($this->return_code) {
-                        $globalReturn = 1;
-                    }
+
+                $string = trim($string);
+                if (
+                    strlen($string) === 0
+                    || substr($string, 0, 1)  === '#'
+                    || substr($string, 0, 13)  === '{OBJECT_TYPE}'
+                ) {
+                    continue;
+                }
+
+                $tab = explode(';', $string, 3);
+                $this->object = trim($tab[0]);
+                $this->action = trim($tab[1]);
+                $this->variables = trim($tab[2]);
+
+                if ($this->debug == 1) {
+                    print "Object : " . $this->object . "\n";
+                    print "Action : " . $this->action . "\n";
+                    print "VARIABLES : " . $this->variables . "\n\n";
+                }
+                try {
+                    $this->launchActionForImport();
+                } catch (CentreonClapiException $e) {
+                    echo "Line $i : " . $e->getMessage() . "\n";
+                } catch (\Exception $e) {
+                    echo "Line $i : " . $e->getMessage() . "\n";
+                }
+                if ($this->return_code) {
+                    $globalReturn = 1;
                 }
             }
             fclose($handle);


### PR DESCRIPTION
## Description

This PR intends to modify clapi configuration file import to:
- Ignore empty lines
- Ignore commented (ie starting with # ) lines
- Review the splitting method:
    - don't use regexp unnecessarily
    - split only the first 3 parts (simpler)

From external contribution : https://github.com/centreon/centreon/pull/785

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
