### PR TITLE
fix(ci): update docker slim configuration and add os to artifact names

### DIFF
--- a/.github/docker/slim-configuration/include-path.txt
+++ b/.github/docker/slim-configuration/include-path.txt
@@ -10,6 +10,7 @@
 /etc/sudoers.d
 /etc/pam.d/sudo
 /usr/libexec/sudo
+/usr/lib64/perl5/vendor_perl
 /var/www/html
 /usr/lib64/httpd/modules
 /var/lib/php/session


### PR DESCRIPTION
## Description

fix(ci): update docker slim configuration and add os to artifact names

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)