### PR TITLE
fix(SAML): remove is_active and is_forced from custom_configuration (#1842)

### DIFF
--- a/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfiguration.php
@@ -85,6 +85,7 @@ class UpdateSAMLConfiguration
             $configuration = $provider->getConfiguration();
             $configuration->update($request->isActive, $request->isForced);
             $requestArray = $request->toArray();
+
             $requestArray['contact_template'] = $request->contactTemplate &&
             array_key_exists('id', $request->contactTemplate) !== null
                 ? $this->getContactTemplateOrFail($request->contactTemplate)
@@ -94,7 +95,6 @@ class UpdateSAMLConfiguration
                 $request->authenticationConditions
             );
             $requestArray["groups_mapping"] = $this->createGroupsMapping($request->groupsMapping);
-            $requestArray["is_active"] = $request->isActive;
             $configuration->setCustomConfiguration(new CustomConfiguration($requestArray));
             $this->updateConfiguration($configuration);
         } catch (AssertionException | AssertionFailedException | ConfigurationException $ex) {

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfigurationRequest.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfigurationRequest.php
@@ -134,8 +134,6 @@ class UpdateSAMLConfigurationRequest
     public function toArray(): array
     {
         return [
-            'is_forced' => $this->isForced,
-            'is_active' => $this->isActive,
             'entity_id_url' => $this->entityIdUrl,
             'remote_login_url' => $this->remoteLoginUrl,
             'user_id_attribute' => $this->userIdAttribute,

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Repository/DbWriteSAMLConfigurationRepository.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Repository/DbWriteSAMLConfigurationRepository.php
@@ -100,8 +100,6 @@ class DbWriteSAMLConfigurationRepository extends AbstractRepositoryDRB implement
         $customConfiguration = $configuration->getCustomConfiguration();
 
         return [
-            'is_active' => $configuration->isActive(),
-            'is_forced' => $configuration->isForced(),
             'remote_login_url' => $customConfiguration->getRemoteLoginUrl(),
             'entity_id_url' => $customConfiguration->getEntityIDUrl(),
             'certificate' => $customConfiguration->getPublicCertificate(),


### PR DESCRIPTION
## Description

This PR is a backport of #1842

**Fixes** # MON-20487

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
