### PR TITLE
fix(popup): add missing id for gorgone central popup configuration

### DIFF
--- a/centreon/www/include/configuration/configServers/popup/central.yaml
+++ b/centreon/www/include/configuration/configServers/popup/central.yaml
@@ -4,6 +4,7 @@ gorgone:
   gorgonecore:
     privkey: "/var/lib/centreon-gorgone/.keys/rsakey.priv.pem"
     pubkey: "/var/lib/centreon-gorgone/.keys/rsakey.pub.pem"
+    id: 1
   modules:
     - name: httpserver
       package: "gorgone::modules::core::httpserver::hooks"


### PR DESCRIPTION
ℹ️ release-23.04-next backport of https://github.com/centreon/centreon/pull/1858