### PR TITLE
enh(templates): remove possibility to enable/disable the object

### DIFF
--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -6879,12 +6879,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "2e5568f2d2150a3fb218ce151f0d56b39acab0fd"
+                "reference": "fa8758e17e8706288fd3775b336b2193ad90629f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/2e5568f2d2150a3fb218ce151f0d56b39acab0fd",
-                "reference": "2e5568f2d2150a3fb218ce151f0d56b39acab0fd",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/fa8758e17e8706288fd3775b336b2193ad90629f",
+                "reference": "fa8758e17e8706288fd3775b336b2193ad90629f",
                 "shasum": ""
             },
             "require": {
@@ -6936,7 +6936,7 @@
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
                 "source": "https://github.com/centreon/centreon-test-lib/tree/master"
             },
-            "time": "2023-06-30T07:26:15+00:00"
+            "time": "2023-07-12T15:49:40+00:00"
         },
         {
             "name": "composer/pcre",

--- a/centreon/features/bootstrap/HostConfigurationContext.php
+++ b/centreon/features/bootstrap/HostConfigurationContext.php
@@ -116,7 +116,6 @@ class HostConfigurationContext extends CentreonContext
         '2d_coords' => '15,84',
         '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategoryName1 (2)',
-        'enabled' => 1,
         'comments' => 'hostMassiveChangeComments'
     );
 
@@ -180,7 +179,6 @@ class HostConfigurationContext extends CentreonContext
         '2d_coords' => '15,84',
         '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategoryName1 (2)',
-        'enabled' => 1,
         'comments' => 'hostMassiveChangeComments'
     );
 
@@ -247,7 +245,6 @@ class HostConfigurationContext extends CentreonContext
         '2d_coords' => '2,3',
         '3d_coords' => '42,24,66',
         'severity_level' => '',
-        'enabled' => 1,
         'comments' => 'hostMassiveChangeCommentsChanged'
     );
 

--- a/centreon/features/bootstrap/HostTemplateBasicsOperationsContext.php
+++ b/centreon/features/bootstrap/HostTemplateBasicsOperationsContext.php
@@ -95,7 +95,6 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
         '2d_coords' => '15,84',
         '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategory1Name (2)',
-        'enabled' => 1,
         'comments' => 'hostTemplateChangeComments'
     );
 
@@ -159,7 +158,6 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
         '2d_coords' => '15,84',
         '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategory1Name (2)',
-        'enabled' => 1,
         'comments' => 'hostTemplateChangeComments'
     );
 
@@ -223,7 +221,6 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
         '2d_coords' => '48,29',
         '3d_coords' => '09,25,27',
         'severity_level' => 'hostCategory2Name (13)',
-        'enabled' => 1,
         'comments' => 'hostTemplateChangeCommentsChanged'
     );
 
@@ -288,7 +285,6 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
         '2d_coords' => '48,29',
         '3d_coords' => '09,25,27',
         'severity_level' => 'hostCategory2Name (13)',
-        'enabled' => 1,
         'comments' => 'hostTemplateChangeCommentsChanged'
     );
 

--- a/centreon/features/bootstrap/MassiveChangeHostsContext.php
+++ b/centreon/features/bootstrap/MassiveChangeHostsContext.php
@@ -119,7 +119,6 @@ class MassiveChangeHostsContext extends CentreonContext
         '2d_coords' => '15,84',
         '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategoryName1 (2)',
-        'enabled' => 0,
         'comments' => 'hostMassiveChangeComments'
     );
 
@@ -188,7 +187,6 @@ class MassiveChangeHostsContext extends CentreonContext
         '2d_coords' => '15,84',
         '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategoryName1 (2)',
-        'enabled' => 0,
         'comments' => 'hostMassiveChangeComments'
     );
 
@@ -257,7 +255,6 @@ class MassiveChangeHostsContext extends CentreonContext
         '2d_coords' => '15,84',
         '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategoryName1 (2)',
-        'enabled' => 0,
         'comments' => 'hostMassiveChangeComments'
     );
 

--- a/centreon/features/bootstrap/ServiceTemplateConfigurationContext.php
+++ b/centreon/features/bootstrap/ServiceTemplateConfigurationContext.php
@@ -86,7 +86,6 @@ class ServiceTemplateConfigurationContext extends CentreonContext
         'icon' => 'centreon (png)',
         'alt_icon' => 'serviceAltIcon',
         'severity' => 'serviceCategory2Name (2)',
-        'status' => 1,
         'comments' => 'serviceComments'
     );
 
@@ -144,7 +143,6 @@ class ServiceTemplateConfigurationContext extends CentreonContext
         'icon' => 'centreon (png)',
         'alt_icon' => 'serviceAltIcon',
         'severity' => 'serviceCategory2Name (2)',
-        'status' => 1,
         'comments' => 'serviceComments'
     );
 
@@ -202,7 +200,6 @@ class ServiceTemplateConfigurationContext extends CentreonContext
         'icon' => '',
         'alt_icon' => 'Empty',
         'severity' => 'serviceCategory1Name (3)',
-        'status' => 1,
         'comments' => 'serviceCommentsChanged'
     );
 
@@ -263,7 +260,6 @@ class ServiceTemplateConfigurationContext extends CentreonContext
         'icon' => '',
         'alt_icon' => 'Empty',
         'severity' => 'serviceCategory1Name (3)',
-        'status' => 1,
         'comments' => 'serviceCommentsChanged'
     );
 

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -2736,7 +2736,7 @@ function sanitizeFormHostParameters(array $ret): array
                 $bindParams[':' . $inputName] = [
                     \PDO::PARAM_STR => in_array($inputValue[$inputName], ['0', '1', '2'])
                         ? $inputValue[$inputName]
-                        : null
+                        : '1'
                 ];
                 break;
         }

--- a/centreon/www/include/configuration/configObject/host/formHost.ihtml
+++ b/centreon/www/include/configuration/configObject/host/formHost.ihtml
@@ -369,7 +369,7 @@
         <h4>{$form.header.HGlinks}</h4>
       </td>
     </tr>
-	{if !$msg.tpl}
+	{if !$msg.isHostTemplate}
 		{if $o == "mc"}
 			<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="mc_update"> {$form.mc_mod_hhg.label}</td><td class="FormRowValue">{$form.mc_mod_hhg.html}</td></tr>
 		{/if}
@@ -542,7 +542,9 @@
 			<h4>{$form.header.furtherInfos}</h4>
 		  </td>
 		</tr>
-		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="host_activate"> {$form.host_activate.label}</td><td class="FormRowValue">{$form.host_activate.html}</td></tr>
+		{if !$msg.isHostTemplate}
+			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="host_activate"> {$form.host_activate.label}</td><td class="FormRowValue">{$form.host_activate.html}</td></tr>
+		{/if}
 		<tr class="list_one"><td class="FormRowField">{$form.host_comment.label}</td><td class="FormRowValue">{$form.host_comment.html}</td></tr>
 		{if $o == "a" || $o == "c"}
 			<tr class="list_lvl_2"><td class="ListColLvl2_name" colspan="2">

--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -1159,7 +1159,7 @@ if ($o === HOST_WATCH) {
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
 }
 
-$tpl->assign('msg', array("nagios" => $centreon->user->get_version(), "tpl" => 0));
+$tpl->assign('msg', array("nagios" => $centreon->user->get_version(), "isHostTemplate" => 0));
 $tpl->assign('min', $min);
 $tpl->assign("sort1", _("Host Configuration"));
 $tpl->assign("sort2", _("Notification"));

--- a/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -685,12 +685,6 @@ $form->addGroup($hostStalOpt, 'host_stalOpts', _("Stalking Options"), '&nbsp;&nb
 ## Further informations
 #
 $form->addElement('header', 'furtherInfos', _("Additional Information"));
-$hostActivation[] = $form->createElement('radio', 'host_activate', null, _("Enabled"), '1');
-$hostActivation[] = $form->createElement('radio', 'host_activate', null, _("Disabled"), '0');
-$form->addGroup($hostActivation, 'host_activate', _("Enable/disable resource"), '&nbsp;');
-if ($o !== HOST_TEMPLATE_MASSIVE_CHANGE) {
-    $form->setDefaults(array('host_activate' => '1'));
-}
 
 $form->addElement('textarea', 'host_comment', _("Comments"), $attrsTextarea);
 
@@ -933,7 +927,7 @@ if ($o === HOST_TEMPLATE_WATCH) {
     $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
 }
 
-$tpl->assign('msg', array("nagios" => $centreon->user->get_version(), "tpl" => 1, "min" => $min));
+$tpl->assign('msg', array("nagios" => $centreon->user->get_version(), "isHostTemplate" => 1, "min" => $min));
 $tpl->assign('min', $min);
 $tpl->assign('p', $p);
 $tpl->assign("sort1", _("Host Configuration"));
@@ -1032,7 +1026,7 @@ if ($valid) {
     $tpl->assign("add_mtp_label", _("Add a template"));
     $tpl->assign('select_template', _('Select a template'));
     $tpl->assign("seconds", _("seconds"));
-    $tpl->assign("tpl", 1);
+    $tpl->assign("isHostTemplate", 1);
     $tpl->display("formHost.ihtml");
 
     ?>

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.ihtml
@@ -49,7 +49,6 @@
 			<td class="ListColHeaderLeft">{$headerMenu_desc}</td>
 			<td class="ListColHeaderCenter" width="62">{$headerMenu_svChilds}</td>
 			<td class="ListColHeaderCenter">{$headerMenu_parent}</td>
-			<td class="ListColHeaderCenter">{$headerMenu_status}</td>
 			<td class="ListColHeaderRight">{$headerMenu_options}</td>
 		</tr>
 		{section name=elem loop=$elemArr}
@@ -70,7 +69,6 @@
 				<td class="ListColLeft resizeTitle"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
 				<td class="ListColCenter">{$elemArr[elem].RowMenu_svChilds}</td>
 				<td class="ListColCenter resizeTitle">{$elemArr[elem].RowMenu_parent}</td>
-				<td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
 				<td class="ListColRight" align="right">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
 			</tr>
 		{/section}

--- a/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
@@ -82,7 +82,7 @@ $centreon->historySearch[$url] = [
 $lockedFilter = $displayLocked ? "" : "AND host_locked = 0 ";
 
 // Host Template list
-$rq = "SELECT SQL_CALC_FOUND_ROWS host_id, host_name, host_alias, host_activate, host_template_model_htm_id " .
+$rq = "SELECT SQL_CALC_FOUND_ROWS host_id, host_name, host_alias, host_template_model_htm_id " .
     "FROM host " .
     "WHERE host_register = '0' " .
     $lockedFilter;
@@ -114,7 +114,6 @@ $tpl->assign("headerMenu_name", _("Name"));
 $tpl->assign("headerMenu_desc", _("Alias"));
 $tpl->assign("headerMenu_svChilds", _("Linked Services Templates"));
 $tpl->assign("headerMenu_parent", _("Templates"));
-$tpl->assign("headerMenu_status", _("Status"));
 $tpl->assign("headerMenu_options", _("Options"));
 
 $search = tidySearchKey($search, $advanced_search);
@@ -140,18 +139,6 @@ for ($i = 0; $host = $DBRESULT->fetch(); $i++) {
     if (isset($lockedElements[$host['host_id']])) {
         $selectedElements->setAttribute('disabled', 'disabled');
     } else {
-        if ($host["host_activate"]) {
-            $moptions .= "<a href='main.php?p=" . $p . "&host_id=" . $host['host_id'] . "&o=u&limit=" . $limit .
-                "&num=" . $num . "&search=" . $search . "&centreon_token=" . $centreonToken .
-                "'><img src='img/icons/disabled.png' " .
-                "class='ico-14 margin_right' border='0' alt='" . _("Disabled") . "'></a>&nbsp;&nbsp;";
-        } else {
-            $moptions .= "<a href='main.php?p=" . $p . "&host_id=" . $host['host_id'] . "&o=s&limit=" . $limit .
-                "&num=" . $num . "&search=" . $search . "&centreon_token=" . $centreonToken .
-                "'><img src='img/icons/enabled.png' " .
-                "class='ico-14 margin_right' border='0' alt='" . _("Enabled") . "'></a>&nbsp;&nbsp;";
-        }
-        $moptions .= "&nbsp;";
         $moptions .= "<input onKeypress=\"if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) " .
             "event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) " .
             "return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" " .
@@ -210,8 +197,6 @@ for ($i = 0; $host = $DBRESULT->fetch(); $i++) {
         "RowMenu_icone" => $host_icone,
         "RowMenu_svChilds" => count($svArr),
         "RowMenu_parent" => CentreonUtils::escapeSecure($tplStr),
-        "RowMenu_status" => $host["host_activate"] ? _("Enabled") : _("Disabled"),
-        "RowMenu_badge" => $host["host_activate"] ? "service_ok" : "service_critical",
         "RowMenu_options" => $moptions,
         "isHostTemplateSvgFile" => $isHostTemplateSvgFile
     );
@@ -258,9 +243,7 @@ foreach (array('o1', 'o2') as $option) {
             null => _("More actions..."),
             "m" => _("Duplicate"),
             "d" => _("Delete"),
-            "mc" => _("Massive Change"),
-            "ms" => _("Enable"),
-            "mu" => _("Disable")
+            "mc" => _("Massive Change")
         ),
         $attrs1
     );

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -1237,7 +1237,7 @@ function insertService($ret = array(), $macro_on_demand = null)
         : $rq .= "NULL, ";
     isset($ret["service_activate"]["service_activate"]) && $ret["service_activate"]["service_activate"] != null
         ? $rq .= "'" . $ret["service_activate"]["service_activate"] . "',"
-        : $rq .= "NULL,";
+        : $rq .= "'1',";
     isset($ret["service_acknowledgement_timeout"]) && $ret["service_acknowledgement_timeout"] != null
         ? $rq .= "'" . $ret["service_acknowledgement_timeout"] . "'"
         : $rq .= "NULL";
@@ -1542,7 +1542,7 @@ function updateService($service_id = null, $from_MC = false, $params = array())
     $rq .= "service_activate = ";
     isset($ret["service_activate"]["service_activate"]) && $ret["service_activate"]["service_activate"] != null
         ? $rq .= "'" . $ret["service_activate"]["service_activate"] . "' "
-        : $rq .= "NULL ";
+        : $rq .= "'1' ";
     $rq .= "WHERE service_id = '" . $service_id . "'";
     $dbResult = $pearDB->query($rq);
 
@@ -1738,9 +1738,10 @@ function updateService_MC($service_id = null, $params = array())
     if (isset($ret["geo_coords"]) && $ret["geo_coords"] != null) {
         $rq .= "geo_coords = '" . $ret["geo_coords"] . "', ";
     }
-    if (isset($ret["service_activate"]["service_activate"]) && $ret["service_activate"]["service_activate"] != null) {
-        $rq .= "service_activate = '" . $ret["service_activate"]["service_activate"] . "', ";
-    }
+
+    $rq .= (isset($ret["service_activate"]["service_activate"]) && $ret["service_activate"]["service_activate"] != null)
+        ? "service_activate = '" . $ret["service_activate"]["service_activate"] . "', "
+        : "service_activate = '1', ";
 
     if (strcmp("UPDATE service SET ", $rq)) {
         // Delete last ',' in request

--- a/centreon/www/include/configuration/configObject/service/formService.ihtml
+++ b/centreon/www/include/configuration/configObject/service/formService.ihtml
@@ -429,7 +429,10 @@
             <h4>{$form.header.furtherInfos}</h4>
           </td>
         </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="service_activate"> {$form.service_activate.label}</td><td class="FormRowValue">{$form.service_activate.html}</td></tr>
+
+        {if !isset($isServiceTemplate)}
+            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="service_activate"> {$form.service_activate.label}</td><td class="FormRowValue">{$form.service_activate.html}</td></tr>
+        {/if}
         <tr class="list_two"><td class="FormRowField">{$form.service_comment.label}</td><td class="FormRowValue">{$form.service_comment.html}</td></tr>
      </table>
 </div>

--- a/centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
@@ -696,12 +696,6 @@ $form->addGroup($serviceStalOpt, 'service_stalOpts', _("Stalking Options"), '&nb
 ## Further informations
 #
 $form->addElement('header', 'furtherInfos', _("Additional Information"));
-$serviceActivation[] = $form->createElement('radio', 'service_activate', null, _("Enabled"), '1');
-$serviceActivation[] = $form->createElement('radio', 'service_activate', null, _("Disabled"), '0');
-$form->addGroup($serviceActivation, 'service_activate', _("Enable/disable resource"), '&nbsp;');
-if ($o != SERVICE_TEMPLATE_MASSIVE_CHANGE) {
-    $form->setDefaults(array('service_activate' => '1'));
-}
 $form->addElement('textarea', 'service_comment', _("Comments"), $attrsTextarea);
 
 #

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.ihtml
@@ -48,7 +48,6 @@
             <td class="ListColHeaderCenter">{$headerMenu_alias}</td>
             <td class="ListColHeaderCenter">{$headerMenu_retry}</td>
             <td class="ListColHeaderCenter">{$headerMenu_parent}</td>
-            <td class="ListColHeaderCenter">{$headerMenu_status}</td>
             <td class="ListColHeaderRight">{$headerMenu_options}</td>
         </tr>
         {section name=elem loop=$elemArr}
@@ -63,8 +62,6 @@
                     href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_alias}</a></td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_retry}</td>
             <td class="ListColLeft">{$elemArr[elem].RowMenu_parent}</td>
-            <td class="ListColCenter"><span
-                    class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
             <td class="ListColRight" align="right">{if $mode_access == 'w'}{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
         </tr>
         {/section}

--- a/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
@@ -78,7 +78,7 @@ $lockedFilter = $displayLocked ? "" : "AND sv.service_locked = 0 ";
 //Service Template Model list
 if ($search) {
     $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sv.service_id, sv.service_description," .
-        " sv.service_alias, sv.service_activate, sv.service_template_model_stm_id FROM service sv " .
+        " sv.service_alias, sv.service_template_model_stm_id FROM service sv " .
         "WHERE (sv.service_description LIKE :search OR sv.service_alias LIKE :search) " .
         "AND sv.service_register = '0' " .
         $lockedFilter .
@@ -86,7 +86,7 @@ if ($search) {
     $statement->bindValue(':search', '%' . $search . '%', \PDO::PARAM_STR);
 } else {
     $statement = $pearDB->prepare("SELECT SQL_CALC_FOUND_ROWS sv.service_id, sv.service_description," .
-        " sv.service_alias, sv.service_activate, sv.service_template_model_stm_id FROM service sv " .
+        " sv.service_alias, sv.service_template_model_stm_id FROM service sv " .
         "WHERE sv.service_register = '0' " . $lockedFilter .
         "ORDER BY service_description LIMIT :scope, :limit");
 }
@@ -143,18 +143,6 @@ for ($i = 0; $service = $statement->fetch(); $i++) {
     if (isset($lockedElements[$service['service_id']])) {
         $selectedElements->setAttribute('disabled', 'disabled');
     } else {
-        if ($service["service_activate"]) {
-            $moptions .= "<a href='main.php?p=" . $p . "&service_id=" . $service['service_id'] . "&o=u&limit=" .
-                $limit . "&num=" . $num . "&search=" . $search . "&centreon_token=" . $centreonToken .
-                "'><img src='img/icons/disabled.png' " .
-                "class='ico-14 margin_right' border='0' alt='" . _("Disabled") . "'></a>&nbsp;&nbsp;";
-        } else {
-            $moptions .= "<a href='main.php?p=" . $p . "&service_id=" . $service['service_id'] . "&o=s&limit=" .
-                $limit . "&num=" . $num . "&search=" . $search . "&centreon_token=" . $centreonToken .
-                "'><img src='img/icons/enabled.png' " .
-                "class='ico-14 margin_right' border='0' alt='" . _("Enabled") . "'></a>&nbsp;&nbsp;";
-        }
-        $moptions .= "&nbsp;";
         $moptions .= "<input onKeypress=\"if(event.keyCode > 31 && (event.keyCode < 45 || event.keyCode > 57)) " .
             "event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57)) return false;" .
             "\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" name='dupNbr[" .
@@ -240,8 +228,6 @@ for ($i = 0; $service = $statement->fetch(); $i++) {
         ),
         "RowMenu_attempts" => getMyServiceField($service['service_id'], "service_max_check_attempts"),
         "RowMenu_link" => "main.php?p=" . $p . "&o=c&service_id=" . $service['service_id'],
-        "RowMenu_status" => $service["service_activate"] ? _("Enabled") : _("Disabled"),
-        "RowMenu_badge" => $service["service_activate"] ? "service_ok" : "service_critical",
         "RowMenu_options" => $moptions
     );
     $style != "two" ? $style = "two" : $style = "one";
@@ -290,9 +276,7 @@ $form->addElement(
         null => _("More actions..."),
         "m" => _("Duplicate"),
         "d" => _("Delete"),
-        "mc" => _("Massive Change"),
-        "ms" => _("Enable"),
-        "mu" => _("Disable")
+        "mc" => _("Massive Change")
     ),
     $attrs1
 );
@@ -322,9 +306,7 @@ $form->addElement(
         null => _("More actions..."),
         "m" => _("Duplicate"),
         "d" => _("Delete"),
-        "mc" => _("Massive Change"),
-        "ms" => _("Enable"),
-        "mu" => _("Disable")
+        "mc" => _("Massive Change")
     ),
     $attrs2
 );

--- a/centreon/www/install/php/Update-23.10.0.php
+++ b/centreon/www/install/php/Update-23.10.0.php
@@ -45,6 +45,28 @@ $alterMetricsTable = function(CentreonDB $pearDBO) {
     );
 };
 
+$enableDisabledServiceTemplates = function(CentreonDB $pearDB) {
+    $pearDB->query(
+        <<<'SQL'
+            UPDATE `service`
+                SET service_activate = '1'
+            WHERE service_register = '0'
+                AND service_activate = '0'
+            SQL
+    );
+};
+
+$enableDisabledHostTemplates = function(CentreonDB $pearDB) {
+    $pearDB->query(
+        <<<'SQL'
+            UPDATE `host`
+                SET host_activate = '1'
+            WHERE host_register = '0'
+                AND host_activate = '0'
+            SQL
+    );
+};
+
 try {
 
     $pearDBO->query($alterResourceTableStmnt);
@@ -59,6 +81,12 @@ try {
     }
     $errorMessage = "Unable to Delete nagios_path_img from options table";
     $removeNagiosPathImg($pearDB);
+
+    $errorMessage = 'Unable to activate deactivated service templates';
+    $enableDisabledServiceTemplates($pearDB);
+
+    $errorMessage = 'Unable to activate deactivated host templates';
+    $enableDisabledHostTemplates($pearDB);
 
     $pearDB->commit();
 } catch (\Exception $e) {


### PR DESCRIPTION
## Description

This PR intends to completely remove the possibility to enable/disable a service/host template.
This feature causes to much trouble regarding configuration generation. If a template is no longer used then it should be unlinked to the resources related and deleted.

This PR intends to
- Remove the enable/disable mass action (more action listing) from host/service template listing
- Remove the enable/disable unitary action (icon action) from host/service template listing
- Remove the "Status" enabled/disabled from host/service template listing
- Remove the enable/disable option from 'Extended information' tab of service/host template forms.
- Add an upgrade script to re-enable all templates that were disabled to give possibility to the user to unlink + delete unused templates.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
