### PR TITLE
fix(gorgone): mbi module is stuck after internal key rotate

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/mbi/etlworkers/hooks.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/mbi/etlworkers/hooks.pm
@@ -186,7 +186,7 @@ sub broadcast {
         $options{gorgone}->send_internal_message(
             identity => 'gorgone-' . NAME .  '-' . $pool_id,
             action => $options{action},
-            data => $options{data},
+            raw_data_ref => $options{frame}->getRawData(),
             token => $options{token}
         );
     }

--- a/centreon-gorgone/gorgone/modules/plugins/newtest/hooks.pm
+++ b/centreon-gorgone/gorgone/modules/plugins/newtest/hooks.pm
@@ -65,12 +65,9 @@ sub init {
 
 sub routing {
     my (%options) = @_;
-    
-    my $data;
-    eval {
-        $data = JSON::XS->new->decode($options{data});
-    };
-    if ($@) {
+
+    my $data = $options{frame}->decodeData();
+    if (!defined($data)) {
         $options{logger}->writeLogError("[newtest] Cannot decode json data: $@");
         gorgone::standard::library::add_history({
             dbh => $options{dbh},
@@ -83,11 +80,11 @@ sub routing {
     }
     
     if ($options{action} eq 'NEWTESTREADY') {
-        $containers->{$data->{container_id}}->{ready} = 1;
+        $containers->{ $data->{container_id} }->{ready} = 1;
         return undef;
     }
     
-    if (!defined($data->{container_id}) || !defined($last_containers->{$data->{container_id}})) {
+    if (!defined($data->{container_id}) || !defined($last_containers->{ $data->{container_id} })) {
         gorgone::standard::library::add_history({
             dbh => $options{dbh},
             code => GORGONE_ACTION_FINISH_KO,
@@ -98,7 +95,7 @@ sub routing {
         return undef;
     }
     
-    if (gorgone::class::core::waiting_ready(ready => \$containers->{$data->{container_id}}->{ready}) == 0) {
+    if (gorgone::class::core::waiting_ready(ready => \$containers->{ $data->{container_id} }->{ready}) == 0) {
         gorgone::standard::library::add_history({
             dbh => $options{dbh},
              code => GORGONE_ACTION_FINISH_KO,
@@ -112,7 +109,7 @@ sub routing {
     $options{gorgone}->send_internal_message(
         identity => 'gorgone-newtest-' . $data->{container_id},
         action => $options{action},
-        data => $options{data},
+        raw_data_ref => $options{frame}->getRawData(),
         token => $options{token}
     );
 }
@@ -180,7 +177,7 @@ sub broadcast {
         $options{gorgone}->send_internal_message(
             identity => 'gorgone-newtest-' . $container_id,
             action => $options{action},
-            raw_data_ref => $options{frame}->getRawData(),
+            frame => $options{frame},
             token => $options{token}
         );
     }


### PR DESCRIPTION
## Description

Gorgone mbi module stop working every 24-48 hrs 23.04

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x
- [X] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Add following option in ```/etc/centreon-gorgone/config.d/40-gorgoned.yaml``` file (avoid to wait 24h):
```
gorgone:
  gorgonecore:
    internal_com_rotation: 3
```

After 10 minutes, if you try to rebuild with mbi command:
```
2023-06-06 11:20:07 - ERROR - [xxxx] decrypt issue: no message
```

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
