### PR TITLE
fix(test): remove cypress-fail-fast to retrieve test logs

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/plugins.ts
+++ b/centreon/packages/js-config/cypress/e2e/plugins.ts
@@ -6,7 +6,6 @@
 import Docker from 'dockerode';
 import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-preprocessor';
 import webpackPreprocessor from '@cypress/webpack-preprocessor';
-import cypressFailFast from 'cypress-fail-fast/plugin';
 
 const docker = new Docker();
 
@@ -42,8 +41,6 @@ const getWebpackOptions = (config): object => {
 
 export default async (on, config): Promise<void> => {
   await addCucumberPreprocessorPlugin(on, config);
-
-  await cypressFailFast(on, config);
 
   const webpackOptions = await getWebpackOptions(config);
   const options = {

--- a/centreon/packages/js-config/package.json
+++ b/centreon/packages/js-config/package.json
@@ -19,7 +19,6 @@
     "@badeball/cypress-cucumber-preprocessor": "^14.0.0",
     "@tsconfig/node16": "^1.0.4",
     "@types/dockerode": "^3.3.16",
-    "cypress-fail-fast": "^7.0.1",
     "dockerode": "^3.3.5",
     "eslint": "^8.17.0",
     "eslint-config-airbnb": "19.0.4",

--- a/centreon/pnpm-lock.yaml
+++ b/centreon/pnpm-lock.yaml
@@ -298,7 +298,6 @@ importers:
       '@badeball/cypress-cucumber-preprocessor': ^14.0.0
       '@tsconfig/node16': ^1.0.4
       '@types/dockerode': ^3.3.16
-      cypress-fail-fast: ^7.0.1
       dockerode: ^3.3.5
       eslint: ^8.17.0
       eslint-config-airbnb: 19.0.4
@@ -321,7 +320,6 @@ importers:
       '@badeball/cypress-cucumber-preprocessor': 14.0.0
       '@tsconfig/node16': 1.0.4
       '@types/dockerode': 3.3.17
-      cypress-fail-fast: 7.0.1
       dockerode: 3.3.5
       eslint: 8.40.0
       eslint-config-airbnb: 19.0.4_bpcxrudljlqusjwrxiqvxpun2y
@@ -505,7 +503,6 @@ importers:
       '@types/dockerode': ^3.3.16
       '@types/node': ^14.14.44
       cypress: ^12.13.0
-      cypress-fail-fast: ^7.0.1
       cypress-wait-until: ^1.7.2
       dockerode: ^3.3.5
       mochawesome: ^7.1.3
@@ -523,7 +520,6 @@ importers:
       '@types/dockerode': 3.3.17
       '@types/node': 14.18.47
       cypress: 12.13.0
-      cypress-fail-fast: 7.0.1_cypress@12.13.0
       cypress-wait-until: 1.7.2
       dockerode: 3.3.5
       mochawesome: 7.1.3
@@ -9450,25 +9446,6 @@ packages:
     dependencies:
       find-pkg: 0.1.2
       fs-exists-sync: 0.1.0
-    dev: true
-
-  /cypress-fail-fast/7.0.1:
-    resolution: {integrity: sha512-v68bfFTjPrn3+i+mEFmxC6Z2ble9+k8xIeEGeZJQS0HU8A9Q3oE1LEEv1SAqgyaYL06PKw4ifHw/aydO6rNFaw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      cypress: '>=8.0.0'
-    dependencies:
-      chalk: 4.1.2
-    dev: true
-
-  /cypress-fail-fast/7.0.1_cypress@12.13.0:
-    resolution: {integrity: sha512-v68bfFTjPrn3+i+mEFmxC6Z2ble9+k8xIeEGeZJQS0HU8A9Q3oE1LEEv1SAqgyaYL06PKw4ifHw/aydO6rNFaw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      cypress: '>=8.0.0'
-    dependencies:
-      chalk: 4.1.2
-      cypress: 12.13.0
     dev: true
 
   /cypress-msw-interceptor/2.1.0_cypress@12.13.0+msw@0.49.1:

--- a/centreon/tests/e2e/cypress.dev.config.ts
+++ b/centreon/tests/e2e/cypress.dev.config.ts
@@ -1,10 +1,6 @@
 import configuration from '@centreon/js-config/cypress/e2e/configuration';
 
 export default configuration({
-  env: {
-    FAIL_FAST_ENABLED: 'true',
-    FAIL_FAST_STRATEGY: 'spec'
-  },
   isDevelopment: true,
   specPattern: 'cypress/e2e/**/*.feature'
 });

--- a/centreon/tests/e2e/cypress/support/e2e.ts
+++ b/centreon/tests/e2e/cypress/support/e2e.ts
@@ -1,6 +1,5 @@
 import 'cypress-wait-until';
 import './commands';
-import 'cypress-fail-fast';
 
 Cypress.on('uncaught:exception', (err) => {
   if (

--- a/centreon/tests/e2e/package.json
+++ b/centreon/tests/e2e/package.json
@@ -20,7 +20,6 @@
     "@types/dockerode": "^3.3.16",
     "@types/node": "^14.14.44",
     "cypress": "^12.13.0",
-    "cypress-fail-fast": "^7.0.1",
     "cypress-wait-until": "^1.7.2",
     "dockerode": "^3.3.5",
     "mochawesome": "^7.1.3",


### PR DESCRIPTION
## Description

fix(test): remove cypress-fail-fast to retrieve test logs
`After` step is not executed : https://github.com/javierbrea/cypress-fail-fast/issues/88

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)