### PR TITLE
enh(packaging): add perl dependency and ship perl script

### DIFF
--- a/centreon-gorgone/packaging/centreon-gorgone.spectemplate
+++ b/centreon-gorgone/packaging/centreon-gorgone.spectemplate
@@ -82,6 +82,7 @@ mkdir -p %{buildroot}/%{perl_vendorlib}/gorgone
 %{__cp} centreon-gorgone/contrib/gorgone_config_init.pl %{buildroot}%{_usr}/local/bin/
 %{__cp} centreon-gorgone/contrib/gorgone_audit.pl %{buildroot}%{_usr}/local/bin/
 %{__cp} centreon-gorgone/contrib/gorgone_install_plugins.pl %{buildroot}%{_usr}/local/bin/
+%{__cp} centreon-gorgone/contrib/gorgone_key_thumbprint.pl %{buildroot}%{_usr}/local/bin/
 
 %{__install} -d %{buildroot}%{_sysconfdir}/centreon-gorgone
 %{__install} -d %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/

--- a/centreon-gorgone/packaging/centreon-gorgone.spectemplate
+++ b/centreon-gorgone/packaging/centreon-gorgone.spectemplate
@@ -110,6 +110,7 @@ rm -rf %{buildroot}
 %attr(755, root, root) %{_usr}/local/bin/gorgone_config_init.pl
 %attr(755, root, root) %{_usr}/local/bin/gorgone_audit.pl
 %attr(750, root, root) %{_usr}/local/bin/gorgone_install_plugins.pl
+%attr(750, root, root) %{_usr}/local/bin/gorgone_key_thumbprint.pl
 %attr(755, root, root) %{_sysconfdir}/systemd/system/gorgoned.service
 %config(noreplace) %{_sysconfdir}/sysconfig/gorgoned
 %config(noreplace) %{_sysconfdir}/logrotate.d/gorgoned

--- a/centreon-gorgone/packaging/centreon-gorgone.spectemplate
+++ b/centreon-gorgone/packaging/centreon-gorgone.spectemplate
@@ -14,6 +14,7 @@ BuildRequires: perl-devel
 Requires:   bzip2
 Requires:   perl-Libssh-Session >= 0.8
 Requires:   perl-CryptX
+Requires:   perl-Mojolicious
 Requires:   perl(Archive::Tar)
 Requires:   perl(Schedule::Cron)
 Requires:   perl(ZMQ::FFI)


### PR DESCRIPTION
This PR intends to add a perl dependency to centreon-gorgone and also ship a perl script that will be used by cloud automation later on

NB: Nothing has been done on debian packaging
packaging: https://github.com/centreon/centreon/blob/997a24e47cc9a23a6e34bd11eacc74f98173c149/centreon-gorgone/packaging/debian/control#L34

script: https://github.com/centreon/centreon/blob/997a24e47cc9a23a6e34bd11eacc74f98173c149/centreon-gorgone/packaging/debian/centreon-gorgone.install#L4 (already included)




**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
