### PR TITLE
fix(auth): update user ACL with roles provided by the provider

### DIFF
--- a/centreon/src/Core/Security/Authentication/Application/Provider/ProviderAuthenticationInterface.php
+++ b/centreon/src/Core/Security/Authentication/Application/Provider/ProviderAuthenticationInterface.php
@@ -129,4 +129,9 @@ interface ProviderAuthenticationInterface
      * @return array<string,mixed>
      */
     public function getIdTokenPayload(): array;
+
+    /**
+     * @return string[]
+     */
+    public function getAclConditionsMatches(): array;
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/AclUpdater.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/AclUpdater.php
@@ -65,10 +65,9 @@ class AclUpdater implements AclUpdaterInterface
             $customConfiguration = $provider->getConfiguration()->getCustomConfiguration();
             $aclConditions = $customConfiguration->getACLConditions();
             if ($aclConditions->isEnabled()) {
+                $aclConditionMatches = $provider->getAclConditionsMatches();
                 /** @phpstan-ignore-next-line */
-                $claims = $aclConditions->getClaimValues();
-                /** @phpstan-ignore-next-line */
-                $userAccessGroups = $this->provider->getUserAccessGroupsFromClaims($claims);
+                $userAccessGroups = $this->provider->getUserAccessGroupsFromClaims($aclConditionMatches);
                 $this->updateAccessGroupsForUser($user, $userAccessGroups);
             }
 

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Local.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Local.php
@@ -215,4 +215,9 @@ class Local implements ProviderAuthenticationInterface
     {
         return [];
     }
+
+    public function getAclConditionsMatches(): array
+    {
+        return [];
+    }
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/OpenId.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/OpenId.php
@@ -305,4 +305,12 @@ class OpenId implements ProviderAuthenticationInterface
     {
         return $this->provider->getUserContactGroups();
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAclConditionsMatches(): array
+    {
+        return $this->provider->getAclConditionsMatches();
+    }
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
@@ -473,6 +473,14 @@ class SAML implements ProviderAuthenticationInterface
     }
 
     /**
+     * @inheritDoc
+     */
+    public function getAclConditionsMatches(): array
+    {
+        return $this->rolesMapping->getConditionMatches();
+    }
+
+    /**
      * @throws Throwable
      * @throws AssertionFailedException
      */

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/WebSSO.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/WebSSO.php
@@ -334,4 +334,9 @@ class WebSSO implements ProviderAuthenticationInterface
     {
         return [];
     }
+
+    public function getAclConditionsMatches(): array
+    {
+        return [];
+    }
 }


### PR DESCRIPTION
This PR intends to fix an issue regarding ACL update when user logs in using an authentication provider (concerned providers: OpenID + SAML).

Lately what happened is that when user connects using the authentication provider the ACL of the user were deleted and re-created using the claim values configured in the Provider configuration without considering the actual role mappings that matched during the authentication process.


**Fixes** MON-20450

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
