### PR TITLE
fix(auth): update user contactgroups with groups provided by IDP

### DIFF
--- a/centreon/src/Core/Security/Authentication/Application/Provider/ProviderAuthenticationInterface.php
+++ b/centreon/src/Core/Security/Authentication/Application/Provider/ProviderAuthenticationInterface.php
@@ -134,4 +134,9 @@ interface ProviderAuthenticationInterface
      * @return string[]
      */
     public function getAclConditionsMatches(): array;
+
+    /**
+     * @return ContactGroup[]
+     */
+    public function getUserContactGroups(): array;
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/AclUpdater.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/AclUpdater.php
@@ -73,12 +73,7 @@ class AclUpdater implements AclUpdaterInterface
 
             $groupMappings = $customConfiguration->getGroupsMapping();
             if ($groupMappings->isEnabled()) {
-                $contactGroupRelations = $groupMappings->getContactGroupRelations();
-                $contactGroups = [];
-                foreach ($contactGroupRelations as $contactGroupRelation) {
-                    $contactGroups[] = $contactGroupRelation->getContactGroup();
-                }
-                $this->updateContactGroupsForUser($user, $contactGroups);
+                $this->updateContactGroupsForUser($user, $this->provider->getUserContactGroups());
             }
         }
     }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Local.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Local.php
@@ -220,4 +220,9 @@ class Local implements ProviderAuthenticationInterface
     {
         return [];
     }
+
+    public function getUserContactGroups(): array
+    {
+        return [];
+    }
 }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/OpenId.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/OpenId.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace Core\Security\Authentication\Infrastructure\Provider;
 
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use Centreon\Domain\Entity\ContactGroup;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Infrastructure\Service\Exception\NotFoundException;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
@@ -299,7 +298,7 @@ class OpenId implements ProviderAuthenticationInterface
     }
 
     /**
-     * @return ContactGroup[]
+     * @inheritDoc
      */
     public function getUserContactGroups(): array
     {

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
@@ -27,7 +27,6 @@ use Assert\AssertionFailedException;
 use Centreon;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Contact\Interfaces\ContactRepositoryInterface;
-use Centreon\Domain\Entity\ContactGroup;
 use Centreon\Domain\Log\LoggerTrait;
 use CentreonSession;
 use Core\Application\Configuration\User\Repository\WriteUserRepositoryInterface;
@@ -404,11 +403,11 @@ class SAML implements ProviderAuthenticationInterface
     }
 
     /**
-     * @return ContactGroup[]
+     * @inheritDoc
      */
     public function getUserContactGroups(): array
     {
-        return [];
+        return $this->groupsMapping->getUserContactGroups();
     }
 
     public function getIdTokenPayload(): array

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/WebSSO.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/WebSSO.php
@@ -339,4 +339,9 @@ class WebSSO implements ProviderAuthenticationInterface
     {
         return [];
     }
+
+    public function getUserContactGroups(): array
+    {
+        return [];
+    }
 }


### PR DESCRIPTION
This PR intends to fix an issue regarding Contact Group update when user logs in using an authentication provider (concerned providers: OpenID + SAML).

Lately what happened is that when user connects using the authentication provider the Contact Groups of the user were deleted and re-created using the claim values configured in the Provider configuration without considering the actual group mappings that matched during the authentication process.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
