### PR TITLE
enh(arch): move metrics related code into more suitable folders

### DIFF
--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -110,8 +110,8 @@ services:
         class: Core\Infrastructure\Common\Presenter\DownloadPresenter
         arguments: ['@Core\Infrastructure\Common\Presenter\CsvFormatter']
 
-    Core\Infrastructure\RealTime\Api\DownloadPerformanceMetrics\DownloadPerformanceMetricsPresenter:
-        class: Core\Infrastructure\RealTime\Api\DownloadPerformanceMetrics\DownloadPerformanceMetricsPresenter
+    Core\Metric\Infrastructure\API\DownloadPerformanceMetrics\DownloadPerformanceMetricsPresenter:
+        class: Core\Metric\Infrastructure\API\DownloadPerformanceMetrics\DownloadPerformanceMetricsPresenter
         arguments: ['@presenter.download.csv']
 
     # Authentication

--- a/centreon/config/routes/Centreon/monitoring/metric.yaml
+++ b/centreon/config/routes/Centreon/monitoring/metric.yaml
@@ -35,7 +35,7 @@ monitoring.metric.downloadPerformanceMetrics:
     requirements:
         hostId: '\d+'
         serviceId: '\d+'
-    controller: 'Core\Infrastructure\RealTime\Api\DownloadPerformanceMetrics\DownloadPerformanceMetricsController'
+    controller: 'Core\Metric\Infrastructure\API\DownloadPerformanceMetrics\DownloadPerformanceMetricsController'
     condition: "request.attributes.get('version') >= 22.10"
 
 monitoring.metric.getServiceStatusMetrics:

--- a/centreon/src/Core/Application/RealTime/Repository/ReadPerformanceDataRepositoryInterface.php
+++ b/centreon/src/Core/Application/RealTime/Repository/ReadPerformanceDataRepositoryInterface.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace Core\Application\RealTime\Repository;
 
-use Core\Domain\RealTime\Model\Metric;
-use Core\Domain\RealTime\Model\PerformanceMetric;
+use Core\Metric\Domain\Model\Metric;
+use Core\Metric\Domain\Model\PerformanceMetric;
 use DateTimeInterface;
 
 interface ReadPerformanceDataRepositoryInterface

--- a/centreon/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
@@ -26,9 +26,9 @@ namespace Core\Infrastructure\RealTime\Repository\DataBin;
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
 use Core\Application\RealTime\Repository\ReadPerformanceDataRepositoryInterface;
-use Core\Domain\RealTime\Model\Metric;
-use Core\Domain\RealTime\Model\MetricValue;
-use Core\Domain\RealTime\Model\PerformanceMetric;
+use Core\Metric\Domain\Model\Metric;
+use Core\Metric\Domain\Model\MetricValue;
+use Core\Metric\Domain\Model\PerformanceMetric;
 use DateTimeInterface;
 use PDO;
 

--- a/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
+++ b/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
@@ -21,10 +21,16 @@
 
 declare(strict_types=1);
 
-namespace Core\Application\RealTime\UseCase\FindPerformanceMetrics;
+namespace Core\Metric\Application\Repository;
 
-use Core\Application\Common\UseCase\PresenterInterface;
+use Core\Metric\Domain\Model\Metric;
 
-interface FindPerformanceMetricPresenterInterface extends PresenterInterface
+interface ReadMetricRepositoryInterface
 {
+    /**
+     * @param int $indexId
+     *
+     * @return array<Metric>
+     */
+    public function findMetricsByIndexId(int $indexId): array;
 }

--- a/centreon/src/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricPresenterInterface.php
+++ b/centreon/src/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricPresenterInterface.php
@@ -21,23 +21,10 @@
 
 declare(strict_types=1);
 
-namespace Core\Application\RealTime\UseCase\FindPerformanceMetrics;
+namespace Core\Metric\Application\UseCase\DownloadPerformanceMetrics;
 
-use DateTimeInterface;
+use Core\Application\Common\UseCase\PresenterInterface;
 
-class FindPerformanceMetricRequest
+interface DownloadPerformanceMetricPresenterInterface extends PresenterInterface
 {
-    /**
-     * @param int $hostId
-     * @param int $serviceId
-     * @param DateTimeInterface $startDate
-     * @param DateTimeInterface $endDate
-     */
-    public function __construct(
-        public int $hostId,
-        public int $serviceId,
-        public DateTimeInterface $startDate,
-        public DateTimeInterface $endDate
-    ) {
-    }
 }

--- a/centreon/src/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricRequest.php
+++ b/centreon/src/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricRequest.php
@@ -21,43 +21,23 @@
 
 declare(strict_types=1);
 
-namespace Core\Domain\RealTime\Model;
+namespace Core\Metric\Application\UseCase\DownloadPerformanceMetrics;
 
 use DateTimeInterface;
 
-class PerformanceMetric
+class DownloadPerformanceMetricRequest
 {
     /**
-     * @param DateTimeInterface $dateValue
-     * @param MetricValue[] $metricValues
+     * @param int $hostId
+     * @param int $serviceId
+     * @param DateTimeInterface $startDate
+     * @param DateTimeInterface $endDate
      */
     public function __construct(
-        private DateTimeInterface $dateValue,
-        private array $metricValues = []
+        public int $hostId,
+        public int $serviceId,
+        public DateTimeInterface $startDate,
+        public DateTimeInterface $endDate
     ) {
-    }
-
-    /**
-     * @param MetricValue $metricValue
-     */
-    public function addMetricValue(MetricValue $metricValue): void
-    {
-        $this->metricValues[] = $metricValue;
-    }
-
-    /**
-     * @return MetricValue[]
-     */
-    public function getMetricValues(): array
-    {
-        return $this->metricValues;
-    }
-
-    /**
-     * @return DateTimeInterface
-     */
-    public function getDateValue(): DateTimeInterface
-    {
-        return $this->dateValue;
     }
 }

--- a/centreon/src/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricResponse.php
+++ b/centreon/src/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricResponse.php
@@ -21,11 +21,11 @@
 
 declare(strict_types=1);
 
-namespace Core\Application\RealTime\UseCase\FindPerformanceMetrics;
+namespace Core\Metric\Application\UseCase\DownloadPerformanceMetrics;
 
-use Core\Domain\RealTime\Model\PerformanceMetric;
+use Core\Metric\Domain\Model\PerformanceMetric;
 
-class FindPerformanceMetricResponse
+class DownloadPerformanceMetricResponse
 {
     /** @var PerformanceMetric[] */
     public iterable $performanceMetrics = [];

--- a/centreon/src/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetrics.php
+++ b/centreon/src/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetrics.php
@@ -21,17 +21,17 @@
 
 declare(strict_types=1);
 
-namespace Core\Application\RealTime\UseCase\FindPerformanceMetrics;
+namespace Core\Metric\Application\UseCase\DownloadPerformanceMetrics;
 
 use Centreon\Domain\Log\LoggerTrait;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
 use Core\Application\RealTime\Repository\ReadIndexDataRepositoryInterface;
-use Core\Application\RealTime\Repository\ReadMetricRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadPerformanceDataRepositoryInterface;
 use Core\Domain\RealTime\Model\IndexData;
+use Core\Metric\Application\Repository\ReadMetricRepositoryInterface;
 
-class FindPerformanceMetrics
+class DownloadPerformanceMetrics
 {
     use LoggerTrait;
 
@@ -48,11 +48,11 @@ class FindPerformanceMetrics
     }
 
     /**
-     * @param FindPerformanceMetricRequest $request
+     * @param DownloadPerformanceMetricRequest $request
      * @param FindPerformanceMetricPresenterInterface $presenter
      */
     public function __invoke(
-        FindPerformanceMetricRequest $request,
+        DownloadPerformanceMetricRequest $request,
         PresenterInterface $presenter
     ): void {
         try {
@@ -75,7 +75,7 @@ class FindPerformanceMetrics
 
             $fileName = $this->generateDownloadFileNameByIndex($index);
             $this->info('Filename used to download metrics', ['filename' => $fileName]);
-            $presenter->present(new FindPerformanceMetricResponse($performanceMetrics, $fileName));
+            $presenter->present(new DownloadPerformanceMetricResponse($performanceMetrics, $fileName));
         } catch (\Throwable $ex) {
             $this->error(
                 'Impossible to retrieve performance metrics',

--- a/centreon/src/Core/Metric/Domain/Model/Metric.php
+++ b/centreon/src/Core/Metric/Domain/Model/Metric.php
@@ -21,20 +21,31 @@
 
 declare(strict_types=1);
 
-namespace Core\Infrastructure\RealTime\Api\DownloadPerformanceMetrics;
+namespace Core\Metric\Domain\Model;
 
-use Core\Application\Common\UseCase\AbstractPresenter;
-use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetricResponse;
-
-class DownloadPerformanceMetricsPresenter extends AbstractPresenter
+class Metric
 {
     /**
-     * {@inheritDoc}
-     *
-     * @param FindPerformanceMetricResponse $data
+     * @param int $id
+     * @param string $name
      */
-    public function present(mixed $data): void
+    public function __construct(private int $id, private string $name)
     {
-        parent::present($data);
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName(): string
+    {
+        return $this->name;
     }
 }

--- a/centreon/src/Core/Metric/Domain/Model/MetricValue.php
+++ b/centreon/src/Core/Metric/Domain/Model/MetricValue.php
@@ -21,24 +21,16 @@
 
 declare(strict_types=1);
 
-namespace Core\Domain\RealTime\Model;
+namespace Core\Metric\Domain\Model;
 
-class Metric
+class MetricValue
 {
     /**
-     * @param int $id
      * @param string $name
+     * @param float $value
      */
-    public function __construct(private int $id, private string $name)
+    public function __construct(private string $name, private float $value)
     {
-    }
-
-    /**
-     * @return int
-     */
-    public function getId(): int
-    {
-        return $this->id;
     }
 
     /**
@@ -47,5 +39,13 @@ class Metric
     public function getName(): string
     {
         return $this->name;
+    }
+
+    /**
+     * @return float
+     */
+    public function getValue(): float
+    {
+        return $this->value;
     }
 }

--- a/centreon/src/Core/Metric/Domain/Model/PerformanceMetric.php
+++ b/centreon/src/Core/Metric/Domain/Model/PerformanceMetric.php
@@ -21,31 +21,43 @@
 
 declare(strict_types=1);
 
-namespace Core\Domain\RealTime\Model;
+namespace Core\Metric\Domain\Model;
 
-class MetricValue
+use DateTimeInterface;
+
+class PerformanceMetric
 {
     /**
-     * @param string $name
-     * @param float $value
+     * @param DateTimeInterface $dateValue
+     * @param MetricValue[] $metricValues
      */
-    public function __construct(private string $name, private float $value)
-    {
+    public function __construct(
+        private DateTimeInterface $dateValue,
+        private array $metricValues = []
+    ) {
     }
 
     /**
-     * @return string
+     * @param MetricValue $metricValue
      */
-    public function getName(): string
+    public function addMetricValue(MetricValue $metricValue): void
     {
-        return $this->name;
+        $this->metricValues[] = $metricValue;
     }
 
     /**
-     * @return float
+     * @return MetricValue[]
      */
-    public function getValue(): float
+    public function getMetricValues(): array
     {
-        return $this->value;
+        return $this->metricValues;
+    }
+
+    /**
+     * @return DateTimeInterface
+     */
+    public function getDateValue(): DateTimeInterface
+    {
+        return $this->dateValue;
     }
 }

--- a/centreon/src/Core/Metric/Infrastructure/API/DownloadPerformanceMetrics/DownloadPerformanceMetricsController.php
+++ b/centreon/src/Core/Metric/Infrastructure/API/DownloadPerformanceMetrics/DownloadPerformanceMetricsController.php
@@ -21,11 +21,11 @@
 
 declare(strict_types=1);
 
-namespace Core\Infrastructure\RealTime\Api\DownloadPerformanceMetrics;
+namespace Core\Metric\Infrastructure\API\DownloadPerformanceMetrics;
 
 use Centreon\Application\Controller\AbstractController;
-use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetricRequest;
-use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetrics;
+use Core\Metric\Application\UseCase\DownloadPerformanceMetrics\DownloadPerformanceMetricRequest;
+use Core\Metric\Application\UseCase\DownloadPerformanceMetrics\DownloadPerformanceMetrics;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -42,12 +42,12 @@ class DownloadPerformanceMetricsController extends AbstractController
 
     private Request $request;
 
-    private FindPerformanceMetricRequest $performanceMetricRequest;
+    private DownloadPerformanceMetricRequest $performanceMetricRequest;
 
     public function __invoke(
         int $hostId,
         int $serviceId,
-        FindPerformanceMetrics $useCase,
+        DownloadPerformanceMetrics $useCase,
         Request $request,
         DownloadPerformanceMetricsPresenter $presenter
     ): Response {
@@ -72,7 +72,7 @@ class DownloadPerformanceMetricsController extends AbstractController
         $this->findStartDate();
         $this->findEndDate();
 
-        $this->performanceMetricRequest = new FindPerformanceMetricRequest(
+        $this->performanceMetricRequest = new DownloadPerformanceMetricRequest(
             $hostId,
             $serviceId,
             $this->startDate,

--- a/centreon/src/Core/Metric/Infrastructure/API/DownloadPerformanceMetrics/DownloadPerformanceMetricsPresenter.php
+++ b/centreon/src/Core/Metric/Infrastructure/API/DownloadPerformanceMetrics/DownloadPerformanceMetricsPresenter.php
@@ -21,16 +21,20 @@
 
 declare(strict_types=1);
 
-namespace Core\Application\RealTime\Repository;
+namespace Core\Metric\Infrastructure\API\DownloadPerformanceMetrics;
 
-use Core\Domain\RealTime\Model\Metric;
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetricResponse;
 
-interface ReadMetricRepositoryInterface
+class DownloadPerformanceMetricsPresenter extends AbstractPresenter
 {
     /**
-     * @param int $indexId
+     * {@inheritDoc}
      *
-     * @return array<Metric>
+     * @param FindPerformanceMetricResponse $data
      */
-    public function findMetricsByIndexId(int $indexId): array;
+    public function present(mixed $data): void
+    {
+        parent::present($data);
+    }
 }

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
@@ -25,7 +25,6 @@ namespace Core\Metric\Infrastructure\Repository;
 
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
-
 use Core\Metric\Application\Repository\ReadMetricRepositoryInterface;
 use Core\Metric\Domain\Model\Metric;
 

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
@@ -21,12 +21,12 @@
 
 declare(strict_types=1);
 
-namespace Core\Infrastructure\RealTime\Repository\FindMetric;
+namespace Core\Metric\Infrastructure\Repository;
 
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
-use Core\Application\RealTime\Repository\ReadMetricRepositoryInterface;
 use Core\Domain\RealTime\Model\Metric;
+use Core\Metric\Application\Repository\ReadMetricRepositoryInterface;
 
 class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetricRepositoryInterface
 {

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
@@ -25,8 +25,9 @@ namespace Core\Metric\Infrastructure\Repository;
 
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\Repository\AbstractRepositoryDRB;
-use Core\Domain\RealTime\Model\Metric;
+
 use Core\Metric\Application\Repository\ReadMetricRepositoryInterface;
+use Core\Metric\Domain\Model\Metric;
 
 class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetricRepositoryInterface
 {

--- a/centreon/tests/php/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricResponseTest.php
+++ b/centreon/tests/php/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricResponseTest.php
@@ -21,12 +21,12 @@
 
 declare(strict_types=1);
 
-namespace Tests\Core\Application\RealTime\UseCase\FindPerformanceMetrics;
+namespace Tests\Core\Metric\Application\UseCase\DownloadPerformanceMetrics;
 
+use Core\Metric\Application\UseCase\DownloadPerformanceMetrics\DownloadPerformanceMetricResponse;
+use Core\Metric\Domain\Model\MetricValue;
+use Core\Metric\Domain\Model\PerformanceMetric;
 use DateTimeImmutable;
-use Core\Domain\RealTime\Model\PerformanceMetric;
-use Core\Domain\RealTime\Model\MetricValue;
-use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetricResponse;
 
 function createPerformanceMetric(
     string $date,
@@ -64,7 +64,7 @@ function generateExpectedResponseData(string $date, float $rta, float $packetLos
 it(
     'response contains properly formatted performanceMetrics',
     function (iterable $performanceMetrics, array $expectedResponseData, string $filename) {
-        $response = new FindPerformanceMetricResponse($performanceMetrics, $filename);
+        $response = new DownloadPerformanceMetricResponse($performanceMetrics, $filename);
 
         $this->assertTrue(property_exists($response, 'performanceMetrics'));
         $this->assertInstanceOf(\Generator::class, $response->performanceMetrics);

--- a/centreon/tests/php/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricsTest.php
+++ b/centreon/tests/php/Core/Metric/Application/UseCase/DownloadPerformanceMetrics/DownloadPerformanceMetricsTest.php
@@ -21,19 +21,19 @@
 
 declare(strict_types=1);
 
-namespace Tests\Core\Application\RealTime\UseCase\FindPerformanceMetrics;
+namespace Tests\Core\Metric\Application\UseCase\DownloadPerformanceMetrics;
 
 use Core\Domain\RealTime\Model\IndexData;
 use DateTimeImmutable;
-use Core\Domain\RealTime\Model\MetricValue;
-use Core\Domain\RealTime\Model\PerformanceMetric;
-use Core\Application\RealTime\Repository\ReadMetricRepositoryInterface;
+use Core\Metric\Domain\Model\MetricValue;
+use Core\Metric\Domain\Model\PerformanceMetric;
+use Core\Metric\Application\Repository\ReadMetricRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadIndexDataRepositoryInterface;
 use Core\Application\RealTime\Repository\ReadPerformanceDataRepositoryInterface;
-use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetrics;
-use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetricRequest;
-use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetricResponse;
-use Core\Application\RealTime\UseCase\FindPerformanceMetrics\FindPerformanceMetricPresenterInterface;
+use Core\Metric\Application\UseCase\DownloadPerformanceMetrics\DownloadPerformanceMetricPresenterInterface;
+use Core\Metric\Application\UseCase\DownloadPerformanceMetrics\DownloadPerformanceMetrics;
+use Core\Metric\Application\UseCase\DownloadPerformanceMetrics\DownloadPerformanceMetricRequest;
+use Core\Metric\Application\UseCase\DownloadPerformanceMetrics\DownloadPerformanceMetricResponse;
 
 beforeEach(function () {
     $this->hostId = 1;
@@ -63,16 +63,16 @@ it(
 
         $metricRepository = $this->createMock(ReadMetricRepositoryInterface::class);
         $performanceDataRepository = $this->createMock(ReadPerformanceDataRepositoryInterface::class);
-        $presenter = $this->createMock(FindPerformanceMetricPresenterInterface::class);
+        $presenter = $this->createMock(DownloadPerformanceMetricPresenterInterface::class);
 
-        $performanceMetricRequest = new FindPerformanceMetricRequest(
+        $performanceMetricRequest = new DownloadPerformanceMetricRequest(
             $this->hostId,
             $this->serviceId,
             new DateTimeImmutable('2022-01-01'),
             new DateTimeImmutable('2023-01-01')
         );
 
-        $sut = new FindPerformanceMetrics($indexDataRepository, $metricRepository, $performanceDataRepository);
+        $sut = new DownloadPerformanceMetrics($indexDataRepository, $metricRepository, $performanceDataRepository);
 
         $sut($performanceMetricRequest, $presenter);
     }
@@ -85,7 +85,7 @@ it(
 
 it(
     'validate presenter response',
-    function (iterable $performanceData, FindPerformanceMetricResponse $expectedResponse) {
+    function (iterable $performanceData, DownloadPerformanceMetricResponse $expectedResponse) {
         $indexDataRepository = $this->createMock(ReadIndexDataRepositoryInterface::class);
         $indexDataRepository
             ->expects($this->once())
@@ -107,26 +107,26 @@ it(
             ->method('findDataByMetricsAndDates')
             ->willReturn($performanceData);
 
-        $presenter = $this->createMock(FindPerformanceMetricPresenterInterface::class);
+        $presenter = $this->createMock(DownloadPerformanceMetricPresenterInterface::class);
         $presenter
             ->expects($this->once())
             ->method('present')
             ->with($this->equalTo($expectedResponse));
 
-        $performanceMetricRequest = new FindPerformanceMetricRequest(
+        $performanceMetricRequest = new DownloadPerformanceMetricRequest(
             $this->hostId,
             $this->serviceId,
             new DateTimeImmutable('2022-02-01'),
             new DateTimeImmutable('2023-01-01')
         );
 
-        $sut = new FindPerformanceMetrics($indexDataRepository, $metricRepository, $performanceDataRepository);
+        $sut = new DownloadPerformanceMetrics($indexDataRepository, $metricRepository, $performanceDataRepository);
         $sut($performanceMetricRequest, $presenter);
     }
 )->with([
     [
         [['rta' => 0.01]],
-        new FindPerformanceMetricResponse(
+        new DownloadPerformanceMetricResponse(
             [
                 new PerformanceMetric(
                     new DateTimeImmutable(),
@@ -138,7 +138,7 @@ it(
     ],
     [
         [['rta' => 0.01], ['pl' => 0.02]],
-        new FindPerformanceMetricResponse(
+        new DownloadPerformanceMetricResponse(
             [
                 new PerformanceMetric(
                     new DateTimeImmutable(),


### PR DESCRIPTION
## Description

this PR intends to move existing metrics related code into more suitable folders to follow the current backend architecture
**Fixes** # MON-20824

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [x] codebase enhancement

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Exports graph in CSV through Performances > Graph page or through Resource Status Graph Panel
No regression should occurs

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
