### PR TITLE
fix(graph): correctly handle negative metric values for min/max/avg

### DIFF
--- a/centreon/www/class/centreonGraphNg.class.php
+++ b/centreon/www/class/centreonGraphNg.class.php
@@ -1107,6 +1107,7 @@ class CentreonGraphNg
             $metric['minimum_value'] = null;
             $metric['maximum_value'] = null;
             $metric['average_value'] = null;
+            $lastValue = null;
             $minimumValue = null;
             $maximumValue = null;
             $averageValue = null;


### PR DESCRIPTION
This PR intends to handle correctly negative values for metrics when gathering information for MAX/MIN/AVG from rrdfiles.
The initial regexp did not match when there was a negative sign before the value.

**Fixes** # REF: MON-16501
## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for the tests

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
