### PR TITLE
fix(gorgone): mbi module is stuck after internal key rotate (again)

### DIFF
--- a/centreon-gorgone/gorgone/class/core.pm
+++ b/centreon-gorgone/gorgone/class/core.pm
@@ -564,6 +564,8 @@ sub send_internal_response {
             $self->{logger}->writeLogError("[core] encrypt issue: $_");
             return undef;
         };
+
+        $message = MIME::Base64::encode_base64($message, '');
     }
 
     $self->{internal_socket}->send(pack('H*', $options{identity}), ZMQ_DONTWAIT | ZMQ_SNDMORE);
@@ -590,6 +592,8 @@ sub send_internal_message {
             $self->{logger}->writeLogError("[core] encrypt issue: $_");
             return undef;
         };
+
+        $message = MIME::Base64::encode_base64($message, '');
     }
 
     $self->{internal_socket}->send($options{identity}, ZMQ_DONTWAIT | ZMQ_SNDMORE);

--- a/centreon-gorgone/gorgone/class/frame.pm
+++ b/centreon-gorgone/gorgone/class/frame.pm
@@ -25,6 +25,7 @@ use warnings;
 
 use JSON::XS;
 use Try::Tiny;
+use MIME::Base64;
 
 sub new {
     my ($class, %options) = @_;
@@ -76,7 +77,7 @@ sub decrypt {
 
     my $plaintext;
     try {
-        $plaintext = $options->{cipher}->decrypt(${$self->{frame}}, $options->{key}, $options->{iv});
+        $plaintext = $options->{cipher}->decrypt(MIME::Base64::decode_base64(${$self->{frame}}), $options->{key}, $options->{iv});
     };
     if (defined($plaintext) && $plaintext =~ /^\[[A-Za-z0-9_\-]+?\]/) {
         $self->{frame} = \$plaintext;

--- a/centreon-gorgone/gorgone/class/module.pm
+++ b/centreon-gorgone/gorgone/class/module.pm
@@ -32,6 +32,7 @@ use JSON::XS;
 use Crypt::Mode::CBC;
 use Try::Tiny;
 use EV;
+use MIME::Base64;
 
 my %handlers = (DIE => {});
 
@@ -171,7 +172,7 @@ sub read_message {
         } else {
             my $plaintext;
             try {
-                $plaintext = $self->{cipher}->decrypt($message, $key, $self->{internal_crypt}->{iv});
+                $plaintext = $self->{cipher}->decrypt(MIME::Base64::decode_base64($message), $key, $self->{internal_crypt}->{iv});
             };
             if (defined($plaintext) && $plaintext =~ /^\[[A-Za-z_\-]+?\]/) {
                 $message = undef;
@@ -188,7 +189,7 @@ sub read_message {
     return (undef, 1);
 }
 
-sub send_internal_key {
+sub renew_internal_key {
     my ($self, %options) = @_;
 
     my $message = gorgone::standard::library::build_protocol(
@@ -203,9 +204,7 @@ sub send_internal_key {
         return -1;
     };
 
-    $options{socket}->send($message, ZMQ_DONTWAIT);
-    $self->event(socket => $options{socket});
-    return 0;
+    return (0, $message);
 }
 
 sub send_internal_action {
@@ -222,6 +221,7 @@ sub send_internal_action {
     }
 
     my $socket = defined($options->{socket}) ? $options->{socket} : $self->{internal_socket};
+    my $message_key;
     if ($self->{internal_crypt}->{enabled} == 1) {
         my $identity = gorgone::standard::library::zmq_get_routing_id(socket => $socket);
 
@@ -232,18 +232,20 @@ sub send_internal_action {
                 my ($rv, $genkey) = gorgone::standard::library::generate_symkey(
                     keysize => $self->get_core_config(name => 'internal_com_keysize')
                 );
-                ($rv) = $self->send_internal_key(
-                    socket => $socket,
+
+                ($rv, $message_key) = $self->renew_internal_key(
                     key => $genkey,
                     encrypt_key => defined($self->{internal_crypt}->{identity_keys}->{$identity}) ?
                         $self->{internal_crypt}->{identity_keys}->{$identity}->{key} : $self->{internal_crypt}->{core_keys}->[0]
                 );
                 return undef if ($rv == -1);
+
                 $self->{internal_crypt}->{identity_keys}->{$identity} = {
                     key => $genkey,
                     ctime => time()
                 };
             }
+
             $key = $self->{internal_crypt}->{identity_keys}->{$identity}->{key};
         }
 
@@ -253,8 +255,11 @@ sub send_internal_action {
             $self->{logger}->writeLogError("[$self->{module_id}]$self->{container} encrypt issue: $_");
             return undef;
         };
+
+        $options->{message} = MIME::Base64::encode_base64($options->{message}, '');
     }
 
+    $socket->send(MIME::Base64::encode_base64($message_key, ''), ZMQ_DONTWAIT) if (defined($message_key));
     $socket->send($options->{message}, ZMQ_DONTWAIT);
     $self->event(socket => $socket);
 }

--- a/centreon-gorgone/gorgone/modules/centreon/mbi/etlworkers/class.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/mbi/etlworkers/class.pm
@@ -296,6 +296,8 @@ sub periodic_exec {
         $connector->{logger}->writeLogInfo("[" . $connector->{module_id} . "] $$ has quit");
         exit(0);
     }
+
+    $connector->event();
 }
 
 sub run {


### PR DESCRIPTION
## Description

The cypher could not pass everytime through the network. So it is now base64 encoded.

**Fixes** MON-20909

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)
