### PR TITLE
fix(update wizard): Avoid cb_module_idx01 Integrity constraint violation

### DIFF
--- a/centreon/www/install/php/Update-22.10.0-beta.1.php
+++ b/centreon/www/install/php/Update-22.10.0-beta.1.php
@@ -304,7 +304,7 @@ function linkFieldsToStreamType(CentreonDB $pearDB, int $streamTypeId, array $fi
  */
 function insertStreams(CentreonDB $pearDB): array
 {
-    $pearDB->query("INSERT INTO cb_module VALUES (NULL, 'BBDO', NULL, NULL, 0, 1)");
+    $pearDB->query("INSERT INTO cb_module VALUES (NULL, 'BBDO', NULL, NULL, 0, 1) ON DUPLICATE KEY UPDATE name='BBDO', libname=NULL, loading_pos=NULL, is_bundle=0, is_activated=1");
     $moduleId = $pearDB->lastInsertId();
 
     $stmt = $pearDB->prepare(


### PR DESCRIPTION
## Description
Add "ON DUPLICATE KEY UPDATE" statement to avoid cb_module_idx01 Integrity constraint violation when calling insertStreams()

**Fixes** # MON-20910

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)