### PR TITLE
[dev-22.10.x] fix(downtimes): Removed author_id property from POST requests in downtime endpoints (#1982)

### DIFF
--- a/centreon/config/json_validator/latest/Centreon/Downtime/Downtime.json
+++ b/centreon/config/json_validator/latest/Centreon/Downtime/Downtime.json
@@ -19,9 +19,6 @@
         "duration": {
             "type": "integer"
         },
-        "author_id": {
-            "type": "integer"
-        },
         "comment": {
             "type": "string"
         },

--- a/centreon/config/json_validator/latest/Centreon/Downtime/DowntimeResources.json
+++ b/centreon/config/json_validator/latest/Centreon/Downtime/DowntimeResources.json
@@ -24,9 +24,6 @@
                 "duration": {
                     "type": "integer"
                 },
-                "author_id": {
-                    "type": "integer"
-                },
                 "comment": {
                     "type": "string"
                 },

--- a/centreon/config/json_validator/latest/Centreon/Downtime/Downtimes.json
+++ b/centreon/config/json_validator/latest/Centreon/Downtime/Downtimes.json
@@ -27,9 +27,6 @@
             "duration": {
                 "type": "integer"
             },
-            "author_id": {
-                "type": "integer"
-            },
             "comment": {
                 "type": "string"
             },

--- a/centreon/doc/API/centreon-api-v22.10.yaml
+++ b/centreon/doc/API/centreon-api-v22.10.yaml
@@ -5874,10 +5874,6 @@ components:
           type: integer
           description: "Downtime duration in seconds"
           example: 3600
-        author_id:
-          type: integer
-          description: "ID of the contact who requested the downtime"
-          example: 3
         comment:
           type: string
           description: "Comment of the downtime"


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/1982 to 22.10

**Fixes** # MON-20919

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
