### PR TITLE
Tests(E2E): Authentication - SAML - Allow users auto import

### DIFF
--- a/centreon/tests/e2e/cypress/commons.ts
+++ b/centreon/tests/e2e/cypress/commons.ts
@@ -298,6 +298,25 @@ const checkIfConfigurationIsExported = ({
   });
 };
 
+const getUserContactId = (userName: string): Cypress.Chainable => {
+  const query = `SELECT contact_id FROM contact WHERE contact_alias = '${userName}';`;
+  const command = `docker exec -i ${Cypress.env(
+    'dockerName'
+  )} mysql -ucentreon -pcentreon centreon -e "${query}"`;
+
+  return cy
+    .exec(command, { failOnNonZeroExit: true, log: true })
+    .then(({ code, stdout, stderr }) => {
+      if (!stderr && code === 0) {
+        const idUser = parseInt(stdout.split('\n')[1], 10);
+
+        return cy.wrap(idUser || '0');
+      }
+
+      return cy.log(`Can't execute command on database.`);
+    });
+};
+
 export {
   ActionClapi,
   SubmitResult,
@@ -314,5 +333,6 @@ export {
   loginAsAdminViaApiV2,
   insertFixture,
   logout,
-  checkIfConfigurationIsExported
+  checkIfConfigurationIsExported,
+  getUserContactId
 };

--- a/centreon/tests/e2e/cypress/e2e/Authentication/Local-authentication/01-local-authentication/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/Local-authentication/01-local-authentication/index.ts
@@ -2,12 +2,12 @@
 import { When, Then, Given } from '@badeball/cypress-cucumber-preprocessor';
 
 import {
-  getUserContactId,
   initializeConfigACLAndGetLoginPage,
   millisecondsValueForSixMonth,
   millisecondsValueForFourHour,
   checkDefaultsValueForm
 } from '../common';
+import { getUserContactId } from '../../../../commons';
 
 before(() => {
   cy.startWebContainer();

--- a/centreon/tests/e2e/cypress/e2e/Authentication/Local-authentication/common.ts
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/Local-authentication/common.ts
@@ -40,25 +40,6 @@ const removeContact = (): Cypress.Chainable => {
   });
 };
 
-const getUserContactId = (userName: string): Cypress.Chainable => {
-  const query = `SELECT contact_id FROM contact WHERE contact_name = '${userName}';`;
-  const command = `docker exec -i ${Cypress.env(
-    'dockerName'
-  )} mysql -ucentreon -pcentreon centreon <<< "${query}"`;
-
-  return cy
-    .exec(command, { failOnNonZeroExit: true, log: true })
-    .then(({ code, stdout, stderr }) => {
-      if (!stderr && code === 0) {
-        const idUser = parseInt(stdout.split('\n')[1], 10);
-
-        return cy.wrap(idUser || '0');
-      }
-
-      return cy.log(`Can't execute command on database.`);
-    });
-};
-
 const checkDefaultsValueForm: Array<DataToUseForCheckForm> = [
   {
     selector: '#Minimumpasswordlength',
@@ -160,7 +141,6 @@ const checkDefaultsValueForm: Array<DataToUseForCheckForm> = [
 export {
   millisecondsValueForSixMonth,
   millisecondsValueForFourHour,
-  getUserContactId,
   removeContact,
   initializeConfigACLAndGetLoginPage,
   checkDefaultsValueForm,

--- a/centreon/tests/e2e/cypress/e2e/Authentication/OpenID-connect/04-oidc-authentication-auto-import/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/OpenID-connect/04-oidc-authentication-auto-import/index.ts
@@ -1,6 +1,7 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 
-import { configureOpenIDConnect, getUserContactId } from '../common';
+import { configureOpenIDConnect } from '../common';
+import { getUserContactId } from '../../../../commons';
 
 before(() => {
   cy.startWebContainer().startOpenIdProviderContainer();

--- a/centreon/tests/e2e/cypress/e2e/Authentication/OpenID-connect/06-oidc-authentication-contact-groups/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/OpenID-connect/06-oidc-authentication-contact-groups/index.ts
@@ -2,9 +2,9 @@ import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
 
 import {
   configureOpenIDConnect,
-  getUserContactId,
   initializeOIDCUserAndGetLoginPage
 } from '../common';
+import { getUserContactId } from '../../../../commons';
 
 before(() => {
   cy.startWebContainer()

--- a/centreon/tests/e2e/cypress/e2e/Authentication/OpenID-connect/common.ts
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/OpenID-connect/common.ts
@@ -60,25 +60,6 @@ const configureOpenIDConnect = (): Cypress.Chainable => {
   });
 };
 
-const getUserContactId = (userName: string): Cypress.Chainable => {
-  const query = `SELECT contact_id FROM contact WHERE contact_alias = '${userName}';`;
-  const command = `docker exec -i ${Cypress.env(
-    'dockerName'
-  )} mysql -ucentreon -pcentreon centreon -e "${query}"`;
-
-  return cy
-    .exec(command, { failOnNonZeroExit: true, log: true })
-    .then(({ code, stdout, stderr }) => {
-      if (!stderr && code === 0) {
-        const idUser = parseInt(stdout.split('\n')[1], 10);
-
-        return cy.wrap(idUser || '0');
-      }
-
-      return cy.log(`Can't execute command on database.`);
-    });
-};
-
 const getAccessGroupId = (accessGroupName: string): Cypress.Chainable => {
   const query = `SELECT acl_group_id FROM acl_groups WHERE acl_group_name = '${accessGroupName}';`;
   const command = `docker exec -i ${Cypress.env(
@@ -102,6 +83,5 @@ export {
   removeContact,
   initializeOIDCUserAndGetLoginPage,
   configureOpenIDConnect,
-  getUserContactId,
   getAccessGroupId
 };

--- a/centreon/tests/e2e/cypress/e2e/Authentication/SAML/02-saml-authentication-only.feature
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/SAML/02-saml-authentication-only.feature
@@ -4,8 +4,6 @@ Feature: SAML authentication
     So that Platform users can use existing authentication services to authenticate
 
 Background:
-    Given an administrator is logged on the platform
-
     Scenario: SAML Authentication mode 
         Given an administrator is logged on the platform
         When the administrator sets authentication mode to SAML only

--- a/centreon/tests/e2e/cypress/e2e/Authentication/SAML/02-saml-authentication-only/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/SAML/02-saml-authentication-only/index.ts
@@ -8,7 +8,7 @@ import {
 
 before(() => {
   cy.startWebContainer()
-    .startOpenIdProviderContainer()
+    // .startOpenIdProviderContainer()
     .then(() => {
       initializeSAMLUser();
     });

--- a/centreon/tests/e2e/cypress/e2e/Authentication/SAML/02-saml-authentication-only/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/SAML/02-saml-authentication-only/index.ts
@@ -8,7 +8,7 @@ import {
 
 before(() => {
   cy.startWebContainer()
-    // .startOpenIdProviderContainer()
+    .startOpenIdProviderContainer()
     .then(() => {
       initializeSAMLUser();
     });

--- a/centreon/tests/e2e/cypress/e2e/Authentication/SAML/03-saml-authentication-auto-import.feature
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/SAML/03-saml-authentication-auto-import.feature
@@ -1,0 +1,9 @@
+Feature: SAML authentication
+    As an admin of Centreon Platform
+    I want to be able to make use of an external authentication provider
+    So that Platform users can use existing authentication services to authenticate
+    
+Scenario: Import users from 3rd party authentication service upon their first login
+    Given an administrator is logged on the platform
+    When the administrator activates the auto-import option for SAML
+    Then the users from the 3rd party authentication service with the contact template are imported

--- a/centreon/tests/e2e/cypress/e2e/Authentication/SAML/03-saml-authentication-auto-import/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/SAML/03-saml-authentication-auto-import/index.ts
@@ -1,0 +1,142 @@
+/* eslint-disable cypress/unsafe-to-chain-command */
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+
+import { configureSAML, navigateToSAMLConfigPage } from '../common';
+import { getUserContactId } from '../../../../commons';
+
+before(() => {
+  cy.startWebContainer().startOpenIdProviderContainer();
+});
+
+beforeEach(() => {
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
+  }).as('getNavigationList');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/latest/administration/authentication/providers/saml'
+  }).as('getSAMLProvider');
+  cy.intercept({
+    method: 'GET',
+    url: '/centreon/api/latest/authentication/providers/configurations'
+  }).as('getCentreonAuthConfigs');
+  cy.intercept({
+    method: 'PUT',
+    url: '/centreon/api/latest/administration/authentication/providers/saml'
+  }).as('updateSAMLProvider');
+  cy.intercept({
+    method: 'POST',
+    url: '/centreon/api/latest/authentication/providers/configurations/local'
+  }).as('postLocalAuthentification');
+});
+
+Given('an administrator is logged on the platform', () => {
+  cy.loginByTypeOfUser({ jsonName: 'admin' });
+});
+
+When('the administrator activates the auto-import option for SAML', () => {
+  navigateToSAMLConfigPage();
+
+  cy.getByLabel({
+    label: 'Enable SAMLv2 authentication',
+    tag: 'input'
+  }).check();
+
+  cy.getByLabel({
+    label: 'Enable auto import',
+    tag: 'input'
+  }).check();
+
+  configureSAML();
+
+  cy.getByLabel({ label: 'Auto import users' })
+    .eq(0)
+    .contains('Auto import users')
+    .click({ force: true });
+
+  cy.getByLabel({
+    label: 'Contact template',
+    tag: 'input'
+  })
+    .clear()
+    .type('contact_template')
+    .wait('@getListContactTemplates')
+    .get('div[role="presentation"] ul li')
+    .eq(-1)
+    .click()
+    .getByLabel({
+      label: 'Contact template',
+      tag: 'input'
+    })
+    .should('have.value', 'contact_template');
+
+  cy.getByLabel({
+    label: 'Email attribute path',
+    tag: 'input'
+  })
+    .clear()
+    .type('email');
+  cy.getByLabel({
+    label: 'Fullname attribute path',
+    tag: 'input'
+  })
+    .clear()
+    .type('name');
+
+  cy.getByLabel({ label: 'save button', tag: 'button' }).click();
+
+  cy.wait('@updateSAMLProvider').its('response.statusCode').should('eq', 204);
+
+  cy.logout();
+});
+
+Then(
+  'the users from the 3rd party authentication service with the contact template are imported',
+  () => {
+    const username = 'user-non-admin-for-SAML-authentication';
+
+    cy.session(username, () => {
+      cy.visit('/').getByLabel({ label: 'Login with SAML', tag: 'a' }).click();
+      cy.loginKeycloack(username)
+        .url()
+        .should('include', '/monitoring/resources')
+        .logout();
+
+      cy.getByLabel({ label: 'Alias', tag: 'input' }).should('exist');
+    });
+
+    cy.loginByTypeOfUser({ jsonName: 'admin' })
+      .wait('@postLocalAuthentification')
+      .its('response.statusCode')
+      .should('eq', 200);
+
+    getUserContactId('saml').then((samlId) => {
+      cy.visit(`/centreon/main.php?p=60301&o=c&contact_id=${samlId}`)
+        .wait('@getTimeZone')
+        .getIframeBody()
+        .find('form')
+        .within(() => {
+          cy.getByTestId({ tag: 'input', testId: 'contact_alias' }).should(
+            'have.value',
+            'saml'
+          );
+          cy.getByTestId({ tag: 'input', testId: 'contact_name' }).should(
+            'have.value',
+            'SAML SAML'
+          );
+          cy.getByTestId({ tag: 'input', testId: 'contact_email' }).should(
+            'have.value',
+            'saml@localhost'
+          );
+          cy.getByTestId({ tag: 'select', testId: 'contact_template_id' })
+            .find(':selected')
+            .contains('contact_template');
+        });
+    });
+  }
+);
+
+after(() => {
+  cy.stopWebContainer().stopOpenIdProviderContainer();
+});

--- a/centreon/tests/e2e/cypress/e2e/Authentication/SAML/common.ts
+++ b/centreon/tests/e2e/cypress/e2e/Authentication/SAML/common.ts
@@ -34,7 +34,7 @@ const configureSAML = (): Cypress.Chainable => {
   cy.getByLabel({
     label: 'Both identity provider and Centreon UI',
     tag: 'input'
-  }).check();
+  }).check({ force: true });
 
   return cy
     .getByLabel({ label: 'Logout URL', tag: 'input' })
@@ -51,9 +51,7 @@ const navigateToSAMLConfigPage = (): Cypress.Chainable => {
 
   cy.wait('@getSAMLProvider');
 
-  return cy
-    .getByLabel({ label: 'Identity provider' })
-    .click();
+  return cy.getByLabel({ label: 'Identity provider' }).click();
 };
 
 const initializeSAMLUser = (): Cypress.Chainable => {


### PR DESCRIPTION
## Description

E2E tests for auto-import users for SAML provider.

**Fixes** # MON-18138

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
