### PR TITLE
fix(packaging): fix conflicts betwwen perl-net-curl and libssh-session

### DIFF
--- a/dependencies/perl-libssh-session/perl-libssh-session.yaml
+++ b/dependencies/perl-libssh-session/perl-libssh-session.yaml
@@ -36,11 +36,11 @@ overrides:
       - perl
       - libssh
     conflicts:
-      - perl-Net-Curl-debuginfo
+      - perl-Libssh-Session-debuginfo
     replaces:
-      - perl-Net-Curl-debuginfo
+      - perl-Libssh-Session-debuginfo
     provides:
-      - perl-Net-Curl-debuginfo
+      - perl-Libssh-Session-debuginfo
       - perl(Libssh::Session)
       - perl(Libssh::Sftp)
   deb:


### PR DESCRIPTION
## Description

fix conflicts betwwen perl-net-curl and libssh-session

avoid `package perl-Libssh-Session-0.8-2.el8.x86_64 conflicts with perl-Net-Curl-debuginfo provided by perl-Net-Curl-0.54-2.el8.x86_64`

**Fixes** MON-20955

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)