### PR TITLE
fix(api): update test-lib to reload properly acl on debian

### DIFF
--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -6879,12 +6879,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "c8c63a0f93be82054194ba325f44e2b87bf1d93a"
+                "reference": "93b58e2397a55e37599128ca22fae31acfe33f8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/c8c63a0f93be82054194ba325f44e2b87bf1d93a",
-                "reference": "c8c63a0f93be82054194ba325f44e2b87bf1d93a",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/93b58e2397a55e37599128ca22fae31acfe33f8e",
+                "reference": "93b58e2397a55e37599128ca22fae31acfe33f8e",
                 "shasum": ""
             },
             "require": {
@@ -6936,7 +6936,7 @@
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
                 "source": "https://github.com/centreon/centreon-test-lib/tree/master"
             },
-            "time": "2023-07-18T11:37:24+00:00"
+            "time": "2023-08-03T11:58:13+00:00"
         },
         {
             "name": "composer/pcre",

--- a/centreon/tests/api/Context/FeatureFlagContext.php
+++ b/centreon/tests/api/Context/FeatureFlagContext.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace Centreon\Test\Api\Context;
 
 use Centreon\Test\Behat\Api\Context\ApiContext;
-use Core\Common\Infrastructure\FeatureFlags;
 
 /**
  * @see FeatureFlags

--- a/centreon/tests/api/features/DashboardWithOpenApi.feature
+++ b/centreon/tests/api/features/DashboardWithOpenApi.feature
@@ -1701,8 +1701,7 @@ Feature:
       ]
     }
     """
-    And I wait 20 seconds
-    When I send a GET request to '/api/latest/monitoring/dashboard/metrics/performances?search={"$and":[{"service.name":{"$in":["Ping"]}}]}'
+    When I wait to get 1 result from '/api/latest/monitoring/dashboard/metrics/performances?search={"$and":[{"service.name":{"$in":["Ping"]}}]}' (tries: 30)
     Then the response code should be "200"
     And the JSON should be equal to:
     """


### PR DESCRIPTION
## Description

* update test-lib to reload properly acl on debian
* do not use arbitrary wait

**Fixes** MON-20805

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)