### PR TITLE
fix(resource status): handle only_with_performance_data parameter

### DIFF
--- a/centreon/src/Centreon/Domain/Monitoring/ResourceService.php
+++ b/centreon/src/Centreon/Domain/Monitoring/ResourceService.php
@@ -71,6 +71,10 @@ class ResourceService extends AbstractCentreonService implements ResourceService
             throw new ResourceException($ex->getMessage(), 0, $ex);
         }
 
+        if ($filter->getOnlyWithPerformanceData() === true) {
+            return $this->extractResourcesWithGraphData($list);
+        }
+
         return $list;
     }
 

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -142,10 +142,10 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
      */
     public function extractResourcesWithGraphData(array $resources): array
     {
-        return array_filter(
+        return array_values(array_filter(
             $resources,
             fn (ResourceEntity $resource) => $resource->hasGraph(),
-        );
+        ));
     }
 
     /**


### PR DESCRIPTION
## Description

this PR intends to handle only_with_performance_data parameter that was currently not working.

**Fixes** # MON-20978

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Call Resource Status endpoint without filter
- You should has many result
- some results should have the property performance_graph set to null
- Call Resource Status endpoint with the only_with_performance_data filter (/monitoring/resources?only_with_performance_data=true)
- All the results should have a property performance_graph that is not null

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
