### PR TITLE
enh(Edit Profile): My account form should not display Password fields

### DIFF
--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -115,7 +115,7 @@ if ($cct["contact_auth_type"] != 'ldap') {
 $form->addElement('text', 'contact_email', _("Email"), $attrsText);
 $form->addElement('text', 'contact_pager', _("Pager"), $attrsText);
 
-if ($cct["contact_auth_type"] != 'ldap') {
+if ($cct["contact_auth_type"] === 'local') {
     $form->addFormRule('validatePasswordModification');
     $statement = $pearDB->prepare(
         "SELECT creation_date FROM contact_password WHERE contact_id = :contactId ORDER BY creation_date DESC LIMIT 1"


### PR DESCRIPTION
## Description

 if user account type is local, display fields ( password and password confirmation ) , else don't display
 so it is useless to leave the Password management section in the Administration > Parameters > My account page.

**Fixes** # (MON-20263)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

 if user account type is local type, display fields ( password and password confirmation ) , else don't display

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
