### PR TITLE
fix(login): don't call custom login page endpoint if the module is not installed (#2022)

### DIFF
--- a/centreon/www/front_src/src/App/useApp.ts
+++ b/centreon/www/front_src/src/App/useApp.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 
-import { useSetAtom } from 'jotai';
-import { equals, not, pathEq } from 'ramda';
+import { useAtom, useSetAtom } from 'jotai';
+import { equals, not, pathEq, path } from 'ramda';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
@@ -20,6 +20,7 @@ import { loginPageCustomisationEndpoint } from '../Login/api/endpoint';
 import { areUserParametersLoadedAtom } from '../Main/useUser';
 import useNavigation from '../Navigation/useNavigation';
 import reactRoutes from '../reactRoutes/routeMap';
+import { platformVersionsAtom } from '../Main/atoms/platformVersionsAtom';
 
 import { aclEndpoint, parametersEndpoint } from './endpoint';
 import { CustomLoginPlatform, DefaultParameters } from './models';
@@ -65,6 +66,7 @@ const useApp = (): UseAppState => {
       request: getData
     });
 
+  const [platformVersion] = useAtom(platformVersionsAtom);
   const setDowntime = useSetAtom(downtimeAtom);
   const setRefreshInterval = useSetAtom(refreshIntervalAtom);
   const setAcl = useSetAtom(aclAtom);
@@ -127,11 +129,13 @@ const useApp = (): UseAppState => {
           logout();
         }
       });
-    getCustomPlatformRequest({
-      endpoint: loginPageCustomisationEndpoint
-    })
-      .then(({ platform_name }) => setPlaformName(platform_name))
-      .catch(() => undefined);
+    if (path(['modules', 'centreon-it-edition-extensions'], platformVersion)) {
+      getCustomPlatformRequest({
+        endpoint: loginPageCustomisationEndpoint
+      })
+        .then(({ platform_name }) => setPlaformName(platform_name))
+        .catch(() => undefined);
+    }
   }, []);
 
   const hasMinArgument = (): boolean => equals(searchParams.get('min'), '1');

--- a/centreon/www/front_src/src/Login/Login.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Login/Login.cypress.spec.tsx
@@ -45,6 +45,23 @@ const retrievedWeb = {
   }
 };
 
+const retrievedWebWithItEditionInstalled = {
+  modules: {
+    'centreon-it-edition-extensions': {
+      fix: '0',
+      major: '23',
+      minor: '10',
+      version: '23.10.0'
+    }
+  },
+  web: {
+    fix: '1',
+    major: '21',
+    minor: '10',
+    version: '21.10.1'
+  }
+};
+
 const retrievedTranslations = {
   en: {
     hello: 'Hello'
@@ -197,14 +214,6 @@ const setupBeforeEach = (): void => {
 describe('Login Page', () => {
   beforeEach(() => {
     setupBeforeEach();
-    cy.fixture('login/defaultLoginPageCustomization.json').then((fixture) =>
-      cy.interceptAPIRequest({
-        alias: 'getDefaultLoginCustomization',
-        method: Method.GET,
-        path: `${replace('./', '**', loginPageCustomisationEndpoint)}`,
-        response: fixture
-      })
-    );
   });
 
   it('displays the login page', () => {
@@ -212,7 +221,6 @@ describe('Login Page', () => {
 
     cy.waitForRequest('@getTranslations');
     cy.waitForRequest('@getProvidersConfiguration');
-    cy.waitForRequest('@getDefaultLoginCustomization');
 
     cy.findByAltText(labelCentreonLogo).should('be.visible');
     cy.findByAltText(labelCentreonWallpaper).should('be.visible');
@@ -255,6 +263,9 @@ describe('Login Page', () => {
     const useNavigate = mountComponentAndStubs();
     mockPostLoginInvalidCredentials();
 
+    cy.waitForRequest('@getTranslations');
+    cy.waitForRequest('@getProvidersConfiguration');
+
     cy.findByAltText(labelCentreonLogo).should('be.visible');
     cy.findByAltText(labelCentreonWallpaper).should('be.visible');
 
@@ -281,6 +292,9 @@ describe('Login Page', () => {
   it('displays errors when fields are cleared', () => {
     mountComponentAndStubs();
 
+    cy.waitForRequest('@getTranslations');
+    cy.waitForRequest('@getProvidersConfiguration');
+
     cy.findByAltText(labelCentreonLogo).should('be.visible');
     cy.findByAltText(labelCentreonWallpaper).should('be.visible');
 
@@ -303,6 +317,9 @@ describe('Login Page', () => {
 
   it('displays the password when the corresponding action is clicked', () => {
     mountComponentAndStubs();
+
+    cy.waitForRequest('@getTranslations');
+    cy.waitForRequest('@getProvidersConfiguration');
 
     cy.findByAltText(labelCentreonLogo).should('be.visible');
     cy.findByAltText(labelCentreonWallpaper).should('be.visible');
@@ -343,6 +360,9 @@ describe('Login Page', () => {
     const useNavigate = mountComponentAndStubs();
     mockPostLoginServerError();
 
+    cy.waitForRequest('@getTranslations');
+    cy.waitForRequest('@getProvidersConfiguration');
+
     cy.findByAltText(labelCentreonLogo).should('be.visible');
     cy.findByAltText(labelCentreonWallpaper).should('be.visible');
 
@@ -368,7 +388,7 @@ describe('Login Page', () => {
 describe('Default custom login page', () => {
   beforeEach(() => {
     setupBeforeEach();
-
+    store.set(platformVersionsAtom, retrievedWebWithItEditionInstalled);
     cy.fixture('login/defaultLoginPageCustomization.json').then((fixture) =>
       cy.interceptAPIRequest({
         alias: 'getDefaultLoginCustomization',
@@ -408,7 +428,7 @@ describe('Default custom login page', () => {
 describe('Custom login page with data', () => {
   beforeEach(() => {
     setupBeforeEach();
-
+    store.set(platformVersionsAtom, retrievedWebWithItEditionInstalled);
     cy.fixture('login/loginPageCustomization.json').then((fixture) =>
       cy.interceptAPIRequest({
         alias: 'getLoginCustomization',
@@ -423,6 +443,7 @@ describe('Custom login page with data', () => {
     mountComponentAndStubs();
 
     cy.waitForRequest('@getLoginCustomization');
+    cy.waitForRequest('@getProvidersConfiguration');
 
     cy.findByAltText(labelCentreonLogo).should('be.visible');
     cy.findByAltText(labelCentreonWallpaper).should('be.visible');
@@ -449,23 +470,12 @@ describe('Custom login page with data', () => {
 describe('Login page without module it edition extensions installed', () => {
   beforeEach(() => {
     setupBeforeEach();
-
-    cy.fixture('login/noModuleInstalledForLoginPageCustomization.json').then(
-      (fixture) =>
-        cy.interceptAPIRequest({
-          alias: 'getNoModuleForLoginCustomization',
-          method: Method.GET,
-          path: `${replace('./', '**', loginPageCustomisationEndpoint)}`,
-          response: fixture,
-          statusCode: 404
-        })
-    );
   });
 
   it('displays the login page when the IT edition extensions module is not installed', () => {
     mountComponentAndStubs();
 
-    cy.waitForRequest('@getNoModuleForLoginCustomization');
+    cy.waitForRequest('@getProvidersConfiguration');
 
     cy.findByAltText(labelCentreonLogo).should('be.visible');
     cy.findByAltText(labelCentreonWallpaper).should('be.visible');


### PR DESCRIPTION
## Description

Backport of #2022

**Fixes** # MON-21097

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
