### PR TITLE
[WIP] enh(notifications): add a new formatted_message property

### DIFF
--- a/centreon/doc/API/v23.10/Configuration/Notification/Schema/Notification.Message.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Notification/Schema/Notification.Message.yaml
@@ -11,3 +11,5 @@ properties:
     type: string
   message:
     type: string
+  message_formatted:
+    type: string

--- a/centreon/doc/API/v23.10/Configuration/Notification/Schema/Notification.Message.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Notification/Schema/Notification.Message.yaml
@@ -11,5 +11,5 @@ properties:
     type: string
   message:
     type: string
-  message_formatted:
+  formatted_message:
     type: string

--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotification.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotification.php
@@ -225,7 +225,8 @@ final class AddNotification
             static fn(NotificationMessage $message): array => [
                 'channel' => $message->getChannel()->value,
                 'subject' => $message->getSubject(),
-                'message' => $message->getMessage(),
+                'message' => $message->getRawMessage(),
+                'message_formatted' => $message->getFormattedMessage()
             ],
             $messages
         );

--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotification.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotification.php
@@ -226,7 +226,7 @@ final class AddNotification
                 'channel' => $message->getChannel()->value,
                 'subject' => $message->getSubject(),
                 'message' => $message->getRawMessage(),
-                'message_formatted' => $message->getFormattedMessage()
+                'formatted_message' => $message->getFormattedMessage()
             ],
             $messages
         );

--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotification.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotification.php
@@ -226,7 +226,7 @@ final class AddNotification
                 'channel' => $message->getChannel()->value,
                 'subject' => $message->getSubject(),
                 'message' => $message->getRawMessage(),
-                'formatted_message' => $message->getFormattedMessage()
+                'formatted_message' => $message->getFormattedMessage(),
             ],
             $messages
         );

--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotificationRequest.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotificationRequest.php
@@ -48,7 +48,7 @@ final class AddNotificationRequest
      *         channel:string,
      *         subject:string,
      *         message:string,
-     *         message_formatted:string
+     *         formatted_message:string
      *     }> $messages
      */
     public array $messages = [];

--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotificationRequest.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotificationRequest.php
@@ -47,7 +47,8 @@ final class AddNotificationRequest
     /** @var array<array{
      *         channel:string,
      *         subject:string,
-     *         message:string
+     *         message:string,
+     *         message_formatted:string
      *     }> $messages
      */
     public array $messages = [];

--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotificationResponse.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotificationResponse.php
@@ -74,7 +74,8 @@ final class AddNotificationResponse
      * @var array<array{
      *         channel:string,
      *         subject:string,
-     *         message:string
+     *         message:string,
+     *         message_formatted:string
      *     }> $messages
      */
     public array $messages = [];

--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotificationResponse.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/AddNotificationResponse.php
@@ -75,7 +75,7 @@ final class AddNotificationResponse
      *         channel:string,
      *         subject:string,
      *         message:string,
-     *         message_formatted:string
+     *         formatted_message:string
      *     }> $messages
      */
     public array $messages = [];

--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/Factory/NotificationMessageFactory.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/Factory/NotificationMessageFactory.php
@@ -37,7 +37,7 @@ class NotificationMessageFactory
      *  channel:string,
      *  subject:string,
      *  message:string,
-     *  message_formatted:string
+     *  formatted_message:string
      * } $message
      *
      * @throws \Assert\AssertionFailedException
@@ -50,7 +50,7 @@ class NotificationMessageFactory
             $messageType,
             $message['subject'],
             $message['message'],
-            $message['message_formatted']
+            $message['formatted_message']
         );
     }
 

--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/Factory/NotificationMessageFactory.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/Factory/NotificationMessageFactory.php
@@ -36,7 +36,8 @@ class NotificationMessageFactory
      * @param array{
      *  channel:string,
      *  subject:string,
-     *  message:string
+     *  message:string,
+     *  message_formatted:string
      * } $message
      *
      * @throws \Assert\AssertionFailedException
@@ -48,7 +49,8 @@ class NotificationMessageFactory
         return new NotificationMessage(
             $messageType,
             $message['subject'],
-            $message['message']
+            $message['message'],
+            $message['message_formatted']
         );
     }
 

--- a/centreon/src/Core/Notification/Application/UseCase/FindNotification/FindNotification.php
+++ b/centreon/src/Core/Notification/Application/UseCase/FindNotification/FindNotification.php
@@ -192,7 +192,7 @@ final class FindNotification
             static fn(NotificationMessage $message): array => [
                 'channel' => $message->getChannel()->value,
                 'subject' => $message->getSubject(),
-                'message' => $message->getMessage(),
+                'message' => $message->getRawMessage(),
             ],
             $notificationMessages
         );

--- a/centreon/src/Core/Notification/Application/UseCase/UpdateNotification/Factory/NotificationMessageFactory.php
+++ b/centreon/src/Core/Notification/Application/UseCase/UpdateNotification/Factory/NotificationMessageFactory.php
@@ -48,7 +48,8 @@ class NotificationMessageFactory
         return new NotificationMessage(
             $messageType,
             $message['subject'],
-            $message['message']
+            $message['message'],
+            $message['formatted_message']
         );
     }
 

--- a/centreon/src/Core/Notification/Application/UseCase/UpdateNotification/UpdateNotificationRequest.php
+++ b/centreon/src/Core/Notification/Application/UseCase/UpdateNotification/UpdateNotificationRequest.php
@@ -56,7 +56,8 @@ final class UpdateNotificationRequest
     /** @var array<array{
      *     channel:string,
      *     subject:string,
-     *     message:string
+     *     message:string,
+     *     formatted_message:string
      * }> $messages
      */
     public array $messages = [];

--- a/centreon/src/Core/Notification/Domain/Model/NotificationMessage.php
+++ b/centreon/src/Core/Notification/Domain/Model/NotificationMessage.php
@@ -34,7 +34,7 @@ class NotificationMessage
      * @param NotificationChannel $channel
      * @param string $subject
      * @param string $message
-     * @param string $messageFormatted
+     * @param string $formattedMessage
      *
      * @throws \Assert\AssertionFailedException
      */

--- a/centreon/src/Core/Notification/Domain/Model/NotificationMessage.php
+++ b/centreon/src/Core/Notification/Domain/Model/NotificationMessage.php
@@ -42,18 +42,19 @@ class NotificationMessage
         protected NotificationChannel $channel,
         protected string $subject = '',
         protected string $message = '',
-        protected string $messageFormatted = ''
+        protected string $formattedMessage = ''
     ) {
         $shortName = (new \ReflectionClass($this))->getShortName();
 
         $this->subject = trim($subject);
         $this->message = trim($message);
+        $this->formattedMessage = trim($formattedMessage);
 
         Assertion::notEmptyString($this->subject, "{$shortName}::subject");
         Assertion::notEmptyString($this->message, "{$shortName}::message");
         Assertion::maxLength($this->subject, self::MAX_SUBJECT_LENGTH, "{$shortName}::subject");
         Assertion::maxLength($this->message, self::MAX_MESSAGE_LENGTH, "{$shortName}::message");
-        Assertion::maxLength($this->message, self::MAX_MESSAGE_LENGTH, "{$shortName}::messageFormatted");
+        Assertion::maxLength($this->message, self::MAX_MESSAGE_LENGTH, "{$shortName}::formattedMessage");
     }
 
     public function getChannel(): NotificationChannel
@@ -73,6 +74,6 @@ class NotificationMessage
 
     public function getFormattedMessage(): string
     {
-        return $this->messageFormatted;
+        return $this->formattedMessage;
     }
 }

--- a/centreon/src/Core/Notification/Domain/Model/NotificationMessage.php
+++ b/centreon/src/Core/Notification/Domain/Model/NotificationMessage.php
@@ -34,13 +34,15 @@ class NotificationMessage
      * @param NotificationChannel $channel
      * @param string $subject
      * @param string $message
+     * @param string $messageFormatted
      *
      * @throws \Assert\AssertionFailedException
      */
     public function __construct(
         protected NotificationChannel $channel,
         protected string $subject = '',
-        protected string $message = ''
+        protected string $message = '',
+        protected string $messageFormatted = ''
     ) {
         $shortName = (new \ReflectionClass($this))->getShortName();
 
@@ -51,6 +53,7 @@ class NotificationMessage
         Assertion::notEmptyString($this->message, "{$shortName}::message");
         Assertion::maxLength($this->subject, self::MAX_SUBJECT_LENGTH, "{$shortName}::subject");
         Assertion::maxLength($this->message, self::MAX_MESSAGE_LENGTH, "{$shortName}::message");
+        Assertion::maxLength($this->message, self::MAX_MESSAGE_LENGTH, "{$shortName}::messageFormatted");
     }
 
     public function getChannel(): NotificationChannel
@@ -63,8 +66,13 @@ class NotificationMessage
         return $this->subject;
     }
 
-    public function getMessage(): string
+    public function getRawMessage(): string
     {
         return $this->message;
+    }
+
+    public function getFormattedMessage(): string
+    {
+        return $this->messageFormatted;
     }
 }

--- a/centreon/src/Core/Notification/Domain/Model/NotificationMessage.php
+++ b/centreon/src/Core/Notification/Domain/Model/NotificationMessage.php
@@ -54,7 +54,7 @@ class NotificationMessage
         Assertion::notEmptyString($this->message, "{$shortName}::message");
         Assertion::maxLength($this->subject, self::MAX_SUBJECT_LENGTH, "{$shortName}::subject");
         Assertion::maxLength($this->message, self::MAX_MESSAGE_LENGTH, "{$shortName}::message");
-        Assertion::maxLength($this->message, self::MAX_MESSAGE_LENGTH, "{$shortName}::formattedMessage");
+        Assertion::maxLength($this->formattedMessage, self::MAX_MESSAGE_LENGTH, "{$shortName}::formattedMessage");
     }
 
     public function getChannel(): NotificationChannel

--- a/centreon/src/Core/Notification/Infrastructure/API/AddNotification/AddNotificationController.php
+++ b/centreon/src/Core/Notification/Infrastructure/API/AddNotification/AddNotificationController.php
@@ -123,7 +123,7 @@ final class AddNotificationController extends AbstractController
                 'channel' => $messageData['channel'],
                 'subject' => $messageData['subject'],
                 'message' => $messageData['message'],
-                'formatted_message' => $messageData['formatted_message']
+                'formatted_message' => $messageData['formatted_message'],
             ];
         }
         foreach ($data['resources'] as $resourceData) {

--- a/centreon/src/Core/Notification/Infrastructure/API/AddNotification/AddNotificationController.php
+++ b/centreon/src/Core/Notification/Infrastructure/API/AddNotification/AddNotificationController.php
@@ -68,7 +68,7 @@ final class AddNotificationController extends AbstractController
              *         channel:string,
              *         subject:string,
              *         message:string,
-             *         message_formatted:string
+             *         formatted_message:string
              *     }>,
              *     is_activated?: bool,
              * } $data
@@ -103,7 +103,7 @@ final class AddNotificationController extends AbstractController
      *         channel:string,
      *         subject:string,
      *         message:string,
-     *         message_formatted:string
+     *         formatted_message:string
      *     }>,
      *     is_activated?: bool,
      * } $data
@@ -123,7 +123,7 @@ final class AddNotificationController extends AbstractController
                 'channel' => $messageData['channel'],
                 'subject' => $messageData['subject'],
                 'message' => $messageData['message'],
-                'message_formatted' => $messageData['message_formatted']
+                'formatted_message' => $messageData['formatted_message']
             ];
         }
         foreach ($data['resources'] as $resourceData) {

--- a/centreon/src/Core/Notification/Infrastructure/API/AddNotification/AddNotificationController.php
+++ b/centreon/src/Core/Notification/Infrastructure/API/AddNotification/AddNotificationController.php
@@ -67,7 +67,8 @@ final class AddNotificationController extends AbstractController
              *     messages: array<array{
              *         channel:string,
              *         subject:string,
-             *         message:string
+             *         message:string,
+             *         message_formatted:string
              *     }>,
              *     is_activated?: bool,
              * } $data
@@ -101,7 +102,8 @@ final class AddNotificationController extends AbstractController
      *     messages: array<array{
      *         channel:string,
      *         subject:string,
-     *         message:string
+     *         message:string,
+     *         message_formatted:string
      *     }>,
      *     is_activated?: bool,
      * } $data
@@ -121,6 +123,7 @@ final class AddNotificationController extends AbstractController
                 'channel' => $messageData['channel'],
                 'subject' => $messageData['subject'],
                 'message' => $messageData['message'],
+                'message_formatted' => $messageData['message_formatted']
             ];
         }
         foreach ($data['resources'] as $resourceData) {

--- a/centreon/src/Core/Notification/Infrastructure/API/AddNotification/AddNotificationSchema.json
+++ b/centreon/src/Core/Notification/Infrastructure/API/AddNotification/AddNotificationSchema.json
@@ -29,7 +29,8 @@
             "required": [
                 "channel",
                 "subject",
-                "message"
+                "message",
+                "message_formatted"
             ],
             "properties": {
                 "channel": {
@@ -40,6 +41,9 @@
                     "type": "string"
                 },
                 "message": {
+                    "type": "string"
+                },
+                "message_formatted": {
                     "type": "string"
                 }
             }

--- a/centreon/src/Core/Notification/Infrastructure/API/AddNotification/AddNotificationSchema.json
+++ b/centreon/src/Core/Notification/Infrastructure/API/AddNotification/AddNotificationSchema.json
@@ -30,7 +30,7 @@
                 "channel",
                 "subject",
                 "message",
-                "message_formatted"
+                "formatted_message"
             ],
             "properties": {
                 "channel": {
@@ -43,7 +43,7 @@
                 "message": {
                     "type": "string"
                 },
-                "message_formatted": {
+                "formatted_message": {
                     "type": "string"
                 }
             }

--- a/centreon/src/Core/Notification/Infrastructure/API/UpdateNotification/UpdateNotificationController.php
+++ b/centreon/src/Core/Notification/Infrastructure/API/UpdateNotification/UpdateNotificationController.php
@@ -93,7 +93,8 @@ final class UpdateNotificationController extends AbstractController
      *     messages: array<array{
      *         channel:string,
      *         subject:string,
-     *         message:string
+     *         message:string,
+     *         formatted_message:string
      *     }>,
      *     is_activated?: bool,
      * } $dataSent
@@ -110,6 +111,7 @@ final class UpdateNotificationController extends AbstractController
                 'channel' => $messageData['channel'],
                 'subject' => $messageData['subject'],
                 'message' => $messageData['message'],
+                'formatted_message' => $messageData['formatted_message'],
             ];
         }
         foreach ($dataSent['resources'] as $resourceData) {

--- a/centreon/src/Core/Notification/Infrastructure/API/UpdateNotification/UpdateNotificationSchema.json
+++ b/centreon/src/Core/Notification/Infrastructure/API/UpdateNotification/UpdateNotificationSchema.json
@@ -29,7 +29,8 @@
             "required": [
                 "channel",
                 "subject",
-                "message"
+                "message",
+                "formatted_message"
             ],
             "properties": {
                 "channel": {
@@ -40,6 +41,9 @@
                     "type": "string"
                 },
                 "message": {
+                    "type": "string"
+                },
+                "formatted_message": {
                     "type": "string"
                 }
             }

--- a/centreon/src/Core/Notification/Infrastructure/Repository/DbReadNotificationRepository.php
+++ b/centreon/src/Core/Notification/Infrastructure/Repository/DbReadNotificationRepository.php
@@ -119,7 +119,7 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
         $this->info('Get all notification messages for notification with ID #' . $notificationId);
 
         $request = $this->translateDbName(
-            'SELECT id, channel, subject, message, message_formatted
+            'SELECT id, channel, subject, message, formatted_message
             FROM `:db`.notification_message
             WHERE notification_id = :notificationId'
         );
@@ -134,7 +134,7 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
                 NotificationChannel::from($result['channel']),
                 $result['subject'],
                 $result['message'],
-                $result['message_formatted']
+                $result['formatted_message']
             );
         }
 

--- a/centreon/src/Core/Notification/Infrastructure/Repository/DbReadNotificationRepository.php
+++ b/centreon/src/Core/Notification/Infrastructure/Repository/DbReadNotificationRepository.php
@@ -119,7 +119,7 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
         $this->info('Get all notification messages for notification with ID #' . $notificationId);
 
         $request = $this->translateDbName(
-            'SELECT id, channel, subject, message
+            'SELECT id, channel, subject, message, message_formatted
             FROM `:db`.notification_message
             WHERE notification_id = :notificationId'
         );
@@ -133,7 +133,8 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
             $messages[] = new NotificationMessage(
                 NotificationChannel::from($result['channel']),
                 $result['subject'],
-                $result['message']
+                $result['message'],
+                $result['message_formatted']
             );
         }
 

--- a/centreon/src/Core/Notification/Infrastructure/Repository/DbWriteNotificationRepository.php
+++ b/centreon/src/Core/Notification/Infrastructure/Repository/DbWriteNotificationRepository.php
@@ -76,15 +76,17 @@ class DbWriteNotificationRepository extends AbstractRepositoryRDB implements Wri
         $queryBinding = [];
         $bindedValues = [];
         foreach ($messages as $key => $message) {
-            $queryBinding[] = "(:notificationId, :channel_{$key}, :subject_{$key}, :message_{$key})";
+            $queryBinding[] = "(:notificationId, :channel_{$key}, :subject_{$key}, :message_{$key},"
+                . " :message_formatted_{$key})";
             $bindedValues[":channel_{$key}"] = $message->getChannel()->value;
             $bindedValues[":subject_{$key}"] = $message->getSubject();
-            $bindedValues[":message_{$key}"] = $message->getMessage();
+            $bindedValues[":message_{$key}"] = $message->getRawMessage();
+            $bindedValues[":message_formatted_{$key}"] = $message->getFormattedMessage();
         }
 
         $request = $this->translateDbName(
             'INSERT INTO `:db`.notification_message
-            (notification_id, channel, subject, message) VALUES '
+            (notification_id, channel, subject, message, message_formatted) VALUES '
             . implode(', ', $queryBinding)
         );
         $statement = $this->db->prepare($request);

--- a/centreon/src/Core/Notification/Infrastructure/Repository/DbWriteNotificationRepository.php
+++ b/centreon/src/Core/Notification/Infrastructure/Repository/DbWriteNotificationRepository.php
@@ -77,16 +77,16 @@ class DbWriteNotificationRepository extends AbstractRepositoryRDB implements Wri
         $bindedValues = [];
         foreach ($messages as $key => $message) {
             $queryBinding[] = "(:notificationId, :channel_{$key}, :subject_{$key}, :message_{$key},"
-                . " :message_formatted_{$key})";
+                . " :formatted_message_{$key})";
             $bindedValues[":channel_{$key}"] = $message->getChannel()->value;
             $bindedValues[":subject_{$key}"] = $message->getSubject();
             $bindedValues[":message_{$key}"] = $message->getRawMessage();
-            $bindedValues[":message_formatted_{$key}"] = $message->getFormattedMessage();
+            $bindedValues[":formatted_message_{$key}"] = $message->getFormattedMessage();
         }
 
         $request = $this->translateDbName(
             'INSERT INTO `:db`.notification_message
-            (notification_id, channel, subject, message, message_formatted) VALUES '
+            (notification_id, channel, subject, message, formatted_message) VALUES '
             . implode(', ', $queryBinding)
         );
         $statement = $this->db->prepare($request);

--- a/centreon/tests/api/features/Notification.feature
+++ b/centreon/tests/api/features/Notification.feature
@@ -889,7 +889,8 @@ Feature:
         {
           "channel": "Slack",
           "subject": "Hello world !",
-          "message": "just a small message"
+          "message": "just a small message",
+          "formatted_message": "just a small message"
         }
       ],
       "users": [20,21],
@@ -1046,7 +1047,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],

--- a/centreon/tests/api/features/Notification.feature
+++ b/centreon/tests/api/features/Notification.feature
@@ -43,7 +43,7 @@ Feature:
           "channel": "Slack",
           "subject": "Hello world !",
           "message": "just a small message",
-          "formatted_message": "just a small message"
+          "formatted_message": "a formatted message"
         }
       ],
       "users": [20,21],
@@ -119,7 +119,7 @@ Feature:
               "channel": "Slack",
               "subject": "Hello world !",
               "message": "just a small message",
-              "formatted_message": "just a small message"
+              "formatted_message": "a formatted message"
           }
       ],
       "is_activated": true
@@ -172,7 +172,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -205,7 +205,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -273,7 +273,7 @@ Feature:
                 "channel": "Slack",
                 "subject": "Hello world !",
                 "message": "just a small message",
-                "formatted_message": "just a small message"
+                "formatted_message": "a formatted message"
             }
         ],
         "is_activated": true
@@ -316,7 +316,7 @@ Feature:
           "channel": "Slack",
           "subject": "Hello world !",
           "message": "just a small message",
-          "formatted_message": "just a small message"
+          "formatted_message": "a formatted message"
         }
       ],
       "users": [20,21],
@@ -412,7 +412,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -506,7 +506,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -555,7 +555,7 @@ Feature:
           "channel": "Slack",
           "subject": "Hello world !",
           "message": "just a small message",
-          "formatted_message": "just a small message"
+          "formatted_message": "a formatted message"
         }
       ],
       "users": [20,21],
@@ -685,7 +685,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -799,7 +799,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -855,7 +855,7 @@ Feature:
           "channel": "Slack",
           "subject": "Hello world !",
           "message": "just a small message",
-          "formatted_message": "just a small message"
+          "formatted_message": "a formatted message"
         }
       ],
       "users": [20,21],
@@ -890,7 +890,7 @@ Feature:
           "channel": "Slack",
           "subject": "Hello world !",
           "message": "just a small message",
-          "formatted_message": "just a small message"
+          "formatted_message": "a formatted message"
         }
       ],
       "users": [20,21],
@@ -1020,7 +1020,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -1048,7 +1048,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -1143,7 +1143,7 @@ Feature:
           "channel": "Slack",
           "subject": "Hello world !",
           "message": "just a small message",
-          "formatted_message": "just a small message"
+          "formatted_message": "a formatted message"
         }
       ],
       "users": [20,21],
@@ -1196,7 +1196,7 @@ Feature:
           "channel": "Slack",
           "subject": "Hello world !",
           "message": "just a small message",
-          "formatted_message": "just a small message"
+          "formatted_message": "a formatted message"
         }
       ],
       "users": [20,21],
@@ -1259,7 +1259,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -1320,7 +1320,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -1375,7 +1375,7 @@ Feature:
           "channel": "Slack",
           "subject": "Hello world !",
           "message": "just a small message",
-          "formatted_message": "just a small message"
+          "formatted_message": "a formatted message"
         }
       ],
       "users": [20,21],
@@ -1432,7 +1432,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -1487,7 +1487,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -1545,7 +1545,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -1590,7 +1590,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -1670,7 +1670,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20,21],
@@ -1702,7 +1702,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [20],
@@ -1827,7 +1827,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [
@@ -1869,7 +1869,7 @@ Feature:
             "channel": "Slack",
             "subject": "Hello world !",
             "message": "just a small message",
-            "formatted_message": "just a small message"
+            "formatted_message": "a formatted message"
           }
         ],
         "users": [

--- a/centreon/tests/api/features/Notification.feature
+++ b/centreon/tests/api/features/Notification.feature
@@ -42,7 +42,8 @@ Feature:
         {
           "channel": "Slack",
           "subject": "Hello world !",
-          "message": "just a small message"
+          "message": "just a small message",
+          "formatted_message": "just a small message"
         }
       ],
       "users": [20,21],
@@ -117,7 +118,8 @@ Feature:
           {
               "channel": "Slack",
               "subject": "Hello world !",
-              "message": "just a small message"
+              "message": "just a small message",
+              "formatted_message": "just a small message"
           }
       ],
       "is_activated": true
@@ -169,7 +171,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -201,7 +204,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -268,7 +272,8 @@ Feature:
             {
                 "channel": "Slack",
                 "subject": "Hello world !",
-                "message": "just a small message"
+                "message": "just a small message",
+                "formatted_message": "just a small message"
             }
         ],
         "is_activated": true
@@ -310,7 +315,8 @@ Feature:
         {
           "channel": "Slack",
           "subject": "Hello world !",
-          "message": "just a small message"
+          "message": "just a small message",
+          "formatted_message": "just a small message"
         }
       ],
       "users": [20,21],
@@ -405,7 +411,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -498,7 +505,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -546,7 +554,8 @@ Feature:
         {
           "channel": "Slack",
           "subject": "Hello world !",
-          "message": "just a small message"
+          "message": "just a small message",
+          "formatted_message": "just a small message"
         }
       ],
       "users": [20,21],
@@ -675,7 +684,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -788,7 +798,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -843,7 +854,8 @@ Feature:
         {
           "channel": "Slack",
           "subject": "Hello world !",
-          "message": "just a small message"
+          "message": "just a small message",
+          "formatted_message": "just a small message"
         }
       ],
       "users": [20,21],
@@ -1006,7 +1018,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -1127,7 +1140,8 @@ Feature:
         {
           "channel": "Slack",
           "subject": "Hello world !",
-          "message": "just a small message"
+          "message": "just a small message",
+          "formatted_message": "just a small message"
         }
       ],
       "users": [20,21],
@@ -1179,7 +1193,8 @@ Feature:
         {
           "channel": "Slack",
           "subject": "Hello world !",
-          "message": "just a small message"
+          "message": "just a small message",
+          "formatted_message": "just a small message"
         }
       ],
       "users": [20,21],
@@ -1241,7 +1256,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -1301,7 +1317,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -1355,7 +1372,8 @@ Feature:
         {
           "channel": "Slack",
           "subject": "Hello world !",
-          "message": "just a small message"
+          "message": "just a small message",
+          "formatted_message": "just a small message"
         }
       ],
       "users": [20,21],
@@ -1411,7 +1429,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -1465,7 +1484,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -1522,7 +1542,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -1566,7 +1587,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -1645,7 +1667,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20,21],
@@ -1676,7 +1699,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [20],
@@ -1800,7 +1824,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [
@@ -1841,7 +1866,8 @@ Feature:
           {
             "channel": "Slack",
             "subject": "Hello world !",
-            "message": "just a small message"
+            "message": "just a small message",
+            "formatted_message": "just a small message"
           }
         ],
         "users": [

--- a/centreon/tests/php/Core/Notification/Application/UseCase/AddNotification/AddNotificationTest.php
+++ b/centreon/tests/php/Core/Notification/Application/UseCase/AddNotification/AddNotificationTest.php
@@ -73,7 +73,7 @@ beforeEach(function (): void {
             'channel' => 'Slack',
             'subject' => 'some subject',
             'message' => 'some message',
-            'message_formatted' => '<h1> A Test Message </h1>'
+            'formatted_message' => '<h1> A Test Message </h1>'
         ],
     ];
     $this->request->isActivated = true;
@@ -103,7 +103,7 @@ beforeEach(function (): void {
             NotificationChannel::from($this->request->messages[0]['channel']),
             $this->request->messages[0]['subject'],
             $this->request->messages[0]['message'],
-            $this->request->messages[0]['message_formatted'],
+            $this->request->messages[0]['formatted_message'],
         ),
     ];
     $this->resources = [
@@ -548,7 +548,7 @@ it('should return created object on success', function (): void {
                 'channel' => $message->getChannel()->value,
                 'subject' => $message->getSubject(),
                 'message' => $message->getRawMessage(),
-                'message_formatted' => $message->getFormattedMessage(),
+                'formatted_message' => $message->getFormattedMessage(),
             ]),
             $this->messages
         ))

--- a/centreon/tests/php/Core/Notification/Application/UseCase/AddNotification/AddNotificationTest.php
+++ b/centreon/tests/php/Core/Notification/Application/UseCase/AddNotification/AddNotificationTest.php
@@ -69,7 +69,12 @@ beforeEach(function (): void {
         ['type' => 'hostgroup', 'ids' => [12, 25], 'events' => 5, 'includeServiceEvents' => 1],
     ];
     $this->request->messages = [
-        ['channel' => 'Slack', 'subject' => 'some subject', 'message' => 'some message'],
+        [
+            'channel' => 'Slack',
+            'subject' => 'some subject',
+            'message' => 'some message',
+            'message_formatted' => '<h1> A Test Message </h1>'
+        ],
     ];
     $this->request->isActivated = true;
 
@@ -98,6 +103,7 @@ beforeEach(function (): void {
             NotificationChannel::from($this->request->messages[0]['channel']),
             $this->request->messages[0]['subject'],
             $this->request->messages[0]['message'],
+            $this->request->messages[0]['message_formatted'],
         ),
     ];
     $this->resources = [
@@ -541,7 +547,8 @@ it('should return created object on success', function (): void {
             (fn($message) => [
                 'channel' => $message->getChannel()->value,
                 'subject' => $message->getSubject(),
-                'message' => $message->getMessage(),
+                'message' => $message->getRawMessage(),
+                'message_formatted' => $message->getFormattedMessage(),
             ]),
             $this->messages
         ))

--- a/centreon/tests/php/Core/Notification/Application/UseCase/FindNotification/FindNotificationTest.php
+++ b/centreon/tests/php/Core/Notification/Application/UseCase/FindNotification/FindNotificationTest.php
@@ -122,7 +122,12 @@ it('should get the resources with ACL calculation when the user is not admin', f
     );
 
     $notification = new Notification(1, 'notification', new ConfigurationTimePeriod(1, '24x7'), false);
-    $notificationMessage = new NotificationMessage(NotificationChannel::from('Slack'), 'Message subject', 'Message content');
+    $notificationMessage = new NotificationMessage(
+        NotificationChannel::from('Slack'),
+        'Message subject',
+        'Message content',
+        '<p>Message content</p>'
+    );
     $notificationUser = new ConfigurationUser(3, 'test-user');
 
     $this->notificationRepository
@@ -173,7 +178,8 @@ it('should present a FindNotificationResponse when everything is OK', function (
     $notificationMessage = new NotificationMessage(
         NotificationChannel::from('Slack'),
         'Message subject',
-        'Message content'
+        'Message content',
+        '<p>Message content</p>'
     );
     $notificationUser = new ConfigurationUser(3, 'test-user');
     $notificationResource = new NotificationResource(

--- a/centreon/tests/php/Core/Notification/Application/UseCase/UpdateNotification/UpdateNotificationTest.php
+++ b/centreon/tests/php/Core/Notification/Application/UseCase/UpdateNotification/UpdateNotificationTest.php
@@ -162,7 +162,8 @@ it('should present an InvalidArgumentResponse when a message has an empty subjec
         [
             "channel" => "Email",
             "subject" => "",
-            "message" => "This is my message"
+            "message" => "This is my message",
+            "formatted_message" => "<h1>This is my message</h1>",
         ]
     ];
 
@@ -199,7 +200,8 @@ it('should present a no content response when everything is ok', function (): vo
         [
             "channel" => "Email",
             "subject" => "Subject",
-            "message" => "This is my message"
+            "message" => "This is my message",
+            "formatted_message" => "<h1>This is my message</h1>",
         ]
     ];
     $request->resources = [

--- a/centreon/tests/php/Core/Notification/Domain/Model/NotificationMessageTest.php
+++ b/centreon/tests/php/Core/Notification/Domain/Model/NotificationMessageTest.php
@@ -31,19 +31,21 @@ beforeEach(function (): void {
     $this->channel = NotificationChannel::Slack;
     $this->subject = 'some subject';
     $this->message = 'some message';
-
+    $this->formattedMessage = '<p>some message</p>';
 });
 
 it('should return properly set notification message instance', function (): void {
     $message = new NotificationMessage(
         $this->channel,
         $this->subject,
-        $this->message
+        $this->message,
+        $this->formattedMessage
     );
 
     expect($message->getChannel())->toBe(NotificationChannel::Slack)
         ->and($message->getSubject())->toBe($this->subject)
-        ->and($message->getMessage())->toBe($this->message);
+        ->and($message->getRawMessage())->toBe($this->message)
+        ->and($message->getFormattedMessage())->toBe($this->formattedMessage);
 });
 
 it('should trim the "subject" and "message" fields', function (): void {
@@ -51,10 +53,12 @@ it('should trim the "subject" and "message" fields', function (): void {
         $this->channel,
         $subjectWithSpaces = '  my-subject  ',
         $messageWithSpaces = '  my-message  ',
+        $formattedMessageWithSpaces = '  <p>my-message</p>  ',
     );
 
     expect($message->getSubject())->toBe(trim($subjectWithSpaces))
-        ->and($message->getMessage())->toBe(trim($messageWithSpaces));
+        ->and($message->getRawMessage())->toBe(trim($messageWithSpaces))
+        ->and($message->getFormattedMessage())->toBe(trim($formattedMessageWithSpaces));
 });
 
 it('should throw an exception when notification message subject is too long', function (): void {

--- a/centreon/tests/php/Core/Notification/Domain/Model/NotificationMessageTest.php
+++ b/centreon/tests/php/Core/Notification/Domain/Model/NotificationMessageTest.php
@@ -92,3 +92,20 @@ it('should throw an exception when notification message content is too long', fu
         'NotificationMessage::message'
     )->getMessage()
 );
+
+it('should throw an exception when notification formatted message content is too long', function (): void {
+    new NotificationMessage(
+        $this->channel,
+        $this->subject,
+        $this->message,
+        str_repeat('a', NotificationMessage::MAX_MESSAGE_LENGTH + 1),
+    );
+})->throws(
+    \Assert\InvalidArgumentException::class,
+    AssertionException::maxLength(
+        str_repeat('a', NotificationMessage::MAX_MESSAGE_LENGTH + 1),
+        NotificationMessage::MAX_MESSAGE_LENGTH + 1,
+        NotificationMessage::MAX_MESSAGE_LENGTH,
+        'NotificationMessage::formattedMessage'
+    )->getMessage()
+);

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2491,7 +2491,7 @@ CREATE TABLE IF NOT EXISTS `notification_message` (
   `channel` enum('Email','Slack','Sms') DEFAULT 'Email',
   `subject` VARCHAR(255) NOT NULL,
   `message` TEXT NOT NULL,
-  `message_formatted` TEXT NOT NULL,
+  `formatted_message` TEXT NOT NULL,
   PRIMARY KEY (`id`),
   CONSTRAINT `notification_message_notification_id`
     FOREIGN KEY (`notification_id`)

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2491,6 +2491,7 @@ CREATE TABLE IF NOT EXISTS `notification_message` (
   `channel` enum('Email','Slack','Sms') DEFAULT 'Email',
   `subject` VARCHAR(255) NOT NULL,
   `message` TEXT NOT NULL,
+  `message_formatted` TEXT NOT NULL,
   PRIMARY KEY (`id`),
   CONSTRAINT `notification_message_notification_id`
     FOREIGN KEY (`notification_id`)

--- a/centreon/www/install/sql/centreon/Update-DB-23.10.0.sql
+++ b/centreon/www/install/sql/centreon/Update-DB-23.10.0.sql
@@ -95,6 +95,7 @@ CREATE TABLE IF NOT EXISTS `notification_message` (
   `channel` enum('Email','Slack','Sms') DEFAULT 'Email',
   `subject` VARCHAR(255) NOT NULL,
   `message` TEXT NOT NULL,
+  `message_formatted` TEXT NOT NULL,
   PRIMARY KEY (`id`),
   CONSTRAINT `notification_message_notification_id`
     FOREIGN KEY (`notification_id`)

--- a/centreon/www/install/sql/centreon/Update-DB-23.10.0.sql
+++ b/centreon/www/install/sql/centreon/Update-DB-23.10.0.sql
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS `notification_message` (
   `channel` enum('Email','Slack','Sms') DEFAULT 'Email',
   `subject` VARCHAR(255) NOT NULL,
   `message` TEXT NOT NULL,
-  `message_formatted` TEXT NOT NULL,
+  `formatted_message` TEXT NOT NULL,
   PRIMARY KEY (`id`),
   CONSTRAINT `notification_message_notification_id`
     FOREIGN KEY (`notification_id`)


### PR DESCRIPTION
## Description

This PR Intends to add a new formatted_message property on POST and PUT notifications endpoints

**Fixes** # MON-20682

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
