### PR TITLE
fix(clapi): unify STPL/getmacro command return with HTPL/getmacro (macro name format)

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php
+++ b/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php
@@ -590,6 +590,21 @@ class CentreonServiceTemplate extends CentreonObject
     }
 
     /**
+     * Extract macro name
+     *
+     * @param string $macroName
+     * @return string
+     */
+    protected function extractMacroName($macroName)
+    {
+        $strippedMacro = $macroName;
+        if (preg_match('/\$_SERVICE([a-zA-Z0-9_-]+)\$/', $strippedMacro, $matches)) {
+            $strippedMacro = $matches[1];
+        }
+        return $strippedMacro;
+    }
+
+    /**
      * Strip macro
      *
      * @param string $macroName
@@ -597,10 +612,7 @@ class CentreonServiceTemplate extends CentreonObject
      */
     protected function stripMacro($macroName)
     {
-        $strippedMacro = $macroName;
-        if (preg_match('/\$_SERVICE([a-zA-Z0-9_-]+)\$/', $strippedMacro, $matches)) {
-            $strippedMacro = $matches[1];
-        }
+        $strippedMacro = $this->extractMacroName($macroName);
         return strtolower($strippedMacro);
     }
 
@@ -653,7 +665,7 @@ class CentreonServiceTemplate extends CentreonObject
         echo "macro name;macro value;description;is_password\n";
         foreach ($macroList as $macro) {
             $password = !empty($macro['is_password']) ? (int)$macro['is_password'] : 0;
-            echo $macro['svc_macro_name'] . $this->delim
+            echo $this->extractMacroName($macro['svc_macro_name']) . $this->delim
             . $macro['svc_macro_value'] . $this->delim
             . $macro['description'] . $this->delim
             . $password . "\n";


### PR DESCRIPTION
## Description

Format the macro name in the CLAPI command STPL/getmacro, to uniformise behaviour with the HTPL/getmacro command

Before fix:
```
centreon -u admin -p 'Centreon!2021' -o STPL -a getmacro -v "generic-service"
macro name;macro value;description;is_password
$_SERVICEDUMMYMACRO$;dummy;;0
```
After fix:
```
# centreon -u admin -p 'Centreon!2021' -o STPL -a getmacro -v "generic-service"
macro name;macro value;description;is_password
DUMMYMACRO;dummy;;0
```

From community contribution: https://github.com/centreon/centreon/pull/1135 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
