### PR TITLE
enh(api): remove is_activate property from hostTemplate and serviceTemplate endpoints

### DIFF
--- a/centreon/doc/API/v23.10/Configuration/HostTemplate/AddAndFindHostTemplates.yaml
+++ b/centreon/doc/API/v23.10/Configuration/HostTemplate/AddAndFindHostTemplates.yaml
@@ -10,7 +10,6 @@ get:
     * id
     * name
     * alias
-    * is_activated
     * is_locked
 
     Changes in 23.10 :

--- a/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
+++ b/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
@@ -231,9 +231,6 @@ properties:
     type: string
     nullable: true
     description: "Host template comments"
-  is_activated:
-    type: boolean
-    description: "Indicates whether the host template is activated or not"
   categories:
     type: array
     items:

--- a/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
+++ b/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
@@ -234,9 +234,6 @@ properties:
     type: string
     nullable: true
     description: "Host template comments"
-  is_activated:
-    type: boolean
-    description: "Indicates whether the host template is activated or not"
   is_locked:
     type: boolean
     description: "Indicates whether the configuration is locked for editing or not"

--- a/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/HostTemplate.yaml
+++ b/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/HostTemplate.yaml
@@ -234,9 +234,6 @@ properties:
     type: string
     nullable: true
     description: "Host template comments"
-  is_activated:
-    type: boolean
-    description: "Indicates whether the host template is activated or not"
   is_locked:
     type: boolean
     description: "Indicates whether the configuration is locked for editing or not"

--- a/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
+++ b/centreon/doc/API/v23.10/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
@@ -280,6 +280,3 @@ properties:
     type: string
     nullable: true
     description: "Host template comments"
-  is_activated:
-    type: boolean
-    description: "Indicates whether the host template is activated or not"

--- a/centreon/doc/API/v23.10/Configuration/ServiceTemplate/AddOneAndFindServiceTemplates.yaml
+++ b/centreon/doc/API/v23.10/Configuration/ServiceTemplate/AddOneAndFindServiceTemplates.yaml
@@ -10,7 +10,6 @@ get:
     * id
     * name
     * alias
-    * is_activated
     * is_locked
   parameters:
     - $ref: '../../Common/QueryParameter/Limit.yaml'

--- a/centreon/doc/API/v23.10/Configuration/ServiceTemplate/Schema/AddServiceTemplateResponse.yaml
+++ b/centreon/doc/API/v23.10/Configuration/ServiceTemplate/Schema/AddServiceTemplateResponse.yaml
@@ -254,10 +254,6 @@ allOf:
         description: "Severity ID."
         minimum: 1
         nullable: true
-      is_activated:
-        type: boolean
-        description: "Indicates whether the service template is activated or not"
-        example: true
       host_templates:
         type: array
         description: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/v23.10/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
+++ b/centreon/doc/API/v23.10/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
@@ -245,10 +245,6 @@ properties:
     description: "Severity ID."
     minimum: 1
     nullable: true
-  is_activated:
-    type: boolean
-    description: "Indicates whether the service template is activated or not"
-    example: true
   host_templates:
     type: array
     descriptions: "IDs of host templates linked to this service template."

--- a/centreon/doc/API/v23.10/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
+++ b/centreon/doc/API/v23.10/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
@@ -236,10 +236,6 @@ properties:
     description: "Severity ID."
     minimum: 1
     nullable: true
-  is_activated:
-    type: boolean
-    description: "Indicates whether the service template is activated or not"
-    example: true
   host_templates:
     type: array
     descriptions: "IDs of host templates linked to this service template."

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateFactory.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateFactory.php
@@ -87,7 +87,6 @@ final class AddHostTemplateFactory
         $dto->iconId = $hostTemplate->getIconId();
         $dto->iconAlternative = $hostTemplate->getIconAlternative();
         $dto->comment = $hostTemplate->getComment();
-        $dto->isActivated = $hostTemplate->isActivated();
         $dto->isLocked = $hostTemplate->isLocked();
 
         $dto->categories = array_map(

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateRequest.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateRequest.php
@@ -101,8 +101,6 @@ final class AddHostTemplateRequest
 
     public string $comment = '';
 
-    public bool $isActivated = true;
-
     /** @var int[] */
     public array $categories = [];
 

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateResponse.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/AddHostTemplateResponse.php
@@ -103,8 +103,6 @@ final class AddHostTemplateResponse
 
     public string $comment = '';
 
-    public bool $isActivated = true;
-
     public bool $isLocked = false;
 
     /** @var array<array{id:int,name:string}> */

--- a/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/NewHostTemplateFactory.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/AddHostTemplate/NewHostTemplateFactory.php
@@ -83,7 +83,6 @@ final class NewHostTemplateFactory
             $dto->iconId,
             $dto->iconAlternative,
             $dto->comment,
-            $dto->isActivated,
         );
     }
 }

--- a/centreon/src/Core/HostTemplate/Application/UseCase/FindHostTemplates/FindHostTemplates.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/FindHostTemplates/FindHostTemplates.php
@@ -124,7 +124,6 @@ final class FindHostTemplates
                 'iconId' => $hostTemplate->getIconId(),
                 'iconAlternative' => $hostTemplate->getIconAlternative(),
                 'comment' => $hostTemplate->getComment(),
-                'isActivated' => $hostTemplate->isActivated(),
                 'isLocked' => $hostTemplate->isLocked(),
             ];
         }

--- a/centreon/src/Core/HostTemplate/Application/UseCase/FindHostTemplates/FindHostTemplatesResponse.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/FindHostTemplates/FindHostTemplatesResponse.php
@@ -65,7 +65,6 @@ final class FindHostTemplatesResponse
      *          iconId: int|null,
      *          iconAlternative: string,
      *          comment: string,
-     *          isActivated: bool,
      *          isLocked: bool
      *     }
      * >

--- a/centreon/src/Core/HostTemplate/Application/UseCase/PartialUpdateHostTemplate/PartialUpdateHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/PartialUpdateHostTemplate/PartialUpdateHostTemplate.php
@@ -362,10 +362,6 @@ final class PartialUpdateHostTemplate
             $hostTemplate->setComment($request->comment);
         }
 
-        if (! $request->isActivated instanceOf NoValue) {
-            $hostTemplate->setIsActivated($request->isActivated);
-        }
-
         $this->writeHostTemplateRepository->update($hostTemplate);
     }
 

--- a/centreon/src/Core/HostTemplate/Application/UseCase/PartialUpdateHostTemplate/PartialUpdateHostTemplateRequest.php
+++ b/centreon/src/Core/HostTemplate/Application/UseCase/PartialUpdateHostTemplate/PartialUpdateHostTemplateRequest.php
@@ -68,7 +68,6 @@ final class PartialUpdateHostTemplateRequest
      * @param NoValue|null|int $iconId
      * @param NoValue|string $iconAlternative
      * @param NoValue|string $comment
-     * @param NoValue|bool $isActivated
      */
     public function __construct(
         public NoValue|array $macros = new NoValue(),
@@ -111,7 +110,6 @@ final class PartialUpdateHostTemplateRequest
         public NoValue|null|int $iconId = new NoValue(),
         public NoValue|string $iconAlternative = new NoValue(),
         public NoValue|string $comment = new NoValue(),
-        public NoValue|bool $isActivated = new NoValue(),
     ) {
     }
 }

--- a/centreon/src/Core/HostTemplate/Domain/Model/HostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Domain/Model/HostTemplate.php
@@ -72,7 +72,6 @@ class HostTemplate extends NewHostTemplate
      * @param null|int $iconId
      * @param string $iconAlternative
      * @param string $comment
-     * @param bool $isActivated
      * @param bool $isLocked
      *
      * @throws AssertionFailedException
@@ -116,7 +115,6 @@ class HostTemplate extends NewHostTemplate
         ?int $iconId = null,
         string $iconAlternative = '',
         string $comment = '',
-        bool $isActivated = true,
         bool $isLocked = false
     ) {
         $this->shortName = (new \ReflectionClass($this))->getShortName();
@@ -161,7 +159,6 @@ class HostTemplate extends NewHostTemplate
             $iconId,
             $iconAlternative,
             $comment,
-            $isActivated,
             $isLocked
         );
     }
@@ -513,10 +510,5 @@ class HostTemplate extends NewHostTemplate
     public function setAddInheritedContact(bool $addInheritedContact): void
     {
         $this->addInheritedContact = $addInheritedContact;
-    }
-
-    public function setIsActivated(bool $isActivated): void
-    {
-        $this->isActivated = $isActivated;
     }
 }

--- a/centreon/src/Core/HostTemplate/Domain/Model/NewHostTemplate.php
+++ b/centreon/src/Core/HostTemplate/Domain/Model/NewHostTemplate.php
@@ -78,7 +78,6 @@ class NewHostTemplate
      * @param null|int $iconId
      * @param string $iconAlternative
      * @param string $comment
-     * @param bool $isActivated
      * @param bool $isLocked
      *
      * @throws AssertionFailedException
@@ -121,7 +120,6 @@ class NewHostTemplate
         protected ?int $iconId = null,
         protected string $iconAlternative = '',
         protected string $comment = '',
-        protected bool $isActivated = true,
         protected readonly bool $isLocked = false
     ) {
         $shortName = (new \ReflectionClass($this))->getShortName();
@@ -382,11 +380,6 @@ class NewHostTemplate
     public function addInheritedContact(): bool
     {
         return $this->addInheritedContact;
-    }
-
-    public function isActivated(): bool
-    {
-        return $this->isActivated;
     }
 
     public function isLocked(): bool

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateController.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateController.php
@@ -118,7 +118,6 @@ final class AddHostTemplateController extends AbstractController
              *     icon_id?: null|int,
              *     icon_alternative?: string,
              *     comment?: string,
-             *     is_activated?: bool,
              *     categories?: int[],
              *     templates?: int[],
              *     macros?: array<array{name:string,value:null|string,is_password:bool,description:null|string}>
@@ -164,7 +163,6 @@ final class AddHostTemplateController extends AbstractController
             $dto->iconId = $data['icon_id'] ?? null;
             $dto->iconAlternative = $data['icon_alternative'] ?? '';
             $dto->comment = $data['comment'] ?? '';
-            $dto->isActivated = $data['is_activated'] ?? true;
             $dto->categories = $data['categories'] ?? [];
             $dto->templates = $data['templates'] ?? [];
             $dto->macros = $data['macros'] ?? [];
@@ -207,7 +205,6 @@ final class AddHostTemplateController extends AbstractController
              *     note_url?: string,
              *     note?: string,
              *     action_url?: string,
-             *     is_activated?: bool,
              *     categories?: int[],
              *     templates?: int[],
              *     macros?: array<array{name:string,value:null|string,is_password:bool,description:null|string}>
@@ -226,7 +223,6 @@ final class AddHostTemplateController extends AbstractController
             $dto->noteUrl = $data['note_url'] ?? '';
             $dto->note = $data['note'] ?? '';
             $dto->actionUrl = $data['action_url'] ?? '';
-            $dto->isActivated = $data['is_activated'] ?? true;
             $dto->categories = $data['categories'] ?? [];
             $dto->templates = $data['templates'] ?? [];
             $dto->macros = $data['macros'] ?? [];

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateOnPremPresenter.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateOnPremPresenter.php
@@ -84,7 +84,6 @@ class AddHostTemplateOnPremPresenter extends AbstractPresenter implements AddHos
                         'icon_id' => $response->iconId,
                         'icon_alternative' => $this->emptyStringAsNull($response->iconAlternative),
                         'comment' => $this->emptyStringAsNull($response->comment),
-                        'is_activated' => $response->isActivated,
                         'is_locked' => $response->isLocked,
                         'categories' => $response->categories,
                         'templates' => $response->templates,

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateOnPremSchema.json
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateOnPremSchema.json
@@ -266,12 +266,6 @@
                 "string"
             ]
         },
-        "is_activated": {
-            "type": [
-                "null",
-                "boolean"
-            ]
-        },
         "categories": {
             "type": "array",
             "items": {

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateSaasSchema.json
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateSaasSchema.json
@@ -68,12 +68,6 @@
                 "string"
             ]
         },
-        "is_activated": {
-            "type": [
-                "null",
-                "boolean"
-            ]
-        },
         "categories": {
             "type": "array",
             "items": {

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/FindHostTemplates/FindHostTemplatesOnPremPresenter.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/FindHostTemplates/FindHostTemplatesOnPremPresenter.php
@@ -91,7 +91,6 @@ class FindHostTemplatesOnPremPresenter extends AbstractPresenter implements Find
                     'icon_id' => $hostTemplate['iconId'],
                     'icon_alternative' => $this->emptyStringAsNull($hostTemplate['iconAlternative']),
                     'comment' => $this->emptyStringAsNull($hostTemplate['comment']),
-                    'is_activated' => $hostTemplate['isActivated'],
                     'is_locked' => $hostTemplate['isLocked'],
                 ];
             }

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/FindHostTemplates/FindHostTemplatesSaasPresenter.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/FindHostTemplates/FindHostTemplatesSaasPresenter.php
@@ -65,7 +65,6 @@ class FindHostTemplatesSaasPresenter extends AbstractPresenter implements FindHo
                     'note_url' => $this->emptyStringAsNull($hostTemplate['noteUrl']),
                     'note' => $this->emptyStringAsNull($hostTemplate['note']),
                     'action_url' => $this->emptyStringAsNull($hostTemplate['actionUrl']),
-                    'is_activated' => $hostTemplate['isActivated'],
                     'is_locked' => $hostTemplate['isLocked'],
                 ];
             }

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/PartialUpdateHostTemplate/PartialUpdateHostTemplateController.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/PartialUpdateHostTemplate/PartialUpdateHostTemplateController.php
@@ -117,8 +117,7 @@ final class PartialUpdateHostTemplateController extends AbstractController
          *      action_url?: null|string,
          *      icon_id?: null|int,
          *      icon_alternative?: null|string,
-         *      comment?: string,
-         *      is_activated?: bool
+         *      comment?: string
          * } $data
          */
         $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/PartialUpdateHostTemplateOnPremSchema.json');
@@ -248,9 +247,6 @@ final class PartialUpdateHostTemplateController extends AbstractController
         if (\array_key_exists('comment', $data)) {
             $dto->comment = $data['comment'] ?? '';
         }
-        if (\array_key_exists('is_activated', $data)) {
-            $dto->isActivated = $data['is_activated'];
-        }
 
         return $dto;
     }
@@ -278,8 +274,7 @@ final class PartialUpdateHostTemplateController extends AbstractController
          *      check_timeperiod_id?: null|int,
          *      note_url?: null|string,
          *      note?: null|string,
-         *      action_url?: null|string,
-         *      is_activated?: bool,
+         *      action_url?: null|string
          * } $data
          */
         $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/PartialUpdateHostTemplateSaasSchema.json');
@@ -324,9 +319,6 @@ final class PartialUpdateHostTemplateController extends AbstractController
         }
         if (\array_key_exists('action_url', $data)) {
             $dto->actionUrl = $data['action_url'] ?? '';
-        }
-        if (\array_key_exists('is_activated', $data)) {
-            $dto->isActivated = $data['is_activated'];
         }
 
         return $dto;

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/PartialUpdateHostTemplate/PartialUpdateHostTemplateOnPremSchema.json
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/PartialUpdateHostTemplate/PartialUpdateHostTemplateOnPremSchema.json
@@ -305,12 +305,6 @@
                 "null",
                 "string"
             ]
-        },
-        "is_activated": {
-            "type": [
-                "null",
-                "boolean"
-            ]
         }
     }
 }

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/PartialUpdateHostTemplate/PartialUpdateHostTemplateSaasSchema.json
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/PartialUpdateHostTemplate/PartialUpdateHostTemplateSaasSchema.json
@@ -107,12 +107,6 @@
                 "null",
                 "string"
             ]
-        },
-        "is_activated": {
-            "type": [
-                "null",
-                "boolean"
-            ]
         }
     }
 }

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
@@ -94,7 +94,6 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
                     h.command_command_id2,
                     h.command_command_id_arg2,
                     h.host_comment,
-                    h.host_activate,
                     h.host_locked,
                     ehi.ehi_notes_url,
                     ehi.ehi_notes,
@@ -123,10 +122,8 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
             'id' => 'h.host_id',
             'name' => 'h.host_name',
             'alias' => 'h.host_alias',
-            'is_activated' => 'h.host_register',
             'is_locked' => 'h.host_locked',
         ]);
-        $sqlTranslator->addNormalizer('is_activated', new BoolToEnumNormalizer());
         $sqlTranslator->addNormalizer('is_locked', new BoolToEnumNormalizer());
         $sqlTranslator->translateForConcatenator($concatenator);
 
@@ -173,7 +170,6 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
              *     command_command_id2: int|null,
              *     command_command_id_arg2: string|null,
              *     host_comment: string|null,
-             *     host_activate: string|null,
              *     host_locked: int|null,
              *     ehi_notes_url: string|null,
              *     ehi_notes: string|null,
@@ -230,7 +226,6 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
                     h.command_command_id2,
                     h.command_command_id_arg2,
                     h.host_comment,
-                    h.host_activate,
                     h.host_locked,
                     ehi.ehi_notes_url,
                     ehi.ehi_notes,
@@ -293,7 +288,6 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
          *     command_command_id2: int|null,
          *     command_command_id_arg2: string|null,
          *     host_comment: string|null,
-         *     host_activate: string|null,
          *     host_locked: int|null,
          *     ehi_notes_url: string|null,
          *     ehi_notes: string|null,
@@ -528,7 +522,6 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
      *     command_command_id2: int|null,
      *     command_command_id_arg2: string|null,
      *     host_comment: string|null,
-     *     host_activate: string|null,
      *     host_locked: int|null,
      *     ehi_notes_url: string|null,
      *     ehi_notes: string|null,
@@ -611,7 +604,6 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
             $result['ehi_icon_image'],
             (string) $result['ehi_icon_image_alt'],
             (string) $result['host_comment'],
-            (bool) $result['host_activate'],
             (bool) $result['host_locked']
         );
     }

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbWriteHostTemplateRepository.php
@@ -634,7 +634,7 @@ class DbWriteHostTemplateRepository extends AbstractRepositoryRDB implements Wri
         );
         $statement->bindValue(
             ':isActivated',
-            (new BoolToEnumNormalizer())->normalize($hostTemplate->isActivated()),
+            (new BoolToEnumNormalizer())->normalize(true),
             \PDO::PARAM_STR
         );
         $statement->bindValue(

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplate.php
@@ -312,7 +312,6 @@ final class AddServiceTemplate
         $response->notificationTypes = $serviceTemplate->getNotificationTypes();
         $response->isContactAdditiveInheritance = $serviceTemplate->isContactAdditiveInheritance();
         $response->isContactGroupAdditiveInheritance = $serviceTemplate->isContactGroupAdditiveInheritance();
-        $response->isActivated = $serviceTemplate->isActivated();
         $response->isLocked = $serviceTemplate->isLocked();
         $response->activeChecks = $serviceTemplate->getActiveChecks();
         $response->passiveCheck = $serviceTemplate->getPassiveCheck();

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateRequest.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateRequest.php
@@ -50,8 +50,6 @@ final class AddServiceTemplateRequest
 
     public bool $isContactGroupAdditiveInheritance = false;
 
-    public bool $isActivated = false;
-
     public int $activeChecks = 0;
 
     public int $passiveCheck = 0;

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateResponse.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateResponse.php
@@ -70,8 +70,6 @@ final class AddServiceTemplateResponse
 
     public string|null $iconAlternativeText = null;
 
-    public bool $isActivated = false;
-
     public bool $isLocked = false;
 
     public YesNoDefault $activeChecks = YesNoDefault::Default;

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/NewServiceTemplateFactory.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/NewServiceTemplateFactory.php
@@ -63,7 +63,6 @@ class NewServiceTemplateFactory
             ($inheritanceMode === 1) ? $request->isContactGroupAdditiveInheritance : false
         );
 
-        $serviceTemplate->setActivated($request->isActivated);
         $serviceTemplate->setLocked(false);
         $serviceTemplate->setActiveChecks(YesNoDefaultConverter::fromInt($request->activeChecks));
         $serviceTemplate->setPassiveCheck(YesNoDefaultConverter::fromInt($request->passiveCheck));

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/FindServiceTemplates.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/FindServiceTemplates.php
@@ -109,7 +109,6 @@ final class FindServiceTemplates
             $dto->highFlapThreshold = $serviceTemplate->getHighFlapThreshold();
             $dto->iconId = $serviceTemplate->getIconId();
             $dto->iconAlternativeText = $serviceTemplate->getIconAlternativeText();
-            $dto->isActivated = $serviceTemplate->isActivated();
             $dto->isLocked = $serviceTemplate->isLocked();
             $dto->activeChecks = $serviceTemplate->getActiveChecks();
             $dto->eventHandlerEnabled = $serviceTemplate->getEventHandlerEnabled();

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/ServiceTemplateDto.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/ServiceTemplateDto.php
@@ -70,8 +70,6 @@ final class ServiceTemplateDto
 
     public string|null $iconAlternativeText = null;
 
-    public bool $isActivated = false;
-
     public bool $isLocked = false;
 
     public YesNoDefault $activeChecks = YesNoDefault::Default;

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
@@ -412,10 +412,6 @@ final class PartialUpdateServiceTemplate
             $serviceTemplate->setContactGroupAdditiveInheritance($request->isContactGroupAdditiveInheritance);
         }
 
-        if (! $request->isActivated instanceof NoValue) {
-            $serviceTemplate->setActivated($request->isActivated);
-        }
-
         if (! $request->activeChecksEnabled instanceof NoValue) {
             $serviceTemplate->setActiveChecks(YesNoDefaultConverter::fromInt($request->activeChecksEnabled));
         }

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateRequest.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateRequest.php
@@ -43,8 +43,6 @@ final class PartialUpdateServiceTemplateRequest
 
     public bool|NoValue $isContactGroupAdditiveInheritance;
 
-    public bool|NoValue $isActivated;
-
     public int|NoValue $activeChecksEnabled;
 
     public int|NoValue $passiveCheckEnabled;
@@ -126,7 +124,6 @@ final class PartialUpdateServiceTemplateRequest
         $this->notificationTypes = new NoValue();
         $this->isContactAdditiveInheritance = new NoValue();
         $this->isContactGroupAdditiveInheritance = new NoValue();
-        $this->isActivated = new NoValue();
         $this->activeChecksEnabled = new NoValue();
         $this->passiveCheckEnabled = new NoValue();
         $this->volatility = new NoValue();

--- a/centreon/src/Core/ServiceTemplate/Domain/Model/NewServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Domain/Model/NewServiceTemplate.php
@@ -61,8 +61,6 @@ class NewServiceTemplate
 
     private bool $isContactGroupAdditiveInheritance = false;
 
-    private bool $isActivated = true;
-
     private bool $isLocked = false;
 
     private YesNoDefault $activeChecks = YesNoDefault::Default;
@@ -287,22 +285,6 @@ class NewServiceTemplate
     public function isContactGroupAdditiveInheritance(): bool
     {
         return $this->isContactGroupAdditiveInheritance;
-    }
-
-    /**
-     * @param bool $isActivated
-     */
-    public function setActivated(bool $isActivated): void
-    {
-        $this->isActivated = $isActivated;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isActivated(): bool
-    {
-        return $this->isActivated;
     }
 
     /**

--- a/centreon/src/Core/ServiceTemplate/Domain/Model/ServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Domain/Model/ServiceTemplate.php
@@ -47,7 +47,6 @@ class ServiceTemplate extends NewServiceTemplate
      * @param list<int> $hostTemplateIds
      * @param bool $contactAdditiveInheritance
      * @param bool $contactGroupAdditiveInheritance
-     * @param bool $isActivated
      * @param bool $isLocked
      * @param YesNoDefault $activeChecks
      * @param YesNoDefault $passiveCheck
@@ -92,7 +91,6 @@ class ServiceTemplate extends NewServiceTemplate
         array $hostTemplateIds = [],
         bool $contactAdditiveInheritance = false,
         bool $contactGroupAdditiveInheritance = false,
-        bool $isActivated = true,
         bool $isLocked = false,
         YesNoDefault $activeChecks = YesNoDefault::Default,
         YesNoDefault $passiveCheck = YesNoDefault::Default,
@@ -155,7 +153,6 @@ class ServiceTemplate extends NewServiceTemplate
         $this->setHighFlapThreshold($highFlapThreshold);
         $this->setContactAdditiveInheritance($contactAdditiveInheritance);
         $this->setContactGroupAdditiveInheritance($contactGroupAdditiveInheritance);
-        $this->setActivated($isActivated);
         $this->setLocked($isLocked);
         $this->setActiveChecks($activeChecks);
         $this->setPassiveCheck($passiveCheck);

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateController.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateController.php
@@ -76,7 +76,6 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
  *     icon_id: int|null,
  *     icon_alternative: string|null,
  *     severity_id: int|null,
- *     is_activated: boolean|null,
  *     is_locked: boolean|null,
  *     macros: array<array{name: string, value: string|null, is_password: bool, description: string|null}>,
  *     service_categories: list<int>|null,
@@ -174,7 +173,6 @@ final class AddServiceTemplateController extends AbstractController
         $dto->iconId = $request['icon_id'] ?? null;
         $dto->iconAlternativeText = $request['icon_alternative'] ?? null;
         $dto->severityId = $request['severity_id'];
-        $dto->isActivated = $request['is_activated'] ?? true;
         $dto->serviceCategories = $request['service_categories'] ?? [];
 
         foreach ($request['service_groups'] as $macro) {

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateOnPremPresenter.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateOnPremPresenter.php
@@ -82,7 +82,6 @@ class AddServiceTemplateOnPremPresenter extends AbstractPresenter implements Add
                         'icon_alternative' => $response->iconAlternativeText,
                         'severity_id' => $response->severityId,
                         'host_templates' => $response->hostTemplateIds,
-                        'is_activated' => $response->isActivated,
                         'is_locked' => $response->isLocked,
                         'macros' => array_map(fn(MacroDto $macro): array => [
                             'name' => $macro->name,

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateOnPremSchema.json
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateOnPremSchema.json
@@ -232,9 +232,6 @@
                 "integer"
             ]
         },
-        "is_activated": {
-            "type": "boolean"
-        },
         "host_templates": {
             "type": "array",
             "items": {

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/FindServiceTemplates/FindServiceTemplatesOnPremPresenter.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/FindServiceTemplates/FindServiceTemplatesOnPremPresenter.php
@@ -94,7 +94,6 @@ class FindServiceTemplatesOnPremPresenter extends AbstractPresenter implements F
                     'icon_alternative' => $dto->iconAlternativeText,
                     'severity_id' => $dto->severityId,
                     'host_templates' => $dto->hostTemplateIds,
-                    'is_activated' => $dto->isActivated,
                     'is_locked' => $dto->isLocked,
                 ];
             }

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateController.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateController.php
@@ -74,7 +74,6 @@ use Symfony\Component\HttpFoundation\Response;
  *     icon_id: int|null,
  *     icon_alternative: string|null,
  *     severity_id: int|null,
- *     is_activated: boolean,
  *     host_templates: list<int>,
  *     service_categories: list<int>,
  *     macros: array<array{name: string, value: string|null, is_password: bool, description: string|null}>,
@@ -279,10 +278,6 @@ final class PartialUpdateServiceTemplateController extends AbstractController
 
         if (array_key_exists('severity_id', $request)) {
             $serviceTemplate->severityId = $request['severity_id'];
-        }
-
-        if (array_key_exists('is_activated', $request)) {
-            $serviceTemplate->isActivated = $request['is_activated'];
         }
 
         if (array_key_exists('host_templates', $request)) {

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateOnPremSchema.json
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateOnPremSchema.json
@@ -222,9 +222,6 @@
                 "integer"
             ]
         },
-        "is_activated": {
-            "type": "boolean"
-        },
         "host_templates": {
             "type": "array",
             "items": {

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbReadServiceTemplateRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbReadServiceTemplateRepository.php
@@ -49,7 +49,6 @@ use Utility\SqlConcatenator;
  *     command_command_id_arg: string|null,
  *     command_command_id_arg2: string|null,
  *     service_acknowledgement_timeout: int|null,
- *     service_activate: string,
  *     service_active_checks_enabled: string,
  *     service_event_handler_enabled: string,
  *     service_flap_detection_enabled: string,
@@ -115,7 +114,6 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
                        service.timeperiod_tp_id,
                        service.timeperiod_tp_id2,
                        service_acknowledgement_timeout,
-                       service_activate,
                        service_active_checks_enabled,
                        service_event_handler_enabled,
                        service_flap_detection_enabled,
@@ -187,10 +185,8 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
             'id' => 'service_id',
             'name' => 'service_description',
             'alias' => 'service_alias',
-            'is_activated' => 'service_activate',
             'is_locked' => 'service_locked',
         ]);
-        $sqlTranslator->addNormalizer('is_activated', new BoolToEnumNormalizer());
         $sqlTranslator->addNormalizer('is_locked', new BoolToEnumNormalizer());
 
         $serviceTemplates = [];
@@ -205,7 +201,6 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
                        service.timeperiod_tp_id,
                        service.timeperiod_tp_id2,
                        service_acknowledgement_timeout,
-                       service_activate,
                        service_active_checks_enabled,
                        service_event_handler_enabled,
                        service_flap_detection_enabled,
@@ -387,7 +382,6 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
             $hostTemplateIds,
             $data['contact_additive_inheritance'] === 1,
             $data['cg_additive_inheritance'] === 1,
-            $data['service_activate'] === '1',
             $data['service_locked'] === 1,
             $this->createYesNoDefault($data['service_active_checks_enabled']),
             $this->createYesNoDefault($data['service_passive_checks_enabled']),

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbWriteServiceTemplateRepository.php
@@ -26,6 +26,7 @@ namespace Core\ServiceTemplate\Infrastructure\Repository;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Infrastructure\DatabaseConnection;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Core\Common\Infrastructure\RequestParameters\Normalizer\BoolToEnumNormalizer;
 use Core\ServiceTemplate\Application\Repository\WriteServiceTemplateRepositoryInterface;
 use Core\ServiceTemplate\Domain\Model\NewServiceTemplate;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
@@ -148,7 +149,8 @@ class DbWriteServiceTemplateRepository extends AbstractRepositoryRDB implements 
         );
         $statement->bindValue(
             ':is_activated',
-            $newServiceTemplate->isActivated()
+            (new BoolToEnumNormalizer())->normalize(true),
+            \PDO::PARAM_STR
         );
         $statement->bindValue(
             ':is_locked',
@@ -455,7 +457,8 @@ class DbWriteServiceTemplateRepository extends AbstractRepositoryRDB implements 
         );
         $statement->bindValue(
             ':is_activated',
-            $serviceTemplate->isActivated()
+            (new BoolToEnumNormalizer())->normalize(true),
+            \PDO::PARAM_STR
         );
         $statement->bindValue(
             ':is_locked',

--- a/centreon/tests/api/features/CloudHostTemplate.feature
+++ b/centreon/tests/api/features/CloudHostTemplate.feature
@@ -32,7 +32,6 @@ Feature:
           "note_url": null,
           "note": null,
           "action_url": null,
-          "is_activated": true,
           "is_locked": false
         }
       ],

--- a/centreon/tests/api/features/HostTemplate.feature
+++ b/centreon/tests/api/features/HostTemplate.feature
@@ -59,7 +59,6 @@ Feature:
           "icon_id": null,
           "icon_alternative": null,
           "comment": null,
-          "is_activated": true,
           "is_locked": false
         }
       ],
@@ -148,7 +147,6 @@ Feature:
         "icon_id": 1,
         "icon_alternative": "iconAlternative-value",
         "comment": "comment-value",
-        "is_activated": false,
         "categories": [2],
         "templates": [],
         "macros": [
@@ -209,7 +207,6 @@ Feature:
         "icon_id": 1,
         "icon_alternative": "iconAlternative-value",
         "comment": "comment-value",
-        "is_activated": false,
         "is_locked": false,
         "categories": [
           {
@@ -301,7 +298,6 @@ Feature:
         "icon_id": 1,
         "icon_alternative": "iconAlternative-value",
         "comment": "comment-value",
-        "is_activated": false,
         "categories": [2],
         "templates": []
       }
@@ -349,7 +345,6 @@ Feature:
         "icon_id": 1,
         "icon_alternative": "iconAlternative-value",
         "comment": "comment-value",
-        "is_activated": false,
         "categories": [],
         "templates": [999]
       }
@@ -403,7 +398,6 @@ Feature:
         "icon_id": 1,
         "icon_alternative": "iconAlternative-value",
         "comment": "comment-value",
-        "is_activated": false,
         "categories": [2],
         "templates": [15],
         "macros": [
@@ -464,7 +458,6 @@ Feature:
         "icon_id": 1,
         "icon_alternative": "iconAlternative-value",
         "comment": "comment-value",
-        "is_activated": false,
         "is_locked": false,
         "categories": [
           {
@@ -696,8 +689,7 @@ Feature:
         "action_url": "actionUrl-value",
         "icon_id": 1,
         "icon_alternative": "iconAlternative-value",
-        "comment": "comment-value",
-        "is_activated": false
+        "comment": "comment-value"
       }
     """
     Then the response code should be "204"

--- a/centreon/tests/api/features/ServiceTemplatesOnPrem.feature
+++ b/centreon/tests/api/features/ServiceTemplatesOnPrem.feature
@@ -165,7 +165,6 @@ Feature:
         "icon_id": 1,
         "icon_alternative": "icon_alternative",
         "severity_id": null,
-        "is_activated": true,
         "macros": [
             {
                 "name": "MACROB",
@@ -247,7 +246,6 @@ Feature:
             3,
             11
         ],
-        "is_activated": true,
         "is_locked": false,
         "macros": [
             {
@@ -342,7 +340,6 @@ Feature:
                     3,
                     11
                 ],
-                "is_activated": true,
                 "is_locked": false
             }
         ],
@@ -400,7 +397,6 @@ Feature:
         "icon_id": null,
         "icon_alternative": "new icon_alternative",
         "severity_id": 5,
-        "is_activated": true,
         "macros": [
             {
                 "name": "MACROB",
@@ -476,7 +472,6 @@ Feature:
                     2,
                     3
                 ],
-                "is_activated": true,
                 "is_locked": false
             }
         ],

--- a/centreon/tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/AddHostTemplate/AddHostTemplateTest.php
@@ -119,7 +119,6 @@ beforeEach(function (): void {
     $this->request->iconId = 1;
     $this->request->iconAlternative = 'iconAlternative-value';
     $this->request->comment = 'comment-value';
-    $this->request->isActivated = false;
 
     $this->hostTemplate = new HostTemplate(
         id: 1,
@@ -160,7 +159,6 @@ beforeEach(function (): void {
         iconId: $this->request->iconId,
         iconAlternative: $this->request->iconAlternative,
         comment: $this->request->comment,
-        isActivated: $this->request->isActivated,
         isLocked: false,
     );
 
@@ -665,8 +663,6 @@ it('should return created object on success (with admin user)', function (): voi
         ->toBe($this->hostTemplate->getIconAlternative())
         ->and($response->comment)
         ->toBe($this->hostTemplate->getComment())
-        ->and($response->isActivated)
-        ->toBe($this->hostTemplate->isActivated())
         ->and($response->categories)
         ->toBe(array_map(
             (fn($category) => ['id' => $category->getId(), 'name' => $category->getName()]),
@@ -848,8 +844,6 @@ it('should return created object on success (with non-admin user)', function ():
         ->toBe($this->hostTemplate->getIconAlternative())
         ->and($response->comment)
         ->toBe($this->hostTemplate->getComment())
-        ->and($response->isActivated)
-        ->toBe($this->hostTemplate->isActivated())
         ->and($response->categories)
         ->toBe(array_map(
             (fn($category) => ['id' => $category->getId(), 'name' => $category->getName()]),

--- a/centreon/tests/php/Core/HostTemplate/Application/FindHostTemplates/FindHostTemplatesTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/FindHostTemplates/FindHostTemplatesTest.php
@@ -91,7 +91,6 @@ beforeEach(function (): void {
         1,
         'iconAlternative-value',
         'comment-value',
-        false,
         true,
     );
     $this->testedHostTemplateArray = [
@@ -133,7 +132,6 @@ beforeEach(function (): void {
         'iconId' => 1,
         'iconAlternative' => 'iconAlternative-value',
         'comment' => 'comment-value',
-        'isActivated' => false,
         'isLocked' => true,
     ];
 });

--- a/centreon/tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Application/PartialUpdateHostTemplate/PartialUpdateHostTemplateTest.php
@@ -141,7 +141,6 @@ beforeEach(function () {
     $this->request->iconId = 1;
     $this->request->iconAlternative = 'iconAlternative-value';
     $this->request->comment = 'comment-value edit';
-    $this->request->isActivated = false;
 
     $this->editedHostTemplate = new HostTemplate(
         id: $this->hostTemplateId,
@@ -182,7 +181,6 @@ beforeEach(function () {
         iconId: $this->request->iconId,
         iconAlternative: $this->request->iconAlternative,
         comment: $this->request->comment,
-        isActivated: $this->request->isActivated,
         isLocked: false,
     );
 

--- a/centreon/tests/php/Core/HostTemplate/Domain/Model/HostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Domain/Model/HostTemplateTest.php
@@ -72,7 +72,6 @@ beforeEach(function (): void {
                 'iconId' => 1,
                 'iconAlternative' => 'iconAlternative-value',
                 'comment' => 'comment-value',
-                'isActivated' => false,
                 'isLocked' => true,
                 ...$fields,
             ]
@@ -123,7 +122,6 @@ it('should return properly set host template instance (all properties)', functio
         ->and($hostTemplate->getIconId())->toBe(1)
         ->and($hostTemplate->getIconAlternative())->toBe('iconAlternative-value')
         ->and($hostTemplate->getComment())->toBe('comment-value')
-        ->and($hostTemplate->isActivated())->toBe(false)
         ->and($hostTemplate->isLocked())->toBe(true);
 });
 
@@ -168,7 +166,6 @@ it('should return properly set host template instance (mandatory properties only
         ->and($hostTemplate->getIconId())->toBe(null)
         ->and($hostTemplate->getIconAlternative())->toBe('')
         ->and($hostTemplate->getComment())->toBe('')
-        ->and($hostTemplate->isActivated())->toBe(true)
         ->and($hostTemplate->isLocked())->toBe(false);
 });
 

--- a/centreon/tests/php/Core/HostTemplate/Domain/Model/NewHostTemplateTest.php
+++ b/centreon/tests/php/Core/HostTemplate/Domain/Model/NewHostTemplateTest.php
@@ -71,7 +71,6 @@ beforeEach(function (): void {
                 'iconId' => 1,
                 'iconAlternative' => 'iconAlternative-value',
                 'comment' => 'comment-value',
-                'isActivated' => false,
                 'isLocked' => true,
                 ...$fields,
             ]
@@ -121,7 +120,6 @@ it('should return properly set host template instance (all properties)', functio
         ->and($hostTemplate->getIconId())->toBe(1)
         ->and($hostTemplate->getIconAlternative())->toBe('iconAlternative-value')
         ->and($hostTemplate->getComment())->toBe('comment-value')
-        ->and($hostTemplate->isActivated())->toBe(false)
         ->and($hostTemplate->isLocked())->toBe(true);
 });
 
@@ -165,7 +163,6 @@ it('should return properly set host template instance (mandatory properties only
         ->and($hostTemplate->getIconId())->toBe(null)
         ->and($hostTemplate->getIconAlternative())->toBe('')
         ->and($hostTemplate->getComment())->toBe('')
-        ->and($hostTemplate->isActivated())->toBe(true)
         ->and($hostTemplate->isLocked())->toBe(false);
 });
 

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/AddServiceTemplate/AddServiceTemplateTest.php
@@ -733,7 +733,6 @@ it('should present an AddServiceTemplateResponse when everything has gone well',
         hostTemplateIds: [2, 3],
         contactAdditiveInheritance: true,
         contactGroupAdditiveInheritance: true,
-        isActivated: true,
         isLocked: true,
         activeChecks: YesNoDefault::Yes,
         passiveCheck: YesNoDefault::No,
@@ -872,7 +871,6 @@ it('should present an AddServiceTemplateResponse when everything has gone well',
     expect($dto->iconId)->toBe($this->serviceTemplateFound->getIconId());
     expect($dto->iconAlternativeText)->toBe($this->serviceTemplateFound->getIconAlternativeText());
     expect($dto->severityId)->toBe($this->serviceTemplateFound->getSeverityId());
-    expect($dto->isActivated)->toBe($this->serviceTemplateFound->isActivated());
     expect($dto->isLocked)->toBe($this->serviceTemplateFound->isLocked());
     expect($dto->hostTemplateIds)->toBe($this->serviceTemplateFound->getHostTemplateIds());
     foreach ($dto->macros as $index => $expectedMacro) {

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/FindServiceTemplatesTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/FindServiceTemplates/FindServiceTemplatesTest.php
@@ -61,7 +61,6 @@ beforeEach(closure: function (): void {
         true,
         true,
         true,
-        true,
         YesNoDefault::Yes,
         YesNoDefault::No,
         YesNoDefault::Default,
@@ -135,7 +134,6 @@ beforeEach(closure: function (): void {
     $this->serviceTemplateDto->iconId = $this->serviceTemplateFound->getIconId();
     $this->serviceTemplateDto->iconAlternativeText = $this->serviceTemplateFound->getIconAlternativeText();
     $this->serviceTemplateDto->severityId = $this->serviceTemplateFound->getSeverityId();
-    $this->serviceTemplateDto->isActivated = $this->serviceTemplateFound->isActivated();
     $this->serviceTemplateDto->isLocked = $this->serviceTemplateFound->isLocked();
     $this->serviceTemplateDto->hostTemplateIds = $this->serviceTemplateFound->getHostTemplateIds();
 });
@@ -279,7 +277,6 @@ it('should present a FindHostTemplatesResponse when user has read or write right
     expect($dto->iconId)->toBe($this->serviceTemplateFound->getIconId());
     expect($dto->iconAlternativeText)->toBe($this->serviceTemplateFound->getIconAlternativeText());
     expect($dto->severityId)->toBe($this->serviceTemplateFound->getSeverityId());
-    expect($dto->isActivated)->toBe($this->serviceTemplateFound->isActivated());
     expect($dto->isLocked)->toBe($this->serviceTemplateFound->isLocked());
     expect($dto->hostTemplateIds)->toBe($this->serviceTemplateFound->getHostTemplateIds());
 });

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
@@ -308,7 +308,6 @@ it('should present a NoContentResponse when everything has gone well for an admi
     $request->notificationTypes = NotificationTypeConverter::toBits($notificationTypes);
     $request->isContactAdditiveInheritance = true;
     $request->isContactGroupAdditiveInheritance = true;
-    $request->isActivated = false;
     $request->activeChecksEnabled = YesNoDefaultConverter::toInt(YesNoDefault::No);
     $request->passiveCheckEnabled = YesNoDefaultConverter::toInt(YesNoDefault::Yes);
     $request->volatility = YesNoDefaultConverter::toInt(YesNoDefault::No);
@@ -520,7 +519,6 @@ it('should present a NoContentResponse when everything has gone well for an admi
         )->toBe(NotificationTypeConverter::toBits($notificationTypes))
         ->and($serviceTemplate->isContactAdditiveInheritance())->toBe($request->isContactAdditiveInheritance)
         ->and($serviceTemplate->isContactGroupAdditiveInheritance())->toBe($request->isContactGroupAdditiveInheritance)
-        ->and($serviceTemplate->isActivated())->toBe($request->isActivated)
         ->and($serviceTemplate->getActiveChecks())->toBe(
             \Core\ServiceTemplate\Application\Model\YesNoDefaultConverter::fromInt($request->activeChecksEnabled)
         )->and($serviceTemplate->getPassiveCheck())->toBe(


### PR DESCRIPTION
## Description

remove 'is_activated' property from all hostTemplate and serviceTemplate configuration API endpoints

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
