### PR TITLE
enh(notifications): Add formatted_message property to GET notification endpoint 

### DIFF
--- a/centreon/src/Core/Notification/Application/UseCase/FindNotification/FindNotification.php
+++ b/centreon/src/Core/Notification/Application/UseCase/FindNotification/FindNotification.php
@@ -193,7 +193,7 @@ final class FindNotification
                 'channel' => $message->getChannel()->value,
                 'subject' => $message->getSubject(),
                 'message' => $message->getRawMessage(),
-                'formatted_message' => $message->getFormattedMessage()
+                'formatted_message' => $message->getFormattedMessage(),
             ],
             $notificationMessages
         );

--- a/centreon/src/Core/Notification/Application/UseCase/FindNotification/FindNotification.php
+++ b/centreon/src/Core/Notification/Application/UseCase/FindNotification/FindNotification.php
@@ -193,6 +193,7 @@ final class FindNotification
                 'channel' => $message->getChannel()->value,
                 'subject' => $message->getSubject(),
                 'message' => $message->getRawMessage(),
+                'formatted_message' => $message->getFormattedMessage()
             ],
             $notificationMessages
         );

--- a/centreon/tests/api/features/Notification.feature
+++ b/centreon/tests/api/features/Notification.feature
@@ -581,7 +581,8 @@ Feature:
             {
                 "channel": "Slack",
                 "subject": "Hello world !",
-                "message": "just a small message"
+                "message": "just a small message",
+                "formatted_message": "a formatted message"
             }
         ],
         "users": [
@@ -712,7 +713,8 @@ Feature:
             {
                 "channel": "Slack",
                 "subject": "Hello world !",
-                "message": "just a small message"
+                "message": "just a small message",
+                "formatted_message": "a formatted message"
             }
         ],
         "users": [
@@ -916,7 +918,8 @@ Feature:
               {
                   "channel": "Slack",
                   "subject": "Hello world !",
-                  "message": "just a small message"
+                  "message": "just a small message",
+                  "formatted_message": "a formatted message"
               }
           ],
           "users": [
@@ -1074,7 +1077,8 @@ Feature:
               {
                   "channel": "Slack",
                   "subject": "Hello world !",
-                  "message": "just a small message"
+                  "message": "just a small message",
+                  "formatted_message": "a formatted message"
               }
           ],
           "users": [


### PR DESCRIPTION
## Description

this PR intends  to Add formatted_message property to GET notification endpoint.

**Fixes** # MON-21183

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
