### PR TITLE
enh(deprecated pages): Remove possibility to enable deprecated pages in Cloud platform

### DIFF
--- a/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
@@ -53,7 +53,7 @@
                 </td>
             </tr>
             <tr class="list_two"><td class="FormRowField">{$form.default_page.label}</td><td class="FormRowValue">{$form.default_page.html}</td></tr>
-            <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="show_deprecated_pages">{$form.show_deprecated_pages.label}</td><td class="FormRowValue">{$form.show_deprecated_pages.html}</td></tr>
+            <tr class="list_one"><td class="FormRowField">{if $form.show_deprecated_pages.label}<img class="helpTooltip" name="show_deprecated_pages">{$form.show_deprecated_pages.label}</td><td class="FormRowValue">{$form.show_deprecated_pages.html}</td>{/if}</tr>
             <tr class="list_lvl_1">
                 <td class="ListColLvl1_name" colspan="2">
                     <h4>{t}Authentication{/t}</h4>

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -169,7 +169,9 @@ $form->addElement(
     "data-testid" => _("Generate")]
 );
 $form->addElement('select', 'contact_lang', _("Language"), $langs);
-$form->addElement('checkbox', 'show_deprecated_pages', _("Use deprecated pages"), null, $attrsText);
+if (!isCloudPlatform()) {
+    $form->addElement('checkbox', 'show_deprecated_pages', _("Use deprecated pages"), null, $attrsText);
+}
 
 
 /* ------------------------ Topoogy ---------------------------- */

--- a/centreon/www/include/common/common-Func.php
+++ b/centreon/www/include/common/common-Func.php
@@ -1567,6 +1567,22 @@ function get_enabled_feature_flags(): array
 }
 
 /**
+ * Indicates whether the platform is Cloud-based or not.
+ *
+ * @return bool
+ */
+function isCloudPlatform(): bool
+{
+    static $isCloudPlatform;
+    if (isset($isCloudPlatform)) {
+        return $isCloudPlatform;
+    }
+    $service = App\Kernel::createForWeb()->getContainer()->get(Core\Common\Infrastructure\FeatureFlags::class);
+
+    return $isCloudPlatform = ($service instanceof Core\Common\Infrastructure\FeatureFlags ? $service->isCloudPlatform() : false);
+}
+
+/**
  * We consider an empty feature **in the legacy code** as enabled.
  * We tolerate this nonsense for the legacy : KISS.
  */


### PR DESCRIPTION
## Description

For Cloud platform, there is not access to monitoring legacy pages

**Fixes** # (Mon20935)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

remove possibility to enable deprecated pages in cloud platform 

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
