### PR TITLE
enh (api): Update of the service template API endpoint (PATCH) for managing service groups

### DIFF
--- a/centreon/doc/API/v23.10/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
+++ b/centreon/doc/API/v23.10/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
@@ -262,3 +262,19 @@ properties:
       If multiple macros are defined with the same name, only the last one will be saved.
     items:
       $ref: 'macro.yaml'
+  service_groups:
+    type: array
+    descriptions: "Service group / host template associations to be linked to this service template."
+    items:
+      type: object
+      properties:
+        service_group_id:
+          type: integer
+          description: "Service group ID"
+          example: 1
+        host_template_id:
+          type: integer
+          description: |
+            Host template ID to be paired with the service template for the service group / template association.
+            The host template ID must be defined in the host_templates list.
+          example: 2

--- a/centreon/src/Core/ServiceGroup/Application/Repository/WriteServiceGroupRepositoryInterface.php
+++ b/centreon/src/Core/ServiceGroup/Application/Repository/WriteServiceGroupRepositoryInterface.php
@@ -52,4 +52,11 @@ interface WriteServiceGroupRepositoryInterface
      * @throws \Throwable
      */
     public function link(array $serviceGroupRelations): void;
+
+    /**
+     * Delete all relations for given IDs.
+     *
+     * @param int ...$serviceGroupIds
+     */
+    public function deleteRelations(int ...$serviceGroupIds): void;
 }

--- a/centreon/src/Core/ServiceGroup/Domain/Model/ServiceGroupRelation.php
+++ b/centreon/src/Core/ServiceGroup/Domain/Model/ServiceGroupRelation.php
@@ -30,7 +30,7 @@ class ServiceGroupRelation
 {
     /**
      * @param int $serviceGroupId
-     * @param int $serviceId
+     * @param int $serviceId (service ID or service template ID)
      * @param null|int $hostId
      * @param null|int $hostGroupId
      *

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
@@ -49,6 +49,8 @@ use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\ServiceCategory;
+use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
+use Core\ServiceGroup\Domain\Model\ServiceGroupRelation;
 use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
 use Core\ServiceTemplate\Application\Model\NotificationTypeConverter;
 use Core\ServiceTemplate\Application\Model\YesNoDefaultConverter;
@@ -75,6 +77,7 @@ final class PartialUpdateServiceTemplate
         private readonly ReadServiceMacroRepositoryInterface $readServiceMacroRepository,
         private readonly WriteServiceMacroRepositoryInterface $writeServiceMacroRepository,
         private readonly ReadCommandMacroRepositoryInterface $readCommandMacroRepository,
+        private readonly WriteServiceGroupRepositoryInterface $writeServiceGroupRepository,
         private readonly ParametersValidation $validation,
         private readonly ContactInterface $user,
         private readonly DataStorageEngineInterface $storageEngine,
@@ -204,6 +207,41 @@ final class PartialUpdateServiceTemplate
 
     /**
      * @param PartialUpdateServiceTemplateRequest $request
+     *
+     * @throws \Throwable
+     */
+    private function linkServiceTemplateToServiceGroups(PartialUpdateServiceTemplateRequest $request): void
+    {
+        if (! is_array($request->serviceGroups)) {
+            return;
+        }
+
+        $this->info(
+            'Link existing service groups to service template',
+            ['service_template_id' => $request->id, 'service_groups' => $request->serviceGroups]
+        );
+
+        $this->validation->assertServiceGroups($request->serviceGroups, $request->id, $this->user, $this->accessGroups);
+
+        $serviceGroupRelations = [];
+        $serviceGroupDtos = $this->removeDuplicatesServiceGroups($request->serviceGroups);
+        foreach ($serviceGroupDtos as $serviceGroup) {
+            $serviceGroupRelations[] = new ServiceGroupRelation(
+                serviceGroupId: $serviceGroup->serviceGroupId,
+                serviceId: $request->id,
+                hostId: $serviceGroup->hostTemplateId
+            );
+        }
+        $this->info('Delete existing service groups relations');
+        $this->writeServiceGroupRepository->deleteRelations(
+            ...array_map(fn (ServiceGroupRelation $rel) => $rel->getServiceGroupId(), $serviceGroupRelations)
+        );
+        $this->info('Create new service groups relations');
+        $this->writeServiceGroupRepository->link($serviceGroupRelations);
+    }
+
+    /**
+     * @param PartialUpdateServiceTemplateRequest $request
      * @param ServiceTemplate $serviceTemplate
      *
      * @throws ServiceTemplateException
@@ -219,6 +257,7 @@ final class PartialUpdateServiceTemplate
             $this->updateServiceTemplate($serviceTemplate, $request);
             $this->linkServiceTemplateToHostTemplates($request);
             $this->linkServiceTemplateToServiceCategories($request);
+            $this->linkServiceTemplateToServiceGroups($request);
             $this->updateMacros($request, $serviceTemplate);
 
             $this->debug('Commit transaction');
@@ -506,5 +545,20 @@ final class PartialUpdateServiceTemplate
         }
 
         $this->writeRepository->update($serviceTemplate);
+    }
+
+    /**
+     * @param ServiceGroupDto[] $serviceGroupDtos
+     *
+     * @return ServiceGroupDto[]
+     */
+    private function removeDuplicatesServiceGroups(array $serviceGroupDtos): array
+    {
+        $uniqueList = [];
+        foreach ($serviceGroupDtos as $item) {
+            $uniqueList[$item->serviceGroupId . '_' . $item->hostTemplateId] = $item;
+        }
+
+        return array_values($uniqueList);
     }
 }

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateRequest.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateRequest.php
@@ -114,6 +114,9 @@ final class PartialUpdateServiceTemplateRequest
     /** @var MacroDto[]|NoValue */
     public array|NoValue $macros;
 
+    /** @var ServiceGroupDto[] */
+    public array|NoValue $serviceGroups;
+
     public function __construct(public int $id)
     {
         $this->name = new NoValue();
@@ -157,5 +160,6 @@ final class PartialUpdateServiceTemplateRequest
         $this->hostTemplates = new NoValue();
         $this->serviceCategories = new NoValue();
         $this->macros = new NoValue();
+        $this->serviceGroups = new NoValue();
     }
 }

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/ServiceGroupDto.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/ServiceGroupDto.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate;
+
+class ServiceGroupDto
+{
+    public function __construct(
+        public int $hostTemplateId,
+        public int $serviceGroupId,
+    ) {
+    }
+}

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateController.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateController.php
@@ -30,6 +30,7 @@ use Core\Infrastructure\Common\Api\DefaultPresenter;
 use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\MacroDto;
 use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\PartialUpdateServiceTemplate;
 use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\PartialUpdateServiceTemplateRequest;
+use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\ServiceGroupDto;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -76,7 +77,8 @@ use Symfony\Component\HttpFoundation\Response;
  *     is_activated: boolean,
  *     host_templates: list<int>,
  *     service_categories: list<int>,
- *     macros: array<array{name: string, value: string|null, is_password: bool, description: string|null}>
+ *     macros: array<array{name: string, value: string|null, is_password: bool, description: string|null}>,
+ *     service_groups: array<array{host_template_id: int, service_group_id: int}>
  * }
  */
 final class PartialUpdateServiceTemplateController extends AbstractController
@@ -300,6 +302,15 @@ final class PartialUpdateServiceTemplateController extends AbstractController
                     $macro['description']
                 ),
                 $request['macros']
+            );
+        }
+
+        if (array_key_exists('service_groups', $request)) {
+            $serviceTemplate->serviceGroups = array_map(
+                fn(array $serviceGroup): ServiceGroupDto => new ServiceGroupDto(
+                    $serviceGroup['host_template_id'], $serviceGroup['service_group_id']
+                ),
+                $request['service_groups']
             );
         }
 

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateOnPremSchema.json
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateOnPremSchema.json
@@ -268,6 +268,24 @@
                     }
                 }
             }
+        },
+        "service_groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "host_template_id",
+                    "service_group_id"
+                ],
+                "properties": {
+                    "host_template_id": {
+                        "type": "integer"
+                    },
+                    "service_group_id": {
+                        "type": "integer"
+                    }
+                }
+            }
         }
     }
 }

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateSaasSchema.json
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateSaasSchema.json
@@ -89,6 +89,24 @@
                     }
                 }
             }
+        },
+        "service_groups": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "host_template_id",
+                    "service_group_id"
+                ],
+                "properties": {
+                    "host_template_id": {
+                        "type": "integer"
+                    },
+                    "service_group_id": {
+                        "type": "integer"
+                    }
+                }
+            }
         }
     }
 }

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
@@ -46,6 +46,7 @@ use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryIn
 use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\ServiceCategory;
+use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
 use Core\ServiceSeverity\Application\Repository\ReadServiceSeverityRepositoryInterface;
 use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
 use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
@@ -54,6 +55,7 @@ use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\MacroD
 use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\ParametersValidation;
 use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\PartialUpdateServiceTemplate;
 use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\PartialUpdateServiceTemplateRequest;
+use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\ServiceGroupDto;
 use Core\ServiceTemplate\Domain\Model\NotificationType;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplateInheritance;
@@ -79,6 +81,7 @@ beforeEach(closure: function (): void {
     $this->serviceSeverityRepository = $this->createMock(ReadServiceSeverityRepositoryInterface::class);
     $this->performanceGraphRepository = $this->createMock(ReadPerformanceGraphRepositoryInterface::class);
     $this->imageRepository = $this->createMock(ReadViewImgRepositoryInterface::class);
+    $this->writeServiceGroupRepository = $this->createMock(WriteServiceGroupRepositoryInterface::class);
 
     $this->parametersValidation = $this->createMock(ParametersValidation::class);
 
@@ -98,6 +101,7 @@ beforeEach(closure: function (): void {
         $this->readServiceMacroRepository,
         $this->writeServiceMacroRepository,
         $this->readCommandMacroRepository,
+        $this->writeServiceGroupRepository,
         $this->parametersValidation,
         $this->contact,
         $this->dataStorageEngine
@@ -252,6 +256,38 @@ it('should present a ErrorResponse when an error occurs during host templates li
         ->expects($this->once())
         ->method('linkToHosts')
         ->with($request->id, $request->hostTemplates)
+        ->willThrowException(new Exception());
+
+    ($this->useCase)($request, $this->presenter);
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceTemplateException::errorWhileUpdating()->getMessage());
+});
+
+it('should present a ErrorResponse when an error occurs during service groups link', function (): void {
+    $request = new PartialUpdateServiceTemplateRequest(1);
+    $request->serviceGroups = [new ServiceGroupDto(1, 2)];
+
+    $this->contact
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturnMap(
+            [
+                [Contact::ROLE_CONFIGURATION_SERVICES_TEMPLATES_READ_WRITE, true],
+            ]
+        );
+
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->with($request->id)
+        ->willReturn(new ServiceTemplate(1, 'fake_name', 'fake_alias'));
+
+    $this->writeServiceGroupRepository
+        ->expects($this->once())
+        ->method('deleteRelations')
         ->willThrowException(new Exception());
 
     ($this->useCase)($request, $this->presenter);


### PR DESCRIPTION
## Description

New property to manage the relationship between a service template and a service group.
```
{
    "service_groups": [
        {
            "host_template_id": <int>,
            "service_group_id": <int>
        }
    ]
}
```

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
