### PR TITLE
fix(e2e): fixing e2e tests related to dashboard sharing

### DIFF
--- a/centreon/tests/e2e/cypress/e2e/Dashboards/06-dashboard-sharing/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Dashboards/06-dashboard-sharing/index.ts
@@ -141,6 +141,7 @@ When('the editor user sets another user as a viewer on the dashboard', () => {
 
   cy.get('[data-state="added"]').should('exist');
   cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+  cy.reload(); // TODO: Find a way to remove reloads
   cy.wait('@addContactToDashboardShareList');
 });
 
@@ -244,6 +245,7 @@ When(
       .should('contain', `${dashboardCreatorUser.login}`);
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactToDashboardShareList');
   }
 );

--- a/centreon/tests/e2e/cypress/e2e/Dashboards/06-dashboard-sharing/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Dashboards/06-dashboard-sharing/index.ts
@@ -141,8 +141,8 @@ When('the editor user sets another user as a viewer on the dashboard', () => {
 
   cy.get('[data-state="added"]').should('exist');
   cy.getByLabel({ label: 'Update', tag: 'button' }).click();
-  cy.reload(); // TODO: Find a way to remove reloads
   cy.wait('@addContactToDashboardShareList');
+  cy.reload(); // TODO: Find a way to remove reloads
 });
 
 Then(
@@ -245,8 +245,8 @@ When(
       .should('contain', `${dashboardCreatorUser.login}`);
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
-    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactToDashboardShareList');
+    cy.reload(); // TODO: Find a way to remove reloads
   }
 );
 
@@ -345,8 +345,8 @@ When(
       .should('contain', 'dashboard-contact-group-viewer');
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
-    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactGroupToDashboardShareList');
+    cy.reload(); // TODO: Find a way to remove reloads
   }
 );
 
@@ -455,8 +455,8 @@ When(
       .should('contain', 'dashboard-contact-group-creator');
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
-    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactGroupToDashboardShareList');
+    cy.reload(); // TODO: Find a way to remove reloads
   }
 );
 
@@ -562,8 +562,8 @@ Given(
       .should('contain', 'dashboard-contact-group-creator');
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
-    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactGroupToDashboardShareList');
+    cy.reload(); // TODO: Find a way to remove reloads
   }
 );
 
@@ -590,8 +590,8 @@ When(
       .should('contain', `${dashboardCGMember3.login}`);
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
-    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactToDashboardShareList');
+    cy.reload(); // TODO: Find a way to remove reloads
   }
 );
 
@@ -681,8 +681,8 @@ When('the admin user appoints one of the users as an editor', () => {
   cy.get('[role="listbox"]').contains('editor').click();
   cy.getByTestId({ testId: 'add' }).click();
   cy.getByLabel({ label: 'Update', tag: 'button' }).click();
-  cy.reload(); // TODO: Find a way to remove reloads
   cy.wait('@addContactToDashboardShareList');
+  cy.reload(); // TODO: Find a way to remove reloads
 });
 
 Then(
@@ -712,8 +712,8 @@ Then(
     cy.getByTestId({ testId: 'add' }).click();
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
-    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactToDashboardShareList');
+    cy.reload(); // TODO: Find a way to remove reloads
 
     cy.getByLabel({ label: 'share', tag: 'button' }).click();
     cy.get('*[class^="MuiList-root"]', { timeout: 12000 })
@@ -739,8 +739,8 @@ Then(
     cy.getByTestId({ testId: 'add' }).click();
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
-    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactToDashboardShareList');
+    cy.reload(); // TODO: Find a way to remove reloads
 
     cy.getByLabel({ label: 'share', tag: 'button' }).click();
     cy.get('*[class^="MuiList-root"]', { timeout: 12000 })

--- a/centreon/tests/e2e/cypress/e2e/Dashboards/06-dashboard-sharing/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Dashboards/06-dashboard-sharing/index.ts
@@ -345,6 +345,7 @@ When(
       .should('contain', 'dashboard-contact-group-viewer');
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactGroupToDashboardShareList');
   }
 );
@@ -454,6 +455,7 @@ When(
       .should('contain', 'dashboard-contact-group-creator');
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactGroupToDashboardShareList');
   }
 );
@@ -560,6 +562,7 @@ Given(
       .should('contain', 'dashboard-contact-group-creator');
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactGroupToDashboardShareList');
   }
 );
@@ -587,6 +590,7 @@ When(
       .should('contain', `${dashboardCGMember3.login}`);
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactToDashboardShareList');
   }
 );
@@ -677,6 +681,7 @@ When('the admin user appoints one of the users as an editor', () => {
   cy.get('[role="listbox"]').contains('editor').click();
   cy.getByTestId({ testId: 'add' }).click();
   cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+  cy.reload(); // TODO: Find a way to remove reloads
   cy.wait('@addContactToDashboardShareList');
 });
 
@@ -707,6 +712,7 @@ Then(
     cy.getByTestId({ testId: 'add' }).click();
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactToDashboardShareList');
 
     cy.getByLabel({ label: 'share', tag: 'button' }).click();
@@ -733,6 +739,7 @@ Then(
     cy.getByTestId({ testId: 'add' }).click();
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.reload(); // TODO: Find a way to remove reloads
     cy.wait('@addContactToDashboardShareList');
 
     cy.getByLabel({ label: 'share', tag: 'button' }).click();

--- a/centreon/tests/e2e/cypress/e2e/Dashboards/06-dashboard-sharing/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Dashboards/06-dashboard-sharing/index.ts
@@ -31,6 +31,14 @@ beforeEach(() => {
     method: 'POST',
     url: '/centreon/api/latest/configuration/dashboards'
   }).as('createDashboard');
+  cy.intercept({
+    method: 'POST',
+    url: `/centreon/api/latest/configuration/dashboards/*/access_rights/contacts`
+  }).as('addContactToDashboardShareList');
+  cy.intercept({
+    method: 'POST',
+    url: `/centreon/api/latest/configuration/dashboards/*/access_rights/contactgroups`
+  }).as('addContactGroupToDashboardShareList');
   cy.loginByTypeOfUser({
     jsonName: dashboardAdministratorUser.login,
     loginViaApi: true
@@ -133,6 +141,7 @@ When('the editor user sets another user as a viewer on the dashboard', () => {
 
   cy.get('[data-state="added"]').should('exist');
   cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+  cy.wait('@addContactToDashboardShareList');
 });
 
 Then(
@@ -235,6 +244,7 @@ When(
       .should('contain', `${dashboardCreatorUser.login}`);
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.wait('@addContactToDashboardShareList');
   }
 );
 
@@ -333,6 +343,7 @@ When(
       .should('contain', 'dashboard-contact-group-viewer');
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.wait('@addContactGroupToDashboardShareList');
   }
 );
 
@@ -441,6 +452,7 @@ When(
       .should('contain', 'dashboard-contact-group-creator');
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.wait('@addContactGroupToDashboardShareList');
   }
 );
 
@@ -546,6 +558,7 @@ Given(
       .should('contain', 'dashboard-contact-group-creator');
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.wait('@addContactGroupToDashboardShareList');
   }
 );
 
@@ -572,6 +585,7 @@ When(
       .should('contain', `${dashboardCGMember3.login}`);
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.wait('@addContactToDashboardShareList');
   }
 );
 
@@ -661,6 +675,7 @@ When('the admin user appoints one of the users as an editor', () => {
   cy.get('[role="listbox"]').contains('editor').click();
   cy.getByTestId({ testId: 'add' }).click();
   cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+  cy.wait('@addContactToDashboardShareList');
 });
 
 Then(
@@ -690,6 +705,7 @@ Then(
     cy.getByTestId({ testId: 'add' }).click();
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.wait('@addContactToDashboardShareList');
 
     cy.getByLabel({ label: 'share', tag: 'button' }).click();
     cy.get('*[class^="MuiList-root"]', { timeout: 12000 })
@@ -715,6 +731,7 @@ Then(
     cy.getByTestId({ testId: 'add' }).click();
 
     cy.getByLabel({ label: 'Update', tag: 'button' }).click();
+    cy.wait('@addContactToDashboardShareList');
 
     cy.getByLabel({ label: 'share', tag: 'button' }).click();
     cy.get('*[class^="MuiList-root"]', { timeout: 12000 })


### PR DESCRIPTION
## Description

the e2e test suite related to dashboard sharing had issues were updates to the sharelist of the dashboard just would not be taken into account; this PR adds intercept commands to make sure that the updates are taken into account following an update before running the next instruction

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
