### PR TITLE
fix(test): fix dashboard check permission flaky test

### DIFF
--- a/centreon/tests/e2e/cypress/support/commands.ts
+++ b/centreon/tests/e2e/cypress/support/commands.ts
@@ -121,13 +121,6 @@ Cypress.Commands.add('logoutViaAPI', (): Cypress.Chainable => {
     .getByLabel({ label: 'Alias', tag: 'input' });
 });
 
-Cypress.Commands.add('logoutViaAPI', (): Cypress.Chainable => {
-  return cy.request({
-    method: 'GET',
-    url: '/centreon/authentication/logout'
-  });
-});
-
 Cypress.Commands.add('removeACL', (): Cypress.Chainable => {
   return cy.setUserTokenApiV1().then(() => {
     cy.executeActionViaClapi({


### PR DESCRIPTION
## Description

fix dashboard check permission flaky test
`logoutViaAPI` was duplicated : 2nd declaration overrided first one and had no assertion

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)