### PR TITLE
fix(cli): Avoids using the host template name instead of the host name when you want to bind a service to an additional host

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonService.class.php
+++ b/centreon/www/class/centreon-clapi/centreonService.class.php
@@ -1266,7 +1266,8 @@ class CentreonService extends CentreonObject
                     null,
                     array(
                         "host_name" => $args[0],
-                        "service_description" => $args[1]
+                        "service_description" => $args[1],
+                        'host_register' => '1',
                     ),
                     "AND"
                 );
@@ -1308,6 +1309,11 @@ class CentreonService extends CentreonObject
                         }
                         if ($matches[2] == "contact") {
                             $tab = $obj->getIdByParameter("contact_alias", array($rel));
+                        } elseif($matches[2] == "host") {
+                            $tab = [];
+                            if (($hostId = $this->getHostIdByName($rel)) !== null) {
+                                $tab[] = $hostId;
+                            }
                         } else {
                             $tab = $obj->getIdByParameter($obj->getUniqueLabelField(), array($rel));
                         }
@@ -1880,5 +1886,29 @@ class CentreonService extends CentreonObject
                 return $macroB;
             }
         }
+    }
+
+    /**
+     * @param string $hostName
+     *
+     * @return int|null
+     */
+    private function getHostIdByName(string $hostName): ?int
+    {
+        if ($hostName === '') {
+            return null;
+        }
+        $statement = $this->db->prepare(<<<'SQL'
+            SELECT host_id FROM host
+            WHERE host_name = :host_name
+                AND host_register = '1'
+            SQL
+        );
+        $statement->bindValue(':host_name', $hostName);
+        $statement->execute();
+        if (($result = $statement->fetch(\PDO::FETCH_ASSOC)) !== false) {
+            return (int) $result['host_id'];
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/2043

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).