### PR TITLE
fix(clapi) remove php warning on SERVICE getparam

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonService.class.php
+++ b/centreon/www/class/centreon-clapi/centreonService.class.php
@@ -576,7 +576,7 @@ class CentreonService extends CentreonObject
         $exportedFields = [];
         $resultString = "";
         foreach ($listParam as $paramSearch) {
-            if (!$paramString) {
+            if (! isset($paramString)) {
                 $paramString = $paramSearch;
             } else {
                 $paramString = $paramString . $this->delim . $paramSearch;
@@ -644,27 +644,29 @@ class CentreonService extends CentreonObject
                     $ret = $ret[$field];
                 }
 
-                switch ($paramSearch) {
-                    case "check_command":
-                    case "event_handler":
-                        $commandObject = new CentreonCommand($this->dependencyInjector);
-                        $field = $commandObject->object->getUniqueLabelField();
-                        $ret = $commandObject->object->getParameters($ret, $field);
-                        $ret = $ret[$field];
-                        break;
-                    case "check_period":
-                    case "notification_period":
-                        $tpObj = new CentreonTimePeriod($this->dependencyInjector);
-                        $field = $tpObj->object->getUniqueLabelField();
-                        $ret = $tpObj->object->getParameters($ret, $field);
-                        $ret = $ret[$field];
-                        break;
-                    case "template":
-                        $tplObj = new CentreonServiceTemplate($this->dependencyInjector);
-                        $field = $tplObj->object->getUniqueLabelField();
-                        $ret = $tplObj->object->getParameters($ret, $field);
-                        $ret = $ret[$field];
-                        break;
+                if ($ret !== null) {
+                    switch ($paramSearch) {
+                        case "check_command":
+                        case "event_handler":
+                            $commandObject = new CentreonCommand($this->dependencyInjector);
+                            $field = $commandObject->object->getUniqueLabelField();
+                            $ret = $commandObject->object->getParameters($ret, $field);
+                            $ret = $ret[$field];
+                            break;
+                        case "check_period":
+                        case "notification_period":
+                            $tpObj = new CentreonTimePeriod($this->dependencyInjector);
+                            $field = $tpObj->object->getUniqueLabelField();
+                            $ret = $tpObj->object->getParameters($ret, $field);
+                            $ret = $ret[$field];
+                            break;
+                        case "template":
+                            $tplObj = new CentreonServiceTemplate($this->dependencyInjector);
+                            $field = $tplObj->object->getUniqueLabelField();
+                            $ret = $tplObj->object->getParameters($ret, $field);
+                            $ret = $ret[$field];
+                            break;
+                    }
                 }
                 if (!isset($exportedFields[$paramSearch])) {
                     $resultString .= $ret . $this->delim;


### PR DESCRIPTION
## Description

Fixing php warning when using `getparam` action on services
```
# centreon -u admin -p 'XX' -o SERVICE -a getparam -v "Central-Server;Ping;check_period"
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
