### PR TITLE
fix(packaging): provides perl(JSON::Path) from perl-json-path rpm

### DIFF
--- a/dependencies/perl-json-path/perl-json-path.yaml
+++ b/dependencies/perl-json-path/perl-json-path.yaml
@@ -43,6 +43,8 @@ overrides:
       - perl(Readonly)
       - perl(Tie::IxHash)
       - perl(Try::Tiny)
+    provides:
+      - perl(JSON::Path)
   deb:
     depends:
       - libcarp-assert-perl


### PR DESCRIPTION
## Description

fix(packaging): provides perl(JSON::Path) from perl-json-path rpm

**Fixes** MON-21108

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)