### PR TITLE
fix(resources): add missing data to detail endpoint creation

### DIFF
--- a/centreon/src/Core/Resources/Application/UseCase/FindResources/FindResourcesFactory.php
+++ b/centreon/src/Core/Resources/Application/UseCase/FindResources/FindResourcesFactory.php
@@ -54,6 +54,7 @@ final class FindResourcesFactory
             $resourceDto = new ResourceResponseDto();
             $resourceDto->uuid = $resource->getUuid();
             $resourceDto->id = $resource->getId();
+            $resourceDto->internalId = $resource->getInternalId();
             $resourceDto->name = $resource->getName();
             $resourceDto->type = $resource->getType();
             $resourceDto->fqdn = $resource->getFqdn();

--- a/centreon/src/Core/Resources/Application/UseCase/FindResources/Response/ResourceResponseDto.php
+++ b/centreon/src/Core/Resources/Application/UseCase/FindResources/Response/ResourceResponseDto.php
@@ -31,6 +31,7 @@ final class ResourceResponseDto
         public ?string $type = null,
         public ?int $serviceId = null,
         public ?int $hostId = null,
+        public ?int $internalId = null,
         public ?string $alias = null,
         public ?string $fqdn = null,
         public ?IconResponseDto $icon = null,

--- a/centreon/src/Core/Resources/Infrastructure/API/FindResources/FindResourcesPresenter.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindResources/FindResourcesPresenter.php
@@ -112,6 +112,7 @@ class FindResourcesPresenter extends AbstractPresenter implements FindResourcesP
                     'serviceId' => $resource->serviceId,
                     'hostId' => $resource->hostId,
                     'hasGraphData' => $resource->hasGraphData,
+                    'internalId' => $resource->internalId,
                 ];
 
                 $endpoints = $this->hypermediaCreator->createEndpoints($parameters);


### PR DESCRIPTION
This PR intends to fix an issue regarding the AD resource type detail endpoint creation. This will also fix the issue for the Metaservice resource type.

**Fixes** MON-21307

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira issue.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
