### PR TITLE
enh(ci): extend apt retry and timeout values

### DIFF
--- a/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
@@ -9,6 +9,16 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN <<EOF
 
 ######################################
+# additional configuration for apt   #
+######################################
+
+echo "\
+Acquire::Retries "10";\
+Acquire::https::Timeout "300";\
+Acquire::http::Timeout "300";
+" > /etc/apt/apt.conf.d/99custom
+
+######################################
 # install and configure repositories #
 ######################################
 

--- a/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
@@ -12,11 +12,11 @@ RUN <<EOF
 # additional configuration for apt   #
 ######################################
 
-echo "\
-Acquire::Retries "10";\
-Acquire::https::Timeout "300";\
+echo '
+Acquire::Retries "10";
+Acquire::https::Timeout "300";
 Acquire::http::Timeout "300";
-" > /etc/apt/apt.conf.d/99custom
+' > /etc/apt/apt.conf.d/99custom
 
 ######################################
 # install and configure repositories #


### PR DESCRIPTION
## Description

Make apt a bit more patient in case of fetch failures to avoid cases where repositories are either being update and/or unreachable for a short time.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
