### PR TITLE
fix(gorgone): pull modules stop responding

### DIFF
--- a/centreon-gorgone/gorgone/modules/core/pullwss/class.pm
+++ b/centreon-gorgone/gorgone/modules/core/pullwss/class.pm
@@ -246,6 +246,18 @@ sub transmit_back {
             return '[SETLOGS] [' . $1 . '] [] ' . $2;
         }
         return undef;
+    } elsif ($options{message} =~ /^\[BCASTCOREKEY\]\s+\[.*?\]\s+\[.*?\]\s+(.*)/m) {
+        my $data;
+        eval {
+            $data = JSON::XS->new->decode($1);
+        };
+        if ($@) {
+            $connector->{logger}->writeLogDebug("[pull] cannot decode BCASTCOREKEY: $@");
+            return undef;
+        }
+
+        $connector->action_bcastcorekey(data => $data);
+        return undef;
     } elsif ($options{message} =~ /^\[(PONG|SYNCLOGS)\]/) {
         return $options{message};
     }


### PR DESCRIPTION
## Description

Fixed recurring unexpected disconnection between pollers using pull mode

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x
- [X] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Configure a poller with the pull mode: https://github.com/centreon/centreon/blob/develop/centreon-gorgone/docs/poller_pull_configuration.md

Add following option in ```/etc/centreon-gorgone/config.d/40-gorgoned.yaml``` file (avoid to wait 24h):
```
gorgone:
  gorgonecore:
    internal_com_rotation: 2
```

After 2 minutes, if you try to reload engine:
```
2023-06-06 11:20:07 - ERROR - [pull] decrypt issue: no message
```

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
