### PR TITLE
fix(test): fix e2e tests when run using cypress:open

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/commands.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands.ts
@@ -225,29 +225,7 @@ interface StartContainerProps {
 Cypress.Commands.add(
   'startContainer',
   ({ name, image, portBindings }: StartContainerProps): Cypress.Chainable => {
-    return cy
-      .exec('docker image list --format "{{.Repository}}:{{.Tag}}"')
-      .then(({ stdout }) => {
-        if (
-          stdout.match(
-            new RegExp(
-              `^${image.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')}`,
-              'm'
-            )
-          )
-        ) {
-          cy.log(`Local docker image found : ${image}`);
-
-          return cy.wrap(image);
-        }
-
-        cy.log(`Pulling remote docker image : ${image}`);
-
-        return cy.exec(`docker pull ${image}`).then(() => cy.wrap(image));
-      })
-      .then((imageName) =>
-        cy.task('startContainer', { image: imageName, name, portBindings })
-      );
+    return cy.task('startContainer', { image, name, portBindings });
   }
 );
 

--- a/centreon/packages/js-config/cypress/e2e/plugins.ts
+++ b/centreon/packages/js-config/cypress/e2e/plugins.ts
@@ -3,6 +3,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 /* eslint-disable no-param-reassign */
 
+import { execSync } from 'child_process';
+
 import Docker from 'dockerode';
 import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-preprocessor';
 import webpackPreprocessor from '@cypress/webpack-preprocessor';
@@ -91,6 +93,21 @@ export default async (on, config): Promise<void> => {
       name,
       portBindings = []
     }: StartContainerProps) => {
+      const imageList = execSync(
+        'docker image list --format "{{.Repository}}:{{.Tag}}"'
+      ).toString('utf8');
+
+      if (
+        !imageList.match(
+          new RegExp(
+            `^${image.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&')}`,
+            'm'
+          )
+        )
+      ) {
+        execSync(`docker pull ${image}`);
+      }
+
       const webContainers = await docker.listContainers({
         all: true,
         filters: { name: [name] }


### PR DESCRIPTION
## Description

fix e2e tests when run using cypress:open
run docker commands using `task` instead of `exec` to avoid right issue
nodejs can run `docker` commands, but browser cannot

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)