### PR TITLE
fix(notifications): get total of results

### DIFF
--- a/centreon/src/Core/Notification/Infrastructure/Repository/DbReadNotificationRepository.php
+++ b/centreon/src/Core/Notification/Infrastructure/Repository/DbReadNotificationRepository.php
@@ -299,6 +299,13 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
         $statement = $this->db->prepare($query);
         $sqlTranslator?->bindSearchValues($statement);
         $statement->execute();
+
+        //Pagination
+        $resultCount = $this->db->query('SELECT FOUND_ROWS()');
+        if ($resultCount !== false && ($total = $resultCount->fetchColumn()) !== false) {
+            $sqlTranslator->getRequestParameters()->setTotal((int) $total);
+        }
+
         $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
 
         $notifications = [];
@@ -362,7 +369,7 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
 
         $query = $this->translateDbName(
             <<<'SQL'
-                    SELECT id, name, timeperiod_id, tp_name, is_activated
+                    SELECT SQL_CALC_FOUND_ROWS id, name, timeperiod_id, tp_name, is_activated
                     FROM `:db`.notification
                     INNER JOIN timeperiod ON timeperiod_id = tp_id
                 SQL

--- a/centreon/tests/api/features/Notification.feature
+++ b/centreon/tests/api/features/Notification.feature
@@ -361,7 +361,7 @@ Feature:
         "limit": 10,
         "search": {},
         "sort_by": {},
-        "total": 0
+        "total": 1
       }
     }
     """
@@ -457,7 +457,7 @@ Feature:
         "limit": 10,
         "search": {},
         "sort_by": {},
-        "total": 0
+        "total": 1
       }
     }
     """


### PR DESCRIPTION
## Description

this PR intends to correctly get total of results on notification listing endpoint

Previously:
```
{
  "result": [
    {
       . . .
    },
    {
       . . .
    },
    {
       . . .
    }
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "search": {},
    "sort_by": {},
    **"total": 0**
  }
}
```

Fixed:
```
{
  "result": [
    {
       . . .
    },
    {
       . . .
    },
    {
       . . .
    }
  ],
  "meta": {
    "page": 1,
    "limit": 10,
    "search": {},
    "sort_by": {},
    **"total": 3**
  }
}
```

**Fixes** # MON-21217

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
