### PR TITLE
fix(resources status): fix query for hostgroups and categories filter

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -231,7 +231,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
                                 ON parent_resource.id = resources.parent_id
                             LEFT JOIN `:dbstg`.resources_tags AS rtags
                               ON rtags.resource_id = resources.resource_id
-                              OR rtags.resource_id = parent_resource.resource_id
+                              OR rtags.resource_id = parent_resource.resource_id 
                             INNER JOIN `:dbstg`.tags
                                 ON tags.tag_id = rtags.tag_id
                             WHERE tags.name IN ({$literalTagKeys})

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -230,7 +230,8 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
                             LEFT JOIN `:dbstg`.`resources` parent_resource
                                 ON parent_resource.id = resources.parent_id
                             LEFT JOIN `:dbstg`.resources_tags AS rtags
-                              ON rtags.resource_id = parent_resource.resource_id
+                              ON rtags.resource_id = resources.resource_id
+                              OR rtags.resource_id = parent_resource.resource_id
                             INNER JOIN `:dbstg`.tags
                                 ON tags.tag_id = rtags.tag_id
                             WHERE tags.name IN ({$literalTagKeys})

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -231,7 +231,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
                                 ON parent_resource.id = resources.parent_id
                             LEFT JOIN `:dbstg`.resources_tags AS rtags
                               ON rtags.resource_id = resources.resource_id
-                              OR rtags.resource_id = parent_resource.resource_id 
+                              OR rtags.resource_id = parent_resource.resource_id
                             INNER JOIN `:dbstg`.tags
                                 ON tags.tag_id = rtags.tag_id
                             WHERE tags.name IN ({$literalTagKeys})


### PR DESCRIPTION
## Description

Fix the query in order to list host member of a hostgroup or a host category

Fixes # (MON-21421)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Fix the query in order to list host member of a hostgroup or a host category


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
