### PR TITLE
fix(logs): do not log error when all access groups are found

### DIFF
--- a/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/UpdateOpenIdConfiguration/UpdateOpenIdConfiguration.php
@@ -212,10 +212,14 @@ class UpdateOpenIdConfiguration
         foreach ($foundAccessGroups as $foundAccessGroup) {
             $foundAccessGroupsId[] = $foundAccessGroup->getId();
         }
+
         $nonExistentAccessGroupsIds = array_diff($accessGroupIdsFromRequest, $foundAccessGroupsId);
-        $this->error('Access Groups not found', [
-            'access_group_ids' => implode(', ', $nonExistentAccessGroupsIds),
-        ]);
+
+        if (! empty($nonExistentAccessGroupsIds)) {
+            $this->error('Access Groups not found', [
+                'access_group_ids' => implode(', ', $nonExistentAccessGroupsIds),
+            ]);
+        }
     }
 
     /**

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfiguration.php
@@ -210,10 +210,14 @@ class UpdateSAMLConfiguration
         foreach ($foundAccessGroups as $foundAccessGroup) {
             $foundAccessGroupsId[] = $foundAccessGroup->getId();
         }
+
         $nonExistentAccessGroupsIds = array_diff($accessGroupIdsFromRequest, $foundAccessGroupsId);
-        $this->error('Access Groups not found', [
-            'access_group_ids' => implode(', ', $nonExistentAccessGroupsIds),
-        ]);
+
+        if (! empty($nonExistentAccessGroupsIds)) {
+            $this->error('Access Groups not found', [
+                'access_group_ids' => implode(', ', $nonExistentAccessGroupsIds),
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

do not log error when all access groups are found
avoid that kind of logs : 
```
[ERROR] [Core\Security\ProviderConfiguration\Application\OpenId\UseCase\UpdateOpenIdConfiguration\UpdateOpenIdConfiguration:407]: Access groups not found {"access_group_ids":""}
[ERROR] [Core\Security\ProviderConfiguration\Application\SAML\UseCase\UpdateSAMLConfiguration\UpdateSAMLConfiguration:215]: Access Groups not found {"access_group_ids":""}
```

**Fixes** MON-21453

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)