### PR TITLE
fix(dashboard): add limit to resources and metrics listing query

### DIFF
--- a/centreon/www/front_src/src/Dashboards/Dashboard/AddEditWidget/WidgetProperties/Inputs/Metrics/useMetrics.ts
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/AddEditWidget/WidgetProperties/Inputs/Metrics/useMetrics.ts
@@ -81,6 +81,7 @@ const useMetrics = (propertyName: string): UseMetricsState => {
       buildListingEndpoint({
         baseEndpoint: metricsEndpoint,
         parameters: {
+          limit: 100,
           search: {
             lists: resources.map((resource) => ({
               field: resourceTypeQueryParameter[resource.resourceType],

--- a/centreon/www/front_src/src/Dashboards/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/useResources.ts
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/useResources.ts
@@ -86,6 +86,10 @@ const resourceQueryParameters = [
   {
     name: 'only_with_performance_data',
     value: true
+  },
+  {
+    name: 'limit',
+    value: 30
   }
 ];
 


### PR DESCRIPTION
## Description

this PR intends to add limit to resources and metrics listing query

Service listing:
![image](https://github.com/centreon/centreon/assets/61694165/491ab503-a77d-4a26-9512-34cce0e7d149)

Metrics listing:
![image](https://github.com/centreon/centreon/assets/61694165/041804f9-95ef-4167-9cbd-a8b2ff96cb2e)


**Fixes** # MON-21558

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
