### PR TITLE
enh(CEIP) add ApiTokens stats to cron

### DIFF
--- a/centreon/cron/centreon-send-stats.php
+++ b/centreon/cron/centreon-send-stats.php
@@ -116,6 +116,7 @@ if ($isRemote === false) {
         $infos = $oStatistics->getPlatformInfo();
         $timezone = $oStatistics->getPlatformTimezone();
         $authentication = $oStatistics->getAuthenticationOptions();
+        $authentication['api_token'] = $oStatistics->getApiTokensInfo();
         $additional = [];
 
         /*


### PR DESCRIPTION
## Description

Add new information in data send by `/usr/share/centreon/cron/centreon-send-stats.php` cron
```
{
	"authentication": {
                ...
		"api_token": {
			"total": 1,
			"managers": 1
		}
	}
}
```

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
