### PR TITLE
Upgrade enshrined/svg-sanitize from 0.14.1 to 0.15.0

### DIFF
--- a/centreon/composer.json
+++ b/centreon/composer.json
@@ -38,7 +38,7 @@
         "beberlei/assert": "^3.3",
         "curl/curl" : "^2.3",
         "dragonmantank/cron-expression": "3.1.0",
-        "enshrined/svg-sanitize": "^0.14",
+        "enshrined/svg-sanitize": "^0.15",
         "doctrine/annotations": "^1.0",
         "ext-ctype": "*",
         "ext-iconv": "*",

--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a462a0aee036805119b458c19f2f9315",
+    "content-hash": "56ca65b179b4ebf7b54bfe6360b4ea04",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -509,16 +509,16 @@
         },
         {
             "name": "enshrined/svg-sanitize",
-            "version": "0.14.1",
+            "version": "0.15.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/darylldoyle/svg-sanitizer.git",
-                "reference": "307b42066fb0b76b5119f5e1f0826e18fefabe95"
+                "reference": "17e12ba9c2881caa6b167d0fbea555c11207fbb0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/307b42066fb0b76b5119f5e1f0826e18fefabe95",
-                "reference": "307b42066fb0b76b5119f5e1f0826e18fefabe95",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/17e12ba9c2881caa6b167d0fbea555c11207fbb0",
+                "reference": "17e12ba9c2881caa6b167d0fbea555c11207fbb0",
                 "shasum": ""
             },
             "require": {
@@ -549,9 +549,9 @@
             "description": "An SVG sanitizer for PHP",
             "support": {
                 "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
-                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.14.1"
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.15.0"
             },
-            "time": "2021-08-09T23:46:54+00:00"
+            "time": "2022-02-13T00:42:56+00:00"
         },
         {
             "name": "friendsofsymfony/rest-bundle",


### PR DESCRIPTION
## Description
Upgrade enshrined/svg-sanitize dependency

**Fixes** # (MON-21576)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [X] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)


#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
