### PR TITLE
fix(dashboard): restore require.php file to unbreak all widgets

### DIFF
--- a/centreon/www/widgets/require.php
+++ b/centreon/www/widgets/require.php
@@ -1,0 +1,3 @@
+<?php
+require_once realpath(dirname(__FILE__) . '/../../config/centreon.config.php');
+require_once realpath(dirname(__FILE__) . '/../../vendor/autoload.php');


### PR DESCRIPTION
Since this commit https://github.com/centreon/centreon/commit/74445be99e8ee1f423fcc63669e7ac6667c5f680#diff-0a343f861f7ebb967389a25f5cf799bc4a566d305d6b801f4f57cda70bc0370a all widgets of the legacy dashboard are broken with the error

```
[15-Sep-2023 15:27:57 Europe/Paris] PHP Warning:  require_once(../require.php): Failed to open stream: No such file or directory in /usr/share/centreon/www/widgets/engine-status/index.php on line 37
[15-Sep-2023 15:27:57 Europe/Paris] PHP Fatal error:  Uncaught Error: Failed opening required '../require.php' (include_path='.:/usr/share/pear:/usr/share/php') in /usr/share/centreon/www/widgets/engine-status/index.php:37
Stack trace:
#0 {main}
  thrown in /usr/share/centreon/www/widgets/engine-status/index.php on line 37
```


That is because the commit removed the required.php file of centreon/www/widgets/ directory and is required by all legacy widgets.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>
Add old widget -> It should work

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
