### PR TITLE
fix(csv-export): protect request from potential MySQL keywords

### DIFF
--- a/centreon/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/DataBin/DbReadPerformanceDataRepository.php
@@ -83,7 +83,7 @@ class DbReadPerformanceDataRepository extends AbstractRepositoryDRB implements R
     {
         $metricIds = [];
         $subQueryColumns = [];
-        $subQueryPattern = 'AVG(CASE WHEN id_metric = %d THEN `value` end) AS "%s"';
+        $subQueryPattern = 'AVG(CASE WHEN id_metric = %d THEN `value` end) AS `%s`';
         foreach ($metrics as $metric) {
             $subQueryColumns[] = sprintf($subQueryPattern, $metric->getId(), $metric->getName());
             $metricIds[] = $metric->getId();


### PR DESCRIPTION
This PR intends to protect the CSV export request from metrics that can have as name a special keyword from MySQL

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
