### PR TITLE
fix(tests): rename feature flag in API test

### DIFF
--- a/centreon/tests/api/features/ResourcesByParentMonitoring.feature
+++ b/centreon/tests/api/features/ResourcesByParentMonitoring.feature
@@ -9,7 +9,7 @@ Feature:
 
   Scenario: Resource listing by parent
     Given I am logged in
-    And a feature flag "resource_status_three_view" of bitmask 3
+    And a feature flag "resource_status_tree_view" of bitmask 3
     And the following CLAPI import data:
     """
     HOST;ADD;host_test;Test host;127.0.0.1;generic-host;central;


### PR DESCRIPTION
Missing feature flag renaming in acceptance tests

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
