### PR TITLE
fix(Resources Status): Filters list deleted pollers dev-23

### DIFF
--- a/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/RealTimeMonitoringServerRepositoryRDB.php
@@ -189,6 +189,9 @@ class RealTimeMonitoringServerRepositoryRDB extends AbstractRepositoryDRB implem
             $request .= 'instances.instance_id IN (' . implode(', ', $instanceIds) . ')';
         }
 
+        $request .= (empty($searchRequest)) ? ' WHERE ' : ' AND ';
+        $request .= 'deleted = 0';
+
         // Sort
         $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();
         $request .= !is_null($sortRequest)


### PR DESCRIPTION
## Description

Update query to not select deleted poller in the filters

**Fixes** # (21741)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)
