### PR TITLE
enh(dashboard): change API graph to query by metric_name

### DIFF
--- a/centreon/doc/API/v23.10/Configuration/Dashboard/Dashboard.MetricsPerformances.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Dashboard/Dashboard.MetricsPerformances.yaml
@@ -19,11 +19,14 @@ get:
       content:
         application/json:
           schema:
-            result:
+            type: object
+            properties:
+              result:
                 type: array
-                items: { $ref: 'Schema/Dashboard.MetricsPerformances.yaml' }
-            meta:
-              $ref: '../../Common/Schema/Meta.yaml'
+                items:
+                  $ref: 'Schema/Dashboard.MetricsPerformances.yaml'
+              meta:
+                $ref: '../../Common/Schema/Meta.yaml'
     '403': { $ref: '../../Common/Response/Forbidden.yaml' }
     '404': { $ref: '../../Common/Response/NotFound.yaml' }
     '500': { $ref: '../../Common/Response/InternalServerError.yaml' }

--- a/centreon/doc/API/v23.10/Configuration/Dashboard/Dashboard.MetricsPerformancesData.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Dashboard/Dashboard.MetricsPerformancesData.yaml
@@ -8,6 +8,15 @@ get:
     - $ref: 'QueryParameter/MetricNames.yaml'
   description: |
     Get data for given metrics
+
+    The available parameters to **search** / **sort_by** are:
+    AND
+    * hostgroup.id
+    * hostcategory.id
+    * host.id
+    * servicegroup.id
+    * servicecategory.id
+    * service.name
   responses:
     '200':
       description: "OK"

--- a/centreon/doc/API/v23.10/Configuration/Dashboard/Dashboard.MetricsPerformancesData.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Dashboard/Dashboard.MetricsPerformancesData.yaml
@@ -5,7 +5,7 @@ get:
   parameters:
     - $ref: 'QueryParameter/Start.yaml'
     - $ref: 'QueryParameter/End.yaml'
-    - $ref: 'QueryParameter/MetricIds.yaml'
+    - $ref: 'QueryParameter/MetricNames.yaml'
   description: |
     Get data for given metrics
   responses:

--- a/centreon/doc/API/v23.10/Configuration/Dashboard/QueryParameter/MetricNames.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Dashboard/QueryParameter/MetricNames.yaml
@@ -1,0 +1,9 @@
+in: query
+name: metric_names
+required: true
+description: "List of metric names"
+schema:
+  type: string
+  pattern: '^\[\w+(,\w+)*\]$'
+  description: should be in form [<metricName1>,<metricName2>,<metricName3>]
+  example: "[rta,pl]"

--- a/centreon/doc/API/v23.10/Configuration/Dashboard/Schema/Dashboard.MetricsPerformances.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Dashboard/Schema/Dashboard.MetricsPerformances.yaml
@@ -25,19 +25,24 @@ properties:
           type: string
           description: unit of the metric
           example: '%'
+          nullable: true
         warning_high_threshold:
           type: number
-          description: warning threshold
+          description: warning high threshold
           example: 200
+          nullable: true
         critical_high_threshold:
           type: number
-          description: critical threshold
+          description: critical high threshold
           example: 400
+          nullable: true
         warning_low_threshold:
           type: number
-          description: warning threshold
+          description: warning low threshold
           example: 200
+          nullable: true
         critical_low_threshold:
           type: number
-          description: critical threshold
+          description: critical low threshold
           example: 400
+          nullable: true

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsData.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsData.php
@@ -23,20 +23,18 @@ declare(strict_types=1);
 
 namespace Core\Dashboard\Application\UseCase\FindPerformanceMetricsData;
 
-use Centreon\Domain\Log\LoggerTrait;
-use Core\Dashboard\Domain\Model\DashboardRights;
-use Core\Application\Common\UseCase\ErrorResponse;
-use Core\Application\Common\UseCase\ForbiddenResponse;
-use Core\Metric\Application\Exception\MetricException;
-use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use Core\Application\Common\UseCase\InvalidArgumentResponse;
-use Core\Dashboard\Application\Exception\DashboardException;
-use Core\Dashboard\Domain\Model\Metric\PerformanceMetricsData;
-use Core\Metric\Application\Repository\ReadMetricRepositoryInterface;
+use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Monitoring\Metric\Interfaces\MetricRepositoryInterface;
 use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+use Core\Application\Common\UseCase\{ErrorResponse, ForbiddenResponse, InvalidArgumentResponse};
+use Core\Dashboard\Application\Exception\DashboardException;
+use Core\Dashboard\Domain\Model\DashboardRights;
+use Core\Dashboard\Domain\Model\Metric\PerformanceMetricsData;
+use Core\Metric\Application\Exception\MetricException;
+use Core\Metric\Application\Repository\ReadMetricRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 
 final class FindPerformanceMetricsData
 {

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsData.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsData.php
@@ -65,14 +65,14 @@ final class FindPerformanceMetricsData
             if ($this->user->IsAdmin()) {
                 $this->info('Retrieving metrics data for admin user', [
                     'user_id' => $this->user->getId(),
-                    'metric_ids' => implode(', ', $request->metricIds),
+                    'metric_names' => implode(', ', $request->metricNames),
                 ]);
 
                 $performanceMetricsData = $this->findPerformanceMetricsDataAsAdmin($request);
             } else {
                 $this->info('Retrieving metrics data for non admin user', [
                     'user_id' => $this->user->getId(),
-                    'metric_ids' => implode(', ', $request->metricIds),
+                    'metric_names' => implode(', ', $request->metricNames),
                 ]);
 
                 $accessGroups = $this->accessGroupRepository->findByContact($this->user);
@@ -101,7 +101,7 @@ final class FindPerformanceMetricsData
     private function findPerformanceMetricsDataAsAdmin(
         FindPerformanceMetricsDataRequest $request
     ): PerformanceMetricsData {
-        $services = $this->metricRepository->findServicesByMetricIds($request->metricIds);
+        $services = $this->metricRepository->findServicesByMetricNames($request->metricNames);
         $metricsData = [];
         $this->metricRepositoryLegacy->setContact($this->user);
         foreach ($services as $service) {
@@ -119,7 +119,7 @@ final class FindPerformanceMetricsData
         }
         $factory = new PerformanceMetricsDataFactory();
 
-        return $factory->createFromRecords($metricsData, $request->metricIds);
+        return $factory->createFromRecords($metricsData, $request->metricNames);
     }
 
     /**
@@ -137,7 +137,10 @@ final class FindPerformanceMetricsData
         FindPerformanceMetricsDataRequest $request,
         array $accessGroups
     ): PerformanceMetricsData {
-        $services = $this->metricRepository->findServicesByMetricIdsAndAccessGroups($request->metricIds, $accessGroups);
+        $services = $this->metricRepository->findServicesByMetricNamesAndAccessGroups(
+            $request->metricNames,
+            $accessGroups
+        );
         $metricsData = [];
         $this->metricRepositoryLegacy->setContact($this->user);
         foreach ($services as $service) {
@@ -155,7 +158,7 @@ final class FindPerformanceMetricsData
         }
         $factory = new PerformanceMetricsDataFactory();
 
-        return $factory->createFromRecords($metricsData, $request->metricIds);
+        return $factory->createFromRecords($metricsData, $request->metricNames);
     }
 
     private function createResponse(PerformanceMetricsData $performanceMetricsData): FindPerformanceMetricsDataResponse

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataRequest.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataRequest.php
@@ -25,8 +25,8 @@ namespace Core\Dashboard\Application\UseCase\FindPerformanceMetricsData;
 
 final class FindPerformanceMetricsDataRequest
 {
-    /** @var int[] */
-    public array $metricIds = [];
+    /** @var string[] */
+    public array $metricNames = [];
 
     public function __construct(
         public \DateTimeInterface $startDate,

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
@@ -96,7 +96,9 @@ class PerformanceMetricsDataFactory
         $times = [];
         foreach ($metricsData as $metricData) {
             $metricBases[] = $metricData['global']['base'];
-            $metrics[] = $metricData['metrics'];
+            \preg_match('/^[a-zA-Z]+ graph on ([[:ascii:]]+)$/', $metricData['global']['title'], $matches);
+            $hostName = $matches[1];
+            $metrics[$hostName] = $metricData['metrics'];
             $times[] = $metricData['times'];
         }
         $base = $this->getHighestBase($metricBases);
@@ -121,18 +123,18 @@ class PerformanceMetricsDataFactory
     /**
      * Filter the metrics to keep only the needed metrics.
      *
-     * @param array<array<_Metrics>> $metricsData
+     * @param array<string,array<_Metrics>> $metricsData
      * @param string[] $metricNames
      *
      * @return array<_Metrics>
      */
-    private function filterMetricsByMetricId(array $metricsData, array $metricNames): array
+    private function filterMetricsByMetricName(array $metricsData, array $metricNames): array
     {
         $metrics = [];
-        foreach ($metricsData as $metricData) {
+        foreach ($metricsData as $hostName => $metricData) {
             foreach ($metricData as $metric) {
                 if (in_array($metric['metric'], $metricNames, true)) {
-                    $metrics[] = $metric;
+                    $metrics[$hostName] = $metric;
                 }
             }
         }
@@ -155,27 +157,27 @@ class PerformanceMetricsDataFactory
     /**
      * Create Metric Information.
      *
-     * @param array<array<_Metrics>> $metricData
-     * @param int[] $metricIds
+     * @param array<string,array<_Metrics>> $metricData
+     * @param string[] $metricNames
      *
      * @throws MetricException
      *
      * @return MetricInformation[]
      */
-    private function createMetricInformations(array $metricData, array $metricIds): array
+    private function createMetricInformations(array $metricData, array $metricNames): array
     {
-        $metrics = $this->filterMetricsByMetricId($metricData, $metricIds);
+        $metrics = $this->filterMetricsByMetricName($metricData, $metricNames);
         $metricsInformation = [];
-        foreach ($metrics as $metric) {
+        foreach ($metrics as $hostName => $metric) {
             try {
                 $generalInformation = new GeneralInformation(
                     $metric['index_id'],
                     $metric['metric_id'],
-                    $metric['metric'],
-                    $metric['metric_legend'],
+                    $hostName . ': ' . $metric['metric'],
+                    $hostName . ': ' . $metric['metric_legend'],
                     $metric['unit'],
                     (bool) $metric['hidden'],
-                    $metric['legend'],
+                    $hostName . ': ' . $metric['legend'],
                     (bool) $metric['virtual'],
                     (bool) $metric['stack'],
                     $metric['ds_order']

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
@@ -85,11 +85,11 @@ class PerformanceMetricsDataFactory
 
     /**
      * @param array<_MetricData> $metricsData
-     * @param int[] $metricIds
+     * @param string[] $metricNames
      *
      * @return PerformanceMetricsData
      */
-    public function createFromRecords(array $metricsData, array $metricIds): PerformanceMetricsData
+    public function createFromRecords(array $metricsData, array $metricNames): PerformanceMetricsData
     {
         $metricBases = [];
         $metrics = [];
@@ -100,7 +100,7 @@ class PerformanceMetricsDataFactory
             $times[] = $metricData['times'];
         }
         $base = $this->getHighestBase($metricBases);
-        $metricsInfo = $this->createMetricInformations($metrics, $metricIds);
+        $metricsInfo = $this->createMetricInformations($metrics, $metricNames);
         $times = $this->getTimes($times);
 
         return new PerformanceMetricsData($base, $metricsInfo, $times);
@@ -122,16 +122,16 @@ class PerformanceMetricsDataFactory
      * Filter the metrics to keep only the needed metrics.
      *
      * @param array<array<_Metrics>> $metricsData
-     * @param int[] $metricIds
+     * @param string[] $metricNames
      *
      * @return array<_Metrics>
      */
-    private function filterMetricsByMetricId(array $metricsData, array $metricIds): array
+    private function filterMetricsByMetricId(array $metricsData, array $metricNames): array
     {
         $metrics = [];
         foreach ($metricsData as $metricData) {
             foreach ($metricData as $metric) {
-                if (in_array($metric['metric_id'], $metricIds, true)) {
+                if (in_array($metric['metric'], $metricNames, true)) {
                     $metrics[] = $metric;
                 }
             }

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
@@ -134,7 +134,10 @@ class PerformanceMetricsDataFactory
         foreach ($metricsData as $hostName => $metricData) {
             foreach ($metricData as $metric) {
                 if (in_array($metric['metric'], $metricNames, true)) {
-                    $metrics[$hostName] = $metric;
+                    $metric['metric'] = $hostName . ': ' . $metric['metric'];
+                    $metric['metric_legend'] = $hostName . ': ' . $metric['metric_legend'];
+                    $metric['legend'] = $hostName . ': ' . $metric['legend'];
+                    $metrics[] = $metric;
                 }
             }
         }
@@ -168,16 +171,16 @@ class PerformanceMetricsDataFactory
     {
         $metrics = $this->filterMetricsByMetricName($metricData, $metricNames);
         $metricsInformation = [];
-        foreach ($metrics as $hostName => $metric) {
+        foreach ($metrics as $metric) {
             try {
                 $generalInformation = new GeneralInformation(
                     $metric['index_id'],
                     $metric['metric_id'],
-                    $hostName . ': ' . $metric['metric'],
-                    $hostName . ': ' . $metric['metric_legend'],
+                    $metric['metric'],
+                    $metric['metric_legend'],
                     $metric['unit'],
                     (bool) $metric['hidden'],
-                    $hostName . ': ' . $metric['legend'],
+                    $metric['legend'],
                     (bool) $metric['virtual'],
                     (bool) $metric['stack'],
                     $metric['ds_order']

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindPerformanceMetricsData/FindPerformanceMetricsDataController.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindPerformanceMetricsData/FindPerformanceMetricsDataController.php
@@ -92,8 +92,11 @@ final class FindPerformanceMetricsDataController extends AbstractController
             throw new \InvalidArgumentException('Invalid metric names provided');
         }
 
+        $sanitizedMetricNames = [];
         foreach ($metricNames as $metricName) {
+            $metricName = \trim($metricName, '"');
             $validationConstraints[] = $validator->validate($metricName, $integerConstraint);
+            $sanitizedMetricNames[] = $metricName;
         }
 
         foreach ($validationConstraints as $validationConstraint) {
@@ -105,7 +108,7 @@ final class FindPerformanceMetricsDataController extends AbstractController
         return [
             'start' => $start,
             'end' => $end,
-            'metric_names' => $metricNames,
+            'metric_names' => $sanitizedMetricNames,
         ];
     }
 

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindPerformanceMetricsData/FindPerformanceMetricsDataController.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindPerformanceMetricsData/FindPerformanceMetricsDataController.php
@@ -37,7 +37,7 @@ final class FindPerformanceMetricsDataController extends AbstractController
     use LoggerTrait;
     private const START_DATE_PARAMETER = 'start';
     private const END_DATE_PARAMETER = 'end';
-    private const METRIC_IDS_PARAMETER = 'metricIds';
+    private const METRIC_NAMES_PARAMETER = 'metric_names';
 
     public function __invoke(
         FindPerformanceMetricsData $useCase,
@@ -68,44 +68,44 @@ final class FindPerformanceMetricsDataController extends AbstractController
     {
         $startParameter = $request->query->get(self::START_DATE_PARAMETER);
         $endParameter = $request->query->get(self::END_DATE_PARAMETER);
-        /** @var string|null $metricIdsParameter */
-        $metricIdsParameter = $request->query->get(self::METRIC_IDS_PARAMETER);
-        if ($startParameter === null || $endParameter === null || $metricIdsParameter === null) {
+        /** @var string|null $metricNamesParameter */
+        $metricNamesParamenter = $request->query->get(self::METRIC_NAMES_PARAMETER);
+        if ($startParameter === null || $endParameter === null || $metricNamesParamenter === null) {
             throw new \InvalidArgumentException('Missing mandatory properties');
         }
 
         $validator = Validation::createValidator();
-        $integerConstraint = new TypeConstraint('int');
+        $integerConstraint = new TypeConstraint('string');
         $validationConstraints = [];
 
         try {
             $start = new \DateTime((string) $startParameter);
             $end = new \DateTime((string) $endParameter);
-            $metricIds = json_decode((string) $metricIdsParameter, true);
+            $metricNames = \explode(',', \trim($metricNamesParamenter, '[]'));
         } catch ( \Throwable $ex) {
             $this->error('Invalid parameters format', ['trace' => (string) $ex]);
 
             throw new \InvalidArgumentException('Invalid parameters format');
         }
 
-        if (! is_array($metricIds) || [] === $metricIds)  {
-            throw new \InvalidArgumentException('invalid metric ids provided');
+        if (! is_array($metricNames) || [] === $metricNames)  {
+            throw new \InvalidArgumentException('Invalid metric names provided');
         }
 
-        foreach ($metricIds as $metricId) {
-            $validationConstraints[] = $validator->validate($metricId, $integerConstraint);
+        foreach ($metricNames as $metricName) {
+            $validationConstraints[] = $validator->validate($metricName, $integerConstraint);
         }
 
         foreach ($validationConstraints as $validationConstraint) {
             if ($validationConstraint->count() > 0) {
-                throw new \InvalidArgumentException('Invalid metric ID format');
+                throw new \InvalidArgumentException('Invalid metric name format');
             }
         }
 
         return [
             'start' => $start,
             'end' => $end,
-            'metricIds' => $metricIds,
+            'metric_names' => $metricNames,
         ];
     }
 
@@ -124,7 +124,7 @@ final class FindPerformanceMetricsDataController extends AbstractController
             $parameterFromRequest['end']
         );
 
-        $requestDto->metricIds = $parameterFromRequest['metricIds'];
+        $requestDto->metricNames = $parameterFromRequest['metric_names'];
 
         return $requestDto;
     }

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindPerformanceMetricsData/FindPerformanceMetricsDataController.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindPerformanceMetricsData/FindPerformanceMetricsDataController.php
@@ -69,8 +69,8 @@ final class FindPerformanceMetricsDataController extends AbstractController
         $startParameter = $request->query->get(self::START_DATE_PARAMETER);
         $endParameter = $request->query->get(self::END_DATE_PARAMETER);
         /** @var string|null $metricNamesParameter */
-        $metricNamesParamenter = $request->query->get(self::METRIC_NAMES_PARAMETER);
-        if ($startParameter === null || $endParameter === null || $metricNamesParamenter === null) {
+        $metricNamesParameter = $request->query->get(self::METRIC_NAMES_PARAMETER);
+        if ($startParameter === null || $endParameter === null || $metricNamesParameter === null) {
             throw new \InvalidArgumentException('Missing mandatory properties');
         }
 
@@ -81,7 +81,7 @@ final class FindPerformanceMetricsDataController extends AbstractController
         try {
             $start = new \DateTime((string) $startParameter);
             $end = new \DateTime((string) $endParameter);
-            $metricNames = \explode(',', \trim($metricNamesParamenter, '[]'));
+            $metricNames = \explode(',', \trim($metricNamesParameter, '[]'));
         } catch ( \Throwable $ex) {
             $this->error('Invalid parameters format', ['trace' => (string) $ex]);
 

--- a/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
+++ b/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
@@ -41,6 +41,7 @@ interface ReadMetricRepositoryInterface
      * Find Service by Metric Names.
      *
      * @param string[] $metricNames
+     * @param RequestParametersInterface $requestParameters
      *
      * @return Service[]
      */
@@ -54,6 +55,7 @@ interface ReadMetricRepositoryInterface
      *
      * @param string[] $metricNames
      * @param AccessGroup[] $accessGroups
+     * @param RequestParametersInterface $requestParameters
      *
      * @return Service[]
      */

--- a/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
+++ b/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
@@ -37,18 +37,18 @@ interface ReadMetricRepositoryInterface
     public function findMetricsByIndexId(int $indexId): array;
 
     /**
-     * Find Service by Metric Ids.
+     * Find Service by Metric Names.
      *
-     * @param string[] $metricIds
+     * @param string[] $metricNames
      *
      * @return Service[]
      */
     public function findServicesByMetricNames(array $metricNames): array;
 
     /**
-     * Find Service by Metric Ids.
+     * Find Service by Metric Names and Access Groups.
      *
-     * @param string[] $metricIds
+     * @param string[] $metricNames
      * @param AccessGroup[] $accessGroups
      *
      * @return Service[]

--- a/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
+++ b/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Core\Metric\Application\Repository;
 
 use Centreon\Domain\Monitoring\Service;
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
 use Core\Metric\Domain\Model\Metric;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 
@@ -43,7 +44,10 @@ interface ReadMetricRepositoryInterface
      *
      * @return Service[]
      */
-    public function findServicesByMetricNames(array $metricNames): array;
+    public function findServicesByMetricNamesAndRequestParameters(
+        array $metricNames,
+        RequestParametersInterface $requestParameters
+    ): array;
 
     /**
      * Find Service by Metric Names and Access Groups.
@@ -53,5 +57,9 @@ interface ReadMetricRepositoryInterface
      *
      * @return Service[]
      */
-    public function findServicesByMetricNamesAndAccessGroups(array $metricNames, array $accessGroups): array;
+    public function findServicesByMetricNamesAndAccessGroupsAndRequestParameters(
+        array $metricNames,
+        array $accessGroups,
+        RequestParametersInterface $requestParameters
+    ): array;
 }

--- a/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
+++ b/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
@@ -39,19 +39,19 @@ interface ReadMetricRepositoryInterface
     /**
      * Find Service by Metric Ids.
      *
-     * @param int[] $metricIds
+     * @param string[] $metricIds
      *
      * @return Service[]
      */
-    public function findServicesByMetricIds(array $metricIds): array;
+    public function findServicesByMetricNames(array $metricNames): array;
 
     /**
      * Find Service by Metric Ids.
      *
-     * @param int[] $metricIds
+     * @param string[] $metricIds
      * @param AccessGroup[] $accessGroups
      *
      * @return Service[]
      */
-    public function findServicesByMetricIdsAndAccessGroups(array $metricIds, array $accessGroups): array;
+    public function findServicesByMetricNamesAndAccessGroups(array $metricNames, array $accessGroups): array;
 }

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
@@ -36,6 +36,12 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
 {
     /**
      * @param DatabaseConnection $db
+     * @param array<
+     *  string, array{
+     *    request: string,
+     *    bindValues: array<mixed>
+     *  }
+     * > $subRequestsInformation
      */
     public function __construct(DatabaseConnection $db, private array $subRequestsInformation = [])
     {
@@ -135,7 +141,7 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
         array $accessGroups,
         array $metricNames
     ): string {
-        $request = <<<SQL
+        $request = <<<'SQL'
             SELECT DISTINCT id.`host_id`,
                 id.`service_id`
             FROM `:dbstg`.`index_data` AS id

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
@@ -70,23 +70,23 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
     /**
      * @inheritDoc
      */
-    public function findServicesByMetricIds(array $metricIds): array
+    public function findServicesByMetricNames(array $metricNames): array
     {
-        if ([] === $metricIds) {
+        if ([] === $metricNames) {
             return [];
         }
 
         $bindValues = [];
-        foreach ($metricIds as $metricId) {
-            $bindValues[':metricid_' . $metricId] = $metricId;
+        foreach ($metricNames as $index => $metricName) {
+            $bindValues[':metric_name_' . $index] = $metricName;
         }
 
-        $metricIdQuery = implode(', ',array_keys($bindValues));
+        $metricNamesQuery = implode(', ',array_keys($bindValues));
         $statement = $this->db->prepare($this->translateDbName(
             <<<SQL
                     SELECT DISTINCT id.host_id, id.service_id FROM `:dbstg`.index_data AS id
                     INNER JOIN `:dbstg`.metrics AS m ON m.index_id = id.id
-                    WHERE m.metric_id IN ({$metricIdQuery})
+                    WHERE m.metric_name IN ({$metricNamesQuery})
                 SQL
         ));
 
@@ -109,18 +109,18 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
     /**
      * @inheritDoc
      */
-    public function findServicesByMetricIdsAndAccessGroups(array $metricIds, array $accessGroups): array
+    public function findServicesByMetricNamesAndAccessGroups(array $metricNames, array $accessGroups): array
     {
-        if ([] === $metricIds) {
+        if ([] === $metricNames) {
             return [];
         }
 
         $bindValues = [];
-        foreach ($metricIds as $metricId) {
-            $bindValues[':metricid_' . $metricId] = $metricId;
+        foreach ($metricNames as $index => $metricName) {
+            $bindValues[':metric_name_' . $index] = $metricName;
         }
 
-        $metricIdQuery = implode(', ',array_keys($bindValues));
+        $metricNamesQuery = implode(', ',array_keys($bindValues));
         $accessGroupIds = array_map(
             fn (AccessGroup $accessGroup): int => $accessGroup->getId(),
             $accessGroups
@@ -134,7 +134,7 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
                     INNER JOIN `:dbstg`.`centreon_acl` acl
                     ON acl.service_id = id.service_id
                     AND acl.group_id IN ({$accessGroupIdsQuery})
-                    WHERE m.metric_id IN ({$metricIdQuery})
+                    WHERE m.metric_name IN ({$metricNamesQuery})
                 SQL
         ));
 

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
@@ -146,7 +146,7 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
                 id.`service_id`
             FROM `:dbstg`.`index_data` AS id
                 INNER JOIN `:dbstg`.`metrics` AS m ON m.`index_id` = id.`id`
-        SQL;
+            SQL;
 
         $accessGroupIds = \array_map(
             fn (AccessGroup $accessGroup): int => $accessGroup->getId(),
@@ -381,6 +381,16 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
         ];
     }
 
+    /**
+     * Build the sub request for service group filter.
+     *
+     * @param non-empty-array<int> $serviceGroupIds
+     *
+     * @return array{
+     *  request: string,
+     *  bindValues: array<mixed>
+     * }
+     */
     private function buildSubRequestForServiceGroupFilter(array $serviceGroupIds): array
     {
         $bindValues = [];
@@ -403,6 +413,16 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
         ];
     }
 
+    /**
+     * Build the sub request for host category filter.
+     *
+     * @param non-empty-array<int> $hostCategoryIds
+     *
+     * @return array{
+     *  request: string,
+     *  bindValues: array<mixed>
+     * }
+     */
     private function buildSubRequestForHostCategoryFilter(array $hostCategoryIds): array
     {
         $bindValues = [];
@@ -426,6 +446,16 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
         ];
     }
 
+    /**
+     * Build the sub request for service category filter.
+     *
+     * @param non-empty-array<int> $serviceCategoryIds
+     *
+     * @return array{
+     *  request: string,
+     *  bindValues: array<mixed>
+     * }
+     */
     private function buildSubRequestForServiceCategoryFilter(array $serviceCategoryIds): array
     {
         $bindValues = [];
@@ -448,6 +478,18 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
         ];
     }
 
+    /**
+     * Build the subrequest for tags filter.
+     *
+     * @param array<
+     *   string, array{
+     *     request: string,
+     *     bindValues: array<mixed>
+     *   }
+     * > $subRequestInformation
+     *
+     * @return string
+     */
     private function buildSubRequestForTags(array $subRequestInformation): string
     {
         $request = '';

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
@@ -94,7 +94,11 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
         foreach ($records as $record) {
             $services[] = (new Service())
                 ->setId($record['service_id'])
-                ->setHost((new Host())->setId($record['host_id']));
+                ->setHost(
+                    (new Host())
+                        ->setId($record['host_id'])
+                        ->setName($record['host_name'])
+                );
         }
 
         return $services;
@@ -121,7 +125,11 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
         foreach ($records as $record) {
             $services[] = (new Service())
                 ->setId($record['service_id'])
-                ->setHost((new Host())->setId($record['host_id']));
+                ->setHost(
+                    (new Host())
+                        ->setId($record['host_id'])
+                        ->setName($record['host_name'])
+                );
         }
 
         return $services;
@@ -143,6 +151,7 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
     ): string {
         $request = <<<'SQL'
             SELECT DISTINCT id.`host_id`,
+                id.`host_name`,
                 id.`service_id`
             FROM `:dbstg`.`index_data` AS id
                 INNER JOIN `:dbstg`.`metrics` AS m ON m.`index_id` = id.`id`

--- a/centreon/tests/api/features/DashboardWithOpenApi.feature
+++ b/centreon/tests/api/features/DashboardWithOpenApi.feature
@@ -1778,10 +1778,10 @@ Feature:
     Then the response code should be "200"
     And the JSON nodes should be equal to:
       | base                | 1000           |
-      | metrics[0].metric   | "pl"           |
-      | metrics[0].legend   | "Packet Loss"  |
-      | metrics[1].metric   | "rta"          |
-      | metrics[2].metric   | "rtmax"        |
+      | metrics[0].metric   | "Centreon-Server: pl"           |
+      | metrics[0].legend   | "Centreon-Server: Packet Loss"  |
+      | metrics[1].metric   | "Centreon-Server: rta"          |
+      | metrics[2].metric   | "Centreon-Server: rtmax"        |
     And the JSON node "metrics[0].data" should have at least 48 elements
     And the JSON node "metrics[1].data" should have at least 48 elements
     And the JSON node "metrics[2].data" should have at least 48 elements

--- a/centreon/tests/api/features/DashboardWithOpenApi.feature
+++ b/centreon/tests/api/features/DashboardWithOpenApi.feature
@@ -1773,8 +1773,8 @@ Feature:
     }
     """
 
-    And I wait to get 3 metrics from '/api/latest/monitoring/dashboard/metrics/performances/data?metricIds=[1,2,3]&start=2023-09-08T04:40:16.344Z&end=2023-09-08T08:40:16.344Z'
-    When I send a GET request to '/api/latest/monitoring/dashboard/metrics/performances/data?metricIds=[1,2,3]&start=2023-09-08T04:40:16.344Z&end=2023-09-08T08:40:16.344Z'
+    And I wait to get 3 metrics from '/api/latest/monitoring/dashboard/metrics/performances/data?metric_names=[pl,rta,rtmax]&start=2023-09-08T04:40:16.344Z&end=2023-09-08T08:40:16.344Z'
+    When I send a GET request to '/api/latest/monitoring/dashboard/metrics/performances/data?metric_names=[pl,rta,rtmax]&start=2023-09-08T04:40:16.344Z&end=2023-09-08T08:40:16.344Z'
     Then the response code should be "200"
     And the JSON nodes should be equal to:
       | base                | 1000           |

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataTest.php
@@ -52,7 +52,7 @@ beforeEach(function () {
 it('should present a ForbiddenResponse when the user does not has sufficient rights', function () {
     $presenter = new FindPerformanceMetricsDataPresenterStub();
     $request =  new FindPerformanceMetricsDataRequest(new \DateTime(), new \DateTime());
-    $request->metricIds = [1,2,3];
+    $request->metricNames = ["rta"];
     $useCase = new FindPerformanceMetricsData(
         $this->nonAdminUser,
         $this->metricRepositoryLegacy,
@@ -77,7 +77,7 @@ it('should present a ForbiddenResponse when the user does not has sufficient rig
 it('should present an ErrorResponse when an error occurs', function () {
     $presenter = new FindPerformanceMetricsDataPresenterStub();
     $request =  new FindPerformanceMetricsDataRequest(new \DateTime(), new \DateTime());
-    $request->metricIds = [1,2,3];
+    $request->metricNames = ["rta","pl"];
     $useCase = new FindPerformanceMetricsData(
         $this->nonAdminUser,
         $this->metricRepositoryLegacy,
@@ -93,7 +93,7 @@ it('should present an ErrorResponse when an error occurs', function () {
 
     $this->metricRepository
         ->expects($this->once())
-        ->method('findServicesByMetricIdsAndAccessGroups')
+        ->method('findServicesByMetricNamesAndAccessGroups')
         ->willThrowException(new \Exception());
 
     $useCase($presenter, $request);
@@ -106,7 +106,7 @@ it('should present an ErrorResponse when an error occurs', function () {
 it('should get the metrics with access group management when the user is not admin', function () {
     $presenter = new FindPerformanceMetricsDataPresenterStub();
     $request =  new FindPerformanceMetricsDataRequest(new \DateTime(), new \DateTime());
-    $request->metricIds = [1,2,3];
+    $request->metricNames = ["rta","pl"];
     $useCase = new FindPerformanceMetricsData(
         $this->nonAdminUser,
         $this->metricRepositoryLegacy,
@@ -122,7 +122,7 @@ it('should get the metrics with access group management when the user is not adm
 
     $this->metricRepository
         ->expects($this->once())
-        ->method('findServicesByMetricIdsAndAccessGroups');
+        ->method('findServicesByMetricNamesAndAccessGroups');
 
     $useCase($presenter, $request);
 });
@@ -130,7 +130,7 @@ it('should get the metrics with access group management when the user is not adm
 it('should get the metrics without access group management when the user is admin', function () {
     $presenter = new FindPerformanceMetricsDataPresenterStub();
     $request =  new FindPerformanceMetricsDataRequest(new \DateTime(), new \DateTime());
-    $request->metricIds = [1,2,3];
+    $request->metricNames = ["rta","pl"];
     $useCase = new FindPerformanceMetricsData(
         $this->adminUser,
         $this->metricRepositoryLegacy,
@@ -146,7 +146,7 @@ it('should get the metrics without access group management when the user is admi
 
     $this->metricRepository
         ->expects($this->once())
-        ->method('findServicesByMetricIds');
+        ->method('findServicesByMetricNames');
 
     $useCase($presenter, $request);
 });
@@ -154,7 +154,7 @@ it('should get the metrics without access group management when the user is admi
 it('should present a FindPerformanceMetricsDataResponse when metrics are correctly retrieve', function () {
     $presenter = new FindPerformanceMetricsDataPresenterStub();
     $request =  new FindPerformanceMetricsDataRequest(new \DateTime(), new \DateTime());
-    $request->metricIds = [1,3];
+    $request->metricNames = ["pl"];
     $useCase = new FindPerformanceMetricsData(
         $this->adminUser,
         $this->metricRepositoryLegacy,
@@ -175,7 +175,7 @@ it('should present a FindPerformanceMetricsDataResponse when metrics are correct
 
     $this->metricRepository
         ->expects($this->once())
-        ->method('findServicesByMetricIds')
+        ->method('findServicesByMetricNames')
         ->willReturn([$service]);
 
     $this->metricRepositoryLegacy

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataTest.php
@@ -172,7 +172,7 @@ it('should present a FindPerformanceMetricsDataResponse when metrics are correct
     $service = (new Service())
         ->setId(1)
         ->setHost(
-            (new Host())->setId(2)
+            (new Host())->setId(2)->setName('myHost')
         );
 
     $this->rights
@@ -197,7 +197,8 @@ it('should present a FindPerformanceMetricsDataResponse when metrics are correct
         ->willReturn(
             [
                 'global' => [
-                    'base' => 1000
+                    'base' => 1000,
+                    'title' => 'Ping graph on myHost'
                 ],
                 'metrics' => [
                     [


### PR DESCRIPTION
## Description

- Changed endpoint `/monitoring/dashboard/metrics/performances/data` to accept query parameter `metric_names` instead of `metricIds`
- Added search parameters (`service.name`, `servicegroup.id`, `servicecategory.id`, `host.id`, `hostgroup.id`, `hostcategory.id`)

**Fixes** # MON-21715

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
