### PR TITLE
fix(ldap): Compare LDAP and database contact info case insensitively

### DIFF
--- a/centreon/www/class/centreonAuth.LDAP.class.php
+++ b/centreon/www/class/centreonAuth.LDAP.class.php
@@ -113,7 +113,7 @@ class CentreonAuthLDAP
             $this->contactInfos['contact_ldap_dn'] = $this->ldap->findUserDn($this->contactInfos['contact_alias']);
         } elseif (
             ($userDn = $this->ldap->findUserDn($this->contactInfos['contact_alias']))
-            && $userDn !== $this->contactInfos['contact_ldap_dn']
+            && strtolower($userDn) !== strtolower($this->contactInfos['contact_ldap_dn']) //Ignore case for LDAP and database contact info comparison
         ) { // validate if user exists in this resource
             if (! $userDn) {
                 //User resource error

--- a/centreon/www/class/centreonAuth.LDAP.class.php
+++ b/centreon/www/class/centreonAuth.LDAP.class.php
@@ -113,7 +113,7 @@ class CentreonAuthLDAP
             $this->contactInfos['contact_ldap_dn'] = $this->ldap->findUserDn($this->contactInfos['contact_alias']);
         } elseif (
             ($userDn = $this->ldap->findUserDn($this->contactInfos['contact_alias']))
-            && strtolower($userDn) !== strtolower($this->contactInfos['contact_ldap_dn']) //Ignore case for LDAP and database contact info comparison
+            && mb_strtolower($userDn, 'UTF-8') !== mb_strtolower($this->contactInfos['contact_ldap_dn'], 'UTF-8') //Ignore case for LDAP and database contact info comparison
         ) { // validate if user exists in this resource
             if (! $userDn) {
                 //User resource error


### PR DESCRIPTION
## Description

Add strtolower function when comparing contact_ldap_dn from LDAP with contact info from database to ignore case differences which can happen cause of LDAP migration or configuration (this info is case insensitive on LDAP side)

Fixes #1343

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>
To test the fix
-Log out from Centreon
-Change the user DN case on Centreon database table "contact", field "contact_ldap_dn"
Ex: Change CN=TEST,OU=FR,OU=TEST,o=test,C=FR to CN=TEST,OU=FR,OU=TEST,O=TEST,C=FR
-Try to login again > the authentication should be ok (without the fix you would have an "invalid credential" error)
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
