### PR TITLE
fix(test): update centreon-test-lib to fix docker composer kill

### DIFF
--- a/centreon/composer.json
+++ b/centreon/composer.json
@@ -18,7 +18,7 @@
         "behat/mink-selenium2-driver": "^1.5",
         "friends-of-behat/mink": "^1.9",
         "friends-of-behat/mink-extension": "^2.5",
-        "centreon/centreon-test-lib": "22.10.x-dev",
+        "centreon/centreon-test-lib": "dev-docker-kill-22.10",
         "phpstan/phpstan": "^1.3.0",
         "phpstan/phpstan-beberlei-assert": "^1.0.0",
         "squizlabs/php_codesniffer": "3.6.2",

--- a/centreon/composer.json
+++ b/centreon/composer.json
@@ -18,7 +18,7 @@
         "behat/mink-selenium2-driver": "^1.5",
         "friends-of-behat/mink": "^1.9",
         "friends-of-behat/mink-extension": "^2.5",
-        "centreon/centreon-test-lib": "dev-docker-kill-22.10",
+        "centreon/centreon-test-lib": "22.10.x-dev",
         "phpstan/phpstan": "^1.3.0",
         "phpstan/phpstan-beberlei-assert": "^1.0.0",
         "squizlabs/php_codesniffer": "3.6.2",

--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bfb155336b20e2d1e9a60c7596052de3",
+    "content-hash": "35528c85b20fc301d61cefdf710cad3a",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -6566,16 +6566,16 @@
         },
         {
             "name": "centreon/centreon-test-lib",
-            "version": "22.10.x-dev",
+            "version": "dev-docker-kill-22.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "a1be7f19ce7d24418e039ba32544095a0b46f7bf"
+                "reference": "2060e36ddfc9b72f997f679adde2765054b897c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/a1be7f19ce7d24418e039ba32544095a0b46f7bf",
-                "reference": "a1be7f19ce7d24418e039ba32544095a0b46f7bf",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/2060e36ddfc9b72f997f679adde2765054b897c2",
+                "reference": "2060e36ddfc9b72f997f679adde2765054b897c2",
                 "shasum": ""
             },
             "require": {
@@ -6622,9 +6622,9 @@
             ],
             "support": {
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
-                "source": "https://github.com/centreon/centreon-test-lib/tree/22.10.x"
+                "source": "https://github.com/centreon/centreon-test-lib/tree/docker-kill-22.10"
             },
-            "time": "2023-03-21T14:41:08+00:00"
+            "time": "2023-09-26T15:05:03+00:00"
         },
         {
             "name": "composer/pcre",

--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35528c85b20fc301d61cefdf710cad3a",
+    "content-hash": "bfb155336b20e2d1e9a60c7596052de3",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -6566,16 +6566,16 @@
         },
         {
             "name": "centreon/centreon-test-lib",
-            "version": "dev-docker-kill-22.10",
+            "version": "22.10.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "2060e36ddfc9b72f997f679adde2765054b897c2"
+                "reference": "d570456dd7266fb12d89b2a5aae98a0f78f131a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/2060e36ddfc9b72f997f679adde2765054b897c2",
-                "reference": "2060e36ddfc9b72f997f679adde2765054b897c2",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/d570456dd7266fb12d89b2a5aae98a0f78f131a5",
+                "reference": "d570456dd7266fb12d89b2a5aae98a0f78f131a5",
                 "shasum": ""
             },
             "require": {
@@ -6622,9 +6622,9 @@
             ],
             "support": {
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
-                "source": "https://github.com/centreon/centreon-test-lib/tree/docker-kill-22.10"
+                "source": "https://github.com/centreon/centreon-test-lib/tree/22.10.x"
             },
-            "time": "2023-09-26T15:05:03+00:00"
+            "time": "2023-09-26T15:29:33+00:00"
         },
         {
             "name": "composer/pcre",


### PR DESCRIPTION
## Description

update centreon-test-lib to fix docker composer kill

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)