### PR TITLE
enh(config): disable engine notifications in cloud/notification context

### DIFF
--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -333,9 +333,8 @@ class Engine extends AbstractObject
     {
         $kernel = \App\Kernel::createForWeb();
         $featureFlags = $kernel->getContainer()->get(Core\Common\Infrastructure\FeatureFlags::class);
-        $flags = $featureFlags->getAll();
 
-        return ($flags['notification'] === true && $featureFlags->isCloudPlatform() === true);
+        return ($featureFlags->isEnabled('notification') === true && $featureFlags->isCloudPlatform() === true);
     }
 
     private function generate($poller_id)


### PR DESCRIPTION
🏷️ MON-20907

This PR intends to disable engine notifications when 2 conditions are matched
- Feature flag "Notification" is true
- Platform context is "Cloud" (isCloudPlatform flag true)

(see video on Jira issue)

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
