### PR TITLE
fix(resources): correctly use inline check endpoint action

### DIFF
--- a/centreon/www/class/centreonAuth.LDAP.class.php
+++ b/centreon/www/class/centreonAuth.LDAP.class.php
@@ -113,7 +113,7 @@ class CentreonAuthLDAP
             $this->contactInfos['contact_ldap_dn'] = $this->ldap->findUserDn($this->contactInfos['contact_alias']);
         } elseif (
             ($userDn = $this->ldap->findUserDn($this->contactInfos['contact_alias']))
-            && $userDn !== $this->contactInfos['contact_ldap_dn']
+            && mb_strtolower($userDn, 'UTF-8') !== mb_strtolower($this->contactInfos['contact_ldap_dn'], 'UTF-8') //Ignore case for LDAP and database contact info comparison
         ) { // validate if user exists in this resource
             if (! $userDn) {
                 //User resource error

--- a/centreon/www/front_src/src/Resources/Listing/index.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/index.tsx
@@ -14,7 +14,9 @@ import {
 import { userAtom } from '@centreon/ui-context';
 
 import { userEndpoint } from '../../App/endpoint';
+import { featureFlagsDerivedAtom } from '../../Main/atoms/platformFeaturesAtom';
 import Actions from '../Actions';
+import { forcedCheckInlineEndpointAtom } from '../Actions/Resource/Check/checkAtoms';
 import VisualizationActions from '../Actions/Visualization';
 import {
   resourcesToAcknowledgeAtom,
@@ -22,14 +24,11 @@ import {
   selectedResourcesAtom,
   selectedVisualizationAtom
 } from '../Actions/actionsAtoms';
-import { forcedCheckInlineEndpointAtom } from '../Actions/Resource/Check/checkAtoms';
-import { adjustCheckedResources } from '../Actions/Resource/Check/helpers';
-import { rowColorConditions } from '../colors';
 import {
   openDetailsTabIdAtom,
   panelWidthStorageAtom,
-  selectedResourcesDetailsAtom,
-  selectedResourceUuidAtom
+  selectedResourceUuidAtom,
+  selectedResourcesDetailsAtom
 } from '../Details/detailsAtoms';
 import { graphTabId } from '../Details/tabs';
 import {
@@ -37,13 +36,13 @@ import {
   searchAtom,
   setCriteriaAndNewFilterDerivedAtom
 } from '../Filter/filterAtoms';
+import { rowColorConditions } from '../colors';
 import { Resource, SortOrder, Visualization } from '../models';
 import {
+  labelForcedCheckCommandSent,
   labelSelectAtLeastOneColumn,
-  labelStatus,
-  labelForcedCheckCommandSent
+  labelStatus
 } from '../translatedLabels';
-import { featureFlagsDerivedAtom } from '../../Main/atoms/platformFeaturesAtom';
 
 import { defaultSelectedColumnIds, getColumns } from './columns';
 import {

--- a/centreon/www/front_src/src/Resources/Listing/index.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/index.tsx
@@ -152,8 +152,7 @@ const ResourceListing = (): JSX.Element => {
 
   const onForcedCheck = (resource: Resource): void => {
     checkResource({
-      check: { is_forced: true },
-      resources: adjustCheckedResources({ resources: [resource] })
+      is_forced: true
     }).then(() => {
       showSuccessMessage(t(labelForcedCheckCommandSent));
     });

--- a/centreon/www/front_src/src/Resources/Listing/index.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/index.tsx
@@ -150,7 +150,7 @@ const ResourceListing = (): JSX.Element => {
     name: 'detailsOpen'
   };
 
-  const onForcedCheck = (resource: Resource): void => {
+  const onForcedCheck = (): void => {
     checkResource({
       is_forced: true
     }).then(() => {


### PR DESCRIPTION
🏷️ MON-21540

This PR intends to fix an issue regarding inline check action that does not do what it is meant to do (a forced check).
This is due to a wrongly formatted payload sent to the endpoint ([API documentation of the endpoint](https://docs-api.centreon.com/api/centreon-web/23.04/#tag/Check/paths/~1monitoring~1hosts~1%7Bhost_id%7D~1services~1%7Bservice_id%7D~1check/post)).

The endpoint expects 
`{is_forced: true}`

But receives
`{"check":{"is_forced":true},"resources":[{"id":27,"parent":{"id":15},"type":"service"}]}`

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>
See Jira ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
