### PR TITLE
enh(monitoring): deletion of monitoring pages for next major message

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -11958,8 +11958,8 @@ msgstr "URL Notizen"
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php:920
 #: centreon/www/include/monitoring/status/Hosts/host.php:189
 #: centreon/www/include/monitoring/status/Services/service.php:219
-msgid "[Page deprecated] Please use the new page: "
-msgstr "[Seite veraltet] Bitte nutzen Sie die neue Seite: "
+msgid "[Page deprecated] This page will be removed in the next major version. Please use the new page: "
+msgstr "[Seite veraltet] Diese Seite wird in der nächsten Hauptversion entfernt werden. Bitte nutzen Sie die neue Seite: "
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php:784
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php:921

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4019,7 +4019,7 @@ msgstr "Page par défaut"
 #: centreon-web/www/include/monitoring/objectDetails/serviceDetails.php:838
 #: centreon-web/www/include/monitoring/objectDetails/hostDetails.php:719
 msgid "[Page deprecated] This page will be removed in the next major version. Please use the new page: "
-msgstr "[Page dépréciée] Cette page sera supprimée dans la prochaine version majeure. Utilisez la nouvelle page: "
+msgstr "[Page dépréciée] Cette page sera supprimée dans la prochaine version majeure. Veuillez utiliser la nouvelle page : "
 
 #: centreon-web/www/include/Administration/myAccount/formMyAccount.php:138
 msgid "Show Up status"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4018,8 +4018,8 @@ msgstr "Page par défaut"
 #: centreon-web/www/include/monitoring/status/Hosts/host.php:189
 #: centreon-web/www/include/monitoring/objectDetails/serviceDetails.php:838
 #: centreon-web/www/include/monitoring/objectDetails/hostDetails.php:719
-msgid "[Page deprecated] Please use the new page: "
-msgstr "[Page dépréciée] Utilisez la nouvelle page: "
+msgid "[Page deprecated] This page will be removed in the next major version. Please use the new page: "
+msgstr "[Page dépréciée] Cette page sera supprimée dans la prochaine version majeure. Utilisez la nouvelle page: "
 
 #: centreon-web/www/include/Administration/myAccount/formMyAccount.php:138
 msgid "Show Up status"

--- a/centreon/www/include/monitoring/objectDetails/hostDetails.php
+++ b/centreon/www/include/monitoring/objectDetails/hostDetails.php
@@ -746,7 +746,7 @@ if (!$is_admin && !$haveAccess) {
             \Centreon\Application\Controller\MonitoringResourceController::class
         );
 
-        $deprecationMessage = _('[Page deprecated] Please use the new page: ');
+        $deprecationMessage = _('[Page deprecated] This page will be removed in the next major version. Please use the new page: ');
         $resourcesStatusLabel = _('Resources Status');
         $redirectionUrl = $resourceController->buildHostDetailsUri($host_id);
         $tpl->display("hostDetails.ihtml");

--- a/centreon/www/include/monitoring/objectDetails/serviceDetails.php
+++ b/centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -872,7 +872,7 @@ if (!is_null($host_id)) {
             \Centreon\Application\Controller\MonitoringResourceController::class
         );
 
-        $deprecationMessage = _('[Page deprecated] Please use the new page: ');
+        $deprecationMessage = _('[Page deprecated] This page will be removed in the next major version. Please use the new page: ');
         $resourcesStatusLabel = _('Resources Status');
         $redirectionUrl = $resourceController->buildServiceDetailsUri($host_id, $service_id);
 

--- a/centreon/www/include/monitoring/status/Hosts/host.php
+++ b/centreon/www/include/monitoring/status/Hosts/host.php
@@ -194,7 +194,7 @@ $resourceController = $kernel->getContainer()->get(
     \Centreon\Application\Controller\MonitoringResourceController::class
 );
 
-$deprecationMessage = _('[Page deprecated] Please use the new page: ');
+$deprecationMessage = _('[Page deprecated] This page will be removed in the next major version. Please use the new page: ');
 $resourcesStatusLabel = _('Resources Status');
 
 $filter = [

--- a/centreon/www/include/monitoring/status/Services/service.php
+++ b/centreon/www/include/monitoring/status/Services/service.php
@@ -261,7 +261,7 @@ $resourceController = $kernel->getContainer()->get(
     \Centreon\Application\Controller\MonitoringResourceController::class
 );
 
-$deprecationMessage = _('[Page deprecated] Please use the new page: ');
+$deprecationMessage = _('[Page deprecated] This page will be removed in the next major version. Please use the new page: ');
 $resourcesStatusLabel = _('Resources Status');
 
 $filter = [


### PR DESCRIPTION
🏷️ MON-22082

This PR intends to alert on the deletion of monitoring pages for next major version (24.04)

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Message should be changed (see ticket)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
