### PR TITLE
enh(broker): add new version of BBDO protocol

### DIFF
--- a/centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+++ b/centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
@@ -190,7 +190,12 @@ $stats_activate[] = $form->createElement('radio', 'stats_activate', null, _("Yes
 $stats_activate[] = $form->createElement('radio', 'stats_activate', null, _("No"), 0);
 $form->addGroup($stats_activate, 'stats_activate', _("Statistics"), '&nbsp;');
 
-$bbdo_versions = [ '2.0.0' => 'v.2.0.0 (old protocol)', '3.0.0' => 'v.3.0.0 (with protobuf)'];
+$bbdo_versions = [
+    '2.0.0' => 'v.2.0.0 (old protocol)',
+    '3.0.0' => 'v.3.0.0 (with protobuf)',
+    '3.0.1' => 'v.3.0.1 (full protobuf)'
+];
+
 $form->addElement('select', 'bbdo_version', _("BBDO version"), $bbdo_versions);
 
 $tags = $cbObj->getTags();
@@ -221,7 +226,7 @@ if (isset($_GET["o"]) && $_GET["o"] == 'a') {
             "stats_activate" => '1',
             "activate" => '1',
             "activate_watchdog" => '1',
-            "bbdo_version" => '3.0.0',
+            "bbdo_version" => '3.0.1',
         ),
         $defaultLog
     );

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -453,7 +453,7 @@ CREATE TABLE `cfg_centreonbroker` (
   `stats_activate` enum('0','1') DEFAULT '1',
   `daemon` TINYINT(1),
   `pool_size` int(11) DEFAULT NULL,
-  `bbdo_version` varchar(50) DEFAULT '3.0.0',
+  `bbdo_version` varchar(50) DEFAULT '3.0.1',
   PRIMARY KEY (`config_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;


### PR DESCRIPTION
🏷️ MON-18089
This PR intends to add a new version of protobuf for broker configuration.
This version is now the default version that will be used for fresh installation.
The upgrade will not change this version that is why there is no upgrade script to handle.

<img width="870" alt="image" src="https://github.com/centreon/centreon/assets/31647811/de675b6f-c200-499d-8467-cef08abe62cd">

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
