### PR TITLE
Fix(Authentification) : The user can login using SAML/OpenID using condition only if all conditions are met

### DIFF
--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/Conditions.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/Conditions.php
@@ -76,6 +76,8 @@ class Conditions implements SecurityAccessInterface
         $this->loginLogger->info($scope, 'Configured attribute path found', $authenticationAttributePath);
         $this->loginLogger->info($scope, 'Configured authorized values', $localConditions);
 
+        $userMatchConditions = false;
+
         foreach ($authenticationAttributePath as $attribute) {
             $providerAuthenticationConditions = [];
             if (array_key_exists($attribute, $identityProviderData)) {
@@ -109,9 +111,12 @@ class Conditions implements SecurityAccessInterface
         }
 
         $conditionMatches = array_intersect($providerAuthenticationConditions, $localConditions);
-        if (empty($conditionMatches)) {
+        if (count($conditionMatches) === count($localConditions)) {
+            $this->info('All conditions matched', ['conditions' => $conditionMatches]);
+            $this->loginLogger->info($scope, 'All conditions matched', $conditionMatches);
+        } else {
             $this->error(
-                'Configured attribute value not found in conditions endpoint',
+                'Not all conditions matched',
                 [
                     'configured_authorized_values' => $authenticationConditions->getAuthorizedValues(),
                 ]
@@ -119,7 +124,7 @@ class Conditions implements SecurityAccessInterface
 
             $this->loginLogger->exception(
                 $scope,
-                'Configured attribute value not found in conditions endpoint: %s, message: %s',
+                'Not all conditions matched',
                 AuthenticationConditionsException::conditionsNotFound()
             );
 


### PR DESCRIPTION
## Description
Fix the authentification so when we enable on SAML/OpenID Conditions we can only login if all conditions are met not if only one is met.

**Fixes** # (MON-20444)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>
Configure SAML authentication

Define several condition values with one will not match user attributes

Received result:

You are connected

Expected result:

User must be redirected to dedicated page “Authorization denied”

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
