### PR TITLE
fix(UI): Avoid widget edition modal overlapping

### DIFF
--- a/centreon/packages/ui/src/components/Modal/Modal.styles.ts
+++ b/centreon/packages/ui/src/components/Modal/Modal.styles.ts
@@ -30,7 +30,8 @@ const useStyles = makeStyles<{
       maxWidth: 'unset',
       position: 'absolute',
       right: props?.right ?? 0,
-      top: props?.top ?? 0
+      top: props?.top ?? 0,
+      transition: theme.transitions.create('left')
     },
     '&[data-size="large"] .MuiDialog-paper': {
       maxWidth: '640px',

--- a/centreon/www/front_src/src/Dashboards/Dashboard/AddEditWidget/AddEditWidgetModal.tsx
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/AddEditWidget/AddEditWidgetModal.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Formik } from 'formik';
 import { isNil } from 'ramda';
+import { useAtomValue } from 'jotai';
 
 import { Paper } from '@mui/material';
 
@@ -10,6 +11,7 @@ import { Modal } from '@centreon/ui/components';
 
 import { labelAddWidget, labelEditWidget } from '../translatedLabels';
 import Title from '../../components/Title';
+import { isSidebarOpenAtom } from '../../../Navigation/navigationAtoms';
 
 import useWidgetForm from './useWidgetModal';
 import { useAddWidgetStyles } from './addWidget.styles';
@@ -30,6 +32,8 @@ const AddWidgetModal = (): JSX.Element | null => {
   const { schema } = useValidationSchema();
 
   const { classes } = useAddWidgetStyles();
+
+  const isSidebarOpen = useAtomValue(isSidebarOpenAtom);
 
   const {
     widgetFormInitialData,
@@ -66,7 +70,7 @@ const AddWidgetModal = (): JSX.Element | null => {
         <Modal
           open
           fullscreenMargins={{
-            left: 48,
+            left: isSidebarOpen ? 165 : 48,
             top: 90
           }}
           size="fullscreen"

--- a/centreon/www/front_src/src/Navigation/Sidebar/index.tsx
+++ b/centreon/www/front_src/src/Navigation/Sidebar/index.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-
+import { useAtom } from 'jotai';
 import { equals } from 'ramda';
 
 import Box from '@mui/material/Box';
@@ -10,6 +9,7 @@ import { ThemeMode } from '@centreon/ui-context';
 
 import { Page } from '../models';
 import { headerHeight } from '../../Header';
+import { isSidebarOpenAtom } from '../navigationAtoms';
 
 import Logo from './Logo';
 import NavigationMenu from './Menu';
@@ -76,7 +76,7 @@ export interface Props {
 }
 
 export default ({ navigationData }: Props): JSX.Element => {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useAtom(isSidebarOpenAtom);
 
   const toggleNavigation = (): void => {
     setIsMenuOpen((currentIsMenuOpened) => !currentIsMenuOpened);

--- a/centreon/www/front_src/src/Navigation/navigationAtoms.ts
+++ b/centreon/www/front_src/src/Navigation/navigationAtoms.ts
@@ -4,4 +4,6 @@ import Navigation from './models';
 
 const navigationAtom = atom<Navigation | null>(null);
 
+export const isSidebarOpenAtom = atom(false);
+
 export default navigationAtom;


### PR DESCRIPTION
## Description

This fixes the widget edition overlapping when the menu is open.

https://github.com/centreon/centreon/assets/12515407/5f2bc54c-d07e-4aa7-9923-716a688638eb

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
