### PR TITLE
fix(authentification) : The user can login using SAML/OpenID using condition only if all conditions are met

### DIFF
--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/Conditions.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/SecurityAccess/Conditions.php
@@ -107,7 +107,7 @@ class Conditions implements SecurityAccessInterface
         }
 
         $conditionMatches = array_intersect($providerAuthenticationConditions, $localConditions);
-        if (empty($conditionMatches)) {
+        if (count($conditionMatches) !== count($localConditions)) {
             $this->error(
                 "Configured attribute value not found in conditions endpoint",
                 [


### PR DESCRIPTION
## Description
Fix the authentification so when we enable on SAML/OpenID Conditions we can only login if all conditions are met not if only one is met.

**Fixes** # (MON-22362)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>
Configure SAML authentication

Define several condition values with one will not match user attributes

Received result:

You are connected

Expected result:

User must be redirected to dedicated page “Authorization denied”

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
