### PR TITLE
fix(gorgone): fix external commands handling when recursion happens

### DIFF
--- a/centreon-gorgone/gorgone/class/core.pm
+++ b/centreon-gorgone/gorgone/class/core.pm
@@ -772,8 +772,8 @@ sub router_internal_event {
         push @{$self->{ievents}}, [$identity, $frame];
     }
 
-
-    if ($self->{recursion_ievents} > 1) {
+    # @todo check why recursion happens and avoid this workaround
+    if ($self->{recursion_ievents} > 10) {
         $self->{recursion_ievents}--;
         return;
     }


### PR DESCRIPTION
## Description

fix external commands handling when recursion happens

**Fixes** MON-21972

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)