### PR TITLE
fix(dashboards): performance endpoint doesn't send back result according to limit

### DIFF
--- a/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
@@ -33,8 +33,6 @@ use Core\Dashboard\Domain\Model\Metric\ResourceMetric;
 
 class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB implements RepositoryInterface
 {
-    private const MAXIMUM_METRICS_COUNT = 100;
-
     /**
      * @param DatabaseConnection $db
      * @param SqlRequestParametersTranslator $sqlRequestTranslator
@@ -412,10 +410,6 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
         array $accessGroups = [],
         $hasMetricName = false): string
     {
-        if ($requestParameters->getLimit() < self::MAXIMUM_METRICS_COUNT) {
-            $requestParameters->setLimit(self::MAXIMUM_METRICS_COUNT);
-        }
-
         $request
         = <<<'SQL'
                 SELECT SQL_CALC_FOUND_ROWS DISTINCT

--- a/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
@@ -63,7 +63,7 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
         $statement = $this->db->prepare($this->translateDbName($request));
         $statement = $this->executeQuery($statement);
 
-        return $this->buildResourceMetrics($statement);
+        return $this->buildResourceMetrics($requestParameters, $statement);
     }
 
     /**
@@ -77,7 +77,7 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
         $statement = $this->db->prepare($this->translateDbName($request));
         $statement = $this->executeQuery($statement);
 
-        return $this->buildResourceMetrics($statement);
+        return $this->buildResourceMetrics($requestParameters, $statement);
     }
 
     /**
@@ -89,7 +89,7 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
         $statement = $this->db->prepare($this->translateDbName($request));
         $statement = $this->executeQuery($statement, $metricName);
 
-        return $this->buildResourceMetrics($statement);
+        return $this->buildResourceMetrics($requestParameters, $statement);
     }
 
     /**
@@ -104,7 +104,7 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
         $statement = $this->db->prepare($this->translateDbName($request));
         $statement = $this->executeQuery($statement, $metricName);
 
-        return $this->buildResourceMetrics($statement);
+        return $this->buildResourceMetrics($requestParameters, $statement);
     }
 
     /**
@@ -507,8 +507,15 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
      *
      * @return ResourceMetrics[]
      */
-    private function buildResourceMetrics(\PDOStatement $statement): array {
+    private function buildResourceMetrics(
+        RequestParametersInterface $requestParameters,
+        \PDOStatement $statement
+    ): array {
+        $foundRecords = $this->db->query('SELECT FOUND_ROWS()');
         $resourceMetrics = [];
+        if ($foundRecords !== false && ($total = $foundRecords->fetchColumn()) !== false) {
+            $requestParameters->setTotal((int) $total);
+        }
 
         if (($records = $statement->fetchAll(\PDO::FETCH_ASSOC)) !== false) {
             $metricsInformation = [];


### PR DESCRIPTION
## Description

Endpoint `GET: /monitoring/dashboard/metrics/performances`
Fixed endpoint not sending data according to set limit.

**Fixes** # MON-22385

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
