### PR TITLE
handle both deprecated and new status details page

### DIFF
--- a/centreon-open-tickets/widgets/open-tickets/src/index.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/index.php
@@ -567,6 +567,20 @@ while ($row = $res->fetch()) {
         );
         $data[$row['host_id'] . "_" . $row['service_id']]['ticket_subject'] = $row['service_ticket_subject'];
     }
+
+    $kernel = \App\Kernel::createForWeb();
+    $resourceController = $kernel->getContainer()->get(
+        \Centreon\Application\Controller\MonitoringResourceController::class
+    );
+
+    $data[$row['host_id'] . '_' . $row['service_id']]['h_details_uri'] = $useDeprecatedPages
+        ? '../../main.php?p=0202&o=hd&host_name=' . $row['hostname']
+        : $resourceController->buildHostDetailsUri($row['host_id']);
+
+    $data[$row['host_id'] . '_' . $row['service_id']]['s_details_uri'] = $useDeprecatedPages
+        ? '../../main.php?p=0202&o=hd&host_name=' . $row['hostname']
+            . '&service_description=' . $row['description']
+        : $resourceController->buildServiceDetailsUri($row['host_id'], $row['service_id']);
 }
 
 $template->assign('widgetId', $widgetId);

--- a/centreon-open-tickets/widgets/open-tickets/src/templates/table.ihtml
+++ b/centreon-open-tickets/widgets/open-tickets/src/templates/table.ihtml
@@ -49,7 +49,7 @@
                             <img src ='../../img/media/{$elem.icon_image}' width='16' height='16' style ='padding-right:5px;' />
                         {/if}
                         <span class="state_badge {$elem.hcolor}"></span>
-                        <a href='../../main.php?p=20202&o=hd&host_name={$elem.encoded_hostname}' target=_blank>{$elem.hostname}</a>
+                        <a href={$elem.h_details_uri} target=_blank>{$elem.hostname}</a>
                     </td>
                     <td class='ListColRight'>
                         <div style='float: right;'>
@@ -79,7 +79,7 @@
                 {if $preferences.display_status == 0}
                     <div class="{$elem.color}">
                 {/if}
-        <a href='../../main.php?p=202&o=svcd&host_name={$elem.encoded_hostname}&service_description={$elem.encoded_description}' target=_blank>{$elem.description}</a>
+        <a href={$elem.s_details_uri} target=_blank>{$elem.description}</a>
         {if $preferences.display_status == 0}
                     </div>
                 {/if}


### PR DESCRIPTION
## Description

the open ticket widget is always redirecting to deprecated pages when you click on the host name or service description.
With this patch it will really take into account the contact parameter that enables deprecated pages

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

- create a very basic open ticket rule (use the simple provider)
- add an open ticket widget in a custom view and select your provider
- in the list of services that are displayed, click on the name of the host and service

you should be redirected to either the deprecated pages or the new resource pages (with details pane opened) according to the configuration of your centreon account.  

Filters must be properly set up in the url (harder to see on new resources page but you can easily see if something is wrong because the details pane is not going to be related to the host or service that you've clicked on).


## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
