### PR TITLE
fix(dashboards): Performance data doesn't display all metrics according to search

### DIFF
--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
@@ -94,11 +94,11 @@ class PerformanceMetricsDataFactory
         $metricBases = [];
         $metrics = [];
         $times = [];
-        foreach ($metricsData as $metricData) {
+        foreach ($metricsData as $index => $metricData) {
             $metricBases[] = $metricData['global']['base'];
-            \preg_match('/^[a-zA-Z]+ graph on ([[:ascii:]]+)$/', $metricData['global']['title'], $matches);
+            \preg_match('/^[[:ascii:]]+ graph on ([[:ascii:]]+)$/', $metricData['global']['title'], $matches);
             $hostName = $matches[1];
-            $metrics[$hostName] = $metricData['metrics'];
+            $metrics['index:' . $index . ';host_name:' . $hostName] = $metricData['metrics'];
             $times[] = $metricData['times'];
         }
         $base = $this->getHighestBase($metricBases);
@@ -132,6 +132,8 @@ class PerformanceMetricsDataFactory
     {
         $metrics = [];
         foreach ($metricsData as $hostName => $metricData) {
+            \preg_match('/^index:\d+;host_name:([[:ascii:]]+)$/', $hostName, $matches);
+            $hostName = $matches[1];
             foreach ($metricData as $metric) {
                 if (in_array($metric['metric'], $metricNames, true)) {
                     $metric['metric'] = $hostName . ': ' . $metric['metric'];


### PR DESCRIPTION
## Description

Endpoint: `GET: /monitoring/dashboard/metrics/performances/data` 
Fixed performance data doesn't display all metrics according to search

**Fixes** # MON-22386

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
