### PR TITLE
add ezv rest in register list

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/register.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/register.php
@@ -35,3 +35,4 @@ $register_providers['Jira'] = 10;
 $register_providers['GlpiRestApi'] = 11;
 $register_providers['RequestTracker2'] = 12;
 $register_providers['Itop'] = 13;
+$register_providers['EasyVistaRest'] = 14;


### PR DESCRIPTION
## Description

the new easy vista provider has been merged but register file has not been updated, therefore it doesn't appear in the provider list when adding a new open ticket rule


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

- in the notification menu, go in the open ticket rule menu
- add a new rule
- the provider dropdown list must display the easy vista rest provider with this patch

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
