### PR TITLE
fix(api/severity) Fixing SQL queries to retrieve the severity correctly in host and host template lists

### DIFF
--- a/centreon/src/Core/Host/Infrastructure/Repository/DbReadHostRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbReadHostRepository.php
@@ -103,7 +103,7 @@ use Utility\SqlConcatenator;
  *     check_timeperiod_name: string|null,
  *     notification_timeperiod_id: int|null,
  *     notification_timeperiod_name: string|null,
- *     severity_id: int|null,
+ *     severity_id: string|null,
  *     severity_name: string|null,
  *     monitoring_server_id: int,
  *     monitoring_server_name: string,
@@ -426,6 +426,8 @@ class DbReadHostRepository extends AbstractRepositoryRDB implements ReadHostRepo
                             ON aclrgr_sev.acl_res_id = aclr_sev.acl_res_id
                             AND aclrgr_sev.acl_group_id IN ({$accessGroupIdsQuery})
                         WHERE sev.level IS NOT NULL
+                        ORDER BY sev.level ASC
+                        LIMIT 1
                     )
                     SQL;
             }
@@ -459,8 +461,8 @@ class DbReadHostRepository extends AbstractRepositoryRDB implements ReadHostRepo
                 ctime.tp_name AS check_timeperiod_name,
                 ntime.tp_id AS notification_timeperiod_id,
                 ntime.tp_name AS notification_timeperiod_name,
-                GROUP_CONCAT(DISTINCT sev.hc_id) AS severity_id,
-                GROUP_CONCAT(DISTINCT sev.hc_name) AS severity_name,
+                GROUP_CONCAT(sev.hc_id ORDER BY sev.level ASC LIMIT 1)  AS severity_id,
+                GROUP_CONCAT(sev.hc_name ORDER BY sev.level ASC LIMIT 1)  AS severity_name,
                 ns.id AS monitoring_server_id,
                 ns.name AS monitoring_server_name,
                 GROUP_CONCAT(DISTINCT hc.hc_id) AS category_ids,
@@ -477,7 +479,7 @@ class DbReadHostRepository extends AbstractRepositoryRDB implements ReadHostRepo
                 AND hc.level IS NULL {$hostCategoriesAcl}
             LEFT JOIN `:db`.hostgroup_relation hgr
                 ON hgr.host_host_id = h.host_id {$hostGroupAcl}
-            INNER JOIN `:db`.hostgroup hg
+            LEFT JOIN `:db`.hostgroup hg
                 ON hg.hg_id = hgr.hostgroup_hg_id
             LEFT JOIN `:db`.ns_host_relation nsr
                 ON nsr.host_host_id = h.host_id

--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
@@ -78,7 +78,7 @@ use Utility\SqlConcatenator;
  *      ehi_action_url: string|null,
  *      ehi_icon_image: int|null,
  *      ehi_icon_image_alt: string|null,
- *      severity_id: int|null
+ *      severity_id: string|null
  *  }
  */
 class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements ReadHostTemplateRepositoryInterface
@@ -143,7 +143,7 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
                     ehi.ehi_action_url,
                     ehi.ehi_icon_image,
                     ehi.ehi_icon_image_alt,
-                    hc.hc_id as severity_id
+                    GROUP_CONCAT(hc.hc_id ORDER BY hc.level ASC LIMIT 1) AS severity_id
                 FROM `:db`.host h
                 LEFT JOIN `:db`.extended_host_information ehi
                     ON h.host_id = ehi.host_host_id
@@ -236,7 +236,7 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
                     ehi.ehi_action_url,
                     ehi.ehi_icon_image,
                     ehi.ehi_icon_image_alt,
-                    hcr.hostcategories_hc_id as severity_id
+                    hcr.hostcategories_hc_id AS severity_id
                 FROM `:db`.host h
                 LEFT JOIN `:db`.extended_host_information ehi
                     ON h.host_id = ehi.host_host_id
@@ -318,7 +318,7 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
                     ehi.ehi_action_url,
                     ehi.ehi_icon_image,
                     ehi.ehi_icon_image_alt,
-                    hcr.hostcategories_hc_id as severity_id
+                    GROUP_CONCAT(hc.hc_id ORDER BY hc.level ASC LIMIT 1) AS severity_id
                 FROM `:db`.host h
                 LEFT JOIN `:db`.extended_host_information ehi
                     ON h.host_id = ehi.host_host_id
@@ -329,6 +329,7 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
                     AND hc.level IS NOT NULL
                 WHERE h.host_register = '0'
                     AND h.host_id IN ({$hostTemplateIdsQuery})
+                GROUP BY h.host_id
                 SQL
         );
         $statement = $this->db->prepare($request);
@@ -571,7 +572,7 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
             },
             (string) $result['host_snmp_community'],
             0 === $result['host_location'] ? null : $result['host_location'],
-            $result['severity_id'],
+            $result['severity_id'] !== null ? (int) $result['severity_id'] : null,
             $result['command_command_id'],
             $extractCommandArguments($result['command_command_id_arg1']),
             $result['timeperiod_tp_id'],


### PR DESCRIPTION
## Description

The aim is to fix the association of a severity with a host or host template.
Currently, the user interface allows multiple severities to be associated with a single host or host template, whereas they can only have one severity.
Until the UI fixes this problem, the API should be able to take this context into account.
From a functional point of view, **the severity returned will be the one with the lowest level**.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
