### PR TITLE
feat(ci) :Get docker image from cache instead of registry

### DIFF
--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -106,9 +106,6 @@ jobs:
           docker tag ${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }} ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
       shell: bash
 
-    # - name: Wait for Centreon Web Container to Start
-    #   run: pnpx wait-on http://localhost:4000/ --timeout 100000
-
     - name: Run Postman Tests and Generate HTML Report
       run: |
         collection_file="collections/${{ matrix.feature }}"

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -100,17 +100,13 @@ jobs:
         username: ${{ secrets.registry_username }}
         password: ${{ secrets.registry_password }}
 
-    - name: List Contents of Cache Directory
-      run: |
-          ls $GITHUB_WORKSPACE/tmp/cache/docker-image
-
     - name: Restore standard slim image from cache
       id: cache-docker-slim
       uses: actions/cache/restore@v3
       continue-on-error: true
       timeout-minutes: 6
       with:
-          path: ../tmp/cache/docker-image
+          path: $GITHUB_WORKSPACE/tmp/cache/docker-image
           key: docker-image-${{ env.SLIM_IMAGE_NAME }}-${{ env.IMAGE_TAG }}
       env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
@@ -118,7 +114,7 @@ jobs:
     - name: Load standard slim image
       if: ${{ steps.cache-docker-slim.outputs.cache-hit == 'true' }}
       run: |
-          docker load --input /tmp/cache/docker-image/${{ env.SLIM_IMAGE_NAME }}.tar
+          docker load --input $GITHUB_WORKSPACE/tmp/cache/docker-image/${{ env.SLIM_IMAGE_NAME }}.tar
           docker tag ${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }} ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
       shell: bash
 

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -119,11 +119,9 @@ jobs:
       shell: bash
 
     - name: Start Centreon Web Container
-      if: ${{ steps.cache-docker-slim.outputs.cache-hit != 'true' }}
       run: docker run --name $CONTAINER_NAME -d -p 4000:80 --health-cmd="curl -f $CENTREON_URL/ || exit 1" --health-interval=5s $CENTREON_IMAGE
 
     - name: Wait for Centreon Web Container to Start
-      if: ${{ steps.cache-docker-slim.outputs.cache-hit != 'true' }}
       run: pnpx wait-on http://localhost:4000/ --timeout 100000
 
     - name: Run Postman Tests and Generate HTML Report

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -106,7 +106,7 @@ jobs:
       continue-on-error: true
       timeout-minutes: 6
       with:
-          path: $GITHUB_WORKSPACE/tmp/cache/docker-image
+          path: ../tmp/cache/docker-image
           key: docker-image-${{ env.SLIM_IMAGE_NAME }}-${{ env.IMAGE_TAG }}
       env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
@@ -114,7 +114,7 @@ jobs:
     - name: Load standard slim image
       if: ${{ steps.cache-docker-slim.outputs.cache-hit == 'true' }}
       run: |
-          docker load --input $GITHUB_WORKSPACE/tmp/cache/docker-image/${{ env.SLIM_IMAGE_NAME }}.tar
+          docker load --input ../tmp/cache/docker-image/${{ env.SLIM_IMAGE_NAME }}.tar
           docker tag ${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }} ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
       shell: bash
 

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -102,7 +102,7 @@ jobs:
 
     - name: List Contents of Cache Directory
       run: |
-          ls ../tmp/cache/docker-image
+          ls $GITHUB_WORKSPACE/centreon/tests/rest_api/tmp/cache/docker-image
 
     - name: Restore standard slim image from cache
       id: cache-docker-slim

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -4,13 +4,10 @@ on:
       collection_path:
         required: true
         type: string
-      container_name:
+      image_name:
         required: true
         type: string
-      centreon_url:
-        required: true
-        type: string
-      centreon_image:
+      os:
         required: true
         type: string
       dependencies_lock_file:

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -62,7 +62,7 @@ jobs:
    defaults:
     run:
       shell: bash
-      # working-directory: centreon/tests/rest_api
+      working-directory: centreon/tests/rest_api
    env:
     IMAGE_TAG: ${{ github.head_ref || github.ref_name }}
     SLIM_IMAGE_NAME: ${{ inputs.image_name }}-slim-${{ inputs.os }}
@@ -102,7 +102,7 @@ jobs:
 
     - name: List Contents of Cache Directory
       run: |
-          ls /tmp/cache/docker-image
+          ls ../tmp/cache/docker-image
 
     - name: Restore standard slim image from cache
       id: cache-docker-slim
@@ -110,7 +110,7 @@ jobs:
       continue-on-error: true
       timeout-minutes: 6
       with:
-          path: /tmp/cache/docker-image
+          path: ../tmp/cache/docker-image
           key: docker-image-${{ env.SLIM_IMAGE_NAME }}-${{ env.IMAGE_TAG }}
       env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -100,6 +100,10 @@ jobs:
         username: ${{ secrets.registry_username }}
         password: ${{ secrets.registry_password }}
 
+    - name: List Contents of Cache Directory
+      run: |
+          ls /tmp/cache/docker-image
+
     - name: Restore standard slim image from cache
       id: cache-docker-slim
       uses: actions/cache/restore@v3

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -107,7 +107,7 @@ jobs:
       timeout-minutes: 6
       with:
           path: /tmp/cache/docker-image
-          key: docker-image-${{ env.SLIM_IMAGE_NAME }}-${{ env.IMAGE_TAG }}
+          key: docker-image-${{ env.SLIM_IMAGE_NAME }}-${{ env.IMAGE_TAG }}S
       env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -58,9 +58,8 @@ jobs:
       shell: bash
       working-directory: centreon/tests/rest_api
    env:
-    CONTAINER_NAME: ${{ inputs.container_name }}
-    CENTREON_URL: ${{ inputs.centreon_url }}
-    CENTREON_IMAGE: ${{ inputs.centreon_image }}
+    IMAGE_TAG: ${{ github.head_ref || github.ref_name }}
+    SLIM_IMAGE_NAME: ${{ inputs.image_name }}-slim-${{ inputs.os }}
 
    steps:
     - name: Checkout Repository
@@ -92,8 +91,23 @@ jobs:
         username: ${{ secrets.registry_username }}
         password: ${{ secrets.registry_password }}
 
-    - name: Start Centreon Web Container
-      run: docker run --name $CONTAINER_NAME -d -p 4000:80 --health-cmd="curl -f $CENTREON_URL/ || exit 1" --health-interval=5s $CENTREON_IMAGE
+    - name: Restore standard slim image from cache
+      id: cache-docker-slim
+      uses: actions/cache/restore@v3
+      continue-on-error: true
+      timeout-minutes: 6
+      with:
+          path: /tmp/cache/docker-image
+          key: docker-image-${{ env.SLIM_IMAGE_NAME }}-${{ env.IMAGE_TAG }}
+      env:
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
+
+    - name: Load standard slim image
+      if: ${{ steps.cache-docker-slim.outputs.cache-hit == 'true' }}
+      run: |
+          docker load --input /tmp/cache/docker-image/${{ env.SLIM_IMAGE_NAME }}.tar
+          docker tag ${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }} ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+      shell: bash
 
     - name: Wait for Centreon Web Container to Start
       run: pnpx wait-on http://localhost:4000/ --timeout 100000

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -10,6 +10,15 @@ on:
       os:
         required: true
         type: string
+      container_name:
+          required: true
+          type: string
+      centreon_url:
+          required: true
+          type: string
+      centreon_image:
+          required: true
+          type: string
       dependencies_lock_file:
         required: true
         type: string
@@ -57,6 +66,9 @@ jobs:
    env:
     IMAGE_TAG: ${{ github.head_ref || github.ref_name }}
     SLIM_IMAGE_NAME: ${{ inputs.image_name }}-slim-${{ inputs.os }}
+    CONTAINER_NAME: ${{ inputs.container_name }}
+    CENTREON_URL: ${{ inputs.centreon_url }}
+    CENTREON_IMAGE: ${{ inputs.centreon_image }}
 
    steps:
     - name: Checkout Repository
@@ -105,6 +117,14 @@ jobs:
           docker load --input /tmp/cache/docker-image/${{ env.SLIM_IMAGE_NAME }}.tar
           docker tag ${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }} ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
       shell: bash
+
+    - name: Start Centreon Web Container
+      if: ${{ steps.cache-docker-slim.outputs.cache-hit == 'true' }}
+      run: docker run --name $CONTAINER_NAME -d -p 4000:80 --health-cmd="curl -f $CENTREON_URL/ || exit 1" --health-interval=5s $CENTREON_IMAGE
+
+    - name: Wait for Centreon Web Container to Start
+      if: ${{ steps.cache-docker-slim.outputs.cache-hit == 'true' }}
+      run: pnpx wait-on http://localhost:4000/ --timeout 100000
 
     - name: Run Postman Tests and Generate HTML Report
       run: |

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -106,8 +106,8 @@ jobs:
           docker tag ${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }} ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
       shell: bash
 
-    - name: Wait for Centreon Web Container to Start
-      run: pnpx wait-on http://localhost:4000/ --timeout 100000
+    # - name: Wait for Centreon Web Container to Start
+    #   run: pnpx wait-on http://localhost:4000/ --timeout 100000
 
     - name: Run Postman Tests and Generate HTML Report
       run: |

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -100,6 +100,10 @@ jobs:
         username: ${{ secrets.registry_username }}
         password: ${{ secrets.registry_password }}
 
+    - name: List Cache Contents
+      run: |
+          ls $RUNNER_TOOL_CACHE
+
     - name: Restore standard slim image from cache
       id: cache-docker-slim
       uses: actions/cache/restore@v3

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -62,6 +62,7 @@ jobs:
    defaults:
     run:
       shell: bash
+      # working-directory: centreon/tests/rest_api
    env:
     IMAGE_TAG: ${{ github.head_ref || github.ref_name }}
     SLIM_IMAGE_NAME: ${{ inputs.image_name }}-slim-${{ inputs.os }}
@@ -84,17 +85,13 @@ jobs:
           cache: pnpm
           cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
-    - name: List Cache Contents
-      run: |
-        ls /tmp/cache/docker-image
-
-    - name: Install Dependencies for tests/rest_api
-      run: pnpm install --frozen-lockfile
-      shell: bash
-      env:
-        CYPRESS_INSTALL_BINARY: “0”
-        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: “1"
-        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: “true”
+    # - name: Install Dependencies for tests/rest_api
+    #   run: pnpm install --frozen-lockfile
+    #   shell: bash
+    #   env:
+    #     CYPRESS_INSTALL_BINARY: “0”
+    #     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: “1"
+    #     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: “true”
 
     - name: Login to registry
       uses: docker/login-action@v2
@@ -117,7 +114,7 @@ jobs:
     - name: Load standard slim image
       if: ${{ steps.cache-docker-slim.outputs.cache-hit == 'true' }}
       run: |
-          docker load --input ../tmp/cache/docker-image/${{ env.SLIM_IMAGE_NAME }}.tar
+          docker load --input /tmp/cache/docker-image/${{ env.SLIM_IMAGE_NAME }}.tar
           docker tag ${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }} ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.SLIM_IMAGE_NAME }}:${{ env.IMAGE_TAG }}
       shell: bash
 

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -123,6 +123,7 @@ jobs:
       run: docker run --name $CONTAINER_NAME -d -p 4000:80 --health-cmd="curl -f $CENTREON_URL/ || exit 1" --health-interval=5s $CENTREON_IMAGE
 
     - name: Wait for Centreon Web Container to Start
+      if: ${{ steps.cache-docker-slim.outputs.cache-hit != 'true' }}
       run: pnpx wait-on http://localhost:4000/ --timeout 100000
 
     - name: Run Postman Tests and Generate HTML Report

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -119,11 +119,10 @@ jobs:
       shell: bash
 
     - name: Start Centreon Web Container
-      if: ${{ steps.cache-docker-slim.outputs.cache-hit == 'true' }}
+      if: ${{ steps.cache-docker-slim.outputs.cache-hit != 'true' }}
       run: docker run --name $CONTAINER_NAME -d -p 4000:80 --health-cmd="curl -f $CENTREON_URL/ || exit 1" --health-interval=5s $CENTREON_IMAGE
 
     - name: Wait for Centreon Web Container to Start
-      if: ${{ steps.cache-docker-slim.outputs.cache-hit == 'true' }}
       run: pnpx wait-on http://localhost:4000/ --timeout 100000
 
     - name: Run Postman Tests and Generate HTML Report

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -62,7 +62,7 @@ jobs:
    defaults:
     run:
       shell: bash
-      working-directory: centreon/tests/rest_api
+      # working-directory: centreon/tests/rest_api
    env:
     IMAGE_TAG: ${{ github.head_ref || github.ref_name }}
     SLIM_IMAGE_NAME: ${{ inputs.image_name }}-slim-${{ inputs.os }}

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -107,7 +107,7 @@ jobs:
       timeout-minutes: 6
       with:
           path: /tmp/cache/docker-image
-          key: docker-image-${{ env.SLIM_IMAGE_NAME }}-${{ env.IMAGE_TAG }}S
+          key: docker-image-${{ env.SLIM_IMAGE_NAME }}-${{ env.IMAGE_TAG }}
       env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5
 

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -62,7 +62,6 @@ jobs:
    defaults:
     run:
       shell: bash
-      working-directory: centreon/tests/rest_api
    env:
     IMAGE_TAG: ${{ github.head_ref || github.ref_name }}
     SLIM_IMAGE_NAME: ${{ inputs.image_name }}-slim-${{ inputs.os }}
@@ -85,6 +84,10 @@ jobs:
           cache: pnpm
           cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
+    - name: List Cache Contents
+      run: |
+        ls /tmp/cache/docker-image
+
     - name: Install Dependencies for tests/rest_api
       run: pnpm install --frozen-lockfile
       shell: bash
@@ -100,17 +103,13 @@ jobs:
         username: ${{ secrets.registry_username }}
         password: ${{ secrets.registry_password }}
 
-    - name: List Cache Contents
-      run: |
-          ls $RUNNER_TOOL_CACHE
-
     - name: Restore standard slim image from cache
       id: cache-docker-slim
       uses: actions/cache/restore@v3
       continue-on-error: true
       timeout-minutes: 6
       with:
-          path: ../tmp/cache/docker-image
+          path: /tmp/cache/docker-image
           key: docker-image-${{ env.SLIM_IMAGE_NAME }}-${{ env.IMAGE_TAG }}
       env:
           SEGMENT_DOWNLOAD_TIMEOUT_MINS: 5

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -11,14 +11,14 @@ on:
         required: true
         type: string
       container_name:
-          required: true
-          type: string
+        required: true
+        type: string
       centreon_url:
-          required: true
-          type: string
+        required: true
+        type: string
       centreon_image:
-          required: true
-          type: string
+        required: true
+        type: string
       dependencies_lock_file:
         required: true
         type: string
@@ -62,7 +62,7 @@ jobs:
    defaults:
     run:
       shell: bash
-      # working-directory: centreon/tests/rest_api
+      working-directory: centreon/tests/rest_api
    env:
     IMAGE_TAG: ${{ github.head_ref || github.ref_name }}
     SLIM_IMAGE_NAME: ${{ inputs.image_name }}-slim-${{ inputs.os }}
@@ -85,13 +85,13 @@ jobs:
           cache: pnpm
           cache-dependency-path: ${{ inputs.dependencies_lock_file }}
 
-    # - name: Install Dependencies for tests/rest_api
-    #   run: pnpm install --frozen-lockfile
-    #   shell: bash
-    #   env:
-    #     CYPRESS_INSTALL_BINARY: “0”
-    #     PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: “1"
-    #     PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: “true”
+    - name: Install Dependencies for tests/rest_api
+      run: pnpm install --frozen-lockfile
+      shell: bash
+      env:
+        CYPRESS_INSTALL_BINARY: “0”
+        PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: “1"
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: “true”
 
     - name: Login to registry
       uses: docker/login-action@v2

--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -102,7 +102,7 @@ jobs:
 
     - name: List Contents of Cache Directory
       run: |
-          ls $GITHUB_WORKSPACE/centreon/tests/rest_api/tmp/cache/docker-image
+          ls $GITHUB_WORKSPACE/tmp/cache/docker-image
 
     - name: Restore standard slim image from cache
       id: cache-docker-slim

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -492,8 +492,8 @@ jobs:
           key: docker-image-${{ env.project }}-slim-${{ matrix.os }}-${{ github.head_ref || github.ref_name }}
 
   newman-test:
-    # needs: [get-version, changes, dockerize]
-    # if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.changes.outputs.has_backend_changes == 'true' }}
+    needs: [get-version, changes, dockerize]
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.changes.outputs.has_backend_changes == 'true' }}
     uses: ./.github/workflows/newman.yml
     with:
       collection_path: centreon/tests/rest_api/collections

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -492,8 +492,8 @@ jobs:
           key: docker-image-${{ env.project }}-slim-${{ matrix.os }}-${{ github.head_ref || github.ref_name }}
 
   newman-test:
-    needs: [get-version, changes, dockerize]
-    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.changes.outputs.has_backend_changes == 'true' }}
+    # needs: [get-version, changes, dockerize]
+    # if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.changes.outputs.has_backend_changes == 'true' }}
     uses: ./.github/workflows/newman.yml
     with:
       collection_path: centreon/tests/rest_api/collections

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -497,9 +497,8 @@ jobs:
     uses: ./.github/workflows/newman.yml
     with:
       collection_path: centreon/tests/rest_api/collections
-      container_name: my_centreon_container
-      centreon_url: http://localhost
-      centreon_image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-slim-alma9:${{ github.head_ref || github.ref_name }}
+      image_name: centreon-web
+      os: ${{ matrix.os }}
       dependencies_lock_file: centreon/pnpm-lock.yaml
     secrets:
       registry_username: ${{ secrets.DOCKER_REGISTRY_ID}}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -492,13 +492,16 @@ jobs:
           key: docker-image-${{ env.project }}-slim-${{ matrix.os }}-${{ github.head_ref || github.ref_name }}
 
   newman-test:
-    needs: [get-version, changes, dockerize]
+    needs: [get-version, changes]
     if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.changes.outputs.has_backend_changes == 'true' }}
     uses: ./.github/workflows/newman.yml
     with:
       collection_path: centreon/tests/rest_api/collections
       image_name: centreon-web
       os: ${{ matrix.os }}
+      container_name: my_centreon_container
+      centreon_url: http://localhost
+      centreon_image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-slim-alma9:${{ github.head_ref || github.ref_name }}
       dependencies_lock_file: centreon/pnpm-lock.yaml
     secrets:
       registry_username: ${{ secrets.DOCKER_REGISTRY_ID}}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -498,7 +498,7 @@ jobs:
     with:
       collection_path: centreon/tests/rest_api/collections
       image_name: centreon-web
-      os: ${{ matrix.os }}
+      os: alma9
       container_name: my_centreon_container
       centreon_url: http://localhost
       centreon_image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-slim-alma9:${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -492,7 +492,7 @@ jobs:
           key: docker-image-${{ env.project }}-slim-${{ matrix.os }}-${{ github.head_ref || github.ref_name }}
 
   newman-test:
-    needs: [get-version, changes, dockerize]
+    needs: [get-version, changes]
     if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.changes.outputs.has_backend_changes == 'true' }}
     uses: ./.github/workflows/newman.yml
     with:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -492,7 +492,7 @@ jobs:
           key: docker-image-${{ env.project }}-slim-${{ matrix.os }}-${{ github.head_ref || github.ref_name }}
 
   newman-test:
-    needs: [get-version, changes]
+    needs: [get-version, changes, dockerize]
     if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.changes.outputs.has_backend_changes == 'true' }}
     uses: ./.github/workflows/newman.yml
     with:

--- a/centreon/tests/rest_api/collections/new-folder/10-Authentication-on-an-admin-account-Centreon-Web-Refactored-API-Test-Collection.postman_collection.json
+++ b/centreon/tests/rest_api/collections/new-folder/10-Authentication-on-an-admin-account-Centreon-Web-Refactored-API-Test-Collection.postman_collection.json
@@ -58,7 +58,6 @@
 							"host": [
 								"{{baseUrl}}"
 							],
-
 							"path": [
 								"login"
 							]

--- a/centreon/tests/rest_api/collections/new-folder/10-Authentication-on-an-admin-account-Centreon-Web-Refactored-API-Test-Collection.postman_collection.json
+++ b/centreon/tests/rest_api/collections/new-folder/10-Authentication-on-an-admin-account-Centreon-Web-Refactored-API-Test-Collection.postman_collection.json
@@ -58,6 +58,7 @@
 							"host": [
 								"{{baseUrl}}"
 							],
+
 							"path": [
 								"login"
 							]


### PR DESCRIPTION
## Description
This PR will get docker image from cache instead of registry into newman pipeline

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
