### PR TITLE
Tests(E2E): Manage centreon e2e tests windows compatibility

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/commands.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands.ts
@@ -3,6 +3,9 @@
 import './commands/configuration';
 import './commands/monitoring';
 
+import { execSync } from 'child_process';
+// import fs from 'fs';
+
 import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector';
 
 installLogsCollector();
@@ -292,7 +295,9 @@ Cypress.Commands.add(
 
     return cy
       .visitEmptyPage()
-      .exec(`mkdir -p "${logDirectory}"`)
+      .then(() => {
+        execSync(`mkdir "${logDirectory}"`, { stdio: 'inherit' });
+      })
       .copyFromContainer({
         destination: `${logDirectory}/broker`,
         name,

--- a/centreon/packages/js-config/cypress/e2e/commands.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands.ts
@@ -3,9 +3,6 @@
 import './commands/configuration';
 import './commands/monitoring';
 
-import { execSync } from 'child_process';
-// import fs from 'fs';
-
 import installLogsCollector from 'cypress-terminal-report/src/installLogsCollector';
 
 installLogsCollector();
@@ -236,6 +233,13 @@ Cypress.Commands.add(
   }
 );
 
+Cypress.Commands.add(
+  'createDirectory',
+  (directoryPath: string): Cypress.Chainable => {
+    return cy.task('createDirectory', directoryPath);
+  }
+);
+
 interface StartWebContainerProps {
   name?: string;
   os?: string;
@@ -295,9 +299,7 @@ Cypress.Commands.add(
 
     return cy
       .visitEmptyPage()
-      .then(() => {
-        execSync(`mkdir "${logDirectory}"`, { stdio: 'inherit' });
-      })
+      .createDirectory(logDirectory)
       .copyFromContainer({
         destination: `${logDirectory}/broker`,
         name,
@@ -468,6 +470,7 @@ declare global {
         props: CopyToContainerProps,
         options?: Partial<Cypress.ExecOptions>
       ) => Cypress.Chainable;
+      createDirectory: (directoryPath: string) => Cypress.Chainable;
       execInContainer: ({
         command,
         name

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'child_process';
-import * as fs from 'fs';
+import { existsSync, mkdirSync } from 'fs';
 
 import Docker from 'dockerode';
 
@@ -23,8 +23,8 @@ export default (on: Cypress.PluginEvents): void => {
 
   on('task', {
     createDirectory: async (directoryPath: string) => {
-      if (!fs.existsSync(directoryPath)) {
-        fs.mkdirSync(directoryPath, { recursive: true });
+      if (!existsSync(directoryPath)) {
+        mkdirSync(directoryPath, { recursive: true });
       }
 
       return null;

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'child_process';
+import * as fs from 'fs';
 
 import Docker from 'dockerode';
 
@@ -21,6 +22,13 @@ export default (on: Cypress.PluginEvents): void => {
   }
 
   on('task', {
+    createDirectory: async (directoryPath: string) => {
+      if (!fs.existsSync(directoryPath)) {
+        fs.mkdirSync(directoryPath, { recursive: true });
+      }
+
+      return null;
+    },
     startContainer: async ({
       image,
       name,


### PR DESCRIPTION
## Description

There are probably some issues to run centreon cypress tests on windows : 

 mkdir command used to create logs directory :arrow_right: fs.mkdirSync could be used

**Fixes** # MON-21386

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
