### PR TITLE
fix(test): do not apply page transition on legacy routes

### DIFF
--- a/centreon/www/front_src/src/route-components/legacyRoute/index.tsx
+++ b/centreon/www/front_src/src/route-components/legacyRoute/index.tsx
@@ -2,18 +2,13 @@ import { useState, useEffect } from 'react';
 
 import { useLocation, useNavigate } from 'react-router-dom';
 import { equals, isNil, replace } from 'ramda';
-import { useTransition, animated } from '@react-spring/web';
 
 import { PageSkeleton } from '@centreon/ui';
-
-import { pageTransitionConfig } from '../../components/ReactRouter';
 
 const LegacyRoute = (): JSX.Element => {
   const [loading, setLoading] = useState(true);
   const location = useLocation();
   const navigate = useNavigate();
-
-  const transitions = useTransition(location, pageTransitionConfig);
 
   const handleHref = (event): void => {
     const { href } = event.detail;
@@ -66,8 +61,8 @@ const LegacyRoute = (): JSX.Element => {
 
   const params = (search || '') + (hash || '');
 
-  return transitions((style) => (
-    <animated.div style={style}>
+  return (
+    <>
       {loading && <PageSkeleton />}
       <iframe
         frameBorder="0"
@@ -79,8 +74,8 @@ const LegacyRoute = (): JSX.Element => {
         title="Main Content"
         onLoad={load}
       />
-    </animated.div>
-  ));
+    </>
+  );
 };
 
 export default LegacyRoute;

--- a/centreon/www/main.get.php
+++ b/centreon/www/main.get.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005-2021 Centreon
+ * Copyright 2005-2023 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *


### PR DESCRIPTION
## Description

do not apply page transition on legacy routes
we will be able to reapply once behat tests are adapted to this : it seems there is 2 div in the same time during transition

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)