### PR TITLE
fix deletion scenario with proper confirmation targeting

### DIFF
--- a/centreon/tests/e2e/cypress/e2e/Dashboards/08-widget-generic-text-configuration/index.ts
+++ b/centreon/tests/e2e/cypress/e2e/Dashboards/08-widget-generic-text-configuration/index.ts
@@ -254,7 +254,7 @@ Then(
 When('the dashboard administrator user deletes one of the widgets', () => {
   cy.getByLabel({ label: 'More actions' }).eq(1).click();
   cy.getByLabel({ label: 'Delete widget' }).click();
-  cy.getByTestId({ testId: 'confirm' }).click();
+  cy.getByLabel({ label: 'Delete' }).click();  
   cy.getByTestId({ testId: 'save_dashboard' }).click();
   cy.wait('@updateDashboard');
 });


### PR DESCRIPTION
## Description

fix deletion scenario of the generic text widget e2e test battery, which was targeting the wrong element for confirming the deletion of a widget (and thus snowballing into failing every scenario that came afterwards) 

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
