### PR TITLE
fix(cloud-notifications): Contact group listing not accessible

### DIFF
--- a/centreon/doc/API/centreon-api-v23.10.yaml
+++ b/centreon/doc/API/centreon-api-v23.10.yaml
@@ -14,6 +14,7 @@ info:
     + Added token endpoints (GET, POST, DELETE)
     + Added resources by parent endpoint (GET)
     + Added command endpoint (ADD)
+    + Added notifiable contact group endpoint (GET)
     +
     # Updated features
     + Updated host template endpoint (GET)
@@ -266,6 +267,8 @@ paths:
     $ref: "./v23.10/Configuration/Notification/FindNotifiableResources.yaml"
   /configuration/notifications/{notification_id}/rules:
     $ref: "./v23.10/Configuration/Notification/FindNotifiableRule.yaml"
+  /configuration/notifications/contact_groups:
+    $ref: "./v23.10/Configuration/Notification/FindNotifiableContactGroups.yaml"
   /configuration/hosts/{host_id}:
     $ref: './v23.10/Configuration/Host/DeleteHost.yaml'
   /configuration/hosts/templates:

--- a/centreon/doc/API/v23.10/Configuration/Notification/FindNotifiableContactGroups.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Notification/FindNotifiableContactGroups.yaml
@@ -1,0 +1,26 @@
+get:
+  tags:
+    - Notification
+  summary: "List notifiable contact groups."
+  description: "List notifiable contact groups for Cloud Notifications rules configuration."
+  responses:
+    '200':
+      description: "OK"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              result:
+                type: array
+                items:
+                  $ref: 'Schema/NotifiableContactGroups.Listing.yaml'
+                meta:
+                  $ref: '../../Common/Schema/Meta.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'
+

--- a/centreon/doc/API/v23.10/Configuration/Notification/FindNotifiableContactGroups.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Notification/FindNotifiableContactGroups.yaml
@@ -2,7 +2,7 @@ get:
   tags:
     - Notification
   summary: "List notifiable contact groups."
-  description: "List notifiable contact groups for Cloud Notifications rules configuration."
+  description: "List notifiable contact groups for Cloud notification rules configuration."
   responses:
     '200':
       description: "OK"

--- a/centreon/doc/API/v23.10/Configuration/Notification/Schema/NotifiableContactGroups.Listing.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Notification/Schema/NotifiableContactGroups.Listing.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   id:
     type: integer
-    description: "Contact group id"
+    description: "Contact group ID"
     example: 1
   name:
     type: string

--- a/centreon/doc/API/v23.10/Configuration/Notification/Schema/NotifiableContactGroups.Listing.yaml
+++ b/centreon/doc/API/v23.10/Configuration/Notification/Schema/NotifiableContactGroups.Listing.yaml
@@ -1,0 +1,13 @@
+type: object
+required:
+  - id
+  - name
+properties:
+  id:
+    type: integer
+    description: "Contact group id"
+    example: 1
+  name:
+    type: string
+    description: "Contact group name"
+    example: "Contact group"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -18289,4 +18289,4 @@ msgid "Error while retrieving a command"
 msgstr "Erreur lors de la récuparation d'une commande"
 
 msgid "Error while retrieving contact groups"
-msgstr "Erreur lors de la récuparation des groupes de contacts"
+msgstr "Erreur lors de la récupération des groupes de contacts"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -18287,3 +18287,6 @@ msgstr "Erreur lors de l'ajout d'une commande"
 
 msgid "Error while retrieving a command"
 msgstr "Erreur lors de la récuparation d'une commande"
+
+msgid "Error while retrieving contact groups"
+msgstr "Erreur lors de la récuparation des groupes de contacts"

--- a/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroups.php
+++ b/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroups.php
@@ -23,11 +23,11 @@ declare(strict_types=1);
 
 namespace Core\Notification\Application\UseCase\FindNotifiableContactGroups;
 
-use Centreon\Domain\Log\LoggerTrait;
-use Core\Contact\Domain\Model\ContactGroup;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Contact\Application\Repository\ReadContactGroupRepositoryInterface;
+use Core\Contact\Domain\Model\ContactGroup;
 use Core\Notification\Application\Repository\ReadNotifiableContactGroupsRepositoryInterface;
 use Core\Notification\Application\UseCase\FindNotifiableContactGroups\Response\NotifiableContactGroupDto;
 
@@ -37,7 +37,7 @@ final class FindNotifiableContactGroups
 
     /**
      * @param ContactInterface $user
-     * @param ReadNotifiableContactGroupsRepositoryInterface $repository
+     * @param ReadContactGroupRepositoryInterface $contactGroupRepository
      */
     public function __construct(
         private readonly ContactInterface $user,

--- a/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroups.php
+++ b/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroups.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Notification\Application\UseCase\FindNotifiableContactGroups;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Contact\Domain\Model\ContactGroup;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Contact\Application\Repository\ReadContactGroupRepositoryInterface;
+use Core\Notification\Application\Repository\ReadNotifiableContactGroupsRepositoryInterface;
+use Core\Notification\Application\UseCase\FindNotifiableContactGroups\Response\NotifiableContactGroupDto;
+
+final class FindNotifiableContactGroups
+{
+    use LoggerTrait;
+
+    /**
+     * @param ContactInterface $user
+     * @param ReadNotifiableContactGroupsRepositoryInterface $repository
+     */
+    public function __construct(
+        private readonly ContactInterface $user,
+        private readonly ReadContactGroupRepositoryInterface $contactGroupRepository,
+    ) {
+    }
+
+    /**
+     * @param FindNotifiableContactGroupsPresenterInterface $presenter
+     */
+    public function __invoke(FindNotifiableContactGroupsPresenterInterface $presenter): void
+    {
+        try {
+            $this->info('Retrieving all contact groups.');
+            $contactGroups = $this->contactGroupRepository->findAll();
+            $response = $this->createResponseDto($contactGroups);
+        } catch (\Throwable $ex) {
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+            $response = new ErrorResponse('');
+        }
+
+        $presenter->presentResponse($response);
+    }
+
+    /**
+     * @param array<ContactGroup> $contactGroups
+     *
+     * @return FindNotifiableContactGroupsResponse
+     */
+    private function createResponseDto(array $contactGroups): FindNotifiableContactGroupsResponse
+    {
+        $responseDto = new FindNotifiableContactGroupsResponse();
+        foreach ($contactGroups as $contactGroup) {
+            $notifiableContactGroupDto = new NotifiableContactGroupDto();
+            $notifiableContactGroupDto->id = $contactGroup->getId();
+            $notifiableContactGroupDto->name = $contactGroup->getName();
+            $responseDto->notifiableContactGroups[] = $notifiableContactGroupDto;
+        }
+
+        return $responseDto;
+    }
+}

--- a/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroups.php
+++ b/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroups.php
@@ -28,7 +28,6 @@ use Centreon\Domain\Log\LoggerTrait;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Contact\Application\Repository\ReadContactGroupRepositoryInterface;
 use Core\Contact\Domain\Model\ContactGroup;
-use Core\Notification\Application\Repository\ReadNotifiableContactGroupsRepositoryInterface;
 use Core\Notification\Application\UseCase\FindNotifiableContactGroups\Response\NotifiableContactGroupDto;
 
 final class FindNotifiableContactGroups

--- a/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroupsPresenterInterface.php
+++ b/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroupsPresenterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Notification\Application\UseCase\FindNotifiableContactGroups;
+
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+interface FindNotifiableContactGroupsPresenterInterface
+{
+    /**
+     * @param FindNotifiableContactGroupsResponse|ResponseStatusInterface $data
+     */
+    public function presentResponse(FindNotifiableContactGroupsResponse|ResponseStatusInterface $data): void;
+}

--- a/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroupsResponse.php
+++ b/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroupsResponse.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Notification\Application\UseCase\FindNotifiableContactGroups;
+
+use Core\Notification\Application\UseCase\FindNotfiableContactGroups\Response\NotifiableContactGroupDto;
+
+final class FindNotifiableContactGroupsResponse
+{
+    /**
+     * Undocumented function
+     *
+     * @param array<NotifiableContactGroupDto> $notifiableContactGroups
+     */
+    public function __construct(public array $notifiableContactGroups = [])
+    {
+    }
+}

--- a/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroupsResponse.php
+++ b/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroupsResponse.php
@@ -28,8 +28,6 @@ use Core\Notification\Application\UseCase\FindNotfiableContactGroups\Response\No
 final class FindNotifiableContactGroupsResponse
 {
     /**
-     * Undocumented function
-     *
      * @param array<NotifiableContactGroupDto> $notifiableContactGroups
      */
     public function __construct(public array $notifiableContactGroups = [])

--- a/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/Response/NotifiableContactGroupDto.php
+++ b/centreon/src/Core/Notification/Application/UseCase/FindNotifiableContactGroups/Response/NotifiableContactGroupDto.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Notification\Application\UseCase\FindNotifiableContactGroups\Response;
+
+final class NotifiableContactGroupDto
+{
+    /**
+     * @param int $id
+     * @param string $name
+     */
+    public function __construct(
+        public int $id = 0,
+        public string $name = '',
+    ) {
+    }
+}

--- a/centreon/src/Core/Notification/Infrastructure/API/FindNotifiableContactGroups/FindNotifiableContactGroupsController.php
+++ b/centreon/src/Core/Notification/Infrastructure/API/FindNotifiableContactGroups/FindNotifiableContactGroupsController.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace Core\Notification\Infrastructure\API\FindNotifiableContactGroups;
 
-use Symfony\Component\HttpFoundation\Response;
 use Centreon\Application\Controller\AbstractController;
 use Core\Notification\Application\UseCase\FindNotifiableContactGroups\FindNotifiableContactGroups;
+use Symfony\Component\HttpFoundation\Response;
 
 final class FindNotifiableContactGroupsController extends AbstractController
 {

--- a/centreon/src/Core/Notification/Infrastructure/API/FindNotifiableContactGroups/FindNotifiableContactGroupsController.php
+++ b/centreon/src/Core/Notification/Infrastructure/API/FindNotifiableContactGroups/FindNotifiableContactGroupsController.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Notification\Infrastructure\API\FindNotifiableContactGroups;
+
+use Symfony\Component\HttpFoundation\Response;
+use Centreon\Application\Controller\AbstractController;
+use Core\Notification\Application\UseCase\FindNotifiableContactGroups\FindNotifiableContactGroups;
+
+final class FindNotifiableContactGroupsController extends AbstractController
+{
+    /**
+     * @param FindNotifiableContactGroups $useCase
+     * @param FindNotifiableContactGroupsPresenter $presenter
+     *
+     * @return Response
+     */
+    public function __invoke(
+        FindNotifiableContactGroups $useCase,
+        FindNotifiableContactGroupsPresenter $presenter
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        $useCase($presenter);
+
+        return $presenter->show();
+    }
+}

--- a/centreon/src/Core/Notification/Infrastructure/API/FindNotifiableContactGroups/FindNotifiableContactGroupsPresenter.php
+++ b/centreon/src/Core/Notification/Infrastructure/API/FindNotifiableContactGroups/FindNotifiableContactGroupsPresenter.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Notification\Infrastructure\API\FindNotifiableContactGroups;
+
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Notification\Application\UseCase\FindNotifiableContactGroups\{
+    FindNotifiableContactGroupsPresenterInterface as PresenterInterface,
+    FindNotifiableContactGroupsResponse
+};
+
+class FindNotifiableContactGroupsPresenter extends AbstractPresenter implements PresenterInterface
+{
+    /**
+     * @param RequestParametersInterface $requestParameters
+     * @param PresenterFormatterInterface $presenterFormatter
+     */
+    public function __construct(
+        private readonly RequestParametersInterface $requestParameters,
+        protected PresenterFormatterInterface $presenterFormatter
+    ) {
+        parent::__construct($presenterFormatter);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function presentResponse(FindNotifiableContactGroupsResponse|ResponseStatusInterface $data): void
+    {
+        if ($data instanceof ResponseStatusInterface) {
+            $this->setResponseStatus($data);
+        } else {
+            $this->present(
+                [
+                    'result' => \array_map(static function ($notifiableContactGroupDto) {
+                        return [
+                            'id' => $notifiableContactGroupDto->id,
+                            'name' => $notifiableContactGroupDto->name,
+                        ];
+                    }, $data->notifiableContactGroups),
+                    'meta' => $this->requestParameters->toArray(),
+                ]
+            );
+        }
+    }
+}

--- a/centreon/src/Core/Notification/Infrastructure/API/FindNotifiableContactGroups/FindNotifiableContactGroupsRoute.yaml
+++ b/centreon/src/Core/Notification/Infrastructure/API/FindNotifiableContactGroups/FindNotifiableContactGroupsRoute.yaml
@@ -1,0 +1,5 @@
+FindNotifiableContactGroups:
+  methods: GET
+  path: /configuration/notifications/contact_groups
+  controller: 'Core\Notification\Infrastructure\API\FindNotifiableContactGroups\FindNotifiableContactGroupsController'
+  condition: "request.attributes.get('version') >= 23.10 and request.attributes.get('feature.notification')"

--- a/centreon/tests/php/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroupsTest.php
+++ b/centreon/tests/php/Core/Notification/Application/UseCase/FindNotifiableContactGroups/FindNotifiableContactGroupsTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : user@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Notification\Application\UseCase\FindNotifiableContactGroups;
+
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Contact\Application\Repository\ReadContactGroupRepositoryInterface;
+use Core\Contact\Domain\Model\ContactGroup;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Notification\Application\UseCase\FindNotifiableContactGroups\FindNotifiableContactGroups;
+use Core\Notification\Application\UseCase\FindNotifiableContactGroups\FindNotifiableContactGroupsResponse;
+use Tests\Core\Notification\Infrastructure\API\FindNotifiableContactGroups\FindNotifiableContactGroupsPresenterStub;
+
+beforeEach(function () {
+    $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
+    $this->presenter = new FindNotifiableContactGroupsPresenterStub($this->presenterFormatter);
+    $this->readRepository = $this->createMock(ReadContactGroupRepositoryInterface::class);
+});
+
+it('should present a Not Found Response when there are no contact groups.', function () {
+    $useCase = new FindNotifiableContactGroups($this->readRepository);
+
+    $this->readRepository
+        ->expects($this->once())
+        ->method('findAll')
+        ->willReturn([]);
+
+    $useCase($this->presenter);
+
+    expect($this->presenter->responseStatus)
+        ->toBeInstanceOf(NotFoundResponse::class)
+        ->and($this->presenter->responseStatus->getMessage())
+        ->toBe('Contact Groups not found');
+});
+
+it('should present an Error Response when an unhandled error occurs.', function () {
+    $useCase = new FindNotifiableContactGroups($this->readRepository);
+
+    $this->readRepository
+        ->expects($this->once())
+        ->method('findAll')
+        ->willThrowException(new \Exception());
+
+    $useCase($this->presenter);
+
+    expect($this->presenter->responseStatus)
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->responseStatus->getMessage())
+        ->toBe('Error while retrieving contact groups');
+});
+
+it('should present a FindNotifiableContactGroups Response.', function () {
+    $contactGroups = [
+        new ContactGroup(1, 'Administrators'),
+        new ContactGroup(2, 'Editors'),
+    ];
+
+    $useCase = new FindNotifiableContactGroups($this->readRepository);
+
+    $this->readRepository
+        ->expects($this->once())
+        ->method('findAll')
+        ->willReturn($contactGroups);
+
+    $useCase($this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(FindNotifiableContactGroupsResponse::class)
+        ->and($this->presenter->response->notifiableContactGroups)
+        ->toBeArray()
+        ->and($this->presenter->response->notifiableContactGroups[0]->id)
+        ->toBe(1)
+        ->and($this->presenter->response->notifiableContactGroups[0]->name)
+        ->toBe('Administrators')
+        ->and($this->presenter->response->notifiableContactGroups[1]->id)
+        ->toBe(2)
+        ->and($this->presenter->response->notifiableContactGroups[1]->name)
+        ->toBe('Editors');
+});

--- a/centreon/tests/php/Core/Notification/Infrastructure/API/FindNotifiableContactGroups/FindNotifiableContactGroupsPresenterStub.php
+++ b/centreon/tests/php/Core/Notification/Infrastructure/API/FindNotifiableContactGroups/FindNotifiableContactGroupsPresenterStub.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : user@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Notification\Infrastructure\API\FindNotifiableContactGroups;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Notification\Application\UseCase\FindNotifiableContactGroups\{
+    FindNotifiableContactGroupsPresenterInterface as PresenterInterface,
+    FindNotifiableContactGroupsResponse
+};
+
+class FindNotifiableContactGroupsPresenterStub extends AbstractPresenter implements PresenterInterface
+{
+    /** @var FindNotifiableContactGroupsResponse|null */
+    public ?FindNotifiableContactGroupsResponse $response = null;
+
+    /** @var ResponseStatusInterface|null */
+    public ?ResponseStatusInterface $responseStatus = null;
+
+    /**
+     * @param PresenterFormatterInterface $presenterFormatter
+     */
+    public function __construct(protected PresenterFormatterInterface $presenterFormatter)
+    {
+        parent::__construct($presenterFormatter);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function presentResponse(FindNotifiableContactGroupsResponse|ResponseStatusInterface $data): void
+    {
+        if ($data instanceof ResponseStatusInterface) {
+            $this->responseStatus = $data;
+        } else {
+            $this->response = $data;
+        }
+    }
+}

--- a/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/FormInputs/useFormInputs.tsx
+++ b/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/FormInputs/useFormInputs.tsx
@@ -31,7 +31,7 @@ import {
 import { hostEvents, serviceEvents } from '../utils';
 import {
   businessViewsEndpoint,
-  contactsGroupsEndpoint,
+  contactGroupsEndpoint,
   hostsGroupsEndpoint,
   serviceGroupsEndpoint,
   usersEndpoint
@@ -331,7 +331,7 @@ const useFormInputs = ({
           {
             connectedAutocomplete: {
               additionalConditionParameters: [],
-              endpoint: contactsGroupsEndpoint
+              endpoint: contactGroupsEndpoint
             },
             dataTestId: 'Search contact groups',
             fieldName: 'contactgroups',

--- a/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/api/endpoints.ts
+++ b/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/api/endpoints.ts
@@ -19,4 +19,4 @@ export const hostsGroupsEndpoint = `${baseEndpoint}/configuration/hosts/groups`;
 export const serviceGroupsEndpoint = `${baseEndpoint}/configuration/services/groups`;
 export const businessViewsEndpoint = `${baseEndpoint}/bam/configuration/business-views`;
 export const usersEndpoint = `${baseEndpoint}/configuration/users`;
-export const contactsGroupsEndpoint = `${baseEndpoint}/configuration/contacts/groups`;
+export const contactsGroupsEndpoint = `${baseEndpoint}/configuration/notifications/contact_groups`;

--- a/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/api/endpoints.ts
+++ b/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/api/endpoints.ts
@@ -19,4 +19,4 @@ export const hostsGroupsEndpoint = `${baseEndpoint}/configuration/hosts/groups`;
 export const serviceGroupsEndpoint = `${baseEndpoint}/configuration/services/groups`;
 export const businessViewsEndpoint = `${baseEndpoint}/bam/configuration/business-views`;
 export const usersEndpoint = `${baseEndpoint}/configuration/users`;
-export const contactsGroupsEndpoint = `${baseEndpoint}/configuration/notifications/contact_groups`;
+export const contactGroupsEndpoint = `${baseEndpoint}/configuration/notifications/contact_groups`;

--- a/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/specs/PanelCreate.cypress.spec.tsx
+++ b/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/specs/PanelCreate.cypress.spec.tsx
@@ -91,7 +91,7 @@ const initialize = (): void => {
   cy.interceptAPIRequest({
     alias: 'contactGroupsEndpoint',
     method: Method.GET,
-    path: `${contactsGroupsEndpoint}**`,
+    path: `${contactGroupsEndpoint}**`,
     response: contactGroupsResponse
   });
 

--- a/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/specs/PanelCreate.cypress.spec.tsx
+++ b/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/specs/PanelCreate.cypress.spec.tsx
@@ -21,9 +21,9 @@ import {
   labelSearchContacts
 } from '../../translatedLabels';
 import { panelWidthStorageAtom } from '../../atom';
-import { contactGroupsEndpoint } from '../../../Authentication/api/endpoints';
 import { platformVersionsAtom } from '../../../Main/atoms/platformVersionsAtom';
 import {
+  contactsGroupsEndpoint,
   hostsGroupsEndpoint,
   notificationEndpoint,
   serviceGroupsEndpoint,
@@ -91,7 +91,7 @@ const initialize = (): void => {
   cy.interceptAPIRequest({
     alias: 'contactGroupsEndpoint',
     method: Method.GET,
-    path: `${contactGroupsEndpoint}**`,
+    path: `${contactsGroupsEndpoint}**`,
     response: contactGroupsResponse
   });
 

--- a/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/specs/PanelCreate.cypress.spec.tsx
+++ b/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/specs/PanelCreate.cypress.spec.tsx
@@ -23,7 +23,7 @@ import {
 import { panelWidthStorageAtom } from '../../atom';
 import { platformVersionsAtom } from '../../../Main/atoms/platformVersionsAtom';
 import {
-  contactsGroupsEndpoint,
+  contactGroupsEndpoint,
   hostsGroupsEndpoint,
   notificationEndpoint,
   serviceGroupsEndpoint,


### PR DESCRIPTION
## Description

Added a new endpoint to list contact groups without ACLs
`GET: /configuration/notifications/contact_groups`

**Fixes** # MON-22543

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04 (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
