### PR TITLE
feat(script): 3 new commands for platform migration

### DIFF
--- a/centreon/bin/platformMigration/command/Migration.php
+++ b/centreon/bin/platformMigration/command/Migration.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace CloudMigration;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+
+class Migration extends Command
+{
+    protected function configure(): void
+    {
+        $this->addArgument(
+            'target-url',
+            InputArgument::REQUIRED,
+            "The target platform base url to connect to the API (ex: 'http://localhost/centreon')."
+        );
+        $this->addArgument(
+            'target-token',
+            InputArgument::REQUIRED,
+            'The API token to connect to the target platform.'
+        );
+    }
+}

--- a/centreon/bin/platformMigration/command/MigrationAll.php
+++ b/centreon/bin/platformMigration/command/MigrationAll.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace CloudMigration;
+
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrationAll extends Migration {
+    use CommandsInfo;
+
+    protected static $defaultName = 'migration:all';
+
+    protected static $defaultDescription = 'Migrate all configuration data from the current platform to the defined target platform.';
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $url = $input->getArgument('target-url');
+        $token = $input->getArgument('target-token');
+
+        foreach ($this->getCommands() as $info) {
+            $command = new ArrayInput([
+                'command' => $info['command'],
+                'target-url' => $url,
+                'target-token' => $token,
+                '-v' => $output->isVerbose(),
+                '-vv' => $output->isVeryVerbose(),
+                '-vvv' => $output->isDebug(),
+                '-q' => $output->isQuiet(),
+                '--ansi' => $output->isDecorated(),
+                '--no-ansi' => ! $output->isDecorated(),
+            ]);
+            $command->setInteractive(false);
+
+            $returnCode = $this->getApplication()?->doRun(
+                $command,
+                $output
+            );
+
+            if ($returnCode !== 0) {
+
+                return self::FAILURE;
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/centreon/bin/platformMigration/command/MigrationCommand.php
+++ b/centreon/bin/platformMigration/command/MigrationCommand.php
@@ -1,0 +1,350 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace CloudMigration;
+
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+/**
+ * Command to migrate the commands configuration from the source platform to a target platform.
+ *
+ * @phpstan-type _Argument = array{
+ *     name: string,
+ *     description: string|null
+ * }
+ * @phpstan-type _Macro = array{
+ *     name: string,
+ *     type: integer,
+ *     description: string|null
+ * }
+ * @phpstan-type _Command = array{
+ *      command_id: int,
+ *      command_name: string,
+ *      command_line: string,
+ *      command_type: int,
+ *      command_example: string|null,
+ *      enable_shell: int,
+ *      graph_name: string|null,
+ *      connector_name: string|null
+ * }
+ */
+class MigrationCommand extends Migration {
+    use CommandsInfo;
+    use CurlRequestHelper;
+
+    protected static $defaultName = 'migration:commands';
+
+    protected static $defaultDescription = 'Migrate commands configuration data from the current platform to the defined target platform.';
+
+    private string $targetUrl;
+
+    private string $targetToken;
+
+    private \CentreonDB $centreonDB;
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $output->writeln('<fg=cyan>Migrating commands...</>');
+
+        /** @var QuestionHelper $helper */
+        $helper = $this->getHelper('question');
+        $question = new ConfirmationQuestion(
+            "Commands configuration migration require some data to be already present on the target platform.\n"
+            . "Please make sure all data from requirements are present on the target platform.\n"
+            . "(Refer to <fg=green>migration:list commands</> for the list of requirements)\n"
+            . 'Do you want to continue ? [Y/n]',
+            true
+        );
+
+        if (! $helper->ask($input, $output, $question))
+        {
+            return self::SUCCESS;
+        }
+
+        $this->centreonDB = new \CentreonDB();
+        $this->targetUrl = $input->getArgument('target-url');
+        $this->targetToken = $input->getArgument('target-token');
+
+        try {
+
+            $output->writeln('<fg=cyan>Retrieving data from target platform...</>');
+
+            [$connectors, $graphTemplates] = $this->getTargetRequiredDataOrFail();
+            $existingCommands = $this->getTargetCommandsOrFail();
+
+            $output->writeln('<fg=cyan>Retrieving data from source platform...</>');
+
+            [$arguments, $macros] = $this->getSourceArgumentsAndMacrosOrFail();
+            $commands = $this->getSourceCommandsOrFail();
+
+        } catch (PlatformMigrationException $ex) {
+            $output->writeln('<error>' . $ex->getMessage() . '</error>');
+            if ($ex->getPrevious() !== null) {
+                $output->writeln('<error>' . $ex->getPrevious()->getMessage() . '</error>', OutputInterface::VERBOSITY_DEBUG);
+            }
+
+            return self::FAILURE;
+        }
+
+        $output->writeln('<fg=cyan>Creating commands on target platform...</>');
+
+        $success = $skipped = $failed = 0;
+        foreach ($commands as $command) {
+            if ($this->assertCommandExistOnTargetPlatform($existingCommands, $command)) {
+                ++$skipped;
+                $output->writeln(
+                    '<fg=yellow>'
+                    . "[Command][SKIPPED]['{$command['command_name']}']"
+                    . " sourceID:{$command['command_id']} => targetID:{$existingCommands[$command['command_name']]}"
+                    . '</>',
+                );
+
+                continue;
+            }
+
+            try {
+                $newCommandId = $this->createCommandOrFail(
+                    $command,
+                    $macros,
+                    $arguments,
+                    $connectors,
+                    $graphTemplates
+                );
+            } catch (PlatformMigrationException $ex) {
+                ++$failed;
+                $output->writeln(
+                    '<fg=red>'
+                    . "[Command][FAILED]['{$command['command_name']}'] sourceID:{$command['command_id']}"
+                    . '</>'
+                );
+                $output->writeln('<fg=red>' . $ex->getMessage() . '</>', OutputInterface::VERBOSITY_DEBUG);
+
+                continue;
+            }
+
+            ++$success;
+            $output->writeln(
+                "[Command][SUCCESS]['{$command['command_name']}']"
+                ." sourceID:{$command['command_id']} => targetID:{$newCommandId}"
+            );
+        }
+
+        $output->writeln("<fg=cyan>Commands migrated (success:{$success}, skipped:{$skipped}, failed:{$failed})</>");
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @throws \Throwable|PlatformMigrationException
+     *
+     * @return array{array<string,int>,array<string,int>}
+     */
+    private function getTargetRequiredDataOrFail(): array
+    {
+        try {
+            /** @var array<array{id:int,name:string}> $connectorsResponse */
+            $connectorsResponse = $this->getAllRequest(
+                url: $this->targetUrl . '/api/latest/configuration/connectors',
+                apiToken: $this->targetToken
+            );
+
+            /** @var array<array{id:int,name:string}> $graphTemplatesResponse */
+            $graphTemplatesResponse = $this->getAllRequest(
+                url: $this->targetUrl . '/api/latest/configuration/graphs/templates',
+                apiToken: $this->targetToken
+            );
+
+            return [
+                array_column($connectorsResponse, 'id', 'name'),
+                array_column($graphTemplatesResponse, 'id', 'name'),
+            ];
+        } catch (PlatformMigrationException $ex) {
+
+            throw PlatformMigrationException::failToRetrieveElements('connectors/graphTemplates', 'target', $ex);
+        }
+    }
+
+    /**
+     * @throws \Throwable|PlatformMigrationException
+     *
+     * @return array<string,int>
+     */
+    private function getTargetCommandsOrFail(): array
+    {
+        try {
+            /** @var array<array{id:int,name:string}> $response */
+            $response = $this->getAllRequest(
+                url: $this->targetUrl . '/api/latest/configuration/commands',
+                apiToken: $this->targetToken
+            );
+
+            return array_column($response['result'], 'id', 'name');
+        } catch (PlatformMigrationException $ex) {
+            throw PlatformMigrationException::failToRetrieveElements('commands', 'target', $ex);
+        }
+    }
+
+    /**
+     * @throws \Throwable|PlatformMigrationException
+     *
+     * @return array{array<int,_Argument[]>,array<int,_Macro[]>}
+     */
+    private function getSourceArgumentsAndMacrosOrFail(): array
+    {
+        try {
+            $argumentStatement = $this->centreonDB->query(
+                <<<'SQL'
+                    SELECT cmd_id, macro_name as name, macro_description as description
+                    FROM command_arg_description
+                    SQL
+            );
+
+            $macroStatement = $this->centreonDB->query(
+                <<<'SQL'
+                    SELECT
+                        command_command_id,
+                        command_macro_name as name,
+                        command_macro_type as type,
+                        command_macro_desciption as description
+                    FROM on_demand_macro_command
+                    SQL
+            );
+
+            if ($argumentStatement === false || $macroStatement === false) {
+                throw new \PDOException('Error during query');
+            }
+
+            return [
+                $argumentStatement->fetchAll(\PDO::FETCH_GROUP),
+                $macroStatement->fetchAll(\PDO::FETCH_GROUP),
+            ];
+        } catch (\Exception $ex) {
+            throw PlatformMigrationException::failToRetrieveElements('arguments/macros', 'source', $ex);
+        }
+    }
+
+    /**
+     * @throws \Throwable|PlatformMigrationException
+     *
+     * @return _Command[]
+     */
+    private function getSourceCommandsOrFail(): array
+    {
+        try {
+
+            $statement = $this->centreonDB->query(
+                <<<'SQL'
+                    SELECT
+                        command.command_id,
+                        command_name,
+                        command.command_line,
+                        command.command_type,
+                        command.command_example,
+                        command.enable_shell,
+                        giv_graphs_template.name as graph_name,
+                        connector.name as connector_name
+                    FROM command
+                    LEFT JOIN connector ON command.connector_id = connector.id
+                    LEFT JOIN giv_graphs_template ON command.graph_id = giv_graphs_template.graph_id
+                    WHERE
+                        command_locked = 0
+                        AND command_activate = '1'
+                    SQL
+            );
+
+            if ($statement === false) {
+                throw new \PDOException('Error during query');
+            }
+
+            return $statement->fetchAll(\PDO::FETCH_ASSOC);
+        } catch (\Exception $ex) {
+            throw PlatformMigrationException::failToRetrieveElements('commands', 'source', $ex);
+        }
+    }
+
+    /**
+     * @param array<string,int> $existingCommands
+     * @param _Command $command
+     *
+     * @return bool
+     */
+    private function assertCommandExistOnTargetPlatform(array $existingCommands, array $command): bool
+    {
+        return array_key_exists($command['command_name'], $existingCommands);
+    }
+
+    /**
+     * @param _Command $command
+     * @param array<int,_Macro[]> $macros
+     * @param array<int,_Argument[]> $arguments
+     * @param array<string,int> $connectors
+     * @param array<string,int> $graphTemplates
+     *
+     * @throws PlatformMigrationException
+     *
+     * @return int
+     */
+    private function createCommandOrFail(
+        array $command,
+        array $macros,
+        array $arguments,
+        array $connectors,
+        array $graphTemplates
+    ): int {
+        /** @var array{id:int} $response */
+        $response = $this->curlCall(
+            url: $this->targetUrl . '/api/latest/configuration/commands',
+            apiToken: $this->targetToken,
+            method: 'POST',
+            body: [
+                'name' => $command['command_name'],
+                'type' => $command['command_type'],
+                'command_line' => $command['command_line'],
+                'argument_example' => $command['command_example'],
+                'is_shell' => (bool) $command['enable_shell'],
+                'connector_id' => $command['connector_name'] !== null ? $connectors[$command['connector_name']] : null,
+                'graph_template_id' => $command['graph_name'] !== null ? $graphTemplates[$command['graph_name']] : null,
+                'arguments' => array_map(
+                    fn(array $arg): array => [
+                        'name' => $arg['name'],
+                        'description' => $arg['description'] === '' ? null : $arg['description'],
+                    ],
+                    $arguments[$command['command_id']] ?? []
+                ),
+                'macros' => array_map(
+                    fn(array $macro): array => [
+                        'name' => $macro['name'],
+                        'type' => (int) $macro['type'],
+                        'description' => $macro['description'] === '' ? null : $macro['description'],
+                    ],
+                    $macros[$command['command_id']] ?? []
+                ),
+            ]
+        );
+
+        return (int) $response['id'];
+    }
+}

--- a/centreon/bin/platformMigration/command/MigrationList.php
+++ b/centreon/bin/platformMigration/command/MigrationList.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace CloudMigration;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrationList extends Command
+{
+    use CommandsInfo;
+
+    protected static $defaultName = 'migration:list';
+
+    protected static $defaultDescription = 'List all elements available for migration, their commands and their requirements.';
+
+    protected function configure(): void
+    {
+        $this->addArgument(
+            'names',
+            InputArgument::IS_ARRAY,
+            'Name of the elements you want information about.'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        /** @var string[] $specifiedNames */
+        $specifiedNames = $input->getArgument('names') ?? [];
+
+        if ($specifiedNames === []) {
+            $output->writeln('Elements available for migration:');
+        }
+
+        foreach ($this->getCommands() as $name => $info) {
+            if ($specifiedNames === [] || in_array($name, $specifiedNames, true)) {
+                $output->writeln(sprintf(
+                    "<fg=yellow>%s</>\n    command: <fg=green>%s</>\n    requirements: %s",
+                    $name,
+                    $info['command'],
+                    isset($info['requirements'])
+                        ? implode(', ', $info['requirements'])
+                        : 'N/A'
+                ));
+            }
+        }
+
+        if ($specifiedNames === []) {
+            $output->writeln("\nOr run <fg=green>migrate:all</> to migrate all elements.");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/centreon/bin/platformMigration/common/CommandsInfo.php
+++ b/centreon/bin/platformMigration/common/CommandsInfo.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace CloudMigration;
+
+trait CommandsInfo {
+    /** @var array<array{command:string,requirements?:string[]}> */
+    private array $commands = [
+        // 'connectors' => [
+        //     'command' => 'migration:connectors',
+        // ],
+        // 'graphTemplates' => [
+        //     'command' => 'migration:graphTemplates',
+        // ],
+        'commands' => [
+            'command' => 'migration:commands',
+            'requirements' => [
+                'connectors',
+                'graphTemplates',
+            ],
+        ],
+    ];
+
+    /**
+     * @return array<array{command:string,requirements?:string[]}>
+     */
+    protected function getCommands(): array
+    {
+        return $this->commands;
+    }
+}

--- a/centreon/bin/platformMigration/common/CurlRequestHelper.php
+++ b/centreon/bin/platformMigration/common/CurlRequestHelper.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace CloudMigration;
+
+/**
+ * Provide some methods to faciliate curl requests.
+ */
+trait CurlRequestHelper {
+    private \CentreonRestHttp $curl;
+
+    /**
+     * @param string $url
+     * @param string $apiToken
+     * @param string $method
+     * @param null|array<mixed> $body
+     *
+     * @throws PlatformMigrationException
+     *
+     * @return array<mixed>
+     */
+    private function curlCall(
+        string $url,
+        string $apiToken,
+        string $method,
+        ?array $body
+    ): array {
+        $headers = [
+            'Content-type: application/json',
+            "X-AUTH-TOKEN: {$apiToken}",
+        ];
+        // TODO should we use certificate ? proxy ?
+
+        try {
+            if (! isset($this->curl)) {
+                $this->curl = new \CentreonRestHttp();
+            }
+
+            return $this->curl->call($url, $method, $body, $headers);
+        } catch (\Throwable $ex) {
+            throw PlatformMigrationException::requestFailed($ex->getMessage());
+        }
+    }
+
+    /**
+     * In case of paginated endpoint, get all available results.
+     *
+     * @param string $url
+     * @param string $apiToken
+     *
+     * @throws PlatformMigrationException
+     *
+     * @return array<string,mixed>
+     */
+    private function getAllRequest(
+        string $url,
+        string $apiToken
+    ): array {
+        /** @var array{result:array<string,mixed>,meta:array{limit:int,total:int}} $response */
+        $response = $this->curlCall(
+            $url,
+            $apiToken,
+            'GET',
+            null
+        );
+
+        if (
+            $response !== false
+            && $response['meta']['total'] > $response['meta']['limit']
+        ) {
+            $url .= "?limit={$response['meta']['total']}";
+
+            /** @var array{result:array<string,mixed>,meta:array{limit:int,total:int}} $response */
+            $response = $this->curlCall(
+                $url,
+                $apiToken,
+                'GET',
+                null
+            );
+        }
+
+        return $response['result'];
+    }
+}

--- a/centreon/bin/platformMigration/common/PlatformMigrationException.php
+++ b/centreon/bin/platformMigration/common/PlatformMigrationException.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace CloudMigration;
+
+class PlatformMigrationException extends \Exception
+{
+    /**
+     * @param string $elementName
+     * @param \Exception $previousException
+     *
+     * @return self
+     */
+    public static function failToCreateElement(
+        string $elementName,
+        \Exception $previousException
+    ): self {
+        return new self(
+            sprintf('Error while creating %s on target platform', $elementName),
+            0,
+            $previousException
+        );
+    }
+
+    /**
+     * @param string $elementName
+     * @param string $platform
+     * @param \Exception $previousException
+     *
+     * @return self
+     */
+    public static function failToRetrieveElements(
+        string $elementName,
+        string $platform,
+        \Exception $previousException
+    ): self {
+        return new self(
+            sprintf('Error while retrieving %s on %s platform', $elementName, $platform),
+            0,
+            $previousException
+        );
+    }
+
+    /**
+     * @param string $message
+     *
+     * @return self
+     */
+    public static function requestFailed(string $message): self
+    {
+        return new self($message);
+    }
+}

--- a/centreon/bin/platformMigration/migration.php
+++ b/centreon/bin/platformMigration/migration.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace CloudMigration;
+
+use Symfony\Component\Console\Application;
+
+include __DIR__ .'/../../vendor/autoload.php';
+
+spl_autoload_register(function (string $class): void {
+    if (! str_starts_with($class, __NAMESPACE__)) {
+
+        return;
+    }
+
+    $file = __DIR__ . '/command/' . mb_substr($class, mb_strlen(__NAMESPACE__) + 1) . '.php';
+
+    if (is_file($file)) {
+        include $file;
+
+        return;
+    }
+
+    $file = __DIR__ . '/common/' . mb_substr($class, mb_strlen(__NAMESPACE__) + 1) . '.php';
+
+    if (is_file($file)) {
+        include $file;
+    }
+});
+
+$app = new Application('PlatformMigration', '24.04.0');
+
+$app->add(new MigrationCommand());
+$app->add(new MigrationList());
+$app->add(new MigrationAll());
+
+$app->setDefaultCommand(MigrationList::getDefaultName() ?? '');
+$app->run();

--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -35,6 +35,7 @@ services:
         resource: '../../src/Core/*'
         exclude:
             - '../../src/Core/Media/*'
+            - '../../src/Core/Command/*'
         bind:
             $isCloudPlatform: '%env(bool:IS_CLOUD_PLATFORM)%'
 

--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -403,6 +403,7 @@ sed -i 's#@VERSION@#%{version}#' centreon/selinux/*
 %{__install} -m 0755 centreon/bin/registerServerTopologyTemplate %buildroot%{_datadir}/centreon/bin/
 %{__install} -m 0755 centreon/bin/centreon-sanitize-images.php %buildroot%{_datadir}/centreon/bin/
 %{__install} -m 0755 centreon/bin/centreon-remove-duplicate-host-service-relations.php %buildroot%{_datadir}/centreon/bin/
+%{__install} -m 0755 -d centreon/bin/platformMigration %buildroot%{_datadir}/centreon/bin/
 
 # Add new installation backup directory
 %{__install} -d -m 0775 %buildroot%{_localstatedir}/lib/centreon/installs

--- a/centreon/src/Core/Command/Application/Repository/ReadCommandRepositoryInterface.php
+++ b/centreon/src/Core/Command/Application/Repository/ReadCommandRepositoryInterface.php
@@ -93,10 +93,21 @@ interface ReadCommandRepositoryInterface
      * @param RequestParametersInterface $requestParameters
      * @param CommandType[] $commandTypes
      *
+     * @throws \Throwable
+     *
      * @return Command[]
      */
     public function findByRequestParameterAndTypes(
         RequestParametersInterface $requestParameters,
         array $commandTypes
     ): array;
+
+    /**
+     * Find all commands.
+     *
+     * @throws \Throwable
+     *
+     * @return \Iterator<int,Command>&\Countable
+     */
+    public function findAll(): \Iterator&\Countable;
 }

--- a/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/CommandRecordedDto.php
+++ b/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/CommandRecordedDto.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Application\UseCase\MigrateAllCommands;
+
+class CommandRecordedDto
+{
+    public int $sourceId = 0;
+
+    public int $targetId = 0;
+
+    public string $name = '';
+}

--- a/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommands.php
+++ b/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommands.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Application\UseCase\MigrateAllCommands;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Command\Application\Exception\CommandException;
+use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
+use Core\Command\Application\Repository\WriteCommandRepositoryInterface;
+use Core\Command\Domain\Model\Command;
+use Core\Command\Domain\Model\NewCommand;
+use Psr\Log\LoggerInterface;
+
+final class MigrateAllCommands
+{
+    private MigrateAllCommandsResponse $response;
+
+    public function __construct(
+        readonly private ReadCommandRepositoryInterface $readCommandRepository,
+        readonly private WriteCommandRepositoryInterface $writeCommandRepository,
+        readonly private LoggerInterface $logger,
+    ) {
+        $this->response = new MigrateAllCommandsResponse();
+    }
+
+    public function __invoke(MigrateAllCommandsPresenterInterface $presenter): void
+    {
+        try {
+            $commands = $this->readCommandRepository->findAll();
+
+            $this->migrateCommands($commands, $this->response);
+
+            $presenter->presentResponse($this->response);
+        } catch (\Throwable $ex) {
+            $this->logger->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+            $presenter->presentResponse(new ErrorResponse($ex->getMessage()));
+        }
+    }
+
+    /**
+     * @param \Iterator<int,Command>&\Countable $commands
+     * @param MigrateAllCommandsResponse $response
+     */
+    private function migrateCommands(\Iterator&\Countable $commands, MigrateAllCommandsResponse $response): void
+    {
+        $response->results = new class(
+            $commands,
+            $this->writeCommandRepository,
+            $this->logger,
+        ) implements \Iterator, \Countable
+        {
+            /**
+             * @param \Iterator<int,Command>&\Countable $commands
+             * @param WriteCommandRepositoryInterface $writeCommandRepository
+             */
+            public function __construct(
+                readonly private \Iterator&\Countable $commands,
+                readonly private WriteCommandRepositoryInterface $writeCommandRepository,
+                readonly private LoggerInterface $logger
+            ) {
+            }
+
+            /**
+             * @return CommandRecordedDto|MigrationErrorDto
+             */
+            public function current(): CommandRecordedDto|MigrationErrorDto
+            {
+                /** @var Command $command */
+                $command = $this->commands->current();
+                try {
+                    if ($command->isLocked() || ! $command->isActivated()) {
+                        $this->logger->debug(
+                            'Command disabled or locked, skip migration',
+                            ['command_id' => $command->getId()]
+                        );
+
+                        throw new \Exception('Command disabled or locked');
+                    }
+                    $targetNewCommandId = $this->writeCommandRepository->add(NewCommand::createFromCommand($command));
+                    $status = new CommandRecordedDto();
+                    $status->targetId = $targetNewCommandId;
+                    $status->sourceId = $command->getId();
+                    $status->name = $command->getName();
+
+                    return $status;
+                } catch (\Throwable $ex) {
+                    $status = new MigrationErrorDto();
+                    $status->id = $command->getId();
+                    $status->name = $command->getName();
+                    $status->reason = $ex->getMessage();
+
+                    return $status;
+                }
+            }
+
+            public function next(): void
+            {
+                $this->commands->next();
+            }
+
+            public function key(): int
+            {
+                return $this->commands->key();
+            }
+
+            public function valid(): bool
+            {
+                return $this->commands->key() < $this->commands->count();
+            }
+
+            public function rewind(): void
+            {
+                $this->commands->rewind();
+            }
+
+            public function count(): int
+            {
+                return $this->commands->count();
+            }
+        };
+    }
+}

--- a/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsPresenterInterface.php
+++ b/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsPresenterInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Application\UseCase\MigrateAllCommands;
+
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+interface MigrateAllCommandsPresenterInterface
+{
+    public function presentResponse(MigrateAllCommandsResponse|ResponseStatusInterface $response): void;
+}

--- a/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsResponse.php
+++ b/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Application\UseCase\MigrateAllCommands;
+
+final class MigrateAllCommandsResponse
+{
+    /** @var \Iterator<CommandRecordedDto|MigrationErrorDto> */
+    public \Iterator $results;
+
+    public function __construct()
+    {
+        $this->results = new \ArrayIterator([]);
+    }
+}

--- a/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrationErrorDto.php
+++ b/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrationErrorDto.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Application\UseCase\MigrateAllCommands;
+
+class MigrationErrorDto
+{
+    public int $id = 0;
+
+    public string $name = '';
+
+    public string $reason = '';
+}

--- a/centreon/src/Core/Command/Domain/Model/NewCommand.php
+++ b/centreon/src/Core/Command/Domain/Model/NewCommand.php
@@ -25,6 +25,7 @@ namespace Core\Command\Domain\Model;
 
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
+use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\NewCommandMacro;
 use Core\Common\Domain\TrimmedString;
 use Core\MonitoringServer\Model\MonitoringServer;
@@ -128,5 +129,32 @@ class NewCommand
     public function getGraphTemplateId(): ?int
     {
         return $this->graphTemplateId;
+    }
+
+    /**
+     * @param Command $command
+     *
+     * @throws AssertionFailedException
+     *
+     * @return NewCommand
+     */
+    public static function createFromCommand(Command $command): self
+    {
+        $newCommand = new self(
+            name: new TrimmedString($command->getName()),
+            commandLine: new TrimmedString($command->getCommandLine()),
+            isShellEnabled: $command->isShellEnabled(),
+            type: $command->getType(),
+            argumentExample: new TrimmedString($command->getArgumentExample()),
+            arguments: $command->getArguments(),
+            macros: array_map(
+                fn(CommandMacro $macro) => NewCommandMacro::createFromMacro($macro),
+                $command->getMacros()
+            ),
+            connectorId: $command->getConnector()?->getId(),
+            graphTemplateId: $command->getGraphTemplate()?->getId(),
+        );
+
+        return $newCommand;
     }
 }

--- a/centreon/src/Core/Command/Infrastructure/Command/Exception/CommandMigrationCommandException.php
+++ b/centreon/src/Core/Command/Infrastructure/Command/Exception/CommandMigrationCommandException.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Infrastructure\Command\Exception;
+
+class CommandMigrationCommandException extends \Exception
+{
+    /**
+     * @return self
+     */
+    public static function contactNotFound(): self
+    {
+        return new self(_('Contact not found'));
+    }
+}

--- a/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsCommand.php
+++ b/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsCommand.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Infrastructure\Command\MigrateAllCommands;
+
+use Centreon\Domain\Contact\Interfaces\ContactRepositoryInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Domain\Option\Interfaces\OptionRepositoryInterface;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommands;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommandsRequest;
+use Core\Command\Infrastructure\Command\Exception\CommandMigrationCommandException;
+use Core\Command\Infrastructure\Repository\ApiWriteCommandRepository;
+use Core\Common\Infrastructure\Command\AbstractMigrationCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrateAllCommandsCommand extends AbstractMigrationCommand
+{
+    use LoggerTrait;
+
+    protected static $defaultName = 'command:all';
+
+    protected static $defaultDescription = 'Migrate all commands from the current platform to the defined target platform';
+
+    public function __construct(
+        OptionRepositoryInterface $optionRepository,
+        readonly private ApiWriteCommandRepository $apiWriteCommandRepository,
+        readonly private MigrateAllCommands $useCase,
+    ) {
+        parent::__construct($optionRepository);
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument(
+            'target-url',
+            InputArgument::REQUIRED,
+            "The target platform base url to connect to the API (ex: 'http://localhost')"
+        );
+        $this->setHelp(
+            "Migrates all commands to the target platform.\r\n"
+            . 'However the commands migration command will not replace commands that already exists on the target platform.'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $this->setStyle($output);
+            $proxy = $this->getProxy();
+            if ($proxy !== null && $proxy !== '') {
+                $this->apiWriteCommandRepository->setProxy($proxy);
+            }
+            if (is_string($target = $input->getArgument('target-url'))) {
+                $this->apiWriteCommandRepository->setUrl($target);
+            } else {
+                // Theoretically it should never happen
+                throw new \InvalidArgumentException('target-url is not a string');
+            }
+            $token = $this->askAuthenticationToken(self::TARGET_PLATFORM, $input, $output);
+
+            $this->apiWriteCommandRepository->setAuthenticationToken($token);
+            ($this->useCase)(new MigrateAllCommandsPresenter($output));
+        } catch (\Throwable $ex) {
+            $this->writeError($ex->getMessage(), $output);
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+}

--- a/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsPresenter.php
+++ b/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsPresenter.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Infrastructure\Command\MigrateAllCommands;
+
+use Core\Application\Common\UseCase\CliAbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Command\Application\UseCase\MigrateAllCommands\CommandRecordedDto;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommandsPresenterInterface;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommandsResponse;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrationErrorDto;
+
+class MigrateAllCommandsPresenter extends CliAbstractPresenter
+    implements MigrateAllCommandsPresenterInterface
+{
+    public function presentResponse(MigrateAllCommandsResponse|ResponseStatusInterface $response): void
+    {
+        if ($response instanceof ResponseStatusInterface) {
+            $this->error($response->getMessage());
+        } else {
+            foreach ($response->results as $result) {
+                if ($result instanceof CommandRecordedDto) {
+                    $this->write("<ok>   OK</>  {$result->name} => source:{$result->sourceId} / target:{$result->targetId}");
+                } elseif ($result instanceof MigrationErrorDto) {
+                    $this->write("<error>ERROR</>  {$result->name}/{$result->id} ({$result->reason})");
+                }
+            }
+        }
+    }
+}

--- a/centreon/src/Core/Command/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Command/Infrastructure/Configuration/symfony.yaml
@@ -1,0 +1,33 @@
+# parameters:
+services:
+    _defaults:
+        public: false
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, controller...
+
+    _instanceof:
+        Symfony\Component\Console\Command\Command:
+            tags: ['script.command']
+
+    Core\Command\:
+        resource: '../../../../Core/Command/*'
+
+    Core\Command\Infrastructure\Repository\DbReadCommandRepository:
+        arguments:
+            $logger: '@Centreon\Domain\Log\Logger'
+
+    Core\Command\Application\Repository\WriteCommandRepositoryInterface:
+        class: Core\Command\Infrastructure\Repository\DbWriteCommandRepository
+
+    Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommands:
+        arguments:
+            $writeCommandRepository: '@Core\Command\Infrastructure\Repository\ApiWriteCommandRepository'
+
+    Core\Command\Application\UseCase\AddCommand\AddCommand:
+        arguments:
+            $writeCommandRepository: '@Core\Command\Infrastructure\Repository\DbWriteCommandRepository'
+
+    Core\Command\Infrastructure\Repository\ApiWriteCommandRepository:
+        calls:
+        - method: setApiTimeOut
+          arguments: [ '%curl.timeout%' ]

--- a/centreon/src/Core/Command/Infrastructure/Repository/ApiWriteCommandRepository.php
+++ b/centreon/src/Core/Command/Infrastructure/Repository/ApiWriteCommandRepository.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Infrastructure\Repository;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Command\Application\Repository\WriteCommandRepositoryInterface;
+use Core\Command\Domain\Model\Argument;
+use Core\Command\Domain\Model\NewCommand;
+use Core\Command\Infrastructure\Model\CommandTypeConverter;
+use Core\CommandMacro\Domain\Model\NewCommandMacro;
+use Core\Common\Infrastructure\Repository\RepositoryTrait;
+use Symfony\Component\Mime\Part\DataPart;
+use Symfony\Component\Mime\Part\Multipart\FormDataPart;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ApiWriteCommandRepository implements WriteCommandRepositoryInterface
+{
+    use LoggerTrait;
+
+    use RepositoryTrait;
+
+    private ?string $proxy = null;
+
+    private ?string $url = null;
+
+    private string $authenticationToken = '';
+
+    private int $timeout = 60; // Default timeout
+
+    public function __construct(readonly private HttpClientInterface $httpClient)
+    {
+    }
+
+    public function setProxy(string $proxy): void
+    {
+        $this->proxy = $proxy;
+    }
+
+    public function setUrl(string $url): void
+    {
+        $this->url = rtrim($url, DIRECTORY_SEPARATOR);
+        if (! str_starts_with($this->url, 'http')) {
+            $this->url = 'https://' . $this->url;
+        }
+    }
+
+    public function setAuthenticationToken(string $token): void
+    {
+        $this->authenticationToken = $token;
+    }
+
+    public function setApiTimeOut(int $timeout): void
+    {
+        $this->timeout = $timeout;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add(NewCommand $command): int
+    {
+        $apiEndpoint = $this->url . DIRECTORY_SEPARATOR . 'centreon/api/latest/configuration/commands';
+        $options = [
+            'verify_peer' => true,
+            'verify_host' => true,
+            'timeout' => $this->timeout,
+        ];
+        if ($this->proxy !== null) {
+            $options['proxy'] = $this->proxy;
+            $this->debug('Adding command using proxy');
+        }
+
+        $options['headers'] = [
+            'Content-Type: application/json',
+            'X-AUTH-TOKEN: ' . $this->authenticationToken,
+            // 'Cookie: XDEBUG_SESSION=XDEBUG_KEY' // TODO remove
+        ];
+        $options['body'] = json_encode([
+            'name' => $command->getName() . '_test',
+            'type' => CommandTypeConverter::toInt($command->getType()),
+            'command_line' => $command->getCommandLine(),
+            'is_shell' => $command->isShellEnabled(),
+            'argument_example' => $this->emptyStringAsNull($command->getArgumentExample()),
+            'arguments' => array_map(
+                fn(Argument $arg) => [
+                    'name' => $arg->getName(),
+                    'description' => $this->emptyStringAsNull($arg->getDescription())
+                ],
+                $command->getArguments(),
+            ),
+            'macros' => array_map(
+                fn(NewCommandMacro $cmd) => [
+                    'name' => $cmd->getName(),
+                    'type'=> $cmd->getType(),
+                    'description' => $this->emptyStringAsNull($cmd->getDescription())
+                ],
+                $command->getMacros(),
+            ),
+            'connector_id' => $command->getConnectorId(),
+            'graph_template_id' => $command->getGraphTemplateId(),
+        ]);
+
+        if($options['body'] === false) {
+            $this->debug('Error when encoding request body');
+
+            throw new \Exception('Request error: unable to encode body');
+        }
+
+        $response = $this->httpClient->request('POST', $apiEndpoint, $options);
+
+        if ($response->getStatusCode() !== 201) {
+            /**
+             * @var array{message:string} $content
+             */
+            $content = $response->toArray(false);
+            $this->debug('API error', [
+                'http_code' => $response->getStatusCode(),
+                'message' => $content['message'],
+            ]);
+
+            throw new \Exception(sprintf('Request error: %s', $content['message']), $response->getStatusCode());
+        }
+
+        return (int) $response->toArray()['id'];
+    }
+}

--- a/centreon/src/Core/CommandMacro/Domain/Model/NewCommandMacro.php
+++ b/centreon/src/Core/CommandMacro/Domain/Model/NewCommandMacro.php
@@ -78,4 +78,13 @@ class NewCommandMacro
         Assertion::maxLength($description, self::MAX_DESCRIPTION_LENGTH, "{$this->shortName}::description");
         $this->description = $description;
     }
+
+    public static function createFromMacro(CommandMacro $macro): self
+    {
+        return new self(
+            $macro->getType(),
+            $macro->getName(),
+            $macro->getDescription()
+        );
+    }
 }

--- a/centreon/src/Core/Media/Infrastructure/Repository/DbReadMediaRepository.php
+++ b/centreon/src/Core/Media/Infrastructure/Repository/DbReadMediaRepository.php
@@ -187,7 +187,6 @@ class DbReadMediaRepository extends AbstractRepositoryRDB implements ReadMediaRe
 
                     $this->statement = $this->db->query($this->translateDbName($request))
                         ?: throw new \Exception('Impossible to retrieve a PDO Statement');
-                    $this->statement->execute();
                     $this->totalItems = (int) $this->statement->fetchColumn();
                 }
 


### PR DESCRIPTION
## Description

Base code for platform migrations and 3 commands.
`php /usr/share/centreon/bin/platformMigration/migration.php migration:list`
List migration commands available and their requirements

`php /usr/share/centreon/bin/platformMigration/migration.php migration:all`
Run all individual migration commands.

`php /usr/share/centreon/bin/platformMigration/migration.php migration:commands`
Migrate command configurations from current platform (source/local) to another (target).
Doesn't migrate disabled and locked commands.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)
- [x] 24.04.x

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
