### PR TITLE
enh(Permissions Rights): add missing rights sql permissions for centreon db user

### DIFF
--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -90,6 +90,7 @@ $mandatoryPrivileges = [
     'CREATE TEMPORARY TABLES',
     'EVENT',
     'CREATE VIEW',
+    'SHOW VIEW',
     'REFERENCES'
 ];
 $privilegesQuery = implode(', ', $mandatoryPrivileges);


### PR DESCRIPTION
## Description

missing show view permissions when you are using modules such as centreon-mbi. It won't let you restore your centreon database from a dump without it

**Fixes** # (MON-23300)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

install a new centreon
install the centreon-bi-server module
with the centreon db user run the following query: show create view mod_bi_publication_relations_v01;

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
