### PR TITLE
enh(CI): Force chromatic to skip tests on non develop branch

### DIFF
--- a/.github/actions/chromatic/action.yml
+++ b/.github/actions/chromatic/action.yml
@@ -58,5 +58,6 @@ runs:
             - "centreon/package.json"
           autoAcceptChanges: ${{ inputs.autoAcceptChanges }}
           exitOnceUploaded: true
+          skip: '!(develop)'
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"

--- a/.github/workflows/ui-beta.yml
+++ b/.github/workflows/ui-beta.yml
@@ -66,7 +66,6 @@ jobs:
           dependencies_lock_file: centreon/pnpm-lock.yaml
           pat: ${{ secrets.CENTREON_TECHNIQUE_TOKEN }}
           project_token: ${{ secrets.CHROMATIC_TOKEN }}
-          ignoreLastBuildOnBranch: true
 
   publish-new-npm-beta-version:
     runs-on: ubuntu-22.04

--- a/.github/workflows/ui-stable.yml
+++ b/.github/workflows/ui-stable.yml
@@ -54,4 +54,3 @@ jobs:
           dependencies_lock_file: centreon/pnpm-lock.yaml
           pat: ${{ secrets.CENTREON_TECHNIQUE_TOKEN }}
           project_token: ${{ secrets.CHROMATIC_TOKEN }}
-          autoAcceptChanges: true


### PR DESCRIPTION
## Description

This forces chromatic to skip tests on non develop branch. But snapshots are still pushed

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
