### PR TITLE
fix(delivery): perl-filesys-smbclient delivery for testing and unstable

### DIFF
--- a/.github/workflows/perl-filesys-smbclient.yml
+++ b/.github/workflows/perl-filesys-smbclient.yml
@@ -147,7 +147,7 @@ jobs:
 
   deliver-rpm:
     needs: [get-version, sign-rpm]
-    if: ${{ contains(fromJson('["stable"]'), needs.get-version.outputs.stability) }}
+    if: ${{ contains(fromJson('["testing", "unstable"]'), needs.get-version.outputs.stability) }}
     runs-on: [self-hosted, common]
     environment: ${{ needs.get-version.outputs.environment }}
 
@@ -171,7 +171,7 @@ jobs:
 
   deliver-deb:
     needs: [get-version, package-deb]
-    if: ${{ contains(fromJson('["stable"]'), needs.get-version.outputs.stability) }}
+    if: ${{ contains(fromJson('["testing", "unstable"]'), needs.get-version.outputs.stability) }}
     runs-on: [self-hosted, common]
     environment: ${{ needs.get-version.outputs.environment }}
 


### PR DESCRIPTION
## Description

Fix delivery for lib filesys-smbclient that was triggered on stable branche only. Now triggers for delivery will happen on testing and unstable branches like the other libs.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x (master)
