### PR TITLE
fix(authentication): auto imported user can reach frontend

### DIFF
--- a/centreon/src/Core/Domain/Configuration/User/Model/NewUser.php
+++ b/centreon/src/Core/Domain/Configuration/User/Model/NewUser.php
@@ -276,15 +276,18 @@ class NewUser
         return $this;
     }
 
-    /** @return bool  */
+    /**
+     * @return bool
+     */
     public function canReachFrontend(): bool
     {
         return $this->canReachFrontend;
     }
 
     /**
-     * @param bool $canReachFrontend 
-     * @return self 
+     * @param bool $canReachFrontend
+     *
+     * @return self
      */
     public function setCanReachFrontend(bool $canReachFrontend): self
     {

--- a/centreon/src/Core/Domain/Configuration/User/Model/NewUser.php
+++ b/centreon/src/Core/Domain/Configuration/User/Model/NewUser.php
@@ -59,6 +59,8 @@ class NewUser
 
     protected string $userInterfaceDensity = self::USER_INTERFACE_DENSITY_COMPACT;
 
+    protected bool $canReachFrontend = true;
+
     /**
      * @param string $alias
      * @param string $name
@@ -270,6 +272,23 @@ class NewUser
         }
 
         $this->userInterfaceDensity = $userInterfaceDensity;
+
+        return $this;
+    }
+
+    /** @return bool  */
+    public function canReachFrontend(): bool
+    {
+        return $this->canReachFrontend;
+    }
+
+    /**
+     * @param bool $canReachFrontend 
+     * @return self 
+     */
+    public function setCanReachFrontend(bool $canReachFrontend): self
+    {
+        $this->canReachFrontend = $canReachFrontend;
 
         return $this;
     }

--- a/centreon/src/Core/Domain/Configuration/User/Model/User.php
+++ b/centreon/src/Core/Domain/Configuration/User/Model/User.php
@@ -57,10 +57,12 @@ class User extends NewUser
         protected bool $isAdmin,
         protected string $theme,
         protected string $userInterfaceDensity,
+        protected bool $canReachFrontend
     ) {
         parent::__construct($alias, $name, $email);
         $this->setTheme($theme);
         $this->setUserInterfaceDensity($userInterfaceDensity);
+        $this->setCanReachFrontend($canReachFrontend);
     }
 
     /**

--- a/centreon/src/Core/Domain/Configuration/User/Model/User.php
+++ b/centreon/src/Core/Domain/Configuration/User/Model/User.php
@@ -46,6 +46,7 @@ class User extends NewUser
      * @param bool $isAdmin
      * @param string $theme
      * @param string $userInterfaceDensity
+     * @param protectedbool $canReachFrontend
      *
      * @throws \Assert\AssertionFailedException
      */

--- a/centreon/src/Core/Infrastructure/Configuration/User/Repository/DbReadUserRepository.php
+++ b/centreon/src/Core/Infrastructure/Configuration/User/Repository/DbReadUserRepository.php
@@ -70,7 +70,8 @@ class DbReadUserRepository extends AbstractRepositoryDRB implements ReadUserRepo
                 contact_email,
                 contact_admin,
                 contact_theme,
-                user_interface_density
+                user_interface_density,
+                contact_oreon AS `user_can_reach_frontend`
             FROM `:db`.contact
             SQL;
 

--- a/centreon/src/Core/Infrastructure/Configuration/User/Repository/DbUserFactory.php
+++ b/centreon/src/Core/Infrastructure/Configuration/User/Repository/DbUserFactory.php
@@ -43,7 +43,8 @@ class DbUserFactory
             $user['contact_email'],
             $user['contact_admin'] === '1',
             $user['contact_theme'],
-            $user['user_interface_density']
+            $user['user_interface_density'],
+            $user['user_can_reach_frontend'] === '1'
         );
     }
 }

--- a/centreon/src/Core/Infrastructure/Configuration/User/Repository/DbWriteUserRepository.php
+++ b/centreon/src/Core/Infrastructure/Configuration/User/Repository/DbWriteUserRepository.php
@@ -52,7 +52,8 @@ class DbWriteUserRepository extends AbstractRepositoryDRB implements WriteUserRe
                     contact_email = :email,
                     contact_admin = :is_admin,
                     contact_theme = :theme,
-                    user_interface_density = :userInterfaceDensity
+                    user_interface_density = :userInterfaceDensity,
+                    contact_oreon = :userCanReachFrontend
                 WHERE contact_id = :id'
             )
         );
@@ -62,6 +63,7 @@ class DbWriteUserRepository extends AbstractRepositoryDRB implements WriteUserRe
         $statement->bindValue(':is_admin', $user->isAdmin() ? '1' : '0', \PDO::PARAM_STR);
         $statement->bindValue(':theme', $user->getTheme(), \PDO::PARAM_STR);
         $statement->bindValue(':userInterfaceDensity', $user->getUserInterfaceDensity(), \PDO::PARAM_STR);
+        $statement->bindValue(':userCanReachFrontend', $user->canReachFrontend() ? '1' : '0', \PDO::PARAM_STR);
         $statement->bindValue(':id', $user->getId(), \PDO::PARAM_INT);
         $statement->execute();
     }
@@ -75,9 +77,9 @@ class DbWriteUserRepository extends AbstractRepositoryDRB implements WriteUserRe
             $this->translateDbName(
                 'INSERT INTO `:db`.contact
                     (contact_name, contact_alias, contact_email, contact_template_id,
-                    contact_admin, contact_theme, user_interface_density, contact_activate)
+                    contact_admin, contact_theme, user_interface_density, contact_activate, contact_oreon)
                     VALUES (:contactName, :contactAlias, :contactEmail, :contactTemplateId,
-                    :isAdmin, :contactTheme, :userInterfaceDensity, :isActivate)'
+                    :isAdmin, :contactTheme, :userInterfaceDensity, :isActivate, :userCanReachFrontend)'
             )
         );
         $statement->bindValue(':contactName', $user->getName(), \PDO::PARAM_STR);
@@ -88,6 +90,7 @@ class DbWriteUserRepository extends AbstractRepositoryDRB implements WriteUserRe
         $statement->bindValue(':contactTheme', $user->getTheme(), \PDO::PARAM_STR);
         $statement->bindValue(':userInterfaceDensity', $user->getUserInterfaceDensity(), \PDO::PARAM_STR);
         $statement->bindValue(':isActivate', $user->isActivate() ? '1' : '0', \PDO::PARAM_STR);
+        $statement->bindValue(':userCanReachFrontend', $user->canReachFrontend() ? '1' : '0', \PDO::PARAM_STR);
         $statement->execute();
     }
 }

--- a/centreon/tests/php/Core/Application/Configuration/User/UseCase/PatchUser/PatchUserTest.php
+++ b/centreon/tests/php/Core/Application/Configuration/User/UseCase/PatchUser/PatchUserTest.php
@@ -82,7 +82,7 @@ it('tests the exception while searching for the user', function () {
 });
 
 it('tests the error message when there are no available themes', function () {
-    $user = new User(1, 'alias', 'name', 'email', true, 'light', 'compact');
+    $user = new User(1, 'alias', 'name', 'email', true, 'light', 'compact', true);
     $this->readUserRepository
         ->expects($this->once())
         ->method('findById')
@@ -104,7 +104,7 @@ it('tests the error message when there are no available themes', function () {
 });
 
 it('tests the error message when the given theme is not in the list of available themes', function () {
-    $user = new User(1, 'alias', 'name', 'email', true, 'light', 'compact');
+    $user = new User(1, 'alias', 'name', 'email', true, 'light', 'compact', true);
     $this->readUserRepository
         ->expects($this->once())
         ->method('findById')
@@ -125,7 +125,7 @@ it('tests the error message when the given theme is not in the list of available
 });
 
 it('tests the exception while searching for available themes', function () {
-    $user = new User(1, 'alias', 'name', 'email', true, 'light', 'compact');
+    $user = new User(1, 'alias', 'name', 'email', true, 'light', 'compact', true);
     $this->readUserRepository
         ->expects($this->once())
         ->method('findById')
@@ -148,7 +148,7 @@ it('tests the exception while searching for available themes', function () {
 });
 
 it('tests the exception while updating the theme of user', function () {
-    $user = new User(1, 'alias', 'name', 'email', true, 'light', 'compact');
+    $user = new User(1, 'alias', 'name', 'email', true, 'light', 'compact', true);
     $this->readUserRepository
         ->expects($this->once())
         ->method('findById')

--- a/centreon/tests/php/Core/Domain/Configuration/User/Model/UserTest.php
+++ b/centreon/tests/php/Core/Domain/Configuration/User/Model/UserTest.php
@@ -52,7 +52,8 @@ class UserTest extends TestCase
             'email',
             false,
             'light',
-            'compact'
+            'compact',
+            true
         );
     }
 
@@ -80,7 +81,8 @@ class UserTest extends TestCase
             'email',
             false,
             'light',
-            'compact'
+            'compact',
+            true
         );
     }
 
@@ -108,7 +110,8 @@ class UserTest extends TestCase
             'email',
             false,
             'light',
-            'compact'
+            'compact',
+            true
         );
     }
 
@@ -136,7 +139,8 @@ class UserTest extends TestCase
             'email',
             false,
             'light',
-            'compact'
+            'compact',
+            true
         );
     }
 
@@ -164,7 +168,8 @@ class UserTest extends TestCase
             $email,
             false,
             'light',
-            'compact'
+            'compact',
+            true
         );
     }
 
@@ -192,7 +197,8 @@ class UserTest extends TestCase
             $email,
             false,
             'light',
-            'compact'
+            'compact',
+            true
         );
     }
 
@@ -220,7 +226,8 @@ class UserTest extends TestCase
             'hellotest@centreon.com',
             false,
             'light',
-            $userInterfaceViewMode
+            $userInterfaceViewMode,
+            true
         );
     }
 
@@ -245,7 +252,8 @@ class UserTest extends TestCase
             'hellotest@centreon.com',
             false,
             'light',
-            $userInterfaceViewMode
+            $userInterfaceViewMode,
+            true
         );
     }
 
@@ -266,7 +274,8 @@ class UserTest extends TestCase
             'hellotest@centreon.com',
             false,
             'light',
-            $userInterfaceViewMode
+            $userInterfaceViewMode,
+            true
         );
     }
 
@@ -290,7 +299,8 @@ class UserTest extends TestCase
             $email,
             $isAdmin,
             'light',
-            'compact'
+            'compact',
+            true
         );
 
         $this->assertEquals($id, $user->getId());

--- a/centreon/tests/php/Core/Infrastructure/Configuration/User/Api/FindUsers/FindUsersPresenterTest.php
+++ b/centreon/tests/php/Core/Infrastructure/Configuration/User/Api/FindUsers/FindUsersPresenterTest.php
@@ -81,7 +81,8 @@ class FindUsersPresenterTest extends TestCase
             'root@localhost',
             true,
             'light',
-            'compact'
+            'compact',
+            true
         );
 
         $this->requestParameters->expects($this->once())

--- a/centreon/tests/php/Core/Infrastructure/Configuration/User/Repository/DbUserFactoryTest.php
+++ b/centreon/tests/php/Core/Infrastructure/Configuration/User/Repository/DbUserFactoryTest.php
@@ -42,7 +42,8 @@ class DbUserFactoryTest extends TestCase
             'contact_email' => 'root@localhost',
             'contact_admin' => '1',
             'contact_theme' => 'light',
-            'user_interface_density' => 'compact'
+            'user_interface_density' => 'compact',
+            'user_can_reach_frontend' => '1'
         ];
     }
 
@@ -60,5 +61,6 @@ class DbUserFactoryTest extends TestCase
         $this->assertEquals(true, $user->isAdmin());
         $this->assertEquals('light', $user->getTheme());
         $this->assertEquals('compact', $user->getUserInterfaceDensity());
+        $this->assertEquals(true, $user->canReachFrontend());
     }
 }


### PR DESCRIPTION
🏷️ MON-22446

This PR intends to fix an issue with auto imported user that could not reach the centreon frontend.
This will ensure that the parameter is set to 1 when the user is imported for the first time.


**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for the more details

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
