### PR TITLE
enh(ci): remove usage of rpm centreon-release

### DIFF
--- a/.github/docker/Dockerfile.centreon-web-centos7
+++ b/.github/docker/Dockerfile.centreon-web-centos7
@@ -28,9 +28,7 @@ innodb_log_file_size=4M
 innodb_fast_shutdown=0
 " > /etc/my.cnf.d/container.cnf
 
-curl -Lo centreon-release.rpm "https://yum.centreon.com/standard/22.04/el7/stable/noarch/RPMS/centreon-release-22.04-3.el7.centos.noarch.rpm"
-yum install -y centreon-release.rpm
-rm -f centreon-release.rpm
+yum-config-manager --add-repo https://packages.centreon.com/rpm-standard/22.04/el7/centreon-22.04.repo
 yum-config-manager --enable 'centreon-testing*'
 yum-config-manager --enable 'centreon-unstable*'
 

--- a/.github/docker/Dockerfile.centreon-web-dependencies-alma8
+++ b/.github/docker/Dockerfile.centreon-web-dependencies-alma8
@@ -12,9 +12,7 @@ dnf config-manager --set-enabled powertools
 
 dnf install -y epel-release
 
-curl -Lo centreon-release.rpm https://yum.centreon.com/standard/22.04/el8/stable/noarch/RPMS/centreon-release-22.04-3.el8.noarch.rpm
-dnf install -y centreon-release.rpm
-rm -f centreon-release.rpm
+dnf config-manager --add-repo https://packages.centreon.com/rpm-standard/22.04/el8/centreon-22.04.repo
 dnf config-manager --set-enabled 'centreon*'
 
 #############################

--- a/centreon-gorgone/docs/rebound_configuration.md
+++ b/centreon-gorgone/docs/rebound_configuration.md
@@ -63,8 +63,8 @@ gorgone:
 We have installed a CentOS 7 server. We install Gorgone daemon:
 
 ```shell
-yum install http://yum.centreon.com/standard/20.04/el7/stable/noarch/RPMS/centreon-release-20.04-1.el7.centos.noarch.rpm
-yum install centreon-gorgone
+yum install yum-utils
+yum-config-manager --add-repo https://packages.centreon.com/rpm-standard/22.04/el7/centreon-22.04.repo
 ```
 
 ## Configuration

--- a/centreon/unattended.sh
+++ b/centreon/unattended.sh
@@ -78,7 +78,7 @@ detected_os_version=
 # Variables will be defined later according to the target system OS
 BASE_PACKAGES=
 CENTREON_SELINUX_PACKAGES=
-RELEASE_RPM_URL=
+RELEASE_REPO_FILE=
 OS_SPEC_SERVICES=
 PKG_MGR=
 has_systemd=
@@ -324,9 +324,9 @@ function set_required_prerequisite() {
             BASE_PACKAGES=(oraclelinux-release-el7)
             ;;
         esac
-        RELEASE_RPM_URL="http://yum.centreon.com/standard/$CENTREON_MAJOR_VERSION/el7/stable/noarch/RPMS/centreon-release-$CENTREON_RELEASE_VERSION.el7.centos.noarch.rpm"
+        RELEASE_REPO_FILE="https://packages.centreon.com/rpm-standard/$CENTREON_MAJOR_VERSION/el7/centreon-$CENTREON_MAJOR_VERSION.repo"
         REMI_RELEASE_RPM_URL="https://rpms.remirepo.net/enterprise/remi-release-7.rpm"
-        log "INFO" "Install Centreon from ${RELEASE_RPM_URL}"
+        log "INFO" "Install Centreon from ${RELEASE_REPO_FILE}"
         OS_SPEC_SERVICES="php-fpm httpd24-httpd"
         PKG_MGR="yum"
 
@@ -345,7 +345,7 @@ function set_required_prerequisite() {
     8*)
         log "INFO" "Setting specific part for v8 ($detected_os_version)"
 
-        RELEASE_RPM_URL="http://yum.centreon.com/standard/$CENTREON_MAJOR_VERSION/el8/stable/noarch/RPMS/centreon-release-$CENTREON_RELEASE_VERSION.el8.noarch.rpm"
+        RELEASE_REPO_FILE="https://packages.centreon.com/rpm-standard/$CENTREON_MAJOR_VERSION/el8/centreon-$CENTREON_MAJOR_VERSION.repo"
         REMI_RELEASE_RPM_URL="https://rpms.remirepo.net/enterprise/remi-release-8.rpm"
         OS_SPEC_SERVICES="php-fpm httpd"
         PKG_MGR="dnf"
@@ -515,16 +515,20 @@ function secure_mariadb_setup() {
 function install_centreon_repo() {
 
 	log "INFO" "Centreon official repositories installation..."
-	$PKG_MGR -q clean all
 
-	rpm -q centreon-release-$CENTREON_MAJOR_VERSION >/dev/null 2>&1
+	get_os_information
+
+    case "$detected_os_version" in
+    7*)
+        yum-config-manager --add-repo $RELEASE_REPO_FILE
+	    ;;
+	*)
+	    $PKG_MGR config-manager --add-repo $RELEASE_REPO_FILE
+	    ;;
+	esac
+
 	if [ $? -ne 0 ]; then
-		$PKG_MGR -q install -y $RELEASE_RPM_URL
-		if [ $? -ne 0 ]; then
-			error_and_exit "Could not install Centreon repository"
-		fi
-	else
-		log "INFO" "Centreon repository seems to be already installed"
+		error_and_exit "Could not install Centreon repository"
 	fi
 }
 #========= end of function install_centreon_repo()


### PR DESCRIPTION
## Description

remove usage of rpm centreon-release

**Fixes** MON-22572

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)