### PR TITLE
enh(ci): remove usage of rpm centreon-release

### DIFF
--- a/.github/docker/Dockerfile.centreon-web-centos7
+++ b/.github/docker/Dockerfile.centreon-web-centos7
@@ -27,9 +27,7 @@ innodb_log_file_size=4M
 innodb_fast_shutdown=0
 " > /etc/my.cnf.d/container.cnf
 
-curl -Lo centreon-release.rpm "https://yum.centreon.com/standard/21.10/el7/stable/noarch/RPMS/centreon-release-21.10-5.el7.centos.noarch.rpm"
-yum install -y centreon-release.rpm
-rm -f centreon-release.rpm
+yum-config-manager --add-repo https://packages.centreon.com/rpm-standard/21.10/el7/centreon-21.10.repo
 yum-config-manager --enable 'centreon-testing*'
 yum-config-manager --enable 'centreon-unstable*'
 

--- a/centreon-gorgone/docs/rebound_configuration.md
+++ b/centreon-gorgone/docs/rebound_configuration.md
@@ -63,7 +63,8 @@ gorgone:
 We have installed a CentOS 7 server. We install Gorgone daemon:
 
 ```shell
-yum install http://yum.centreon.com/standard/20.04/el7/stable/noarch/RPMS/centreon-release-20.04-1.el7.centos.noarch.rpm
+yum install yum-utils
+yum-config-manager --add-repo https://packages.centreon.com/rpm-standard/21.10/el7/centreon-21.10.repo
 yum install centreon-gorgone
 ```
 


### PR DESCRIPTION
## Description

remove usage of rpm centreon-release

**Fixes** MON-22572

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x (master)
