### PR TITLE
enh(LDAP):  filter syntax validation method appears erroneous

### DIFF
--- a/centreon/www/include/Administration/parameters/ldap/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/ldap/DB-Func.php
@@ -59,5 +59,5 @@ function minimalValue(int $value): bool
 function checkLdapFilterSyntax(string $filterValue): bool
 {
     return preg_match('/=%s\)/', $filterValue)
-        && preg_match('/^(\s*\((?:[&|](?1)+|(?:!(?1))|[a-zA-Z][a-zA-Z0-9-]*[<>~]?=[^()]*)\s*\)\s*)$/', $filterValue);
+        && preg_match('/.*/', $filterValue);
 }

--- a/centreon/www/include/Administration/parameters/ldap/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/ldap/DB-Func.php
@@ -58,6 +58,5 @@ function minimalValue(int $value): bool
  */
 function checkLdapFilterSyntax(string $filterValue): bool
 {
-    return preg_match('/=%s\)/', $filterValue)
-        && preg_match('/.*/', $filterValue);
+    return preg_match('/=%s\)/', $filterValue);
 }


### PR DESCRIPTION
## Description

Impossible to save the ldap form because of filter syntax error : 

**Fixes** # (MON-21663)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Login to the Centreon Platform

Go to Administration  >  Parameters  >  LDAP > edit the ldap config

Set this filter (&(samAccountName=%s)(objectClass=user)(!(UserAccountControl:1.2.840.113556.1.4.803:=2)))

And you should get an error syntax

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
