### PR TITLE
fix(gorgone): missing dependency on debian

### DIFF
--- a/centreon-gorgone/packaging/debian/control
+++ b/centreon-gorgone/packaging/debian/control
@@ -36,6 +36,7 @@ Depends:
   libauthen-simple-net-perl,
   libnet-curl-perl,
   libssh-session-perl,
+  libssh-4,
   libev-perl,
   libzmq-ffi-perl,
   sudo,


### PR DESCRIPTION
## Description

libssh-4 was missing in the debian packaging.

REFS: MON-22444

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
