### PR TITLE
fix(api/monitoring): move filter on resources with graph data in the request

### DIFF
--- a/centreon/src/Core/Resources/Application/Repository/ReadResourceRepositoryInterface.php
+++ b/centreon/src/Core/Resources/Application/Repository/ReadResourceRepositoryInterface.php
@@ -59,9 +59,4 @@ interface ReadResourceRepositoryInterface
      * @return ResourceEntity[]
      */
     public function findParentResourcesById(ResourceFilter $filter): array;
-
-    /**
-     * Get list of resources with graph data.
-     */
-    public function extractResourcesWithGraphData(): void;
 }

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -459,6 +459,11 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
             AND resources.parent_name NOT LIKE '\_Module\_BAM%'
             AND resources.enabled = 1 AND resources.type != 3";
 
+        // Apply only_with_performance_data
+        if ($filter->getOnlyWithPerformanceData() === true) {
+            $request .= ' AND resources.has_graph = 1';
+        }
+
         $request .= $accessGroupRequest;
 
         $request .= $this->addResourceParentIdSubRequest($filter, $collector);
@@ -562,12 +567,6 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         while ($resourceRecord = $statement->fetch(\PDO::FETCH_ASSOC)) {
             /** @var array<string,int|string|null> $resourceRecord */
             $this->resources[] = DbResourceFactory::createFromRecord($resourceRecord, $this->resourceTypes);
-        }
-
-        // Apply only_with_performance_data
-        if ($filter->getOnlyWithPerformanceData() === true) {
-            $this->extractResourcesWithGraphData();
-            $this->sqlRequestTranslator->getRequestParameters()->setTotal((int) count($this->resources));
         }
 
         $iconIds = $this->getIconIdsFromResources();

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -242,19 +242,6 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
     }
 
     /**
-     * Only return resources that has performance data available in order to display graphs.
-     */
-    public function extractResourcesWithGraphData(): void
-    {
-        $this->resources = array_values(
-            array_filter(
-                $this->resources,
-                static fn (ResourceEntity $resource) => $resource->hasGraph(),
-            )
-        );
-    }
-
-    /**
      * This adds the subrequest filter for tags (servicegroups, hostgroups).
      *
      * @param ResourceFilter $filter


### PR DESCRIPTION
## Description

To avoid user confusion in the number of returned resources when using only_with_performance_data filter, the resources are know filtered direclty in the request instead of afterwards.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
