### PR TITLE
enh(dashboards): allow widget edition without editing dashboard

### DIFF
--- a/centreon/www/front_src/src/Dashboards/Dashboard/Dashboard.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/Dashboard.cypress.spec.tsx
@@ -376,22 +376,22 @@ describe('Dashboard', () => {
   });
 
   describe('View mode', () => {
-    it('displays the widget form in view mode when the user has editor role and the user is not editing the dashboard', () => {
+    it('displays the widget form in editor mode when the user has editor role and the user is not editing the dashboard', () => {
       initializeAndMount(editorRoles);
 
       cy.contains(labelCancel).click();
 
-      cy.findAllByLabelText(labelMoreActions).eq(0).trigger('click');
+      cy.findAllByLabelText(labelMoreActions).eq(0).click();
 
-      cy.findByLabelText(labelViewProperties).click();
+      cy.findByLabelText(labelEditWidget).click();
 
-      cy.findByLabelText(labelWidgetType).should('be.disabled');
-      cy.findByLabelText(labelCancel).should('not.exist');
-      cy.findByLabelText(labelSave).should('not.exist');
+      cy.findByLabelText(labelWidgetType).should('be.enabled');
+      cy.findByLabelText(labelCancel).should('exist');
+      cy.findByLabelText(labelSave).should('exist');
 
       cy.findByLabelText('close').click();
 
-      cy.findByLabelText(labelWidgetType).should('not.exist');
+      cy.findByLabelText(labelWidgetType).should('exist');
 
       cy.makeSnapshot();
     });

--- a/centreon/www/front_src/src/Dashboards/Dashboard/Dashboard.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/Dashboard.cypress.spec.tsx
@@ -386,7 +386,6 @@ describe('Dashboard', () => {
       cy.findByLabelText(labelEditWidget).click();
 
       cy.findByLabelText(labelWidgetType).should('be.enabled');
-      cy.findByLabelText(labelSave).should('exist');
 
       cy.findByLabelText('close').click();
 

--- a/centreon/www/front_src/src/Dashboards/Dashboard/Dashboard.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/Dashboard.cypress.spec.tsx
@@ -386,7 +386,6 @@ describe('Dashboard', () => {
       cy.findByLabelText(labelEditWidget).click();
 
       cy.findByLabelText(labelWidgetType).should('be.enabled');
-      cy.findByLabelText(labelCancel).should('exist');
       cy.findByLabelText(labelSave).should('exist');
 
       cy.findByLabelText('close').click();

--- a/centreon/www/front_src/src/Dashboards/Dashboard/Layout/Panel/MorePanelActions.tsx
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/Layout/Panel/MorePanelActions.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useAtomValue } from 'jotai';
+import { useAtomValue, useAtom } from 'jotai';
 import { equals } from 'ramda';
 
 import { Menu } from '@mui/material';
@@ -48,8 +48,9 @@ const MorePanelActions = ({
 }: Props): JSX.Element => {
   const { t } = useTranslation();
 
+  const [, isEditing] = useAtom(isEditingAtom);
+
   const dashboard = useAtomValue(dashboardAtom);
-  const isEditing = useAtomValue(isEditingAtom);
 
   const { deleteWidget } = useDeleteWidgetModal();
 
@@ -58,6 +59,7 @@ const MorePanelActions = ({
   const { openModal } = useWidgetForm();
 
   const edit = (): void => {
+    isEditing(true);
     openModal(dashboard.layout.find((panel) => equals(panel.i, id)) || null);
     close();
   };
@@ -67,7 +69,7 @@ const MorePanelActions = ({
     close();
   };
 
-  const displayEditButtons = canEdit && isEditing;
+  const displayEditButtons = canEdit;
 
   const editActions = (openConfirmationTooltip): ActionsListActions => [
     {

--- a/centreon/www/front_src/src/Dashboards/Dashboard/Layout/Panel/MorePanelActions.tsx
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/Layout/Panel/MorePanelActions.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { useAtomValue, useAtom } from 'jotai';
+import { useAtomValue, useSetAtom } from 'jotai';
 import { equals } from 'ramda';
 
 import { Menu } from '@mui/material';
@@ -48,9 +48,8 @@ const MorePanelActions = ({
 }: Props): JSX.Element => {
   const { t } = useTranslation();
 
-  const [, isEditing] = useAtom(isEditingAtom);
-
   const dashboard = useAtomValue(dashboardAtom);
+  const setIsEditing = useSetAtom(isEditingAtom);
 
   const { deleteWidget } = useDeleteWidgetModal();
 
@@ -59,7 +58,7 @@ const MorePanelActions = ({
   const { openModal } = useWidgetForm();
 
   const edit = (): void => {
-    isEditing(true);
+    setIsEditing(true);
     openModal(dashboard.layout.find((panel) => equals(panel.i, id)) || null);
     close();
   };

--- a/centreon/www/front_src/src/Dashboards/Dashboard/Layout/Panel/PanelHeader.tsx
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/Layout/Panel/PanelHeader.tsx
@@ -9,7 +9,11 @@ import MoreVertIcon from '@mui/icons-material/MoreVert';
 
 import { IconButton, useDeepCompare } from '@centreon/ui';
 
-import { dashboardAtom, duplicatePanelDerivedAtom } from '../../atoms';
+import {
+  dashboardAtom,
+  duplicatePanelDerivedAtom,
+  isEditingAtom
+} from '../../atoms';
 import { labelMoreActions } from '../../translatedLabels';
 
 import { usePanelHeaderStyles } from './usePanelStyles';
@@ -33,9 +37,11 @@ const PanelHeader = ({
   const dashboard = useAtomValue(dashboardAtom);
   const duplicatePanel = useSetAtom(duplicatePanelDerivedAtom);
 
+  const setIsEditing = useSetAtom(isEditingAtom);
+
   const duplicate = (event): void => {
     event.preventDefault();
-
+    setIsEditing(true);
     duplicatePanel(id);
   };
 

--- a/centreon/www/front_src/src/Dashboards/Dashboard/hooks/useDeleteWidget.ts
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/hooks/useDeleteWidget.ts
@@ -1,6 +1,6 @@
 import { useSetAtom } from 'jotai';
 
-import { removePanelDerivedAtom } from '../atoms';
+import { removePanelDerivedAtom, isEditingAtom } from '../atoms';
 
 interface UseDeleteWidgetState {
   deleteWidget: (id: string) => () => void;
@@ -8,8 +8,10 @@ interface UseDeleteWidgetState {
 
 const useDeleteWidget = (): UseDeleteWidgetState => {
   const removePanel = useSetAtom(removePanelDerivedAtom);
+  const setIsEditing = useSetAtom(isEditingAtom);
 
   const deleteWidget = (id: string) => (): void => {
+    setIsEditing(true);
     removePanel(id);
   };
 


### PR DESCRIPTION
## Description

This PR Intends to allow widget edition without editing entire dashboard
![image](https://github.com/centreon/centreon/assets/61694165/67136eaf-ad08-437e-a40b-3bd8d009bf97)


**Fixes** # MON-22407

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

Create a dashboard
Add a widget
You should be able to edit the widget without clicking on Edit Dashboard

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
