### PR TITLE
fix(dashboard): Error 500 while no search parameters on top metrics listing

### DIFF
--- a/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
@@ -481,8 +481,8 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
             foreach ($this->subRequestsInformation as $subRequestInformation) {
                 $boundValues[] = $subRequestInformation['bindValues'];
             }
-            $boundValues = array_merge(...$boundValues);
         }
+        $boundValues = array_merge(...$boundValues);
         foreach ($boundValues as $bindToken => $bindValueInformation){
             foreach ($bindValueInformation as $bindValue => $paramType) {
                 $statement->bindValue($bindToken, $bindValue, $paramType);


### PR DESCRIPTION
## Description

this PR intends to fix an Error 500 while no search parameters on top metrics listing

**Fixes** # MON-24099

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x (master)

<h2> How this pull request can be tested ? </h2>

- Login to APIv2
- Call /monitoring/dashboard/metrics/top?metric_name=rta
- No 500 error should occurs

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
