### PR TITLE
fix(cloud notifications): Double display of configured resources and resources' count

### DIFF
--- a/centreon/src/Core/Notification/Infrastructure/Repository/DbHostGroupResourceRepository.php
+++ b/centreon/src/Core/Notification/Infrastructure/Repository/DbHostGroupResourceRepository.php
@@ -482,7 +482,7 @@ class DbHostGroupResourceRepository extends AbstractRepositoryRDB implements Not
         $concatenator = (new SqlConcatenator())
             ->defineSelect(
                 <<<'SQL'
-                    SELECT
+                    SELECT DISTINCT
                         rel.hg_id, hg.hg_name
                     SQL
             )->defineFrom(
@@ -530,7 +530,7 @@ class DbHostGroupResourceRepository extends AbstractRepositoryRDB implements Not
             ->defineSelect(
                 <<<'SQL'
                     SELECT
-                    notification_id, COUNT(rel.hg_id)
+                    notification_id, COUNT(DISTINCT rel.hg_id)
                     SQL
             )->defineFrom(
                 <<<'SQL'

--- a/centreon/src/Core/Notification/Infrastructure/Repository/DbServiceGroupResourceRepository.php
+++ b/centreon/src/Core/Notification/Infrastructure/Repository/DbServiceGroupResourceRepository.php
@@ -476,7 +476,7 @@ class DbServiceGroupResourceRepository extends AbstractRepositoryRDB implements 
         $concatenator = (new SqlConcatenator())
             ->defineSelect(
                 <<<'SQL'
-                    SELECT
+                    SELECT DISTINCT
                         rel.sg_id, sg.sg_name
                     SQL
             )->defineFrom(
@@ -524,7 +524,7 @@ class DbServiceGroupResourceRepository extends AbstractRepositoryRDB implements 
             ->defineSelect(
                 <<<'SQL'
                     SELECT
-                        notification_id, COUNT(rel.sg_id)
+                        notification_id, COUNT(DISTINCT rel.sg_id)
                     SQL
             )->defineFrom(
                 <<<'SQL'


### PR DESCRIPTION
## Description

Fixed double display of resources and resources' count when notification contact group contains configured contact. 

**Fixes** # MON-24160

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 21.10.x
- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
