### PR TITLE
fix(ci): avoid to go back after visiting centreon.com (#2474)

### DIFF
--- a/centreon/packaging/centreon.spectemplate
+++ b/centreon/packaging/centreon.spectemplate
@@ -428,6 +428,7 @@ sed -i 's#@VERSION@#%{version}#' centreon/selinux/*
 %{__cp} additional/centreon-apache-https.conf %buildroot%{_datadir}/centreon/examples/centreon.apache.https.conf
 
 # Copy base files.
+%{__rm} -rf centreon/www/front_src
 %{__cp} -r centreon/.env centreon/.env.local.php centreon/bootstrap.php centreon/composer.json centreon/composer.lock centreon/symfony.lock centreon/container.php centreon/package.json centreon/pnpm-lock.yaml centreon/pnpm-workspace.yaml centreon/config centreon/GPL_LIB centreon/api centreon/src centreon/vendor centreon/www %buildroot%{_datadir}/centreon/
 
 # Install configuration files.

--- a/centreon/tests/e2e/features/Dashboards/08-widget-generic-text-configuration/index.ts
+++ b/centreon/tests/e2e/features/Dashboards/08-widget-generic-text-configuration/index.ts
@@ -338,6 +338,5 @@ Then(
     cy.contains('Link to Centreon website').invoke('attr', 'target', '_self');
     cy.contains('Link to Centreon website').click({ force: true });
     cy.url().should('equal', 'https://www.centreon.com/');
-    cy.go('back');
   }
 );


### PR DESCRIPTION
## Description

avoid to go back after visiting centreon.com

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)