### PR TITLE
fix(packaging): set mode to central in centreontrapd.pm on debian

### DIFF
--- a/centreon/packaging/debian/centreon-web-common.postinst
+++ b/centreon/packaging/debian/centreon-web-common.postinst
@@ -3,6 +3,8 @@
 if [ "$1" = "configure" ] ; then
     update-alternatives --set php /usr/bin/php8.1
 
+    sed -i -e 's/mode => 1/mode => 0/g' /etc/centreon/centreontrapd.pm
+
     if [ -d /etc/centreon-broker ] && [ "$(getent passwd centreon-broker)" ]; then
         chown centreon-broker:centreon /etc/centreon-broker/*
     fi

--- a/centreon/packaging/debian/control
+++ b/centreon/packaging/debian/control
@@ -106,8 +106,10 @@ Description: This package add rights and default directories for a poller
 Package: centreon-web-common
 Architecture: all
 Depends:
+    centreon-poller-centreon-engine (>= ${centreon:version}~),
     centreon-common (>= ${centreon:version}~),
     centreon-perl-libs (>= ${centreon:version}~),
+    centreon-poller-centreon-engine (<< ${centreon:versionThreshold}~),
     centreon-common (<< ${centreon:versionThreshold}~),
     centreon-perl-libs (<< ${centreon:versionThreshold}~),
     php8.1,


### PR DESCRIPTION
## Description

set mode to central in centreontrapd.pm on debian

**Fixes** MON-21036

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)