### PR TITLE
enh(centreon cloud): Allow to manage groups and contacts

### DIFF
--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -44,6 +44,8 @@ class CentreonACL
     const ACL_ACCESS_READ_WRITE = 1;
     const ACL_ACCESS_READ_ONLY = 2;
 
+    const CUSTOMER_ADMIN_ACL = 'customer_admin_acl';
+
     private $userID; /* ID of the user */
     private $parentTemplates = null;
     public $admin; /* Flag that tells us if the user is admin or not */
@@ -2551,7 +2553,7 @@ class CentreonACL
     public function getContactAclConf($options = array())
     {
         $request = $this->constructRequest($options, true);
-        if ($this->admin) {
+        if ($this->admin || (isCloudPlatform() && \in_array(self::CUSTOMER_ADMIN_ACL, $this->accessGroups))) {
             $sql = $request['select'] . $request['fields'] . " "
                 . "FROM contact "
                 . $request['join']
@@ -2606,7 +2608,7 @@ class CentreonACL
         }
 
 
-        if ($this->admin) {
+        if ($this->admin || (isCloudPlatform() && \in_array(self::CUSTOMER_ADMIN_ACL, $this->accessGroups))) {
             $sql = $request['select'] . $request['fields'] . " "
                 . "FROM contactgroup cg " . $sJointure
                 . "WHERE (cg.cg_type = 'local' " . $ldapCondition . ") "

--- a/centreon/www/include/configuration/configObject/contactgroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contactgroup/DB-Func.php
@@ -199,6 +199,10 @@ function insertContactGroup($ret)
         $ret = $form->getSubmitValues();
     }
 
+    if (isCloudPlatform() && isset($ret['cg_acl_groups'])) {
+        unset($ret['cg_acl_groups']);
+    }
+
     $cgName = $centreon->checkIllegalChar(
         \HtmlAnalyzer::sanitizeAndRemoveTags($ret["cg_name"])
     );

--- a/centreon/www/include/configuration/configObject/contactgroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contactgroup/DB-Func.php
@@ -264,6 +264,10 @@ function updateContactGroup($cgId = null, $params = array())
         $ret = $form->getSubmitValues();
     }
 
+    if (isCloudPlatform() && isset($ret['cg_acl_groups'])) {
+        unset($ret['cg_acl_groups']);
+    }
+
     $cgName = $centreon->checkIllegalChar(
         \HtmlAnalyzer::sanitizeAndRemoveTags($ret["cg_name"])
     );

--- a/centreon/www/include/configuration/configObject/contactgroup/formContactGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/contactgroup/formContactGroup.ihtml
@@ -36,8 +36,10 @@
           </td>
         </tr>
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="members"> {$form.cg_contacts.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.cg_contacts.html}</p></td></tr>
-		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="acl_groups"> {$form.cg_acl_groups.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.cg_acl_groups.html}</p></td></tr>
-	 	
+		{if isset($form.cg_acl_groups)}
+			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="acl_groups"> {$form.cg_acl_groups.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.cg_acl_groups.html}</p></td></tr>
+	 	{/if}
+
 	 	<tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="2">
             <h4>{$form.header.furtherInfos}</h4>

--- a/centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+++ b/centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
@@ -135,8 +135,10 @@ $attrAclgroup1 = array_merge(
     $attrAclgroups,
     array('defaultDatasetRoute' => $aclRoute)
 );
-$form->addElement('select2', 'cg_acl_groups', _("Linked ACL groups"), array(), $attrAclgroup1);
 
+if (! isCloudPlatform()) {
+    $form->addElement('select2', 'cg_acl_groups', _("Linked ACL groups"), array(), $attrAclgroup1);
+}
 
 /*
  * Further informations
@@ -178,8 +180,8 @@ $tpl = initSmartyTpl($path, $tpl);
 $tpl->assign(
     "helpattr",
     'TITLE, "' . _("Help") . '", CLOSEBTN, true, FIX, [this, 0, 5], BGCOLOR, "#ffff99", BORDERCOLOR, '
-    . '"orange", TITLEFONTCOLOR, "black", TITLEBGCOLOR, "orange", CLOSEBTNCOLORS, ["","black", "white", "red"],'
-    . ' WIDTH, -300, SHADOW, true, TEXTALIGN, "justify"'
+        . '"orange", TITLEFONTCOLOR, "black", TITLEBGCOLOR, "orange", CLOSEBTNCOLORS, ["","black", "white", "red"],'
+        . ' WIDTH, -300, SHADOW, true, TEXTALIGN, "justify"'
 );
 # prepare help texts
 $helptext = "";


### PR DESCRIPTION
## Description

- Removed "Linked ACL Groups" from Create Contact Groups form in Cloud context
- Allowed to ACL group Administrators in Cloud context to access all contacts and contact groups

**Fixes** # MON-22680

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
