### PR TITLE
fix(test): update viewport before mounting panel edit component

### DIFF
--- a/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/specs/PanelEdit.cypress.spec.tsx
+++ b/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/specs/PanelEdit.cypress.spec.tsx
@@ -77,6 +77,10 @@ const initialize = ({
 }: {
   isBamModuleInstalled: boolean;
 }): void => {
+  cy.cssDisableMotion();
+
+  cy.viewport(1280, 590);
+
   cy.interceptAPIRequest({
     alias: 'getNotificationRequest',
     method: Method.GET,
@@ -105,13 +109,10 @@ const initialize = ({
     path: notificationEndpoint({}),
     response: { status: 'ok' }
   });
+
   cy.mount({
     Component: <PanelWithQueryProvider />
   });
-
-  cy.viewport(1280, 590);
-
-  cy.cssDisableMotion();
 };
 
 describe('Edit Panel', () => {


### PR DESCRIPTION
## Description

update viewport before mounting panel edit component in order to avoid these diff : 
![image](https://github.com/centreon/centreon/assets/11978823/b1db6659-6700-4b7d-8723-cf8dabf1fd3c)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)