### PR TITLE
fix(web): Avoid crash in partitioning script/cron if server is not compatible

### DIFF
--- a/centreon/bin/centreon-partitioning.php
+++ b/centreon/bin/centreon-partitioning.php
@@ -55,12 +55,9 @@ $centstorageDb = new CentreonDB('centstorage', 3);
 $partEngine = new PartEngine();
 
 if (!$partEngine->isCompatible($centstorageDb)) {
-    exitProcess(
-        PROCESS_ID,
-        1,
-        "[" . date(DATE_RFC822) . "] "
-        . "CRITICAL: MySQL server is not compatible with partitioning. MySQL version must be greater or equal to 5.1\n"
-    );
+    echo "[" . date(DATE_RFC822) . "] "
+         . "CRITICAL: MySQL server is not compatible with partitionning. MySQL version must be greater or equal to 5.1\n";
+    exit(1);
 }
 
 echo "[" . date(DATE_RFC822) . "] PARTITIONING STARTED\n";

--- a/centreon/cron/centreon-partitioning.php
+++ b/centreon/cron/centreon-partitioning.php
@@ -41,8 +41,6 @@ require_once _CENTREON_PATH_ . '/www/class/centreon-partition/config.class.php';
 require_once _CENTREON_PATH_ . '/www/class/centreon-partition/mysqlTable.class.php';
 require_once _CENTREON_PATH_ . '/www/class/centreon-partition/options.class.php';
 
-echo "[" . date(DATE_RFC822) . "] PARTITIONING STARTED\n";
-
 /* Create partitioned tables */
 $centreonDb = new CentreonDB('centreon');
 $centstorageDb = new CentreonDB('centstorage', 3);
@@ -53,6 +51,8 @@ if (!$partEngine->isCompatible($centstorageDb)) {
          . "CRITICAL: MySQL server is not compatible with partitionning. MySQL version must be greater or equal to 5.1\n";
     exit(1);
 }
+
+echo "[" . date(DATE_RFC822) . "] PARTITIONING STARTED\n";
 
 $tables = [
     'data_bin',

--- a/centreon/cron/centreon-partitioning.php
+++ b/centreon/cron/centreon-partitioning.php
@@ -49,12 +49,9 @@ $centstorageDb = new CentreonDB('centstorage', 3);
 $partEngine = new PartEngine();
 
 if (!$partEngine->isCompatible($centstorageDb)) {
-    exitProcess(
-        PROCESS_ID,
-        1,
-        "[" . date(DATE_RFC822) . "] "
-        . "CRITICAL: MySQL server is not compatible with partitionning. MySQL version must be greater or equal to 5.1\n"
-    );
+    echo "[" . date(DATE_RFC822) . "] "
+         . "CRITICAL: MySQL server is not compatible with partitionning. MySQL version must be greater or equal to 5.1\n";
+    exit(1);
 }
 
 $tables = [


### PR DESCRIPTION
This is a forward-port of https://github.com/centreon/centreon/pull/2392

## Description

fix(web): Avoid crash in partitioning script/cron if server is not compatible

There is no exitProcess function to be used in these scripts.

**Fixes** MON-18861

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Modify the script to simulate a not compatible db server : 

commented the `if (!$partEngine->isCompatible($centstorageDb)) {
`
and added if `($partEngine->isCompatible($centstorageDb)) {`

```
[root@avea-central-2210-env-test ~]# grep "isComp" /usr/share/centreon/cron/centreon-partitioning.php
//if (!$partEngine->isCompatible($centstorageDb)) {
if ($partEngine->isCompatible($centstorageDb)) {
```

Execute the script manually : 

`sudo -u centreon /usr/bin/php /usr/share/centreon/cron/centreon-partitioning.php`

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
