### PR TITLE
(fix:cloud notification) :[backport]selector hostgroups displays multiple same values

### DIFF
--- a/centreon/packages/ui/src/Form/Inputs/ConnectedAutocomplete.tsx
+++ b/centreon/packages/ui/src/Form/Inputs/ConnectedAutocomplete.tsx
@@ -25,7 +25,8 @@ const ConnectedAutocomplete = ({
   connectedAutocomplete,
   change,
   additionalMemoProps,
-  type
+  type,
+  disableSortedOptions = false
 }: InputPropsWithoutGroup): JSX.Element => {
   const { t } = useTranslation();
 
@@ -106,6 +107,7 @@ const ConnectedAutocomplete = ({
       <AutocompleteField
         dataTestId={dataTestId}
         disableClearable={false}
+        disableSortedOptions={disableSortedOptions}
         disabled={disabled}
         error={error}
         field={filterKey}

--- a/centreon/packages/ui/src/Form/Inputs/models.ts
+++ b/centreon/packages/ui/src/Form/Inputs/models.ts
@@ -52,6 +52,7 @@ export interface InputProps {
     Component: React.ComponentType<InputPropsWithoutGroup>;
   };
   dataTestId?: string;
+  disableSortedOptions?: boolean;
   fieldName: string;
   fieldsTable?: {
     additionalFieldsToMemoize?: Array<string>;

--- a/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/FormInputs/useFormInputs.tsx
+++ b/centreon/www/front_src/src/CloudNotificationsConfiguration/Panel/FormInputs/useFormInputs.tsx
@@ -102,7 +102,8 @@ const useFormInputs = ({
               additionalConditionParameters: [],
               endpoint: hostsGroupsEndpoint
             },
-            dataTestId: t(labelSearchHostGroups),
+            dataTestId: labelSearchHostGroups,
+            disableSortedOptions: true,
             fieldName: 'hostGroups.ids',
             label: t(labelSearchHostGroups),
             required: true,
@@ -166,7 +167,8 @@ const useFormInputs = ({
               additionalConditionParameters: [],
               endpoint: serviceGroupsEndpoint
             },
-            dataTestId: t(labelSearchServiceGroups),
+            dataTestId: labelSearchServiceGroups,
+            disableSortedOptions: true,
             fieldName: 'serviceGroups.ids',
             label: t(labelSearchServiceGroups),
             required: true,
@@ -207,6 +209,7 @@ const useFormInputs = ({
                     endpoint: businessViewsEndpoint
                   },
                   dataTestId: labelSearchBusinessViews,
+                  disableSortedOptions: true,
                   fieldName: 'businessviews.ids',
                   label: t(labelSearchBusinessViews),
                   required: true,


### PR DESCRIPTION
**Description**
backport to 23.10.x
**more information** : https://centreon.atlassian.net/jira/software/c/projects/MON/boards/211?assignee=61d809797c6f9800706f84a7&selectedIssue=MON-24325

**video**

https://github.com/centreon/centreon/assets/97687698/65da905e-8e83-4fc0-9162-07aed9905be3

