### PR TITLE
fix (symfony)!: Symfony console error when executing the clear:cache command

### DIFF
--- a/centreon/src/Core/Command/Application/UseCase/AddCommand/AddCommand.php
+++ b/centreon/src/Core/Command/Application/UseCase/AddCommand/AddCommand.php
@@ -143,15 +143,15 @@ final class AddCommand
         }
 
         return new NewCommand(
-            name: new TrimmedString($request->name),
-            commandLine: new TrimmedString($request->commandLine),
-            type: $request->type,
-            isShellEnabled: $request->isShellEnabled,
-            argumentExample: new TrimmedString($request->argumentExample),
-            arguments: $arguments,
-            macros: $macros,
-            connectorId: $request->connectorId,
-            graphTemplateId: $request->graphTemplateId,
+            new TrimmedString($request->name),
+            new TrimmedString($request->commandLine),
+            $request->type,
+            $request->isShellEnabled,
+            new TrimmedString($request->argumentExample),
+            $arguments,
+            $macros,
+            $request->connectorId,
+            $request->graphTemplateId,
         );
     }
 

--- a/centreon/src/Core/Command/Application/UseCase/AddCommand/AddCommand.php
+++ b/centreon/src/Core/Command/Application/UseCase/AddCommand/AddCommand.php
@@ -143,15 +143,15 @@ final class AddCommand
         }
 
         return new NewCommand(
-            new TrimmedString($request->name),
-            new TrimmedString($request->commandLine),
-            $request->type,
-            $request->isShellEnabled,
-            new TrimmedString($request->argumentExample),
-            $arguments,
-            $macros,
-            $request->connectorId,
-            $request->graphTemplateId,
+            name: new TrimmedString($request->name),
+            commandLine: new TrimmedString($request->commandLine),
+            isShellEnabled: $request->isShellEnabled,
+            type: $request->type,
+            argumentExample: new TrimmedString($request->argumentExample),
+            arguments: $arguments,
+            macros: $macros,
+            connectorId: $request->connectorId,
+            graphTemplateId: $request->graphTemplateId,
         );
     }
 

--- a/centreon/src/Core/Command/Domain/Model/NewCommand.php
+++ b/centreon/src/Core/Command/Domain/Model/NewCommand.php
@@ -38,8 +38,8 @@ class NewCommand
     /**
      * @param TrimmedString $name
      * @param TrimmedString $commandLine
-     * @param CommandType $type
      * @param bool $isShellEnabled
+     * @param CommandType $type
      * @param TrimmedString $argumentExample
      * @param Argument[] $arguments
      * @param NewCommandMacro[] $macros
@@ -51,8 +51,8 @@ class NewCommand
     public function __construct(
         private readonly TrimmedString $name,
         private readonly TrimmedString $commandLine,
-        private readonly CommandType $type = CommandType::Check,
         private readonly bool $isShellEnabled = false,
+        private readonly CommandType $type = CommandType::Check,
         private readonly TrimmedString $argumentExample = new TrimmedString(''),
         private readonly array $arguments = [],
         private readonly array $macros = [],

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboardResponse.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboardResponse.php
@@ -42,6 +42,7 @@ final class FindDashboardResponse
 
     public \DateTimeImmutable $updatedAt;
 
+    /** @var array<PanelResponseDto> */
     public array $panels = [];
 
     public DashboardSharingRole $ownRole = DashboardSharingRole::Viewer;

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboardResponse.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboardResponse.php
@@ -28,29 +28,29 @@ use Core\Dashboard\Domain\Model\Role\DashboardSharingRole;
 
 final class FindDashboardResponse
 {
-    /**
-     * @param int $id
-     * @param string $name
-     * @param string $description
-     * @param UserResponseDto|null $createdBy
-     * @param UserResponseDto|null $updatedBy
-     * @param \DateTimeImmutable $createdAt
-     * @param \DateTimeImmutable $updatedAt
-     * @param array<PanelResponseDto> $panels
-     * @param DashboardSharingRole $ownRole
-     * @param RefreshResponseDto $refresh
-     */
-    public function __construct(
-        public int $id = 0,
-        public string $name = '',
-        public string $description = '',
-        public ?UserResponseDto $createdBy = null,
-        public ?UserResponseDto $updatedBy = null,
-        public \DateTimeImmutable $createdAt = new \DateTimeImmutable(),
-        public \DateTimeImmutable $updatedAt = new \DateTimeImmutable(),
-        public array $panels = [],
-        public DashboardSharingRole $ownRole = DashboardSharingRole::Viewer,
-        public RefreshResponseDto $refresh = new RefreshResponseDto(),
-    ) {
+    public int $id = 0;
+
+    public string $name = '';
+
+    public string $description = '';
+
+    public ?UserResponseDto $createdBy = null;
+
+    public ?UserResponseDto $updatedBy = null;
+
+    public \DateTimeImmutable $createdAt;
+
+    public \DateTimeImmutable $updatedAt;
+
+    public array $panels = [];
+
+    public DashboardSharingRole $ownRole = DashboardSharingRole::Viewer;
+
+    public RefreshResponseDto $refresh;
+
+    public function __construct() {
+        $this->createdAt = new \DateTimeImmutable();
+        $this->updatedAt = new \DateTimeImmutable();
+        $this->refresh = new RefreshResponseDto();
     }
 }


### PR DESCRIPTION
## Description

When the .env.local.php file contains the APP_DEBUG property with the value true, running the Symfony console with the clear:cache command generates an error (**Unable to dump a service container if a parameter is an object or a resource.**)

**Fixes** # MON-24284

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
