### PR TITLE
fix(sql): queries not supported on Mysql 8.0 [23.10]

### DIFF
--- a/centreon/src/Core/Host/Infrastructure/Repository/DbReadHostRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbReadHostRepository.php
@@ -103,7 +103,7 @@ use Utility\SqlConcatenator;
  *     check_timeperiod_name: string|null,
  *     notification_timeperiod_id: int|null,
  *     notification_timeperiod_name: string|null,
- *     severity_id: string|null,
+ *     severity_id: int|null,
  *     severity_name: string|null,
  *     monitoring_server_id: int,
  *     monitoring_server_name: string,
@@ -459,8 +459,26 @@ class DbReadHostRepository extends AbstractRepositoryRDB implements ReadHostRepo
                 ctime.tp_name AS check_timeperiod_name,
                 ntime.tp_id AS notification_timeperiod_id,
                 ntime.tp_name AS notification_timeperiod_name,
-                GROUP_CONCAT(sev.hc_id ORDER BY sev.level ASC LIMIT 1)  AS severity_id,
-                GROUP_CONCAT(sev.hc_name ORDER BY sev.level ASC LIMIT 1)  AS severity_name,
+                (
+                    SELECT sev.hc_id
+                    FROM `:db`.hostcategories sev
+                    INNER JOIN `:db`.hostcategories_relation hcr
+                            ON sev.hc_id = hcr.hostcategories_hc_id
+                    WHERE sev.level IS NOT NULL
+                      AND hcr.host_host_id = h.host_id {$hostSeveritiesAcl}
+                    ORDER BY sev.level, sev.hc_id
+                    LIMIT 1
+                ) AS severity_id,
+                (
+                    SELECT sev.hc_name
+                    FROM `:db`.hostcategories sev
+                    INNER JOIN `:db`.hostcategories_relation hcr
+                            ON sev.hc_id = hcr.hostcategories_hc_id
+                    WHERE sev.level IS NOT NULL
+                      AND hcr.host_host_id = h.host_id {$hostSeveritiesAcl}
+                    ORDER BY sev.level, sev.hc_id
+                    LIMIT 1
+                ) AS severity_name,
                 ns.id AS monitoring_server_id,
                 ns.name AS monitoring_server_name,
                 GROUP_CONCAT(DISTINCT hc.hc_id) AS category_ids,
@@ -469,9 +487,6 @@ class DbReadHostRepository extends AbstractRepositoryRDB implements ReadHostRepo
             FROM `:db`.host h {$aclQuery}
             LEFT JOIN `:db`.hostcategories_relation hcr
                 ON hcr.host_host_id = h.host_id
-            LEFT JOIN `:db`.hostcategories sev
-                ON sev.hc_id = hcr.hostcategories_hc_id
-                AND sev.level IS NOT NULL {$hostSeveritiesAcl}
             LEFT JOIN `:db`.hostcategories hc
                 ON hc.hc_id = hcr.hostcategories_hc_id
                 AND hc.level IS NULL {$hostCategoriesAcl}


### PR DESCRIPTION
## Description

Backport of #2558 

Jira: :label: **MON-24423**

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x (master)


## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
