### PR TITLE
fix(Extension) : Issue of modules dependencies on install/update

### DIFF
--- a/centreon/src/CentreonModule/Infrastructure/Source/ModuleSource.php
+++ b/centreon/src/CentreonModule/Infrastructure/Source/ModuleSource.php
@@ -372,7 +372,9 @@ class ModuleSource extends SourceAbstract
             $dependencies[] = $dependency;
 
             $dependencyDetails = $this->getDetail($dependency);
-
+            if (! $dependencyDetails){
+                throw ModuleException::moduleIsMissing($dependency);
+            }
             $dependencies = array_unique([
                 ...$this->getSortedDependencies($dependencyDetails->getId(), $alreadyProcessed),
                 ...$dependencies,


### PR DESCRIPTION
## Description

PHP 500 error when trying to install/update a module having a dependency not present

**Fixes** # (MON-24538)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Load centreon-cloud-extensions-alma9:develop pr centreon-cloud-extensions-alma9:dev-23.10.x

- uninstall CCE

- reintall CCE

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
