### PR TITLE
fix(test): assert resource columns filter is visible before snapshot

### DIFF
--- a/centreon/www/front_src/src/Resources/Listing/ResourceListing.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/ResourceListing.cypress.spec.tsx
@@ -684,6 +684,7 @@ describe('Notification column', () => {
 
     cy.findByTestId('Add columns').click();
 
+    cy.findByText('Severity (S)').should('exist');
     cy.findByText('Notification (Notif)').should('not.exist');
 
     cy.makeSnapshot();


### PR DESCRIPTION
## Description

assert resource columns filter is visible before snapshot

this avoid following failure :
![image](https://github.com/centreon/centreon/assets/11978823/9dbbc11c-d6f4-4574-bd62-8c514e3c2928)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)