### PR TITLE
fix(test): assert resource columns filter is visible before snapshot

### DIFF
--- a/centreon/www/front_src/src/Resources/Listing/ResourceListing.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/ResourceListing.cypress.spec.tsx
@@ -664,6 +664,8 @@ describe('Notification column', () => {
     );
     interceptRequestsAndMountBeforeEach();
 
+    cy.waitFiltersAndListingRequests();
+
     cy.contains('E0').should('be.visible');
 
     cy.findByTestId('Add columns').click();
@@ -680,10 +682,13 @@ describe('Notification column', () => {
     );
     interceptRequestsAndMountBeforeEach();
 
+    cy.waitFiltersAndListingRequests();
+
     cy.contains('E0').should('be.visible');
 
     cy.findByTestId('Add columns').click();
 
+    cy.findByText('Severity (S)').should('exist');
     cy.findByText('Notification (Notif)').should('not.exist');
 
     cy.makeSnapshot();


### PR DESCRIPTION
## Description

assert resource columns filter is visible before snapshot (#2623)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)