### PR TITLE
fix(cloud): allow one host selection for cloud form for service

### DIFF
--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -3338,3 +3338,28 @@ function getPollersForConfigChangeFlagFromServiceId(int $serviceId): array
     $hostIds = findHostsForConfigChangeFlagFromServiceIds([$serviceId]);
     return findPollersForConfigChangeFlagFromHostIds($hostIds);
 }
+
+/**
+ * Find all the host IDs for which the service is bound
+ *
+ * @param int $serviceid
+ * @return int[]
+ */
+function findHostsOfService(int $serviceId): array
+{
+    global $pearDB;
+    $statement = $pearDB->prepare(
+        'SELECT host.host_id
+        FROM host
+        INNER JOIN host_service_relation hsr
+          ON hsr.host_host_id = host.host_id
+        WHERE hsr.service_service_id = :service_id'
+    );
+    $statement->bindValue(':service_id', $serviceId, \PDO::PARAM_INT);
+    $statement->execute();
+    $hostIds = [];
+    while (($hostId = $statement->fetchColumn(0)) !== false) {
+        $hostIds[] = $hostId;
+    }
+    return $hostIds;
+}

--- a/centreon/www/include/configuration/configObject/service/formService.php
+++ b/centreon/www/include/configuration/configObject/service/formService.php
@@ -97,6 +97,13 @@ $attributes = [
         'multiple' => true,
         'linkedObject' => 'centreonHost',
     ],
+    'hosts_cloud_specific' => [
+        'datasourceOrigin' => 'ajax',
+        'availableDatasetRoute' => $datasetRoutes['hosts'],
+        'defaultDatasetRoute' => $datasetRoutes['default_hosts'],
+        'multiple' => false,
+        'linkedObject' => 'centreonHost',
+    ],
     'host_groups' => [
         'datasourceOrigin' => 'ajax',
         'availableDatasetRoute' => $datasetRoutes['host_groups'],
@@ -784,12 +791,28 @@ if ($o === SERVICE_MASSIVE_CHANGE) {
 
 $sgReadOnly = false;
 if ($form_service_type === 'BYHOST') {
-    if (isset($service['service_hPars']) && count($service['service_hPars']) > 1) {
-        $sgReadOnly = true;
-    }
+    if ($isCloudPlatform) {
+        if ($service_id !== false) {
+            $hostsBounded = findHostsOfService($service_id);
+            $defaultDataset = (! empty($hostsBounded))
+            ? ['0' => $hostsBounded[0]]
+            : [];
+        };
+        $form->addElement(
+            'select2',
+            'service_hPars',
+            _('Host'),
+            [],
+            array_merge($attributes['hosts_cloud_specific'], ['defaultDataset' => $defaultDataset])
+        );
+    } else {
+        if (isset($service['service_hPars']) && count($service['service_hPars']) > 1) {
+            $sgReadOnly = true;
+        }
 
-    $form->addElement('select2', 'service_hPars', _('Hosts'), [], $attributes['hosts']);
-    $serviceHParsFieldIsAdded = true;
+        $form->addElement('select2', 'service_hPars', _('Hosts'), [], $attributes['hosts']);
+        $serviceHParsFieldIsAdded = true;
+    }
 }
 
 if ($form_service_type === 'BYHOSTGROUP') {


### PR DESCRIPTION
🏷️ MON-24727

This PR intends to retrieve a behaviour from the cloud forms. In cloud platforms it is possible to link only one host to a service.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
