### PR TITLE
[MBI] In the table mod_bi_tmp_today_servicemetrics, use the same type as defined in mod_bi_servicemetrics

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/mbi/libs/bi/BIMetric.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/mbi/libs/bi/BIMetric.pm
@@ -153,7 +153,7 @@ sub createTodayTable {
 	
 	$db->query({ query => "DROP TABLE IF EXISTS `".$self->{"today_table"}."`" });
 	my $query = "CREATE TABLE `" . $self->{"today_table"} . "` (";
-	$query .= "`id` INT NOT NULL,";
+	$query .= "`id` BIGINT(20) UNSIGNED NOT NULL,";
 	$query .= "`metric_id` int(11) NOT NULL,";
 	$query .= "`metric_name` varchar(255) NOT NULL,";
 	$query .= "`sc_id` int(11) NOT NULL,";


### PR DESCRIPTION
## Description

We take data in the table mod_bi_servicemetrics and put them into mod_bi_tmp_today_servicemetrics.
The problem is that we don't use the same type for the id field so we have to change it.
The table is recreated each night so it will be fixed by a simple gorgone update.

**Fixes** MON-24657

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)
