### PR TITLE
enh(command): add command migration script

### DIFF
--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -35,6 +35,7 @@ services:
         resource: '../../src/Core/*'
         exclude:
             - '../../src/Core/Media/*'
+            - '../../src/Core/Command/*'
         bind:
             $isCloudPlatform: '%env(bool:IS_CLOUD_PLATFORM)%'
 

--- a/centreon/phpstan.core.neon
+++ b/centreon/phpstan.core.neon
@@ -66,6 +66,8 @@ parameters:
                 - src/Core/Common/Infrastructure/Repository/FileDataStoreEngine.php
                 - src/Core/Media/Infrastructure/Command/MigrateAllMedias/MigrateAllMediasCommand.php
                 - src/Core/Media/Application/UseCase/MigrateAllMedias/MigrateAllMedias.php
+                - src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsCommand.php
+                - src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommands.php
 
         - # [CENTREON-RULE]: The class is extended or mocked. MUST be used only as a baseline.
             reportUnmatched: false
@@ -90,6 +92,7 @@ parameters:
                 - src/Core/Tag/RealTime/Application/UseCase/FindTag/FindTagResponse.php
                 - src/Core/Media/Application/UseCase/AddMedia/AddMedia.php
                 - src/Core/Media/Application/UseCase/MigrateAllMedias/MigrateAllMedias.php
+                - src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommands.php
 
           # 👇👇 Software architecture problem MUST be fixed !!! Only here as a baseline 👇👇
         - # [CENTREON-RULE]: Domain must not call Application or Infrastructure namespaces.

--- a/centreon/src/Core/Command/Application/Repository/ReadCommandRepositoryInterface.php
+++ b/centreon/src/Core/Command/Application/Repository/ReadCommandRepositoryInterface.php
@@ -93,10 +93,21 @@ interface ReadCommandRepositoryInterface
      * @param RequestParametersInterface $requestParameters
      * @param CommandType[] $commandTypes
      *
+     * @throws \Throwable
+     *
      * @return Command[]
      */
     public function findByRequestParameterAndTypes(
         RequestParametersInterface $requestParameters,
         array $commandTypes
     ): array;
+
+    /**
+     * Find all commands.
+     *
+     * @throws \Throwable
+     *
+     * @return \Iterator<int,Command>&\Countable
+     */
+    public function findAll(): \Iterator&\Countable;
 }

--- a/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/CommandRecordedDto.php
+++ b/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/CommandRecordedDto.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Application\UseCase\MigrateAllCommands;
+
+class CommandRecordedDto
+{
+    public int $sourceId = 0;
+
+    public int $targetId = 0;
+
+    public string $name = '';
+}

--- a/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommands.php
+++ b/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommands.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Application\UseCase\MigrateAllCommands;
+
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
+use Core\Command\Application\Repository\WriteCommandRepositoryInterface;
+use Core\Command\Domain\Model\Command;
+use Core\Command\Domain\Model\NewCommand;
+use Psr\Log\LoggerInterface;
+
+final class MigrateAllCommands
+{
+    private MigrateAllCommandsResponse $response;
+
+    public function __construct(
+        readonly private ReadCommandRepositoryInterface $readCommandRepository,
+        readonly private WriteCommandRepositoryInterface $writeCommandRepository,
+        readonly private LoggerInterface $logger,
+    ) {
+        $this->response = new MigrateAllCommandsResponse();
+    }
+
+    public function __invoke(MigrateAllCommandsPresenterInterface $presenter): void
+    {
+        try {
+            $commands = $this->readCommandRepository->findAll();
+
+            $this->migrateCommands($commands, $this->response);
+
+            $presenter->presentResponse($this->response);
+        } catch (\Throwable $ex) {
+            $this->logger->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+            $presenter->presentResponse(new ErrorResponse($ex->getMessage()));
+        }
+    }
+
+    /**
+     * @param \Iterator<int,Command>&\Countable $commands
+     * @param MigrateAllCommandsResponse $response
+     */
+    private function migrateCommands(\Iterator&\Countable $commands, MigrateAllCommandsResponse $response): void
+    {
+        $response->results = new class(
+            $commands,
+            $this->writeCommandRepository,
+            $this->logger,
+        ) implements \Iterator, \Countable
+        {
+            /**
+             * @param \Iterator<int,Command>&\Countable $commands
+             * @param WriteCommandRepositoryInterface $writeCommandRepository
+             * @param LoggerInterface $logger
+             */
+            public function __construct(
+                readonly private \Iterator&\Countable $commands,
+                readonly private WriteCommandRepositoryInterface $writeCommandRepository,
+                readonly private LoggerInterface $logger
+            ) {
+            }
+
+            /**
+             * @return CommandRecordedDto|MigrationErrorDto
+             */
+            public function current(): CommandRecordedDto|MigrationErrorDto
+            {
+                /** @var Command $command */
+                $command = $this->commands->current();
+                try {
+                    if ($command->isLocked() || ! $command->isActivated()) {
+                        $this->logger->debug(
+                            'Command disabled or locked, skip migration',
+                            ['command_id' => $command->getId()]
+                        );
+
+                        throw new \Exception('Command disabled or locked');
+                    }
+                    $targetNewCommandId = $this->writeCommandRepository->add(NewCommand::createFromCommand($command));
+                    $status = new CommandRecordedDto();
+                    $status->targetId = $targetNewCommandId;
+                    $status->sourceId = $command->getId();
+                    $status->name = $command->getName();
+
+                    return $status;
+                } catch (\Throwable $ex) {
+                    $status = new MigrationErrorDto();
+                    $status->id = $command->getId();
+                    $status->name = $command->getName();
+                    $status->reason = $ex->getMessage();
+
+                    return $status;
+                }
+            }
+
+            public function next(): void
+            {
+                $this->commands->next();
+            }
+
+            public function key(): int
+            {
+                return $this->commands->key();
+            }
+
+            public function valid(): bool
+            {
+                return $this->commands->key() < $this->commands->count();
+            }
+
+            public function rewind(): void
+            {
+                $this->commands->rewind();
+            }
+
+            public function count(): int
+            {
+                return $this->commands->count();
+            }
+        };
+    }
+}

--- a/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsPresenterInterface.php
+++ b/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsPresenterInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Application\UseCase\MigrateAllCommands;
+
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+interface MigrateAllCommandsPresenterInterface
+{
+    public function presentResponse(MigrateAllCommandsResponse|ResponseStatusInterface $response): void;
+}

--- a/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsResponse.php
+++ b/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Application\UseCase\MigrateAllCommands;
+
+final class MigrateAllCommandsResponse
+{
+    /** @var \Iterator<CommandRecordedDto|MigrationErrorDto> */
+    public \Iterator $results;
+
+    public function __construct()
+    {
+        $this->results = new \ArrayIterator([]);
+    }
+}

--- a/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrationErrorDto.php
+++ b/centreon/src/Core/Command/Application/UseCase/MigrateAllCommands/MigrationErrorDto.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Application\UseCase\MigrateAllCommands;
+
+class MigrationErrorDto
+{
+    public int $id = 0;
+
+    public string $name = '';
+
+    public string $reason = '';
+}

--- a/centreon/src/Core/Command/Domain/Model/NewCommand.php
+++ b/centreon/src/Core/Command/Domain/Model/NewCommand.php
@@ -25,6 +25,7 @@ namespace Core\Command\Domain\Model;
 
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
+use Core\CommandMacro\Domain\Model\CommandMacro;
 use Core\CommandMacro\Domain\Model\NewCommandMacro;
 use Core\Common\Domain\TrimmedString;
 use Core\MonitoringServer\Model\MonitoringServer;
@@ -128,5 +129,30 @@ class NewCommand
     public function getGraphTemplateId(): ?int
     {
         return $this->graphTemplateId;
+    }
+
+    /**
+     * @param Command $command
+     *
+     * @throws AssertionFailedException
+     *
+     * @return NewCommand
+     */
+    public static function createFromCommand(Command $command): self
+    {
+        return new self(
+            name: new TrimmedString($command->getName()),
+            commandLine: new TrimmedString($command->getCommandLine()),
+            isShellEnabled: $command->isShellEnabled(),
+            type: $command->getType(),
+            argumentExample: new TrimmedString($command->getArgumentExample()),
+            arguments: $command->getArguments(),
+            macros: array_map(
+                fn(CommandMacro $macro) => NewCommandMacro::createFromMacro($macro),
+                $command->getMacros()
+            ),
+            connectorId: $command->getConnector()?->getId(),
+            graphTemplateId: $command->getGraphTemplate()?->getId(),
+        );
     }
 }

--- a/centreon/src/Core/Command/Infrastructure/Command/Exception/CommandMigrationCommandException.php
+++ b/centreon/src/Core/Command/Infrastructure/Command/Exception/CommandMigrationCommandException.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Infrastructure\Command\Exception;
+
+class CommandMigrationCommandException extends \Exception
+{
+    /**
+     * @return self
+     */
+    public static function contactNotFound(): self
+    {
+        return new self(_('Contact not found'));
+    }
+}

--- a/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsCommand.php
+++ b/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Infrastructure\Command\MigrateAllCommands;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Domain\Option\Interfaces\OptionRepositoryInterface;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommands;
+use Core\Command\Infrastructure\Repository\ApiWriteCommandRepository;
+use Core\Common\Infrastructure\Command\AbstractMigrationCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class MigrateAllCommandsCommand extends AbstractMigrationCommand
+{
+    use LoggerTrait;
+
+    protected static $defaultName = 'command:all';
+
+    protected static $defaultDescription = 'Migrate all commands from the current platform to the defined target platform';
+
+    public function __construct(
+        OptionRepositoryInterface $optionRepository,
+        readonly private ApiWriteCommandRepository $apiWriteCommandRepository,
+        readonly private MigrateAllCommands $useCase,
+    ) {
+        parent::__construct($optionRepository);
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument(
+            'target-url',
+            InputArgument::REQUIRED,
+            "The target platform base url to connect to the API (ex: 'http://localhost')"
+        );
+        $this->setHelp(
+            "Migrates all commands to the target platform.\r\n"
+            . 'However the commands migration command will not replace commands that already exists on the target platform.'
+        );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $this->setStyle($output);
+            $proxy = $this->getProxy();
+            if ($proxy !== null && $proxy !== '') {
+                $this->apiWriteCommandRepository->setProxy($proxy);
+            }
+            if (is_string($target = $input->getArgument('target-url'))) {
+                $this->apiWriteCommandRepository->setUrl($target);
+            } else {
+                // Theoretically it should never happen
+                throw new \InvalidArgumentException('target-url is not a string');
+            }
+            $token = $this->askAuthenticationToken(self::TARGET_PLATFORM, $input, $output);
+
+            $this->apiWriteCommandRepository->setAuthenticationToken($token);
+            ($this->useCase)(new MigrateAllCommandsPresenter($output));
+        } catch (\Throwable $ex) {
+            $this->writeError($ex->getMessage(), $output);
+
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsPresenter.php
+++ b/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsPresenter.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Infrastructure\Command\MigrateAllCommands;
+
+use Core\Application\Common\UseCase\CliAbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Command\Application\UseCase\MigrateAllCommands\CommandRecordedDto;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommandsPresenterInterface;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommandsResponse;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrationErrorDto;
+
+class MigrateAllCommandsPresenter extends CliAbstractPresenter
+    implements MigrateAllCommandsPresenterInterface
+{
+    public function presentResponse(MigrateAllCommandsResponse|ResponseStatusInterface $response): void
+    {
+        if ($response instanceof ResponseStatusInterface) {
+            $this->error($response->getMessage());
+        } else {
+            foreach ($response->results as $result) {
+                if ($result instanceof CommandRecordedDto) {
+                    $this->write("<ok>   OK</>  {$result->name} => source:{$result->sourceId} / target:{$result->targetId}");
+                } elseif ($result instanceof MigrationErrorDto) {
+                    $this->write("<error>ERROR</>  {$result->name}/{$result->id} ({$result->reason})");
+                }
+            }
+        }
+    }
+}

--- a/centreon/src/Core/Command/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Command/Infrastructure/Configuration/symfony.yaml
@@ -1,0 +1,33 @@
+# parameters:
+services:
+    _defaults:
+        public: false
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, controller...
+
+    _instanceof:
+        Symfony\Component\Console\Command\Command:
+            tags: ['script.command']
+
+    Core\Command\:
+        resource: '../../../../Core/Command/*'
+
+    Core\Command\Infrastructure\Repository\DbReadCommandRepository:
+        arguments:
+            $logger: '@Centreon\Domain\Log\Logger'
+
+    Core\Command\Application\Repository\WriteCommandRepositoryInterface:
+        class: Core\Command\Infrastructure\Repository\DbWriteCommandRepository
+
+    Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommands:
+        arguments:
+            $writeCommandRepository: '@Core\Command\Infrastructure\Repository\ApiWriteCommandRepository'
+
+    Core\Command\Application\UseCase\AddCommand\AddCommand:
+        arguments:
+            $writeCommandRepository: '@Core\Command\Infrastructure\Repository\DbWriteCommandRepository'
+
+    Core\Command\Infrastructure\Repository\ApiWriteCommandRepository:
+        calls:
+        - method: setApiTimeOut
+          arguments: [ '%curl.timeout%' ]

--- a/centreon/src/Core/Command/Infrastructure/Repository/ApiWriteCommandRepository.php
+++ b/centreon/src/Core/Command/Infrastructure/Repository/ApiWriteCommandRepository.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Command\Infrastructure\Repository;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Command\Application\Repository\WriteCommandRepositoryInterface;
+use Core\Command\Domain\Model\Argument;
+use Core\Command\Domain\Model\NewCommand;
+use Core\Command\Infrastructure\Model\CommandTypeConverter;
+use Core\CommandMacro\Domain\Model\NewCommandMacro;
+use Core\Common\Infrastructure\Repository\RepositoryTrait;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ApiWriteCommandRepository implements WriteCommandRepositoryInterface
+{
+    use LoggerTrait;
+    use RepositoryTrait;
+
+    private ?string $proxy = null;
+
+    private ?string $url = null;
+
+    private string $authenticationToken = '';
+
+    private int $timeout = 60; // Default timeout
+
+    public function __construct(readonly private HttpClientInterface $httpClient)
+    {
+    }
+
+    public function setProxy(string $proxy): void
+    {
+        $this->proxy = $proxy;
+    }
+
+    public function setUrl(string $url): void
+    {
+        $this->url = rtrim($url, DIRECTORY_SEPARATOR);
+        if (! str_starts_with($this->url, 'http')) {
+            $this->url = 'https://' . $this->url;
+        }
+    }
+
+    public function setAuthenticationToken(string $token): void
+    {
+        $this->authenticationToken = $token;
+    }
+
+    public function setApiTimeOut(int $timeout): void
+    {
+        $this->timeout = $timeout;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function add(NewCommand $command): int
+    {
+        $apiEndpoint = $this->url . DIRECTORY_SEPARATOR . 'centreon/api/latest/configuration/commands';
+        $options = [
+            'verify_peer' => true,
+            'verify_host' => true,
+            'timeout' => $this->timeout,
+        ];
+        if ($this->proxy !== null) {
+            $options['proxy'] = $this->proxy;
+            $this->debug('Adding command using proxy');
+        }
+
+        $options['headers'] = [
+            'Content-Type: application/json',
+            'X-AUTH-TOKEN: ' . $this->authenticationToken,
+        ];
+        $options['body'] = json_encode([
+            'name' => $command->getName(),
+            'type' => CommandTypeConverter::toInt($command->getType()),
+            'command_line' => $command->getCommandLine(),
+            'is_shell' => $command->isShellEnabled(),
+            'argument_example' => $this->emptyStringAsNull($command->getArgumentExample()),
+            'arguments' => array_map(
+                fn(Argument $arg) => [
+                    'name' => $arg->getName(),
+                    'description' => $this->emptyStringAsNull($arg->getDescription()),
+                ],
+                $command->getArguments(),
+            ),
+            'macros' => array_map(
+                fn(NewCommandMacro $cmd) => [
+                    'name' => $cmd->getName(),
+                    'type' => $cmd->getType(),
+                    'description' => $this->emptyStringAsNull($cmd->getDescription()),
+                ],
+                $command->getMacros(),
+            ),
+            'connector_id' => $command->getConnectorId(),
+            'graph_template_id' => $command->getGraphTemplateId(),
+        ]);
+
+        if ($options['body'] === false) {
+            $this->debug('Error when encoding request body');
+
+            throw new \Exception('Request error: unable to encode body');
+        }
+
+        $response = $this->httpClient->request('POST', $apiEndpoint, $options);
+
+        if ($response->getStatusCode() !== 201) {
+            /**
+             * @var array{message:string} $content
+             */
+            $content = $response->toArray(false);
+            $this->debug('API error', [
+                'http_code' => $response->getStatusCode(),
+                'message' => $content['message'],
+            ]);
+
+            throw new \Exception(sprintf('Request error: %s', $content['message']), $response->getStatusCode());
+        }
+
+        return (int) $response->toArray()['id'];
+    }
+}

--- a/centreon/src/Core/Command/Infrastructure/Repository/DbReadCommandRepository.php
+++ b/centreon/src/Core/Command/Infrastructure/Repository/DbReadCommandRepository.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace Core\Command\Infrastructure\Repository;
 
 use Assert\AssertionFailedException;
-use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
 use Centreon\Domain\RequestParameters\RequestParameters;
 use Centreon\Infrastructure\DatabaseConnection;
@@ -40,6 +39,7 @@ use Core\Common\Domain\SimpleEntity;
 use Core\Common\Domain\TrimmedString;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
 use Core\Common\Infrastructure\RequestParameters\Normalizer\BoolToIntegerNormalizer;
+use Psr\Log\LoggerInterface;
 use Utility\SqlConcatenator;
 
 /**
@@ -60,12 +60,13 @@ use Utility\SqlConcatenator;
  */
 class DbReadCommandRepository extends AbstractRepositoryRDB implements ReadCommandRepositoryInterface
 {
-    use LoggerTrait;
+    private const MAX_ITEMS_BY_REQUEST = 100;
 
     /**
      * @param DatabaseConnection $db
+     * @param LoggerInterface $logger
      */
-    public function __construct(DatabaseConnection $db)
+    public function __construct(DatabaseConnection $db, readonly private LoggerInterface $logger)
     {
         $this->db = $db;
     }
@@ -75,7 +76,7 @@ class DbReadCommandRepository extends AbstractRepositoryRDB implements ReadComma
      */
     public function exists(int $commandId): bool
     {
-        $this->info(sprintf('Check existence of command with ID #%d', $commandId));
+        $this->logger->info(sprintf('Check existence of command with ID #%d', $commandId));
 
         $request = $this->translateDbName(
             <<<'SQL'
@@ -96,7 +97,7 @@ class DbReadCommandRepository extends AbstractRepositoryRDB implements ReadComma
      */
     public function existsByIdAndCommandType(int $commandId, CommandType $commandType): bool
     {
-        $this->info(
+        $this->logger->info(
             sprintf(
                 'Check existence of command with ID #%d and type %s',
                 $commandId,
@@ -294,6 +295,204 @@ class DbReadCommandRepository extends AbstractRepositoryRDB implements ReadComma
         }
 
         return $commands;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findAll(): \Iterator&\Countable {
+        $this->logger->debug(sprintf('Loading commands in blocks of %d elements', self::MAX_ITEMS_BY_REQUEST));
+
+        return new class (
+            $this->db,
+            self::MAX_ITEMS_BY_REQUEST,
+            $this->createCommand(...),
+            $this->findArgumentsByCommandId(...),
+            $this->findMacrosByCommandId(...),
+            $this->logger
+        )   extends AbstractRepositoryRDB
+            implements \Iterator, \Countable
+        {
+            /** @var callable */
+            protected $createCommand;
+
+            /** @var callable */
+            protected $findArguments;
+
+            /** @var callable */
+            protected $findMacros;
+
+            private int $position = 0;
+
+            private int $requestIndex = 0;
+
+            private int $totalItems = 0;
+
+            private false|\PDOStatement $statement = false;
+
+            /**
+             * @var false|array{
+             *     command_id: int,
+             *     command_name: string,
+             *     command_line: string,
+             *     command_example?: string|null,
+             *     command_type: int,
+             *     enable_shell: int,
+             *     command_activate: string,
+             *     command_locked: int,
+             *     connector_id?: int|null,
+             *     connector_name?: string|null,
+             *     graph_template_id?: int|null,
+             *     graph_template_name?: string|null,
+             * }
+             */
+            private false|array $currentItem;
+
+            public function __construct(
+                protected DatabaseConnection $db,
+                readonly private int $maxItemByRequest,
+                callable $createCommand,
+                callable $findArguments,
+                callable $findMacros,
+                readonly private LoggerInterface $logger
+            ) {
+                $this->createCommand = $createCommand;
+                $this->findArguments = $findArguments;
+                $this->findMacros = $findMacros;
+            }
+
+            public function current(): Command
+            {
+                return $this->createCommandWithArgumentsAndMacros();
+            }
+
+            public function next(): void
+            {
+                $this->position++;
+                if (! $this->statement || ($nextItem = $this->statement->fetch()) === false) {
+                    if ($this->valid()) {
+                        // There are still items to be retrieved
+                        $this->requestIndex += $this->maxItemByRequest;
+                        $this->loadDatabase();
+                    }
+                } else {
+                    /**
+                     * @var array{
+                     *     command_id: int,
+                     *     command_name: string,
+                     *     command_line: string,
+                     *     command_example?: string|null,
+                     *     command_type: int,
+                     *     enable_shell: int,
+                     *     command_activate: string,
+                     *     command_locked: int,
+                     *     connector_id?: int|null,
+                     *     connector_name?: string|null,
+                     *     graph_template_id?: int|null,
+                     *     graph_template_name?: string|null,
+                     * } $nextItem
+                     */
+                    $this->currentItem = $nextItem;
+                }
+            }
+
+            public function key(): int
+            {
+                return $this->position;
+            }
+
+            public function valid(): bool
+            {
+                return $this->position < $this->totalItems;
+            }
+
+            public function rewind(): void
+            {
+                $this->position = 0;
+                $this->requestIndex = 0;
+                $this->totalItems = 0;
+                $this->loadDatabase();
+            }
+
+            public function count(): int
+            {
+                if (! $this->statement) {
+                    $request = <<<'SQL'
+                        SELECT COUNT(*)
+                        FROM `:db`.command
+                        SQL;
+
+                    $this->statement = $this->db->query($this->translateDbName($request))
+                        ?: throw new \Exception('Impossible to retrieve a PDO Statement');
+                    $this->totalItems = (int) $this->statement->fetchColumn();
+                }
+
+                return $this->totalItems;
+            }
+
+            private function loadDatabase(): void
+            {
+                $this->logger->debug(
+                    sprintf(
+                        'Loading commands from %d/%d',
+                        $this->requestIndex,
+                        $this->maxItemByRequest
+                    )
+                );
+                $request = <<<'SQL'
+                    SELECT SQL_CALC_FOUND_ROWS
+                        command_id,
+                        command_name,
+                        command_line,
+                        command_type,
+                        enable_shell,
+                        command_activate,
+                        command_locked
+                    FROM `:db`.command
+                    ORDER BY command_id
+                    LIMIT :from, :max_item_by_request
+                    SQL;
+
+                $this->statement = $this->db->prepare($this->translateDbName($request));
+                $this->statement->bindValue(':from', $this->requestIndex, \PDO::PARAM_INT);
+                $this->statement->bindValue(':max_item_by_request', $this->maxItemByRequest, \PDO::PARAM_INT);
+                $this->statement->setFetchMode(\PDO::FETCH_ASSOC);
+                $this->statement->execute();
+
+                $result = $this->db->query('SELECT FOUND_ROWS()');
+
+                if ($result !== false && ($total = $result->fetchColumn()) !== false) {
+                    $this->totalItems = (int) $total;
+                }
+                /**
+                 * @var false|array{
+                 *     command_id: int,
+                 *     command_name: string,
+                 *     command_line: string,
+                 *     command_example?: string|null,
+                 *     command_type: int,
+                 *     enable_shell: int,
+                 *     command_activate: string,
+                 *     command_locked: int,
+                 *     connector_id?: int|null,
+                 *     connector_name?: string|null,
+                 *     graph_template_id?: int|null,
+                 *     graph_template_name?: string|null,
+                 * } $result
+                 */
+                $result = $this->statement->fetch();
+                $this->currentItem = $result;
+            }
+
+            private function createCommandWithArgumentsAndMacros(): Command
+            {
+                $command = ($this->createCommand)($this->currentItem);
+                $command->setArguments(($this->findArguments)($command->getId()));
+                $command->setMacros(($this->findMacros)($command->getId()));
+
+                return $command;
+            }
+        };
     }
 
     /**

--- a/centreon/src/Core/CommandMacro/Domain/Model/NewCommandMacro.php
+++ b/centreon/src/Core/CommandMacro/Domain/Model/NewCommandMacro.php
@@ -78,4 +78,13 @@ class NewCommandMacro
         Assertion::maxLength($description, self::MAX_DESCRIPTION_LENGTH, "{$this->shortName}::description");
         $this->description = $description;
     }
+
+    public static function createFromMacro(CommandMacro $macro): self
+    {
+        return new self(
+            $macro->getType(),
+            $macro->getName(),
+            $macro->getDescription()
+        );
+    }
 }

--- a/centreon/src/Core/Media/Infrastructure/Repository/DbReadMediaRepository.php
+++ b/centreon/src/Core/Media/Infrastructure/Repository/DbReadMediaRepository.php
@@ -187,7 +187,6 @@ class DbReadMediaRepository extends AbstractRepositoryRDB implements ReadMediaRe
 
                     $this->statement = $this->db->query($this->translateDbName($request))
                         ?: throw new \Exception('Impossible to retrieve a PDO Statement');
-                    $this->statement->execute();
                     $this->totalItems = (int) $this->statement->fetchColumn();
                 }
 

--- a/centreon/tests/php/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsTest.php
+++ b/centreon/tests/php/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommandsTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Tests\Core\Command\Application\UseCase\MigrateAllCommands;
+
+use Core\Command\Application\Repository\ReadCommandRepositoryInterface;
+use Core\Command\Application\Repository\WriteCommandRepositoryInterface;
+use Core\Command\Application\UseCase\MigrateAllCommands\CommandRecordedDto;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommands;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommandsResponse;
+use Core\Command\Domain\Model\Command;
+use Psr\Log\LoggerInterface;
+use Tests\Core\Command\Infrastructure\Command\MigrateAllCommands\MigrateAllCommandsPresenterStub;
+
+beforeEach(function (): void {
+    $this->readCommandRepository = $this->createMock(ReadCommandRepositoryInterface::class);
+    $this->writeCommandRepository = $this->createMock(WriteCommandRepositoryInterface::class);
+    $this->logger = $this->createMock(LoggerInterface::class);
+
+    $this->useCase = new MigrateAllCommands($this->readCommandRepository, $this->writeCommandRepository, $this->logger);
+    $this->presenter = new MigrateAllCommandsPresenterStub();
+});
+
+it('should present a MigrateAllCommandsResponse', function (): void{
+    $commandA = new Command(1, 'command-name A', 'command line A');
+    $commandB = new Command(2, 'command-name B', 'command line B');
+    $this->readCommandRepository
+        ->expects($this->once())
+        ->method('findAll')
+        ->willReturn(new \ArrayIterator([$commandA, $commandB]));
+
+    ($this->useCase)($this->presenter);
+    $firstResponseCommand = $this->presenter->response->results->current();
+    expect($this->presenter->response)
+        ->toBeInstanceOf(MigrateAllCommandsResponse::class)
+        ->and($firstResponseCommand->name)
+        ->tobe('command-name A');
+
+    $this->presenter->response->results->next();
+
+    /** @var CommandRecordedDto $secondeResponseCommand */
+    $secondeResponseCommand = $this->presenter->response->results->current();
+    expect($this->presenter->response)
+        ->toBeInstanceOf(MigrateAllCommandsResponse::class)
+        ->and($secondeResponseCommand->name)
+        ->tobe('command-name B');
+});

--- a/centreon/tests/php/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsPresenterStub.php
+++ b/centreon/tests/php/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsPresenterStub.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Tests\Core\Command\Infrastructure\Command\MigrateAllCommands;
+
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommandsPresenterInterface;
+use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommandsResponse;
+
+class MigrateAllCommandsPresenterStub implements MigrateAllCommandsPresenterInterface
+{
+    public ResponseStatusInterface|MigrateAllCommandsResponse $response;
+
+    public function presentResponse(MigrateAllCommandsResponse|ResponseStatusInterface $response): void
+    {
+        $this->response = $response;
+    }
+}


### PR DESCRIPTION
## Description

New  command to migrate command between to platforms:
```
php /usr/share/centreon/bin/migration command:all {target_url}
```

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
