### PR TITLE
fix(api): service group update on PartialUpdateServiceTemplate

### DIFF
--- a/centreon/src/Core/ServiceGroup/Application/Repository/WriteServiceGroupRepositoryInterface.php
+++ b/centreon/src/Core/ServiceGroup/Application/Repository/WriteServiceGroupRepositoryInterface.php
@@ -62,11 +62,4 @@ interface WriteServiceGroupRepositoryInterface
      */
     public function unlink(array $serviceGroupRelations): void;
 
-    /**
-     * Delete all relations for given serviceGroup IDs
-     * (only works for relation with serviceTemplate(s)).
-     *
-     * @param int ...$serviceGroupIds
-     */
-    public function deleteRelations(int ...$serviceGroupIds): void;
 }

--- a/centreon/src/Core/ServiceGroup/Application/Repository/WriteServiceGroupRepositoryInterface.php
+++ b/centreon/src/Core/ServiceGroup/Application/Repository/WriteServiceGroupRepositoryInterface.php
@@ -61,5 +61,4 @@ interface WriteServiceGroupRepositoryInterface
      * @throws \Throwable
      */
     public function unlink(array $serviceGroupRelations): void;
-
 }

--- a/centreon/src/Core/ServiceGroup/Infrastructure/Repository/DbWriteServiceGroupRepository.php
+++ b/centreon/src/Core/ServiceGroup/Infrastructure/Repository/DbWriteServiceGroupRepository.php
@@ -95,38 +95,6 @@ class DbWriteServiceGroupRepository extends AbstractRepositoryRDB implements Wri
     /**
      * @inheritDoc
      */
-    public function deleteRelations(int ...$serviceGroupIds) : void
-    {
-        if ($serviceGroupIds === []) {
-            return;
-        }
-        $serviceGroupIds = array_unique($serviceGroupIds);
-        $fields = '';
-        foreach (array_keys($serviceGroupIds) as $index) {
-            $fields .= ($fields === '' ? '' : ', ') . ':id_' . $index;
-        }
-
-        $statement = $this->db->prepare(
-            $this->translateDbName(<<<SQL
-                DELETE rel FROM `:db`.`servicegroup_relation` rel
-                INNER JOIN `:db`.service srv
-                    ON srv.service_id = rel.service_service_id
-                WHERE rel.servicegroup_sg_id IN ({$fields})
-                    AND srv.service_register = '0'
-                    AND rel.hostgroup_hg_id IS NULL
-                SQL
-            )
-        );
-        foreach ($serviceGroupIds as $index => $id) {
-            $statement->bindValue(':id_' . $index, $id, \PDO::PARAM_INT);
-        }
-
-        $statement->execute();
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function link(array $serviceGroupRelations): void
     {
         if ($serviceGroupRelations === []) {

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
@@ -47,6 +47,7 @@ use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryIn
 use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\ServiceCategory;
+use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface;
 use Core\ServiceGroup\Application\Repository\WriteServiceGroupRepositoryInterface;
 use Core\ServiceSeverity\Application\Repository\ReadServiceSeverityRepositoryInterface;
 use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
@@ -83,6 +84,7 @@ beforeEach(closure: function (): void {
     $this->performanceGraphRepository = $this->createMock(ReadPerformanceGraphRepositoryInterface::class);
     $this->imageRepository = $this->createMock(ReadViewImgRepositoryInterface::class);
     $this->writeServiceGroupRepository = $this->createMock(WriteServiceGroupRepositoryInterface::class);
+    $this->readServiceGroupRepository = $this->createMock(ReadServiceGroupRepositoryInterface::class);
     $this->optionService = $this->createMock(OptionService::class);
 
     $this->parametersValidation = $this->createMock(ParametersValidation::class);
@@ -104,6 +106,7 @@ beforeEach(closure: function (): void {
         $this->writeServiceMacroRepository,
         $this->readCommandMacroRepository,
         $this->writeServiceGroupRepository,
+        $this->readServiceGroupRepository,
         $this->parametersValidation,
         $this->contact,
         $this->dataStorageEngine,
@@ -288,9 +291,14 @@ it('should present a ErrorResponse when an error occurs during service groups li
         ->with($request->id)
         ->willReturn(new ServiceTemplate(1, 'fake_name', 'fake_alias'));
 
-    $this->writeServiceGroupRepository
+    $this->contact
+        ->expects($this->exactly(2))
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceGroupRepository
         ->expects($this->once())
-        ->method('deleteRelations')
+        ->method('findByService')
         ->willThrowException(new Exception());
 
     ($this->useCase)($request, $this->presenter);


### PR DESCRIPTION
## Description

Fix service group relation update in PartialUpdateServiceTemplate:
- it's impossible to remove a serviceGroup (SG) relation to a  serviceTemplate (ST)
- relations to all STs are removed from the SGs linked to the ST being updated.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
