### PR TITLE
enh(ci): display container logs when api tests fail

### DIFF
--- a/.github/workflows/newman.yml
+++ b/.github/workflows/newman.yml
@@ -371,6 +371,10 @@ jobs:
               exit 1
           fi
 
+      - name: Display container logs
+        if: failure()
+        run: docker logs $CONTAINER_NAME
+
       - name: Upload HTML Reports
         if: failure()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
## Description

display container logs when api tests fail

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)