### PR TITLE
enh(chore): disable scan on release branches (#2654)

### DIFF
--- a/.github/workflows/veracode-analysis.yml
+++ b/.github/workflows/veracode-analysis.yml
@@ -61,7 +61,7 @@ jobs:
           elif [[ $CHECK_BRANCH == "merge" && -n '${{ github.head_ref }}' && '${{ github.head_ref }}' =~ ^release-[2-9][0-9].[0-9][0-9]-next ]]; then
             # e.g release-23.04-next
             FAIL_BUILD="false"
-            DEVELOPMENT_STAGE="Testing"
+            DEVELOPMENT_STAGE="Development"
             DISPLAY_SUMMARY="false"
           else
             FAIL_BUILD="${{ vars.VERACODE_QUALITY_GATE }}"

--- a/.github/workflows/veracode-analysis.yml
+++ b/.github/workflows/veracode-analysis.yml
@@ -49,11 +49,18 @@ jobs:
         run: |
           CHECK_BRANCH=`echo "${{ github.ref_name }}" | cut -d'/' -f2`
           if [[ $CHECK_BRANCH != "merge" && '${{ github.event_name }}' != 'pull_request' && '${{ inputs.stability }}' == 'stable' ]]; then
+            # e.g master
             FAIL_BUILD="false"
             DEVELOPMENT_STAGE="Release"
             DISPLAY_SUMMARY="false"
           elif [[ $CHECK_BRANCH != "merge" && '${{ github.event_name }}' != 'pull_request' && '${{ inputs.stability }}' == 'unstable' ]]; then
+            # e.g develop
             FAIL_BUILD="${{ vars.VERACODE_QUALITY_GATE }}"
+            DEVELOPMENT_STAGE="Testing"
+            DISPLAY_SUMMARY="false"
+          elif [[ $CHECK_BRANCH == "merge" && -n '${{ github.head_ref }}' && '${{ github.head_ref }}' =~ ^release-[2-9][0-9].[0-9][0-9]-next ]]; then
+            # e.g release-23.04-next
+            FAIL_BUILD="false"
             DEVELOPMENT_STAGE="Testing"
             DISPLAY_SUMMARY="false"
           else
@@ -61,14 +68,11 @@ jobs:
             DEVELOPMENT_STAGE="Development"
             DISPLAY_SUMMARY="true"
           fi
+
           echo "fail_build=$FAIL_BUILD" >> $GITHUB_OUTPUT
           echo "development_stage=$DEVELOPMENT_STAGE" >> $GITHUB_OUTPUT
           echo "display_summary=$DISPLAY_SUMMARY" >> $GITHUB_OUTPUT
-
-          echo "[INFO] - fail_build = $FAIL_BUILD"
-          echo "[INFO] - development_stage = $DEVELOPMENT_STAGE"
-          echo "[INFO] - display_summary = $DISPLAY_SUMMARY"
-          echo "[INFO] - check if PR branch = $CHECK_BRANCH"
+          cat $GITHUB_OUTPUT
 
   pipeline-scan:
     needs: [build]


### PR DESCRIPTION
## Description

disable veracode analysis on release branches

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)
