### PR TITLE
fix(dependencies): fixed version of perl-uuid to 0.30

### DIFF
--- a/.github/workflows/perl-cpan-libraries.yml
+++ b/.github/workflows/perl-cpan-libraries.yml
@@ -144,6 +144,7 @@ jobs:
             version: "0.53"
           - name: "UUID"
             use_dh_make_perl: "false"
+            version: "0.30"
           - name: "ZMQ::Constants"
             build_distribs: "el9,bullseye"
           - name: "ZMQ::FFI"


### PR DESCRIPTION
## Description

fixed version of perl-uuid to 0.30

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)