### PR TITLE
enh(dashboard): remove version column from dashboard_widgets table

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Platform/PlatformRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Platform/PlatformRepositoryRDB.php
@@ -83,9 +83,10 @@ class PlatformRepositoryRDB extends AbstractRepositoryDRB implements PlatformRep
         }
 
         $dashboardWidgetsRequest = $this->translateDbName('SELECT `name`, `version` FROM `:db`.dashboard_widgets');
+        $version = $this->getWebVersion();
         if (($statement = $this->db->query($dashboardWidgetsRequest)) !== false) {
             while ($result = $statement->fetch(\PDO::FETCH_ASSOC)) {
-                $versions[(string) $result['name']] = (string) $result['version'];
+                $versions[(string) $result['name']] = $version;
             }
         }
 

--- a/centreon/src/Centreon/Infrastructure/Platform/PlatformRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Platform/PlatformRepositoryRDB.php
@@ -82,7 +82,7 @@ class PlatformRepositoryRDB extends AbstractRepositoryDRB implements PlatformRep
             }
         }
 
-        $dashboardWidgetsRequest = $this->translateDbName('SELECT `name`, `version` FROM `:db`.dashboard_widgets');
+        $dashboardWidgetsRequest = $this->translateDbName('SELECT `name` FROM `:db`.dashboard_widgets');
         $version = $this->getWebVersion();
         if (($statement = $this->db->query($dashboardWidgetsRequest)) !== false) {
             while ($result = $statement->fetch(\PDO::FETCH_ASSOC)) {

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2634,7 +2634,6 @@ CREATE TABLE IF NOT EXISTS `dashboard_contactgroup_relation` (
 CREATE TABLE IF NOT EXISTS `dashboard_widgets` (
   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
-  `version` varchar(255) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -1488,14 +1488,14 @@ VALUES (1, 4);
 INSERT INTO provider_configuration (`type`, `name`, `custom_configuration`, `is_active`, `is_forced`)
 VALUES ('saml', 'SAML', '{"remote_login_url":"","entity_id_url":"","certificate":"","user_id_attribute":"","logout_from":false,"logout_from_url":null,"auto_import":false,"contact_template_id":null,"email_bind_attribute":null,"fullname_bind_attribute":null,"authentication_conditions":{"is_enabled":false,"attribute_path":"","authorized_values":[]},"roles_mapping":{"is_enabled":false,"apply_only_first_role":false,"attribute_path":""},"groups_mapping":{"is_enabled":false,"attribute_path":""}}', 0, 0);
 
-INSERT INTO dashboard_widgets (`name`, `version`)
-VALUES ('centreon-widget-generictext', '23.10.0');
+INSERT INTO dashboard_widgets (`name`)
+VALUES ('centreon-widget-generictext');
 
-INSERT INTO dashboard_widgets (`name`, `version`)
-VALUES ('centreon-widget-singlemetric', '23.10.0');
+INSERT INTO dashboard_widgets (`name`)
+VALUES ('centreon-widget-singlemetric');
 
-INSERT INTO dashboard_widgets (`name`, `version`)
-VALUES ('centreon-widget-graph', '23.10.0');
+INSERT INTO dashboard_widgets (`name`)
+VALUES ('centreon-widget-graph');
 
-INSERT INTO dashboard_widgets (`name`, `version`)
-VALUES ('centreon-widget-topbottom', '23.10.0');
+INSERT INTO dashboard_widgets (`name`)
+VALUES ('centreon-widget-topbottom');

--- a/centreon/www/install/php/Update-23.10.2.php
+++ b/centreon/www/install/php/Update-23.10.2.php
@@ -110,8 +110,20 @@ $createDashboardsPlaylistTables = function(CentreonDB $pearDB) use (&$errorMessa
     );
 };
 
+$dropColumnVersionFromDashboardWidgetsTable = function(CentreonDB $pearDB): void {
+    if($pearDB->isColumnExist('dashboard_widgets', 'version')) {
+        $pearDB->query(
+            <<<'SQL'
+                    ALTER TABLE dashboard_widgets
+                    DROP COLUMN `version`
+                SQL
+        );
+    }
+};
+
 try {
     $createDashboardsPlaylistTables($pearDB);
+    $dropColumnVersionFromDashboardWidgetsTable($pearDB);
 } catch (\Exception $e) {
 
     $centreonLog->insertLog(

--- a/centreon/www/install/php/Update-24.04.0.php
+++ b/centreon/www/install/php/Update-24.04.0.php
@@ -211,6 +211,17 @@ $alterAclResourceGroupRelation = function (CentreonDB $pearDB) {
     }
 };
 
+$dropColumnVersionFromDashboardWidgetsTable = function(CentreonDB $pearDB): void {
+    if($pearDB->isColumnExist('dashboard_widgets', 'version')) {
+        $pearDB->query(
+            <<<'SQL'
+                    ALTER TABLE dashboard_widgets
+                    DROP COLUMN `version`
+                SQL
+        );
+    }
+};
+
 try {
     $createDashboardsPlaylistTables($pearDB);
 
@@ -224,6 +235,8 @@ try {
 
     $errorMessage = 'Unable to add column order to acl_res_group_relations table';
     $alterAclResourceGroupRelation($pearDB);
+
+    $dropColumnVersionFromDashboardWidgetsTable($pearDB);
 
     // Tansactional queries
     if (! $pearDB->inTransaction()) {


### PR DESCRIPTION
## Description

this PR intends to  remove version column from dashboard_widgets table

**Fixes** # MON-24909

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
