### PR TITLE
enh(UI): Display a no preview message on map

### DIFF
--- a/centreon/www/front_src/src/Dashboards/Dashboard/Layout/Panel/Panel.tsx
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/Layout/Panel/Panel.tsx
@@ -13,7 +13,6 @@ import FederatedComponent from '../../../../components/FederatedComponents';
 import { editProperties } from '../../hooks/useCanEditDashboard';
 import useSaveDashboard from '../../hooks/useSaveDashboard';
 import { isGenericText, isRichTextEditorEmpty } from '../../utils';
-import { widgetFormInitialDataAtom } from '../../AddEditWidget/atoms';
 
 import { usePanelHeaderStyles } from './usePanelStyles';
 
@@ -33,7 +32,6 @@ const Panel = ({ id, refreshCount }: Props): JSX.Element => {
   );
   const refreshInterval = useAtomValue(dashboardRefreshIntervalAtom);
   const isEditing = useAtomValue(isEditingAtom);
-  const widgetFormInitialData = useAtomValue(widgetFormInitialDataAtom);
   const setPanelOptions = useSetAtom(setPanelOptionsAndDataDerivedAtom);
 
   const { canEditField } = editProperties.useCanEditProperties();
@@ -77,7 +75,6 @@ const Panel = ({ id, refreshCount }: Props): JSX.Element => {
               globalRefreshInterval={refreshInterval}
               id={id}
               isEditingDashboard={isEditing}
-              isEditingWidget={!!widgetFormInitialData}
               panelData={panelOptionsAndData?.data}
               panelOptions={panelOptionsAndData?.options}
               path={panelConfigurations.path}

--- a/centreon/www/front_src/src/Dashboards/Dashboard/Layout/Panel/Panel.tsx
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/Layout/Panel/Panel.tsx
@@ -13,6 +13,7 @@ import FederatedComponent from '../../../../components/FederatedComponents';
 import { editProperties } from '../../hooks/useCanEditDashboard';
 import useSaveDashboard from '../../hooks/useSaveDashboard';
 import { isGenericText, isRichTextEditorEmpty } from '../../utils';
+import { widgetFormInitialDataAtom } from '../../AddEditWidget/atoms';
 
 import { usePanelHeaderStyles } from './usePanelStyles';
 
@@ -32,6 +33,7 @@ const Panel = ({ id, refreshCount }: Props): JSX.Element => {
   );
   const refreshInterval = useAtomValue(dashboardRefreshIntervalAtom);
   const isEditing = useAtomValue(isEditingAtom);
+  const widgetFormInitialData = useAtomValue(widgetFormInitialDataAtom);
   const setPanelOptions = useSetAtom(setPanelOptionsAndDataDerivedAtom);
 
   const { canEditField } = editProperties.useCanEditProperties();
@@ -74,7 +76,8 @@ const Panel = ({ id, refreshCount }: Props): JSX.Element => {
               canEdit={canEditField}
               globalRefreshInterval={refreshInterval}
               id={id}
-              isEditing={isEditing}
+              isEditingDashboard={isEditing}
+              isEditingWidget={!!widgetFormInitialData}
               panelData={panelOptionsAndData?.data}
               panelOptions={panelOptionsAndData?.options}
               path={panelConfigurations.path}

--- a/centreon/www/front_src/src/federatedModules/Load/index.tsx
+++ b/centreon/www/front_src/src/federatedModules/Load/index.tsx
@@ -39,7 +39,8 @@ export const Remote = ({
   const Component = useMemo(
     () =>
       lazy(() =>
-        equals(window.Cypress?.testingType, 'component')
+        equals(window.Cypress?.testingType, 'component') &&
+        process.env.NODE_ENV !== 'production'
           ? import(`www/widgets/src/${moduleFederationName}`)
           : importRemote({
               bustRemoteEntryCache: false,


### PR DESCRIPTION
## Description

This displays a no preview on map widget

<img width="888" alt="Screenshot 2023-11-22 at 15 49 56" src="https://github.com/centreon/centreon/assets/12515407/781a0f05-87b2-4078-b7cd-197a4d747f7d">

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
