### PR TITLE
[WIP] enh(dashboards): add uuid to dashboard metrics listing and top bottom widget

### DIFF
--- a/centreon/doc/API/v24.04/Configuration/Dashboard/Schema/Dashboard.MetricsPerformances.yaml
+++ b/centreon/doc/API/v24.04/Configuration/Dashboard/Schema/Dashboard.MetricsPerformances.yaml
@@ -8,6 +8,10 @@ properties:
     type: string
     description: concatenation of host name and service name
     example: Printers_Ping
+  uuid:
+    type: string
+    description: UUID of the resource
+    example: h24-s16
   metrics:
     type: array
     items:

--- a/centreon/doc/API/v24.04/Configuration/Dashboard/Schema/Dashboard.MetricsTop.yaml
+++ b/centreon/doc/API/v24.04/Configuration/Dashboard/Schema/Dashboard.MetricsTop.yaml
@@ -25,6 +25,10 @@ properties:
           type: number
           description: "ID of the service"
           example: 1
+        uuid:
+          type: string
+          description: "UUID of the resource"
+          example: "h16-s24"
         name:
           type: string
           description: concatenation of host name and service name

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindMetricsTop/FindMetricsTop.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindMetricsTop/FindMetricsTop.php
@@ -120,6 +120,7 @@ final class FindMetricsTop
             $metric = $resourceMetric->getMetrics()[0];
             $metricInformation->serviceId = $resourceMetric->getServiceId();
             $metricInformation->resourceName = $resourceMetric->getResourceName();
+            $metricInformation->parentId = $resourceMetric->getParentId();
             $metricInformation->currentValue = $metric->getCurrentValue();
             $metricInformation->warningHighThreshold = $metric->getWarningHighThreshold();
             $metricInformation->criticalHighThreshold = $metric->getCriticalHighThreshold();

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindMetricsTop/Response/MetricInformationDto.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindMetricsTop/Response/MetricInformationDto.php
@@ -29,6 +29,8 @@ class MetricInformationDto
 
     public string $resourceName = '';
 
+    public int $parentId = 0;
+
     public ?float $currentValue = null;
 
     public ?float $warningHighThreshold = null;

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetrics/FindPerformanceMetrics.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetrics/FindPerformanceMetrics.php
@@ -107,6 +107,7 @@ final class FindPerformanceMetrics
             $resourceMetricDto = new ResourceMetricDto();
             $resourceMetricDto->serviceId = $resourceMetric->getServiceId();
             $resourceMetricDto->resourceName = $resourceMetric->getResourceName();
+            $resourceMetricDto->parentId = $resourceMetric->getParentId();
             $resourceMetricDto->metrics = array_map(
                 fn (PerformanceMetric $metric) => [
                     'id' => $metric->getId(),

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetrics/ResourceMetricDto.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetrics/ResourceMetricDto.php
@@ -29,6 +29,8 @@ class ResourceMetricDto
 
     public string $resourceName = '';
 
+    public int $parentId = 0;
+
     /**
      * @var array<
      *  array{

--- a/centreon/src/Core/Dashboard/Domain/Model/Metric/ResourceMetric.php
+++ b/centreon/src/Core/Dashboard/Domain/Model/Metric/ResourceMetric.php
@@ -28,6 +28,7 @@ class ResourceMetric
     /**
      * @param int $serviceId
      * @param string $resourceName
+     * @param int $parentId
      * @param PerformanceMetric[] $metrics
      */
     public function __construct(

--- a/centreon/src/Core/Dashboard/Domain/Model/Metric/ResourceMetric.php
+++ b/centreon/src/Core/Dashboard/Domain/Model/Metric/ResourceMetric.php
@@ -33,6 +33,7 @@ class ResourceMetric
     public function __construct(
         private readonly int $serviceId,
         private readonly string $resourceName,
+        private readonly int $parentId,
         private readonly array $metrics
     ) {
     }
@@ -45,6 +46,11 @@ class ResourceMetric
     public function getResourceName(): string
     {
         return $this->resourceName;
+    }
+
+    public function getParentId(): int
+    {
+        return $this->parentId;
     }
 
     /**

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindMetricsTop/FindMetricsTopPresenter.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindMetricsTop/FindMetricsTopPresenter.php
@@ -65,6 +65,7 @@ class FindMetricsTopPresenter extends AbstractPresenter implements FindMetricsTo
             return [
                 'id' => $metricInformation->serviceId,
                 'name' => $metricInformation->resourceName,
+                'uuid' => 'h' . $metricInformation->parentId . '-s' . $metricInformation->serviceId,
                 'current_value' => $metricInformation->currentValue,
                 'warning_high_threshold' => $metricInformation->warningHighThreshold,
                 'critical_high_threshold' => $metricInformation->criticalHighThreshold,

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindPerformanceMetrics/FindPerformanceMetricsPresenter.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindPerformanceMetrics/FindPerformanceMetricsPresenter.php
@@ -48,6 +48,7 @@ class FindPerformanceMetricsPresenter extends AbstractPresenter implements FindP
                     return [
                         'id' => $resourceMetric->serviceId,
                         'name' => $resourceMetric->resourceName,
+                        'uuid' => 'h' . $resourceMetric->parentId . '-s' . $resourceMetric->serviceId,
                         'metrics' => $resourceMetric->metrics,
                     ];
                 },$response->resourceMetrics),

--- a/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
@@ -416,7 +416,7 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
         = <<<'SQL'
                 SELECT SQL_CALC_FOUND_ROWS DISTINCT
                 m.metric_id, m.metric_name, m.unit_name, m.warn, m.crit, m.current_value, m.warn_low, m.crit_low, m.min,
-                m.max, CONCAT(r.parent_name, '_', r.name) AS resource_name, r.id as service_id
+                m.max, CONCAT(r.parent_name, '_', r.name) AS resource_name, r.id as service_id, r.parent_id
                 FROM `:dbstg`.`metrics` AS m
                 INNER JOIN `:dbstg`.`index_data` AS id ON id.id = m.index_id
                 INNER JOIN `:dbstg`.`resources` AS r ON r.id = id.service_id
@@ -520,6 +520,7 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
                     $metricsInformation[$record['service_id']] = [
                         'service_id' => $record['service_id'],
                         'resource_name' => $record['resource_name'],
+                        'parent_id' => $record['parent_id'],
                         'metrics' => [],
                     ];
                 }
@@ -540,6 +541,7 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
                 $resourceMetrics[] = new ResourceMetric(
                     $information['service_id'],
                     $information['resource_name'],
+                    $information['parent_id'],
                     $information['metrics']
                 );
             }

--- a/centreon/tests/api/features/DashboardWithOpenApi.feature
+++ b/centreon/tests/api/features/DashboardWithOpenApi.feature
@@ -1722,6 +1722,7 @@ Feature:
         {
           "id": 26,
           "name": "Centreon-Server_Ping",
+          "uuid": "h14-s26",
           "metrics": [
             {
               "id": 1,
@@ -1823,6 +1824,7 @@ Feature:
         {
           "id": 26,
           "name": "Centreon-Server_Ping",
+          "uuid": "h14-s26"
           "metrics": [
             {
               "id": 1,

--- a/centreon/tests/api/features/DashboardWithOpenApi.feature
+++ b/centreon/tests/api/features/DashboardWithOpenApi.feature
@@ -1824,7 +1824,7 @@ Feature:
         {
           "id": 26,
           "name": "Centreon-Server_Ping",
-          "uuid": "h14-s26"
+          "uuid": "h14-s26",
           "metrics": [
             {
               "id": 1,

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindMetricsTop/FindMetricsTopTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindMetricsTop/FindMetricsTopTest.php
@@ -147,6 +147,7 @@ it('should present a FindMetricsTopResponse when metrics are found', function ()
         new ResourceMetric(
             1,
             "Centreon-Server_Ping",
+            3,
             [
                 new PerformanceMetric(2,'rta','ms', 20, 50, 0, 11.2, 12.2, 8.2, 14.2),
             ]
@@ -154,6 +155,7 @@ it('should present a FindMetricsTopResponse when metrics are found', function ()
         new ResourceMetric(
             2,
             "Centreon-Server_Ping_1",
+            3,
             [
                 new PerformanceMetric(5,'rta','ms', 20, 50, null, 21.2, 22.2, 21.2, 24.2),
             ]
@@ -184,6 +186,7 @@ it('should present a FindMetricsTopResponse when metrics are found', function ()
 
     $this->expect($metricOne)->toBeInstanceOf(MetricInformationDto::class);
     $this->expect($metricOne->serviceId)->toBe(1);
+    $this->expect($metricOne->parentId)->toBe(3);
     $this->expect($metricOne->resourceName)->toBe('Centreon-Server_Ping');
     $this->expect($metricOne->currentValue)->toBe(12.2);
     $this->expect($metricOne->warningHighThreshold)->toBe(20.0);
@@ -195,6 +198,7 @@ it('should present a FindMetricsTopResponse when metrics are found', function ()
 
     $this->expect($metricTwo)->toBeInstanceOf(MetricInformationDto::class);
     $this->expect($metricTwo->serviceId)->toBe(2);
+    $this->expect($metricTwo->parentId)->toBe(3);
     $this->expect($metricTwo->resourceName)->toBe('Centreon-Server_Ping_1');
     $this->expect($metricTwo->currentValue)->toBe(22.2);
     $this->expect($metricTwo->warningHighThreshold)->toBe(20.0);

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetrics/FindPerformanceMetricsTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetrics/FindPerformanceMetricsTest.php
@@ -88,6 +88,7 @@ it('should present a FindPerformanceMetricsResponse when metrics are found', fun
         new ResourceMetric(
             1,
             "Centreon-Server_Ping",
+            3,
             [
                 new PerformanceMetric(1,'pl','%', 400.3, null, null, null, null, null, null),
                 new PerformanceMetric(2,'rta','ms', 20, 50, null, null, null, null, null),
@@ -98,6 +99,7 @@ it('should present a FindPerformanceMetricsResponse when metrics are found', fun
         new ResourceMetric(
             2,
             "Centreon-Server_Traffic",
+            3,
             [
                 new PerformanceMetric(5,'traffic_in','M', null, null, null, null, null, null, null),
                 new PerformanceMetric(6,'traffic_out','M', null, null, null, null, null, null, null),
@@ -206,6 +208,7 @@ it('should present a FindPerformanceMetricsResponse when metrics are found as no
         new ResourceMetric(
             1,
             "Centreon-Server_Ping",
+            3,
             [
                 new PerformanceMetric(1,'pl','%', 400.3, null, null, null, null, null, null),
                 new PerformanceMetric(2,'rta','ms', 20, 50, null, null, null, null, null),
@@ -216,6 +219,7 @@ it('should present a FindPerformanceMetricsResponse when metrics are found as no
         new ResourceMetric(
             2,
             "Centreon-Server_Traffic",
+            3,
             [
                 new PerformanceMetric(5,'traffic_in','M', null, null, null, null, null, null, null),
                 new PerformanceMetric(6,'traffic_out','M', null, null, null, null, null, null, null),


### PR DESCRIPTION
## Description

this PR intends to add the uuid of the service on the metrics listing and top bottom widget resources

![image](https://github.com/centreon/centreon/assets/61694165/b366b6d1-0d41-4e4f-8f59-f87c6149b827)


**Fixes** # MON-29306

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
