### PR TITLE
fix(clapi): Secure SENDTRAPCFG to avoid command injection v23-04-x

### DIFF
--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -499,10 +499,18 @@ class CentreonConfigPoller
             /* Change files owner */
             if ($apacheUser != "") {
                 foreach (glob($Nagioscfg["cfg_dir"] . '/*.{json,cfg}', GLOB_BRACE) as $file) {
+                    //handle path traversal vulnerability
+                    if (strpos($file, '..') !== false) {
+                        throw new Exception('Path traversal found');
+                    }
                     @chown($file, $apacheUser);
                     @chgrp($file, $apacheUser);
                 }
                 foreach (glob($Nagioscfg["cfg_dir"] . "/*.DEBUG") as $file) {
+                    //handle path traversal vulnerability
+                    if (strpos($file, '..') !== false) {
+                        throw new Exception('Path traversal found');
+                    }
                     @chown($file, $apacheUser);
                     @chgrp($file, $apacheUser);
                 }
@@ -548,6 +556,10 @@ class CentreonConfigPoller
                 /* Change files owner */
                 if ($apacheUser != "") {
                     foreach (glob(rtrim($centreonBrokerDirCfg, "/") . "/" . "/*.{xml,json,cfg}", GLOB_BRACE) as $file) {
+                        //handle path traversal vulnerability
+                        if (strpos($file, '..') !== false) {
+                            throw new Exception('Path traversal found');
+                        }
                         @chown($file, $apacheUser);
                         @chgrp($file, $apacheUser);
                     }
@@ -684,6 +696,10 @@ class CentreonConfigPoller
             mkdir("{$trapdPath}/{$pollerId}");
         }
         $filename = "{$trapdPath}/{$pollerId}/centreontrapd.sdb";
+        //handle path traversal vulnerability
+        if (strpos($filename, '..') !== false) {
+            throw new Exception('Path traversal found');
+        }
         passthru("$centreonDir/bin/generateSqlLite '{$pollerId}' '{$filename}' 2>&1");
         exec("echo 'SYNCTRAP:" . $pollerId . "' >> " . $this->centcore_pipe, $stdout, $return);
         return $return;

--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -101,26 +101,30 @@ class CentreonConfigPoller
         $this->container = $kernel->getContainer();
     }
 
+
     /**
+     * Check for the existence of poller with ID or name $poller, and return
+     * the ID of that poller. If the poller does not exist, raise an exception.
      *
-     * @param type $poller
-     * @return type
+     * @param string|int $poller
+     * @return int
      */
-    private function testPollerId($poller)
+    private function ensurePollerId($poller)
     {
         if (is_numeric($poller)) {
-            $sQuery = "SELECT id FROM nagios_server WHERE `id` = '" . $this->DB->escape($poller) . "'";
+            $statement = $this->DB->prepare("SELECT id FROM nagios_server WHERE id = :poller");
+            $statement->bindValue(':poller', $poller, \PDO::PARAM_INT);
         } else {
-            $sQuery = "SELECT id FROM nagios_server WHERE `name` = '" . $this->DB->escape($poller) . "'";
+            $statement = $this->DB->prepare("SELECT id FROM nagios_server WHERE name = :poller");
+            $statement->bindValue(':poller', $poller, \PDO::PARAM_STR);
         }
 
-        $DBRESULT = $this->DB->query($sQuery);
-        if ($DBRESULT->rowCount() != 0) {
-            return;
+        $statement->execute();
+        if ($statement->rowCount() > 0) {
+            $row = $statement->fetchRow();
+            return $row['id'];
         } else {
-            print "ERROR: Unknown poller...\n";
-            $this->getPollerList($this->format);
-            exit(1);
+            throw new CentreonClapiException(self::UNKNOWN_POLLER_ID);
         }
     }
 
@@ -188,8 +192,7 @@ class CentreonConfigPoller
             exit(1);
         }
 
-        $poller_id = $this->getPollerId($variables);
-        $this->testPollerId($poller_id);
+        $poller_id = $this->ensurePollerId($variables);
 
         $statement = $this->DB->prepare(
             "SELECT * FROM `nagios_server` WHERE `id` = :poller_id  LIMIT 1"
@@ -226,15 +229,13 @@ class CentreonConfigPoller
      */
     public function execCmd($pollerId)
     {
-        $this->testPollerId($pollerId);
-
         $instanceClassFile = $this->centreon_path . 'www/class/centreonInstance.class.php';
         if (!is_file($instanceClassFile)) {
             throw new CentreonClapiException('This action is not available in the version of Centreon you are using');
         }
         require_once $instanceClassFile;
 
-        $pollerId = $this->getPollerId($pollerId);
+        $pollerId = $this->ensurePollerId($pollerId);
 
         $instanceObj = new \CentreonInstance($this->DB);
         $cmds = $instanceObj->getCommandData($pollerId);
@@ -266,8 +267,7 @@ class CentreonConfigPoller
             exit(1);
         }
 
-        $this->testPollerId($variables);
-        $poller_id = $this->getPollerId($variables);
+        $poller_id = $this->ensurePollerId($variables);
 
         $statement = $this->DB->prepare(
             "SELECT * FROM `nagios_server` WHERE `id` = :poller_id  LIMIT 1"
@@ -309,9 +309,7 @@ class CentreonConfigPoller
             exit(1);
         }
 
-        $this->testPollerId($variables);
-
-        $idPoller = $this->getPollerId($variables);
+        $idPoller = $this->ensurePollerId($variables);
 
         /**
          * Get Nagios Bin
@@ -402,12 +400,7 @@ class CentreonConfigPoller
 
         $config_generate = new \Generate($this->dependencyInjector);
 
-        $this->testPollerId($variables);
-
-        $poller_id = $this->getPollerId($variables);
-        //sanitize poller id against traversal path vulnerability
-        $poller_id = basename($poller_id);
-        $config_generate->configPollerFromId($poller_id, $login);
+        $poller_id = $this->ensurePollerId($variables);
 
         /* Change files owner */
         $apacheUser = $this->getApacheUser();
@@ -471,12 +464,7 @@ class CentreonConfigPoller
 
         $return = 0;
 
-        /**
-         * Check poller existence
-         */
-        $this->testPollerId($variables);
-
-        $pollerId = (int) $this->getPollerId($variables);
+        $pollerId = $this->ensurePollerId($variables);
 
         $statement = $pearDB->prepare("SELECT * FROM `nagios_server` WHERE `id` = :pollerId");
         $statement->bindValue(':pollerId', $pollerId, \PDO::PARAM_INT);
@@ -511,18 +499,10 @@ class CentreonConfigPoller
             /* Change files owner */
             if ($apacheUser != "") {
                 foreach (glob($Nagioscfg["cfg_dir"] . '/*.{json,cfg}', GLOB_BRACE) as $file) {
-                    //handle path traversal vulnerability
-                    if (strpos($file, '..') !== false) {
-                        throw new Exception('Path traversal found');
-                    }
                     @chown($file, $apacheUser);
                     @chgrp($file, $apacheUser);
                 }
                 foreach (glob($Nagioscfg["cfg_dir"] . "/*.DEBUG") as $file) {
-                    //handle path traversal vulnerability
-                    if (strpos($file, '..') !== false) {
-                        throw new Exception('Path traversal found');
-                    }
                     @chown($file, $apacheUser);
                     @chgrp($file, $apacheUser);
                 }
@@ -568,10 +548,6 @@ class CentreonConfigPoller
                 /* Change files owner */
                 if ($apacheUser != "") {
                     foreach (glob(rtrim($centreonBrokerDirCfg, "/") . "/" . "/*.{xml,json,cfg}", GLOB_BRACE) as $file) {
-                        //handle path traversal vulnerability
-                        if (strpos($file, '..') !== false) {
-                            throw new Exception('Path traversal found');
-                        }
                         @chown($file, $apacheUser);
                         @chgrp($file, $apacheUser);
                     }
@@ -696,20 +672,18 @@ class CentreonConfigPoller
         if (is_null($pollerId)) {
             throw new CentreonClapiException(self::MISSING_POLLER_ID);
         }
-        $this->testPollerId($pollerId);
+        $pollerId = $this->ensurePollerId($pollerId);
         $centreonDir = $this->centreon_path;
         $pearDB = $this->dependencyInjector['configuration_db'];
-        $res = $pearDB->query("SELECT snmp_trapd_path_conf FROM nagios_server WHERE id = '" . $pollerId . "'");
-        $row = $res->fetchRow();
+        $statement = $pearDB->prepare("SELECT snmp_trapd_path_conf FROM nagios_server WHERE id = :pollerId");
+        $statement->bindValue(':pollerId', $pollerId, \PDO::PARAM_INT);
+        $statement->execute();
+        $row = $statement->fetchRow();
         $trapdPath = $row['snmp_trapd_path_conf'];
         if (!is_dir("{$trapdPath}/{$pollerId}")) {
             mkdir("{$trapdPath}/{$pollerId}");
         }
         $filename = "{$trapdPath}/{$pollerId}/centreontrapd.sdb";
-        //handle path traversal vulnerability
-        if (strpos($filename, '..') !== false) {
-            throw new Exception('Path traversal found');
-        }
         passthru("$centreonDir/bin/generateSqlLite '{$pollerId}' '{$filename}' 2>&1");
         exec("echo 'SYNCTRAP:" . $pollerId . "' >> " . $this->centcore_pipe, $stdout, $return);
         return $return;
@@ -729,27 +703,6 @@ class CentreonConfigPoller
         }
         $str = "- " . $filename . " -> " . $status . "\n";
         return $str;
-    }
-
-    /**
-     *
-     * @param type $poller
-     * @return type
-     */
-    private function getPollerId($poller)
-    {
-        if (is_numeric($poller)) {
-            return $poller;
-        }
-
-        $sQuery = "SELECT id FROM nagios_server WHERE `name` = '" . $this->DB->escape($poller) . "'";
-        $DBRESULT = $this->DB->query($sQuery);
-        if ($DBRESULT->rowCount() > 0) {
-            $row = $DBRESULT->fetchRow();
-            return $row['id'];
-        } else {
-            throw new CentreonClapiException(self::UNKNOWN_POLLER_ID);
-        }
     }
 
     public function getPollerState()

--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -401,7 +401,9 @@ class CentreonConfigPoller
         $config_generate = new \Generate($this->dependencyInjector);
 
         $poller_id = $this->ensurePollerId($variables);
-
+        //sanitize poller id against traversal path vulnerability
+        $poller_id = basename($poller_id);
+        $config_generate->configPollerFromId($poller_id, $login);
         /* Change files owner */
         $apacheUser = $this->getApacheUser();
 
@@ -499,10 +501,18 @@ class CentreonConfigPoller
             /* Change files owner */
             if ($apacheUser != "") {
                 foreach (glob($Nagioscfg["cfg_dir"] . '/*.{json,cfg}', GLOB_BRACE) as $file) {
+                    //handle path traversal vulnerability
+                    if (strpos($file, '..') !== false) {
+                        throw new Exception('Path traversal found');
+                    }
                     @chown($file, $apacheUser);
                     @chgrp($file, $apacheUser);
                 }
                 foreach (glob($Nagioscfg["cfg_dir"] . "/*.DEBUG") as $file) {
+                    //handle path traversal vulnerability
+                    if (strpos($file, '..') !== false) {
+                        throw new Exception('Path traversal found');
+                    }
                     @chown($file, $apacheUser);
                     @chgrp($file, $apacheUser);
                 }
@@ -548,6 +558,10 @@ class CentreonConfigPoller
                 /* Change files owner */
                 if ($apacheUser != "") {
                     foreach (glob(rtrim($centreonBrokerDirCfg, "/") . "/" . "/*.{xml,json,cfg}", GLOB_BRACE) as $file) {
+                        //handle path traversal vulnerability
+                        if (strpos($file, '..') !== false) {
+                            throw new Exception('Path traversal found');
+                        }
                         @chown($file, $apacheUser);
                         @chgrp($file, $apacheUser);
                     }
@@ -684,6 +698,10 @@ class CentreonConfigPoller
             mkdir("{$trapdPath}/{$pollerId}");
         }
         $filename = "{$trapdPath}/{$pollerId}/centreontrapd.sdb";
+        //handle path traversal vulnerability
+        if (strpos($filename, '..') !== false) {
+            throw new Exception('Path traversal found');
+        }
         passthru("$centreonDir/bin/generateSqlLite '{$pollerId}' '{$filename}' 2>&1");
         exec("echo 'SYNCTRAP:" . $pollerId . "' >> " . $this->centcore_pipe, $stdout, $return);
         return $return;

--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -499,18 +499,10 @@ class CentreonConfigPoller
             /* Change files owner */
             if ($apacheUser != "") {
                 foreach (glob($Nagioscfg["cfg_dir"] . '/*.{json,cfg}', GLOB_BRACE) as $file) {
-                    //handle path traversal vulnerability
-                    if (strpos($file, '..') !== false) {
-                        throw new Exception('Path traversal found');
-                    }
                     @chown($file, $apacheUser);
                     @chgrp($file, $apacheUser);
                 }
                 foreach (glob($Nagioscfg["cfg_dir"] . "/*.DEBUG") as $file) {
-                    //handle path traversal vulnerability
-                    if (strpos($file, '..') !== false) {
-                        throw new Exception('Path traversal found');
-                    }
                     @chown($file, $apacheUser);
                     @chgrp($file, $apacheUser);
                 }
@@ -556,10 +548,6 @@ class CentreonConfigPoller
                 /* Change files owner */
                 if ($apacheUser != "") {
                     foreach (glob(rtrim($centreonBrokerDirCfg, "/") . "/" . "/*.{xml,json,cfg}", GLOB_BRACE) as $file) {
-                        //handle path traversal vulnerability
-                        if (strpos($file, '..') !== false) {
-                            throw new Exception('Path traversal found');
-                        }
                         @chown($file, $apacheUser);
                         @chgrp($file, $apacheUser);
                     }
@@ -696,10 +684,6 @@ class CentreonConfigPoller
             mkdir("{$trapdPath}/{$pollerId}");
         }
         $filename = "{$trapdPath}/{$pollerId}/centreontrapd.sdb";
-        //handle path traversal vulnerability
-        if (strpos($filename, '..') !== false) {
-            throw new Exception('Path traversal found');
-        }
         passthru("$centreonDir/bin/generateSqlLite '{$pollerId}' '{$filename}' 2>&1");
         exec("echo 'SYNCTRAP:" . $pollerId . "' >> " . $this->centcore_pipe, $stdout, $return);
         return $return;


### PR DESCRIPTION
## Description

Always use the poller ID (and fetch it from poller name if necessary) to ensure we know what we send in the command, since the ID is an int.

This also makes the command work when using the poller name, as it was failing to fetch the directory because the SQL query assumed the variable was an ID.

**Fixes** # (MON-25130)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)
