### PR TITLE
fix(centcore): add carriage return between external commands

### DIFF
--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -108,12 +108,12 @@ class CentreonConfigPoller
     private function writeToCentcorePipe($cmd, $id): int
     {
         if (is_dir(_CENTREON_VARLIB_ . '/centcore')) {
-            $pipe = _CENTREON_VARLIB_ . '/centcore/' . microtime(true) . '-externalcommand.cmd';
+            $pipe = _CENTREON_VARLIB_ . '/centcore/' . hrtime(true) . '-externalcommand.cmd';
         } else {
             $pipe = _CENTREON_VARLIB_ . '/centcore.cmd';
         }
-        $full_command = sprintf("%s:%d", $cmd, $id);
-        $result = file_put_contents($pipe, $full_command, FILE_APPEND);
+        $fullCommand = sprintf("%s:%d" . PHP_EOL, $cmd, $id);
+        $result = file_put_contents($pipe, $fullCommand, FILE_APPEND);
         return ($result !== false) ? 0 : 1;
     }
 


### PR DESCRIPTION
## Description

add carriage return between external commands when using legacy centcore pipefile
It was failing when commands was sent during the same microsecond
I use `hrtime` instead of `microtime` to use nanoseconds, because it seems centcore does not manage properly concurrent read/write on pipe files

**Fixes** MON-20979

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)