### PR TITLE
enh(ci): use upload instead of copy for promote

### DIFF
--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -56,8 +56,14 @@ runs:
 
           echo "[DEBUG] - Promoting $ARCH testing artifacts to stable."
           for ARTIFACT in ${SRC_PATHS[@]}; do
-            echo "[DEBUG] - Promoting $ARTIFACT to stable."
-            jf rt copy $ARTIFACT $TARGET_PATH --flat=true --threads=1
+            echo "[DEBUG] - Downloading $ARTIFACT from TESTING."
+            jf rt download $ARTIFACT --flat
+          done
+
+          for ARTIFACT_DL in $(dir); do
+            ARCH=$(echo $ARTIFACT_DL | grep -oP '(x86_64|noarch)')
+            echo "[DEBUG] - Promoting (upload) $ARTIFACT_DL to stable $TARGET_PATH."
+            jf rt upload "$ARTIFACT_DL" "$TARGET_PATH" --flat
           done
         done
 
@@ -88,8 +94,14 @@ runs:
 
         echo "[DEBUG] - Promoting DEB testing artifacts to stable."
         for ARTIFACT in ${SRC_PATHS[@]}; do
-          echo "[DEBUG] - Promoting $ARTIFACT to stable."
-          jf rt copy $ARTIFACT $TARGET_PATH --flat=true --threads=1
+          echo "[DEBUG] - Downloading $ARTIFACT from TESTING."
+          jf rt download $ARTIFACT --flat
+        done
+
+        for ARTIFACT_DL in $(dir); do
+          ARCH=$(echo $ARTIFACT_DL | cut -d '_' -f3 | cut -d '.' -f1)
+          echo "[DEBUG] - Promoting (upload) $ARTIFACT_DL to stable $TARGET_PATH."
+          jf rt upload "$ARTIFACT_DL" "$TARGET_PATH" --deb "${{ inputs.distrib }}/main/$ARCH"
         done
 
       shell: bash

--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -49,7 +49,6 @@ runs:
             continue
           fi
 
-
           echo "[DEBUG] - Build $ARCH target path."
           TARGET_PATH="rpm-standard/${{ inputs.major_version }}/${{ inputs.distrib }}/${{ inputs.stability }}/$ARCH/RPMS/${{ inputs.module }}/"
           echo "[DEBUG] - Target path: $TARGET_PATH"
@@ -60,7 +59,7 @@ runs:
             jf rt download $ARTIFACT --flat
           done
 
-          for ARTIFACT_DL in $(dir|grep *.rpm); do
+          for ARTIFACT_DL in $(dir|grep -E "*.rpm"); do
             echo "[DEBUG] - Promoting (upload) $ARTIFACT_DL to stable $TARGET_PATH."
             jf rt upload "$ARTIFACT_DL" "$TARGET_PATH" --flat
           done
@@ -98,10 +97,12 @@ runs:
           jf rt download $ARTIFACT --flat
         done
 
-        for ARTIFACT_DL in $(dir); do
+        for ARTIFACT_DL in $(dir|grep -E "*.deb"); do
           ARCH=$(echo $ARTIFACT_DL | cut -d '_' -f3 | cut -d '.' -f1)
           echo "[DEBUG] - Promoting (upload) $ARTIFACT_DL to stable $TARGET_PATH."
           jf rt upload "$ARTIFACT_DL" "$TARGET_PATH" --deb "${{ inputs.distrib }}/main/$ARCH"
         done
+
+        rm -f *.deb
 
       shell: bash

--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -64,7 +64,7 @@ runs:
             echo "[DEBUG] - Promoting (upload) $ARTIFACT_DL to stable $TARGET_PATH."
             jf rt upload "$ARTIFACT_DL" "$TARGET_PATH" --flat
           done
-          rm *.rpm
+          rm -f *.rpm
         done
 
       shell: bash

--- a/.github/actions/promote-to-stable/action.yml
+++ b/.github/actions/promote-to-stable/action.yml
@@ -60,11 +60,11 @@ runs:
             jf rt download $ARTIFACT --flat
           done
 
-          for ARTIFACT_DL in $(dir); do
-            ARCH=$(echo $ARTIFACT_DL | grep -oP '(x86_64|noarch)')
+          for ARTIFACT_DL in $(dir|grep *.rpm); do
             echo "[DEBUG] - Promoting (upload) $ARTIFACT_DL to stable $TARGET_PATH."
             jf rt upload "$ARTIFACT_DL" "$TARGET_PATH" --flat
           done
+          rm *.rpm
         done
 
       shell: bash


### PR DESCRIPTION
## Description

Use upload instead of copy for promote, as it is more reliable even if generating a bit more traffic.
This should mitigate the metadata issue encountered during promotion of packages (rpm or deb)

**Fixes** #MON-21835 #MON-32880

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)
