### PR TITLE
fix(chore): set APP_SECRET randomly in .env.local.php file (#2787)

### DIFF
--- a/centreon/packaging/debian/centreon-web.postinst
+++ b/centreon/packaging/debian/centreon-web.postinst
@@ -22,12 +22,16 @@ if [ "$1" = "configure" ] ; then
       /usr/share/centreon/.env.local.php
   fi
 
+  # Generate HASH secret for Symfony application
+  REPLY=$(dd if=/dev/urandom bs=32 count=1 status=none | /usr/bin/php -r "echo bin2hex(fread(STDIN, 32));")
+
   # Replace macros ----
   sed -i "s#@PHP_BIN@#/usr/bin/php#g" /usr/share/centreon/bin/centreon
   sed -i "s#@PHP_BIN@#/usr/bin/php#g" /usr/share/centreon/bin/console
   sed -i "s#@PHP_BIN@#/usr/bin/php#g" /usr/share/centreon/bin/export-mysql-indexes
   sed -i "s#@PHP_BIN@#/usr/bin/php#g" /usr/share/centreon/bin/generateSqlLite
   sed -i "s#@PHP_BIN@#/usr/bin/php#g" /usr/share/centreon/bin/import-mysql-indexes
+  sed -i "s/%APP_SECRET%/$REPLY/g" /usr/share/centreon/.env.local.php
 
   chmod +x \
     /usr/share/centreon/bin/centFillTrapDB \


### PR DESCRIPTION
## Description

Debian package APP_SECRET is not set randomly in env.local.php file

Fixes # MON-14453

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
