### PR TITLE
fix(administration) : Make the users not created on centreon plateform unenabled to edit their profile information

### DIFF
--- a/centreon/www/include/Administration/myAccount/DB-Func.php
+++ b/centreon/www/include/Administration/myAccount/DB-Func.php
@@ -258,7 +258,7 @@ function checkAutologinValue(array $fields)
 
     return count($errors) > 0 ? $errors : true;
 }
-function updateLocalContactInDB($contact_id = null): void
+function updateNonLocalContactInDB($contact_id = null): void
 {
     global $pearDB, $centreon, $form;
 

--- a/centreon/www/include/Administration/myAccount/DB-Func.php
+++ b/centreon/www/include/Administration/myAccount/DB-Func.php
@@ -124,7 +124,7 @@ function updateContact($contactId = null)
         return;
     }
 
-    $ret = array();
+    $ret = [];
     $ret = $form->getSubmitValues();
     // remove illegal chars in data sent by the user
     $ret['contact_name'] = CentreonUtils::escapeSecure($ret['contact_name'], CentreonUtils::ESCAPE_ILLEGAL_CHARS);
@@ -257,4 +257,69 @@ function checkAutologinValue(array $fields)
     }
 
     return count($errors) > 0 ? $errors : true;
+}
+function updateLocalContactInDB($contact_id = null): void
+{
+    global $pearDB, $centreon, $form;
+
+    if (! $contact_id){
+        return ;
+    }
+    $ret = $form->getSubmitValues();
+    $ret['contact_pager'] = !empty($ret['contact_pager']) ?
+        CentreonUtils::escapeSecure($ret['contact_pager'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
+    $ret['contact_autologin_key'] = !empty($ret['contact_autologin_key']) ?
+        CentreonUtils::escapeSecure($ret['contact_autologin_key'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
+    $ret['contact_lang'] = !empty($ret['contact_lang']) ?
+        CentreonUtils::escapeSecure($ret['contact_lang'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
+
+    $rq = 'UPDATE contact SET ' .
+        'contact_location = :contactLocation, ' .
+        'contact_lang = :contactLang, ' .
+        'contact_pager = :contactPager, ' .
+        'default_page = :defaultPage, ' .
+        'show_deprecated_pages = :showDeprecatedPages, ' .
+        'contact_autologin_key = :contactAutologinKey, ' .
+        'contact_theme = :contactTheme';
+    $rq .= ' WHERE contact_id = :contactId';
+
+    $stmt = $pearDB->prepare($rq);
+    $stmt->bindValue(':contactLang', $ret['contact_lang'], \PDO::PARAM_STR);
+    $stmt->bindValue(
+        ':contactPager',
+        !empty($ret['contact_pager']) ? $ret['contact_pager'] : null,
+        \PDO::PARAM_STR
+    );
+    $stmt->bindValue(
+        ':contactAutologinKey',
+        !empty($ret['contact_autologin_key']) ? $ret['contact_autologin_key'] : null,
+        \PDO::PARAM_STR
+    );
+    $stmt->bindValue(
+        ':contactLocation',
+        !empty($ret['contact_location']) ? $ret['contact_location'] : null,
+        \PDO::PARAM_INT
+    );
+    $stmt->bindValue(
+        ':contactTheme',
+        !empty($ret['contact_theme']['contact_theme']) ? $ret['contact_theme']['contact_theme'] : "light",
+        \PDO::PARAM_STR
+    );
+    $stmt->bindValue(':defaultPage', !empty($ret['default_page']) ? $ret['default_page'] : null, \PDO::PARAM_INT);
+    $stmt->bindValue(':showDeprecatedPages', isset($ret['show_deprecated_pages']) ? 1 : 0, \PDO::PARAM_STR);
+    $stmt->bindValue(':contactId', $contact_id, \PDO::PARAM_INT);
+    $stmt->execute();
+    $stmt->closeCursor();
+    if (! empty($ret["contact_passwd"])) {
+        $hashedPassword = password_hash($ret["contact_passwd"], \CentreonAuth::PASSWORD_HASH_ALGORITHM);
+        $contact = new \CentreonContact($pearDB);
+        $contact->renewPasswordByContactId($contact_id, $hashedPassword);
+    }
+
+    /*
+     * Update user object..
+     */
+    $centreon->user->lang = $ret['contact_lang'];
+    $centreon->user->setToken(isset($ret['contact_autologin_key']) ? $ret['contact_autologin_key'] : "''");
+    updateNotificationOptions($contact_id);
 }

--- a/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
@@ -38,7 +38,7 @@
     		<tr class="list_two"><td class="FormRowField">{$form.contact_pager.label}</td><td class="FormRowValue">{$form.contact_pager.html}</td></tr>
             <tr class="list_one"><td class="FormRowField">{$form.contact_lang.label}</td><td class="FormRowValue">{$form.contact_lang.html}</td></tr>
             <tr class="list_two"><td class="FormRowField">{$form.contact_location.label}</td><td class="FormRowValue">{$form.contact_location.html}</td></tr>
-            {if $cct.contact_auth_type != 'ldap'}
+            {if $centreon.user.authType === 'local'}
             <tr class="list_lvl_1">
                 <td class="ListColLvl1_name" colspan="2">
                     <h4>{t}Password Management{/t}</h4>

--- a/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
@@ -38,7 +38,7 @@
     		<tr class="list_two"><td class="FormRowField">{$form.contact_pager.label}</td><td class="FormRowValue">{$form.contact_pager.html}</td></tr>
             <tr class="list_one"><td class="FormRowField">{$form.contact_lang.label}</td><td class="FormRowValue">{$form.contact_lang.html}</td></tr>
             <tr class="list_two"><td class="FormRowField">{$form.contact_location.label}</td><td class="FormRowValue">{$form.contact_location.html}</td></tr>
-            {if $centreon.user.authType === 'local'}
+            {if $cct.contact_auth_type === 'local'}
             <tr class="list_lvl_1">
                 <td class="ListColLvl1_name" colspan="2">
                     <h4>{t}Password Management{/t}</h4>

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -106,7 +106,7 @@ $attrsText = ["size" => "35"];
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
 $form->addElement('header', 'title', _("Change my settings"));
 $form->addElement('header', 'information', _("General Information"));
-if ($centreon->user->authType === 'local') {
+if ($cct['contact_auth_type'] === 'local') {
     $form->addElement('text', 'contact_name', _("Name"), $attrsText);
     $form->addElement('text', 'contact_alias', _("Alias / Login"), $attrsText);
     $form->addElement('text', 'contact_email', _("Email"), $attrsText);
@@ -117,7 +117,7 @@ if ($centreon->user->authType === 'local') {
 }
 $form->addElement('text', 'contact_pager', _("Pager"), $attrsText);
 
-if ($centreon->user->authType === 'local') {
+if ($cct['contact_auth_type'] === 'local') {
     $form->addFormRule('validatePasswordModification');
     $statement = $pearDB->prepare(
         "SELECT creation_date FROM contact_password WHERE contact_id = :contactId ORDER BY creation_date DESC LIMIT 1"
@@ -383,7 +383,7 @@ $form->applyFilter('contact_name', 'myReplace');
 $form->addRule('contact_name', _("Compulsory name"), 'required');
 $form->addRule('contact_alias', _("Compulsory alias"), 'required');
 $form->addRule('contact_email', _("Valid Email"), 'required');
-if ($centreon->user->authType === 'local') {
+if ($cct['contact_auth_type'] === 'local') {
     $form->addRule(array('contact_passwd', 'contact_passwd2'), _("Passwords do not match"), 'compare');
 }
 $form->registerRule('exist', 'callback', 'testExistence');
@@ -420,7 +420,7 @@ if ($o == "c") {
 $sessionKeyFreeze = 'administration-form-my-account-freeze';
 
 if ($form->validate()) {
-    if ($centreon->user->authType === 'local') {
+    if ($cct['contact_auth_type'] === 'local') {
         updateContactInDB($centreon->user->get_id());
     } else {
         updateLocalContactInDB($centreon->user->get_id());

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -67,7 +67,7 @@ $encodedPasswordPolicy = json_encode($passwordSecurityPolicy);
 /*
  * Database retrieve information for the User
  */
-$cct = array();
+$cct = [];
 if ($o == "c") {
     $query = "SELECT contact_id, contact_name, contact_alias, contact_lang, contact_email, contact_pager,
         contact_autologin_key, default_page, show_deprecated_pages, contact_auth_type
@@ -99,23 +99,25 @@ if ($o == "c") {
  *
  * Langs -> $langs Array
  */
-$langs = array();
+$langs = [];
 $langs = getLangs();
-$attrsText = array("size" => "35");
+$attrsText = ["size" => "35"];
 
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
 $form->addElement('header', 'title', _("Change my settings"));
 $form->addElement('header', 'information', _("General Information"));
-$form->addElement('text', 'contact_name', _("Name"), $attrsText);
-if ($cct["contact_auth_type"] != 'ldap') {
+if ($centreon->user->authType === 'local') {
+    $form->addElement('text', 'contact_name', _("Name"), $attrsText);
     $form->addElement('text', 'contact_alias', _("Alias / Login"), $attrsText);
+    $form->addElement('text', 'contact_email', _("Email"), $attrsText);
 } else {
+    $form->addElement('text', 'contact_name', _("Name"), $attrsText)->freeze();
     $form->addElement('text', 'contact_alias', _("Alias / Login"), $attrsText)->freeze();
+    $form->addElement('text', 'contact_email', _("Email"), $attrsText)->freeze();
 }
-$form->addElement('text', 'contact_email', _("Email"), $attrsText);
 $form->addElement('text', 'contact_pager', _("Pager"), $attrsText);
 
-if ($cct["contact_auth_type"] === 'local') {
+if ($centreon->user->authType === 'local') {
     $form->addFormRule('validatePasswordModification');
     $statement = $pearDB->prepare(
         "SELECT creation_date FROM contact_password WHERE contact_id = :contactId ORDER BY creation_date DESC LIMIT 1"
@@ -158,7 +160,7 @@ if ($cct["contact_auth_type"] === 'local') {
         ['onclick' => "generatePassword('passwd', '$encodedPasswordPolicy');", 'class' => 'btc bt_info']
     );
 }
-$form->addElement('text', 'contact_autologin_key', _("Autologin Key"), array("size" => "30", "id" => "aKey"));
+$form->addElement('text', 'contact_autologin_key', _("Autologin Key"), ["size" => "30", "id" => "aKey"]);
 $form->addElement(
     'button',
     'contact_gen_akey',
@@ -327,9 +329,9 @@ $form->addElement('checkbox', 'monitoring_svc_notification_3', _('Show Unknown s
 
 /* Add feature information */
 $features = $centreonFeature->getFeatures();
-$defaultFeatures = array();
+$defaultFeatures = [];
 foreach ($features as $feature) {
-    $featRadio = array();
+    $featRadio = [];
     $featRadio[] = $form->createElement('radio', $feature['version'], null, _('New version'), '1');
     $featRadio[] = $form->createElement('radio', $feature['version'], null, _('Legacy version'), '0');
     $feat = $form->addGroup($featRadio, 'features[' . $feature['name'] . ']', $feature['name'], '&nbsp;');
@@ -337,7 +339,7 @@ foreach ($features as $feature) {
 }
 
 $sound_files = scandir(_CENTREON_PATH_ . "www/sounds/");
-$sounds = array(null => null);
+$sounds = [null => null];
 foreach ($sound_files as $f) {
     if ($f == "." || $f == "..") {
         continue;
@@ -357,14 +359,14 @@ $form->addElement('select', 'monitoring_sound_svc_notification_3', _("Sound for 
 $availableRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_timezone&action=list';
 $defaultRoute = './include/common/webServices/rest/internal.php?object=centreon_configuration_timezone' .
     '&action=defaultValues&target=contact&field=contact_location&id=' . $centreon->user->get_id();
-$attrTimezones = array(
+$attrTimezones = [
     'datasourceOrigin' => 'ajax',
     'availableDatasetRoute' => $availableRoute,
     'defaultDatasetRoute' => $defaultRoute,
     'multiple' => false,
     'linkedObject' => 'centreonGMT'
-);
-$form->addElement('select2', 'contact_location', _("Timezone / Location"), array(), $attrTimezones);
+];
+$form->addElement('select2', 'contact_location', _("Timezone / Location"), [], $attrTimezones);
 
 $redirect = $form->addElement('hidden', 'o');
 $redirect->setValue($o);
@@ -381,7 +383,7 @@ $form->applyFilter('contact_name', 'myReplace');
 $form->addRule('contact_name', _("Compulsory name"), 'required');
 $form->addRule('contact_alias', _("Compulsory alias"), 'required');
 $form->addRule('contact_email', _("Valid Email"), 'required');
-if ($cct["contact_auth_type"] !== 'ldap') {
+if ($centreon->user->authType === 'local') {
     $form->addRule(array('contact_passwd', 'contact_passwd2'), _("Passwords do not match"), 'compare');
 }
 $form->registerRule('exist', 'callback', 'testExistence');
@@ -403,12 +405,12 @@ $cct['contact_alias'] = CentreonUtils::escapeSecure($cct['contact_alias'], Centr
 
 // Modify a contact information
 if ($o == "c") {
-    $subC = $form->addElement('submit', 'submitC', _("Save"), array("class" => "btc bt_success"));
-    $res = $form->addElement('reset', 'reset', _("Reset"), array("class" => "btc bt_default"));
+    $subC = $form->addElement('submit', 'submitC', _("Save"), ["class" => "btc bt_success"]);
+    $res = $form->addElement('reset', 'reset', _("Reset"), ["class" => "btc bt_default"]);
     $form->setDefaults($cct);
     /* Add saved value for feature testing */
     $userFeatures = $centreonFeature->userFeaturesValue($centreon->user->get_id());
-    $defaultUserFeatures = array();
+    $defaultUserFeatures = [];
     foreach ($userFeatures as $feature) {
         $defaultUserFeatures['features'][$feature['name']][$feature['version']] = $feature['enabled'];
     }
@@ -418,7 +420,11 @@ if ($o == "c") {
 $sessionKeyFreeze = 'administration-form-my-account-freeze';
 
 if ($form->validate()) {
-    updateContactInDB($centreon->user->get_id());
+    if ($centreon->user->authType === 'local') {
+        updateContactInDB($centreon->user->get_id());
+    } else {
+        updateLocalContactInDB($centreon->user->get_id());
+    }
     $o = null;
     $features = $form->getSubmitValue('features');
 
@@ -431,7 +437,7 @@ if ($form->validate()) {
         "button",
         "change",
         _("Modify"),
-        array("onClick" => "javascript:window.location.href='?p=" . $p . "&o=c'", 'class' => 'btc bt_info')
+        ["onClick" => "javascript:window.location.href='?p=" . $p . "&o=c'", 'class' => 'btc bt_info']
     );
     $form->freeze();
 
@@ -461,7 +467,7 @@ if ($form->validate()) {
         "button",
         "change",
         _("Modify"),
-        array("onClick" => "javascript:window.location.href='?p=" . $p . "&o=c'", 'class' => 'btc bt_info')
+        ["onClick" => "javascript:window.location.href='?p=" . $p . "&o=c'", 'class' => 'btc bt_info']
     );
     $form->freeze();
 }

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -422,7 +422,7 @@ if ($form->validate()) {
     if ($cct['contact_auth_type'] === 'local') {
         updateContactInDB($centreon->user->get_id());
     } else {
-        updateLocalContactInDB($centreon->user->get_id());
+        updateNonLocalContactInDB($centreon->user->get_id());
     }
     $o = null;
     $features = $form->getSubmitValue('features');

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -116,7 +116,7 @@ if ($cct['contact_auth_type'] === 'local') {
     $form->addElement('text', 'contact_email', _("Email"), $attrsText)->freeze();
 }
 $form->addElement('text', 'contact_pager', _("Pager"), $attrsText);
-
+$cct['contact_auth_type'] = $centreon->user->authType;
 if ($cct['contact_auth_type'] === 'local') {
     $form->addFormRule('validatePasswordModification');
     $statement = $pearDB->prepare(

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -102,7 +102,7 @@ if ($o == "c") {
 $langs = [];
 $langs = getLangs();
 $attrsText = ["size" => "35"];
-
+$cct['contact_auth_type'] = $centreon->user->authType;
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
 $form->addElement('header', 'title', _("Change my settings"));
 $form->addElement('header', 'information', _("General Information"));
@@ -116,7 +116,6 @@ if ($cct['contact_auth_type'] === 'local') {
     $form->addElement('text', 'contact_email', _("Email"), $attrsText)->freeze();
 }
 $form->addElement('text', 'contact_pager', _("Pager"), $attrsText);
-$cct['contact_auth_type'] = $centreon->user->authType;
 if ($cct['contact_auth_type'] === 'local') {
     $form->addFormRule('validatePasswordModification');
     $statement = $pearDB->prepare(


### PR DESCRIPTION
## Description

Users created not using Centreon Plateform cannot update their information(Alias, Name, Email, Password Management)

**Fixes** # (MON-24798)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Given a user authenticated through SSO (or LDAP) and having rights to access to “Administration > My Account”
When he access to “Administration > My Account” menu
He can’t change his following properties:

- Name
- Alias / Login
- Email

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
