### PR TITLE
fix(Install): missing sql right for centreon user blocking ba edition

### DIFF
--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -90,11 +90,12 @@ $mandatoryPrivileges = [
     'CREATE TEMPORARY TABLES',
     'EVENT',
     'CREATE VIEW',
+    'DROP VIEW',
     'SHOW VIEW',
     'REFERENCES'
 ];
 $privilegesQuery = implode(', ', $mandatoryPrivileges);
-$query = "GRANT ALL PRIVILEGES ON `%s`.* TO " . $parameters['db_user'] . "@" . $host . " WITH GRANT OPTION";
+$query = "GRANT " . $privilegesQuery . " ON `%s`.* TO '" . $parameters['db_user'] . "'@'" . $host . "'";
 $flushQuery = "FLUSH PRIVILEGES";
 
 try {

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -126,7 +126,7 @@ try {
         if (strpos($versionName, "MySQL") !== false && version_compare($versionNumber, '8.0.0', '>=')) {
             // Compatibility adaptation for mysql 8 with php7.1 before 7.1.16, or php7.2 before 7.2.4.
             $prepareAlter = $link->prepare(
-                "ALTER USER :dbUser@:host IDENTIFIED WITH mysql_native_password BY :dbPass"
+                "DROP USER :dbUser@:host IDENTIFIED WITH mysql_native_password BY :dbPass"
             );
             foreach ($queryValues as $key => $value) {
                 $prepareAlter->bindValue($key, $value, \PDO::PARAM_STR);

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -90,9 +90,9 @@ $mandatoryPrivileges = [
     'CREATE TEMPORARY TABLES',
     'EVENT',
     'CREATE VIEW',
+    'ALTER VIEW',
     'SHOW VIEW',
-    'REFERENCES',
-    'ALTER VIEW'
+    'REFERENCES'
 ];
 $privilegesQuery = implode(', ', $mandatoryPrivileges);
 $query = "GRANT " . $privilegesQuery . " ON `%s`.* TO '" . $parameters['db_user'] . "'@'" . $host . "'";

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -85,7 +85,6 @@ $mandatoryPrivileges = [
     'CREATE',
     'DROP',
     'INDEX',
-    'ALTER',
     'LOCK TABLES',
     'CREATE TEMPORARY TABLES',
     'EVENT',

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -90,9 +90,9 @@ $mandatoryPrivileges = [
     'CREATE TEMPORARY TABLES',
     'EVENT',
     'CREATE VIEW',
-    'ALTER VIEW',
     'SHOW VIEW',
-    'REFERENCES'
+    'REFERENCES',
+    'ALTER VIEW'
 ];
 $privilegesQuery = implode(', ', $mandatoryPrivileges);
 $query = "GRANT " . $privilegesQuery . " ON `%s`.* TO '" . $parameters['db_user'] . "'@'" . $host . "'";

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -76,7 +76,7 @@ $queryValues = [
     ':dbPass' => $parameters['db_password'],
 ];
 
-// Set defined privileges for the user.	$query = "GRANT ALL PRIVILEGES ON `%s`.* TO " . $parameters['db_user'] . "@" . $host . " WITH GRANT OPTION";
+// Set defined privileges for the user.
 $mandatoryPrivileges = [
     'SELECT',
     'UPDATE',

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -170,7 +170,6 @@ try {
                     }
                     $resultPrivileges = explode(', ', $matches[1]);
 
-
                     //Check that user has sufficient privileges to perform all needed actions.
                     $missingPrivileges = [];
                     if ($resultPrivileges[0] !== 'ALL PRIVILEGES') {

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -85,11 +85,12 @@ $mandatoryPrivileges = [
     'CREATE',
     'DROP',
     'INDEX',
-    'ALTER VIEW',
+    'ALTER',
     'LOCK TABLES',
     'CREATE TEMPORARY TABLES',
     'EVENT',
     'CREATE VIEW',
+    'ALTER VIEW',
     'SHOW VIEW',
     'REFERENCES'
 ];

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -94,7 +94,7 @@ $mandatoryPrivileges = [
     'REFERENCES'
 ];
 $privilegesQuery = implode(', ', $mandatoryPrivileges);
-$query = "GRANT " . $privilegesQuery . " ON `%s`.* TO '" . $parameters['db_user'] . "'@'" . $host . "'";
+$query = "GRANT ALL PRIVILEGES ON `%s`.* TO " . $parameters['db_user'] . "@" . $host . " WITH GRANT OPTION";
 $flushQuery = "FLUSH PRIVILEGES";
 
 try {

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -90,6 +90,7 @@ $mandatoryPrivileges = [
     'CREATE TEMPORARY TABLES',
     'EVENT',
     'CREATE VIEW',
+    'ALTER VIEW',
     'SHOW VIEW',
     'REFERENCES'
 ];

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -90,7 +90,6 @@ $mandatoryPrivileges = [
     'CREATE TEMPORARY TABLES',
     'EVENT',
     'CREATE VIEW',
-    'DROP VIEW',
     'SHOW VIEW',
     'REFERENCES'
 ];

--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -85,11 +85,11 @@ $mandatoryPrivileges = [
     'CREATE',
     'DROP',
     'INDEX',
+    'ALTER VIEW',
     'LOCK TABLES',
     'CREATE TEMPORARY TABLES',
     'EVENT',
     'CREATE VIEW',
-    'ALTER VIEW',
     'SHOW VIEW',
     'REFERENCES'
 ];


### PR DESCRIPTION
## Description

Missing SQL right for centreon user blocking BA edition because Centreon BAM 23.04.0 update contains ALTER View.

**Fixes** # (Mon 32999)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

add the missing sql contains  ALTER View.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
