### PR TITLE
fix(configuration): Export configuration failing due to method call by reference after upgrade (#2843) [dev-23.10.x]

### DIFF
--- a/centreon/www/class/config-generate/escalation.class.php
+++ b/centreon/www/class/config-generate/escalation.class.php
@@ -250,7 +250,7 @@ class Escalation extends AbstractObject
             if (isset($this->escalation_cache[$escalation_id]['host_inheritance_to_services']) &&
                 $this->escalation_cache[$escalation_id]['host_inheritance_to_services'] == 1
             ) {
-                $services = &$this->service_instance->getGeneratedServices();
+                $services = $this->service_instance->getGeneratedServices();
                 // host without services
                 if (!isset($services[$host_id])) {
                     continue;
@@ -288,7 +288,7 @@ class Escalation extends AbstractObject
             if (isset($this->escalation_cache[$escalation_id]['hostgroup_inheritance_to_services']) &&
                 $this->escalation_cache[$escalation_id]['hostgroup_inheritance_to_services'] == 1
             ) {
-                $services = &$this->service_instance->getGeneratedServices();
+                $services = $this->service_instance->getGeneratedServices();
 
                 foreach ($hostgroup['members'] as $host_name) {
                     $host_id = $this->host_instance->getHostIdByHostName($host_name);


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/2843 to dev-23.10.x

**Fixes** # MON-33116

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
