### PR TITLE
fix(clapi): remove semicolumn on hostname parameter of applytpl function

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonHost.class.php
+++ b/centreon/www/class/centreon-clapi/centreonHost.class.php
@@ -1143,6 +1143,7 @@ class CentreonHost extends CentreonObject
         if (!$this->register) {
             throw new CentreonClapiException(self::UNKNOWN_METHOD);
         }
+        $hostName = substr($hostName, 0, strpos($hostName, ';'));
         if (($hostId = $this->getObjectId($hostName)) == 0) {
             throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ":" . $hostName);
         }


### PR DESCRIPTION
## Description

Removes the trailing semicolumns when using the APPLYTPL function on a CLAPI CSV file (loaded through UI or with -i option).

The following example shows the result of a CSV file, built from Excel or such, to import a host :
```
HOST;ADD;Toto;Tata;Toto-Template;1.2.3.4;popo01;blip|bloup
HOST;APPLYTPL;Toto;;;;;
```
Without the fix, it should break on the second line :
```
Line 2 : Object not found:Toto;;;;;
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Create a CSV file where there is at least a HOST;ADD and a HOST;APPLYTPL command,
2. Import the file using CLAPI : centreon -u admin -p xxx -i test.clapi
3. No error should be shown,
4. The host should be created alongside the services coming from the template defined on HOST;ADD line.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
