### PR TITLE
fix(ui/topcounter): fix hosts down and unreachable count excluding SOFT state

### DIFF
--- a/centreon/www/api/class/centreon_topcounter.class.php
+++ b/centreon/www/api/class/centreon_topcounter.class.php
@@ -609,9 +609,11 @@ class CentreonTopCounter extends CentreonWebService
             COALESCE(SUM(CASE WHEN h.state = 1 THEN 1 ELSE 0 END), 0) AS down_total,
             COALESCE(SUM(CASE WHEN h.state = 2 THEN 1 ELSE 0 END), 0) AS unreachable_total,
             COALESCE(SUM(CASE WHEN h.state = 4 THEN 1 ELSE 0 END), 0) AS pending_total,
-            COALESCE(SUM(CASE WHEN h.state = 1 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0)
+            COALESCE(SUM(CASE WHEN h.state = 1 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0
+                AND h.state_type = 1)
                 THEN 1 ELSE 0 END), 0) AS down_unhandled,
-            COALESCE(SUM(CASE WHEN h.state = 2 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0)
+            COALESCE(SUM(CASE WHEN h.state = 2 AND (h.acknowledged = 0 AND h.scheduled_downtime_depth = 0
+                AND h.state_type = 1)
                 THEN 1 ELSE 0 END), 0) AS unreachable_unhandled
             FROM hosts h, instances i';
         $query .= ' WHERE i.deleted = 0


### PR DESCRIPTION
## Description

As for the services, only the HARD states should be used for hosts statuses count calculation.

Without the fix, hosts DOWN or UNREACHABLE but in SOFT state appear in the top counter.

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Make one host goes from UP to DOWN,
2. While in SOFT state, the top counter should show 0 host DOWN,
3. When state becomes HARD, the top counter should show 1 host DOWN.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
