### PR TITLE
fix(ui/timeline): remove INITIAL STATE logs

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Monitoring/Timeline/TimelineRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Monitoring/Timeline/TimelineRepositoryRDB.php
@@ -300,7 +300,7 @@ final class TimelineRepositoryRDB extends AbstractRepositoryDRB implements Timel
             FROM `:dbstg`.`logs` l
             WHERE l.host_id = :host_id
             AND (l.service_id = " . ($serviceId !== null ? ':service_id)' : '0 OR l.service_id IS NULL)') . "
-            AND l.msg_type IN (0,1,8,9)
+            AND l.msg_type IN (0,1)
             AND l.output NOT LIKE 'INITIAL % STATE:%'
             AND l.instance_name != ''
         ");


### PR DESCRIPTION
## Description

Removes the INITIAL STATE logs, generated by Engine each time it restarts, from the Timeline tab.

Without the fix, events will be shown eventhough there is no status change (Engine restarted twice at 11:47 and 11:49 AM) :
![image](https://github.com/centreon/centreon/assets/23257354/50199e49-5c2e-440c-93c3-9d9d7e881243)

This is the behaviour of the Event Logs page : 
![image](https://github.com/centreon/centreon/assets/23257354/3e1a799b-0cb5-4c02-8003-29b08e4cbda2)

What's odd is the "AND l.output NOT LIKE 'INITIAL % STATE:%" statement : there is no such strings in INITIAL STATE logs so Engine may have change its behaviour. Also, the msg_type 8 and 9 must be better explained by the Collect dev team (cc @bouda1).

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Restart an Engine,
2. No new event should be listed in the Timeline tab of any resource.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
