### PR TITLE
fix(smarty) : refactor deprecated {php}

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/list.ihtml
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/list.ihtml
@@ -21,9 +21,7 @@
                 <a class='btc bt_success ml-1' href="{$msg.addL}">{$msg.add}</a>
             </td>
             <td class='toolbarPagination'>
-                {php}
-                    include('./include/common/pagination.php');
-                {/php}
+                {pagination}
             </td>
         </tr>
     </table>

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/list.ihtml
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/list.ihtml
@@ -71,9 +71,7 @@
                 <a class='btc bt_success' href="{$msg.addL}">{$msg.add}</a>
             </td>
             <td class='toolbarPagination'>
-                {php}
-                    include('./include/common/pagination.php');
-                {/php}
+                {pagination}
             </td>
         </tr>
     </table>


### PR DESCRIPTION
## Description

The tag {php} is deprecated for 12 years and we must refactor it to avoid its usage.

**Fixes** # (MON-33166)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check if the pagination isn't broken on the page

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
