### PR TITLE
fix(gorgone): Gorgone stops responding every 24-48 hrs with pull mode - backport 22.10

### DIFF
--- a/centreon-gorgone/gorgone/modules/core/pullwss/class.pm
+++ b/centreon-gorgone/gorgone/modules/core/pullwss/class.pm
@@ -248,6 +248,18 @@ sub transmit_back {
             return '[SETLOGS] [' . $1 . '] [] ' . $2;
         }
         return undef;
+    } elsif ($options{message} =~ /^\[BCASTCOREKEY\]\s+\[.*?\]\s+\[.*?\]\s+(.*)/m) {
+        my $data;
+        eval {
+            $data = JSON::XS->new->decode($1);
+        };
+        if ($@) {
+            $connector->{logger}->writeLogDebug("[pull] cannot decode BCASTCOREKEY: $@");
+            return undef;
+        }
+
+        $connector->action_bcastcorekey(data => $data);
+        return undef;
     } elsif ($options{message} =~ /^\[(PONG|SYNCLOGS)\]/) {
         return $options{message};
     }


### PR DESCRIPTION
## Description

backporting jira MON-21371 in version 22.10

**Fixes** # MON-23884

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [X] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>
Configure a poller using the pull mode of Centreon Gorgone 

Add the following option in /etc/centreon-gorgone/config.d/40-gorgoned.yaml file (avoid to wait 24h):
```gorgone:
  gorgonecore:
    internal_com_rotation: 3
```
After 10 minutes, you should have this error:
2023-09-01 11:20:07 - ERROR - [pull] decrypt issue: no message




#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
