### PR TITLE
feat(api) Add read repository for Proxy configuration

### DIFF
--- a/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsCommand.php
+++ b/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsCommand.php
@@ -24,10 +24,10 @@ declare(strict_types = 1);
 namespace Core\Command\Infrastructure\Command\MigrateAllCommands;
 
 use Centreon\Domain\Log\LoggerTrait;
-use Centreon\Domain\Option\Interfaces\OptionRepositoryInterface;
 use Core\Command\Application\UseCase\MigrateAllCommands\MigrateAllCommands;
 use Core\Command\Infrastructure\Repository\ApiWriteCommandRepository;
 use Core\Common\Infrastructure\Command\AbstractMigrationCommand;
+use Core\Proxy\Application\Repository\ReadProxyRepositoryInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -41,11 +41,11 @@ class MigrateAllCommandsCommand extends AbstractMigrationCommand
     protected static $defaultDescription = 'Migrate all commands from the current platform to the defined target platform';
 
     public function __construct(
-        OptionRepositoryInterface $optionRepository,
+        ReadProxyRepositoryInterface $readProxyRepository,
         readonly private ApiWriteCommandRepository $apiWriteCommandRepository,
         readonly private MigrateAllCommands $useCase,
     ) {
-        parent::__construct($optionRepository);
+        parent::__construct($readProxyRepository);
     }
 
     protected function configure(): void

--- a/centreon/src/Core/Media/Infrastructure/Command/MigrateAllMedias/MigrateAllMediasCommand.php
+++ b/centreon/src/Core/Media/Infrastructure/Command/MigrateAllMedias/MigrateAllMediasCommand.php
@@ -24,11 +24,11 @@ declare(strict_types = 1);
 namespace Core\Media\Infrastructure\Command\MigrateAllMedias;
 
 use Centreon\Domain\Log\LoggerTrait;
-use Centreon\Domain\Option\Interfaces\OptionRepositoryInterface;
 use Core\Common\Infrastructure\Command\AbstractMigrationCommand;
 use Core\Media\Application\UseCase\MigrateAllMedias\MigrateAllMedias;
 use Core\Media\Application\UseCase\MigrateAllMedias\MigrateAllMediasRequest;
 use Core\Media\Infrastructure\Repository\ApiWriteMediaRepository;
+use Core\Proxy\Application\Repository\ReadProxyRepositoryInterface;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -46,14 +46,14 @@ class MigrateAllMediasCommand extends AbstractMigrationCommand
     private int $postMax;
 
     public function __construct(
-        OptionRepositoryInterface $optionRepository,
+        ReadProxyRepositoryInterface $readProxyRepository,
         readonly private ApiWriteMediaRepository $apiWriteMediaRepository,
         readonly private MigrateAllMedias $useCase,
         readonly private int $maxFile,
         string $maxFilesize,
         string $postMax,
     ) {
-        parent::__construct($optionRepository);
+        parent::__construct($readProxyRepository);
         $this->maxFilesize = $this->parseSize($maxFilesize);
         $this->postMax = $this->parseSize($postMax);
     }

--- a/centreon/src/Core/Proxy/Application/Repository/ReadProxyRepositoryInterface.php
+++ b/centreon/src/Core/Proxy/Application/Repository/ReadProxyRepositoryInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Proxy\Application\Repository;
+
+use Core\Proxy\Domain\Model\Proxy;
+
+interface ReadProxyRepositoryInterface
+{
+    /**
+     * Return the proxy configuration or null.
+     *
+     * @return Proxy|null
+     */
+    public function getProxy(): ?Proxy;
+
+    /**
+     * Return true if a proxy is defined false otherwise.
+     *
+     * @return bool
+     */
+    public function hasProxy(): bool;
+}

--- a/centreon/src/Core/Proxy/Infrastructure/Repository/DbReadProxyRepository.php
+++ b/centreon/src/Core/Proxy/Infrastructure/Repository/DbReadProxyRepository.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Proxy\Infrastructure\Repository;
+
+use Centreon\Infrastructure\DatabaseConnection;
+use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Core\Proxy\Application\Repository\ReadProxyRepositoryInterface;
+use Core\Proxy\Domain\Model\Proxy;
+
+class DbReadProxyRepository extends AbstractRepositoryRDB implements ReadProxyRepositoryInterface
+{
+    /**
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getProxy(): ?Proxy
+    {
+        $statement = $this->db->query($this->translateDbName(
+            <<<'SQL'
+                SELECT `proxy_url`, `proxy_port`, `proxy_user`, `proxy_password`  FROM `:db`.`options`
+                SQL
+        ));
+        /**
+         * @var array{
+         *  proxy_url:string|null,
+         *  proxy_port:string|null,
+         *  proxy_user: string|null,
+         *  proxy_password: string|null
+         * }|false $proxyInfo
+         */
+        $proxyInfo = $statement === false ? false : $statement->fetch(\PDO::FETCH_ASSOC);
+
+        if (isset($proxyInfo['proxy_url']) && $proxyInfo['proxy_url'] !== '') {
+            $port = isset($proxyInfo['proxy_port']) ? (int) $proxyInfo['proxy_port'] : null;
+
+            return new Proxy(
+                $proxyInfo['proxy_url'],
+                $port,
+                $proxyInfo['proxy_user'],
+                $proxyInfo['proxy_password'],
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasProxy(): bool
+    {
+        $statement = $this->db->query($this->translateDbName(
+            <<<'SQL'
+                SELECT 1 FROM `:db`.`options`
+                WHERE `key` = 'proxy_url'
+                SQL
+        ));
+
+        return $statement && $statement->fetchColumn();
+    }
+}


### PR DESCRIPTION
## Description

Add new proxy read repositry for use in Api and migration commands.
Modified the AbstractMigrationCommand to use this new repository.

Requirement for https://github.com/centreon/centreon-modules/pull/2123


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)
