### PR TITLE
fix(install): correctly check user rights on step7

### DIFF
--- a/centreon/www/install/steps/process/createDbUser.php
+++ b/centreon/www/install/steps/process/createDbUser.php
@@ -38,11 +38,11 @@ session_start();
 require_once __DIR__ . '/../../../../bootstrap.php';
 require_once '../functions.php';
 
-$return = array(
+$return = [
     'id' => 'createuser',
     'result' => 1,
     'msg' => ''
-);
+];
 
 $step = new \CentreonLegacy\Core\Install\Step\Step6($dependencyInjector);
 $parameters = $step->getDatabaseConfiguration();
@@ -154,7 +154,7 @@ try {
         while ($result = $privilegesStatement->fetch(\PDO::FETCH_ASSOC)) {
             foreach ($result as $grant) {
                 // Format Grant result to get privileges list, and concerned database.
-                if (preg_match('/^GRANT\s(?!USAGE)(.+)\sON\s?(.+)\./', $grant, $matches)) {
+                if (preg_match('/^GRANT\s(?!USAGE)(.+)\sON\s?(.+)\.\*/', $grant, $matches)) {
                     // Check if privileges has been found for global (*) or centreon databases.
                     switch ($matches[2]) {
                         case '`' . $parameters['db_configuration'] . '`':


### PR DESCRIPTION
This PR intends to fix an issue regarding the 7th step on the installation process.
Issue here is that if user has been created before the step7 then the step7 will only check users rights by catching the returned output of `SHOW GRANTS FOR ...`

However if there is a dot for instance in the address (IP / domain) then the regexp no longer works and the second chunk of the regexp match will not hold the name of the database for which USER is granted

Huge thanks to @alexvea for investigation and the patch 💯 

**Fixes** 🔨 MON-25070

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Follow the procedure indicated in the ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
