### PR TITLE
fix(api/notification): correction of contact and contact group inheritance

### DIFF
--- a/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryApi.php
+++ b/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryApi.php
@@ -157,7 +157,7 @@ class MonitoringServerConfigurationRepositoryApi implements MonitoringServerConf
                 'proxy' => null,
                 'no_proxy' => '*',
                 'verify_peer' => false,
-                'headers' => ['X-AUTH-TOKEN' => $providerToken->getToken(), 'Cookie' => 'XDEBUG_SESSION=XDEBUG_KEY'],
+                'headers' => ['X-AUTH-TOKEN' => $providerToken->getToken()],
                 'body' => $payloadBody,
                 'timeout' => $this->timeout,
             ];

--- a/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryApi.php
+++ b/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryApi.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2021 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,54 +18,45 @@
  * For more information : contact@centreon.com
  *
  */
+
 declare(strict_types=1);
 
 namespace Centreon\Infrastructure\MonitoringServer\Repository;
 
 use Centreon\Domain\Authentication\Exception\AuthenticationException;
 use Centreon\Domain\Common\Assertion\Assertion;
-use Centreon\Domain\Log\LoggerTrait;
-use DateTime;
-use Symfony\Component\HttpClient\Exception\TransportException;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use Security\Domain\Authentication\Interfaces\AuthenticationTokenServiceInterface;
+use Centreon\Domain\Exception\TimeoutException;
+use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerConfigurationRepositoryInterface;
 use Centreon\Domain\Repository\RepositoryException;
-use Centreon\Domain\Exception\TimeoutException;
 use Centreon\Infrastructure\MonitoringServer\Repository\Exception\MonitoringServerConfigurationRepositoryException;
+use DateTime;
+use Security\Domain\Authentication\Interfaces\AuthenticationTokenServiceInterface;
+use Symfony\Component\HttpClient\Exception\TransportException;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 /**
  * This class is designed to represent the API repository to manage the generation/move/reload of the monitoring
  * server configuration.
- *
- * @package Centreon\Infrastructure\MonitoringServer\Repository
  */
 class MonitoringServerConfigurationRepositoryApi implements MonitoringServerConfigurationRepositoryInterface
 {
     use LoggerTrait;
 
-    /**
-     * @var ContactInterface
-     */
+    /** @var ContactInterface */
     private $contact;
-    /**
-     * @var AuthenticationTokenServiceInterface
-     */
+
+    /** @var AuthenticationTokenServiceInterface */
     private $authenticationTokenService;
-    /**
-     * @var \Symfony\Contracts\HttpClient\HttpClientInterface
-     */
+
+    /** @var \Symfony\Contracts\HttpClient\HttpClientInterface */
     private $httpClient;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $serverUri;
 
-    /**
-     * @var int
-     */
+    /** @var int */
     private $timeout = 60;
 
     /**
@@ -87,27 +78,14 @@ class MonitoringServerConfigurationRepositoryApi implements MonitoringServerConf
      * To be used by the dependency injector to increase the timeout limit.
      *
      * @param int $timeout
+     *
      * @return MonitoringServerConfigurationRepositoryApi
      */
-    public function setTimeout(int $timeout): MonitoringServerConfigurationRepositoryApi
+    public function setTimeout(int $timeout): self
     {
         $this->timeout = $timeout;
-        return $this;
-    }
 
-    /**
-     * @throws \Assert\AssertionFailedException
-     */
-    private function initUri(): void
-    {
-        if ($this->serverUri === null) {
-            $serverScheme = $_SERVER['REQUEST_SCHEME'] ?: 'http';
-            Assertion::notEmpty($_SERVER['SERVER_NAME']);
-            Assertion::notEmpty($_SERVER['REQUEST_URI']);
-            $prefixUri = explode('/', $_SERVER['REQUEST_URI'])[1];
-            // ex: http://localhost:80/centreon
-            $this->serverUri = $serverScheme . '://' . $_SERVER['SERVER_NAME'] . '/' . $prefixUri;
-        }
+        return $this;
     }
 
     /**
@@ -126,7 +104,7 @@ class MonitoringServerConfigurationRepositoryApi implements MonitoringServerConf
         $this->callHttp('moveFiles.php', 'poller=' . $monitoringServerId);
     }
 
-     /**
+    /**
      * @inheritDoc
      */
     public function reloadConfiguration(int $monitoringServerId): void
@@ -135,8 +113,24 @@ class MonitoringServerConfigurationRepositoryApi implements MonitoringServerConf
     }
 
     /**
+     * @throws \Assert\AssertionFailedException
+     */
+    private function initUri(): void
+    {
+        if ($this->serverUri === null) {
+            $serverScheme = $_SERVER['REQUEST_SCHEME'] ?: 'http';
+            Assertion::notEmpty($_SERVER['SERVER_NAME']);
+            Assertion::notEmpty($_SERVER['REQUEST_URI']);
+            $prefixUri = explode('/', $_SERVER['REQUEST_URI'])[1];
+            // ex: http://localhost:80/centreon
+            $this->serverUri = $serverScheme . '://' . $_SERVER['SERVER_NAME'] . '/' . $prefixUri;
+        }
+    }
+
+    /**
      * @param string $filePath
      * @param string $payloadBody
+     *
      * @throws RepositoryException
      * @throws TimeoutException
      * @throws AuthenticationException
@@ -163,9 +157,9 @@ class MonitoringServerConfigurationRepositoryApi implements MonitoringServerConf
                 'proxy' => null,
                 'no_proxy' => '*',
                 'verify_peer' => false,
-                'headers' => ['X-AUTH-TOKEN' => $providerToken->getToken()],
+                'headers' => ['X-AUTH-TOKEN' => $providerToken->getToken(), 'Cookie' => 'XDEBUG_SESSION=XDEBUG_KEY'],
                 'body' => $payloadBody,
-                'timeout' => $this->timeout
+                'timeout' => $this->timeout,
             ];
 
             $optionPayload['verify_host'] = $optionPayload['verify_peer'];
@@ -176,7 +170,7 @@ class MonitoringServerConfigurationRepositoryApi implements MonitoringServerConf
             }
 
             $xml = $response->getContent();
-            if (!empty($xml)) {
+            if (! empty($xml)) {
                 if (($element = simplexml_load_string($xml)) !== false) {
                     if ((string) $element->statuscode !== '0') {
                         throw new RepositoryException((string) $element->error);
@@ -185,14 +179,15 @@ class MonitoringServerConfigurationRepositoryApi implements MonitoringServerConf
             } else {
                 throw MonitoringServerConfigurationRepositoryException::responseEmpty();
             }
-        } catch (RepositoryException | AuthenticationException $ex) {
+        } catch (RepositoryException|AuthenticationException $ex) {
             throw $ex;
         } catch (\Assert\AssertionFailedException $ex) {
             throw MonitoringServerConfigurationRepositoryException::errorWhenInitializingApiUri();
         } catch (\Throwable $ex) {
-            if ($ex instanceof TransportException && strpos($ex->getMessage(), 'timeout') > 0) {
+            if ($ex instanceof TransportException && mb_strpos($ex->getMessage(), 'timeout') > 0) {
                 throw MonitoringServerConfigurationRepositoryException::timeout($ex);
             }
+
             throw MonitoringServerConfigurationRepositoryException::unexpectedError($ex);
         }
     }

--- a/centreon/src/Core/Application/Configuration/Notification/Repository/ReadServiceNotificationRepositoryInterface.php
+++ b/centreon/src/Core/Application/Configuration/Notification/Repository/ReadServiceNotificationRepositoryInterface.php
@@ -29,16 +29,18 @@ use Core\Domain\Configuration\Notification\Model\NotifiedContactGroup;
 interface ReadServiceNotificationRepositoryInterface
 {
     /**
+     * @param int $hostId
      * @param int $serviceId
      *
      * @return NotifiedContact[]
      */
-    public function findNotifiedContactsById(int $serviceId): array;
+    public function findNotifiedContactsById(int $hostId, int $serviceId): array;
 
     /**
+     * @param int $hostId
      * @param int $serviceId
      *
      * @return NotifiedContactGroup[]
      */
-    public function findNotifiedContactGroupsById(int $serviceId): array;
+    public function findNotifiedContactGroupsById(int $hostId, int $serviceId): array;
 }

--- a/centreon/src/Core/Application/Configuration/NotificationPolicy/UseCase/FindServiceNotificationPolicy.php
+++ b/centreon/src/Core/Application/Configuration/NotificationPolicy/UseCase/FindServiceNotificationPolicy.php
@@ -92,8 +92,9 @@ class FindServiceNotificationPolicy
             return;
         }
 
-        $notifiedContacts = $this->readServiceNotificationRepository->findNotifiedContactsById($serviceId);
-        $notifiedContactGroups = $this->readServiceNotificationRepository->findNotifiedContactGroupsById($serviceId);
+        $notifiedContacts = $this->readServiceNotificationRepository->findNotifiedContactsById($hostId, $serviceId);
+        $notifiedContactGroups = $this->readServiceNotificationRepository->findNotifiedContactGroupsById($hostId,
+            $serviceId);
 
         $realtimeService = $this->readRealTimeServiceRepository->findServiceById($hostId, $serviceId);
         if ($realtimeService === null) {

--- a/centreon/src/Core/Infrastructure/Configuration/NotificationPolicy/Repository/LegacyReadServiceNotificationRepository.php
+++ b/centreon/src/Core/Infrastructure/Configuration/NotificationPolicy/Repository/LegacyReadServiceNotificationRepository.php
@@ -51,10 +51,10 @@ class LegacyReadServiceNotificationRepository extends AbstractDbReadNotification
     /**
      * @inheritDoc
      */
-    public function findNotifiedContactsById(int $serviceId): array
+    public function findNotifiedContactsById(int $hostId, int $serviceId): array
     {
         if (! isset($this->notifiedContacts[$serviceId])) {
-            $this->fetchNotifiedContactsAndContactGroups($serviceId);
+            $this->fetchNotifiedContactsAndContactGroups($hostId, $serviceId);
         }
 
         return $this->notifiedContacts[$serviceId];
@@ -63,10 +63,10 @@ class LegacyReadServiceNotificationRepository extends AbstractDbReadNotification
     /**
      * @inheritDoc
      */
-    public function findNotifiedContactGroupsById(int $serviceId): array
+    public function findNotifiedContactGroupsById(int $hostId, int $serviceId): array
     {
         if (! isset($this->notifiedContactGroups[$serviceId])) {
-            $this->fetchNotifiedContactsAndContactGroups($serviceId);
+            $this->fetchNotifiedContactsAndContactGroups($hostId, $serviceId);
         }
 
         return $this->notifiedContactGroups[$serviceId];
@@ -75,10 +75,12 @@ class LegacyReadServiceNotificationRepository extends AbstractDbReadNotification
     /**
      * Initialize notified contacts and contactgroups for given service id.
      *
+     * @param int $hostId
      * @param int $serviceId
      */
-    private function fetchNotifiedContactsAndContactGroups(int $serviceId): void
+    private function fetchNotifiedContactsAndContactGroups(int $hostId, int $serviceId): void
     {
+
         /**
          * Call to Legacy code to get the contacts and contactgroups
          * that will be notified for the Service regarding global
@@ -86,11 +88,25 @@ class LegacyReadServiceNotificationRepository extends AbstractDbReadNotification
          */
         $serviceInstance = \Service::getInstance($this->dependencyInjector);
 
+        $serviceInstance->generateServiceCache();
+        /**
+         * @var array{service_use_only_contacts_from_host: string}|null $service
+         */
+        $service = $serviceInstance->getServiceFromCache($serviceId);
         [
             'contact' => $notifiedContactIds,
             'cg' => $notifiedContactGroupIds,
         ] = $serviceInstance->getCgAndContacts($serviceId);
 
+        if ($service !== null && $service['service_use_only_contacts_from_host'] === '1') {
+            $hostInstance = \Host::getInstance($this->dependencyInjector);
+            $host = [
+                'host_id' => $hostId,
+            ];
+            $hostInstance->processingFromHost($host, false);
+            $notifiedContactIds = $host['contacts_cache'] ?? [];
+            $notifiedContactGroupIds = $host['contact_groups_cache'] ?? [];
+        }
         $this->notifiedContacts[$serviceId] = $this->findContactsByIds($notifiedContactIds);
         $this->notifiedContactGroups[$serviceId] = $this->findContactGroupsByIds($notifiedContactGroupIds);
     }

--- a/centreon/src/Core/Infrastructure/Configuration/NotificationPolicy/Repository/LegacyReadServiceNotificationRepository.php
+++ b/centreon/src/Core/Infrastructure/Configuration/NotificationPolicy/Repository/LegacyReadServiceNotificationRepository.php
@@ -87,26 +87,23 @@ class LegacyReadServiceNotificationRepository extends AbstractDbReadNotification
          * notification inheritance parameter.
          */
         $serviceInstance = \Service::getInstance($this->dependencyInjector);
-
-        $serviceInstance->generateServiceCache();
-        /**
-         * @var array{service_use_only_contacts_from_host: string}|null $service
-         */
-        $service = $serviceInstance->getServiceFromCache($serviceId);
         [
             'contact' => $notifiedContactIds,
             'cg' => $notifiedContactGroupIds,
         ] = $serviceInstance->getCgAndContacts($serviceId);
 
+        /**
+         * @var array{service_use_only_contacts_from_host: string}|null $service
+         */
+        $service = $serviceInstance->getServiceFromCache($serviceId);
         if ($service !== null && $service['service_use_only_contacts_from_host'] === '1') {
             $hostInstance = \Host::getInstance($this->dependencyInjector);
-            $host = [
-                'host_id' => $hostId,
-            ];
+            $host = ['host_id' => $hostId];
             $hostInstance->processingFromHost($host, false);
             $notifiedContactIds = $host['contacts_cache'] ?? [];
             $notifiedContactGroupIds = $host['contact_groups_cache'] ?? [];
         }
+
         $this->notifiedContacts[$serviceId] = $this->findContactsByIds($notifiedContactIds);
         $this->notifiedContactGroups[$serviceId] = $this->findContactGroupsByIds($notifiedContactGroupIds);
     }

--- a/centreon/www/class/config-generate/abstract/object.class.php
+++ b/centreon/www/class/config-generate/abstract/object.class.php
@@ -37,6 +37,7 @@ abstract class AbstractObject
 {
     protected const VAULT_PATH_REGEX = '/^secret::[^:]*::/';
 
+    /** @var Backend|null  */
     protected $backend_instance = null;
     protected $generate_subpath = 'nagios';
     protected $generate_filename = null;

--- a/centreon/www/class/config-generate/backend.class.php
+++ b/centreon/www/class/config-generate/backend.class.php
@@ -48,6 +48,8 @@ class Backend
     public $generate_path = '/var/cache/centreon/config';
     public $engine_sub = 'engine';
     public $broker_sub = 'broker';
+
+    /** @var CentreonDB|null  */
     public $db = null;
     public $db_cs = null;
 

--- a/centreon/www/class/config-generate/host.class.php
+++ b/centreon/www/class/config-generate/host.class.php
@@ -478,14 +478,14 @@ class Host extends AbstractHost
         $this->hosts = $stmt->fetchAll(PDO::FETCH_GROUP | PDO::FETCH_UNIQUE | PDO::FETCH_ASSOC);
     }
 
-    public function generateFromHostId(&$host)
+    public function processingFromHost(&$host, $generateConfigurationFile = true): void
     {
         $this->getImages($host);
         $this->getMacros($host);
         $host['macros']['_HOST_ID'] = $host['host_id'];
 
         $this->getHostTimezone($host);
-        $this->getHostTemplates($host);
+        $this->getHostTemplates($host, $generateConfigurationFile);
         $this->getHostCommands($host);
         $this->getHostPeriods($host);
         $this->getContactGroups($host);
@@ -500,7 +500,13 @@ class Host extends AbstractHost
         $this->getParents($host);
         $this->getSeverity($host['host_id']);
 
-        $this->manageNotificationInheritance($host);
+        $this->manageNotificationInheritance($host, $generateConfigurationFile);
+
+    }
+
+    public function generateFromHostId(&$host)
+    {
+        $this->processingFromHost($host);
 
         $this->getServices($host);
         $this->getServicesByHg($host);

--- a/centreon/www/class/config-generate/service.class.php
+++ b/centreon/www/class/config-generate/service.class.php
@@ -80,7 +80,7 @@ class Service extends AbstractService
         }
     }
 
-    private function getServiceByPollerCache() : void
+    private function generateServiceCacheByPollerCache() : void
     {
         $query = "SELECT $this->attributes_select FROM ns_host_relation, host_service_relation, service " .
             "LEFT JOIN extended_service_information ON extended_service_information.service_service_id = " .
@@ -96,7 +96,7 @@ class Service extends AbstractService
         }
     }
 
-    private function getServiceCache() : void
+    public function generateServiceCache() : void
     {
         $query = "SELECT $this->attributes_select FROM service " .
             "LEFT JOIN extended_service_information ON extended_service_information.service_service_id = " .
@@ -514,9 +514,9 @@ class Service extends AbstractService
             return;
         }
         if ($this->use_cache_poller == 1) {
-            $this->getServiceByPollerCache();
+            $this->generateServiceCacheByPollerCache();
         } else {
-            $this->getServiceCache();
+            $this->generateServiceCache();
         }
         $this->done_cache = 1;
     }
@@ -648,5 +648,13 @@ class Service extends AbstractService
         }
         $this->generated_services = array();
         parent::reset();
+    }
+
+    public function getServiceFromCache(int $serviceId): ?array
+    {
+        if ($this->service_cache !== null && ! array_key_exists($serviceId, $this->service_cache)) {
+            return null;
+        }
+        return $this->service_cache[$serviceId];
     }
 }

--- a/centreon/www/class/config-generate/service.class.php
+++ b/centreon/www/class/config-generate/service.class.php
@@ -96,7 +96,7 @@ class Service extends AbstractService
         }
     }
 
-    public function generateServiceCache() : void
+    private function generateServiceCache() : void
     {
         $query = "SELECT $this->attributes_select FROM service " .
             "LEFT JOIN extended_service_information ON extended_service_information.service_service_id = " .


### PR DESCRIPTION
## Description

When calling API `configuration/hosts/{host_id}/services/{service_id}/notification-policy`, the inheritance calculation for contacts and contact groups was not correct when the calculation mode was based on "Cumulative inheritance".

**Fixes** # MON-32888

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
