### PR TITLE
fix(gorgone): backport 22.10 - Gorgone stops responding every 24-48 hrs with pull mode

### DIFF
--- a/centreon-gorgone/gorgone/modules/core/pullwss/class.pm
+++ b/centreon-gorgone/gorgone/modules/core/pullwss/class.pm
@@ -248,7 +248,20 @@ sub transmit_back {
             return '[SETLOGS] [' . $1 . '] [] ' . $2;
         }
         return undef;
-    } elsif ($options{message} =~ /^\[(PONG|SYNCLOGS)\]/) {
+    } elsif ($options{message} =~ /^\[BCASTCOREKEY\]\s+\[.*?\]\s+\[.*?\]\s+(.*)/m) {
+        my $data;
+        eval {
+            $data = JSON::XS->new->decode($1);
+        };
+        if ($@) {
+            $connector->{logger}->writeLogDebug("[pull] cannot decode BCASTCOREKEY: $@");
+            return undef;
+        }
+
+        $connector->action_bcastcorekey(data => $data);
+        return undef;
+    }
+    elsif ($options{message} =~ /^\[(PONG|SYNCLOGS)\]/) {
         return $options{message};
     }
     return undef;


### PR DESCRIPTION
## Description

Gorgone continues to be running/active but does not send information to other pollers who are using pull mode.
The workaround is to restart the gorgoned process.
this pr backport the change made by the ticket MON-21371.

**Fixes** # (MON-23884)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

**How to reproduce**

Configure a poller using the pull mode of Centreon Gorgone 

Add the following option in /etc/centreon-gorgone/config.d/40-gorgoned.yaml file (avoid to wait 24h):
```
gorgone:
  gorgonecore:
    internal_com_rotation: 3
```

wait 10 minutes, you should see error in the log in the form 
```
2023-09-01 11:20:07 - ERROR - [pull] decrypt issue: no message
2023-09-01 11:20:07 - ERROR - [pull] decrypt issue: padding_depad failed: Invalid argument provided. at /usr/lib/x86_64-linux-gnu/perl5/5.32/Crypt/Mode/CBC.pm line 20.
```

one the patch is applied, there should be no more error in the logs, and informations should be sent normaly.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
