### PR TITLE
fix(test): disable send_statistics for upgrade test in TA

### DIFF
--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -105,7 +105,7 @@ runs:
         key: ${{ inputs.cache_key }}
 
     # Update if condition to true to get packages as artifacts
-    - if: ${{ false }}
+    - if: ${{ true }}
       name: Upload package artifacts
       uses: actions/upload-artifact@v3
       with:

--- a/centreon/packages/js-config/cypress/e2e/commands.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands.ts
@@ -14,12 +14,12 @@ const artifactIllegalCharactersMatcher = /[,\s/|<>*?:"]/g;
 Cypress.Commands.add('getWebVersion', (): Cypress.Chainable => {
   return (
     cy
-      // .exec(
-      //   `bash -c "grep version ../../www/install/insertBaseConf.sql | cut -d \\' -f 4 | awk 'NR==2'"`
-      // )
       .exec(
-        `wsl bash -c "grep version ../../www/install/insertBaseConf.sql | cut -d \\\\' -f 4 | awk 'NR==2'"`
+        `bash -c "grep version ../../www/install/insertBaseConf.sql | cut -d \\' -f 4 | awk 'NR==2'"`
       )
+      // .exec(
+      //   `wsl bash -c "grep version ../../www/install/insertBaseConf.sql | cut -d \\\\' -f 4 | awk 'NR==2'"`
+      // )
       .then(({ stdout }) => {
         const found = stdout.match(/(\d+\.\d+)\.(\d+)/);
         if (found) {

--- a/centreon/packages/js-config/cypress/e2e/commands.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands.ts
@@ -12,18 +12,23 @@ const apiLoginV2 = '/centreon/authentication/providers/configurations/local';
 const artifactIllegalCharactersMatcher = /[,\s/|<>*?:"]/g;
 
 Cypress.Commands.add('getWebVersion', (): Cypress.Chainable => {
-  return cy
-    .exec(
-      `bash -c "grep version ../../www/install/insertBaseConf.sql | cut -d \\' -f 4 | awk 'NR==2'"`
-    )
-    .then(({ stdout }) => {
-      const found = stdout.match(/(\d+\.\d+)\.(\d+)/);
-      if (found) {
-        return cy.wrap({ major_version: found[1], minor_version: found[2] });
-      }
+  return (
+    cy
+      // .exec(
+      //   `bash -c "grep version ../../www/install/insertBaseConf.sql | cut -d \\' -f 4 | awk 'NR==2'"`
+      // )
+      .exec(
+        `wsl bash -c "grep version ../../www/install/insertBaseConf.sql | cut -d \\\\' -f 4 | awk 'NR==2'"`
+      )
+      .then(({ stdout }) => {
+        const found = stdout.match(/(\d+\.\d+)\.(\d+)/);
+        if (found) {
+          return cy.wrap({ major_version: found[1], minor_version: found[2] });
+        }
 
-      throw new Error('Current web version cannot be parsed.');
-    });
+        throw new Error('Current web version cannot be parsed.');
+      })
+  );
 });
 
 Cypress.Commands.add('getIframeBody', (): Cypress.Chainable => {

--- a/centreon/packages/js-config/cypress/e2e/commands.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands.ts
@@ -12,23 +12,18 @@ const apiLoginV2 = '/centreon/authentication/providers/configurations/local';
 const artifactIllegalCharactersMatcher = /[,\s/|<>*?:"]/g;
 
 Cypress.Commands.add('getWebVersion', (): Cypress.Chainable => {
-  return (
-    cy
-      .exec(
-        `bash -c "grep version ../../www/install/insertBaseConf.sql | cut -d \\' -f 4 | awk 'NR==2'"`
-      )
-      // .exec(
-      //   `wsl bash -c "grep version ../../www/install/insertBaseConf.sql | cut -d \\\\' -f 4 | awk 'NR==2'"`
-      // )
-      .then(({ stdout }) => {
-        const found = stdout.match(/(\d+\.\d+)\.(\d+)/);
-        if (found) {
-          return cy.wrap({ major_version: found[1], minor_version: found[2] });
-        }
+  return cy
+    .exec(
+      `bash -c "grep version ../../www/install/insertBaseConf.sql | cut -d \\' -f 4 | awk 'NR==2'"`
+    )
+    .then(({ stdout }) => {
+      const found = stdout.match(/(\d+\.\d+)\.(\d+)/);
+      if (found) {
+        return cy.wrap({ major_version: found[1], minor_version: found[2] });
+      }
 
-        throw new Error('Current web version cannot be parsed.');
-      })
-  );
+      throw new Error('Current web version cannot be parsed.');
+    });
 });
 
 Cypress.Commands.add('getIframeBody', (): Cypress.Chainable => {

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -179,6 +179,7 @@ EOF`,
   cy.get('input[name="email"]').type(
     '{selectall}{backspace}centreon@localhost'
   );
+  cy.get('#send_statistics').invoke('val', '0').should('have.attr', 'value', '0');
   cy.wait('@nextStep').get('#next').click();
 
   // Step 6

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -179,7 +179,7 @@ EOF`,
   cy.get('input[name="email"]').type(
     '{selectall}{backspace}centreon@localhost'
   );
-  cy.get('#send_statistics').invoke('val', '0').should('have.attr', 'value', '0');
+
   cy.wait('@nextStep').get('#next').click();
 
   // Step 6
@@ -327,6 +327,7 @@ When('administrator runs the update procedure', () => {
   cy.get('.btc.bt_info', { timeout: 15000 }).should('be.visible').click();
 
   cy.wait('@getStep5').get('.btc.bt_success').should('be.visible').click();
+  cy.get('#send_statistics').invoke('val', '0').should('have.attr', 'value', '0');
 });
 
 Then(


### PR DESCRIPTION
## Description

The update acceptance test run update wizard and this one enable send_statistics option (centreon.options) automatically.
We needed to disable send_statistics option (set to '0') before login.

**Fixes** # MON-24742

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
