### PR TITLE
[MON-33148] remove trim which fail on array

### DIFF
--- a/centreon/www/class/centreonAuth.LDAP.class.php
+++ b/centreon/www/class/centreonAuth.LDAP.class.php
@@ -211,7 +211,7 @@ class CentreonAuthLDAP
             $userEmail = $this->contactInfos['contact_email'];
             if (
                 isset($userInfos[$this->ldap->getAttrName('user', 'email')])
-                && trim($userInfos[$this->ldap->getAttrName('user', 'email')]) != ''
+                && ($userInfos[$this->ldap->getAttrName('user', 'email')]) != ''
             ) {
                 if (is_array($userInfos[$this->ldap->getAttrName('user', 'email')])) {
                     // Get the first if there are multiple entries
@@ -226,7 +226,7 @@ class CentreonAuthLDAP
             $userPager = $this->contactInfos['contact_pager'];
             if (
                 isset($userInfos[$this->ldap->getAttrName('user', 'pager')])
-                && trim($userInfos[$this->ldap->getAttrName('user', 'pager')]) != ''
+                && ($userInfos[$this->ldap->getAttrName('user', 'pager')]) != ''
             ) {
                 if (is_array($userInfos[$this->ldap->getAttrName('user', 'pager')])) {
                     // Get the first if there are multiple entries


### PR DESCRIPTION
## Description

Remove trim which fail on array

**Fixes** # (issue)
MON-33148-Unable-to-login-if-2-mails-addresses-on-LDAP

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Log in Centreon with an LDAP account which have 2 mails attributes.
