### PR TITLE
fix(curves): fix templates edition always raising errors

### DIFF
--- a/centreon/www/include/views/componentTemplates/DB-Func.php
+++ b/centreon/www/include/views/componentTemplates/DB-Func.php
@@ -49,12 +49,12 @@ function DsHsrTestExistence($name = null)
 
     $query = 'SELECT compo_id FROM giv_components_template WHERE ds_name = :ds_name';
 
-    if (!empty($formValues['host_id'])) {
-        if (preg_match('/([0-9]+)-([0-9]+)/', $formValues['host_id'], $matches)) {
+    if (!empty($formValues['host_service_id'])) {
+        if (preg_match('/([0-9]+)-([0-9]+)/', $formValues['host_service_id'], $matches)) {
             $formValues['host_id'] = (int) $matches[1];
             $formValues['service_id'] = (int) $matches[2];
         } else {
-            throw new \InvalidArgumentException('host_id must be a combination of integers');
+            throw new \InvalidArgumentException('host_service_id must be a combination of integers');
         }
     }
 
@@ -81,9 +81,9 @@ function DsHsrTestExistence($name = null)
 
     $stmt->execute();
     $compo = $stmt->fetch();
-    if ($stmt->rowCount() >= 1 && $compo['compo_id'] === $formValues['compo_id']) {
+    if ($stmt->rowCount() >= 1 && $compo['compo_id'] === (int) $formValues['compo_id']) {
         return true;
-    } elseif ($stmt->rowCount() >= 1 && $compo['compo_id'] !== $formValues['compo_id']) {
+    } elseif ($stmt->rowCount() >= 1 && $compo['compo_id'] !== (int) $formValues['compo_id']) {
         return false;
     } else {
         return true;
@@ -98,13 +98,15 @@ function NameHsrTestExistence($name = null)
     if (isset($form)) {
         $formValues = $form->getSubmitValues();
     }
+
     $query = 'SELECT compo_id FROM giv_components_template WHERE name = :name';
-    if (!empty($formValues['host_id'])) {
-        if (preg_match('/([0-9]+)-([0-9]+)/', $formValues['host_id'], $matches)) {
+    
+    if (!empty($formValues['host_service_id'])) {
+        if (preg_match('/([0-9]+)-([0-9]+)/', $formValues['host_service_id'], $matches)) {
             $formValues['host_id'] = (int) $matches[1];
             $formValues['service_id'] = (int) $matches[2];
         } else {
-            throw new \InvalidArgumentException('chartId must be a combination of integers');
+            throw new \InvalidArgumentException('host_service_id must be a combination of integers');
         }
     }
 
@@ -131,9 +133,9 @@ function NameHsrTestExistence($name = null)
 
     $stmt->execute();
     $compo = $stmt->fetch();
-    if ($stmt->rowCount() >= 1 && $compo['compo_id'] === $formValues['compo_id']) {
+    if ($stmt->rowCount() >= 1 && $compo['compo_id'] === (int) $formValues['compo_id']) {
         return true;
-    } elseif ($stmt->rowCount() >= 1 && $compo['compo_id'] !== $formValues['compo_id']) {
+    } elseif ($stmt->rowCount() >= 1 && $compo['compo_id'] !== (int) $formValues['compo_id']) {
         return false;
     } else {
         return true;
@@ -247,7 +249,7 @@ function insertComponentTemplate()
         $formValues['ds_color_area'] = $formValues['ds_color_line'];
     }
 
-    list($formValues['host_id'], $formValues['service_id']) = parseHostIdPostParameter($formValues['host_id']);
+    list($formValues['host_id'], $formValues['service_id']) = parseHostIdPostParameter($formValues['host_service_id']);
 
     $bindParams = sanitizeFormComponentTemplatesParameters($formValues);
 

--- a/centreon/www/include/views/componentTemplates/DB-Func.php
+++ b/centreon/www/include/views/componentTemplates/DB-Func.php
@@ -48,15 +48,10 @@ function DsHsrTestExistence($name = null)
     }
 
     $query = 'SELECT compo_id FROM giv_components_template WHERE ds_name = :ds_name';
-
-    if (!empty($formValues['host_service_id'])) {
-        if (preg_match('/([0-9]+)-([0-9]+)/', $formValues['host_service_id'], $matches)) {
-            $formValues['host_id'] = (int) $matches[1];
-            $formValues['service_id'] = (int) $matches[2];
-        } else {
-            throw new \InvalidArgumentException('host_service_id must be a combination of integers');
-        }
-    }
+    
+    list($formValues['host_id'], $formValues['service_id']) = parseHostServiceIdPostParameter(
+        $formValues['host_service_id']
+    );
 
     if (!empty($formValues['host_id']) && !empty($formValues['service_id'])) {
         $query .= ' AND host_id = :hostId AND service_id = :serviceId';
@@ -101,14 +96,9 @@ function NameHsrTestExistence($name = null)
 
     $query = 'SELECT compo_id FROM giv_components_template WHERE name = :name';
     
-    if (!empty($formValues['host_service_id'])) {
-        if (preg_match('/([0-9]+)-([0-9]+)/', $formValues['host_service_id'], $matches)) {
-            $formValues['host_id'] = (int) $matches[1];
-            $formValues['service_id'] = (int) $matches[2];
-        } else {
-            throw new \InvalidArgumentException('host_service_id must be a combination of integers');
-        }
-    }
+    list($formValues['host_id'], $formValues['service_id']) = parseHostServiceIdPostParameter(
+        $formValues['host_service_id']
+    );
 
     if (!empty($formValues['host_id']) && !empty($formValues['service_id'])) {
         $query .= ' AND host_id = :hostId AND service_id = :serviceId';
@@ -249,7 +239,9 @@ function insertComponentTemplate()
         $formValues['ds_color_area'] = $formValues['ds_color_line'];
     }
 
-    list($formValues['host_id'], $formValues['service_id']) = parseHostIdPostParameter($formValues['host_service_id']);
+    list($formValues['host_id'], $formValues['service_id']) = parseHostServiceIdPostParameter(
+        $formValues['host_service_id']
+    );
 
     $bindParams = sanitizeFormComponentTemplatesParameters($formValues);
 
@@ -274,20 +266,20 @@ function insertComponentTemplate()
 }
 
 /**
- * Parses the host_id parameter from the form and checks the hostId-serviceId format
+ * Parses the host_service_id parameter from the form and checks the hostId-serviceId format
  * and returns the hostId et serviceId when defined.
  *
- * @param string|null $hostIdParameter
+ * @param string|null $hostServiceIdParameter
  * @return array
  */
-function parseHostIdPostParameter(?string $hostIdParameter): array
+function parseHostServiceIdPostParameter(?string $hostServiceIdParameter): array
 {
-    if (!empty($hostIdParameter)) {
-        if (preg_match('/([0-9]+)-([0-9]+)/', $hostIdParameter, $matches)) {
+    if (!empty($hostServiceIdParameter)) {
+        if (preg_match('/([0-9]+)-([0-9]+)/', $hostServiceIdParameter, $matches)) {
             $hostId = (int) $matches[1];
             $serviceId = (int) $matches[2];
         } else {
-            throw new \InvalidArgumentException('host_id must be a combination of integers');
+            throw new \InvalidArgumentException('host_service_id must be a combination of integers');
         }
     } else {
         $hostId = null;
@@ -313,7 +305,9 @@ function updateComponentTemplate($compoId = null)
         $formValues['ds_color_area'] = $formValues['ds_color_line'];
     }
 
-    list($formValues['host_id'], $formValues['service_id']) = parseHostIdPostParameter($formValues['host_service_id']);
+    list($formValues['host_id'], $formValues['service_id']) = parseHostServiceIdPostParameter(
+        $formValues['host_service_id']
+    );
 
     // Sets the default values if they have not been sent (used to deselect the checkboxes)
     $checkBoxValueToSet = [


### PR DESCRIPTION
## Description

When editing a curve template, errors on both template and metric names are raised.
This is due to a string/int comparison on the template ID when determining if template or metric names already exist.

This fix casts the form value to make sure that comparison can work.

It also fixes the use of host_service_id form value (when user select "Linked Host Services").

Fixes #463

## Type of change

- [x] Patch fixing an issue (non-breaking change)

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Add a curve template,
2. Edit the newly created curve template,
3. Save the curve template.

No error should be shown.

Do the same but select a host/service couple. No error should be shown either.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the parsing of host and service IDs to enhance code readability and validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->