### PR TITLE
fix(smarty) : refactor deprecated {php} tag

### DIFF
--- a/centreon/GPL_LIB/smarty-plugins/compiler.paginationknowledge.php
+++ b/centreon/GPL_LIB/smarty-plugins/compiler.paginationknowledge.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+/**
+ * This plugin exists to avoid using the deprecated {php} tag
+ * when we use it only for the pagination.
+ *
+ * Before <pre>
+ *     {php}
+ *     include('./include/common/pagination.php');
+ *     {/php}
+ * </pre>
+ *
+ * After <pre>
+ *     {pagination}
+ * </pre>
+ */
+class Smarty_Compiler_Paginationknowledge extends Smarty_Internal_CompileBase
+{
+    /**
+     * @param array<mixed> $args
+     * @param Smarty_Internal_TemplateCompilerBase $compiler
+     *
+     * @return string
+     */
+    public function compile($args, Smarty_Internal_TemplateCompilerBase $compiler): string
+    {
+        return "<?php include('./include/configuration/configKnowledge/pagination.php'); ?>";
+    }
+}

--- a/centreon/composer.json
+++ b/centreon/composer.json
@@ -100,6 +100,7 @@
         },
         "classmap": ["www/class/", "lib/Centreon"],
         "files" : [
+            "GPL_LIB/smarty-plugins/compiler.paginationknowledge.php",
             "GPL_LIB/smarty-plugins/compiler.displaysvg.php",
             "GPL_LIB/smarty-plugins/compiler.pagination.php",
             "GPL_LIB/smarty-plugins/compiler.php.php",

--- a/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
+++ b/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
@@ -94,7 +94,7 @@
             <td class="ListColHeaderCenter">{$actions_trans}&nbsp;&nbsp;&nbsp;</td>
         </tr>
         {assign var="line" value=0}
-        {php} $l = 0; {/php}
+        {assign var="l" value=0}
         {if $selection == 1}
         {foreach key=elem from=$content item=stt}
         <tr class="{php} global $line; print $line[$l%2]; {/php}">
@@ -136,10 +136,10 @@
                 {/if}
             </td>
         </tr>
-        {php} $l++ ; {/php}
+        {inc var="l"}
         {/foreach}
         {else}
-        {php} $l = 0; {/php}
+        {assign var="l" value=0}
         {foreach key=elem from=$content item=stt}
         <tr class="{php} global $line; print $line[$l%2]; {/php}">
             <td class="ListColCenter">
@@ -213,7 +213,7 @@
                 {/if}
             </td>
         </tr>
-        {php} $l++ ; {/php}
+        {inc var="l"}
         {/foreach}
         {/if}
     </table>

--- a/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
+++ b/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
@@ -93,12 +93,11 @@
             <td class="ListColHeaderCenter" style="width:170px;">{$status_trans}</td>
             <td class="ListColHeaderCenter">{$actions_trans}&nbsp;&nbsp;&nbsp;</td>
         </tr>
-        {assign var=line value=0}
         {assign var=l value=0}
+        {assign var=line value=$l%2}
         {if $selection == 1}
         {foreach key=elem from=$content item=stt}
-        {math equation="x % 2" x=$l assign="modulo"}
-        <tr class="{if $modulo eq 0}even{else}odd{/if}">
+        <tr class="{$line}">
             <td class="ListColCenter"><img class="ico-14" src="./img/icons/service.png"></td>
             <td class="ListColLeft">
                 <a
@@ -142,8 +141,7 @@
         {else}
         {assign var=l value=0}
         {foreach key=elem from=$content item=stt}
-        {math equation="x % 2" x=$l assign="modulo"}
-        <tr class="{if $modulo eq 0}even{else}odd{/if}">
+        <tr class="{$line}">
             <td class="ListColCenter">
             {if $selection == 1 || $selection == 3}
                 <img class="ico-14" src="./img/icons/service.png">

--- a/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
+++ b/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
@@ -94,7 +94,7 @@
             <td class="ListColHeaderCenter">{$actions_trans}&nbsp;&nbsp;&nbsp;</td>
         </tr>
         {assign var="line" value=0}
-        {assign var="l" value=0}
+        {$l = 0}
         {if $selection == 1}
         {foreach key=elem from=$content item=stt}
         <tr class="{php} global $line; print $line[$l%2]; {/php}">
@@ -136,10 +136,10 @@
                 {/if}
             </td>
         </tr>
-        {inc var="l"}
+        {$l = $l + 1}
         {/foreach}
         {else}
-        {assign var="l" value=0}
+        {$l = 0}
         {foreach key=elem from=$content item=stt}
         <tr class="{php} global $line; print $line[$l%2]; {/php}">
             <td class="ListColCenter">
@@ -213,7 +213,7 @@
                 {/if}
             </td>
         </tr>
-        {inc var="l"}
+        {$l = $l + 1}
         {/foreach}
         {/if}
     </table>

--- a/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
+++ b/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
@@ -97,7 +97,8 @@
         {assign var=l value=0}
         {if $selection == 1}
         {foreach key=elem from=$content item=stt}
-        <tr class="{php} global $line; print $line[$l%2]; {/php}">
+        {math equation="x % 2" x=$l assign="modulo"}
+        <tr class="{if $modulo eq 0}even{else}odd{/if}">
             <td class="ListColCenter"><img class="ico-14" src="./img/icons/service.png"></td>
             <td class="ListColLeft">
                 <a
@@ -141,7 +142,8 @@
         {else}
         {assign var=l value=0}
         {foreach key=elem from=$content item=stt}
-        <tr class="{php} global $line; print $line[$l%2]; {/php}">
+        {math equation="x % 2" x=$l assign="modulo"}
+        <tr class="{if $modulo eq 0}even{else}odd{/if}">
             <td class="ListColCenter">
             {if $selection == 1 || $selection == 3}
                 <img class="ico-14" src="./img/icons/service.png">

--- a/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
+++ b/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
@@ -71,9 +71,7 @@
     </table>
     <table class="ToolbarTable table">
         <tr class="ToolbarTR">
-            {php}
-            include('./include/configuration/configKnowledge/pagination.php');
-            {/php}
+            {paginationknowledge}
         </tr>
     </table>
     <table class="ListTable">
@@ -221,9 +219,7 @@
     </table>
     <table class="ToolbarTable table">
         <tr class="ToolbarTR">
-            {php}
-            include('./include/configuration/configKnowledge/pagination.php');
-            {/php}
+            {paginationknowledge}
         </tr>
     </table>
     <input type='hidden' name='o' id='o' value='42'>

--- a/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
+++ b/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
@@ -93,10 +93,8 @@
             <td class="ListColHeaderCenter" style="width:170px;">{$status_trans}</td>
             <td class="ListColHeaderCenter">{$actions_trans}&nbsp;&nbsp;&nbsp;</td>
         </tr>
-        {assign var="line" value=0}
-        {if !isset($l)}
-            {$l = 0}
-        {/if}
+        {assign var=line value=0}
+        {assign var=l value=0}
         {if $selection == 1}
         {foreach key=elem from=$content item=stt}
         <tr class="{php} global $line; print $line[$l%2]; {/php}">
@@ -138,10 +136,10 @@
                 {/if}
             </td>
         </tr>
-        {$l = $l + 1}
+        {inc var=l}
         {/foreach}
         {else}
-        {$l = 0}
+        {assign var=l value=0}
         {foreach key=elem from=$content item=stt}
         <tr class="{php} global $line; print $line[$l%2]; {/php}">
             <td class="ListColCenter">
@@ -215,7 +213,7 @@
                 {/if}
             </td>
         </tr>
-        {$l = $l + 1}
+        {inc var=l}
         {/foreach}
         {/if}
     </table>

--- a/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
+++ b/centreon/www/include/configuration/configKnowledge/templates/display.ihtml
@@ -94,7 +94,9 @@
             <td class="ListColHeaderCenter">{$actions_trans}&nbsp;&nbsp;&nbsp;</td>
         </tr>
         {assign var="line" value=0}
-        {$l = 0}
+        {if !isset($l)}
+            {$l = 0}
+        {/if}
         {if $selection == 1}
         {foreach key=elem from=$content item=stt}
         <tr class="{php} global $line; print $line[$l%2]; {/php}">


### PR DESCRIPTION
## Description

The tag {php} is deprecated for 12 years and we must refactor it to avoid its usage.

**Fixes** # (MON-33164)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Check if the pagination isn't broken on the page

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
