### PR TITLE
enh(Dashboards) : add unhandled problems filter to Status Grid widget

### DIFF
--- a/centreon/www/widgets/src/centreon-widget-statusgrid/properties.json
+++ b/centreon/www/widgets/src/centreon-widget-statusgrid/properties.json
@@ -77,6 +77,10 @@
       "label": "Display resources with this state",
       "options": [
         {
+          "id": "unhandled_problems",
+          "name": "Unhandled"
+        },
+        {
           "id": "acknowledged",
           "name": "Acknowledged"
         },


### PR DESCRIPTION
## Description

Why: be able to hide “acknowledged” and “in downtime” resources

How: 

add a state checkbox named “unhandled” in the widget properties panel (before “Acknowledged”)

must be unchecked by default

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)


#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
