### PR TITLE
fix(access groups) : Remove access to groups for contact management

### DIFF
--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -44,8 +44,6 @@ class CentreonACL
     const ACL_ACCESS_READ_WRITE = 1;
     const ACL_ACCESS_READ_ONLY = 2;
 
-    const CUSTOMER_ADMIN_ACL = 'customer_admin_acl';
-
     private $userID; /* ID of the user */
     private $parentTemplates = null;
     public $admin; /* Flag that tells us if the user is admin or not */
@@ -2553,7 +2551,7 @@ class CentreonACL
     public function getContactAclConf($options = array())
     {
         $request = $this->constructRequest($options, true);
-        if ($this->admin || (isCloudPlatform() && \in_array(self::CUSTOMER_ADMIN_ACL, $this->accessGroups))) {
+        if ($this->admin) {
             $sql = $request['select'] . $request['fields'] . " "
                 . "FROM contact "
                 . $request['join']
@@ -2608,7 +2606,7 @@ class CentreonACL
         }
 
 
-        if ($this->admin || (isCloudPlatform() && \in_array(self::CUSTOMER_ADMIN_ACL, $this->accessGroups))) {
+        if ($this->admin) {
             $sql = $request['select'] . $request['fields'] . " "
                 . "FROM contactgroup cg " . $sJointure
                 . "WHERE (cg.cg_type = 'local' " . $ldapCondition . ") "

--- a/centreon/www/include/configuration/configObject/contactgroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contactgroup/DB-Func.php
@@ -199,10 +199,6 @@ function insertContactGroup($ret)
         $ret = $form->getSubmitValues();
     }
 
-    if (isCloudPlatform() && isset($ret['cg_acl_groups'])) {
-        unset($ret['cg_acl_groups']);
-    }
-
     $cgName = $centreon->checkIllegalChar(
         \HtmlAnalyzer::sanitizeAndRemoveTags($ret["cg_name"])
     );
@@ -262,10 +258,6 @@ function updateContactGroup($cgId = null, $params = array())
         $ret = $params;
     } else {
         $ret = $form->getSubmitValues();
-    }
-
-    if (isCloudPlatform() && isset($ret['cg_acl_groups'])) {
-        unset($ret['cg_acl_groups']);
     }
 
     $cgName = $centreon->checkIllegalChar(

--- a/centreon/www/include/configuration/configObject/contactgroup/formContactGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/contactgroup/formContactGroup.ihtml
@@ -36,9 +36,7 @@
           </td>
         </tr>
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="members"> {$form.cg_contacts.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.cg_contacts.html}</p></td></tr>
-		{if isset($form.cg_acl_groups)}
-			<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="acl_groups"> {$form.cg_acl_groups.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.cg_acl_groups.html}</p></td></tr>
-	 	{/if}
+		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="acl_groups"> {$form.cg_acl_groups.label}</td><td class="FormRowValue"><p class="oreonbutton">{$form.cg_acl_groups.html}</p></td></tr>
 
 	 	<tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="2">

--- a/centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+++ b/centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
@@ -135,10 +135,7 @@ $attrAclgroup1 = array_merge(
     $attrAclgroups,
     array('defaultDatasetRoute' => $aclRoute)
 );
-
-if (! isCloudPlatform()) {
-    $form->addElement('select2', 'cg_acl_groups', _("Linked ACL groups"), array(), $attrAclgroup1);
-}
+$form->addElement('select2', 'cg_acl_groups', _("Linked ACL groups"), array(), $attrAclgroup1);
 
 /*
  * Further informations
@@ -180,8 +177,8 @@ $tpl = initSmartyTpl($path, $tpl);
 $tpl->assign(
     "helpattr",
     'TITLE, "' . _("Help") . '", CLOSEBTN, true, FIX, [this, 0, 5], BGCOLOR, "#ffff99", BORDERCOLOR, '
-        . '"orange", TITLEFONTCOLOR, "black", TITLEBGCOLOR, "orange", CLOSEBTNCOLORS, ["","black", "white", "red"],'
-        . ' WIDTH, -300, SHADOW, true, TEXTALIGN, "justify"'
+    . '"orange", TITLEFONTCOLOR, "black", TITLEBGCOLOR, "orange", CLOSEBTNCOLORS, ["","black", "white", "red"],'
+    . ' WIDTH, -300, SHADOW, true, TEXTALIGN, "justify"'
 );
 # prepare help texts
 $helptext = "";


### PR DESCRIPTION
## Description

Remove access to groups for contact management (Revert MON-22680).

**Fixes** # (MON-24833)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)
- 
#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
