### PR TITLE
enh(ci): autogenerate and save debug report on sast failure

### DIFF
--- a/.github/workflows/veracode-analysis.yml
+++ b/.github/workflows/veracode-analysis.yml
@@ -151,7 +151,7 @@ jobs:
 
       - name: Backup analysis reports
         # debug step used to investigate support case
-        if: ( success() || failure() ) && vars.VERACODE_BACKUP_DEBUG == 'true'
+        if: ( success() && vars.VERACODE_BACKUP_DEBUG == 'true' ) || failure()
         run: |
           echo "[DEBUG] downloaded baseline details in /tmp"
           ls -la /tmp


### PR DESCRIPTION
## Description

After any SAST report, the debug binary will be generated and saved to investigate failure's cause

![image](https://github.com/centreon/centreon/assets/34628915/4b7fd65c-9d60-4d7b-9eeb-1036c0a3c374)

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)
