### PR TITLE
fix(test): avoid test failure when 24.04.1 will be released

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -336,9 +336,9 @@ When('administrator runs the update procedure', () => {
   cy.contains('Congratulations');
 
   // disable statistics if checkbox is available (only on upgrade to new major version)
-  cy.get('#send_statistics').then(($el) => {
-    if ($el.length) {
-      $el.prop('checked', false);
+  cy.get('body').then(($body) => {
+    if ($body.find('#send_statistics').length) {
+      cy.get('#send_statistics').uncheck({ force: true });
     }
   });
 


### PR DESCRIPTION
## Description

fix(test): avoid test failure when 24.04.1 will be released

**Fixes** MON-24742

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)