### PR TITLE
fix ldap auth spam leading to ldap account lock

### DIFF
--- a/centreon/www/class/centreonAuth.class.php
+++ b/centreon/www/class/centreonAuth.class.php
@@ -244,8 +244,9 @@ class CentreonAuth
         }
 
         foreach ($authResources as $arId) {
-            // only try to log in using the ldap config that has been used to import the user
-            if ($this->userInfos['ar_id'] != $arId) {
+            // only try to log in using the ldap config that has been used to import the user if it still exists
+            // we check array key 0 because if the ldap config exist and match the contact ar id it defaults to index 0.
+            if ($this->userInfos['ar_id'] != $arId && array_key_exists(0, $authResources)) {
                 if ($this->debug) {
                     $this->CentreonLog->insertLog(
                         CentreonUserLog::TYPE_LDAP,

--- a/centreon/www/class/centreonAuth.class.php
+++ b/centreon/www/class/centreonAuth.class.php
@@ -246,7 +246,7 @@ class CentreonAuth
         foreach ($authResources as $arId) {
             // only try to log in using the ldap config that has been used to import the user if it still exists
             // we check array key 0 because if the ldap config exist and match the contact ar id it defaults to index 0.
-            if ($this->userInfos['ar_id'] != $arId && array_key_exists(0, $authResources)) {
+            if ($this->userInfos['ar_id'] !== $arId && array_key_exists(0, $authResources)) {
                 if ($this->debug) {
                     $this->CentreonLog->insertLog(
                         CentreonUserLog::TYPE_LDAP,

--- a/centreon/www/class/centreonAuth.class.php
+++ b/centreon/www/class/centreonAuth.class.php
@@ -244,6 +244,18 @@ class CentreonAuth
         }
 
         foreach ($authResources as $arId) {
+            // only try to log in using the ldap config that has been used to import the user
+            if ($this->userInfos['ar_id'] != $arId) {
+                if ($this->debug) {
+                    $this->CentreonLog->insertLog(
+                        CentreonUserLog::TYPE_LDAP,
+                        "[" . self::AUTH_TYPE_LDAP . "] Ignoring LDAP config ID  " . $arId
+                            . " because user " . $this->userInfos['contact_alias']
+                            . " has been imported into Centreon using LDAP config ID " . $this->userInfos['ar_id']
+                    );
+                }
+                continue;
+            }
             if ($autoImport && !isset($this->ldap_auto_import[$arId])) {
                 break;
             }


### PR DESCRIPTION
## Description

When you have many ldap configurations that all points towards the same LDAP server. If a user makes a mistake with his password, it may trigger ldap security because Centreon will do a fail authentication for each ldap config inside Centreon. 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

- have one ldap server with a security policy that will lock an account after a certain number of fail attempts
- create dozens of ldap configuration inside centreon
- import user from one of those said ldap config into centreon
- try to log in with the right password (it will work)
- try to log in with a wrong password (obviously you won't be logged in)
- try to log in with the right password  (you still can't log into centreon because your account is locked on the ldap server)

with this patch, you should be able to log in even after having done a fail attempt

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
