### PR TITLE
[BACKPORT]: frontend router v24.04 to v23.10 

### DIFF
--- a/centreon/www/front_src/src/components/ReactRouter/index.tsx
+++ b/centreon/www/front_src/src/components/ReactRouter/index.tsx
@@ -57,7 +57,7 @@ interface IsAllowedPageProps {
 }
 
 const isAllowedPage = ({ path, allowedPages }: IsAllowedPageProps): boolean =>
-  flatten(allowedPages || []).some((allowedPage) => 
+  flatten(allowedPages || []).some((allowedPage) =>
     path?.includes(allowedPage)
   );
 

--- a/centreon/www/front_src/src/components/ReactRouter/index.tsx
+++ b/centreon/www/front_src/src/components/ReactRouter/index.tsx
@@ -57,9 +57,9 @@ interface IsAllowedPageProps {
 }
 
 const isAllowedPage = ({ path, allowedPages }: IsAllowedPageProps): boolean =>
-  flatten(allowedPages || []).some(
-    (allowedPage) => path?.includes(allowedPage)
-  );
+flatten(allowedPages || []).some((allowedPage) =>
+path?.includes(allowedPage)
+);
 
 const getExternalPageRoutes = ({
   allowedPages,

--- a/centreon/www/front_src/src/components/ReactRouter/index.tsx
+++ b/centreon/www/front_src/src/components/ReactRouter/index.tsx
@@ -57,8 +57,8 @@ interface IsAllowedPageProps {
 }
 
 const isAllowedPage = ({ path, allowedPages }: IsAllowedPageProps): boolean =>
-  flatten(allowedPages || []).some((allowedPage) =>
-    path?.includes(allowedPage)
+  flatten(allowedPages || []).some(
+    (allowedPage) => path?.includes(allowedPage)
   );
 
 const getExternalPageRoutes = ({
@@ -66,7 +66,13 @@ const getExternalPageRoutes = ({
   federatedModules
 }): Array<JSX.Element> => {
   return federatedModules?.map(
-    ({ federatedPages, remoteEntry, moduleFederationName, moduleName }) => {
+    ({
+      federatedPages,
+      remoteEntry,
+      moduleFederationName,
+      moduleName,
+      remoteUrl
+    }) => {
       return federatedPages?.map(({ component, route }) => {
         if (not(isAllowedPage({ allowedPages, path: route }))) {
           return null;
@@ -83,6 +89,7 @@ const getExternalPageRoutes = ({
                   moduleFederationName={moduleFederationName}
                   moduleName={moduleName}
                   remoteEntry={remoteEntry}
+                  remoteUrl={remoteUrl}
                 />
               </PageContainer>
             }

--- a/centreon/www/front_src/src/components/ReactRouter/index.tsx
+++ b/centreon/www/front_src/src/components/ReactRouter/index.tsx
@@ -57,9 +57,9 @@ interface IsAllowedPageProps {
 }
 
 const isAllowedPage = ({ path, allowedPages }: IsAllowedPageProps): boolean =>
-flatten(allowedPages || []).some((allowedPage) =>
-path?.includes(allowedPage)
-);
+  flatten(allowedPages || []).some((allowedPage) => 
+    path?.includes(allowedPage)
+  );
 
 const getExternalPageRoutes = ({
   allowedPages,

--- a/centreon/www/front_src/src/federatedModules/Load/index.tsx
+++ b/centreon/www/front_src/src/federatedModules/Load/index.tsx
@@ -19,12 +19,14 @@ interface RemoteProps {
   moduleFederationName: string;
   moduleName: string;
   remoteEntry: string;
+  remoteUrl?: string;
   styleMenuSkeleton?: StyleMenuSkeleton;
 }
 
 export const Remote = ({
   component,
   remoteEntry,
+  remoteUrl,
   moduleName,
   moduleFederationName,
   isFederatedComponent,
@@ -45,10 +47,10 @@ export const Remote = ({
               module: component,
               remoteEntryFileName: remoteEntry,
               scope: moduleFederationName,
-              url: `./${prefix}/${moduleName}/static`
+              url: remoteUrl ?? `./${prefix}/${moduleName}/static`
             })
       ),
-    [component, moduleName, remoteEntry, moduleFederationName]
+    [component, moduleName, remoteEntry, moduleFederationName, remoteUrl]
   );
 
   const fallback = isFederatedComponent ? (

--- a/centreon/www/front_src/src/federatedModules/models.ts
+++ b/centreon/www/front_src/src/federatedModules/models.ts
@@ -14,6 +14,7 @@ export interface FederatedModule {
   moduleFederationName: string;
   moduleName: string;
   remoteEntry: string;
+  remoteUrl?: string;
 }
 
 interface PageComponent {


### PR DESCRIPTION
## Description

- [SAAS-1158](https://centreon.atlassian.net/browse/SAAS-1137): Backport frontend router v24.04 to v23.10  for load remotes federated modules

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

N/A

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).


[SAAS-1158]: https://centreon.atlassian.net/browse/SAAS-1158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ