### PR TITLE
fix(api) fix downtime recuperation when getting a service resource detail

### DIFF
--- a/centreon/src/Core/Infrastructure/RealTime/Repository/Service/DbServiceFactory.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/Service/DbServiceFactory.php
@@ -85,7 +85,7 @@ class DbServiceFactory
             ->setCommandLine($data['command_line'])
             ->setIsFlapping((int) $data['flapping'] === 1)
             ->setIsAcknowledged((int) $data['acknowledged'] === 1)
-            ->setIsInDowntime((int) $data['in_downtime'] === 1)
+            ->setIsInDowntime((int) $data['in_downtime'] > 0)
             ->setPassiveChecks((int) $data['passive_checks'] === 1)
             ->setActiveChecks((int) $data['active_checks'] === 1)
             ->setLatency(self::getFloatOrNull($data['latency']))


### PR DESCRIPTION
## Description

information about downtimes where not accurate in `centreon_application_monitoring_resource_details_service` endpoint when a service had multiple dowtimes.


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
