### PR TITLE
fix(cloud notification) : make the possibility to save any BV with any ACL Groups to any contact & contact groups

### DIFF
--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/Factory/NotificationResourceFactory.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/Factory/NotificationResourceFactory.php
@@ -63,15 +63,7 @@ class NotificationResourceFactory
     public function create(NotificationResourceRepositoryInterface $repository, array $resource): NotificationResource
     {
         $resourceIds = array_unique($resource['ids']);
-
-        if ($this->user->isAdmin()) {
-            // Assert IDs validity without ACLs
-            $existingResources = $repository->exist($resourceIds);
-        } else {
-            // Assert IDs validity with ACLs
-            $accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
-            $existingResources = $repository->existByAccessGroups($resourceIds, $accessGroups);
-        }
+        $existingResources = $repository->exist($resourceIds);
 
         $difference = new BasicDifference($resourceIds, $existingResources);
         $missingResources = $difference->getRemoved();

--- a/centreon/src/Core/Notification/Application/UseCase/AddNotification/Validator/NotificationValidator.php
+++ b/centreon/src/Core/Notification/Application/UseCase/AddNotification/Validator/NotificationValidator.php
@@ -106,12 +106,7 @@ class NotificationValidator
         ContactInterface $user
     ):void {
         $contactGroupIds = array_unique($contactGroupIds);
-
-        if ($user->isAdmin()) {
-            $contactGroups = $contactGroupRepository->findByIds($contactGroupIds);
-        } else {
-            $contactGroups = $contactGroupRepository->findByIdsAndUserId($contactGroupIds, $user->getId());
-        }
+        $contactGroups = $contactGroupRepository->findByIds($contactGroupIds);
         $existingContactGroups = array_map(fn (ContactGroup $contactgroup) => $contactgroup->getId(), $contactGroups);
         $difference = new BasicDifference($contactGroupIds, $existingContactGroups);
         $missingContactGroups = $difference->getRemoved();


### PR DESCRIPTION
## Description

An error occurs when trying to save a notification for a Business View (BV) configured under the ACL group "Editor". This issue was identified in a specific use case and persists despite appropriate configurations.

**Fixes** # (MON-24984)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Connected with a non is_admin user (Me, administrator by the CIAM)

- Create a BV with a ACL_group “editor” 

- Save and export configuration

- Create a notification with this BV

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
