### PR TITLE
fix(dashboards): use dynamic database name in query

### DIFF
--- a/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardShareRepository.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardShareRepository.php
@@ -314,8 +314,8 @@ class DbReadDashboardShareRepository extends AbstractRepositoryDRB implements Re
                 cg.`cg_name`,
                 dcgr.`dashboard_id`,
                 dcgr.`role`
-            FROM `centreon`.`dashboard_contactgroup_relation` dcgr
-                     INNER JOIN `centreon`.`contactgroup` cg ON cg.`cg_id`= dcgr.`contactgroup_id`
+            FROM `:db`.`dashboard_contactgroup_relation` dcgr
+                     INNER JOIN `:db`.`contactgroup` cg ON cg.`cg_id`= dcgr.`contactgroup_id`
             WHERE dcgr.`dashboard_id` IN (:dashboard_ids)
             SQL;
 


### PR DESCRIPTION
## Description

This PR intends to fix an issue where the database name is not `centreon`

**Fixes** # MON-34370

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
