### PR TITLE
fix(anomaly detection) : Fix Issue on SQL Violation when selecting a host while creating a new anomaly detection on MySQL8

### DIFF
--- a/centreon/www/api/class/centreon_performance_service.class.php
+++ b/centreon/www/api/class/centreon_performance_service.class.php
@@ -179,7 +179,7 @@ class CentreonPerformanceService extends CentreonConfigurationObjects
 
         $query .= $virtualServicesCondition . ') as t_union ' .
             'WHERE fullname LIKE :fullName ' .
-            'GROUP BY host_id, service_id ' .
+            'GROUP BY host_id, service_id, fullname, index_id ' .
             'ORDER BY fullname ';
 
         if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {


### PR DESCRIPTION
## Description

encountering an issue when attempting to add a new anomaly detection service within our system. Specifically, the problem arises in the user interface where a host is supposed to be selected for the anomaly detection service. Despite the apparent functionality being available, the selection process for a host is not operational. This issue is hindering the configuration and utilization of the anomaly detection service, as assigning a host is a critical step in this process.

**Fixes** # (MON-34337)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Create a new anomaly detection Service

Result : 

We can select a host of the list

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
