### PR TITLE
fix(Resource Status): bad redirection to Reporting > Availability > Services

### DIFF
--- a/centreon/www/include/reporting/dashboard/viewServicesLog.php
+++ b/centreon/www/include/reporting/dashboard/viewServicesLog.php
@@ -73,6 +73,7 @@ $select = $formPeriod->addElement(
         "onChange" => "this.form.submit();"
     ]
 );
+$select->setSelected((string) $serviceId);
 $form->addElement(
     'hidden',
     'period',


### PR DESCRIPTION
## Description

Fix issue when clicking on View Report icon in Service Details doesn't preselect a service in Reporting > Availability > Services

**Fixes** # MON-34343

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
