### PR TITLE
fix sql query for realtime host api v1

### DIFF
--- a/centreon/www/api/class/centreon_realtime_hosts.class.php
+++ b/centreon/www/api/class/centreon_realtime_hosts.class.php
@@ -332,7 +332,7 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
 
         $query .= " LEFT JOIN `customvariables` cv ";
         $query .= " ON (cv.host_id = h.host_id ";
-        $query .= " AND cv.service_id IS NULL ";
+        $query .= " AND (cv.service_id IS NULL OR cv.service_id = '')";
         $query .= " AND cv.name = 'CRITICALITY_LEVEL') ";
 
         $query .= " WHERE h.name NOT LIKE '\_Module\_%'";
@@ -341,7 +341,7 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
         if ($this->criticality) {
             $query .= " AND h.host_id = cvs.host_id ";
             $query .= " AND cvs.name = 'CRITICALITY_LEVEL' ";
-            $query .= " AND cvs.service_id IS NULL ";
+            $query .= " AND (cvs.service_id IS NULL OR csv.service_id = '')";
             $query .= " AND cvs.value = :criticality ";
             $queryValues['criticality'] = (string)$this->criticality;
         }


### PR DESCRIPTION
## Description

fix an issue with realtime host api v1. When you have a severity on your host, it might be `null` in the result because sometimes the service_id is just empty not null

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

may only happen on platforms with historical data where the service_id is set as empty in the centreon_storage.customvariables table.

useful curl command 

```bash
curl 'https://xxx.xxx.xxx.xxx/centreon/api/index.php?object=centreon_realtime_hosts&action=list&limit=50&search=<host_name> -H 'Content-Type: application/json' -H 'centreon-auth-token: ******'
```

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
