### PR TITLE
enh (host): new API-type repositories for hosts

### DIFF
--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -18,6 +18,7 @@ parameters:
     curl.timeout: 60
     debug_level: "%env(int:DEBUG_LEVEL)%"
     env(DEBUG_CONTACT): null
+    db.max_items_by_request: 1000
     api.max_items_by_request: 100
     api.max_query_string_length: 2048
 
@@ -40,6 +41,7 @@ services:
             - '../../src/Core/Command/*'
             - '../../src/Core/ResourceAccess/*'
             - '../../src/Core/Service/*'
+            - '../../src/Core/Host/*'
         bind:
             $isCloudPlatform: '%env(bool:IS_CLOUD_PLATFORM)%'
 

--- a/centreon/src/Core/Common/Infrastructure/Repository/AbstractRepositoryRDB.php
+++ b/centreon/src/Core/Common/Infrastructure/Repository/AbstractRepositoryRDB.php
@@ -30,7 +30,7 @@ class AbstractRepositoryRDB
 {
     use LoggerTrait;
 
-    /** @var int Maximum number of elements an SQL query can return */
+    /** @var positive-int Maximum number of elements an SQL query can return */
     protected int $maxItemsByRequest = 5000;
 
     protected DatabaseConnection $db;

--- a/centreon/src/Core/Host/Application/Repository/ReadHostRepositoryInterface.php
+++ b/centreon/src/Core/Host/Application/Repository/ReadHostRepositoryInterface.php
@@ -67,7 +67,7 @@ interface ReadHostRepositoryInterface
     public function findByIds(array $hostIds): array;
 
     /**
-     * Find hosts by their id.
+     * Find hosts by their names.
      *
      * @param list<string> $hostNames
      *

--- a/centreon/src/Core/Host/Application/Repository/ReadHostRepositoryInterface.php
+++ b/centreon/src/Core/Host/Application/Repository/ReadHostRepositoryInterface.php
@@ -26,6 +26,7 @@ namespace Core\Host\Application\Repository;
 use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
 use Core\Host\Domain\Model\Host;
 use Core\Host\Domain\Model\HostNamesById;
+use Core\Host\Domain\Model\SmallHost;
 use Core\Host\Domain\Model\TinyHost;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 
@@ -55,13 +56,35 @@ interface ReadHostRepositoryInterface
     public function findById(int $hostId): ?Host;
 
     /**
+     * Find hosts by their id.
+     *
+     * @param list<int> $hostIds
+     *
+     * @throws \Throwable
+     *
+     * @return list<TinyHost>
+     */
+    public function findByIds(array $hostIds): array;
+
+    /**
+     * Find hosts by their id.
+     *
+     * @param list<string> $hostNames
+     *
+     * @throws \Throwable
+     *
+     * @return list<TinyHost>
+     */
+    public function findByNames(array $hostNames): array;
+
+    /**
      * Find hosts based on query parameters.
      *
      * @param RequestParametersInterface $requestParameters
      *
      * @throws \Throwable
      *
-     * @return TinyHost[]
+     * @return SmallHost[]
      */
     public function findByRequestParameters(RequestParametersInterface $requestParameters): array;
 
@@ -72,7 +95,9 @@ interface ReadHostRepositoryInterface
      * @param RequestParametersInterface $requestParameters
      * @param AccessGroup[] $accessGroups If the list is empty, no restrictions will be applied
      *
-     * @return TinyHost[]
+     * @throws \Throwable
+     *
+     * @return SmallHost[]
      */
     public function findByRequestParametersAndAccessGroups(
         RequestParametersInterface $requestParameters,
@@ -95,6 +120,8 @@ interface ReadHostRepositoryInterface
      *
      * @param int $hostId
      *
+     * @throws \Throwable
+     *
      * @return bool
      */
     public function exists(int $hostId): bool;
@@ -103,6 +130,8 @@ interface ReadHostRepositoryInterface
      * Indicates whether the hosts exist and return the ids found.
      *
      * @param int[] $hostIds
+     *
+     * @throws \Throwable
      *
      * @return int[]
      */
@@ -114,6 +143,8 @@ interface ReadHostRepositoryInterface
      * @param int $hostId
      * @param AccessGroup[] $accessGroups
      *
+     * @throws \Throwable
+     *
      * @return bool
      */
     public function existsByAccessGroups(int $hostId, array $accessGroups): bool;
@@ -122,6 +153,8 @@ interface ReadHostRepositoryInterface
      * Find host names by their IDs.
      *
      * @param int[] $hostGroupIds
+     *
+     * @throws \Throwable
      *
      * @return HostNamesById
      */

--- a/centreon/src/Core/Host/Application/UseCase/FindHosts/FindHosts.php
+++ b/centreon/src/Core/Host/Application/UseCase/FindHosts/FindHosts.php
@@ -32,7 +32,7 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
-use Core\Host\Domain\Model\TinyHost;
+use Core\Host\Domain\Model\SmallHost;
 use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
 use Core\HostGroup\Application\Repository\ReadHostGroupRepositoryInterface;
 use Core\HostTemplate\Application\Repository\ReadHostTemplateRepositoryInterface;
@@ -119,7 +119,7 @@ final class FindHosts
     }
 
     /**
-     * @param TinyHost[] $hosts
+     * @param SmallHost[] $hosts
      *
      * @throws \Throwable
      *

--- a/centreon/src/Core/Host/Domain/Model/SmallHost.php
+++ b/centreon/src/Core/Host/Domain/Model/SmallHost.php
@@ -1,0 +1,183 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Host\Domain\Model;
+
+use Assert\AssertionFailedException;
+use Centreon\Domain\Common\Assertion\Assertion;
+use Core\Common\Domain\SimpleEntity;
+use Core\Common\Domain\TrimmedString;
+
+class SmallHost
+{
+    public const MAX_NAME_LENGTH = NewHost::MAX_NAME_LENGTH,
+        MAX_ADDRESS_LENGTH = NewHost::MAX_ADDRESS_LENGTH;
+
+    /** @var list<int> */
+    private array $categoryIds = [];
+
+    /** @var list<int> */
+    private array $groupIds = [];
+
+    /** @var list<int> */
+    private array $templateIds = [];
+
+    /**
+     * @param int $id
+     * @param TrimmedString $name
+     * @param ?TrimmedString $alias
+     * @param TrimmedString $ipAddress
+     * @param int|null $normalCheckInterval
+     * @param int|null $retryCheckInterval
+     * @param bool $isActivated
+     * @param SimpleEntity $monitoringServer
+     * @param SimpleEntity|null $checkTimePeriod
+     * @param SimpleEntity|null $notificationTimePeriod
+     * @param SimpleEntity|null $severity
+     *
+     * @throws AssertionFailedException
+     */
+    public function __construct(
+        private readonly int $id,
+        private readonly TrimmedString $name,
+        private readonly ?TrimmedString $alias,
+        private readonly TrimmedString $ipAddress,
+        private readonly ?int $normalCheckInterval,
+        private readonly ?int $retryCheckInterval,
+        private readonly bool $isActivated,
+        private readonly SimpleEntity $monitoringServer,
+        private readonly ?SimpleEntity $checkTimePeriod,
+        private readonly ?SimpleEntity $notificationTimePeriod,
+        private readonly ?SimpleEntity $severity,
+    )
+    {
+        $shortName = 'Host';
+        Assertion::positiveInt($id, "{$shortName}::id");
+        Assertion::notEmptyString($name->value, "{$shortName}::name");
+        if ($alias !== null) {
+            Assertion::notEmptyString($alias->value, "{$shortName}::alias");
+        }
+        Assertion::notEmptyString($ipAddress->value, "{$shortName}::ipAddress");
+
+        if ($normalCheckInterval !== null) {
+            Assertion::positiveInt($normalCheckInterval, "{$shortName}::checkInterval");
+        }
+        if ($retryCheckInterval !== null) {
+            Assertion::min($retryCheckInterval, 1, "{$shortName}::retryCheckInterval");
+        }
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): TrimmedString
+    {
+        return $this->name;
+    }
+
+    public function getAlias(): ?TrimmedString
+    {
+        return $this->alias;
+    }
+
+    public function getIpAddress(): TrimmedString
+    {
+        return $this->ipAddress;
+    }
+
+    public function getNormalCheckInterval(): ?int
+    {
+        return $this->normalCheckInterval;
+    }
+
+    public function getRetryCheckInterval(): ?int
+    {
+        return $this->retryCheckInterval;
+    }
+
+    public function isActivated(): bool
+    {
+        return $this->isActivated;
+    }
+
+    public function getCheckTimePeriod(): ?SimpleEntity
+    {
+        return $this->checkTimePeriod;
+    }
+
+    public function getNotificationTimePeriod(): ?SimpleEntity
+    {
+        return $this->notificationTimePeriod;
+    }
+
+    public function getSeverity(): ?SimpleEntity
+    {
+        return $this->severity;
+    }
+
+    public function getMonitoringServer(): SimpleEntity
+    {
+        return $this->monitoringServer;
+    }
+
+    public function addCategoryId(int $categoryId): void
+    {
+        $this->categoryIds[] = $categoryId;
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function getCategoryIds(): array
+    {
+        return $this->categoryIds;
+    }
+
+    public function addGroupId(int $groupId): void
+    {
+        $this->groupIds[] = $groupId;
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function getGroupIds(): array
+    {
+        return $this->groupIds;
+    }
+
+    public function addTemplateId(int $templateId): void
+    {
+        $this->templateIds[] = $templateId;
+    }
+
+    /**
+     * @return list<int>
+     */
+    public function getTemplateIds(): array
+    {
+        return $this->templateIds;
+    }
+}

--- a/centreon/src/Core/Host/Domain/Model/TinyHost.php
+++ b/centreon/src/Core/Host/Domain/Model/TinyHost.php
@@ -25,66 +25,33 @@ namespace Core\Host\Domain\Model;
 
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
-use Core\Common\Domain\SimpleEntity;
-use Core\Common\Domain\TrimmedString;
+use Core\Common\Domain\Comparable;
+use Core\Common\Domain\Identifiable;
 
-class TinyHost
+class TinyHost implements Comparable, Identifiable
 {
-    public const MAX_NAME_LENGTH = NewHost::MAX_NAME_LENGTH,
-        MAX_ADDRESS_LENGTH = NewHost::MAX_ADDRESS_LENGTH;
-
-    /** @var list<int> */
-    private array $categoryIds = [];
-
-    /** @var list<int> */
-    private array $groupIds = [];
-
-    /** @var list<int> */
-    private array $templateIds = [];
-
     /**
      * @param int $id
-     * @param TrimmedString $name
-     * @param ?TrimmedString $alias
-     * @param TrimmedString $ipAddress
-     * @param int|null $normalCheckInterval
-     * @param int|null $retryCheckInterval
-     * @param bool $isActivated
-     * @param SimpleEntity $monitoringServer
-     * @param SimpleEntity|null $checkTimePeriod
-     * @param SimpleEntity|null $notificationTimePeriod
-     * @param SimpleEntity|null $severity
+     * @param string $name
+     * @param ?string $alias
+     * @param int $monitoringServerId
      *
      * @throws AssertionFailedException
      */
     public function __construct(
         private readonly int $id,
-        private readonly TrimmedString $name,
-        private readonly ?TrimmedString $alias,
-        private readonly TrimmedString $ipAddress,
-        private readonly ?int $normalCheckInterval,
-        private readonly ?int $retryCheckInterval,
-        private readonly bool $isActivated,
-        private readonly SimpleEntity $monitoringServer,
-        private readonly ?SimpleEntity $checkTimePeriod,
-        private readonly ?SimpleEntity $notificationTimePeriod,
-        private readonly ?SimpleEntity $severity,
-    )
-    {
-        $shortName = 'Host';
-        Assertion::positiveInt($id, "{$shortName}::id");
-        Assertion::notEmptyString($name->value, "{$shortName}::name");
-        if ($alias !== null) {
-            Assertion::notEmptyString($alias->value, "{$shortName}::alias");
+        private string $name,
+        private ?string $alias,
+        private readonly int $monitoringServerId,
+    ) {
+        Assertion::positiveInt($this->id, 'Host::id');
+        $this->name = trim($this->name);
+        Assertion::notEmptyString($this->name, 'Host::name');
+        if ($this->alias !== null) {
+            $this->alias = trim($this->alias);
+            Assertion::notEmptyString($this->alias, 'Host::alias');
         }
-        Assertion::notEmptyString($ipAddress->value, "{$shortName}::ipAddress");
-
-        if ($normalCheckInterval !== null) {
-            Assertion::positiveInt($normalCheckInterval, "{$shortName}::checkInterval");
-        }
-        if ($retryCheckInterval !== null) {
-            Assertion::min($retryCheckInterval, 1, "{$shortName}::retryCheckInterval");
-        }
+        Assertion::positiveInt($this->id, 'Host::monitoringServerId');
     }
 
     public function getId(): int
@@ -92,92 +59,28 @@ class TinyHost
         return $this->id;
     }
 
-    public function getName(): TrimmedString
+    public function getName(): string
     {
         return $this->name;
     }
 
-    public function getAlias(): ?TrimmedString
+    public function getAlias(): ?string
     {
         return $this->alias;
     }
 
-    public function getIpAddress(): TrimmedString
+    public function getMonitoringServerId(): int
     {
-        return $this->ipAddress;
+        return $this->monitoringServerId;
     }
 
-    public function getNormalCheckInterval(): ?int
+    public function isEqual(object $object): bool
     {
-        return $this->normalCheckInterval;
+        return $object instanceof self && $object->getEqualityHash() === $this->getEqualityHash();
     }
 
-    public function getRetryCheckInterval(): ?int
+    public function getEqualityHash(): string
     {
-        return $this->retryCheckInterval;
-    }
-
-    public function isActivated(): bool
-    {
-        return $this->isActivated;
-    }
-
-    public function getCheckTimePeriod(): ?SimpleEntity
-    {
-        return $this->checkTimePeriod;
-    }
-
-    public function getNotificationTimePeriod(): ?SimpleEntity
-    {
-        return $this->notificationTimePeriod;
-    }
-
-    public function getSeverity(): ?SimpleEntity
-    {
-        return $this->severity;
-    }
-
-    public function getMonitoringServer(): SimpleEntity
-    {
-        return $this->monitoringServer;
-    }
-
-    public function addCategoryId(int $categoryId): void
-    {
-        $this->categoryIds[] = $categoryId;
-    }
-
-    /**
-     * @return list<int>
-     */
-    public function getCategoryIds(): array
-    {
-        return $this->categoryIds;
-    }
-
-    public function addGroupId(int $groupId): void
-    {
-        $this->groupIds[] = $groupId;
-    }
-
-    /**
-     * @return list<int>
-     */
-    public function getGroupIds(): array
-    {
-        return $this->groupIds;
-    }
-
-    public function addTemplateId(int $templateId): void
-    {
-        $this->templateIds[] = $templateId;
-    }
-
-    /**
-     * @return list<int>
-     */
-    public function getTemplateIds(): array
-    {
-        return $this->templateIds;
+        return md5($this->getName());
     }
 }

--- a/centreon/src/Core/Host/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Host/Infrastructure/Configuration/symfony.yaml
@@ -1,0 +1,23 @@
+services:
+    _defaults:
+        public: false
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, controller...
+
+
+    Core\Host\:
+        resource: '../../../../Core/Host/*'
+        bind:
+          $isCloudPlatform: '%env(bool:IS_CLOUD_PLATFORM)%'
+
+    Core\Host\Infrastructure\Repository\DbReadHostRepository:
+        calls:
+            - method: setMaxItemsByRequest
+              arguments: [ '%db.max_items_by_request%' ]
+
+    Core\Host\Application\Repository\ReadHostRepositoryInterface:
+        class: Core\Host\Infrastructure\Repository\DbReadHostRepository
+
+    Core\Host\Infrastructure\Repository\ApiReadHostRepository:
+        arguments:
+            $logger: '@Centreon\Domain\Log\Logger'

--- a/centreon/src/Core/Host/Infrastructure/Repository/ApiReadHostRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/ApiReadHostRepository.php
@@ -1,0 +1,208 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Host\Infrastructure\Repository;
+
+use Centreon\Domain\Repository\RepositoryException;
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+use Core\Common\Infrastructure\Repository\ApiRepositoryTrait;
+use Core\Common\Infrastructure\Repository\ApiResponseTrait;
+use Core\Common\Infrastructure\Repository\ValuesByPackets;
+use Core\Host\Application\Repository\ReadHostRepositoryInterface;
+use Core\Host\Domain\Model\Host;
+use Core\Host\Domain\Model\HostNamesById;
+use Core\Host\Domain\Model\TinyHost;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\RedirectionExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ApiReadHostRepository implements ReadHostRepositoryInterface
+{
+    use ApiResponseTrait;
+    use ApiRepositoryTrait;
+    public const URL_SAFETY_MARGIN = 50;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly RouterInterface $router,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function existsByName(string $hostName): bool
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findById(int $hostId): ?Host
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByIds(array $hostIds): array
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByNames(array $hostNames): array
+    {
+        $apiEndpoint = $this->router->generate('FindHosts');
+        $options = [
+            'verify_peer' => true,
+            'verify_host' => true,
+            'timeout' => $this->timeout,
+            'headers' => ['X-AUTH-TOKEN: ' . $this->authenticationToken],
+        ];
+
+        if ($this->proxy !== null) {
+            $options['proxy'] = $this->proxy;
+            $this->logger->info('Getting hosts using proxy');
+        }
+
+        $debugOptions = $options;
+        unset($debugOptions['headers'][0]);
+
+        $this->logger->debug('Connexion configuration', [
+            'url' => $apiEndpoint,
+            'options' => $debugOptions,
+        ]);
+
+        $url = $this->url . $apiEndpoint;
+
+        /**
+         * @param list<string> $hostNames
+         *
+         * @throws TransportExceptionInterface
+         * @throws ClientExceptionInterface
+         * @throws RedirectionExceptionInterface
+         * @throws ServerExceptionInterface
+         *
+         * @return \Generator<TinyHost>
+         */
+        $findHosts = function (array $hostNames) use ($url, $options): \Generator {
+            // Surround hostnames with double quotes
+            $hostNames = array_map(fn(string $name) => sprintf('"%s"', $name), $hostNames);
+
+            $options['query'] = [
+                'limit' => count($hostNames),
+                'search' => sprintf('{"name": {"$in": [%s]}}', implode(',', $hostNames)),
+            ];
+            $this->logger->debug('Call API', ['url' => $url, 'query_parameter' => $options['query']['search']]);
+
+            /**
+             * @var array{
+             *     result: array<array{id: int, name: string, alias: string|null, monitoring_server: array{id: int}}>
+             * } $response
+             */
+            $response = $this->getResponseOrFail($this->httpClient->request('GET', $url, $options));
+            foreach ($response['result'] as $result) {
+                yield (TinyHostFactory::createFromApi(...))($result);
+            }
+        };
+
+        $hosts = [];
+        $maxQueryStringLength = $this->maxQueryStringLength - mb_strlen($url) - self::URL_SAFETY_MARGIN;
+        foreach (new ValuesByPackets($hostNames, $this->maxItemsByRequest, $maxQueryStringLength) as $names) {
+            foreach ($findHosts($names) as $host) {
+                $hosts[] = $host;
+            }
+        }
+
+        return $hosts;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByRequestParameters(RequestParametersInterface $requestParameters): array
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByRequestParametersAndAccessGroups(
+        RequestParametersInterface $requestParameters,
+        array $accessGroups
+    ): array
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findParents(int $hostId): array
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function exists(int $hostId): bool
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function existsByAccessGroups(int $hostId, array $accessGroups): bool
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findNames(array $hostGroupIds): HostNamesById
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function exist(array $hostIds): array
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+}

--- a/centreon/src/Core/Host/Infrastructure/Repository/DbReadHostRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbReadHostRepository.php
@@ -25,12 +25,12 @@ namespace Core\Host\Infrastructure\Repository;
 
 use Assert\AssertionFailedException;
 use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Domain\Repository\RepositoryException;
 use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
 use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 use Core\Common\Application\Converter\YesNoDefaultConverter;
 use Core\Common\Domain\HostType;
-use Core\Common\Domain\SimpleEntity;
 use Core\Common\Domain\TrimmedString;
 use Core\Common\Domain\YesNoDefault;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
@@ -42,7 +42,6 @@ use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Domain\Model\Host;
 use Core\Host\Domain\Model\HostNamesById;
 use Core\Host\Domain\Model\SnmpVersion;
-use Core\Host\Domain\Model\TinyHost;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Utility\SqlConcatenator;
 
@@ -123,6 +122,16 @@ class DbReadHostRepository extends AbstractRepositoryRDB implements ReadHostRepo
     public function __construct(DatabaseConnection $db)
     {
         $this->db = $db;
+    }
+
+    /**
+     * @param int $maxItemsByRequest
+     */
+    public function setMaxItemsByRequest(int $maxItemsByRequest): void
+    {
+        if ($maxItemsByRequest > 0) {
+            $this->maxItemsByRequest = $maxItemsByRequest;
+        }
     }
 
     /**
@@ -322,6 +331,53 @@ class DbReadHostRepository extends AbstractRepositoryRDB implements ReadHostRepo
 
         /** @var _Host $result */
         return $this->createHostFromArray($result);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByIds(array $hostIds): array
+    {
+        $request = $this->translateDbName(
+            <<<'SQL'
+                SELECT
+                    h.host_id AS id,
+                    h.host_name AS name,
+                    h.host_alias AS alias,
+                    nsr.nagios_server_id AS monitoring_server_id
+                FROM `:db`.host h
+                LEFT JOIN `:db`.ns_host_relation nsr
+                    ON nsr.host_host_id = h.host_id
+                WHERE h.host_id IN (%s)
+                SQL
+        );
+
+        $hosts = [];
+        foreach (array_chunk($hostIds, $this->maxItemsByRequest) as $ids) {
+            [$bindValues, $hostIdsQuery] = $this->createMultipleBindQuery($ids, ':id_');
+            $finalRequest = sprintf($request, $hostIdsQuery);
+            $statement = $this->db->prepare($finalRequest);
+            foreach ($bindValues as $bindKey => $hostGroupId) {
+                $statement->bindValue($bindKey, $hostGroupId, \PDO::PARAM_INT);
+            }
+            $statement->setFetchMode(\PDO::FETCH_ASSOC);
+            $statement->execute();
+
+            /** @var array{id: int, name: string, alias: string|null, monitoring_server_id: int} $result */
+            foreach ($statement as $result) {
+                $hosts[] = TinyHostFactory::createFromDb($result);
+            }
+        }
+
+        return $hosts;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByNames(array $hostNames): array
+    {
+        throw RepositoryException::notYetImplemented();
     }
 
     /**
@@ -593,7 +649,7 @@ class DbReadHostRepository extends AbstractRepositoryRDB implements ReadHostRepo
 
         foreach ($statement as $data) {
             /** @var _TinyHost $data */
-            $hosts[] = $this->createLittleHost($data);
+            $hosts[] = SmallHostFactory::createFromDb($data);
         }
 
         return $hosts;
@@ -749,90 +805,5 @@ class DbReadHostRepository extends AbstractRepositoryRDB implements ReadHostRepo
             addInheritedContact: (bool) $result['contact_additive_inheritance'],
             isActivated: (bool) $result['host_activate'],
         );
-    }
-
-    /**
-     * @param _TinyHost $result
-     *
-     * @throws AssertionFailedException
-     *
-     * @return TinyHost
-     */
-    private function createLittleHost(array $result): TinyHost
-    {
-        $severity = $result['severity_id'] !== null && $result['severity_name'] !== null
-            ? new SimpleEntity(
-                (int) $result['severity_id'],
-                new TrimmedString($result['severity_name']),
-                'Host'
-            ) : null;
-
-        $checkTimePeriod
-            = $result['check_timeperiod_id'] !== null && $result['check_timeperiod_name'] !== null
-                ? new SimpleEntity(
-                    (int) $result['check_timeperiod_id'],
-                    new TrimmedString($result['check_timeperiod_name']),
-                    'Host'
-                ) : null;
-
-        $notificationTimePeriod
-            = $result['notification_timeperiod_id'] !== null && $result['notification_timeperiod_name'] !== null
-            ? new SimpleEntity(
-                (int) $result['notification_timeperiod_id'],
-                new TrimmedString($result['notification_timeperiod_name']),
-                'Host'
-            ) : null;
-
-        $host = new TinyHost(
-            (int) $result['id'],
-            new TrimmedString($result['name']),
-            $result['alias'] !== null ? new TrimmedString($result['alias']) : null ,
-            new TrimmedString($result['ip_address']),
-            $this->intOrNull($result, 'check_interval'),
-            $this->intOrNull($result, 'retry_check_interval'),
-            $result['is_activated'] === '1',
-            new SimpleEntity(
-                (int) $result['monitoring_server_id'],
-                new TrimmedString($result['monitoring_server_name']),
-                'Host'
-            ),
-            $checkTimePeriod,
-            $notificationTimePeriod,
-            $severity,
-        );
-
-        if ($result['category_ids'] !== null) {
-            $categoryIds = explode(',', $result['category_ids']);
-            foreach ($categoryIds as $categoryId) {
-                $host->addCategoryId((int) $categoryId);
-            }
-        }
-        if ($result['hostgroup_ids'] !== null) {
-            $groupIds = explode(',', $result['hostgroup_ids']);
-            foreach ($groupIds as $groupId) {
-                $host->addGroupId((int) $groupId);
-            }
-        }
-        if ($result['template_ids'] !== null) {
-            $templateIds = explode(',', $result['template_ids']);
-            foreach ($templateIds as $templateId) {
-                $host->addTemplateId((int) $templateId);
-            }
-        }
-
-        return $host;
-    }
-
-    /**
-     * @param _TinyHost $data
-     * @param string $property
-     *
-     * @return int|null
-     */
-    private function intOrNull(array $data, string $property): ?int
-    {
-        return array_key_exists($property, $data) && $data[$property] !== null
-            ? (int) $data[$property]
-            : null;
     }
 }

--- a/centreon/src/Core/Host/Infrastructure/Repository/SmallHostFactory.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/SmallHostFactory.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Host\Infrastructure\Repository;
+
+use Assert\AssertionFailedException;
+use Core\Common\Domain\SimpleEntity;
+use Core\Common\Domain\TrimmedString;
+use Core\Host\Domain\Model\SmallHost;
+
+/**
+ * @phpstan-type _SmallHost array{
+ *      id: int,
+ *      name: string,
+ *      alias: string|null,
+ *      ip_address: string,
+ *      check_interval: int|null,
+ *      retry_check_interval: int|null,
+ *      is_activated: string,
+ *      check_timeperiod_id: int|null,
+ *      check_timeperiod_name: string|null,
+ *      notification_timeperiod_id: int|null,
+ *      notification_timeperiod_name: string|null,
+ *      severity_id: int|null,
+ *      severity_name: string|null,
+ *      monitoring_server_id: int,
+ *      monitoring_server_name: string,
+ *      category_ids: string,
+ *      hostgroup_ids: string,
+ *      template_ids: string
+ *  }
+ */
+class SmallHostFactory
+{
+    /**
+     * @param _SmallHost $data
+     *
+     * @throws AssertionFailedException
+     */
+    public static function createFromDb(array $data): SmallHost
+    {
+        $severity = $data['severity_id'] !== null && $data['severity_name'] !== null
+            ? new SimpleEntity(
+                (int) $data['severity_id'],
+                new TrimmedString($data['severity_name']),
+                'Host'
+            ) : null;
+
+        $checkTimePeriod
+            = $data['check_timeperiod_id'] !== null && $data['check_timeperiod_name'] !== null
+                ? new SimpleEntity(
+                    (int) $data['check_timeperiod_id'],
+                    new TrimmedString($data['check_timeperiod_name']),
+                    'Host'
+                ) : null;
+
+        $notificationTimePeriod
+            = $data['notification_timeperiod_id'] !== null && $data['notification_timeperiod_name'] !== null
+            ? new SimpleEntity(
+                (int) $data['notification_timeperiod_id'],
+                new TrimmedString($data['notification_timeperiod_name']),
+                'Host'
+            ) : null;
+
+        $host = new SmallHost(
+            (int) $data['id'],
+            new TrimmedString($data['name']),
+            $data['alias'] !== null ? new TrimmedString($data['alias']) : null ,
+            new TrimmedString($data['ip_address']),
+            self::intOrNull($data, 'check_interval'),
+            self::intOrNull($data, 'retry_check_interval'),
+            $data['is_activated'] === '1',
+            new SimpleEntity(
+                (int) $data['monitoring_server_id'],
+                new TrimmedString($data['monitoring_server_name']),
+                'Host'
+            ),
+            $checkTimePeriod,
+            $notificationTimePeriod,
+            $severity,
+        );
+
+        if ($data['category_ids'] !== null) {
+            $categoryIds = explode(',', $data['category_ids']);
+            foreach ($categoryIds as $categoryId) {
+                $host->addCategoryId((int) $categoryId);
+            }
+        }
+        if ($data['hostgroup_ids'] !== null) {
+            $groupIds = explode(',', $data['hostgroup_ids']);
+            foreach ($groupIds as $groupId) {
+                $host->addGroupId((int) $groupId);
+            }
+        }
+        if ($data['template_ids'] !== null) {
+            $templateIds = explode(',', $data['template_ids']);
+            foreach ($templateIds as $templateId) {
+                $host->addTemplateId((int) $templateId);
+            }
+        }
+
+        return $host;
+    }
+
+    /**
+     * @param _SmallHost $data
+     * @param string $property
+     *
+     * @return int|null
+     */
+    private static function intOrNull(array $data, string $property): ?int
+    {
+        return array_key_exists($property, $data) && $data[$property] !== null
+            ? (int) $data[$property]
+            : null;
+    }
+}

--- a/centreon/src/Core/Host/Infrastructure/Repository/TinyHostFactory.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/TinyHostFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Host\Infrastructure\Repository;
+
+use Assert\AssertionFailedException;
+use Core\Host\Domain\Model\TinyHost;
+
+/**
+ * @phpstan-type _TinyHost array{
+ *      id: int,
+ *      name: string,
+ *      alias: string|null,
+ *      monitoring_server_id: int
+ *  }
+ */
+class TinyHostFactory
+{
+    /**
+     * @param array{id: int, name: string, alias:string|null, monitoring_server_id: int} $data
+     *
+     * @throws AssertionFailedException
+     *
+     * @return TinyHost
+     */
+    public static function createFromDb(array $data): TinyHost
+    {
+        return new TinyHost(
+            $data['id'],
+            $data['name'],
+            $data['alias'] ?? null,
+            $data['monitoring_server_id'],
+        );
+    }
+
+    /**
+     * @param array{id: int, name: string, alias:string|null, monitoring_server: array{id: int}} $data
+     *
+     * @throws AssertionFailedException
+     *
+     * @return TinyHost
+     */
+    public static function createFromApi(array $data): TinyHost
+    {
+        return new TinyHost(
+            $data['id'],
+            $data['name'],
+            $data['alias'] ?? null,
+            $data['monitoring_server']['id'],
+        );
+    }
+}

--- a/centreon/tests/php/Core/Host/Application/UseCase/FindHosts/FindHostsTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/FindHosts/FindHostsTest.php
@@ -34,7 +34,7 @@ use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\UseCase\FindHosts\FindHosts;
 use Core\Host\Application\UseCase\FindHosts\FindHostsResponse;
-use Core\Host\Domain\Model\TinyHost;
+use Core\Host\Domain\Model\SmallHost;
 use Core\Common\Domain\SimpleEntity;
 use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
 use Core\HostCategory\Domain\Model\HostCategory;
@@ -147,7 +147,7 @@ it('should present a FindHostsResponse when no error occurs for an admin user', 
         ->method('isAdmin')
         ->willReturn(true);
 
-    $oneHost = new TinyHost(
+    $oneHost = new SmallHost(
         1,
         new TrimmedString('my_host'),
         new TrimmedString('my_alias'),

--- a/centreon/tests/php/Core/Host/Domain/Model/SmallHostTest.php
+++ b/centreon/tests/php/Core/Host/Domain/Model/SmallHostTest.php
@@ -25,7 +25,7 @@ namespace Tests\Core\Host\Domain\Model;
 
 use Core\Common\Domain\TrimmedString;
 use Core\Common\Domain\SimpleEntity;
-use Core\Host\Domain\Model\TinyHost;
+use Core\Host\Domain\Model\SmallHost;
 
 beforeEach(function (): void {
     $this->parameters = [
@@ -45,30 +45,30 @@ beforeEach(function (): void {
 
 it('should throw an exception when the id property is not a positive number', function (): void {
     $this->parameters['id'] = 0;
-    new TinyHost(...$this->parameters);
+    new SmallHost(...$this->parameters);
 })->expectException(\Assert\AssertionFailedException::class);
 
 it('should throw an exception when the name property is empty', function (): void {
     $this->parameters['name'] = new TrimmedString('');
-    new TinyHost(...$this->parameters);
+    new SmallHost(...$this->parameters);
 })->expectException(\Assert\AssertionFailedException::class);
 
 it('should throw an exception when the alias property is empty', function (): void {
     $this->parameters['alias'] = new TrimmedString('');
-    new TinyHost(...$this->parameters);
+    new SmallHost(...$this->parameters);
 })->expectException(\Assert\AssertionFailedException::class);
 
 it('should throw an exception when the ipAddress property is empty', function (): void {
     $this->parameters['ipAddress'] = new TrimmedString('');
-    new TinyHost(...$this->parameters);
+    new SmallHost(...$this->parameters);
 })->expectException(\Assert\AssertionFailedException::class);
 
 it('should throw an exception when the normalCheckInterval property is not a positive number', function (): void {
     $this->parameters['normalCheckInterval'] = -1;
-    new TinyHost(...$this->parameters);
+    new SmallHost(...$this->parameters);
 })->expectException(\Assert\AssertionFailedException::class);
 
 it('should throw an exception when the retryCheckInterval property is not a positive number greater than 1', function (): void {
     $this->parameters['retryCheckInterval'] = 0;
-    new TinyHost(...$this->parameters);
+    new SmallHost(...$this->parameters);
 })->expectException(\Assert\AssertionFailedException::class);


### PR DESCRIPTION
## Description

🏷️ MON-21552

As part of the migration from an on-premises Centreon platform to a remote platform, we need to set up a new repository that allows us to retrieve hosts by making HTTP calls to the remote Centreon platform.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
