### PR TITLE
MON-34649-web-empty-service-arguments-error-message-does-not-display

### DIFF
--- a/centreon/www/include/configuration/configObject/service/formServiceOnPrem.ihtml
+++ b/centreon/www/include/configuration/configObject/service/formServiceOnPrem.ihtml
@@ -106,8 +106,8 @@
                 <img class="helpTooltip" name="check_command_args">{$form.command_command_id_arg.label}
             </td>
             <td class="FormRowValue">
-                {if isset($form.hiddenArg) && isset($argChecker)}
-                    {$form.hiddenArg.html}{$argChecker}
+                {if isset($argChecker)}
+                    {$argChecker}
                 {/if}
                 <div id='dynamicDiv'></div>
             </td>


### PR DESCRIPTION
## Description

Empty service arguments filed error message does not display. [This is due to a check that looks](https://github.com/centreon/centreon/blob/dev-23.10.x/centreon/www/include/configuration/configObject/service/formService.ihtml#L109) for `isset($form.hiddenArg) && isset($argChecker)`  but the issue is that `$form.hiddenArg` does not exist
**Fixes** # MON-34649

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

- Create a check command with args, for exemple :

`$USER1$/customs/centreon-plugins/centreon_plugins.pl --plugin=apps::protocols::http::plugin --http-backend=curl --curl-opt='CURLOPT_SSL_VERIFYPEER => 0' --insecure --mode=json-content --hostname='$ARG1$' --urlpath='$ARG2$' --lookup='$ARG3$' --header='Content-Type: application/json' --proto=$ARG4$ --critical-numeric $ARG5$ --threshold-value values --format-critical '$ARG6$' --format-ok '$ARG7$' --filter-perfdata '$ARG9$' --timeout $ARG8$ --warning-numeric '$_SERVICEWARNING$' $_SERVICEEXTRAOPTIONS$ $_HOSTEXTRAOPTIONS$` 

- Add the created command to a service

- Do not fill in all the argument fileds.

- Click on save