### PR TITLE
enh(api) : add the posibility to search using host categories

### DIFF
--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -671,7 +671,7 @@ paths:
         * name
         * alias
         * is_activated
-        * hostcategories_id
+        * host_category_ids
 
         Changes in 23.04 :
 

--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -671,7 +671,8 @@ paths:
         * name
         * alias
         * is_activated
-        * host.category.id
+        * hostcategory.id
+        * hostcategory.name
 
         Changes in 23.04 :
 

--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -671,7 +671,7 @@ paths:
         * name
         * alias
         * is_activated
-        * host_category_id
+        * host.category.id
 
         Changes in 23.04 :
 

--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -671,6 +671,7 @@ paths:
         * name
         * alias
         * is_activated
+        * hostcategories_id
 
         Changes in 23.04 :
 

--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -671,7 +671,7 @@ paths:
         * name
         * alias
         * is_activated
-        * host_category_ids
+        * host_category_id
 
         Changes in 23.04 :
 

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -372,7 +372,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                 ->storeBindValueMultiple(':ids', $accessGroupIds, \PDO::PARAM_INT);
         }
 
-        if (! empty($_GET['search']) && strpos($_GET['search'], 'host_category_id')) {
+        if (! empty($_GET['search']) && mb_strpos($_GET['search'], 'host_category_id') !== false) {
             $concatenator
                 ->appendJoins(
                 <<<'SQL'

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -413,7 +413,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             'is_activated' => 'hg.hg_activate',
             'host_category_id' => 'hc.hc_id',
         ]);
-        if (mb_strpos($requestParameters?->getSearchAsString(), 'host_category_id')) {
+        if (mb_strpos($requestParameters?->getSearchAsString() ?? "", 'host_category_id')) {
             $concatenator->appendJoins(
                 <<<'SQL'
                         LEFT JOIN `:db`.hostgroup_relation hgr

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -423,7 +423,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             'alias' => 'hg.hg_alias',
             'name' => 'hg.hg_name',
             'is_activated' => 'hg.hg_activate',
-            'hostcategories_id' => 'hc.hc_id',
+            'host_category_ids' => 'hc.hc_id',
         ]);
         $sqlTranslator?->addNormalizer('is_activated', new BoolToEnumNormalizer());
 

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -413,19 +413,19 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             'is_activated' => 'hg.hg_activate',
             'host_category_id' => 'hc.hc_id',
         ]);
-        if (mb_strpos($requestParameters->getSearchAsString(), "host_category_id")) {
+        if (mb_strpos($requestParameters->getSearchAsString(), 'host_category_id')) {
             $concatenator->appendJoins(
                 <<<'SQL'
-                            LEFT JOIN `:db`.hostgroup_relation hgr
-                                ON hg.hg_id = hgr.hostgroup_hg_id
-                            LEFT JOIN `:db`.host h
-                                ON hgr.host_host_id = h.host_id
-                            LEFT JOIN `:db`.hostcategories_relation hcr
-                                ON h.host_id = hcr.host_host_id
-                            LEFT JOIN `:db`.hostcategories hc
-                                ON hcr.hostcategories_hc_id = hc.hc_id
-                                AND hc.level IS NOT NULL
-                        SQL
+                        LEFT JOIN `:db`.hostgroup_relation hgr
+                            ON hg.hg_id = hgr.hostgroup_hg_id
+                        LEFT JOIN `:db`.host h
+                            ON hgr.host_host_id = h.host_id
+                        LEFT JOIN `:db`.hostcategories_relation hcr
+                            ON h.host_id = hcr.host_host_id
+                        LEFT JOIN `:db`.hostcategories hc
+                            ON hcr.hostcategories_hc_id = hc.hc_id
+                            AND hc.level IS NOT NULL
+                    SQL
             );
         }
         $sqlTranslator?->addNormalizer('is_activated', new BoolToEnumNormalizer());

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -413,7 +413,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             'is_activated' => 'hg.hg_activate',
             'host_category_id' => 'hc.hc_id',
         ]);
-        if (mb_strpos($requestParameters?->getSearchAsString() ?? "", 'host_category_id')) {
+        if (mb_strpos($requestParameters?->getSearchAsString() ?? '', 'host_category_id')) {
             $concatenator->appendJoins(
                 <<<'SQL'
                         LEFT JOIN `:db`.hostgroup_relation hgr

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -372,23 +372,6 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                 ->storeBindValueMultiple(':ids', $accessGroupIds, \PDO::PARAM_INT);
         }
 
-        if (! empty($_GET['search']) && mb_strpos($_GET['search'], 'host_category_id') !== false) {
-            $concatenator
-                ->appendJoins(
-                <<<'SQL'
-                        LEFT JOIN `:db`.hostgroup_relation hgr
-                            ON hg.hg_id = hgr.hostgroup_hg_id
-                        LEFT JOIN `:db`.host h
-                            ON hgr.host_host_id = h.host_id
-                        LEFT JOIN `:db`.hostcategories_relation hcr
-                            ON h.host_id = hcr.host_host_id
-                        LEFT JOIN `:db`.hostcategories hc
-                            ON hcr.hostcategories_hc_id = hc.hc_id
-                            AND hc.level IS NOT NULL
-                    SQL
-            );
-        }
-
         return $concatenator;
     }
 
@@ -430,7 +413,22 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             'is_activated' => 'hg.hg_activate',
             'host_category_id' => 'hc.hc_id',
         ]);
+        if (mb_strpos($requestParameters->getSearchAsString(), "host_category_id")) {
+            $concatenator->appendJoins(
+                <<<'SQL'
+                            LEFT JOIN `:db`.hostgroup_relation hgr
+                                ON hg.hg_id = hgr.hostgroup_hg_id
+                            LEFT JOIN `:db`.host h
+                                ON hgr.host_host_id = h.host_id
+                            LEFT JOIN `:db`.hostcategories_relation hcr
+                                ON h.host_id = hcr.host_host_id
+                            LEFT JOIN `:db`.hostcategories hc
+                                ON hcr.hostcategories_hc_id = hc.hc_id
+                        SQL
+            );
+        }
         $sqlTranslator?->addNormalizer('is_activated', new BoolToEnumNormalizer());
+
 
         // Update the SQL string builder with the RequestParameters through SqlRequestParametersTranslator
         $sqlTranslator?->translateForConcatenator($concatenator);

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -430,7 +430,6 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
         }
         $sqlTranslator?->addNormalizer('is_activated', new BoolToEnumNormalizer());
 
-
         // Update the SQL string builder with the RequestParameters through SqlRequestParametersTranslator
         $sqlTranslator?->translateForConcatenator($concatenator);
 

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -391,7 +391,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                                 ON h.host_id = hcr.host_host_id
                             LEFT JOIN `:db`.hostcategories hc
                                 ON hcr.hostcategories_hc_id = hc.hc_id
-                    SQL
+                        SQL
                 )
                 ->appendWhere(
                     <<<'SQL'

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -423,7 +423,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             'alias' => 'hg.hg_alias',
             'name' => 'hg.hg_name',
             'is_activated' => 'hg.hg_activate',
-            'host_category_ids' => 'hc.hc_id',
+            'host_category_id' => 'hc.hc_id',
         ]);
         $sqlTranslator?->addNormalizer('is_activated', new BoolToEnumNormalizer());
 

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -372,7 +372,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                 ->storeBindValueMultiple(':ids', $accessGroupIds, \PDO::PARAM_INT);
         }
 
-        if (!empty($_GET['search']) && strpos($_GET['search'], 'host_category_id')) {
+        if (! empty($_GET['search']) && strpos($_GET['search'], 'host_category_id')) {
             $concatenator
                 ->appendJoins(
                 <<<'SQL'

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -358,8 +358,8 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             )
             ->appendWhere(
                 <<<'SQL'
-                    hc.hc_level is not null
-                SQL
+                        hc.hc_level is not null
+                    SQL
             )
             ->defineOrderBy(
                 <<<'SQL'

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -323,7 +323,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
         $concatenator = (new SqlConcatenator())
             ->defineSelect(
                 <<<'SQL'
-                    SELECT
+                    SELECT DISTINCT
                         hg.hg_id,
                         hg.hg_name,
                         hg.hg_alias,

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -376,16 +376,16 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             $concatenator
                 ->appendJoins(
                 <<<'SQL'
-                            LEFT JOIN `:db`.hostgroup_relation hgr
-                                ON hg.hg_id = hgr.hostgroup_hg_id
-                            LEFT JOIN `:db`.host h
-                                ON hgr.host_host_id = h.host_id
-                            LEFT JOIN `:db`.hostcategories_relation hcr
-                                ON h.host_id = hcr.host_host_id
-                            LEFT JOIN `:db`.hostcategories hc
-                                ON hcr.hostcategories_hc_id = hc.hc_id
-                                AND hc.level IS NOT NULL
-                        SQL
+                        LEFT JOIN `:db`.hostgroup_relation hgr
+                            ON hg.hg_id = hgr.hostgroup_hg_id
+                        LEFT JOIN `:db`.host h
+                            ON hgr.host_host_id = h.host_id
+                        LEFT JOIN `:db`.hostcategories_relation hcr
+                            ON h.host_id = hcr.host_host_id
+                        LEFT JOIN `:db`.hostcategories hc
+                            ON hcr.hostcategories_hc_id = hc.hc_id
+                            AND hc.level IS NOT NULL
+                    SQL
             );
         }
 

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -383,14 +383,14 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                 )
                 ->appendJoins(
                     <<<'SQL'
-                    LEFT JOIN `:db`.hostgroup_relation hgr
-                        ON hg.hg_id = hgr.hostgroup_hg_id
-                    LEFT JOIN `:db`.host h
-                        ON hgr.host_host_id = h.host_id
-                    LEFT JOIN `:db`.hostcategories_relation hcr
-                        ON h.host_id = hcr.host_host_id
-                    LEFT JOIN `:db`.hostcategories hc
-                        ON hcr.hostcategories_hc_id = hc.hc_id
+                        LEFT JOIN `:db`.hostgroup_relation hgr
+                            ON hg.hg_id = hgr.hostgroup_hg_id
+                        LEFT JOIN `:db`.host h
+                            ON hgr.host_host_id = h.host_id
+                        LEFT JOIN `:db`.hostcategories_relation hcr
+                            ON h.host_id = hcr.host_host_id
+                        LEFT JOIN `:db`.hostcategories hc
+                            ON hcr.hostcategories_hc_id = hc.hc_id
                     SQL
                 )
                 ->appendWhere(

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -413,7 +413,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             'is_activated' => 'hg.hg_activate',
             'host_category_id' => 'hc.hc_id',
         ]);
-        if (mb_strpos($requestParameters->getSearchAsString(), 'host_category_id')) {
+        if (mb_strpos($requestParameters?->getSearchAsString(), 'host_category_id')) {
             $concatenator->appendJoins(
                 <<<'SQL'
                         LEFT JOIN `:db`.hostgroup_relation hgr

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -383,14 +383,14 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                 )
                 ->appendJoins(
                     <<<'SQL'
-                        LEFT JOIN `:db`.hostgroup_relation hgr
-                            ON hg.hg_id = hgr.hostgroup_hg_id
-                        LEFT JOIN `:db`.host h
-                            ON hgr.host_host_id = h.host_id
-                        LEFT JOIN `:db`.hostcategories_relation hcr
-                            ON h.host_id = hcr.host_host_id
-                        LEFT JOIN `:db`.hostcategories hc
-                            ON hcr.hostcategories_hc_id = hc.hc_id
+                            LEFT JOIN `:db`.hostgroup_relation hgr
+                                ON hg.hg_id = hgr.hostgroup_hg_id
+                            LEFT JOIN `:db`.host h
+                                ON hgr.host_host_id = h.host_id
+                            LEFT JOIN `:db`.hostcategories_relation hcr
+                                ON h.host_id = hcr.host_host_id
+                            LEFT JOIN `:db`.hostcategories hc
+                                ON hcr.hostcategories_hc_id = hc.hc_id
                     SQL
                 )
                 ->appendWhere(

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -424,6 +424,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                                 ON h.host_id = hcr.host_host_id
                             LEFT JOIN `:db`.hostcategories hc
                                 ON hcr.hostcategories_hc_id = hc.hc_id
+                                AND hc.level IS NOT NULL
                         SQL
             );
         }

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -356,6 +356,11 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                         ON hcr.hostcategories_hc_id = hc.hc_id
                     SQL
             )
+            ->appendWhere(
+                <<<'SQL'
+                    hc.hc_level is not null
+                SQL
+            )
             ->defineOrderBy(
                 <<<'SQL'
                     ORDER BY hg.hg_name ASC
@@ -376,9 +381,21 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                             ON argr.acl_group_id = ag.acl_group_id
                         SQL
                 )
+                ->appendJoins(
+                    <<<'SQL'
+                    LEFT JOIN `:db`.hostgroup_relation hgr
+                        ON hg.hg_id = hgr.hostgroup_hg_id
+                    LEFT JOIN `:db`.host h
+                        ON hgr.host_host_id = h.host_id
+                    LEFT JOIN `:db`.hostcategories_relation hcr
+                        ON h.host_id = hcr.host_host_id
+                    LEFT JOIN `:db`.hostcategories hc
+                        ON hcr.hostcategories_hc_id = hc.hc_id
+                    SQL
+                )
                 ->appendWhere(
                     <<<'SQL'
-                        WHERE ag.acl_group_id IN (:ids)
+                        WHERE ag.acl_group_id IN (:ids) AND hc.hc_level is not null
                         SQL
                 )
                 ->storeBindValueMultiple(':ids', $accessGroupIds, \PDO::PARAM_INT);

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -108,8 +108,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
     {
         $concatenator = $this->getFindHostGroupConcatenator();
 
-        if (mb_strpos($requestParameters?->getSearchAsString() ?? '', 'host.category.id')) {
-            $concatenator->appendJoins(
+        $concatenator->appendJoins(
                 <<<'SQL'
                         LEFT JOIN `:db`.hostgroup_relation hgr
                             ON hg.hg_id = hgr.hostgroup_hg_id
@@ -122,7 +121,6 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                             AND hc.level IS NOT NULL
                     SQL
             );
-        }
 
         return new \ArrayIterator($this->retrieveHostGroups($concatenator, $requestParameters));
     }
@@ -363,7 +361,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
         $concatenator = (new SqlConcatenator())
             ->defineSelect(
                 <<<'SQL'
-                    SELECT DISTINCT
+                    SELECT
                         hg.hg_id,
                         hg.hg_name,
                         hg.hg_alias,
@@ -451,8 +449,8 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             'alias' => 'hg.hg_alias',
             'name' => 'hg.hg_name',
             'is_activated' => 'hg.hg_activate',
-            'host.category.id' => 'hc.hc_id',
-            'host.category.name' => 'hc.hc_name',
+            'hostcategory.id' => 'hc.hc_id',
+            'hostcategory.name' => 'hc.hc_name',
         ]);
 
         $sqlTranslator?->addNormalizer('is_activated', new BoolToEnumNormalizer());

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -344,6 +344,18 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
                         `:db`.`hostgroup` hg
                     SQL
             )
+            ->appendJoins(
+                <<<'SQL'
+                    LEFT JOIN `:db`.hostgroup_relation hgr
+                        ON hg.hg_id = hgr.hostgroup_hg_id
+                    LEFT JOIN `:db`.host h
+                        ON hgr.host_host_id = h.host_id
+                    LEFT JOIN `:db`.hostcategories_relation hcr
+                        ON h.host_id = hcr.host_host_id
+                    LEFT JOIN `:db`.hostcategories hc
+                        ON hcr.hostcategories_hc_id = hc.hc_id
+                    SQL
+            )
             ->defineOrderBy(
                 <<<'SQL'
                     ORDER BY hg.hg_name ASC
@@ -411,6 +423,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             'alias' => 'hg.hg_alias',
             'name' => 'hg.hg_name',
             'is_activated' => 'hg.hg_activate',
+            'hostcategories_id' => 'hc.hc_id',
         ]);
         $sqlTranslator?->addNormalizer('is_activated', new BoolToEnumNormalizer());
 

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -346,14 +346,14 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
             )
             ->appendJoins(
                 <<<'SQL'
-                    LEFT JOIN `:db`.hostgroup_relation hgr
-                        ON hg.hg_id = hgr.hostgroup_hg_id
-                    LEFT JOIN `:db`.host h
-                        ON hgr.host_host_id = h.host_id
-                    LEFT JOIN `:db`.hostcategories_relation hcr
-                        ON h.host_id = hcr.host_host_id
-                    LEFT JOIN `:db`.hostcategories hc
-                        ON hcr.hostcategories_hc_id = hc.hc_id
+                        LEFT JOIN `:db`.hostgroup_relation hgr
+                            ON hg.hg_id = hgr.hostgroup_hg_id
+                        LEFT JOIN `:db`.host h
+                            ON hgr.host_host_id = h.host_id
+                        LEFT JOIN `:db`.hostcategories_relation hcr
+                            ON h.host_id = hcr.host_host_id
+                        LEFT JOIN `:db`.hostcategories hc
+                            ON hcr.hostcategories_hc_id = hc.hc_id
                     SQL
             )
             ->appendWhere(


### PR DESCRIPTION
## Description

Enhance endpoint GET: /configuration/hosts/groups by adding possibility to search by host categories

**Fixes** # (MON-34388)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

try to filter hostgroups using the new option on the filter : http://localhost:8080/centreon/api/v24.04/configuration/hosts/groups?search={"hostcategories_id":1}
You should create a hostcategorie to test it

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
