### PR TITLE
enh (media): new API-type repositories for medias

### DIFF
--- a/centreon/src/Core/Media/Application/Repository/ReadMediaRepositoryInterface.php
+++ b/centreon/src/Core/Media/Application/Repository/ReadMediaRepositoryInterface.php
@@ -42,9 +42,9 @@ interface ReadMediaRepositoryInterface
     /**
      * @throws \Throwable
      *
-     * @return \Iterator<int, Media>&\Countable
+     * @return \Traversable<int, Media>&\Countable
      */
-    public function findAll(): \Iterator&\Countable;
+    public function findAll(): \Traversable&\Countable;
 
     /**
      * @param RequestParametersInterface $requestParameters

--- a/centreon/src/Core/Media/Application/UseCase/FindMedias/FindMedias.php
+++ b/centreon/src/Core/Media/Application/UseCase/FindMedias/FindMedias.php
@@ -51,7 +51,10 @@ final class FindMedias
     public function __invoke(FindMediasPresenterInterface $presenter): void
     {
         try {
-            $this->info('Find medias', ['user' => $this->user->getId()]);
+            $this->info(
+                'Find medias',
+                ['user' => $this->user->getId(), 'request' => $this->requestParameters->toArray()]
+            );
             if (! $this->canAccessToListing()) {
                 $this->error(
                     "User doesn't have sufficient rights to list media",

--- a/centreon/src/Core/Media/Application/UseCase/MigrateAllMedias/MigrationAllMediasResponse.php
+++ b/centreon/src/Core/Media/Application/UseCase/MigrateAllMedias/MigrationAllMediasResponse.php
@@ -25,8 +25,8 @@ namespace Core\Media\Application\UseCase\MigrateAllMedias;
 
 final class MigrationAllMediasResponse
 {
-    /** @var \Iterator<MediaRecordedDto|MigrationErrorDto> */
-    public \Iterator $results;
+    /** @var \Traversable<MediaRecordedDto|MigrationErrorDto> */
+    public \Traversable $results;
 
     public function __construct()
     {

--- a/centreon/src/Core/Media/Domain/Model/Media.php
+++ b/centreon/src/Core/Media/Domain/Model/Media.php
@@ -25,8 +25,10 @@ namespace Core\Media\Domain\Model;
 
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
+use Core\Common\Domain\Comparable;
+use Core\Common\Domain\Identifiable;
 
-class Media
+class Media implements Comparable, Identifiable
 {
     /**
      * @param int $id
@@ -92,5 +94,15 @@ class Media
     public function hash(): ?string
     {
         return $this->data !== null ? md5($this->data) : null;
+    }
+
+    public function isEqual(object $object): bool
+    {
+        return $object instanceof self && $object->getEqualityHash() === $this->getEqualityHash();
+    }
+
+    public function getEqualityHash(): string
+    {
+        return md5($this->getRelativePath());
     }
 }

--- a/centreon/src/Core/Media/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/Media/Infrastructure/Configuration/symfony.yaml
@@ -42,9 +42,13 @@ services:
             $dataStorageEngine: '@Core\Common\Infrastructure\Repository\DataStorageObserver'
             $readMediaRepository: '@Core\Media\Infrastructure\Repository\DbReadMediaRepository'
 
+    Core\Media\Infrastructure\Repository\ApiReadMediaRepository:
+        arguments:
+            $logger: '@Centreon\Domain\Log\Logger'
+
     Core\Media\Infrastructure\Repository\ApiWriteMediaRepository:
         calls:
-        - method: setApiTimeOut
+        - method: setTimeOut
           arguments: [ '%curl.timeout%' ]
 
 

--- a/centreon/src/Core/Media/Infrastructure/Repository/ApiReadMediaRepository.php
+++ b/centreon/src/Core/Media/Infrastructure/Repository/ApiReadMediaRepository.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Media\Infrastructure\Repository;
+
+use Assert\AssertionFailedException;
+use Centreon\Domain\Repository\RepositoryException;
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+use Core\Common\Infrastructure\Repository\ApiCallIterator;
+use Core\Common\Infrastructure\Repository\ApiRepositoryTrait;
+use Core\Media\Application\Repository\ReadMediaRepositoryInterface;
+use Core\Media\Domain\Model\Media;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+class ApiReadMediaRepository implements ReadMediaRepositoryInterface
+{
+    use ApiRepositoryTrait;
+
+    public function __construct(
+        private readonly HttpClientInterface $httpClient,
+        private readonly RouterInterface $router,
+        private readonly LoggerInterface $logger,
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function existsByPath(string $path): bool
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findAll(): \Traversable&\Countable
+    {
+        $apiEndpoint = $this->router->generate('FindMedias');
+        $options = [
+            'verify_peer' => true,
+            'verify_host' => true,
+            'timeout' => $this->timeout,
+            'headers' => ['X-AUTH-TOKEN: ' . $this->authenticationToken],
+        ];
+
+        if ($this->proxy !== null) {
+            $options['proxy'] = $this->proxy;
+            $this->logger->info('Getting media using proxy');
+        }
+        $debugOptions = $options;
+        unset($debugOptions['headers'][0]);
+
+        $this->logger->debug('Connexion configuration', [
+            'url' => $apiEndpoint,
+            'options' => $debugOptions,
+        ]);
+
+        return new ApiCallIterator(
+            $this->httpClient,
+            $this->url . $apiEndpoint,
+            $options,
+            $this->maxItemsByRequest,
+            $this->createMedia(...),
+            $this->logger
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByRequestParameters(RequestParametersInterface $requestParameters): \Traversable
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @param array{id: int, filename: string, directory: string} $data
+     *
+     * @throws AssertionFailedException
+     *
+     * @return Media
+     */
+    private function createMedia(array $data): Media
+    {
+        return new Media(
+            $data['id'],
+            (string) $data['filename'],
+            (string) $data['directory'],
+            null,
+            null
+        );
+    }
+}

--- a/centreon/src/Core/Media/Infrastructure/Repository/ApiWriteMediaRepository.php
+++ b/centreon/src/Core/Media/Infrastructure/Repository/ApiWriteMediaRepository.php
@@ -24,6 +24,8 @@ declare(strict_types = 1);
 namespace Core\Media\Infrastructure\Repository;
 
 use Centreon\Domain\Log\LoggerTrait;
+use Core\Common\Infrastructure\Repository\ApiRepositoryTrait;
+use Core\Common\Infrastructure\Repository\ApiResponseTrait;
 use Core\Media\Application\Repository\WriteMediaRepositoryInterface;
 use Core\Media\Domain\Model\NewMedia;
 use Symfony\Component\Mime\Part\DataPart;
@@ -33,40 +35,11 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class ApiWriteMediaRepository implements WriteMediaRepositoryInterface
 {
     use LoggerTrait;
-
-    private ?string $proxy = null;
-
-    private ?string $url = null;
-
-    private string $authenticationToken = '';
-
-    private int $timeout = 60; // Default timeout
+    use ApiRepositoryTrait;
+    use ApiResponseTrait;
 
     public function __construct(readonly private HttpClientInterface $httpClient)
     {
-    }
-    
-    public function setProxy(string $proxy): void
-    {
-        $this->proxy = $proxy;
-    }
-
-    public function setUrl(string $url): void
-    {
-        $this->url = rtrim($url, DIRECTORY_SEPARATOR);
-        if (! str_starts_with($this->url, 'http')) {
-            $this->url = 'https://' . $this->url;
-        }
-    }
-
-    public function setAuthenticationToken(string $token): void
-    {
-        $this->authenticationToken = $token;
-    }
-    
-    public function setApiTimeOut(int $timeout): void
-    {
-        $this->timeout = $timeout;
     }
 
     /**
@@ -74,7 +47,7 @@ class ApiWriteMediaRepository implements WriteMediaRepositoryInterface
      */
     public function add(NewMedia $media): int
     {
-        $apiEndpoint = $this->url . DIRECTORY_SEPARATOR . 'centreon/api/latest/configuration/medias';
+        $apiEndpoint = $this->url . '/api/latest/configuration/medias';
         $options = [
             'verify_peer' => true,
             'verify_host' => true,
@@ -104,30 +77,13 @@ class ApiWriteMediaRepository implements WriteMediaRepositoryInterface
         $options['headers'][] = 'X-AUTH-TOKEN: ' . $this->authenticationToken;
         $options['body'] = $formData->bodyToString();
 
-        $response = $this->httpClient->request('POST', $apiEndpoint, $options);
-        if ($response->getStatusCode() !== 200) {
-            /**
-             * @var array{message: string} $content
-             */
-            $content = $response->toArray(false);
-            $this->debug('API error', [
-                'http_code' => $response->getStatusCode(),
-                'message' => $content['message'],
-            ]);
+        /** @var array{result: array<int, array{id: int}>, errors: array<int, array{reason: string}>} $response */
+        $response = $this->getResponseOrFail($this->httpClient->request('POST', $apiEndpoint, $options));
 
-            throw new \Exception(sprintf('Request error: %s', $content['message']), $response->getStatusCode());
-        }
-        /**
-         * @var array{
-         *     result: array<int, array{id: int}>,
-         *     errors: array<int, array{reason: string}>
-         * } $content
-         */
-        $content = $response->toArray(false);
-        if (isset($content['errors'][0]['reason'])) {
-            throw new \Exception($content['errors'][0]['reason']);
+        if (isset($response['errors'][0]['reason'])) {
+            throw new \Exception($response['errors'][0]['reason']);
         }
 
-        return (int) $content['result'][0]['id'];
+        return (int) $response['result'][0]['id'];
     }
 }


### PR DESCRIPTION
## Description

🏷️ MON-21552

As part of the migration from an on-premises Centreon platform to a remote platform, we need to set up a new repository that allows us to retrieve medias by making HTTP calls to the remote Centreon platform.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
