### PR TITLE
[Backport] Fix(UI): Fix item composition spacing

### DIFF
--- a/centreon/packages/ui/src/components/ItemComposition/ItemComposition.styles.ts
+++ b/centreon/packages/ui/src/components/ItemComposition/ItemComposition.styles.ts
@@ -9,13 +9,13 @@ export const useItemCompositionStyles = makeStyles()((theme) => ({
     width: '100%'
   },
   itemCompositionContainer: {
+    width: '100%'
+  },
+  itemCompositionItems: {
     alignItems: 'flex-start',
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(2),
-    width: '100%'
-  },
-  itemCompositionItems: {
     width: '100%'
   },
   itemCompositionItemsAndLink: {

--- a/centreon/www/front_src/src/Dashboards/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.tsx
+++ b/centreon/www/front_src/src/Dashboards/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.tsx
@@ -70,6 +70,7 @@ const Resources = ({ propertyName }: Props): JSX.Element => {
       </div>
       <div className={classes.resourceComposition}>
         <ItemComposition
+          displayItemsAsLinked
           IconAdd={<AddIcon />}
           addButtonHidden={!canEditField}
           addbuttonDisabled={!areResourcesFullfilled(value)}


### PR DESCRIPTION
## Description

Missing space between items in the Item Composition component

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
