### PR TITLE
fix(conf gorgone backport) YAML templates need actions enabled by default for …

### DIFF
--- a/centreon-gorgone/config/gorgoned-central-ssh.yml
+++ b/centreon-gorgone/config/gorgoned-central-ssh.yml
@@ -31,6 +31,13 @@ configuration:
       - name: action
         package: gorgone::modules::core::action::hooks
         enable: true
+        command_timeout: 30
+        whitelist_cmds: true
+        allowed_cmds:
+          - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+          - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+          - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+          - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
       - name: proxy
         package: gorgone::modules::core::proxy::hooks

--- a/centreon-gorgone/config/gorgoned-central-zmq.yml
+++ b/centreon-gorgone/config/gorgoned-central-zmq.yml
@@ -55,6 +55,13 @@ configuration:
       - name: action
         package: gorgone::modules::core::action::hooks
         enable: true
+        command_timeout: 30
+        whitelist_cmds: true
+        allowed_cmds:
+          - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+          - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+          - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+          - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
       - name: proxy
         package: gorgone::modules::core::proxy::hooks

--- a/centreon-gorgone/config/gorgoned-poller.yml
+++ b/centreon-gorgone/config/gorgoned-poller.yml
@@ -13,6 +13,13 @@ configuration:
       - name: action
         package: gorgone::modules::core::action::hooks
         enable: true
+        command_timeout: 30
+        whitelist_cmds: true
+        allowed_cmds:
+          - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+          - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+          - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+          - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
       - name: engine
         package: gorgone::modules::centreon::engine::hooks

--- a/centreon-gorgone/config/gorgoned-remote-ssh.yml
+++ b/centreon-gorgone/config/gorgoned-remote-ssh.yml
@@ -18,6 +18,13 @@ configuration:
       - name: action
         package: gorgone::modules::core::action::hooks
         enable: true
+        command_timeout: 30
+        whitelist_cmds: true
+        allowed_cmds:
+          - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+          - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+          - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+          - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
       - name: proxy
         package: gorgone::modules::core::proxy::hooks

--- a/centreon-gorgone/config/gorgoned-remote-zmq.yml
+++ b/centreon-gorgone/config/gorgoned-remote-zmq.yml
@@ -23,6 +23,13 @@ configuration:
       - name: action
         package: gorgone::modules::core::action::hooks
         enable: true
+        command_timeout: 30
+        whitelist_cmds: true
+        allowed_cmds:
+          - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+          - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+          - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+          - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
       - name: proxy
         package: gorgone::modules::core::proxy::hooks

--- a/centreon-gorgone/contrib/gorgone_config_init.pl
+++ b/centreon-gorgone/contrib/gorgone_config_init.pl
@@ -94,7 +94,7 @@ configuration:
         dsn: "mysql:host=$centreon_config->{db_host}${db_port};dbname=$centreon_config->{centstorage_db}"
         username: "$centreon_config->{db_user}"
         password: "$centreon_config->{db_passwd}"
-  gorgone:      
+  gorgone:
     gorgonecore:
       hostname:
       id:
@@ -121,6 +121,13 @@ configuration:
       - name: action
         package: gorgone::modules::core::action::hooks
         enable: true
+        command_timeout: 30
+        whitelist_cmds: true
+        allowed_cmds:
+          - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+          - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+          - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+          - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
       - name: proxy
         package: gorgone::modules::core::proxy::hooks

--- a/centreon-gorgone/docs/migration.md
+++ b/centreon-gorgone/docs/migration.md
@@ -53,6 +53,13 @@ configuration:
       - name: action
         package: gorgone::modules::core::action::hooks
         enable: true
+        command_timeout: 30
+        whitelist_cmds: true
+        allowed_cmds:
+          - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+          - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+          - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+          - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
       - name: cron
         package: gorgone::modules::core::cron::hooks

--- a/centreon-gorgone/docs/modules/core/action.md
+++ b/centreon-gorgone/docs/modules/core/action.md
@@ -20,12 +20,12 @@ name: action
 package: "gorgone::modules::core::action::hooks"
 enable: true
 command_timeout: 30
-whitelist_cmds: false
+whitelist_cmds: true
 allowed_cmds:
   - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
   - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
   - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
-  - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$ 
+  - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 ```
 
 ## Events

--- a/centreon-gorgone/docs/poller_pull_configuration.md
+++ b/centreon-gorgone/docs/poller_pull_configuration.md
@@ -38,6 +38,13 @@ gorgone:
     - name: action
       package: gorgone::modules::core::action::hooks
       enable: true
+      command_timeout: 30
+      whitelist_cmds: true
+      allowed_cmds:
+        - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+        - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+        - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+        - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
     - name: engine
       package: gorgone::modules::centreon::engine::hooks

--- a/centreon-gorgone/docs/rebound_configuration.md
+++ b/centreon-gorgone/docs/rebound_configuration.md
@@ -42,6 +42,13 @@ gorgone:
     - name: action
       package: gorgone::modules::core::action::hooks
       enable: true
+      command_timeout: 30
+      whitelist_cmds: true
+      allowed_cmds:
+        - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+        - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+        - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+        - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
     - name: engine
       package: gorgone::modules::centreon::engine::hooks

--- a/centreon-gorgone/gorgone/modules/core/action/hooks.pm
+++ b/centreon-gorgone/gorgone/modules/core/action/hooks.pm
@@ -67,7 +67,7 @@ sub routing {
             dbh => $options{dbh},
             code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
-            data => { msg => 'gorgoneaction: still no ready' },
+            data => { msg => 'gorgoneaction: still not ready' },
             json_encode => 1
         });
         return undef;

--- a/centreon/www/include/configuration/configServers/popup/central.yaml
+++ b/centreon/www/include/configuration/configServers/popup/central.yaml
@@ -21,6 +21,13 @@ gorgone:
     - name: action
       package: "gorgone::modules::core::action::hooks"
       enable: true
+      command_timeout: 30
+      whitelist_cmds: true
+      allowed_cmds:
+        - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+        - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+        - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+        - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
     - name: cron
       package: "gorgone::modules::core::cron::hooks"
       enable: true

--- a/centreon/www/include/configuration/configServers/popup/poller.yaml
+++ b/centreon/www/include/configuration/configServers/popup/poller.yaml
@@ -12,6 +12,12 @@ gorgone:
     - name: action
       package: gorgone::modules::core::action::hooks
       enable: true
+      whitelist_cmds: true
+      allowed_cmds:
+        - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+        - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+        - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+        - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
     - name: engine
       package: gorgone::modules::centreon::engine::hooks

--- a/centreon/www/include/configuration/configServers/popup/remote.yaml
+++ b/centreon/www/include/configuration/configServers/popup/remote.yaml
@@ -12,6 +12,13 @@ gorgone:
     - name: action
       package: gorgone::modules::core::action::hooks
       enable: true
+      command_timeout: 30
+      whitelist_cmds: true
+      allowed_cmds:
+        - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+        - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+        - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+        - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
     - name: cron
       package: "gorgone::modules::core::cron::hooks"

--- a/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
+++ b/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
@@ -21,6 +21,13 @@ gorgone:
     - name: action
       package: "gorgone::modules::core::action::hooks"
       enable: true
+      command_timeout: 30
+      whitelist_cmds: true
+      allowed_cmds:
+        - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+        - ^sudo\s+(/usr/bin/)?service\s+(centengine|centreontrapd|cbd)\s+(reload|restart)\s*$
+        - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine.cfg\s*$
+        - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats.json\s*$
 
     - name: cron
       package: "gorgone::modules::core::cron::hooks"


### PR DESCRIPTION
…gorgone::modules::core::action::hooks (#3222)

## Description
Backport to `dev-23.04.x` (parent PR: https://github.com/centreon/centreon/pull/3222)

JIRA: MON-34912 (Parent: MON-34285)


## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)
