### PR TITLE
enh(api) : add the posibility to search using host groups

### DIFF
--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -2184,7 +2184,9 @@ paths:
         * host.state
         * poller.id
         * service.display_name
-        * host_group.id
+        * host.group.id
+        * host.group.name
+
       parameters:
         - $ref: '#/components/parameters/ShowHost'
         - $ref: '#/components/parameters/ShowService'

--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -290,6 +290,8 @@ paths:
         * name
         * alias
         * is_activated
+        * hostgroup.id
+        * hostgroup.name
       responses:
         "200":
           description: "OK"

--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadHostCategoryRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadHostCategoryRepository.php
@@ -527,6 +527,8 @@ class DbReadHostCategoryRepository extends AbstractRepositoryRDB implements Read
             'name' => 'hc.hc_name',
             'alias' => 'hc.hc_alias',
             'is_activated' => 'hc.hc_activate',
+            'hostgroup.id' => 'hostgroup.hg_id',
+            'hostgroup.name' => 'hostgroup.hg_name',
         ]);
         $sqlTranslator?->addNormalizer('is_activated', new BoolToEnumNormalizer());
         $sqlTranslator?->translateForConcatenator($concatenator);

--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadHostCategoryRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadHostCategoryRepository.php
@@ -104,7 +104,7 @@ class DbReadHostCategoryRepository extends AbstractRepositoryRDB implements Read
         $concatenator = new SqlConcatenator();
         $concatenator->withCalcFoundRows(true);
         $concatenator->defineSelect(
-            'SELECT hc.hc_id, hc.hc_name, hc.hc_alias, hc.hc_activate, hc.hc_comment
+            'SELECT DISTINCT hc.hc_id, hc.hc_name, hc.hc_alias, hc.hc_activate, hc.hc_comment
             FROM `:db`.hostcategories hc'
         );
 


### PR DESCRIPTION
## Description

Enhance endpoint GET: /configuration/hosts/categories by adding possibility to search by host groups

**Fixes** # (MON-34389)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

try to filter hostgroups using the new option on the filter : http://localhost:8080/centreon/api/v24.04/configuration/hosts/categories?search={"hostgroups_id":1}
You should create a hostgroups related to hostcategories to test it

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
