### PR TITLE
fix(web): decode html special chars

### DIFF
--- a/centreon/www/class/centreonUtils.class.php
+++ b/centreon/www/class/centreonUtils.class.php
@@ -319,17 +319,18 @@ class CentreonUtils
         $stringToEscape,
         $escapeMethod = self::ESCAPE_LEGACY_METHOD
     ) {
+        $stringDecoded = htmlspecialchars_decode($stringToEscape);
         switch ($escapeMethod) {
             case self::ESCAPE_LEGACY_METHOD:
                 // Remove script and input tags by default
-                return preg_replace(array("/<script.*?\/script>/si", "/<input[^>]+\>/si"), "", $stringToEscape ?? '');
+                return preg_replace(array("/<script.*?\/script>/si", "/<input[^>]+\>/si"), "", $stringDecoded ?? '');
             case self::ESCAPE_ALL_EXCEPT_LINK:
-                return self::escapeAllExceptLink($stringToEscape);
+                return self::escapeAllExceptLink($stringDecoded);
             case self::ESCAPE_ALL:
-                return self::escapeAll($stringToEscape);
+                return self::escapeAll($stringDecoded);
             case self::ESCAPE_ILLEGAL_CHARS:
                 $chars = (string) $_SESSION['centreon']->Nagioscfg['illegal_object_name_chars'];
-                return str_replace(str_split($chars), '', $stringToEscape);
+                return str_replace(str_split($chars), '', $stringDecoded);
         }
     }
 

--- a/centreon/www/class/centreonUtils.class.php
+++ b/centreon/www/class/centreonUtils.class.php
@@ -319,18 +319,17 @@ class CentreonUtils
         $stringToEscape,
         $escapeMethod = self::ESCAPE_LEGACY_METHOD
     ) {
-        $stringDecoded = htmlspecialchars_decode($stringToEscape);
         switch ($escapeMethod) {
             case self::ESCAPE_LEGACY_METHOD:
                 // Remove script and input tags by default
-                return preg_replace(array("/<script.*?\/script>/si", "/<input[^>]+\>/si"), "", $stringDecoded ?? '');
+                return preg_replace(array("/<script.*?\/script>/si", "/<input[^>]+\>/si"), "", $stringToEscape ?? '');
             case self::ESCAPE_ALL_EXCEPT_LINK:
-                return self::escapeAllExceptLink($stringDecoded);
+                return self::escapeAllExceptLink($stringToEscape);
             case self::ESCAPE_ALL:
-                return self::escapeAll($stringDecoded);
+                return self::escapeAll($stringToEscape);
             case self::ESCAPE_ILLEGAL_CHARS:
                 $chars = (string) $_SESSION['centreon']->Nagioscfg['illegal_object_name_chars'];
-                return str_replace(str_split($chars), '', $stringDecoded);
+                return str_replace(str_split($chars), '', $stringToEscape);
         }
     }
 

--- a/centreon/www/include/configuration/configObject/host/listHost.php
+++ b/centreon/www/include/configuration/configObject/host/listHost.php
@@ -394,7 +394,7 @@ for ($i = 0; $host = $dbResult->fetch(); $i++) {
             "RowMenu_id" => $host["host_id"],
             "RowMenu_icone" => $host_icone,
             "RowMenu_link" => "main.php?p=" . $p . "&o=c&host_id=" . $host['host_id'],
-            "RowMenu_desc" => CentreonUtils::escapeSecure($host["host_alias"]),
+            "RowMenu_desc" => htmlspecialchars_decode(CentreonUtils::escapeSecure($host["host_alias"])),
             "RowMenu_address" => CentreonUtils::escapeSecure($host["host_address"]),
             "RowMenu_poller" => isset($tab_relation[$host["host_id"]])
                 ? $tab_relation[$host["host_id"]]


### PR DESCRIPTION
## Description

Host Alias not decoded on Configuration  >  Hosts

How to reproduce :

- Create a new host with ”Ceci est l’alias”
- Go to the Configuration  >  Hosts page
- “Ceci est l’alias“ will be replace by “Central est l&#39;alias“

**Fixes** # MON-35035

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

- Create a new host with ”Ceci est l’alias”
- Go to the Configuration  >  Hosts page