### PR TITLE
fix(gorgone): change several log levels for discovery module

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -143,7 +143,7 @@ sub send_email {
             }
 
             if (scalar(@$body) > 0) {
-                $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} send email to '" . $contact_id .  "' (" . $self->{discovery}->{rules}->{$rule_id}->{contact}->{$contact_id}->{contact_email} . ")");
+                $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} send email to '" . $contact_id .  "' (" . $self->{discovery}->{rules}->{$rule_id}->{contact}->{$contact_id}->{contact_email} . ")");
 
                 my $smtp = Net::SMTP->new('localhost', Timeout => 15);
                 if (!defined($smtp)) {
@@ -294,7 +294,7 @@ sub update_service {
             msg => 'template',
             rule_id => $options{rule_id}
         }; 
-        $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update template");
+        $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update template");
         if ($self->{discovery}->{is_manual} == 1) {
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{service_template_model_stm_id} = $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id};
         }
@@ -307,7 +307,7 @@ sub update_service {
             type => 'enable',
             rule_id => $options{rule_id}
         };
-        $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service enable");
+        $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service enable");
     }
 
     foreach my $macro_name (keys %{$options{macros}}) {
@@ -338,7 +338,7 @@ sub update_service {
             msg => 'macros',
             rule_id => $options{rule_id}
         };
-        $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update/insert macros");
+        $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update/insert macros");
     }
 
     return $options{service}->{id} if ($self->{discovery}->{dry_run} == 1 || scalar(@journal) == 0);
@@ -499,7 +499,7 @@ sub crud_service {
     my $service_id;
     if (!defined($options{service})) {
         $service_id = $self->create_service(%options);
-        $self->{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service created");
+        $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service created");
         if ($service_id != -1) {
             push @{$self->{discovery}->{journal}}, {
                 host_name => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
@@ -524,13 +524,13 @@ sub disable_services {
 
         if (!defined($options{discovery_svc}->{discovered_services}->{$service_description}) && 
             $self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }->{$service}->{service_activate} == 1) {
-            $self->{logger}->writeLogInfo("$options{logger_pre_message} -> disable service '" . $service_description . "'");
+            $self->{logger}->writeLogDebug("$options{logger_pre_message} -> disable service '" . $service_description . "'");
             next if ($self->{discovery}->{dry_run} == 1);
 
             my $query = "UPDATE service SET service_activate = '0' WHERE service_id = " . $service;
             my ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
             if ($status == -1) {
-                $self->{logger}->writeLogInfo("$options{logger_pre_message} -> cannot disable service '" . $service_description . "'");
+                $self->{logger}->writeLogError("$options{logger_pre_message} -> cannot disable service '" . $service_description . "'");
                 next;
             }
             
@@ -707,7 +707,7 @@ sub discoverylistener {
 
     $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} current count $self->{discovery}->{done_discoveries}/$self->{discovery}->{count_discoveries}");
     if ($self->{discovery}->{done_discoveries} == $self->{discovery}->{count_discoveries}) {
-        $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} discovery finished");
+        $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} discovery finished");
         $self->{finished} = 1;
 
         $self->send_log(
@@ -754,7 +754,7 @@ sub service_execute_commands {
                     vault_count => $options{vault_count}
                 );
 
-                $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} [" .
+                $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} [" .
                     $self->{discovery}->{rules}->{$rule_id}->{rule_alias} . "] [" . 
                     $self->{service_pollers}->{$poller_id}->{name} . "] [" .
                     $host->{host_name} . "] -> substitute string: " . $command
@@ -810,7 +810,7 @@ sub launchdiscovery {
     ################
     # get pollers
     ################
-    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load pollers configuration");
+    $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} load pollers configuration");
     my ($status, $message, $pollers) = gorgone::modules::centreon::autodiscovery::services::resources::get_pollers(
         class_object_centreon => $self->{class_object_centreon}
     );
@@ -823,7 +823,7 @@ sub launchdiscovery {
     ################
     # get audit user
     ################
-    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load audit configuration");
+    $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} load audit configuration");
 
     ($status, $message, my $audit_enable) = gorgone::modules::centreon::autodiscovery::services::resources::get_audit(
         class_object_centstorage => $self->{class_object_centstorage}
@@ -861,7 +861,7 @@ sub launchdiscovery {
     ################
     # get rules
     ################
-    $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} load rules configuration");
+    $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} load rules configuration");
     
     ($status, $message, my $rules) = gorgone::modules::centreon::autodiscovery::services::resources::get_rules(
         class_object_centreon => $self->{class_object_centreon},

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -586,10 +586,10 @@ sub check_exinc {
             attributes => $options{discovery_svc}->{attributes}
         );
         if ($exinc->{exinc_type} == 1 && $value =~ /$exinc->{exinc_regexp}/) {
-            $options{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> inclusion '$exinc->{exinc_regexp}'");
+            $options{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> inclusion '$exinc->{exinc_regexp}'");
             return 0;
         } elsif ($exinc->{exinc_type} == 0 && $value =~ /$exinc->{exinc_regexp}/) {
-            $options{logger}->writeLogInfo("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> exclusion '$exinc->{exinc_regexp}'");
+            $options{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> exclusion '$exinc->{exinc_regexp}'");
             return 1;
         }
     }


### PR DESCRIPTION
## Description

Gorgone talks to much on the info level when it comes to service discovery, showing executed command and internal stuff that are supposed to be used for debugging.
In the other hand it isn't showing when the discovery ends.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Set the log level to info,
2. Launch a service discovery.

You should not see the executed command nor logs about the internal stuff.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
