### PR TITLE
enh(cloud/configuration): restore command / args configuration

### DIFF
--- a/centreon/www/include/configuration/configObject/command/command.php
+++ b/centreon/www/include/configuration/configObject/command/command.php
@@ -49,6 +49,8 @@ $path = "./include/configuration/configObject/command/";
 require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
 
+const COMMAND_TYPE_CHECK = 2;
+
 $command_id = filter_var(
     $_GET['command_id'] ?? $_POST['command_id'] ?? null,
     FILTER_VALIDATE_INT
@@ -76,6 +78,13 @@ if (isset($_POST["o1"]) && isset($_POST["o2"])) {
     if ($_POST["o2"] != "") {
         $o = $_POST["o2"];
     }
+}
+
+global $isCloudPlatform;
+
+// In Cloud context we force the type to Check. That is the only possible optio
+if ($isCloudPlatform = isCloudPlatform() === true) {
+    $type = COMMAND_TYPE_CHECK;
 }
 
 $commandObj = new CentreonCommand($pearDB);

--- a/centreon/www/include/configuration/configObject/command/formCommand.ihtml
+++ b/centreon/www/include/configuration/configObject/command/formCommand.ihtml
@@ -26,10 +26,12 @@
                 <td class="FormRowField"><img class="helpTooltip" name="command_name"> {$form.command_name.label}</td>
                 <td class="FormRowValue">{$form.command_name.html}</td>
             </tr>
-            <tr class="list_two">
-                <td class="FormRowField"><img class="helpTooltip" name="command_type"> {$form.command_type.label}</td>
-                <td class="FormRowValue">{$form.command_type.html}</td>
-            </tr>
+            {if $is_cloud_platform === false}
+                <tr class="list_two">
+                    <td class="FormRowField"><img class="helpTooltip" name="command_type"> {$form.command_type.label}</td>
+                    <td class="FormRowValue">{$form.command_type.html}</td>
+                </tr>
+            {/if}
             <tr class="list_one">
                 <td class="FormRowField"><img class="helpTooltip" name="command_line_help"> {$form.command_line.label}</td>
                 <td>

--- a/centreon/www/include/configuration/configObject/command/formCommand.php
+++ b/centreon/www/include/configuration/configObject/command/formCommand.php
@@ -178,7 +178,7 @@ if ($o == "a") {
 /*
  * Command information
  */
-if ($type !== false && isset($tabCommandType[$type])) {
+if ($type !== false && isset($tabCommandType[$type]) && $isCloudPlatform === false) {
     $form->addElement('header', 'information', $tabCommandType[$type]);
 } else {
     $form->addElement('header', 'information', _("Information"));
@@ -186,23 +186,26 @@ if ($type !== false && isset($tabCommandType[$type])) {
 
 $form->addElement('header', 'furtherInfos', _("Additional Information"));
 
-foreach ($tabCommandType as $id => $name) {
-    $cmdType[] = $form->createElement(
-        'radio',
-        'command_type',
-        null,
-        $name,
-        $id,
-        'onChange=checkType(this.value);'
-    );
-}
+// possibility to change the type of command is only possible out of the Cloud context
+if (! $isCloudPlatform) {
+    foreach ($tabCommandType as $id => $name) {
+        $cmdType[] = $form->createElement(
+            'radio',
+            'command_type',
+            null,
+            $name,
+            $id,
+            'onChange=checkType(this.value);'
+        );
+    }
 
-$form->addGroup($cmdType, 'command_type', _("Command Type"), '&nbsp;&nbsp;');
+    $form->addGroup($cmdType, 'command_type', _("Command Type"), '&nbsp;&nbsp;');
 
-if ($type !== false) {
-    $form->setDefaults(array('command_type' => $type));
-} else {
-    $form->setDefaults(array('command_type' => '2'));
+    if ($type !== false) {
+        $form->setDefaults(array('command_type' => $type));
+    } else {
+        $form->setDefaults(array('command_type' => '2'));
+    }
 }
 
 if (isset($cmd['connector_id']) && is_numeric($cmd['connector_id'])) {
@@ -312,6 +315,7 @@ if ($o == "w") {
 
 $tpl->assign('msg', array("comment" => _("Commands definitions can contain Macros but they have to be valid.")));
 $tpl->assign('cmd_help', _("Plugin Help"));
+$tpl->assign("is_cloud_platform", $isCloudPlatform);
 
 $valid = false;
 if ($form->validate()) {

--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -529,17 +529,17 @@ $form->addElement('text', 'host_max_check_attempts', _('Max Check Attempts'), $a
 $form->addElement('text', 'host_check_interval', _('Normal Check Interval'), $attrsText2);
 $form->addElement('text', 'host_retry_check_interval', _('Retry Check Interval'), $attrsText2);
 
+$form->addElement('header', 'check', _('Host Check Properties'));
+
+$checkCommandSelect = $form->addElement('select2', 'command_command_id', _('Check Command'), [], $attributes['check_commands']);
+$checkCommandSelect->addJsCallback(
+    'change',
+    'setArgument(jQuery(this).closest("form").get(0),"command_command_id","example1");'
+);
+
+$form->addElement('text', 'command_command_id_arg1', _('Args'), $attrsText);
+
 if (! $isCloudPlatform) {
-    $form->addElement('header', 'check', _('Host Check Properties'));
-
-    $checkCommandSelect = $form->addElement('select2', 'command_command_id', _('Check Command'), [], $attributes['check_commands']);
-    $checkCommandSelect->addJsCallback(
-        'change',
-        'setArgument(jQuery(this).closest("form").get(0),"command_command_id","example1");'
-    );
-
-    $form->addElement('text', 'command_command_id_arg1', _('Args'), $attrsText);
-
     $hostEHE[] = $form->createElement('radio', 'host_event_handler_enabled', null, _('Yes'), '1');
     $hostEHE[] = $form->createElement('radio', 'host_event_handler_enabled', null, _('No'), '0');
     $hostEHE[] = $form->createElement('radio', 'host_event_handler_enabled', null, _('Default'), '2');

--- a/centreon/www/include/configuration/configObject/host/formHostCloud.ihtml
+++ b/centreon/www/include/configuration/configObject/host/formHostCloud.ihtml
@@ -111,19 +111,6 @@
 		        <td class="FormRowField"><img class="helpTooltip" name="snmp_options"> {$form.host_snmp_community.label} & {$form.host_snmp_version.label}</td>
 		        <td class="FormRowValue">{$form.host_snmp_community.html}&nbsp;&nbsp;{$form.host_snmp_version.html}</td>
 		    </tr>
-			<tr class="list_one">
-				<td class="FormRowField"><img class="helpTooltip" name="macro"> {$custom_macro_label} <br>
-					<div class="macro_legend">
-						<p><span class="state_badge"
-								style="background-color: var(--custom-macros-template-background-color);"></span>{$template_inheritance}
-						</p>
-						<p><span class="state_badge"
-								style="background-color: var(--custom-macros-command-background-color);"></span>{$command_inheritance}
-						</p>
-					</div>
-				</td>
-				<td class="FormRowValue">{include file="file:$centreon_path/www/include/common/templates/cloneMacro.ihtml" cloneId="macro" cloneSet=$cloneSetMacro}</td>
-			</tr>
 			<tr class="list_two">
 				<td class="FormRowField"><img class="helpTooltip" name="check_period"> {$form.timeperiod_tp_id.label}</td>
 				<td class="FormRowValue">{$form.timeperiod_tp_id.html} </td>
@@ -133,6 +120,38 @@
 				<td class="FormRowValue">{$form.host_location.html}</td>
 			</tr>
 
+			<tr class="list_lvl_1">
+			    <td class="ListColLvl1_name" colspan="2"><h4>{t}Host check options{/t}</h4></td>
+			</tr>
+		 	<tr class="list_one">
+				<td class="FormRowField"><img class="helpTooltip" name="check_command"> {$form.command_command_id.label}</td>
+				<td class="FormRowValue">
+					{$form.command_command_id.html}
+					{if $o == "a" || $o == "c"}
+					<span style="cursor:help; margin-left: 4px;">
+						<img src='./img/icons/info.png' class='ico-14' style='vertical-align:middle;' onclick="window.open('main.php?p=60801&command_id='+ document.Form.elements['command_command_id'].options[document.Form.elements['command_command_id'].selectedIndex].value + '&o=w&min=1','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=500, height=200');">
+					</span>
+					{/if}
+				</td>
+			</tr>
+			<tr class="list_two">
+				<td class="FormRowField"><img class="helpTooltip" name="check_command_args"> {$form.command_command_id_arg1.label}</td>
+				<td class="FormRowValue">
+					{$form.command_command_id_arg1.html}
+					{if $o == "a" || $o == "c"}
+						<img src="./img/icons/arrow-left.png" style='cursor:pointer;margin: 0 6px;vertical-align: middle;' alt="*" class="ico-14" onclick="set_arg('example1','command_command_id_arg1');"><input type="text" name="example1" disabled>
+					{/if}
+				</td>
+			</tr>
+			<tr class="list_one">
+				<td class="FormRowField"><img class="helpTooltip" name="macro"> {$custom_macro_label} <br>
+					<div class="macro_legend">
+						<p><span class="state_badge" style="background-color: var(--custom-macros-template-background-color);"></span>{$template_inheritance}</p>
+						<p><span class="state_badge" style="background-color: var(--custom-macros-command-background-color);"></span>{$command_inheritance}</p>
+					</div>
+				</td>
+				<td class="FormRowValue">{include file="file:$centreon_path/www/include/common/templates/cloneMacro.ihtml" cloneId="macro" cloneSet=$cloneSetMacro}</td>
+			</tr>
 			<tr class="list_lvl_1">
 			    <td class="ListColLvl1_name" colspan="2"><h4>{t}Scheduling options{/t}</h4></td>
 			</tr>

--- a/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -432,15 +432,16 @@ $cloneSetMacro = [
     ),
 ];
 
+$form->addElement('header', 'check', _('Host Check Properties'));
+
+$checkCommandSelect = $form->addElement('select2', 'command_command_id', _('Check Command'), [], $attributes['check_commands']);
+$checkCommandSelect->addJsCallback(
+    'change',
+    'setArgument(jQuery(this).closest("form").get(0),"command_command_id","example1");'
+);
+
 // Check information
 if (! $isCloudPlatform) {
-    $form->addElement('header', 'check', _('Host Check Properties'));
-
-    $checkCommandSelect = $form->addElement('select2', 'command_command_id', _('Check Command'), [], $attributes['check_commands']);
-    $checkCommandSelect->addJsCallback(
-        'change',
-        'setArgument(jQuery(this).closest("form").get(0),"command_command_id","example1");'
-    );
 
     $form->addElement('text', 'command_command_id_arg1', _('Args'), $attrsText);
 

--- a/centreon/www/include/configuration/configObject/service/formService.php
+++ b/centreon/www/include/configuration/configObject/service/formService.php
@@ -396,6 +396,25 @@ $form->addElement('static', 'tplText', _('Using a Template exempts you to fill r
 //
 $form->addElement('header', 'check', _('Service State'));
 
+$checkCommandSelect = $form->addElement(
+    'select2',
+    'command_command_id',
+    _('Check Command'),
+    [],
+    $attributes['check_commands']
+);
+if ($o === SERVICE_MASSIVE_CHANGE) {
+    $checkCommandSelect->addJsCallback(
+        'change',
+        'setArgument(jQuery(this).closest("form").get(0),"command_command_id","example1");'
+    );
+} else {
+    $checkCommandSelect->addJsCallback('change', 'changeCommand(this.value);');
+}
+
+$form->addElement('text', 'command_command_id_arg', _('Args'), $attrsText);
+
+
 if (! $isCloudPlatform) {
     $serviceIV = [
         $form->createElement('radio', 'service_is_volatile', null, _('Yes'), '1'),
@@ -406,24 +425,6 @@ if (! $isCloudPlatform) {
     if ($o !== SERVICE_MASSIVE_CHANGE) {
         $form->setDefaults(['service_is_volatile' => '2']);
     }
-
-    $checkCommandSelect = $form->addElement(
-        'select2',
-        'command_command_id',
-        _('Check Command'),
-        [],
-        $attributes['check_commands']
-    );
-    if ($o === SERVICE_MASSIVE_CHANGE) {
-        $checkCommandSelect->addJsCallback(
-            'change',
-            'setArgument(jQuery(this).closest("form").get(0),"command_command_id","example1");'
-        );
-    } else {
-        $checkCommandSelect->addJsCallback('change', 'changeCommand(this.value);');
-    }
-
-    $form->addElement('text', 'command_command_id_arg', _('Args'), $attrsText);
 
     $serviceEHE = [
         $form->createElement('radio', 'service_event_handler_enabled', null, _('Yes'), '1'),

--- a/centreon/www/include/configuration/configObject/service/formServiceCloud.ihtml
+++ b/centreon/www/include/configuration/configObject/service/formServiceCloud.ihtml
@@ -74,6 +74,21 @@
             <h4>{t}Monitoring settings{/t}</h4>
           </td>
         </tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="check_period"> {$form.timeperiod_tp_id.label}</td><td class="FormRowValue">{$form.timeperiod_tp_id.html}</td></tr>
+        <tr class="list_lvl_1">
+          <td class="ListColLvl1_name" colspan="2">
+            <h4>{t}Service Check Options{/t}</h4>
+          </td>
+        </tr>
+        <tr class="list_two">
+            <td class="FormRowField"><img class="helpTooltip" name="check_command"> {$form.command_command_id.label}</td>
+            <td class="FormRowValue">
+                {$form.command_command_id.html}
+                {if $o == "a" || $o == "c"}
+                &nbsp;<img class='ico-14' src='./img/icons/info.png' style='cursor:help;vertical-align:middle;' onClick="window.open('main.php?p=60801&command_id='+ document.Form.elements['command_command_id'].options[document.Form.elements['command_command_id'].selectedIndex].value + '&o=w&min=1','','toolbar=no,location=no,directories=no,status=no,scrollbars=yes,resizable=yes,copyhistory=no, width=1000, height=200');">
+                {/if}
+            </td>
+        </tr>
         <tr class="list_one">
             <td class="FormRowField"><img class="helpTooltip" name="macro"> {$custom_macro_label} <br>
                 <div class="macro_legend">
@@ -85,7 +100,25 @@
                 {include file="file:$centreon_path/www/include/common/templates/cloneMacro.ihtml" cloneId="macro" cloneSet=$cloneSetMacro}
             </td>
         </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="check_period"> {$form.timeperiod_tp_id.label}</td><td class="FormRowValue">{$form.timeperiod_tp_id.html}</td></tr>
+        {if $o == "a" || $o == "c" || $o == "w" || $o == "mc"}
+        <tr class="list_one">
+            <td class="FormRowField">
+                <img class="helpTooltip" name="check_command_args">{$form.command_command_id_arg.label}
+            </td>
+            <td class="FormRowValue">
+                {if isset($form.hiddenArg) && isset($argChecker)}
+                    {$form.hiddenArg.html}{$argChecker}
+                {/if}
+                <div id='dynamicDiv'></div>
+            </td>
+        </tr>
+        {/if}
+        {if $o == "mc"}
+        <tr class="list_one">
+            <td class="FormRowField"><img class="helpTooltip" name="check_command_args"> {$form.command_command_id_arg.label}</td>
+            <td class="FormRowValue">{$form.command_command_id_arg.html}&nbsp;<img src="./img/icones/16x16/arrow_left_blue.gif" style='cursor:pointer;' alt="*"  onClick="set_arg('example1','command_command_id_arg');"></a><input type="text" name="example1" disabled></td>
+        </tr>
+        {/if}
         <tr class="list_lvl_1">
           <td class="ListColLvl1_name" colspan="2">
             <h4>{t}Service Scheduling Options{/t}</h4>

--- a/centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
@@ -359,6 +359,16 @@ $form->addElement('select2', 'service_hPars', _('Host Templates'), [], $attribut
 // # Check information
 //
 $form->addElement('header', 'check', _('Service State'));
+$checkCommandSelect = $form->addElement('select2', 'command_command_id', _('Check Command'), [], $attributes['check_commands']);
+
+if ($o === SERVICE_TEMPLATE_MASSIVE_CHANGE) {
+    $checkCommandSelect->addJsCallback(
+        'change',
+        'setArgument(jQuery(this).closest("form").get(0),"command_command_id","example1");'
+    );
+} else {
+    $checkCommandSelect->addJsCallback('change', 'changeCommand(this.value);');
+}
 
 if (! $isCloudPlatform) {
     $serviceIV = [
@@ -370,17 +380,6 @@ if (! $isCloudPlatform) {
     if ($o !== SERVICE_TEMPLATE_MASSIVE_CHANGE) {
         $form->setDefaults(['service_is_volatile' => '2']);
     }
-    $checkCommandSelect = $form->addElement('select2', 'command_command_id', _('Check Command'), [], $attributes['check_commands']);
-
-    if ($o === SERVICE_TEMPLATE_MASSIVE_CHANGE) {
-        $checkCommandSelect->addJsCallback(
-            'change',
-            'setArgument(jQuery(this).closest("form").get(0),"command_command_id","example1");'
-        );
-    } else {
-        $checkCommandSelect->addJsCallback('change', 'changeCommand(this.value);');
-    }
-
     $serviceEHE = [
         $form->createElement('radio', 'service_event_handler_enabled', null, _('Yes'), '1'),
         $form->createElement('radio', 'service_event_handler_enabled', null, _('No'), '0'),


### PR DESCRIPTION
🏷️ **MON-34463**

This PR intends to (in Cloud Context)

- Re-enable the possibility to handle check commands and args for Hosts / Host Templates / Services / Service Templates
- Restrict the usage of command types that the user can configure (only the Check type is allowed)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
