### PR TITLE
enh(API): Allow access to Realtime API if user has access to Centreon Frontend

### DIFF
--- a/centreon/src/Core/Domain/Configuration/User/Model/NewUser.php
+++ b/centreon/src/Core/Domain/Configuration/User/Model/NewUser.php
@@ -61,6 +61,8 @@ class NewUser
 
     protected bool $canReachFrontend = true;
 
+    protected bool $canReachRealtimeApi = false;
+
     /**
      * @param string $alias
      * @param string $name
@@ -292,6 +294,26 @@ class NewUser
     public function setCanReachFrontend(bool $canReachFrontend): self
     {
         $this->canReachFrontend = $canReachFrontend;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function canReachRealtimeApi(): bool
+    {
+        return $this->canReachRealtimeApi;
+    }
+
+    /**
+     * @param bool $canReachRealtimeApi
+     *
+     * @return self
+     */
+    public function setCanReachRealtimeApi(bool $canReachRealtimeApi): self
+    {
+        $this->canReachRealtimeApi = $canReachRealtimeApi;
 
         return $this;
     }

--- a/centreon/src/Core/Infrastructure/Configuration/User/Repository/DbWriteUserRepository.php
+++ b/centreon/src/Core/Infrastructure/Configuration/User/Repository/DbWriteUserRepository.php
@@ -75,11 +75,12 @@ class DbWriteUserRepository extends AbstractRepositoryDRB implements WriteUserRe
     {
         $statement = $this->db->prepare(
             $this->translateDbName(
-                'INSERT INTO `:db`.contact
-                    (contact_name, contact_alias, contact_email, contact_template_id,
-                    contact_admin, contact_theme, user_interface_density, contact_activate, contact_oreon)
-                    VALUES (:contactName, :contactAlias, :contactEmail, :contactTemplateId,
-                    :isAdmin, :contactTheme, :userInterfaceDensity, :isActivate, :userCanReachFrontend)'
+                <<<'SQL'
+                    INSERT INTO `:db`.contact (contact_name, contact_alias, contact_email, contact_template_id,
+                    contact_admin, contact_theme, user_interface_density, contact_activate, contact_oreon, reach_api_rt)
+                    VALUES (:contactName, :contactAlias, :contactEmail, :contactTemplateId, :isAdmin, :contactTheme,
+                    :userInterfaceDensity, :isActivate, :userCanReachFrontend, :userCanReachRealtimeApi)
+                    SQL
             )
         );
         $statement->bindValue(':contactName', $user->getName(), \PDO::PARAM_STR);
@@ -91,6 +92,7 @@ class DbWriteUserRepository extends AbstractRepositoryDRB implements WriteUserRe
         $statement->bindValue(':userInterfaceDensity', $user->getUserInterfaceDensity(), \PDO::PARAM_STR);
         $statement->bindValue(':isActivate', $user->isActivate() ? '1' : '0', \PDO::PARAM_STR);
         $statement->bindValue(':userCanReachFrontend', $user->canReachFrontend() ? '1' : '0', \PDO::PARAM_STR);
+        $statement->bindValue(':userCanReachRealtimeApi', $user->canReachRealtimeApi() ? 1 : 0, \PDO::PARAM_INT);
         $statement->execute();
     }
 }

--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -189,7 +189,9 @@ class OpenIdProvider implements OpenIdProviderInterface
             $this->userInformations[$customConfiguration->getUserNameBindAttribute()],
             $this->userInformations[$customConfiguration->getEmailBindAttribute()],
         );
-        ! $user->canReachFrontend() ?: $user->setCanReachRealtimeApi(true);
+        if ($user->canReachFrontend()) {
+            $user->setCanReachRealtimeApi(true);
+        }
         $user->setContactTemplate($customConfiguration->getContactTemplate());
         $this->userRepository->create($user);
         $this->info('Auto import complete', [

--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -189,6 +189,7 @@ class OpenIdProvider implements OpenIdProviderInterface
             $this->userInformations[$customConfiguration->getUserNameBindAttribute()],
             $this->userInformations[$customConfiguration->getEmailBindAttribute()],
         );
+        ! $user->canReachFrontend() ?: $user->setCanReachRealtimeApi(true);
         $user->setContactTemplate($customConfiguration->getContactTemplate());
         $this->userRepository->create($user);
         $this->info('Auto import complete', [

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
@@ -494,6 +494,7 @@ class SAML implements ProviderAuthenticationInterface
 
         $alias = $this->username;
         $user = new NewUser($alias, $fullname, $email);
+        ! $user->canReachFrontend() ?: $user->setCanReachRealtimeApi(true);
         $user->setContactTemplate($customConfiguration->getContactTemplate());
         $this->userRepository->create($user);
         $this->info('Auto import complete', [

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
@@ -494,7 +494,9 @@ class SAML implements ProviderAuthenticationInterface
 
         $alias = $this->username;
         $user = new NewUser($alias, $fullname, $email);
-        ! $user->canReachFrontend() ?: $user->setCanReachRealtimeApi(true);
+        if ($user->canReachFrontend()) {
+            $user->setCanReachRealtimeApi(true);
+        }
         $user->setContactTemplate($customConfiguration->getContactTemplate());
         $this->userRepository->create($user);
         $this->info('Auto import complete', [

--- a/centreon/www/class/centreonAuth.LDAP.class.php
+++ b/centreon/www/class/centreonAuth.LDAP.class.php
@@ -254,18 +254,26 @@ class CentreonAuthLDAP
                         'LDAP AUTH : Updating user DN of ' . $userDisplay
                     );
                     $stmt = $this->pearDB->prepare(
-                        'UPDATE contact SET
+                        <<<'SQL'
+                        UPDATE contact SET
                         contact_ldap_dn = :userDn,
                         contact_name = :userDisplay,
                         contact_email = :userEmail,
                         contact_pager = :userPager,
+                        reach_api_rt = :reachApiRt,
                         ar_id = :arId
-                        WHERE contact_id = :contactId'
+                        WHERE contact_id = :contactId
+                        SQL
                     );
                     $stmt->bindValue(':userDn', $userDn, \PDO::PARAM_STR);
                     $stmt->bindValue(':userDisplay', $userDisplay, \PDO::PARAM_STR);
                     $stmt->bindValue(':userEmail', $userEmail, \PDO::PARAM_STR);
                     $stmt->bindValue(':userPager', $userPager, \PDO::PARAM_STR);
+                    $stmt->bindValue(
+                        ':reachApiRt',
+                        $this->contactInfos['contact_oreon'] === '1' ? 1 : 0,
+                        \PDO::PARAM_INT
+                    );
                     $stmt->bindValue(':arId', $this->arId, \PDO::PARAM_INT);
                     $stmt->bindValue(':contactId', $this->contactInfos['contact_id'], \PDO::PARAM_INT);
                     $stmt->execute();
@@ -327,16 +335,15 @@ class CentreonAuthLDAP
 
                 // Inserting the new user in the database
                 $stmt = $this->pearDB->prepare(
-                    "INSERT INTO contact
-                    (contact_template_id, contact_alias, contact_name,
-                    contact_auth_type, contact_ldap_dn, ar_id,
-                    contact_email, contact_pager, contact_oreon,
-                    contact_activate, contact_register, contact_enable_notifications)
+                    <<<'SQL'
+                    INSERT INTO contact
+                        (contact_template_id, contact_alias, contact_name, contact_auth_type, contact_ldap_dn, ar_id,
+                        contact_email, contact_pager, contact_oreon, reach_api_rt, contact_activate, contact_register,
+                        contact_enable_notifications)
                     VALUES
-                    (:templateId, :contactAlias, :userDisplay,
-                    'ldap', :userDn, :arId,
-                    :userEmail, :userPager, '1',
-                    '1', '1', '2')"
+                        (:templateId, :contactAlias, :userDisplay, 'ldap', :userDn, :arId, :userEmail, :userPager, '1',
+                        1, '1', '1', '2')
+                    SQL
                 );
                 try {
                     $stmt->bindValue(':templateId', $tmplId, \PDO::PARAM_INT);

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -635,7 +635,11 @@ function insertContact($ret = array())
         $ret = $form->getSubmitValues();
     }
     $ret["contact_name"] = $centreon->checkIllegalChar($ret["contact_name"]);
-    if (isset($ret['contact_oreon']) && $ret['contact_oreon']['contact_oreon'] === '1') {
+    if (
+        isset($ret['contact_oreon'])
+        && isset($ret['contact_oreon']['contact_oreon'])
+        && $ret['contact_oreon']['contact_oreon'] === '1'
+    ) {
         $ret['reach_api_rt']['reach_api_rt'] = '1';
     }
 

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -635,11 +635,7 @@ function insertContact($ret = array())
         $ret = $form->getSubmitValues();
     }
     $ret["contact_name"] = $centreon->checkIllegalChar($ret["contact_name"]);
-    if (
-        isset($ret['contact_oreon'])
-        && isset($ret['contact_oreon']['contact_oreon'])
-        && $ret['contact_oreon']['contact_oreon'] === '1'
-    ) {
+    if (isset($ret['contact_oreon']['contact_oreon']) && $ret['contact_oreon']['contact_oreon'] === '1') {
         $ret['reach_api_rt']['reach_api_rt'] = '1';
     }
 

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -635,7 +635,7 @@ function insertContact($ret = array())
         $ret = $form->getSubmitValues();
     }
     $ret["contact_name"] = $centreon->checkIllegalChar($ret["contact_name"]);
-    if ($ret['contact_oreon']['contact_oreon'] === '1') {
+    if (isset($ret['contact_oreon']) && $ret['contact_oreon']['contact_oreon'] === '1') {
         $ret['reach_api_rt']['reach_api_rt'] = '1';
     }
 

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -635,6 +635,9 @@ function insertContact($ret = array())
         $ret = $form->getSubmitValues();
     }
     $ret["contact_name"] = $centreon->checkIllegalChar($ret["contact_name"]);
+    if ($ret['contact_oreon']['contact_oreon'] === '1') {
+        $ret['reach_api_rt']['reach_api_rt'] = '1';
+    }
 
     $bindParams = sanitizeFormContactParameters($ret);
     $params = [];
@@ -1084,8 +1087,9 @@ function insertLdapContactInDB($tmpContacts = array())
 
             // Insert the relation between contact and contactgroups
             $query = <<<SQL
-                        INSERT INTO contactgroup_contact_relation (contactgroup_cg_id, contact_contact_id) VALUES (:contactgroup_cg_id, :contact_contact_id)" 
-                      SQL;
+                INSERT INTO contactgroup_contact_relation (contactgroup_cg_id, contact_contact_id)
+                VALUES (:contactgroup_cg_id, :contact_contact_id)
+                SQL;
             $statement = $pearDB->prepare($query);
             while ($row = $res->fetch()) {
                 $statement->bindValue(':contactgroup_cg_id', (int) $row['cg_id'], \PDO::PARAM_INT);


### PR DESCRIPTION
## Description

Integrated the following enhancements:

Local account : when creating a user that has access to Centreon Frontend explicitly set Reach Realtime API
LDAP account: when importing a LDAP user that has access to Centreon Frontend explicitly set Reach Realtime API
OpenID account: when auto-importing a user that has access to Centreon Frontend explicitly set Reach Realtime API
SAML account: when auto-importing a user that has access to Centreon Frontend explicitly set Reach Realtime API

**Fixes** # MON-24970

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
