### PR TITLE
fix(dashboards): fix filter of contacts and contactgroups on dashboard listing and detail

### DIFF
--- a/centreon/src/Core/Contact/Application/Repository/ReadContactRepositoryInterface.php
+++ b/centreon/src/Core/Contact/Application/Repository/ReadContactRepositoryInterface.php
@@ -107,7 +107,6 @@ interface ReadContactRepositoryInterface
      * @throws \Throwable
      *
      * @return Contact[]
-     *
      */
     public function findAdminsByIds(array $contactIds): array;
 }

--- a/centreon/src/Core/Contact/Application/Repository/ReadContactRepositoryInterface.php
+++ b/centreon/src/Core/Contact/Application/Repository/ReadContactRepositoryInterface.php
@@ -107,7 +107,7 @@ interface ReadContactRepositoryInterface
      * @throws \Throwable
      *
      * @return Contact[]
-     *                   /
+     *
      */
     public function findAdminsByIds(array $contactIds): array;
 }

--- a/centreon/src/Core/Dashboard/Application/Repository/ReadDashboardShareRepositoryInterface.php
+++ b/centreon/src/Core/Dashboard/Application/Repository/ReadDashboardShareRepositoryInterface.php
@@ -98,6 +98,18 @@ interface ReadDashboardShareRepositoryInterface
     public function findDashboardsContactShares(Dashboard ...$dashboards): array;
 
     /**
+     * Retrieve all the contacts shares for several dashboards based on contact IDs.
+     *
+     * @param int[] $contactIds
+     * @param Dashboard ...$dashboards
+     *
+     * @throws \Throwable
+     *
+     * @return array<int, array<DashboardContactShare>>
+     */
+    public function findDashboardsContactSharesByContactIds(array $contactIds, Dashboard ...$dashboards): array;
+
+    /**
      * Retrieve all the contact groups shares for several dashboards.
      *
      * @param Dashboard ...$dashboards

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboard.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboard.php
@@ -36,6 +36,8 @@ use Core\Dashboard\Application\Repository\ReadDashboardShareRepositoryInterface;
 use Core\Dashboard\Domain\Model\Dashboard;
 use Core\Dashboard\Domain\Model\DashboardRights;
 use Core\Dashboard\Domain\Model\Role\DashboardSharingRole;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 
 final class FindDashboard
 {
@@ -47,7 +49,8 @@ final class FindDashboard
         private readonly ReadDashboardShareRepositoryInterface $readDashboardShareRepository,
         private readonly ReadContactRepositoryInterface $readContactRepository,
         private readonly DashboardRights $rights,
-        private readonly ContactInterface $contact
+        private readonly ContactInterface $contact,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
     ) {
     }
 
@@ -117,7 +120,7 @@ final class FindDashboard
             return new NotFoundResponse('Dashboard');
         }
 
-        return $this->createResponse($dashboard, DashboardSharingRole::Viewer);
+        return $this->createResponseAsNonAdmin($dashboard, DashboardSharingRole::Viewer);
     }
 
     /**
@@ -139,6 +142,43 @@ final class FindDashboard
             $this->readDashboardShareRepository->getOneSharingRoles($this->contact, $dashboard),
             $this->readDashboardShareRepository->findDashboardsContactShares($dashboard),
             $this->readDashboardShareRepository->findDashboardsContactGroupShares($dashboard),
+            $defaultRole
+        );
+    }
+
+    /**
+     * @param Dashboard $dashboard
+     * @param DashboardSharingRole $defaultRole
+     *
+     * @throws \Throwable
+     *
+     * @return FindDashboardResponse
+     */
+    private function createResponseAsNonAdmin(Dashboard $dashboard, DashboardSharingRole $defaultRole): FindDashboardResponse
+    {
+        $editorIds = $this->extractAllContactIdsFromDashboard($dashboard);
+
+        $userAccessGroups = $this->readAccessGroupRepository->findByContact($this->contact);
+        $accessGroupsIds = array_map(
+            static fn(AccessGroup $accessGroup): int => $accessGroup->getId(),
+            $userAccessGroups
+        );
+
+        $userInCurrentUserAccessGroups = $this->readContactRepository->findContactIdsByAccessGroups($accessGroupsIds);
+
+        return FindDashboardFactory::createResponse(
+            $dashboard,
+            $this->readContactRepository->findNamesByIds(...$editorIds),
+            $this->readDashboardPanelRepository->findPanelsByDashboardId($dashboard->getId()),
+            $this->readDashboardShareRepository->getOneSharingRoles($this->contact, $dashboard),
+            $this->readDashboardShareRepository->findDashboardsContactSharesByContactIds(
+                $userInCurrentUserAccessGroups,
+                $dashboard
+            ),
+            $this->readDashboardShareRepository->findDashboardsContactGroupSharesByContact(
+                $this->contact,
+                $dashboard
+            ),
             $defaultRole
         );
     }

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindDashboards/FindDashboards.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindDashboards/FindDashboards.php
@@ -120,7 +120,10 @@ final class FindDashboards
             $dashboards,
             $this->readContactRepository->findNamesByIds(...$editorIds),
             $this->readDashboardShareRepository->getMultipleSharingRoles($this->contact, ...$dashboards),
-            $this->readDashboardShareRepository->findDashboardsContactSharesByContactIds($userInCurrentUserAccessGroups, ...$dashboards),
+            $this->readDashboardShareRepository->findDashboardsContactSharesByContactIds(
+                $userInCurrentUserAccessGroups,
+                ...$dashboards
+            ),
             $this->readDashboardShareRepository->findDashboardsContactGroupSharesByContact($this->contact, ...$dashboards),
             DashboardSharingRole::Viewer
         );

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboardTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboardTest.php
@@ -39,6 +39,7 @@ use Core\Dashboard\Domain\Model\Refresh;
 use Core\Dashboard\Domain\Model\DashboardPanel;
 use Core\Dashboard\Domain\Model\DashboardRights;
 use Core\Dashboard\Domain\Model\Refresh\RefreshType;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
 
 beforeEach(function (): void {
     $this->presenter = new FindDashboardPresenterStub();
@@ -48,7 +49,8 @@ beforeEach(function (): void {
         $this->readDashboardRelationRepository = $this->createMock(ReadDashboardShareRepositoryInterface::class),
         $this->readContactRepository = $this->createMock(ReadContactRepositoryInterface::class),
         $this->rights = $this->createMock(DashboardRights::class),
-        $this->contact = $this->createMock(ContactInterface::class)
+        $this->contact = $this->createMock(ContactInterface::class),
+        $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
     );
 
     $this->testedDashboard = new Dashboard(

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboards/FindDashboardsTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboards/FindDashboardsTest.php
@@ -37,6 +37,7 @@ use Core\Dashboard\Domain\Model\Dashboard;
 use Core\Dashboard\Domain\Model\Refresh;
 use Core\Dashboard\Domain\Model\DashboardRights;
 use Core\Dashboard\Domain\Model\Refresh\RefreshType;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
 
 beforeEach(function (): void {
     $this->presenter = new FindDashboardsPresenterStub();
@@ -46,7 +47,8 @@ beforeEach(function (): void {
         $this->createMock(RequestParametersInterface::class),
         $this->createMock(ReadContactRepositoryInterface::class),
         $this->rights = $this->createMock(DashboardRights::class),
-        $this->contact = $this->createMock(ContactInterface::class)
+        $this->contact = $this->createMock(ContactInterface::class),
+        $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
     );
 
     $this->testedDashboard = new Dashboard(


### PR DESCRIPTION
## Description

this PR intends to fix filter of contacts and contactgroups on dashboard listing and detail. There was an issue where while requestion dashboard listing or details as non admin, all the shared contact & contactgroups were returned regardless of current user ACLs or contactgroup membership

**Fixes** # MON-35174

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
