### PR TITLE
Fix(UI): Fix animation error on metrics graph

### DIFF
--- a/.github/actions/lighthouse-performance-testing/action.yml
+++ b/.github/actions/lighthouse-performance-testing/action.yml
@@ -41,7 +41,7 @@ runs:
         php-version: 8.1
         extensions: yaml, xml, mysql, dom, mbstring, intl, pdo, zip
         coverage: none
-        tools: composer:v2
+        tools: composer:v2.6
 
     - name: "Start Centreon container"
       run: docker run -p 4000:80 -d -v "/var/run/docker.sock:/var/run/docker.sock" --name lighthouse-tests-${{ inputs.module }} ${{ inputs.image }}:${{ inputs.image_version }}

--- a/centreon/packages/ui/src/Graph/LineChart/Legend/Legend.styles.ts
+++ b/centreon/packages/ui/src/Graph/LineChart/Legend/Legend.styles.ts
@@ -8,7 +8,7 @@ interface MakeStylesProps {
 
 export const legendWidth = 21;
 const legendItemHeight = 5.25;
-const legendItemHeightCompact = 1.75;
+const legendItemHeightCompact = 2;
 
 export const useStyles = makeStyles<MakeStylesProps>()(
   (theme, { limitLegendRows }) => ({

--- a/centreon/packages/ui/src/Graph/LineChart/Legend/LegendHeader.tsx
+++ b/centreon/packages/ui/src/Graph/LineChart/Legend/LegendHeader.tsx
@@ -38,7 +38,7 @@ const LegendHeader = ({
 
   const getEndText = (): string => {
     if (value) {
-      return `${value}${hasUnit ? ` ${unit}` : ''}`;
+      return value;
     }
 
     return hasUnit ? ` ${unitName}` : '';

--- a/centreon/packages/ui/src/Graph/LineChart/Legend/useInteractiveValues.ts
+++ b/centreon/packages/ui/src/Graph/LineChart/Legend/useInteractiveValues.ts
@@ -5,7 +5,7 @@ import { equals, find, isNil } from 'ramda';
 
 import { mousePositionAtom } from '../InteractiveComponents/interactionWithGraphAtoms';
 import {
-  formatMetricValue,
+  formatMetricValueWithUnit,
   getLineForMetric,
   getMetrics,
   getTimeValue
@@ -73,7 +73,7 @@ const useInteractiveValues = ({
       metric_id
     }) as Line;
 
-    const formattedValue = formatMetricValue({
+    const formattedValue = formatMetricValueWithUnit({
       base,
       unit,
       value

--- a/centreon/packages/ui/src/Graph/LineChart/index.tsx
+++ b/centreon/packages/ui/src/Graph/LineChart/index.tsx
@@ -78,7 +78,7 @@ const WrapperLineChart = ({
   return (
     <div
       ref={lineChartRef as MutableRefObject<HTMLDivElement>}
-      style={{ height: '100%', width: '100%' }}
+      style={{ height: '100%', overflowY: 'hidden', width: '100%' }}
     >
       <ParentSize>
         {({

--- a/centreon/packages/ui/src/Graph/common/timeSeries/index.ts
+++ b/centreon/packages/ui/src/Graph/common/timeSeries/index.ts
@@ -499,14 +499,9 @@ const formatMetricValue = ({
 
   const base1024 = base2Units.includes(unit) || Number(base) === 1024;
 
-  const formatSuffix = cond([
-    [equals('ms'), always(' ms')],
-    [T, always(base1024 ? ' ib' : 'a')]
-  ])(unit);
-
-  const formattedMetricValue = numeral(Math.abs(value))
-    .format(`0.[00]${formatSuffix}`)
-    .replace(/iB/g, unit);
+  const formattedMetricValue = base1024
+    ? numeral(Math.abs(value)).format(`0.[00] ib`).replace(/iB/g, unit)
+    : `${numeral(Math.abs(value)).format(`0.[00]a`)} ${unit}`;
 
   if (lt(value, 0)) {
     return `-${formattedMetricValue}`;

--- a/centreon/packages/ui/src/Graph/common/timeSeries/index.ts
+++ b/centreon/packages/ui/src/Graph/common/timeSeries/index.ts
@@ -499,15 +499,17 @@ const formatMetricValue = ({
 
   const base1024 = base2Units.includes(unit) || Number(base) === 1024;
 
-  const formattedMetricValue = base1024
+  const formattedMetricValue: string = base1024
     ? numeral(Math.abs(value)).format(`0.[00] ib`).replace(/iB/g, unit)
     : `${numeral(Math.abs(value)).format(`0.[00]a`)} ${unit}`;
 
+  const trimmedMetricValue = formattedMetricValue.trim();
+
   if (lt(value, 0)) {
-    return `-${formattedMetricValue}`;
+    return `-${trimmedMetricValue}`;
   }
 
-  return formattedMetricValue;
+  return trimmedMetricValue;
 };
 
 const formatMetricValueWithUnit = ({

--- a/centreon/packages/ui/src/Graph/common/timeSeries/index.ts
+++ b/centreon/packages/ui/src/Graph/common/timeSeries/index.ts
@@ -499,17 +499,20 @@ const formatMetricValue = ({
 
   const base1024 = base2Units.includes(unit) || Number(base) === 1024;
 
-  const formattedMetricValue: string = base1024
-    ? numeral(Math.abs(value)).format(`0.[00] ib`).replace(/iB/g, unit)
-    : `${numeral(Math.abs(value)).format(`0.[00]a`)} ${unit}`;
+  const formatSuffix = cond([
+    [equals('ms'), always(' ms')],
+    [T, always(base1024 ? ' ib' : 'a')]
+  ])(unit);
 
-  const trimmedMetricValue = formattedMetricValue.trim();
+  const formattedMetricValue = numeral(Math.abs(value))
+    .format(`0.[00]${formatSuffix}`)
+    .replace(/iB/g, unit);
 
   if (lt(value, 0)) {
-    return `-${trimmedMetricValue}`;
+    return `-${formattedMetricValue}`;
   }
 
-  return trimmedMetricValue;
+  return formattedMetricValue;
 };
 
 const formatMetricValueWithUnit = ({


### PR DESCRIPTION
## Description

Thix fixes infinite animation on metrics graph. For a specific width, the graph balanced between normal legend display (with a scroll bar) and the compact legend (without scroll bar)

https://github.com/centreon/centreon/assets/12515407/bcca402d-d209-485c-967d-ee131fcbeca2

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
