### PR TITLE
fix(dashboard shares): fix topology_name in query

### DIFF
--- a/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardShareRepository.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardShareRepository.php
@@ -402,7 +402,7 @@ class DbReadDashboardShareRepository extends AbstractRepositoryDRB implements Re
 
         $query .= <<<'SQL'
             parent.topology_name = 'Dashboards'
-            AND topology.topology_name IN ('Viewer','Editor','Creator')
+            AND topology.topology_name IN ('Viewer','Editor','Administrator')
             AND acltr.access_right IS NOT NULL
                 AND c.contact_oreon = '1'
             GROUP BY c.contact_id
@@ -494,7 +494,7 @@ class DbReadDashboardShareRepository extends AbstractRepositoryDRB implements Re
 
         $query .= <<<SQL
             parent.topology_name = 'Dashboards'
-                AND topology.topology_name IN ('Viewer','Editor','Creator')
+                AND topology.topology_name IN ('Viewer','Editor','Administrator')
                 AND gcr.acl_group_id IN ({$bindTokenAsString})
                 AND acltr.access_right IS NOT NULL
                 AND c.contact_oreon = '1'


### PR DESCRIPTION
## Description

This PR intends to fix an issue where the dashboard administrators were not correctly retrieved

**Fixes** # MON-35289

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
