### PR TITLE
enh(api): return error when token is_revoked is true

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -192,23 +192,26 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
     {
         $statement = $this->db->prepare(
             $this->translateDbName(
-                "SELECT contact.*, cp.password AS contact_passwd, t.topology_url,
-                t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name, t.topology_page as default_page
-                FROM `:db`.contact
-                LEFT JOIN `:db`.contact as template
-                    ON contact.contact_template_id = template.contact_id
-                LEFT JOIN `:db`.contact_password cp
-                    ON cp.contact_id = contact.contact_id
-                LEFT JOIN `:db`.timezone tz
-                    ON tz.timezone_id = contact.contact_location
-                LEFT JOIN `:db`.topology t
-                    ON t.topology_page = COALESCE(contact.default_page, template.default_page)
-                INNER JOIN `:db`.security_authentication_tokens sat
-                    ON sat.user_id = contact.contact_id
-                INNER JOIN `:db`.security_token st
-                    ON st.id = sat.provider_token_id
-                WHERE (sat.token = :token OR st.token = :token)
-                ORDER BY cp.creation_date DESC LIMIT 1"
+                <<<'SQL'
+                    SELECT contact.*, cp.password AS contact_passwd, t.topology_url,
+                    t.topology_url_opt, t.is_react, t.topology_id, tz.timezone_name, t.topology_page as default_page
+                    FROM `:db`.contact
+                    LEFT JOIN `:db`.contact as template
+                        ON contact.contact_template_id = template.contact_id
+                    LEFT JOIN `:db`.contact_password cp
+                        ON cp.contact_id = contact.contact_id
+                    LEFT JOIN `:db`.timezone tz
+                        ON tz.timezone_id = contact.contact_location
+                    LEFT JOIN `:db`.topology t
+                        ON t.topology_page = COALESCE(contact.default_page, template.default_page)
+                    INNER JOIN `:db`.security_authentication_tokens sat
+                        ON sat.user_id = contact.contact_id
+                    INNER JOIN `:db`.security_token st
+                        ON st.id = sat.provider_token_id
+                    WHERE (sat.token = :token OR st.token = :token)
+                        AND sat.is_revoked = 0
+                    ORDER BY cp.creation_date DESC LIMIT 1
+                    SQL
             )
         );
         $statement->bindValue(':token', $token, \PDO::PARAM_STR);

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Repository/DbReadTokenRepositoryInterface.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Repository/DbReadTokenRepositoryInterface.php
@@ -53,21 +53,22 @@ class DbReadTokenRepositoryInterface extends AbstractRepositoryDRB implements Re
     {
         $statement = $this->db->prepare(
             $this->translateDbName(
-                '
-            SELECT sat.user_id, sat.provider_configuration_id,
-              provider_token.id as pt_id,
-              provider_token.token AS provider_token,
-              provider_token.creation_date as provider_token_creation_date,
-              provider_token.expiration_date as provider_token_expiration_date,
-              refresh_token.id as rt_id,
-              refresh_token.token AS refresh_token,
-              refresh_token.creation_date as refresh_token_creation_date,
-              refresh_token.expiration_date as refresh_token_expiration_date
-            FROM `:db`.security_authentication_tokens sat
-            INNER JOIN `:db`.security_token provider_token ON provider_token.id = sat.provider_token_id
-            LEFT JOIN `:db`.security_token refresh_token ON refresh_token.id = sat.provider_token_refresh_id
-            WHERE sat.token = :token
-        '
+                <<<'SQL'
+                    SELECT sat.user_id, sat.provider_configuration_id,
+                    provider_token.id as pt_id,
+                    provider_token.token AS provider_token,
+                    provider_token.creation_date as provider_token_creation_date,
+                    provider_token.expiration_date as provider_token_expiration_date,
+                    refresh_token.id as rt_id,
+                    refresh_token.token AS refresh_token,
+                    refresh_token.creation_date as refresh_token_creation_date,
+                    refresh_token.expiration_date as refresh_token_expiration_date
+                    FROM `:db`.security_authentication_tokens sat
+                    INNER JOIN `:db`.security_token provider_token ON provider_token.id = sat.provider_token_id
+                    LEFT JOIN `:db`.security_token refresh_token ON refresh_token.id = sat.provider_token_refresh_id
+                    WHERE sat.token = :token
+                        AND sat.is_revoked = 0
+                    SQL
             )
         );
         $statement->bindValue(':token', $token);

--- a/centreon/www/api/external.php
+++ b/centreon/www/api/external.php
@@ -47,10 +47,13 @@ $user = null;
 if (isset($_SERVER['HTTP_CENTREON_AUTH_TOKEN'])) {
     try {
         $contactStatement = $pearDB->prepare(
-            "SELECT c.*
-            FROM security_authentication_tokens sat, contact c
-            WHERE c.contact_id = sat.user_id
-            AND sat.token = :token"
+            <<<'SQL'
+                SELECT c.*
+                FROM security_authentication_tokens sat, contact c
+                WHERE c.contact_id = sat.user_id
+                    AND sat.token = :token
+                    AND sat.is_revoked = 0
+                SQL
         );
         $contactStatement->bindValue(':token', $_SERVER['HTTP_CENTREON_AUTH_TOKEN'], \PDO::PARAM_STR);
         $contactStatement->execute();


### PR DESCRIPTION
## Description

Manually created tokens can be revoked, but is_revoked property is not check during token validation.
Modify authentication process so it does not accept token with is_revoked !== 0 as a valid authentication token anymore.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

