### PR TITLE
enh(authentication): move the removal of old tokens to a cron

### DIFF
--- a/centreon/cron/outdated-token-removal.php
+++ b/centreon/cron/outdated-token-removal.php
@@ -1,0 +1,94 @@
+#!@PHP_BIN@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+require_once realpath(__DIR__ . "/../config/centreon.config.php");
+include_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
+include_once _CENTREON_PATH_ . "/www/class/centreonLog.class.php";
+
+$centreonDbName = $conf_centreon['db'];
+$centreonLog = new CentreonLog();
+
+/*
+* Init DB connections
+*/
+$pearDB = new CentreonDB();
+
+$pearDB->beginTransaction();
+ try {
+    deleteExpiredProviderRefreshTokens($centreonLog, $pearDB);
+    deleteExpiredProviderTokens($centreonLog, $pearDB);
+
+    $pearDB->commit();
+} catch (\PDOException $e) {
+    $pearDB->rollBack();
+    $centreonLog->insertLog(
+        2,
+        "TokenRemoval CRON: failed to delete old tokens"
+    );
+}
+
+
+/**
+ * Delete expired provider refresh tokens.
+ */
+function deleteExpiredProviderRefreshTokens(CentreonLog $logger, CentreonDB $pearDB): void
+{
+    $logger->insertLog(2, 'Deleting expired refresh tokens');
+
+    $pearDB->query(
+        <<<'SQL'
+            DELETE st FROM security_token st
+            WHERE st.expiration_date < UNIX_TIMESTAMP(NOW())
+            AND EXISTS (
+                SELECT 1
+                FROM security_authentication_tokens sat
+                WHERE sat.provider_token_refresh_id = st.id
+                AND sat.token_type = 'auto'
+                LIMIT 1
+            )
+            SQL
+    );
+}
+
+/**
+ * Delete provider refresh tokens which are not linked to a refresh token.
+ */
+function deleteExpiredProviderTokens(CentreonLog $logger, CentreonDB $pearDB): void
+{
+    $logger->insertLog(2, 'Deleting expired tokens which are not linked to a refresh token');
+
+    $pearDB->query(
+        <<<'SQL'
+            DELETE st FROM security_token st
+            WHERE st.expiration_date < UNIX_TIMESTAMP(NOW())
+            AND NOT EXISTS (
+                SELECT 1
+                FROM security_authentication_tokens sat
+                WHERE sat.provider_token_id = st.id
+                AND (sat.provider_token_refresh_id IS NOT NULL OR sat.token_type = 'manual')
+                LIMIT 1
+            )
+            SQL
+    );
+}

--- a/centreon/src/Centreon/Domain/Authentication/UseCase/AuthenticateApi.php
+++ b/centreon/src/Centreon/Domain/Authentication/UseCase/AuthenticateApi.php
@@ -30,11 +30,9 @@ use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInte
 use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
 use Core\Security\Authentication\Application\UseCase\Login\LoginRequest;
 use Core\Security\Authentication\Domain\Model\NewProviderToken;
-use Core\Security\Authentication\Infrastructure\Provider\ProviderAuthenticationFactory;
 use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use Security\Domain\Authentication\Exceptions\ProviderException;
-use Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface;
 use Security\Domain\Authentication\Model\LocalProvider;
 use Security\Encryption;
 
@@ -43,12 +41,10 @@ class AuthenticateApi
     use LoggerTrait;
 
     /**
-     * @param AuthenticationServiceInterface $authenticationService
      * @param WriteTokenRepositoryInterface $writeTokenRepository
      * @param ProviderAuthenticationFactoryInterface $providerFactory
      */
     public function __construct(
-        private AuthenticationServiceInterface $authenticationService,
         private WriteTokenRepositoryInterface $writeTokenRepository,
         private ProviderAuthenticationFactoryInterface $providerFactory
     ) {

--- a/centreon/src/Centreon/Domain/Authentication/UseCase/AuthenticateApi.php
+++ b/centreon/src/Centreon/Domain/Authentication/UseCase/AuthenticateApi.php
@@ -63,7 +63,6 @@ class AuthenticateApi
     public function execute(AuthenticateApiRequest $request, AuthenticateApiResponse $response): void
     {
         $this->info(sprintf("[AUTHENTICATE API] Beginning API authentication for contact '%s'", $request->getLogin()));
-        $this->deleteExpiredToken();
 
         $localProvider = $this->findLocalProviderOrFail();
         $this->authenticateOrFail($localProvider, $request);
@@ -86,21 +85,6 @@ class AuthenticateApi
                 "contact_alias" => $contact->getAlias()
             ]
         );
-    }
-
-    /**
-     * Delete all expired Security tokens.
-     */
-    private function deleteExpiredToken(): void
-    {
-        /**
-         * Remove all expired token before starting authentication process.
-         */
-        try {
-            $this->authenticationService->deleteExpiredSecurityTokens();
-        } catch (AuthenticationException $ex) {
-            $this->notice('[AUTHENTICATE API] Unable to delete expired security tokens');
-        }
     }
 
     /**

--- a/centreon/src/Centreon/Domain/Authentication/UseCase/Logout.php
+++ b/centreon/src/Centreon/Domain/Authentication/UseCase/Logout.php
@@ -34,20 +34,13 @@ class Logout
     use LoggerTrait;
 
     /**
-     * @var AuthenticationServiceInterface
-     */
-    private $authenticationService;
-
-    /**
      * @var AuthenticationRepositoryInterface
      */
     private $authenticationRepository;
 
     public function __construct(
-        AuthenticationServiceInterface $authenticationService,
         AuthenticationRepositoryInterface $authenticationRepository
     ) {
-        $this->authenticationService = $authenticationService;
         $this->authenticationRepository = $authenticationRepository;
     }
 

--- a/centreon/src/Centreon/Domain/Authentication/UseCase/Logout.php
+++ b/centreon/src/Centreon/Domain/Authentication/UseCase/Logout.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\Authentication\UseCase;
 
+use Centreon\Domain\Authentication\Exception\AuthenticationException;
 use Centreon\Domain\Authentication\UseCase\LogoutRequest;
 use Centreon\Domain\Log\LoggerTrait;
-use Centreon\Domain\Authentication\Exception\AuthenticationException;
 use Security\Domain\Authentication\Interfaces\AuthenticationRepositoryInterface;
 use Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface;
 
@@ -60,7 +60,6 @@ class Logout
     public function execute(LogoutRequest $request): void
     {
         $this->info('Processing api logout...');
-        $this->authenticationService->deleteExpiredSecurityTokens();
         $this->authenticationRepository->deleteSecurityToken($request->getToken());
     }
 }

--- a/centreon/src/Core/Security/Authentication/Application/Repository/WriteTokenRepositoryInterface.php
+++ b/centreon/src/Core/Security/Authentication/Application/Repository/WriteTokenRepositoryInterface.php
@@ -30,11 +30,6 @@ use Core\Security\Authentication\Domain\Model\ProviderToken;
 interface WriteTokenRepositoryInterface
 {
     /**
-     * Delete all expired tokens registered.
-     */
-    public function deleteExpiredSecurityTokens(): void;
-
-    /**
      * @param string $token
      * @param int $providerConfigurationId
      * @param int $contactId

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Repository/DbWriteTokenRepository.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Repository/DbWriteTokenRepository.php
@@ -47,15 +47,6 @@ class DbWriteTokenRepository extends AbstractRepositoryDRB implements WriteToken
 
     /**
      * @inheritDoc
-     */
-    public function deleteExpiredSecurityTokens(): void
-    {
-        $this->deleteExpiredProviderRefreshTokens();
-        $this->deleteExpiredProviderTokens();
-    }
-
-    /**
-     * @inheritDoc
      *
      * @throws Exception
      */
@@ -166,49 +157,6 @@ class DbWriteTokenRepository extends AbstractRepositoryDRB implements WriteToken
         );
         $deleteSecurityTokenStatement->bindValue(':token', $token, \PDO::PARAM_STR);
         $deleteSecurityTokenStatement->execute();
-    }
-
-    /**
-     * Delete expired provider refresh tokens.
-     */
-    private function deleteExpiredProviderRefreshTokens(): void
-    {
-        $this->debug('Deleting expired refresh tokens');
-
-        $this->db->query(
-            $this->translateDbName(
-                'DELETE st FROM `:db`.security_token st
-                WHERE st.expiration_date < UNIX_TIMESTAMP(NOW())
-                AND EXISTS (
-                    SELECT 1
-                    FROM `:db`.security_authentication_tokens sat
-                    WHERE sat.provider_token_refresh_id = st.id
-                    LIMIT 1
-                )'
-            )
-        );
-    }
-
-    /**
-     * Delete provider refresh tokens which are not linked to a refresh token.
-     */
-    private function deleteExpiredProviderTokens(): void
-    {
-        $this->debug('Deleting expired tokens which are not linked to a refresh token');
-
-        $this->db->query(
-            $this->translateDbName(
-                'DELETE st FROM `:db`.security_token st
-                WHERE st.expiration_date < UNIX_TIMESTAMP(NOW())
-                AND NOT EXISTS (
-                    SELECT 1
-                    FROM `:db`.security_authentication_tokens sat
-                    WHERE sat.provider_token_id = st.id
-                    AND sat.provider_token_refresh_id IS NOT NULL
-                    LIMIT 1
-                )'
-            )
-        );
     }
 
     /**

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Repository/WriteSessionRepository.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Repository/WriteSessionRepository.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Log\LoggerTrait;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
 use Core\Security\Authentication\Application\Repository\WriteSessionRepositoryInterface;
 use Core\Security\Authentication\Application\Repository\WriteSessionTokenRepositoryInterface;
-use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
 use Core\Security\Authentication\Infrastructure\Provider\SAML;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use Core\Security\ProviderConfiguration\Domain\SAML\Model\CustomConfiguration;
@@ -40,13 +39,11 @@ class WriteSessionRepository implements WriteSessionRepositoryInterface
     /**
      * @param SessionInterface $session
      * @param WriteSessionTokenRepositoryInterface $writeSessionTokenRepository
-     * @param WriteTokenRepositoryInterface $writeTokenRepository
      * @param ProviderAuthenticationFactoryInterface $providerFactory
      */
     public function __construct(
         private readonly SessionInterface $session,
         private readonly WriteSessionTokenRepositoryInterface $writeSessionTokenRepository,
-        private readonly WriteTokenRepositoryInterface $writeTokenRepository,
         private readonly ProviderAuthenticationFactoryInterface $providerFactory
     ) {
     }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Repository/WriteSessionRepository.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Repository/WriteSessionRepository.php
@@ -56,7 +56,6 @@ class WriteSessionRepository implements WriteSessionRepositoryInterface
      */
     public function invalidate(): void
     {
-        $this->writeTokenRepository->deleteExpiredSecurityTokens();
         $this->writeSessionTokenRepository->deleteSession($this->session->getId());
         $centreon = $this->session->get('centreon');
         $this->session->invalidate();

--- a/centreon/src/Security/Domain/Authentication/AuthenticationService.php
+++ b/centreon/src/Security/Domain/Authentication/AuthenticationService.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Authentication\Exception\AuthenticationException;
 use Centreon\Domain\Log\LoggerTrait;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
 use Core\Security\Authentication\Application\Repository\ReadTokenRepositoryInterface;
-use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
 use Core\Security\Authentication\Domain\Model\AuthenticationTokens;
 use Core\Security\ProviderConfiguration\Application\Repository\ReadConfigurationRepositoryInterface;
 use Security\Domain\Authentication\Exceptions\ProviderException;
@@ -42,7 +41,6 @@ class AuthenticationService implements AuthenticationServiceInterface
     /**
      * @param AuthenticationRepositoryInterface $authenticationRepository
      * @param SessionRepositoryInterface $sessionRepository
-     * @param WriteTokenRepositoryInterface $writeTokenRepository
      * @param ReadConfigurationRepositoryInterface $readConfigurationFactory
      * @param ProviderAuthenticationFactoryInterface $providerFactory
      * @param ReadTokenRepositoryInterface $readTokenRepository
@@ -50,7 +48,6 @@ class AuthenticationService implements AuthenticationServiceInterface
     public function __construct(
         private AuthenticationRepositoryInterface $authenticationRepository,
         private SessionRepositoryInterface $sessionRepository,
-        private WriteTokenRepositoryInterface $writeTokenRepository,
         private ReadConfigurationRepositoryInterface $readConfigurationFactory,
         private ProviderAuthenticationFactoryInterface $providerFactory,
         private ReadTokenRepositoryInterface $readTokenRepository

--- a/centreon/src/Security/Domain/Authentication/AuthenticationService.php
+++ b/centreon/src/Security/Domain/Authentication/AuthenticationService.php
@@ -119,18 +119,6 @@ class AuthenticationService implements AuthenticationServiceInterface
     /**
      * @inheritDoc
      */
-    public function deleteExpiredSecurityTokens(): void
-    {
-        try {
-            $this->writeTokenRepository->deleteExpiredSecurityTokens();
-        } catch (\Exception $ex) {
-            throw AuthenticationException::deleteExpireToken($ex);
-        }
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function findAuthenticationTokensByToken(string $token): ?AuthenticationTokens
     {
         try {

--- a/centreon/src/Security/Domain/Authentication/Interfaces/AuthenticationServiceInterface.php
+++ b/centreon/src/Security/Domain/Authentication/Interfaces/AuthenticationServiceInterface.php
@@ -51,13 +51,6 @@ interface AuthenticationServiceInterface
     public function deleteSession(string $sessionToken): void;
 
     /**
-     * Delete all expired API tokens.
-     *
-     * @throws AuthenticationException
-     */
-    public function deleteExpiredSecurityTokens(): void;
-
-    /**
      * @param AuthenticationTokens $authenticationToken
      *
      * @throws AuthenticationException

--- a/centreon/src/Security/SessionAPIAuthenticator.php
+++ b/centreon/src/Security/SessionAPIAuthenticator.php
@@ -146,7 +146,6 @@ class SessionAPIAuthenticator extends AbstractAuthenticator
     {
         $isValidToken = $this->authenticationService->isValidToken($sessionId);
 
-        $this->authenticationService->deleteExpiredSecurityTokens();
         $this->sessionRepository->deleteExpiredSession();
 
         if (! $isValidToken) {

--- a/centreon/tests/php/Centreon/Domain/Authentication/UseCase/AuthenticateApiTest.php
+++ b/centreon/tests/php/Centreon/Domain/Authentication/UseCase/AuthenticateApiTest.php
@@ -28,8 +28,8 @@ use Centreon\Domain\Authentication\UseCase\AuthenticateApiRequest;
 use Centreon\Domain\Authentication\UseCase\AuthenticateApiResponse;
 use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
+use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
 use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
 use Core\Security\Authentication\Application\UseCase\Login\LoginRequest;
 use Core\Security\Authentication\Domain\Model\NewProviderToken;
@@ -105,10 +105,6 @@ class AuthenticateApiTest extends TestCase
         $authenticateApiRequest = new AuthenticateApiRequest('admin', 'centreon');
         $authenticateApiResponse = new AuthenticateApiResponse();
 
-        $this->authenticationService
-            ->expects($this->once())
-            ->method('deleteExpiredSecurityTokens');
-
         $this->providerFactory
             ->expects($this->once())
             ->method('create')
@@ -129,10 +125,6 @@ class AuthenticateApiTest extends TestCase
         $authenticateApi = $this->createAuthenticationAPI();
         $authenticateApiRequest = new AuthenticateApiRequest('admin', 'centreon');
         $authenticateApiResponse = new AuthenticateApiResponse();
-
-        $this->authenticationService
-            ->expects($this->once())
-            ->method('deleteExpiredSecurityTokens');
 
         $this->providerFactory
             ->expects($this->once())
@@ -160,10 +152,6 @@ class AuthenticateApiTest extends TestCase
         $authenticateApi = $this->createAuthenticationAPI();
         $authenticateApiRequest = new AuthenticateApiRequest('admin', 'centreon');
         $authenticateApiResponse = new AuthenticateApiResponse();
-
-        $this->authenticationService
-            ->expects($this->once())
-            ->method('deleteExpiredSecurityTokens');
 
         $this->providerFactory
             ->expects($this->once())
@@ -195,10 +183,6 @@ class AuthenticateApiTest extends TestCase
         $authenticateApi = $this->createAuthenticationAPI();
         $authenticateApiRequest = new AuthenticateApiRequest('admin', 'centreon');
         $authenticateApiResponse = new AuthenticateApiResponse();
-
-        $this->authenticationService
-            ->expects($this->once())
-            ->method('deleteExpiredSecurityTokens');
 
         $this->providerFactory
             ->expects($this->once())
@@ -237,10 +221,6 @@ class AuthenticateApiTest extends TestCase
         $authenticateApi = $this->createAuthenticationAPI();
         $authenticateApiRequest = new AuthenticateApiRequest('admin', 'centreon');
         $authenticateApiResponse = new AuthenticateApiResponse();
-
-        $this->authenticationService
-            ->expects($this->once())
-            ->method('deleteExpiredSecurityTokens');
 
         $this->providerFactory
             ->expects($this->once())

--- a/centreon/tests/php/Centreon/Domain/Authentication/UseCase/AuthenticateApiTest.php
+++ b/centreon/tests/php/Centreon/Domain/Authentication/UseCase/AuthenticateApiTest.php
@@ -27,7 +27,6 @@ use Centreon\Domain\Authentication\UseCase\AuthenticateApi;
 use Centreon\Domain\Authentication\UseCase\AuthenticateApiRequest;
 use Centreon\Domain\Authentication\UseCase\AuthenticateApiResponse;
 use Centreon\Domain\Contact\Contact;
-use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
 use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
@@ -37,19 +36,12 @@ use Core\Security\ProviderConfiguration\Domain\Model\Configuration;
 use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use PHPUnit\Framework\TestCase;
 use Security\Domain\Authentication\Exceptions\ProviderException;
-use Security\Domain\Authentication\Interfaces\AuthenticationRepositoryInterface;
-use Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface;
 
 /**
  * @package Tests\Centreon\Domain\Authentication\UseCase
  */
 class AuthenticateApiTest extends TestCase
 {
-    /**
-     * @var AuthenticationServiceInterface&\PHPUnit\Framework\MockObject\MockObject
-     */
-    private $authenticationService;
-
     /**
      * @var ProviderAuthenticationFactoryInterface&\PHPUnit\Framework\MockObject\MockObject
      */
@@ -82,7 +74,6 @@ class AuthenticateApiTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->authenticationService = $this->createMock(AuthenticationServiceInterface::class);
         $this->providerFactory = $this->createMock(ProviderAuthenticationFactoryInterface::class);
         $this->providerAuthentication = $this->createMock(ProviderAuthenticationInterface::class);
         $this->configuration = $this->createMock(Configuration::class);
@@ -270,7 +261,6 @@ class AuthenticateApiTest extends TestCase
     private function createAuthenticationAPI(): AuthenticateApi
     {
         return new AuthenticateApi(
-            $this->authenticationService,
             $this->writeTokenRepository,
             $this->providerFactory
         );

--- a/centreon/tests/php/Centreon/Domain/Authentication/UseCase/LogoutTest.php
+++ b/centreon/tests/php/Centreon/Domain/Authentication/UseCase/LogoutTest.php
@@ -26,7 +26,6 @@ use Centreon\Domain\Authentication\UseCase\Logout;
 use Centreon\Domain\Authentication\UseCase\LogoutRequest;
 use PHPUnit\Framework\TestCase;
 use Security\Domain\Authentication\Interfaces\AuthenticationRepositoryInterface;
-use Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface;
 
 /**
  * @package Tests\Centreon\Domain\Authentication\UseCase
@@ -34,18 +33,12 @@ use Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface;
 class LogoutTest extends TestCase
 {
     /**
-     * @var AuthenticationServiceInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private $authenticationService;
-
-    /**
      * @var AuthenticationRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $authenticationRepository;
 
     protected function setUp(): void
     {
-        $this->authenticationService = $this->createMock(AuthenticationServiceInterface::class);
         $this->authenticationRepository = $this->createMock(AuthenticationRepositoryInterface::class);
     }
 
@@ -54,7 +47,7 @@ class LogoutTest extends TestCase
      */
     public function testExecute(): void
     {
-        $logout = new Logout($this->authenticationService, $this->authenticationRepository);
+        $logout = new Logout($this->authenticationRepository);
 
         $logoutRequest = new LogoutRequest('abc123');
 

--- a/centreon/tests/php/Centreon/Domain/Authentication/UseCase/LogoutTest.php
+++ b/centreon/tests/php/Centreon/Domain/Authentication/UseCase/LogoutTest.php
@@ -22,11 +22,11 @@ declare(strict_types=1);
 
 namespace Tests\Centreon\Domain\Authentication\UseCase;
 
-use PHPUnit\Framework\TestCase;
 use Centreon\Domain\Authentication\UseCase\Logout;
 use Centreon\Domain\Authentication\UseCase\LogoutRequest;
-use Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface;
+use PHPUnit\Framework\TestCase;
 use Security\Domain\Authentication\Interfaces\AuthenticationRepositoryInterface;
+use Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface;
 
 /**
  * @package Tests\Centreon\Domain\Authentication\UseCase
@@ -57,10 +57,6 @@ class LogoutTest extends TestCase
         $logout = new Logout($this->authenticationService, $this->authenticationRepository);
 
         $logoutRequest = new LogoutRequest('abc123');
-
-        $this->authenticationService
-            ->expects($this->once())
-            ->method('deleteExpiredSecurityTokens');
 
         $this->authenticationRepository
             ->expects($this->once())

--- a/centreon/tests/php/Security/Domain/Authentication/AuthenticationServiceTest.php
+++ b/centreon/tests/php/Security/Domain/Authentication/AuthenticationServiceTest.php
@@ -22,9 +22,11 @@ declare(strict_types=1);
 
 namespace Tests\Security\Domain\Authentication;
 
+use Centreon\Domain\Authentication\Exception\AuthenticationException;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
 use Core\Security\Authentication\Application\Repository\ReadTokenRepositoryInterface;
+use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
 use Core\Security\Authentication\Domain\Model\AuthenticationTokens;
 use Core\Security\Authentication\Domain\Model\ProviderToken;
 use Core\Security\ProviderConfiguration\Application\Repository\ReadConfigurationRepositoryInterface;
@@ -33,8 +35,6 @@ use Security\Domain\Authentication\AuthenticationService;
 use Security\Domain\Authentication\Exceptions\ProviderException;
 use Security\Domain\Authentication\Interfaces\AuthenticationRepositoryInterface;
 use Security\Domain\Authentication\Interfaces\SessionRepositoryInterface;
-use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
-use Centreon\Domain\Authentication\Exception\AuthenticationException;
 
 /**
  * @package Tests\Security\Domain\Authentication
@@ -310,38 +310,6 @@ class AuthenticationServiceTest extends TestCase
             ->with('abc123');
 
         $authenticationService->deleteSession('abc123');
-    }
-
-    /**
-     * test deleteExpiredSecurityTokens on failure
-     */
-    public function testDeleteExpiredSecurityTokensFailed(): void
-    {
-        $authenticationService = $this->createAuthenticationService();
-
-        $this->writeTokenRepository
-            ->expects($this->once())
-            ->method('deleteExpiredSecurityTokens')
-            ->willThrowException(new \Exception());
-
-        $this->expectException(AuthenticationException::class);
-        $this->expectExceptionMessage('Error while deleting expired token');
-
-        $authenticationService->deleteExpiredSecurityTokens();
-    }
-
-    /**
-     * test deleteExpiredSecurityTokens on success
-     */
-    public function testDeleteExpiredSecurityTokensSucceed(): void
-    {
-        $authenticationService = $this->createAuthenticationService();
-
-        $this->writeTokenRepository
-            ->expects($this->once())
-            ->method('deleteExpiredSecurityTokens');
-
-        $authenticationService->deleteExpiredSecurityTokens();
     }
 
     /**

--- a/centreon/tests/php/Security/Domain/Authentication/AuthenticationServiceTest.php
+++ b/centreon/tests/php/Security/Domain/Authentication/AuthenticationServiceTest.php
@@ -26,7 +26,6 @@ use Centreon\Domain\Authentication\Exception\AuthenticationException;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
 use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
 use Core\Security\Authentication\Application\Repository\ReadTokenRepositoryInterface;
-use Core\Security\Authentication\Application\Repository\WriteTokenRepositoryInterface;
 use Core\Security\Authentication\Domain\Model\AuthenticationTokens;
 use Core\Security\Authentication\Domain\Model\ProviderToken;
 use Core\Security\ProviderConfiguration\Application\Repository\ReadConfigurationRepositoryInterface;
@@ -50,11 +49,6 @@ class AuthenticationServiceTest extends TestCase
      * @var SessionRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
      */
     private $sessionRepository;
-
-    /**
-     * @var WriteTokenRepositoryInterface|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private $writeTokenRepository;
 
     /**
      * @var ProviderAuthenticationInterface|\PHPUnit\Framework\MockObject\MockObject
@@ -95,7 +89,6 @@ class AuthenticationServiceTest extends TestCase
     {
         $this->authenticationRepository = $this->createMock(AuthenticationRepositoryInterface::class);
         $this->sessionRepository = $this->createMock(SessionRepositoryInterface::class);
-        $this->writeTokenRepository = $this->createMock(WriteTokenRepositoryInterface::class);
         $this->provider = $this->createMock(ProviderAuthenticationInterface::class);
         $this->authenticationTokens = $this->createMock(AuthenticationTokens::class);
         $this->providerToken = $this->createMock(ProviderToken::class);
@@ -388,7 +381,6 @@ class AuthenticationServiceTest extends TestCase
         return new AuthenticationService(
             $this->authenticationRepository,
             $this->sessionRepository,
-            $this->writeTokenRepository,
             $this->readConfigurationFactory,
             $this->providerFactory,
             $this->readTokenRepository

--- a/centreon/tmpl/install/centreon.cron
+++ b/centreon/tmpl/install/centreon.cron
@@ -34,3 +34,7 @@ CRONTAB_EXEC_USER=""
 ##########################
 # Cron for Centreon-Backup
 30 3 * * * root @INSTALL_DIR_CENTREON@/cron/centreon-backup.pl >> @CENTREON_LOG@/centreon-backup.log 2>&1
+
+##########################
+# Cron for Outdated Token removal
+0 * * * * root @INSTALL_DIR_CENTREON@/cron/outdated-token-removal.php >> @CENTREON_LOG@/centreon-tokens.log 2>&1

--- a/centreon/www/api/index.php
+++ b/centreon/www/api/index.php
@@ -91,11 +91,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_GET['action']) && $_GET['ac
     } else {
         CentreonWebService::sendResult('Invalid credentials', 401);
     }
-} else { // Purge old tokens
-    $authenticationService = $kernel->getContainer()->get(
-        \Security\Domain\Authentication\Interfaces\AuthenticationServiceInterface::class
-    );
-    $authenticationService->deleteExpiredSecurityTokens();
 }
 
 /* Test authentication */


### PR DESCRIPTION
## Description

Move the deletion of outdated tokens to a cron and exclude token created manually from the deletion.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

