### PR TITLE
fix(api) fix downtime recuperation when getting a host resource detail

### DIFF
--- a/centreon/src/Core/Infrastructure/RealTime/Repository/Host/DbHostFactory.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/Host/DbHostFactory.php
@@ -39,7 +39,7 @@ use Core\Infrastructure\RealTime\Repository\Icon\DbIconFactory;
  *     command_line: string|null,
  *     flapping: int|string|null,
  *     acknowledged: int|string|null,
- *     in_downtime: int|string|null,
+ *     nb_downtime: int|string|null,
  *     passive_checks: int|string|null,
  *     active_checks: int|string|null,
  *     latency: int|string|null,
@@ -84,7 +84,7 @@ class DbHostFactory
             ->setCommandLine($data['command_line'])
             ->setIsFlapping((int) $data['flapping'] === 1)
             ->setIsAcknowledged((int) $data['acknowledged'] === 1)
-            ->setIsInDowntime((int) $data['in_downtime'] === 1)
+            ->setIsInDowntime((int) $data['nb_downtime'] > 0)
             ->setPassiveChecks((int) $data['passive_checks'] === 1)
             ->setActiveChecks((int) $data['active_checks'] === 1)
             ->setLatency(self::getFloatOrNull($data['latency']))

--- a/centreon/src/Core/Infrastructure/RealTime/Repository/Host/DbReadHostRepository.php
+++ b/centreon/src/Core/Infrastructure/RealTime/Repository/Host/DbReadHostRepository.php
@@ -112,7 +112,7 @@ class DbReadHostRepository extends AbstractRepositoryDRB implements ReadHostRepo
                 h.alias,
                 h.timezone,
                 h.flapping,
-                h.scheduled_downtime_depth AS `in_downtime`,
+                h.scheduled_downtime_depth AS `nb_downtime`,
                 h.acknowledged,
                 i.name AS `monitoring_server_name`,
                 h.state AS `status_code`,


### PR DESCRIPTION
## Description

information about downtimes where not accurate in centreon_application_monitoring_resource_details_host endpoint when a host had multiple dowtimes.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
