### PR TITLE
fix(cloud/service): command id not saved when creating / updating a s…

### DIFF
--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -934,7 +934,11 @@ function updateServiceForCloud($serviceId = null, $massiveChange = false, $param
     isset($ret["service_template_model_stm_id"]) && $ret["service_template_model_stm_id"] != null
         ? $rq .= "'" . $ret["service_template_model_stm_id"] . "', "
         : $rq .= "NULL, ";
-    $rq .= "command_command_id = null, ";
+
+    $rq .= "command_command_id = ";
+    isset($ret["command_command_id"]) && $ret["command_command_id"] != null
+        ? $rq .= "'" . $ret["command_command_id"] . "', "
+        : $rq .= "NULL, ";
         $rq .= "timeperiod_tp_id = ";
     isset($ret["timeperiod_tp_id"]) && $ret["timeperiod_tp_id"] != null
         ? $rq .= "'" . $ret["timeperiod_tp_id"] . "', "
@@ -1640,7 +1644,10 @@ function insertServiceForCloud($submittedValues = [], $onDemandMacro = null)
     isset($submittedValues["service_template_model_stm_id"]) && $submittedValues["service_template_model_stm_id"] != null
         ? $request .= "'" . $submittedValues["service_template_model_stm_id"] . "', "
         : $request .= "NULL, ";
-    $request .= "null, "; // command_command_id => null
+
+    isset($submittedValues["command_command_id"]) && $submittedValues["command_command_id"] != null
+        ? $request .= "'" . $submittedValues["command_command_id"] . "', "
+        : $request .= "NULL, ";
 
     isset($submittedValues["timeperiod_tp_id"]) && $submittedValues["timeperiod_tp_id"] != null
         ? $request .= "'" . $submittedValues["timeperiod_tp_id"] . "', "


### PR DESCRIPTION
…ervice

🏷️ MON-35438

Issue when creating / updating a service command field it was not saved in cloud context

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
