### PR TITLE
fix(api): addHostTemplate and addHost mixing severities and categories in response

### DIFF
--- a/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/Repository/DbReadHostTemplateRepository.php
@@ -240,7 +240,7 @@ class DbReadHostTemplateRepository extends AbstractRepositoryRDB implements Read
                     ehi.ehi_action_url,
                     ehi.ehi_icon_image,
                     ehi.ehi_icon_image_alt,
-                    hcr.hostcategories_hc_id AS severity_id
+                    hc.hc_id AS severity_id
                 FROM `:db`.host h
                 LEFT JOIN `:db`.extended_host_information ehi
                     ON h.host_id = ehi.host_host_id


### PR DESCRIPTION
## Description

When creating a host / host template with only a category, its ID was also listed as the newly created host/host template severity in response data.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)
