### PR TITLE
fix(api): update route name to avoid conflict with it edition extensions

### DIFF
--- a/centreon/src/Core/Dashboard/Infrastructure/API/ShareDashboard/ShareDashboardRoute.yaml
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/ShareDashboard/ShareDashboardRoute.yaml
@@ -1,4 +1,4 @@
-ShareDashboardPlaylist:
+ShareDashboard:
   methods: PUT
   path: /configuration/dashboards/{dashboardId}/shares
   requirements:


### PR DESCRIPTION
## Description

fix(api): update route name to avoid conflict with it edition extensions

**Fixes** MON-35489

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)