### PR TITLE
fix (clapi): decode HTML entities when exporting command configuration with CLAPI (#2850)

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonCommand.class.php
+++ b/centreon/www/class/centreon-clapi/centreonCommand.class.php
@@ -362,7 +362,14 @@ class CentreonCommand extends CentreonObject
         foreach ($elements as $element) {
             $addStr = $this->action . $this->delim . "ADD";
             foreach ($this->insertParams as $param) {
-                $addStr .= $this->delim . $element[$param];
+                $addStr .= $this->delim;
+                if ($param === 'command_line') {
+                    $decodedHtmlParam = CentreonUtils::convertSpecialPattern(html_entity_decode($element[$param]));
+                    $decodedHtmlParam = CentreonUtils::convertLineBreak($decodedHtmlParam);
+                    $addStr .= $decodedHtmlParam;
+                } else {
+                    $addStr .= $element[$param];
+                }
             }
             $addStr .= "\n";
             echo $addStr;


### PR DESCRIPTION
## Description

BACKPORT of https://github.com/centreon/centreon/pull/2850

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)
