### PR TITLE
fix(Notifications): contacts from dropdone are not accessible for Editor role

### DIFF
--- a/centreon/src/Core/User/Application/UseCase/FindUsers/FindUsers.php
+++ b/centreon/src/Core/User/Application/UseCase/FindUsers/FindUsers.php
@@ -61,9 +61,15 @@ final class FindUsers
             if ($this->hasAccessToAllUsers()) {
                 $users = $this->readUserRepository->findAllByRequestParameters($this->requestParameters);
             } else {
+                $this->accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
+                $accessGroupNames = array_map(
+                    fn(AccessGroup $accessGroup): string => $accessGroup->getName(),
+                    $this->accessGroups,
+                );
                 if (
                     ! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_CONTACTS_READ)
                     && ! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_CONTACTS_READ_WRITE)
+                    && ! ($this->isCloudPlatform && in_array('customer_editor_acl', $accessGroupNames, true))
                 ) {
                     $this->error(
                         "User doesn't have sufficient rights to see users/contacts",

--- a/centreon/tests/php/Core/User/Application/UseCase/FindUsers/FindUsersTest.php
+++ b/centreon/tests/php/Core/User/Application/UseCase/FindUsers/FindUsersTest.php
@@ -93,7 +93,7 @@ it(
             ->willReturn(false);
 
         $this->readAccessGroupRepository
-            ->expects($this->once())
+            ->expects($this->exactly(2))
             ->method('findByContact')
             ->willReturn([]);
 
@@ -169,9 +169,9 @@ it(
             ->willReturn(false);
 
         $this->readAccessGroupRepository
-            ->expects($this->once())
-            ->method('findByContact')
-            ->willReturn([]);
+             ->expects($this->exactly(2))
+             ->method('findByContact')
+             ->willReturn([]);
 
         $this->user
             ->expects($this->exactly(2))


### PR DESCRIPTION
## Description

Fixed the issue when contacts are not accessible from dropdown in Cloud Notifications configuration form when creating a notification as Editor user

**Fixes** # MON-35510

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
