### PR TITLE
fix (update): fix Centreon update from 23.10.2 to 23.10.3

### DIFF
--- a/centreon/www/install/php/Update-23.10.8.php
+++ b/centreon/www/install/php/Update-23.10.8.php
@@ -25,6 +25,16 @@ $centreonLog = new CentreonLog();
 $versionOfTheUpgrade = 'UPGRADE - 23.10.8: ';
 $errorMessage = '';
 
+$dropColumnVersionFromDashboardWidgetsTable = function(CentreonDB $pearDB): void {
+    if($pearDB->isColumnExist('dashboard_widgets', 'version')) {
+        $pearDB->query(
+            <<<'SQL'
+                    ALTER TABLE dashboard_widgets
+                    DROP COLUMN `version`
+                SQL
+        );
+    }
+};
 
 $insertResourcesTableWidget = function(CentreonDB $pearDB) use(&$errorMessage): void {
     $errorMessage = 'Unable to insert centreon-widget-resourcestable in dashboard_widgets';
@@ -41,6 +51,7 @@ $insertResourcesTableWidget = function(CentreonDB $pearDB) use(&$errorMessage): 
 
 try {
     $errorMessage = '';
+    $dropColumnVersionFromDashboardWidgetsTable($pearDB);
     // Transactional queries
     if (! $pearDB->inTransaction()) {
         $pearDB->beginTransaction();


### PR DESCRIPTION
## Description

The problem only occurs when updating from 23.10.2 to 23.10.3.
When updating Centreon 23.10.2 to 23.10.3 the upgrade script is empty. The SQL query that was supposed to delete the column could not be executed.
We replay the column deletion request before adding it to the table 'dashboard_widgets'.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
