### PR TITLE
fix(Notification): Duplicate users in dropdone menu

### DIFF
--- a/centreon/src/Core/User/Infrastructure/Repository/DbReadUserRepository.php
+++ b/centreon/src/Core/User/Infrastructure/Repository/DbReadUserRepository.php
@@ -62,7 +62,7 @@ class DbReadUserRepository extends AbstractRepositoryRDB implements ReadUserRepo
         $concatenator = new SqlConcatenator();
         $concatenator->defineSelect(
             <<<'SQL'
-                SELECT SQL_CALC_FOUND_ROWS
+                SELECT DISTINCT SQL_CALC_FOUND_ROWS
                     contact_id,
                     contact_alias,
                     contact_name,
@@ -129,7 +129,7 @@ class DbReadUserRepository extends AbstractRepositoryRDB implements ReadUserRepo
         $concatenator = new SqlConcatenator();
         $concatenator->defineSelect(
             <<<'SQL'
-                SELECT SQL_CALC_FOUND_ROWS
+                SELECT DISTINCT SQL_CALC_FOUND_ROWS
                     contact_id,
                     contact_alias,
                     contact_name,


### PR DESCRIPTION
## Description

Fixed issue when endpoint called in dropdone menu returns duplicate users.

**Fixes** # MON-35528

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
