### PR TITLE
[doc] Replace Slack by The Watch in 23.10 API doc

### DIFF
--- a/centreon/doc/API/centreon-api-v23.10.yaml
+++ b/centreon/doc/API/centreon-api-v23.10.yaml
@@ -38,8 +38,8 @@ info:
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
   version: "23.10"
 externalDocs:
-  description: You can contact us on our community Slack
-  url: 'https://centreon.slack.com/messages/CCRGLQSE5'
+  description: You can contact us on our community platform The Watch
+  url: 'https://thewatch.centreon.com/'
 servers:
   - url: '{protocol}://{server}:{port}/centreon/api/{version}'
     variables:


### PR DESCRIPTION
## Description

[doc] Replace Slack by The Watch in 23.10 API doc

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Go to the page for the 23.10 API doc and check that the link at the beginning points to The Watch.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
