### PR TITLE
feat(api/conf) new endpoint: UpdateStreamConnectorFile

### DIFF
--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -254,6 +254,8 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /configuration/broker/{brokerId}/outputs:
     $ref: "./v24.04/Configuration/Broker/AddBrokerOutput.yaml"
+  /configuration/broker/{brokerId}/outputs/{outputId}/file:
+    $ref: "./v24.04/Configuration/Broker/UpdateStreamConnectorFile.yaml"
   /configuration/commands:
     $ref: "./v24.04/Configuration/Command/AddAndFindCommands.yaml"
   /configuration/graphs/templates:

--- a/centreon/doc/API/v24.04/Configuration/Broker/QueryParameter/OutputId.yaml
+++ b/centreon/doc/API/v24.04/Configuration/Broker/QueryParameter/OutputId.yaml
@@ -1,0 +1,8 @@
+in: path
+name: output_id
+description: "ID of the broker configuration output"
+required: true
+schema:
+  type: integer
+  format: int64
+  example: 5

--- a/centreon/doc/API/v24.04/Configuration/Broker/UpdateStreamConnectorFile.yaml
+++ b/centreon/doc/API/v24.04/Configuration/Broker/UpdateStreamConnectorFile.yaml
@@ -1,0 +1,41 @@
+put:
+  tags:
+    - Broker
+  summary: "Update a broker stream connector output file"
+  description: |
+    Create a configuration file with provided JSON content and update te output configuration accordingly
+  parameters:
+    - $ref: 'QueryParameter/BrokerId.yaml'
+    - $ref: 'QueryParameter/OutputId.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required: ['file_content']
+          properties:
+            file_content:
+              type: string
+              description: Content of the file to be created. Must be a valid JSON encoded string.
+              example: "{\"test\": \"hello world\"}"
+  responses:
+    '201':
+      description: "Object created"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              path:
+                type: string
+                description: Path of the created file
+                example: '/some/path/my-new-file.json'
+    '400':
+      $ref: '../../Common/Response/BadRequest.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'

--- a/centreon/doc/API/v24.04/Configuration/Broker/UpdateStreamConnectorFile.yaml
+++ b/centreon/doc/API/v24.04/Configuration/Broker/UpdateStreamConnectorFile.yaml
@@ -3,7 +3,7 @@ put:
     - Broker
   summary: "Update a broker stream connector output file"
   description: |
-    Create a configuration file with provided JSON content and update te output configuration accordingly
+    Create a configuration file with provided JSON content and update the output configuration accordingly
   parameters:
     - $ref: 'QueryParameter/BrokerId.yaml'
     - $ref: 'QueryParameter/OutputId.yaml'

--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -16695,7 +16695,7 @@ msgstr "Erweiterter Modus"
 # msgstr ""
 
 # msgid "Dashboard deleted"
-# msgstr 
+# msgstr
 
 # msgid "Dashboard duplicated"
 # msgstr ""
@@ -16744,3 +16744,18 @@ msgstr "Erweiterter Modus"
 
 # msgid "All resources selected"
 # msgstr ""
+
+#  msgid "Error while updating a broker output"
+#  msgstr ""
+
+#  msgid "Action not permitted for output of type '%s'"
+#  msgstr ""
+
+#  msgid "Content is not a valid JSON string"
+#  msgstr ""
+
+#  msgid "An error occured while creating the file '%s'"
+#  msgstr ""
+
+#  msgid "An error occured while deleting the file '%s'"
+#  msgstr ""

--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -16754,8 +16754,8 @@ msgstr "Erweiterter Modus"
 #  msgid "Content is not a valid JSON string"
 #  msgstr ""
 
-#  msgid "An error occured while creating the file '%s'"
+#  msgid "An error occurred while creating the file '%s'"
 #  msgstr ""
 
-#  msgid "An error occured while deleting the file '%s'"
+#  msgid "An error occurred while deleting the file '%s'"
 #  msgstr ""

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -17088,8 +17088,8 @@ msgstr "Modo avanzado"
 #  msgid "Content is not a valid JSON string"
 #  msgstr ""
 
-#  msgid "An error occured while creating the file '%s'"
+#  msgid "An error occurred while creating the file '%s'"
 #  msgstr ""
 
-#  msgid "An error occured while deleting the file '%s'"
+#  msgid "An error occurred while deleting the file '%s'"
 #  msgstr ""

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -17029,7 +17029,7 @@ msgstr "Modo avanzado"
 # msgstr ""
 
 # msgid "Dashboard deleted"
-# msgstr 
+# msgstr
 
 # msgid "Dashboard duplicated"
 # msgstr ""
@@ -17078,3 +17078,18 @@ msgstr "Modo avanzado"
 
 # msgid "All resources selected"
 # msgstr ""
+
+#  msgid "Error while updating a broker output"
+#  msgstr ""
+
+#  msgid "Action not permitted for output of type '%s'"
+#  msgstr ""
+
+#  msgid "Content is not a valid JSON string"
+#  msgstr ""
+
+#  msgid "An error occured while creating the file '%s'"
+#  msgstr ""
+
+#  msgid "An error occured while deleting the file '%s'"
+#  msgstr ""

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -18880,3 +18880,18 @@ msgstr "Toutes les ressources"
 
 msgid "All resources selected"
 msgstr "Toutes les ressources sont sélectionnées"
+
+msgid "Error while updating a broker output"
+msgstr "Erreur lors de la mise à jour d'une sortie Centreon Broker"
+
+msgid "Action not permitted for output of type '%s'"
+msgstr "Action non autorisée pour une sortie de type '%s'"
+
+msgid "Content is not a valid JSON string"
+msgstr "Le contenu n'est pas une chaîne de charactère JSON valide"
+
+msgid "An error occured while creating the file '%s'"
+msgstr "Une erreur est survenue lors de la creation du fichier '%s'"
+
+msgid "An error occured while deleting the file '%s'"
+msgstr "Une erreur est survenue lors de la suppression du fichier '%s'"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -18888,10 +18888,10 @@ msgid "Action not permitted for output of type '%s'"
 msgstr "Action non autorisée pour une sortie de type '%s'"
 
 msgid "Content is not a valid JSON string"
-msgstr "Le contenu n'est pas une chaîne de charactère JSON valide"
+msgstr "Le contenu n'est pas une chaîne de caractères JSON valide"
 
-msgid "An error occured while creating the file '%s'"
-msgstr "Une erreur est survenue lors de la creation du fichier '%s'"
+msgid "An error occurred while creating the file '%s'"
+msgstr "Une erreur est survenue lors de la création du fichier '%s'"
 
-msgid "An error occured while deleting the file '%s'"
+msgid "An error occurred while deleting the file '%s'"
 msgstr "Une erreur est survenue lors de la suppression du fichier '%s'"

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -17555,8 +17555,8 @@ msgstr ""
 #  msgid "Content is not a valid JSON string"
 #  msgstr ""
 
-#  msgid "An error occured while creating the file '%s'"
+#  msgid "An error occurred while creating the file '%s'"
 #  msgstr ""
 
-#  msgid "An error occured while deleting the file '%s'"
+#  msgid "An error occurred while deleting the file '%s'"
 #  msgstr ""

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -17529,7 +17529,7 @@ msgstr ""
 # msgstr ""
 
 # msgid "Dashboard deleted"
-# msgstr 
+# msgstr
 
 # msgid "Dashboard duplicated"
 # msgstr ""
@@ -17545,3 +17545,18 @@ msgstr ""
 
 # msgid "All resources selected"
 # msgstr ""
+
+#  msgid "Error while updating a broker output"
+#  msgstr ""
+
+#  msgid "Action not permitted for output of type '%s'"
+#  msgstr ""
+
+#  msgid "Content is not a valid JSON string"
+#  msgstr ""
+
+#  msgid "An error occured while creating the file '%s'"
+#  msgstr ""
+
+#  msgid "An error occured while deleting the file '%s'"
+#  msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -17536,8 +17536,8 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 #  msgid "Content is not a valid JSON string"
 #  msgstr ""
 
-#  msgid "An error occured while creating the file '%s'"
+#  msgid "An error occurred while creating the file '%s'"
 #  msgstr ""
 
-#  msgid "An error occured while deleting the file '%s'"
+#  msgid "An error occurred while deleting the file '%s'"
 #  msgstr ""

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -17477,7 +17477,7 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 # msgstr ""
 
 # msgid "Dashboard deleted"
-# msgstr 
+# msgstr
 
 # msgid "Dashboard duplicated"
 # msgstr ""
@@ -17526,3 +17526,18 @@ msgstr "Você não salvou as alterações, deseja continuar?"
 
 # msgid "All resources selected"
 # msgstr ""
+
+#  msgid "Error while updating a broker output"
+#  msgstr ""
+
+#  msgid "Action not permitted for output of type '%s'"
+#  msgstr ""
+
+#  msgid "Content is not a valid JSON string"
+#  msgstr ""
+
+#  msgid "An error occured while creating the file '%s'"
+#  msgstr ""
+
+#  msgid "An error occured while deleting the file '%s'"
+#  msgstr ""

--- a/centreon/src/Core/Broker/Application/Exception/BrokerException.php
+++ b/centreon/src/Core/Broker/Application/Exception/BrokerException.php
@@ -157,7 +157,7 @@ class BrokerException extends \Exception
      */
     public static function errorWhenCreatingFile(string $filePath): self
     {
-        return new self(sprintf(_("An error occured while creating the file '%s'"), $filePath));
+        return new self(sprintf(_("An error occurred while creating the file '%s'"), $filePath));
     }
 
     /**
@@ -167,6 +167,6 @@ class BrokerException extends \Exception
      */
     public static function errorWhenDeletingFile(string $filePath): self
     {
-        return new self(sprintf(_("An error occured while deleting the file '%s'"), $filePath));
+        return new self(sprintf(_("An error occurred while deleting the file '%s'"), $filePath));
     }
 }

--- a/centreon/src/Core/Broker/Application/Exception/BrokerException.php
+++ b/centreon/src/Core/Broker/Application/Exception/BrokerException.php
@@ -157,7 +157,7 @@ class BrokerException extends \Exception
      */
     public static function errorWhenCreatingFile(string $filePath): self
     {
-        return new self(sprintf(_("An error occured when creating the file '%s'"), $filePath));
+        return new self(sprintf(_("An error occured while creating the file '%s'"), $filePath));
     }
 
     /**
@@ -167,6 +167,6 @@ class BrokerException extends \Exception
      */
     public static function errorWhenDeletingFile(string $filePath): self
     {
-        return new self(sprintf(_("An error occured when deleting the file '%s'"), $filePath));
+        return new self(sprintf(_("An error occured while deleting the file '%s'"), $filePath));
     }
 }

--- a/centreon/src/Core/Broker/Application/Exception/BrokerException.php
+++ b/centreon/src/Core/Broker/Application/Exception/BrokerException.php
@@ -39,6 +39,14 @@ class BrokerException extends \Exception
     /**
      * @return self
      */
+    public static function updateBrokerOutput(): self
+    {
+        return new self(_('Error while updating a broker output'));
+    }
+
+    /**
+     * @return self
+     */
     public static function editNotAllowed(): self
     {
         return new self(_('You are not allowed to edit a broker configuration'));
@@ -122,5 +130,43 @@ class BrokerException extends \Exception
     public static function outputNotFound(int $brokerId, int $outputId): self
     {
         return new self(sprintf(_('Output #%d not found for broker configuration #%d'), $outputId, $brokerId));
+    }
+
+    /**
+     * @param string $outputType
+     *
+     * @return self
+     */
+    public static function outputTypeInvalidForThisAction(string $outputType): self
+    {
+        return new self(sprintf(_("Action not permitted for output of type '%s'"), $outputType));
+    }
+
+    /**
+     * @return self
+     */
+    public static function invalidJsonContent(): self
+    {
+        return new self(_('Content is not a valid JSON string'));
+    }
+
+    /**
+     * @param string $filePath
+     *
+     * @return self
+     */
+    public static function errorWhenCreatingFile(string $filePath): self
+    {
+        return new self(sprintf(_("An error occured when creating the file '%s'"), $filePath));
+    }
+
+    /**
+     * @param string $filePath
+     *
+     * @return self
+     */
+    public static function errorWhenDeletingFile(string $filePath): self
+    {
+        return new self(sprintf(_("An error occured when deleting the file '%s'"), $filePath));
     }
 }

--- a/centreon/src/Core/Broker/Application/Repository/FileBrokerRepositoryInterface.php
+++ b/centreon/src/Core/Broker/Application/Repository/FileBrokerRepositoryInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Broker\Application\Repository;
+
+interface FileBrokerRepositoryInterface
+{
+    /**
+     * Create a file with defined content.
+     *
+     * @param string $filename
+     * @param string $content
+     *
+     * @throws \Throwable
+     */
+    public function create(string $filename, string $content): void;
+
+    /**
+     * Delete a file.
+     *
+     * @param string $filename
+     *
+     * @throws \Throwable
+     */
+    public function delete(string $filename): void;
+}

--- a/centreon/src/Core/Broker/Application/Repository/WriteBrokerOutputRepositoryInterface.php
+++ b/centreon/src/Core/Broker/Application/Repository/WriteBrokerOutputRepositoryInterface.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Core\Broker\Application\Repository;
 
 use Core\Broker\Domain\Model\Broker;
+use Core\Broker\Domain\Model\BrokerOutput;
 use Core\Broker\Domain\Model\BrokerOutputField;
 use Core\Broker\Domain\Model\NewBrokerOutput;
 
@@ -41,4 +42,25 @@ interface WriteBrokerOutputRepositoryInterface
      * @return int
      */
     public function add(NewBrokerOutput $output, int $brokerId, array $parameters): int;
+
+    /**
+     * Delete a broker output configuration.
+     *
+     * @param int $brokerId
+     * @param int $outputId
+     *
+     * @throws \Throwable
+     */
+    public function delete(int $brokerId, int $outputId): void;
+
+    /**
+     * Update a broker output configuration.
+     *
+     * @param BrokerOutput $output
+     * @param int $brokerId
+     * @param array<string,BrokerOutputField|array<string,BrokerOutputField>> $outputFields
+     *
+     * @throws \Throwable
+     */
+    public function update(BrokerOutput $output, int $brokerId, array $outputFields): void;
 }

--- a/centreon/src/Core/Broker/Application/Repository/WriteBrokerRepositoryInterface.php
+++ b/centreon/src/Core/Broker/Application/Repository/WriteBrokerRepositoryInterface.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Broker\Application\Repository;
 
-interface FileBrokerRepositoryInterface
+interface WriteBrokerRepositoryInterface
 {
     /**
      * Create a file with defined content.

--- a/centreon/src/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFile.php
+++ b/centreon/src/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFile.php
@@ -32,9 +32,9 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Broker\Application\Exception\BrokerException;
-use Core\Broker\Application\Repository\FileBrokerRepositoryInterface;
 use Core\Broker\Application\Repository\ReadBrokerOutputRepositoryInterface;
 use Core\Broker\Application\Repository\WriteBrokerOutputRepositoryInterface;
+use Core\Broker\Application\Repository\WriteBrokerRepositoryInterface;
 use Core\Broker\Domain\Model\BrokerOutput;
 
 final class UpdateStreamConnectorFile
@@ -44,7 +44,7 @@ final class UpdateStreamConnectorFile
     public function __construct(
         private readonly WriteBrokerOutputRepositoryInterface $writeOutputRepository,
         private readonly ReadBrokerOutputRepositoryInterface $readOutputRepository,
-        private readonly FileBrokerRepositoryInterface $fileRepository,
+        private readonly WriteBrokerRepositoryInterface $fileRepository,
         private readonly ContactInterface $user,
     ) {
     }
@@ -131,9 +131,7 @@ final class UpdateStreamConnectorFile
             try {
                 $this->fileRepository->delete($pathParameter);
             } catch (\Throwable $ex) {
-                $this->error((string) $ex);
-
-                throw BrokerException::errorWhenDeletingFile($pathParameter);
+                $this->info('Could not delete file', ['file_path' => $pathParameter, 'message' => (string) $ex]);
             }
         }
     }
@@ -144,7 +142,7 @@ final class UpdateStreamConnectorFile
         $parameters['path'] = $filePath;
         $output->setParameters($parameters);
 
-        $fields = $this->readOutputRepository->findParametersByType($output->getType()->id, true);
+        $fields = $this->readOutputRepository->findParametersByType($output->getType()->id);
         $this->writeOutputRepository->update($output, $brokerId, $fields);
     }
 }

--- a/centreon/src/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFile.php
+++ b/centreon/src/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFile.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Broker\Application\UseCase\UpdateStreamConnectorFile;
+
+use Assert\AssertionFailedException;
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ConflictResponse;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Broker\Application\Exception\BrokerException;
+use Core\Broker\Application\Repository\FileBrokerRepositoryInterface;
+use Core\Broker\Application\Repository\ReadBrokerOutputRepositoryInterface;
+use Core\Broker\Application\Repository\WriteBrokerOutputRepositoryInterface;
+use Core\Broker\Domain\Model\BrokerOutput;
+
+final class UpdateStreamConnectorFile
+{
+    use LoggerTrait;
+
+    public function __construct(
+        private readonly WriteBrokerOutputRepositoryInterface $writeOutputRepository,
+        private readonly ReadBrokerOutputRepositoryInterface $readOutputRepository,
+        private readonly FileBrokerRepositoryInterface $fileRepository,
+        private readonly ContactInterface $user,
+    ) {
+    }
+
+    /**
+     * @param UpdateStreamConnectorFileRequest $request
+     * @param UpdateStreamConnectorFilePresenterInterface $presenter
+     */
+    public function __invoke(UpdateStreamConnectorFileRequest $request, UpdateStreamConnectorFilePresenterInterface $presenter): void
+    {
+        try {
+            if (! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_BROKER_RW)) {
+                $this->error(
+                    "User doesn't have sufficient rights to edit a broker output",
+                    ['user_id' => $this->user->getId()]
+                );
+                $presenter->presentResponse(
+                    new ForbiddenResponse(BrokerException::editNotAllowed()->getMessage())
+                );
+
+                return;
+            }
+
+            if (! ($output = $this->readOutputRepository->findByIdAndBrokerId($request->outputId, $request->brokerId))) {
+                throw BrokerException::outputNotFound($request->brokerId, $request->outputId);
+            }
+
+            if ($output->getType()->name !== 'lua') {
+                throw BrokerException::outputTypeInvalidForThisAction($output->getType()->name);
+            }
+
+            if (! \json_decode($request->fileContent)) {
+                throw BrokerException::invalidJsonContent();
+            }
+
+            $filePath = $this->createFile($request->fileContent);
+
+            $this->deletePreviousFile($output);
+
+            $this->updateOutput($request->brokerId, $output, $filePath);
+
+            $presenter->presentResponse(
+                new UpdateStreamConnectorFileResponse($filePath)
+            );
+        } catch (AssertionFailedException $ex) {
+            $presenter->presentResponse(new InvalidArgumentResponse($ex));
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        } catch (BrokerException $ex) {
+            $presenter->presentResponse(
+                match ($ex->getCode()) {
+                    BrokerException::CODE_CONFLICT => new ConflictResponse($ex),
+                    default => new ErrorResponse($ex),
+                }
+            );
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        } catch (\Throwable $ex) {
+            $presenter->presentResponse(
+                new ErrorResponse(BrokerException::updateBrokerOutput())
+            );
+            $this->error((string) $ex);
+        }
+    }
+
+    private function createFile(string $content): string
+    {
+        $timestamp = time();
+        $filePath = "/var/lib/centreon/stream_connector_{$timestamp}.json";
+
+        try {
+            $this->fileRepository->create($filePath, $content);
+        } catch (\Throwable $ex) {
+            $this->error((string) $ex);
+
+            throw BrokerException::errorWhenCreatingFile($filePath);
+        }
+
+        return $filePath;
+    }
+
+    private function deletePreviousFile(BrokerOutput $output): void
+    {
+        $pathParameter = $output->getParameters()['path'] ?? null;
+        if ($pathParameter && is_string($pathParameter)) {
+            try {
+                $this->fileRepository->delete($pathParameter);
+            } catch (\Throwable $ex) {
+                $this->error((string) $ex);
+
+                throw BrokerException::errorWhenDeletingFile($pathParameter);
+            }
+        }
+    }
+
+    private function updateOutput(int $brokerId, BrokerOutput $output, string $filePath): void
+    {
+        $parameters = $output->getParameters();
+        $parameters['path'] = $filePath;
+        $output->setParameters($parameters);
+
+        $fields = $this->readOutputRepository->findParametersByType($output->getType()->id, true);
+        $this->writeOutputRepository->update($output, $brokerId, $fields);
+    }
+}

--- a/centreon/src/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFilePresenterInterface.php
+++ b/centreon/src/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFilePresenterInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Broker\Application\UseCase\UpdateStreamConnectorFile;
+
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+interface UpdateStreamConnectorFilePresenterInterface
+{
+    public function presentResponse(UpdateStreamConnectorFileResponse|ResponseStatusInterface $response): void;
+}

--- a/centreon/src/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileRequest.php
+++ b/centreon/src/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Broker\Application\UseCase\UpdateStreamConnectorFile;
+
+final class UpdateStreamConnectorFileRequest
+{
+    public int $brokerId = 0;
+
+    public int $outputId = 0;
+
+    public string $fileContent = '';
+}

--- a/centreon/src/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileResponse.php
+++ b/centreon/src/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Broker\Application\UseCase\UpdateStreamConnectorFile;
+
+final class UpdateStreamConnectorFileResponse
+{
+    /**
+     * @param string $path
+     */
+    public function __construct(
+        public string $path = '',
+    ) {
+    }
+}

--- a/centreon/src/Core/Broker/Domain/Model/BrokerOutput.php
+++ b/centreon/src/Core/Broker/Domain/Model/BrokerOutput.php
@@ -76,4 +76,12 @@ class BrokerOutput
     {
         return $this->parameters;
     }
+
+    /**
+     * @param _BrokerOutputParameter[] $parameters
+     */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
+    }
 }

--- a/centreon/src/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFileController.php
+++ b/centreon/src/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFileController.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Broker\Infrastructure\API\UpdateStreamConnectorFile;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Broker\Application\Exception\BrokerException;
+use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFile;
+use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFileRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class UpdateStreamConnectorFileController extends AbstractController
+{
+    use LoggerTrait;
+
+    /**
+     * @param int $brokerId
+     * @param int $outputId
+     * @param Request $request
+     * @param UpdateStreamConnectorFile $useCase
+     * @param UpdateStreamConnectorFilePresenter $presenter
+     *
+     * @throws AccessDeniedException
+     *
+     * @return Response
+     */
+    public function __invoke(
+        int $brokerId,
+        int $outputId,
+        Request $request,
+        UpdateStreamConnectorFile $useCase,
+        UpdateStreamConnectorFilePresenter $presenter,
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        try {
+            /**
+             * @var array{
+             *     file_content: string
+             * } $data
+             */
+            $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/UpdateStreamConnectorFileSchema.json');
+
+            $dto = new UpdateStreamConnectorFileRequest();
+            $dto->brokerId = $brokerId;
+            $dto->outputId = $outputId;
+            $dto->fileContent = $data['file_content'];
+
+            $useCase($dto, $presenter);
+        } catch (\InvalidArgumentException $ex) {
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+        } catch (\Throwable $ex) {
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+            $presenter->setResponseStatus(new ErrorResponse(BrokerException::updateBrokerOutput()));
+        }
+
+        return $presenter->show();
+    }
+}

--- a/centreon/src/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFilePresenter.php
+++ b/centreon/src/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFilePresenter.php
@@ -47,18 +47,10 @@ class UpdateStreamConnectorFilePresenter extends AbstractPresenter implements Up
                     $response->path,
                     [
                         'path' => $response->path,
-                        // 'broker_id' => $response->brokerId,
-                        // 'name' => $response->name,
-                        // 'type' => [
-                        //     'id' => $response->type->id,
-                        //     'name' => $response->type->name,
-                        // ],
-                        // 'parameters' => (object) $response->parameters,
                     ]
                 )
             );
 
-            // NOT setting location as required route does not currently exist
         }
     }
 }

--- a/centreon/src/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFilePresenter.php
+++ b/centreon/src/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFilePresenter.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Broker\Infrastructure\API\UpdateStreamConnectorFile;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\CreatedResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFilePresenterInterface;
+use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFileResponse;
+use Core\Infrastructure\Common\Presenter\PresenterTrait;
+
+class UpdateStreamConnectorFilePresenter extends AbstractPresenter implements UpdateStreamConnectorFilePresenterInterface
+{
+    use PresenterTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function presentResponse(UpdateStreamConnectorFileResponse|ResponseStatusInterface $response): void
+    {
+        if ($response instanceof ResponseStatusInterface) {
+            $this->setResponseStatus($response);
+        } else {
+            $this->present(
+                new CreatedResponse(
+                    $response->path,
+                    [
+                        'path' => $response->path,
+                        // 'broker_id' => $response->brokerId,
+                        // 'name' => $response->name,
+                        // 'type' => [
+                        //     'id' => $response->type->id,
+                        //     'name' => $response->type->name,
+                        // ],
+                        // 'parameters' => (object) $response->parameters,
+                    ]
+                )
+            );
+
+            // NOT setting location as required route does not currently exist
+        }
+    }
+}

--- a/centreon/src/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFileRoute.yaml
+++ b/centreon/src/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFileRoute.yaml
@@ -1,0 +1,8 @@
+UpdateStreamConnectorFile:
+  methods: PUT
+  path: /configuration/broker/{brokerId}/outputs/{outputId}/file
+  requirements:
+    brokerId: '\d+'
+    outputId: '\d+'
+  controller: 'Core\Broker\Infrastructure\API\UpdateStreamConnectorFile\UpdateStreamConnectorFileController'
+  condition: "request.attributes.get('version') >= 24.04"

--- a/centreon/src/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFileSchema.json
+++ b/centreon/src/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFileSchema.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Add a file to a broker stream connector output configuration",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "file_content"
+    ],
+    "properties": {
+        "file_content": {
+            "type": "string"
+        }
+    }
+}

--- a/centreon/src/Core/Broker/Infrastructure/Repository/FileBrokerRepository.php
+++ b/centreon/src/Core/Broker/Infrastructure/Repository/FileBrokerRepository.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Broker\Infrastructure\Repository;
+
+use Core\Broker\Application\Repository\FileBrokerRepositoryInterface;
+
+class FileBrokerRepository implements FileBrokerRepositoryInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function create(string $filename, string $content): void
+    {
+        if (false === \file_put_contents($filename, $content)) {
+            $error = error_get_last();
+            $errorMessage = (isset($error) && $error['message'] !== '')
+                ? $error['message'] : 'Error while creating file.';
+
+            throw new \Exception($errorMessage);
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function delete(string $filename): void
+    {
+        if (false === \unlink($filename)) {
+            $error = error_get_last();
+            $errorMessage = (isset($error) && $error['message'] !== '')
+                ? $error['message'] : 'Error while deleting file.';
+
+            throw new \Exception($errorMessage);
+        }
+    }
+}

--- a/centreon/src/Core/Broker/Infrastructure/Repository/FileBrokerRepository.php
+++ b/centreon/src/Core/Broker/Infrastructure/Repository/FileBrokerRepository.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace Core\Broker\Infrastructure\Repository;
 
-use Core\Broker\Application\Repository\FileBrokerRepositoryInterface;
+use Core\Broker\Application\Repository\WriteBrokerRepositoryInterface;
 
-class FileBrokerRepository implements FileBrokerRepositoryInterface
+class FileBrokerRepository implements WriteBrokerRepositoryInterface
 {
     /**
      * @inheritDoc

--- a/centreon/tests/php/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileTest.php
+++ b/centreon/tests/php/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileTest.php
@@ -1,0 +1,188 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\HostCategory\Application\UseCase\AddHostCategory;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Broker\Application\Exception\BrokerException;
+use Core\Broker\Application\Repository\FileBrokerRepositoryInterface;
+use Core\Broker\Application\Repository\ReadBrokerOutputRepositoryInterface;
+use Core\Broker\Application\Repository\WriteBrokerOutputRepositoryInterface;
+use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFile;
+use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFileRequest;
+use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFileResponse;
+use Core\Broker\Domain\Model\BrokerOutput;
+use Core\Broker\Domain\Model\BrokerOutputField;
+use Core\Broker\Domain\Model\Type;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Tests\Core\Broker\Infrastructure\API\UpdateStreamConnectorFile\UpdateStreamConnectorFilePresenterStub;
+
+beforeEach(function (): void {
+    $this->request = new UpdateStreamConnectorFileRequest();
+    $this->request->brokerId = 1;
+    $this->request->outputId = 2;
+    $this->request->fileContent = '{"test": "hello world"}';
+
+    $this->type = new Type(33, 'lua');
+    $this->output = new BrokerOutput(1, $this->type, 'my-output-test', ['path' => 'some/fake/path.json']);
+    $this->outputFields = [
+        $this->field = new BrokerOutputField(
+            1, 'path', 'text', null, null, true, false, null, []
+        ),
+    ];
+
+    $this->presenter = new UpdateStreamConnectorFilePresenterStub(
+        $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class)
+    );
+
+    $this->useCase = new UpdateStreamConnectorFile(
+        $this->writeOutputRepository = $this->createMock(WriteBrokerOutputRepositoryInterface::class),
+        $this->readOutputRepository = $this->createMock(ReadBrokerOutputRepositoryInterface::class),
+        $this->fileRepository = $this->createMock(FileBrokerRepositoryInterface::class),
+        $this->user = $this->createMock(ContactInterface::class),
+    );
+});
+
+it('should present a ForbiddenResponse when a user has insufficient rights', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)($this->request, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(BrokerException::editNotAllowed()->getMessage());
+});
+
+it('should present an ErrorResponse when the output is invalid', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readOutputRepository
+        ->expects($this->once())
+        ->method('findByIdAndBrokerId')
+        ->willReturn(null);
+
+    ($this->useCase)($this->request, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(BrokerException::outputNotFound($this->request->brokerId, $this->request->outputId)->getMessage());
+});
+
+it('should present an ErrorResponse if the file content is invalid', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readOutputRepository
+        ->expects($this->once())
+        ->method('findByIdAndBrokerId')
+        ->willReturn($this->output);
+
+    $this->request->fileContent = '';
+
+    ($this->useCase)($this->request, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->response?->getMessage())
+        ->toBe(BrokerException::invalidJsonContent()->getMessage());
+});
+
+it('should present an ErrorResponse when a generic exception is thrown', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readOutputRepository
+        ->expects($this->once())
+        ->method('findByIdAndBrokerId')
+        ->willReturn($this->output);
+
+    $this->fileRepository
+        ->expects($this->once())
+        ->method('create');
+
+    $this->fileRepository
+        ->expects($this->once())
+        ->method('delete');
+
+    $this->readOutputRepository
+        ->expects($this->once())
+        ->method('findParametersByType')
+        ->willThrowException(new \Exception());
+
+    ($this->useCase)($this->request, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(BrokerException::updateBrokerOutput()->getMessage());
+});
+
+it('should return created file path on success', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readOutputRepository
+        ->expects($this->once())
+        ->method('findByIdAndBrokerId')
+        ->willReturn($this->output);
+
+    $this->fileRepository
+        ->expects($this->once())
+        ->method('create');
+
+    $this->fileRepository
+        ->expects($this->once())
+        ->method('delete');
+
+    $this->readOutputRepository
+        ->expects($this->once())
+        ->method('findParametersByType')
+        ->willReturn($this->outputFields);
+
+    $this->writeOutputRepository
+        ->expects($this->once())
+        ->method('update');
+
+    ($this->useCase)($this->request, $this->presenter);
+
+    $response = $this->presenter->response;
+    expect($this->presenter->response)->toBeInstanceOf(UpdateStreamConnectorFileResponse::class)
+        ->and($response->path)
+        ->toBeString();
+});

--- a/centreon/tests/php/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileTest.php
+++ b/centreon/tests/php/Core/Broker/Application/UseCase/UpdateStreamConnectorFile/UpdateStreamConnectorFileTest.php
@@ -27,9 +27,9 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Broker\Application\Exception\BrokerException;
-use Core\Broker\Application\Repository\FileBrokerRepositoryInterface;
 use Core\Broker\Application\Repository\ReadBrokerOutputRepositoryInterface;
 use Core\Broker\Application\Repository\WriteBrokerOutputRepositoryInterface;
+use Core\Broker\Application\Repository\WriteBrokerRepositoryInterface;
 use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFile;
 use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFileRequest;
 use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFileResponse;
@@ -60,7 +60,7 @@ beforeEach(function (): void {
     $this->useCase = new UpdateStreamConnectorFile(
         $this->writeOutputRepository = $this->createMock(WriteBrokerOutputRepositoryInterface::class),
         $this->readOutputRepository = $this->createMock(ReadBrokerOutputRepositoryInterface::class),
-        $this->fileRepository = $this->createMock(FileBrokerRepositoryInterface::class),
+        $this->fileRepository = $this->createMock(WriteBrokerRepositoryInterface::class),
         $this->user = $this->createMock(ContactInterface::class),
     );
 });

--- a/centreon/tests/php/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFilePresenterStub.php
+++ b/centreon/tests/php/Core/Broker/Infrastructure/API/UpdateStreamConnectorFile/UpdateStreamConnectorFilePresenterStub.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Broker\Infrastructure\API\UpdateStreamConnectorFile;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFilePresenterInterface;
+use Core\Broker\Application\UseCase\UpdateStreamConnectorFile\UpdateStreamConnectorFileResponse;
+
+class UpdateStreamConnectorFilePresenterStub extends AbstractPresenter implements UpdateStreamConnectorFilePresenterInterface
+{
+    public ResponseStatusInterface|UpdateStreamConnectorFileResponse $response;
+
+    public function presentResponse(ResponseStatusInterface|UpdateStreamConnectorFileResponse $response): void
+    {
+        $this->response = $response;
+    }
+}


### PR DESCRIPTION
## Description

New configuration endpoint `UpdateStreamConnectorFile`:
- create a JSON file in the /var/lib/centreon directory with the provided content
- update the output.path configuration property with the path to the new file
- delete the previous file listed in the output.path property

Only valid for output of type stream connector (aka lua)

```
PUT /configuration/broker/<brokerId>/outputs/<outputId>/file
Body
{
 file_content: string
}
```


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)
