### PR TITLE
fix(export) remove warning when exporting broker bbdo server cfg

### DIFF
--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -387,7 +387,7 @@ class Broker extends AbstractObjectJSON
                     unset($config['input'][$key]['compression']);
                     unset($config['input'][$key]['retention']);
 
-                    if ($config['input']['encrypt'] === 'no') {
+                    if ($config['input'][$key]['encryption'] === 'no') {
                         unset($config['input'][$key]['private_key']);
                         unset($config['input'][$key]['certificate']);
                     }
@@ -395,7 +395,7 @@ class Broker extends AbstractObjectJSON
                 if ($inputCfg['type'] === self::STREAM_BBDO_CLIENT) {
                     unset($config['input'][$key]['compression']);
 
-                    if ($config['input'][$key]['encrypt'] === 'no') {
+                    if ($config['input'][$key]['encryption'] === 'no') {
                         unset($config['input'][$key]['ca_certificate']);
                         unset($config['input'][$key]['ca_name']);
                     }


### PR DESCRIPTION
## Description

Fixing some warning when export broker cfg with BBDO server/client input

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)
