### PR TITLE
fix(packaging): add missing debian lib dependency to gorgone 

### DIFF
--- a/centreon-gorgone/packaging/debian/control
+++ b/centreon-gorgone/packaging/debian/control
@@ -39,6 +39,7 @@ Depends:
   libssh-4,
   libev-perl,
   libzmq-ffi-perl,
+  libclone-choose-perl,
   sudo,
   ${shlibs:Depends},
   ${misc:Depends}


### PR DESCRIPTION
## Description

libclone-choose-perl was missing from dependencies and would break gorgone startup unless it was installed previously manually installed.
it should now be pulled as a dependency

**Fixes** #MON-36968

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)
