### PR TITLE
fix(api/conf) categories missing in service/service template creation response for non-admin

### DIFF
--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbReadServiceCategoryRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbReadServiceCategoryRepository.php
@@ -343,6 +343,13 @@ class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements R
             $accessGroups
         );
 
+        // if service categories are not filtered in ACLs, then user has access to ALL service categories
+        if (! $this->hasRestrictedAccessToServiceCategories($accessGroupIds)) {
+            $this->info('Service categories access not filtered');
+
+            return $this->findByService($serviceId);
+        }
+
         $sqlConcatenator = new SqlConcatenator();
         $sqlConcatenator->defineSelect(
             $this->translateDbName(<<<'SQL'


### PR DESCRIPTION
## Description

In AddService & AddServiceTemplate request with non-admin user, linked categories were missing in the response

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)
