### PR TITLE
feat(resource-access): add endpoint to delete resource access rule

### DIFF
--- a/centreon/doc/API/centreon-cloud-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-cloud-api-v24.04.yaml
@@ -49,5 +49,4 @@ paths:
   /administration/resource-access/rules:
     $ref: "./latest/Cloud/ResourceAccessManagement/AddAndFindRules.yaml"
   /administration/resource-access/rules/{rule_id}:
-    $ref: "./latest/Cloud/ResourceAccessManagement/FindAndUpdateRule.yaml"
-
+    $ref: "./latest/Cloud/ResourceAccessManagement/FindUpdateAndDeleteRule.yaml"

--- a/centreon/doc/API/latest/Cloud/ResourceAccessManagement/FindUpdateAndDeleteRule.yaml
+++ b/centreon/doc/API/latest/Cloud/ResourceAccessManagement/FindUpdateAndDeleteRule.yaml
@@ -90,3 +90,21 @@ put:
       $ref: '../../../Common/Response/Conflict.yaml'
     '500':
       $ref: '../../../Common/Response/InternalServerError.yaml'
+delete:
+  tags:
+    - Resource Access Management
+  summary: "Delete a resource access rule configuration"
+  description: |
+    Delete a resource access rule configuration.
+  parameters:
+    - $ref: 'QueryParameter/RuleId.yaml'
+  responses:
+    '204':
+      $ref: '../../../Common/Response/NoContent.yaml'
+    '403':
+      $ref: '../../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../../Common/Response/InternalServerError.yaml'
+

--- a/centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
+++ b/centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
@@ -28,6 +28,16 @@ class RuleException extends \Exception
     public const CODE_CONFLICT = 1;
 
     /**
+     * @param \Throwable $ex
+     *
+     * @return self
+     */
+    public static function errorWhileDeleting(\Throwable $ex): self
+    {
+        return new self(_('Error while deleting the resource access rule'), 0, $ex);
+    }
+
+    /**
      * @return self
      */
     public static function notAllowed(): self

--- a/centreon/src/Core/ResourceAccess/Application/Repository/ReadResourceAccessRepositoryInterface.php
+++ b/centreon/src/Core/ResourceAccess/Application/Repository/ReadResourceAccessRepositoryInterface.php
@@ -58,4 +58,13 @@ interface ReadResourceAccessRepositoryInterface
      * @return int[]
      */
     public function findDatasetIdsByRuleId(int $ruleId): array;
+
+    /**
+     * Checks if the rule identified by ruleId exists.
+     *
+     * @param int $ruleId
+     *
+     * @return bool
+     */
+    public function exists(int $ruleId): bool;
 }

--- a/centreon/src/Core/ResourceAccess/Application/Repository/WriteResourceAccessRepositoryInterface.php
+++ b/centreon/src/Core/ResourceAccess/Application/Repository/WriteResourceAccessRepositoryInterface.php
@@ -71,11 +71,6 @@ interface WriteResourceAccessRepositoryInterface
     public function addDataset(string $name): int;
 
     /**
-     * @param int[] $ids
-     */
-    public function deleteDatasets(array $ids): void;
-
-    /**
      * @param int $ruleId
      * @param int $datasetId
      */
@@ -98,5 +93,15 @@ interface WriteResourceAccessRepositoryInterface
      * @param int $ruleId
      */
     public function linkResourcesToDataset(int $ruleId, int $datasetId, string $resourceType, array $resourceIds): void;
+
+    /**
+     * @param int $ruleId
+     */
+    public function deleteRuleAndDatasets(int $ruleId): void;
+
+    /**
+     * @param int[] $ids
+     */
+    public function deleteDatasets(array $ids): void;
 }
 

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/AddRule/AddRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/AddRule/AddRule.php
@@ -161,7 +161,7 @@ final class AddRule
         );
 
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            || $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
     }
 
     /**

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRule.php
@@ -1,0 +1,152 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRule;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\PresenterInterface;
+use Core\ResourceAccess\Application\Exception\RuleException;
+use Core\ResourceAccess\Application\Repository\ReadResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\Repository\WriteResourceAccessRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+
+final class DeleteRule
+{
+    use LoggerTrait;
+    public const AUTHORIZED_ACL_GROUPS = ['customer_admin_acl'];
+
+    /**
+     * @param ReadResourceAccessRepositoryInterface $readRepository
+     * @param WriteResourceAccessRepositoryInterface $writeRepository
+     * @param ContactInterface $user
+     * @param ReadAccessGroupRepositoryInterface $accessGroupRepository
+     * @param DataStorageEngineInterface $dataStorageEngine
+     */
+    public function __construct(
+        private readonly ReadResourceAccessRepositoryInterface $readRepository,
+        private readonly WriteResourceAccessRepositoryInterface $writeRepository,
+        private readonly ContactInterface $user,
+        private readonly ReadAccessGroupRepositoryInterface $accessGroupRepository,
+        private readonly DataStorageEngineInterface $dataStorageEngine
+    ) {
+    }
+
+    /**
+     * @param int $ruleId
+     * @param PresenterInterface $presenter
+     */
+    public function __invoke(int $ruleId, PresenterInterface $presenter): void
+    {
+        try {
+            /**
+             * Check if current user is authorized to perform the action.
+             * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+             * are authorized to add a Resource Access Rule.
+             */
+            if (! $this->isAuthorized()) {
+                $this->error(
+                    "User doesn't have sufficient rights to delete a resource access rule",
+                    [
+                        'user_id' => $this->user->getId(),
+                    ]
+                );
+                $presenter->setResponseStatus(
+                    new ForbiddenResponse(RuleException::notAllowed()->getMessage())
+                );
+
+                return;
+            }
+
+            $this->info('Starting resource access rule deletion', ['rule_id' => $ruleId]);
+            if (! $this->readRepository->exists($ruleId)) {
+                $this->error('Resource access rule not found', ['rule_id' => $ruleId]);
+                $presenter->setResponseStatus(new NotFoundResponse('Resource access rule'));
+
+                return;
+            }
+
+            $this->deleteRule($ruleId);
+            $presenter->setResponseStatus(new NoContentResponse());
+        } catch (\Throwable $exception) {
+            $presenter->setResponseStatus(new ErrorResponse(RuleException::errorWhileDeleting($exception)));
+            $this->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
+        }
+    }
+
+    /**
+     * @return bool
+     */
+    private function isAuthorized(): bool
+    {
+        $userAccessGroupNames = array_map(
+            static fn (AccessGroup $accessGroup): string => $accessGroup->getName(),
+            $this->accessGroupRepository->findByContact($this->user)
+        );
+
+        /**
+         * User must be
+         *     - An admin (belongs to the centreon_admin_acl ACL group)
+         *     - authorized to reach the Resource Access Management page.
+         */
+        return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+    }
+
+    /**
+     * @param int $ruleId
+     *
+     * @throws \Exception
+     * @throws \Throwable
+     */
+    private function deleteRule(int $ruleId): void
+    {
+        $this->debug('Starting transaction');
+        $this->dataStorageEngine->startTransaction();
+
+        try {
+            /**
+             * Here are the deletions (on cascade or not) that will occur on rule deletion
+             *     - Contact relations (ON DELETE CASCADE)
+             *     - Contact Group relations (ON DELETE CASCADE)
+             *     - Datasets relations + datasets (NEED MANUAL DELETION)
+             *     - DatasetFilters (ON DELETE CASCADE).
+             */
+            $this->writeRepository->deleteRuleAndDatasets($ruleId);
+            $this->debug('Commit transaction');
+            $this->dataStorageEngine->commitTransaction();
+        } catch (\Throwable $exception) {
+            $this->debug('Rollback transaction');
+            $this->dataStorageEngine->rollbackTransaction();
+
+            throw $exception;
+        }
+    }
+}

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
@@ -188,6 +188,6 @@ final class FindRule
          *     - authorized to reach the Resource Access Management page.
          */
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            || $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
     }
 }

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRules/FindRules.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRules/FindRules.php
@@ -125,6 +125,6 @@ final class FindRules
         );
 
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            || $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
     }
 }

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
@@ -82,7 +82,7 @@ final class UpdateRule
          */
         if (! $this->isAuthorized()) {
             $this->error(
-                "User doesn't have sufficient rights to create a resource access rule",
+                "User doesn't have sufficient rights to update a resource access rule",
                 [
                     'user_id' => $this->user->getId(),
                 ]
@@ -474,6 +474,6 @@ final class UpdateRule
         );
 
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            || $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
     }
 }

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRule/DeleteRuleController.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRule/DeleteRuleController.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Infrastructure\API\DeleteRule;
+
+use Centreon\Application\Controller\AbstractController;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\ResourceAccess\Application\UseCase\DeleteRule\DeleteRule;
+use Symfony\Component\HttpFoundation\Response;
+
+final class DeleteRuleController extends AbstractController
+{
+    public function __invoke(
+        int $ruleId,
+        DeleteRule $useCase,
+        DefaultPresenter $presenter
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        $useCase($ruleId, $presenter);
+
+        return $presenter->show();
+    }
+}
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRule/DeleteRuleRoute.yaml
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRule/DeleteRuleRoute.yaml
@@ -1,0 +1,9 @@
+DeleteRule:
+  methods: DELETE
+  path: /administration/resource-access/rules/{ruleId}
+  controller: 'Core\ResourceAccess\Infrastructure\API\DeleteRule\DeleteRuleController'
+  condition: "request.attributes.get('version') >= 24.04 and request.attributes.get('feature.resource_access_management')"
+  requirements:
+    ruleId: '\d+'
+
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbReadResourceAccessRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbReadResourceAccessRepository.php
@@ -68,6 +68,27 @@ final class DbReadResourceAccessRepository extends AbstractRepositoryRDB impleme
     /**
      * @inheritDoc
      */
+    public function exists(int $ruleId): bool
+    {
+        $request = $this->translateDbName(
+            <<<'SQL'
+                    SELECT 1
+                    FROM `:db`.acl_groups
+                    WHERE acl_group_id = :ruleId
+                        AND cloud_specific = 1
+                SQL
+        );
+
+        $statement = $this->db->prepare($request);
+        $statement->bindValue(':ruleId', $ruleId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        return (bool) $statement->fetchColumn();
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function findById(int $ruleId): ?Rule
     {
         $basicInformation = $this->findBasicInformation($ruleId);

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbWriteResourceAccessRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbWriteResourceAccessRepository.php
@@ -90,7 +90,7 @@ final class DbWriteResourceAccessRepository extends AbstractRepositoryRDB implem
         [$bindValues, $bindQuery] = $this->createMultipleBindQuery($ids, ':dataset_id_');
 
         $request = <<<SQL
-                DELETE FROM `:db`.acl_resources WHERE acl_res_id IN ($bindQuery)
+                DELETE FROM `:db`.acl_resources WHERE acl_res_id IN ({$bindQuery})
             SQL;
 
         $statement = $this->db->prepare($this->translateDbName($request));

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/AddRule/AddRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/AddRule/AddRuleTest.php
@@ -19,7 +19,7 @@
  *
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Tests\Core\ResourceAccess\Application\UseCase\AddRule;
 
@@ -47,6 +47,7 @@ use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceFilterType;
 use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceGroupFilterType;
 use Core\ResourceAccess\Domain\Model\Rule;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Tests\Core\ResourceAccess\Infrastructure\API\AddRule\AddRulePresenterStub;
 
 beforeEach(closure: function (): void {
@@ -72,7 +73,7 @@ beforeEach(closure: function (): void {
         user: $this->user = $this->createMock(ContactInterface::class),
         dataStorageEngine: $this->createMock(DataStorageEngineInterface::class),
         validator: $this->validator = $this->createMock(AddRuleValidation::class),
-        accessGroupRepository: $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
         datasetValidator: $this->datasetValidator
     );
 
@@ -134,26 +135,53 @@ beforeEach(closure: function (): void {
     );
 });
 
-it(
-    'should present a ForbiddenResponse when a user has insufficient rights',
-    function (): void {
-        $this->user
-            ->expects($this->once())
-            ->method('hasTopologyRole')
-            ->willReturn(false);
+it('should present a Forbidden response when user does not have sufficient rights (missing page access)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
 
-        ($this->useCase)($this->request, $this->presenter);
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(false);
 
-        expect($this->presenter->response)
-            ->toBeInstanceOf(ForbiddenResponse::class)
-            ->and($this->presenter->response->getMessage())
-            ->toBe(RuleException::notAllowed()->getMessage());
-    }
-);
+    ($this->useCase)($this->request, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (not an admin)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'lame_acl', 'not an admin')]
+        );
+
+    ($this->useCase)($this->request, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
 
 it(
     'should present a ConflictResponse when name is already used',
     function (): void {
+        $this->accessGroupRepository
+            ->expects($this->once())
+            ->method('findByContact')
+            ->willReturn(
+                [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+            );
+
         $this->user
             ->expects($this->once())
             ->method('hasTopologyRole')
@@ -186,6 +214,13 @@ it(
 it(
     'should present an ErrorResponse when contact ids provided does not exist',
     function (): void {
+        $this->accessGroupRepository
+            ->expects($this->once())
+            ->method('findByContact')
+            ->willReturn(
+                [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+            );
+
         $this->user
             ->expects($this->once())
             ->method('hasTopologyRole')
@@ -218,6 +253,13 @@ it(
 it(
     'should present an ErrorResponse when contact group ids provided does not exist',
     function (): void {
+        $this->accessGroupRepository
+            ->expects($this->once())
+            ->method('findByContact')
+            ->willReturn(
+                [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+            );
+
         $this->user
             ->expects($this->once())
             ->method('hasTopologyRole')
@@ -250,6 +292,13 @@ it(
 it(
     'should present an ErrorResponse when resources provided does not exist',
     function (): void {
+        $this->accessGroupRepository
+            ->expects($this->once())
+            ->method('findByContact')
+            ->willReturn(
+                [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+            );
+
         $this->user
             ->expects($this->once())
             ->method('hasTopologyRole')
@@ -284,6 +333,13 @@ it(
 );
 
 it('should present an ErrorResponse if the newly created rule cannot be retrieved', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
     $this->user
         ->expects($this->once())
         ->method('hasTopologyRole')
@@ -308,6 +364,13 @@ it('should present an ErrorResponse if the newly created rule cannot be retrieve
 });
 
 it('should return created object on success', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
     $this->user
         ->expects($this->once())
         ->method('hasTopologyRole')

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRuleTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Tests\Core\ResourceAccess\Application\UseCase\DeleteRule;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\ResourceAccess\Application\Exception\RuleException;
+use Core\ResourceAccess\Application\Repository\ReadResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\Repository\WriteResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRule\DeleteRule;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Tests\Core\ResourceAccess\Infrastructure\API\DeleteRule\DeleteRulePresenterStub;
+
+beforeEach(closure: function (): void {
+    $this->useCase = new DeleteRule(
+        readRepository: $this->readRepository = $this->createMock(ReadResourceAccessRepositoryInterface::class),
+        writeRepository: $this->writeRepository = $this->createMock(WriteResourceAccessRepositoryInterface::class),
+        user: $this->user = $this->createMock(ContactInterface::class),
+        accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        dataStorageEngine: $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class)
+    );
+
+    $this->presenter = new DeleteRulePresenterStub($this->createMock(PresenterFormatterInterface::class));
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (missing page access)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (not admin)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'centreon_not_admin', 'not an admin')]
+        );
+
+    ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a NotFoundResponse when rule ID provided does not correspond to an existing rule', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readRepository
+        ->expects($this->once())
+        ->method('exists')
+        ->willReturn(false);
+
+    ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(NotFoundResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe((new NotFoundResponse('Resource access rule'))->getMessage());
+});
+
+it('should present a ErrorResponse when deletion goes wrong', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readRepository
+        ->expects($this->once())
+        ->method('exists')
+        ->willReturn(true);
+
+    $this->dataStorageEngine
+        ->expects($this->once())
+        ->method('startTransaction');
+
+    $this->writeRepository
+        ->expects($this->once())
+        ->method('deleteRuleAndDatasets')
+        ->with(1)
+        ->willThrowException(new \Exception());
+
+    $this->dataStorageEngine
+        ->expects($this->once())
+        ->method('rollbackTransaction');
+
+    ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::errorWhileDeleting(new \Exception())->getMessage());
+});
+
+it('should present a NoContentResponse when deletion goes well', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->readRepository
+        ->expects($this->once())
+        ->method('exists')
+        ->willReturn(true);
+
+    $this->dataStorageEngine
+        ->expects($this->once())
+        ->method('startTransaction');
+
+    $this->writeRepository
+        ->expects($this->once())
+        ->method('deleteRuleAndDatasets')
+        ->with(1);
+
+    $this->dataStorageEngine
+        ->expects($this->once())
+        ->method('commitTransaction');
+
+    ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(NoContentResponse::class);
+});

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
@@ -19,11 +19,10 @@
  *
  */
 
-declare(strict_types = 1);
+declare(strict_types=1);
 
 namespace Tests\Core\ResourceAccess\Application\UseCase\FindRule;
 
-use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
@@ -55,6 +54,7 @@ use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceFilterType;
 use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceGroupFilterType;
 use Core\ResourceAccess\Domain\Model\Rule;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
 use Core\ServiceGroup\Application\Repository\ReadServiceGroupRepositoryInterface;
 use Tests\Core\ResourceAccess\Infrastructure\API\FindRule\FindRulePresenterStub;
@@ -112,15 +112,37 @@ beforeEach(closure: function (): void {
     );
 });
 
-it('should present a Forbidden response when user does not have sufficient rights', function (): void {
+it('should present a Forbidden response when user does not have sufficient rights (missing page access)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
     $this->user
         ->expects($this->once())
         ->method('hasTopologyRole')
-        ->willReturnMap([
-            [Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW, false],
-        ]);
+        ->willReturn(false);
 
     ($this->useCase)(1, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (not an admin)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'lame_acl', 'not an admin')]
+        );
+
+    ($this->useCase)(1, $this->presenter);
+
     expect($this->presenter->response)
         ->toBeInstanceOf(ForbiddenResponse::class)
         ->and($this->presenter->response->getMessage())
@@ -128,10 +150,16 @@ it('should present a Forbidden response when user does not have sufficient right
 });
 
 it('should present an ErrorResponse when an exception occurs', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
     $this->user
         ->expects($this->once())
         ->method('hasTopologyRole')
-        ->with(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
         ->willReturn(true);
 
     $exception = new \Exception();
@@ -149,10 +177,16 @@ it('should present an ErrorResponse when an exception occurs', function (): void
 });
 
 it('should present a FindRuleResponse when no error occurs', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
     $this->user
         ->expects($this->once())
         ->method('hasTopologyRole')
-        ->with(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
         ->willReturn(true);
 
     $this->repository
@@ -175,7 +209,7 @@ it('should present a FindRuleResponse when no error occurs', function (): void {
 
     ($this->useCase)(1, $this->presenter);
     $response = $this->presenter->response;
-    var_dump($response);
+
     expect($response)->toBeInstanceOf(FindRuleResponse::class)
         ->and($response->id)->toBe($this->rule->getId())
         ->and($response->name)->toBe($this->rule->getName())

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRules/FindRulesTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRules/FindRulesTest.php
@@ -23,7 +23,6 @@ declare(strict_types = 1);
 
 namespace Tests\Core\ResourceAccess\Application\UseCase\FindRules;
 
-use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
 use Centreon\Infrastructure\RequestParameters\RequestParametersTranslatorException;
@@ -45,6 +44,7 @@ use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceFilterType;
 use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceGroupFilterType;
 use Core\ResourceAccess\Domain\Model\Rule;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Tests\Core\ResourceAccess\Infrastructure\API\FindRules\FindRulesPresenterStub;
 
 beforeEach(closure: function (): void {
@@ -71,15 +71,37 @@ beforeEach(closure: function (): void {
     $this->useCase = new FindRules($this->user, $this->repository, $this->requestParameters, $this->accessGroupRepository);
 });
 
-it('should present a Forbidden response when user does not have sufficient rights', function (): void {
+it('should present a Forbidden response when user does not have sufficient rights (missing page access)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
     $this->user
         ->expects($this->once())
         ->method('hasTopologyRole')
-        ->willReturnMap([
-            [Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW, false],
-        ]);
+        ->willReturn(false);
 
     ($this->useCase)($this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (not an admin)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'lame_acl', 'not an admin')]
+        );
+
+    ($this->useCase)($this->presenter);
+
     expect($this->presenter->response)
         ->toBeInstanceOf(ForbiddenResponse::class)
         ->and($this->presenter->response->getMessage())
@@ -87,10 +109,16 @@ it('should present a Forbidden response when user does not have sufficient right
 });
 
 it('should present an ErrorResponse when an exception occurs', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
     $this->user
         ->expects($this->once())
         ->method('hasTopologyRole')
-        ->with(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
         ->willReturn(true);
 
     $exception = new \Exception();
@@ -108,10 +136,16 @@ it('should present an ErrorResponse when an exception occurs', function (): void
 });
 
 it('should present an ErrorResponse when an error occurs concerning the request parameters', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
     $this->user
         ->expects($this->once())
         ->method('hasTopologyRole')
-        ->with(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
         ->willReturn(true);
 
     $this->repository
@@ -126,10 +160,16 @@ it('should present an ErrorResponse when an error occurs concerning the request 
 });
 
 it('should present a FindRulesResponse when no error occurs', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
     $this->user
         ->expects($this->once())
         ->method('hasTopologyRole')
-        ->with(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
         ->willReturn(true);
 
     $rule = new Rule(

--- a/centreon/tests/php/Core/ResourceAccess/Infrastructure/API/DeleteRule/DeleteRulePresenterStub.php
+++ b/centreon/tests/php/Core/ResourceAccess/Infrastructure/API/DeleteRule/DeleteRulePresenterStub.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ResourceAccess\Infrastructure\API\DeleteRule;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+class DeleteRulePresenterStub extends AbstractPresenter
+{
+    public ?ResponseStatusInterface $response;
+
+    public function setResponseStatus(?ResponseStatusInterface $responseStatus): void
+    {
+        $this->response = $responseStatus;
+    }
+}


### PR DESCRIPTION
🏷️ MON-37003

This PR intends to add a new endpoint that will allow the user to delete a given Resource Access Rule.
Here is the video demonstrating the endpoint call. It fixes also a few things found during validation

https://github.com/centreon/centreon/assets/31647811/94265a14-56a0-4ec9-aefa-012b476debfc

Code
- PHPStan level 9 ✔️ 
- PHPCSFixer ✔️ 
- Pest unit tests added ✔️ 

<img width="1055" alt="image" src="https://github.com/centreon/centreon/assets/31647811/89c30be7-e90b-4b5c-97ce-c97c2e5f71d5">


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
