### PR TITLE
(gorgone): Gorgone fix backport (#3473)

### DIFF
--- a/centreon-gorgone/config/gorgoned-central-ssh.yml
+++ b/centreon-gorgone/config/gorgoned-central-ssh.yml
@@ -44,6 +44,7 @@ configuration:
           - ^centreon
           - ^mkdir
           - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy
         package: gorgone::modules::core::proxy::hooks

--- a/centreon-gorgone/config/gorgoned-central-zmq.yml
+++ b/centreon-gorgone/config/gorgoned-central-zmq.yml
@@ -68,6 +68,7 @@ configuration:
           - ^centreon
           - ^mkdir
           - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy
         package: gorgone::modules::core::proxy::hooks

--- a/centreon-gorgone/config/gorgoned-poller.yml
+++ b/centreon-gorgone/config/gorgoned-poller.yml
@@ -26,6 +26,7 @@ configuration:
           - ^centreon
           - ^mkdir
           - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: engine
         package: gorgone::modules::centreon::engine::hooks

--- a/centreon-gorgone/config/gorgoned-remote-ssh.yml
+++ b/centreon-gorgone/config/gorgoned-remote-ssh.yml
@@ -3,11 +3,11 @@ description: Configuration example in a SSH environment for Remote server
 configuration:
   centreon:
     database:
-      db_configuration: 
+      db_configuration:
         dsn: "mysql:host=localhost;dbname=centreon"
         username: centreon
         password: centreon
-      db_realtime: 
+      db_realtime:
         dsn: "mysql:host=localhost;dbname=centreon_storage"
         username: centreon
         password: centreon
@@ -31,6 +31,7 @@ configuration:
           - ^centreon
           - ^mkdir
           - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy
         package: gorgone::modules::core::proxy::hooks

--- a/centreon-gorgone/config/gorgoned-remote-zmq.yml
+++ b/centreon-gorgone/config/gorgoned-remote-zmq.yml
@@ -36,6 +36,7 @@ configuration:
           - ^centreon
           - ^mkdir
           - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy
         package: gorgone::modules::core::proxy::hooks

--- a/centreon-gorgone/contrib/gorgone_config_init.pl
+++ b/centreon-gorgone/contrib/gorgone_config_init.pl
@@ -134,6 +134,7 @@ configuration:
           - ^centreon
           - ^mkdir
           - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy
         package: gorgone::modules::core::proxy::hooks

--- a/centreon-gorgone/docs/client_server_zmq.md
+++ b/centreon-gorgone/docs/client_server_zmq.md
@@ -39,7 +39,7 @@ $ perl /usr/local/bin/gorgone_key_thumbprint.pl --key-path='/var/spool/centreon/
 
 #### Server
 
-In the */etc/centreon/confid.d/20-gorgoned.yaml* configuration file, add the following directives under the 
+In the */etc/centreon/config.d/20-gorgoned.yaml* configuration file, add the following directives under the 
 *gorgonecore* 
 section:
 

--- a/centreon-gorgone/docs/migration.md
+++ b/centreon-gorgone/docs/migration.md
@@ -66,6 +66,7 @@ configuration:
           - ^centreon
           - ^mkdir
           - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: cron
         package: gorgone::modules::core::cron::hooks

--- a/centreon-gorgone/docs/modules/core/action.md
+++ b/centreon-gorgone/docs/modules/core/action.md
@@ -32,6 +32,7 @@ allowed_cmds:
   - ^centreon
   - ^mkdir
   - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+  - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 ```
 
 ## Events

--- a/centreon-gorgone/docs/poller_pull_configuration.md
+++ b/centreon-gorgone/docs/poller_pull_configuration.md
@@ -51,6 +51,7 @@ gorgone:
         - ^centreon
         - ^mkdir
         - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: engine
       package: gorgone::modules::centreon::engine::hooks

--- a/centreon-gorgone/docs/rebound_configuration.md
+++ b/centreon-gorgone/docs/rebound_configuration.md
@@ -55,6 +55,7 @@ gorgone:
         - ^centreon
         - ^mkdir
         - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: engine
       package: gorgone::modules::centreon::engine::hooks

--- a/centreon/www/include/configuration/configServers/popup/central.yaml
+++ b/centreon/www/include/configuration/configServers/popup/central.yaml
@@ -33,6 +33,7 @@ gorgone:
         - ^centreon
         - ^mkdir
         - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
     - name: cron
       package: "gorgone::modules::core::cron::hooks"
       enable: true

--- a/centreon/www/include/configuration/configServers/popup/poller.yaml
+++ b/centreon/www/include/configuration/configServers/popup/poller.yaml
@@ -24,6 +24,7 @@ gorgone:
         - ^centreon
         - ^mkdir
         - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: engine
       package: gorgone::modules::centreon::engine::hooks

--- a/centreon/www/include/configuration/configServers/popup/remote.yaml
+++ b/centreon/www/include/configuration/configServers/popup/remote.yaml
@@ -25,6 +25,7 @@ gorgone:
         - ^centreon
         - ^mkdir
         - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: cron
       package: "gorgone::modules::core::cron::hooks"

--- a/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
+++ b/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
@@ -33,6 +33,7 @@ gorgone:
         - ^centreon
         - ^mkdir
         - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: cron
       package: "gorgone::modules::core::cron::hooks"


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/3473 onto `dev-22.04.x`

JIRA: MON-37105 (parent: MON-36482)

## Target serie

- [X] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)


## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
