### PR TITLE
feat(resource-access): add partial rule update endpoint

### DIFF
--- a/centreon/doc/API/centreon-cloud-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-cloud-api-v24.04.yaml
@@ -49,4 +49,4 @@ paths:
   /administration/resource-access/rules:
     $ref: "./latest/Cloud/ResourceAccessManagement/AddAndFindRules.yaml"
   /administration/resource-access/rules/{rule_id}:
-    $ref: "./latest/Cloud/ResourceAccessManagement/FindUpdateAndDeleteRule.yaml"
+    $ref: "./latest/Cloud/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml"

--- a/centreon/doc/API/latest/Cloud/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml
+++ b/centreon/doc/API/latest/Cloud/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml
@@ -112,7 +112,12 @@ patch:
     - Resource Access Management
   summary: "Update partially a resource access rule"
   description: |
-    Update a resource access rule configuration
+    Partial update of resource access rule configuration.
+    The available parameters to **update** are:
+
+    * name
+    * description
+    * is_enabled
   parameters:
     - $ref: 'QueryParameter/RuleId.yaml'
   requestBody:

--- a/centreon/doc/API/latest/Cloud/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml
+++ b/centreon/doc/API/latest/Cloud/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml
@@ -107,4 +107,31 @@ delete:
       $ref: '../../../Common/Response/NotFound.yaml'
     '500':
       $ref: '../../../Common/Response/InternalServerError.yaml'
+patch:
+  tags:
+    - Resource Access Management
+  summary: "Update partially a resource access rule"
+  description: |
+    Update a resource access rule configuration
+  parameters:
+    - $ref: 'QueryParameter/RuleId.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: 'Schema/PartialRuleUpdateRequest.yaml'
+  responses:
+    '204':
+      $ref: '../../../Common/Response/NoContent.yaml'
+    '400':
+      $ref: '../../../Common/Response/BadRequest.yaml'
+    '403':
+      $ref: '../../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../../Common/Response/NotFound.yaml'
+    '409':
+      $ref: '../../../Common/Response/Conflict.yaml'
+    '500':
+      $ref: '../../../Common/Response/InternalServerError.yaml'
 

--- a/centreon/doc/API/latest/Cloud/ResourceAccessManagement/Schema/PartialRuleUpdateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/ResourceAccessManagement/Schema/PartialRuleUpdateRequest.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  name:
+    type: string
+    description: "Resource access rule name"
+    example: "Rule for viewers"
+  description:
+    type: string
+    nullable: true
+    description: "Short description of the rule"
+    example: "Rule dedicated for users with limited rights"
+  is_enabled:
+    type: boolean
+    description: "Indicate the status of the rule enabled/disabled"
+    example: true

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/AddRule/AddRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/AddRule/AddRule.php
@@ -75,11 +75,6 @@ final class AddRule
         AddRulePresenterInterface $presenter
     ): void {
         try {
-            /**
-             * Check if current user is authorized to perform the action.
-             * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
-             * are authorized to add a Resource Access Rule.
-             */
             if (! $this->isAuthorized()) {
                 $this->error(
                     "User doesn't have sufficient rights to create a resource access rule",
@@ -153,6 +148,13 @@ final class AddRule
         }
     }
 
+    /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
+     * @return bool
+     */
     private function isAuthorized(): bool
     {
         $userAccessGroupNames = array_map(

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRule.php
@@ -63,11 +63,6 @@ final class DeleteRule
     public function __invoke(int $ruleId, PresenterInterface $presenter): void
     {
         try {
-            /**
-             * Check if current user is authorized to perform the action.
-             * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
-             * are authorized to add a Resource Access Rule.
-             */
             if (! $this->isAuthorized()) {
                 $this->error(
                     "User doesn't have sufficient rights to delete a resource access rule",
@@ -99,6 +94,10 @@ final class DeleteRule
     }
 
     /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
      * @return bool
      */
     private function isAuthorized(): bool
@@ -126,13 +125,6 @@ final class DeleteRule
     private function deleteRule(int $ruleId): void
     {
         $this->debug('Starting transaction');
-        /**
-         * Here are the deletions (on cascade or not) that will occur on rule deletion
-         *     - Contact relations (ON DELETE CASCADE)
-         *     - Contact Group relations (ON DELETE CASCADE)
-         *     - Datasets relations + datasets (NEED MANUAL DELETION)
-         *     - DatasetFilters (ON DELETE CASCADE).
-         */
         $this->writeRepository->deleteRuleAndDatasets($ruleId);
     }
 }

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
@@ -174,6 +174,10 @@ final class FindRule
     }
 
     /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
      * @return bool
      */
     private function isAuthorized(): bool

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
@@ -124,6 +124,7 @@ final class FindRule
         $response->id = $rule->getId();
         $response->name = $rule->getName();
         $response->description = $rule->getDescription();
+        $response->isEnabled = $rule->isEnabled();
 
         // retrieve names of linked contact IDs
         $response->contacts = array_values(

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRules/FindRules.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRules/FindRules.php
@@ -62,8 +62,6 @@ final class FindRules
     {
         $this->info('Finding resource access rules', ['request_parameters' => $this->requestParameters]);
 
-        // check if current user is authorized to perform the action.
-        // Only users linked to AUTHORIZED_ACL_GROUPS and having access in RW to the page are authorized
         if (! $this->isAuthorized()) {
             $this->error(
                 "User doesn't have sufficient rights to list resource access rules",
@@ -115,6 +113,10 @@ final class FindRules
     }
 
     /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
      * @return bool
      */
     private function isAuthorized(): bool

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdate.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdate.php
@@ -65,12 +65,10 @@ final class PartialRuleUpdate
     }
 
     /**
-     * @param int $ruleId
      * @param PartialRuleUpdateRequest $request
      * @param PresenterInterface $presenter
      */
     public function __invoke(
-        int $ruleId,
         PartialRuleUpdateRequest $request,
         PresenterInterface $presenter
     ): void {
@@ -91,8 +89,8 @@ final class PartialRuleUpdate
                 return;
             }
 
-            $this->debug('Find resource access rule to partially update', ['id' => $ruleId]);
-            $rule = $this->readRepository->findById($ruleId);
+            $this->debug('Find resource access rule to partially update', ['id' => $request->id]);
+            $rule = $this->readRepository->findById($request->id);
 
             if ($rule === null) {
                 $presenter->setResponseStatus(new NotFoundResponse('Resource access rule'));

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdate.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdate.php
@@ -77,11 +77,6 @@ final class PartialRuleUpdate
         try {
             $this->info('Start resource access rule update process');
 
-            /**
-             * Check if current user is authorized to perform the action.
-             * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
-             * are authorized to add a Resource Access Rule.
-             */
             if (! $this->isAuthorized()) {
                 $this->error(
                     "User doesn't have sufficient rights to create a resource access rule",
@@ -153,6 +148,10 @@ final class PartialRuleUpdate
     }
 
     /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
      * @return bool
      */
     private function isAuthorized(): bool

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateRequest.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateRequest.php
@@ -28,11 +28,13 @@ use Core\Common\Application\Type\NoValue;
 final class PartialRuleUpdateRequest
 {
     /**
+     * @param int $id
      * @param NoValue|string $name
      * @param NoValue|null|string $description
      * @param NoValue|bool $isEnabled
      */
     public function __construct(
+        public int $id = 0,
         public NoValue|string $name = new NoValue(),
         public NoValue|null|string $description = new NoValue(),
         public NoValue|bool $isEnabled = new NoValue(),

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateRequest.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\PartialRuleUpdate;
+
+use Core\Common\Application\Type\NoValue;
+
+final class PartialRuleUpdateRequest
+{
+    /**
+     * @param NoValue|string $name
+     * @param NoValue|null|string $description
+     * @param NoValue|bool $isEnabled
+     */
+    public function __construct(
+        public NoValue|string $name = new NoValue(),
+        public NoValue|null|string $description = new NoValue(),
+        public NoValue|bool $isEnabled = new NoValue(),
+    ) {
+    }
+}

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
@@ -441,7 +441,7 @@ final class UpdateRule
         sort($current);
         sort($update);
 
-        return $current === $update;
+        return $current !== $update;
     }
 
     /**

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
@@ -75,11 +75,6 @@ final class UpdateRule
      */
     public function __invoke(UpdateRuleRequest $request, UpdateRulePresenterInterface $presenter): void
     {
-        /**
-         * Check if current user is authorized to perform the action.
-         * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
-         * are authorized to add a Resource Access Rule.
-         */
         if (! $this->isAuthorized()) {
             $this->error(
                 "User doesn't have sufficient rights to update a resource access rule",
@@ -464,6 +459,10 @@ final class UpdateRule
     }
 
     /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
      * @return bool
      */
     private function isAuthorized(): bool

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
@@ -446,7 +446,7 @@ final class UpdateRule
         sort($current);
         sort($update);
 
-        return array_diff($current, $update) !== [];
+        return array_diff($current, $update) !== array_diff($update, $current);
     }
 
     /**

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
@@ -441,7 +441,7 @@ final class UpdateRule
         sort($current);
         sort($update);
 
-        return array_diff($current, $update) !== array_diff($update, $current);
+        return $current === $update;
     }
 
     /**

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateController.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateController.php
@@ -45,8 +45,8 @@ final class PartialRuleUpdateController extends AbstractController
         $this->denyAccessUnlessGrantedForApiConfiguration();
 
         try {
-            $dto = $this->createDtoFromRequest($request);
-            $useCase($ruleId, $dto, $presenter);
+            $dto = $this->createDtoFromRequest($ruleId, $request);
+            $useCase($dto, $presenter);
         } catch (\InvalidArgumentException $ex) {
             $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
             $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
@@ -56,13 +56,14 @@ final class PartialRuleUpdateController extends AbstractController
     }
 
     /**
+     * @param int $ruleId
      * @param Request $request
      *
      * @throws \InvalidArgumentException
      *
      * @return PartialRuleUpdateRequest
      */
-    private function createDtoFromRequest(Request $request): PartialRuleUpdateRequest
+    private function createDtoFromRequest(int $ruleId, Request $request): PartialRuleUpdateRequest
     {
         /**
          * @var array{
@@ -74,6 +75,7 @@ final class PartialRuleUpdateController extends AbstractController
         $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/PartialRuleUpdateSchema.json');
 
         $dto = new PartialRuleUpdateRequest();
+        $dto->id = $ruleId;
 
         if (\array_key_exists('name', $data)) {
             $dto->name = $data['name'];

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateController.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateController.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Infrastructure\API\PartialRuleUpdate;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\ResourceAccess\Application\UseCase\PartialRuleUpdate\PartialRuleUpdate;
+use Core\ResourceAccess\Application\UseCase\PartialRuleUpdate\PartialRuleUpdateRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class PartialRuleUpdateController extends AbstractController
+{
+    use LoggerTrait;
+
+    public function __invoke(
+        int $ruleId,
+        Request $request,
+        PartialRuleUpdate $useCase,
+        DefaultPresenter $presenter
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        try {
+            $dto = $this->createDtoFromRequest($request);
+            $useCase($ruleId, $dto, $presenter);
+        } catch (\InvalidArgumentException $ex) {
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+        }
+
+        return $presenter->show();
+    }
+
+    /**
+     * @param Request $request
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return PartialRuleUpdateRequest
+     */
+    private function createDtoFromRequest(Request $request): PartialRuleUpdateRequest
+    {
+        /**
+         * @var array{
+         *      name?: string,
+         *      description?: string|null,
+         *      is_enabled?: bool
+         * }
+         */
+        $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/PartialRuleUpdateSchema.json');
+
+        $dto = new PartialRuleUpdateRequest();
+
+        if (\array_key_exists('name', $data)) {
+            $dto->name = $data['name'];
+        }
+
+        if (\array_key_exists('description', $data)) {
+            $dto->description = $data['description'];
+        }
+
+        if (\array_key_exists('is_enabled', $data)) {
+            $dto->isEnabled = $data['is_enabled'];
+        }
+
+        return $dto;
+    }
+}

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateRoute.yaml
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateRoute.yaml
@@ -1,0 +1,9 @@
+PartialRuleUpdate:
+  methods: PATCH
+  path: /administration/resource-access/rules/{ruleId}
+  controller: 'Core\ResourceAccess\Infrastructure\API\PartialRuleUpdate\PartialRuleUpdateController'
+  condition: "request.attributes.get('version') >= 24.04 and request.attributes.get('feature.resource_access_management')"
+  requirements:
+    ruleId: '\d+'
+
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateSchema.json
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateSchema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Update partially the resource access rule",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "description": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "is_enabled": {
+            "type": "boolean"
+        }
+    }
+}
+
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbWriteResourceAccessRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbWriteResourceAccessRepository.php
@@ -53,16 +53,14 @@ final class DbWriteResourceAccessRepository extends AbstractRepositoryRDB implem
 
     /**
      * @inheritDoc
+     * Here are the deletions (on cascade or not) that will occur on rule deletion
+     *     - Contact relations (ON DELETE CASCADE)
+     *     - Contact Group relations (ON DELETE CASCADE)
+     *     - Datasets relations + datasets (NEED MANUAL DELETION)
+     *     - DatasetFilters (ON DELETE CASCADE).
      */
     public function deleteRuleAndDatasets(int $ruleId): void
     {
-        /**
-         * Here are the deletions (on cascade or not) that will occur on rule deletion
-         *     - Contact relations (ON DELETE CASCADE)
-         *     - Contact Group relations (ON DELETE CASCADE)
-         *     - Datasets relations + datasets (NEED MANUAL DELETION)
-         *     - DatasetFilters (ON DELETE CASCADE).
-         */
         $datasetIds = $this->findDatasetIdsByRuleId($ruleId);
         $alreadyInTransaction = $this->db->inTransaction();
 

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbWriteResourceAccessRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbWriteResourceAccessRepository.php
@@ -56,7 +56,13 @@ final class DbWriteResourceAccessRepository extends AbstractRepositoryRDB implem
      */
     public function deleteRuleAndDatasets(int $ruleId): void
     {
-
+        /**
+         * Here are the deletions (on cascade or not) that will occur on rule deletion
+         *     - Contact relations (ON DELETE CASCADE)
+         *     - Contact Group relations (ON DELETE CASCADE)
+         *     - Datasets relations + datasets (NEED MANUAL DELETION)
+         *     - DatasetFilters (ON DELETE CASCADE).
+         */
         $datasetIds = $this->findDatasetIdsByRuleId($ruleId);
         $alreadyInTransaction = $this->db->inTransaction();
 

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRuleTest.php
@@ -24,7 +24,6 @@ declare(strict_types = 1);
 namespace Tests\Core\ResourceAccess\Application\UseCase\DeleteRule;
 
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
@@ -44,7 +43,6 @@ beforeEach(closure: function (): void {
         writeRepository: $this->writeRepository = $this->createMock(WriteResourceAccessRepositoryInterface::class),
         user: $this->user = $this->createMock(ContactInterface::class),
         accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
-        dataStorageEngine: $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class)
     );
 
     $this->presenter = new DeleteRulePresenterStub($this->createMock(PresenterFormatterInterface::class));
@@ -131,19 +129,11 @@ it('should present a ErrorResponse when deletion goes wrong', function (): void 
         ->method('exists')
         ->willReturn(true);
 
-    $this->dataStorageEngine
-        ->expects($this->once())
-        ->method('startTransaction');
-
     $this->writeRepository
         ->expects($this->once())
         ->method('deleteRuleAndDatasets')
         ->with(1)
         ->willThrowException(new \Exception());
-
-    $this->dataStorageEngine
-        ->expects($this->once())
-        ->method('rollbackTransaction');
 
     ($this->useCase)(1, $this->presenter);
 
@@ -171,18 +161,10 @@ it('should present a NoContentResponse when deletion goes well', function (): vo
         ->method('exists')
         ->willReturn(true);
 
-    $this->dataStorageEngine
-        ->expects($this->once())
-        ->method('startTransaction');
-
     $this->writeRepository
         ->expects($this->once())
         ->method('deleteRuleAndDatasets')
         ->with(1);
-
-    $this->dataStorageEngine
-        ->expects($this->once())
-        ->method('commitTransaction');
 
     ($this->useCase)(1, $this->presenter);
 

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateTest.php
@@ -142,7 +142,7 @@ it('should present a Forbidden response when user does not have sufficient right
         ->method('hasTopologyRole')
         ->willReturn(false);
 
-    ($this->useCase)(1, $this->request, $this->presenter);
+    ($this->useCase)($this->request, $this->presenter);
 
     expect($this->presenter->responseStatus)
         ->toBeInstanceOf(ForbiddenResponse::class)
@@ -158,7 +158,7 @@ it('should present a Forbidden response when user does not have sufficient right
             [new AccessGroup(1, 'lame_acl', 'not an admin')]
         );
 
-    ($this->useCase)(1, $this->request, $this->presenter);
+    ($this->useCase)($this->request, $this->presenter);
 
     expect($this->presenter->responseStatus)
         ->toBeInstanceOf(ForbiddenResponse::class)
@@ -186,7 +186,7 @@ it(
             ->method('findById')
             ->willReturn(null);
 
-        ($this->useCase)(1, $this->request, $this->presenter);
+        ($this->useCase)($this->request, $this->presenter);
 
         expect($this->presenter->responseStatus)->toBeInstanceOf(NotFoundResponse::class);
     }
@@ -224,7 +224,7 @@ it(
                 )
             );
 
-        ($this->useCase)(1, $this->request, $this->presenter);
+        ($this->useCase)($this->request, $this->presenter);
 
         expect($this->presenter->responseStatus)
             ->toBeInstanceOf(ConflictResponse::class)
@@ -258,7 +258,7 @@ it(
             ->method('findById')
             ->willReturn($this->rule);
 
-        ($this->useCase)(1, $this->request, $this->presenter);
+        ($this->useCase)($this->request, $this->presenter);
 
         expect($this->presenter->responseStatus)
             ->toBeInstanceOf(NoContentResponse::class);

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ResourceAccess\Application\UseCase\PartialRuleUpdate;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ConflictResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\ResourceAccess\Application\Exception\RuleException;
+use Core\ResourceAccess\Application\Repository\ReadResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\Repository\WriteResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\UseCase\PartialRuleUpdate\PartialRuleUpdate;
+use Core\ResourceAccess\Application\UseCase\PartialRuleUpdate\PartialRuleUpdateRequest;
+use Core\ResourceAccess\Application\UseCase\UpdateRule\UpdateRuleValidation;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\DatasetFilter;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\DatasetFilterValidator;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\HostCategoryFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\HostFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\HostGroupFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\MetaServiceFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceCategoryFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceGroupFilterType;
+use Core\ResourceAccess\Domain\Model\NewRule;
+use Core\ResourceAccess\Domain\Model\Rule;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Tests\Core\ResourceAccess\Infrastructure\API\PartialRuleUpdate\PartialRuleUpdatePresenterStub;
+
+beforeEach(closure: function (): void {
+   $this->presenter = new PartialRuleUpdatePresenterStub($this->createMock(PresenterFormatterInterface::class));
+
+    foreach ([
+        HostFilterType::class,
+        HostGroupFilterType::class,
+        HostCategoryFilterType::class,
+        ServiceFilterType::class,
+        ServiceGroupFilterType::class,
+        ServiceCategoryFilterType::class,
+        MetaServiceFilterType::class,
+    ] as $className) {
+        $this->filterTypes[] = new $className();
+    }
+
+    $this->datasetValidator = new DatasetFilterValidator(new \ArrayObject($this->filterTypes));
+
+    $this->useCase = new PartialRuleUpdate(
+        user: $this->user = $this->createMock(ContactInterface::class),
+        accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        readRepository: $this->readRepository = $this->createMock(ReadResourceAccessRepositoryInterface::class),
+        writeRepository: $this->writeRepository = $this->createMock(WriteResourceAccessRepositoryInterface::class),
+        validator: $this->validator = $this->createMock(UpdateRuleValidation::class),
+    );
+
+    $this->request = new PartialRuleUpdateRequest();
+    $this->request->name = 'Rule 1';
+    $this->request->description = 'Description of Rule 1';
+    $this->request->isEnabled = true;
+
+    $datasetFilterData0 = [
+        'type' => 'hostgroup',
+        'resources' => [11, 12],
+        'dataset_filter' => [
+            'type' => 'host',
+            'resources' => [110, 120],
+            'dataset_filter' => null,
+        ],
+    ];
+
+    $datasetFilterData1 = [
+        'type' => 'host',
+        'resources' => [111, 121],
+        'dataset_filter' => null,
+    ];
+
+    $datasetFilter0 = new DatasetFilter(
+        $datasetFilterData0['type'],
+        $datasetFilterData0['resources'],
+        $this->datasetValidator
+    );
+
+    $datasetFilter0->setDatasetFilter(
+        new DatasetFilter(
+            $datasetFilterData0['dataset_filter']['type'],
+            $datasetFilterData0['dataset_filter']['resources'],
+            $this->datasetValidator
+        )
+    );
+
+    $datasetFilter1 = new DatasetFilter(
+        $datasetFilterData1['type'],
+        $datasetFilterData1['resources'],
+        $this->datasetValidator
+    );
+
+    $this->datasetFilters = [$datasetFilter0, $datasetFilter1];
+
+    $this->rule = new Rule(
+        id: 1,
+        name: Rule::formatName($this->request->name),
+        description: $this->request->name,
+        linkedContacts: [1],
+        linkedContactGroups: [2],
+        datasets: $this->datasetFilters,
+        isEnabled: true
+    );
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (missing page access)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)(1, $this->request, $this->presenter);
+
+    expect($this->presenter->responseStatus)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->responseStatus->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (not an admin)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'lame_acl', 'not an admin')]
+        );
+
+    ($this->useCase)(1, $this->request, $this->presenter);
+
+    expect($this->presenter->responseStatus)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->responseStatus->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it(
+    'should present a NotFoundResponse when ruleId requested does not exist',
+    function (): void {
+        $this->accessGroupRepository
+            ->expects($this->once())
+            ->method('findByContact')
+            ->willReturn(
+                [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+            );
+
+        $this->user
+            ->expects($this->once())
+            ->method('hasTopologyRole')
+            ->willReturn(true);
+
+        $this->readRepository
+            ->expects($this->once())
+            ->method('findById')
+            ->willReturn(null);
+
+        ($this->useCase)(1, $this->request, $this->presenter);
+
+        expect($this->presenter->responseStatus)->toBeInstanceOf(NotFoundResponse::class);
+    }
+);
+
+it(
+    'should present ConflictResponse when name provided is already used',
+    function (): void {
+        $this->accessGroupRepository
+            ->expects($this->once())
+            ->method('findByContact')
+            ->willReturn(
+                [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+            );
+
+        $this->user
+            ->expects($this->once())
+            ->method('hasTopologyRole')
+            ->willReturn(true);
+
+        $this->readRepository
+            ->expects($this->once())
+            ->method('findById')
+            ->willReturn($this->rule);
+
+        $this->request->name = 'fake-existing-name';
+
+        $this->validator
+            ->expects($this->once())
+            ->method('assertIsValidName')
+            ->willThrowException(
+                RuleException::nameAlreadyExists(
+                    NewRule::formatName($this->request->name),
+                    $this->request->name
+                )
+            );
+
+        ($this->useCase)(1, $this->request, $this->presenter);
+
+        expect($this->presenter->responseStatus)
+            ->toBeInstanceOf(ConflictResponse::class)
+            ->and($this->presenter->responseStatus->getMessage())
+            ->toBe(
+                RuleException::nameAlreadyExists(
+                    NewRule::formatName($this->request->name),
+                    $this->request->name
+                )->getMessage()
+            );
+    }
+);
+
+it(
+    'should present a NoContentResponse when everything goes well',
+    function (): void {
+        $this->accessGroupRepository
+            ->expects($this->once())
+            ->method('findByContact')
+            ->willReturn(
+                [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+            );
+
+        $this->user
+            ->expects($this->once())
+            ->method('hasTopologyRole')
+            ->willReturn(true);
+
+        $this->readRepository
+            ->expects($this->once())
+            ->method('findById')
+            ->willReturn($this->rule);
+
+        ($this->useCase)(1, $this->request, $this->presenter);
+
+        expect($this->presenter->responseStatus)
+            ->toBeInstanceOf(NoContentResponse::class);
+    }
+);
+

--- a/centreon/tests/php/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdatePresenterStub.php
+++ b/centreon/tests/php/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdatePresenterStub.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ResourceAccess\Infrastructure\API\PartialRuleUpdate;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+class PartialRuleUpdatePresenterStub extends AbstractPresenter
+{
+    public ?ResponseStatusInterface $responseStatus;
+
+    public function setResponseStatus(?ResponseStatusInterface $responseStatus): void
+    {
+        $this->responseStatus = $responseStatus;
+    }
+}
+


### PR DESCRIPTION
🏷️ MON-37007

This PR intends to add a new endpoint that will allow to perform partial updates of a resource access rule (name, description and status enabled/disabled)

Here is a video demonstrating the endpoint working.

https://github.com/centreon/centreon/assets/31647811/7bce0dca-d206-4f18-8af5-83817f8af330

- PHPStan level 9 ✔️ 
- PHPCSFixer ✔️ 
- Unit tests added ✔️ 

<img width="1432" alt="image" src="https://github.com/centreon/centreon/assets/31647811/6bde4e56-380f-4894-9c2b-4f87c2545b60">

ℹ️ Some fixes / enhancements were also done for previously created endpoints
- **DELETE** - remove useless transaction mechanism
- **GET** - is_enabled key in JSON returned was never set.
- **UPDATE** - Fix condition regarding the update of contact/contactgroups

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
