### PR TITLE
fix(docker): add missing dependencies to bullseye web dependencies image

### DIFF
--- a/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
@@ -69,6 +69,7 @@ apt-get install -y \
   libxml-libxml-perl \
   libauthen-sasl-perl \
   libclone-perl \
+  libclone-choose-perl \
   libdata-dump-perl \
   libencode-locale-perl \
   libfile-listing-perl \

--- a/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
@@ -6,7 +6,7 @@ ARG VERSION
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN bash -e <<EOF
+RUN <<EOF
 
 ######################################
 # additional configuration for apt   #

--- a/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
@@ -6,7 +6,7 @@ ARG VERSION
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN <<EOF
+RUN bash -e <<EOF
 
 ######################################
 # additional configuration for apt   #
@@ -31,15 +31,15 @@ VERSION_CODENAME=$(
     echo $VERSION_CODENAME
 )
 
-echo "deb https://packages.sury.org/php/ $VERSION_CODENAME main" | tee /etc/apt/sources.list.d/sury-php.list
+echo "deb https://packages.sury.org/php/ '$VERSION_CODENAME' main" | tee /etc/apt/sources.list.d/sury-php.list
 wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/php.gpg  > /dev/null 2>&1
 
-echo "deb https://packages.centreon.com/apt-standard-${VERSION}-stable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
-echo "deb https://packages.centreon.com/apt-standard-${VERSION}-testing/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
-echo "deb https://packages.centreon.com/apt-standard-${VERSION}-unstable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
-echo "deb https://packages.centreon.com/apt-plugins-stable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
-echo "deb https://packages.centreon.com/apt-plugins-testing/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
-echo "deb https://packages.centreon.com/apt-plugins-unstable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
+echo "deb https://packages.centreon.com/apt-standard-'${VERSION}'-stable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
+echo "deb https://packages.centreon.com/apt-standard-'${VERSION}'-testing/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
+echo "deb https://packages.centreon.com/apt-standard-'${VERSION}'-unstable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ '$VERSION_CODENAME' main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
+echo "deb https://packages.centreon.com/apt-plugins-testing/ '$VERSION_CODENAME' main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
+echo "deb https://packages.centreon.com/apt-plugins-unstable/ '$VERSION_CODENAME' main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
 wget -O- https://packages.centreon.com/api/security/keypair/Debian/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 
 apt-get update

--- a/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
@@ -67,6 +67,41 @@ apt-get install -y \
   libnet-http-perl \
   libwww-perl \
   libxml-libxml-perl \
+  libauthen-sasl-perl \
+  libclone-perl \
+  libdata-dump-perl \
+  libencode-locale-perl \
+  libfile-listing-perl \
+  libfont-afm-perl \
+  libgdbm-compat4 \
+  libgdbm6 \
+  libhtml-form-perl \
+  libhtml-format-perl \
+  libhtml-parser-perl \
+  libhtml-tagset-perl \
+  libhtml-tree-perl \
+  libhttp-cookies-perl \
+  libhttp-daemon-perl \
+  libhttp-date-perl \
+  libhttp-message-perl \
+  libhttp-negotiate-perl \
+  libio-html-perl \
+  libio-socket-ssl-perl \
+  liblwp-mediatypes-perl \
+  liblwp-protocol-https-perl \
+  libmailtools-perl \
+  libnet-smtp-ssl-perl
+  libnet-ssleay-perl \
+  libperl5.32 \
+  libtimedate-perl \
+  libtry-tiny-perl \
+  liburi-perl \
+  libwww-robotrules-perl \
+  libxml-namespacesupport-perl \
+  libxml-parser-perl \
+  libxml-sax-base-perl \
+  libxml-sax-expat-perl \
+  libxml-sax-perl \
   perl
 
 #############################

--- a/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
@@ -6,7 +6,7 @@ ARG VERSION
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN <<EOF
+RUN bash -e <<EOF
 
 ######################################
 # additional configuration for apt   #
@@ -102,6 +102,7 @@ apt-get install -y \
   libxml-sax-base-perl \
   libxml-sax-expat-perl \
   libxml-sax-perl \
+  libcarp-assert-perl \
   perl
 
 #############################

--- a/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
@@ -6,7 +6,7 @@ ARG VERSION
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN bash -e <<EOF
+RUN <<EOF
 
 ######################################
 # additional configuration for apt   #
@@ -31,15 +31,15 @@ VERSION_CODENAME=$(
     echo $VERSION_CODENAME
 )
 
-echo "deb https://packages.sury.org/php/ '$VERSION_CODENAME' main" | tee /etc/apt/sources.list.d/sury-php.list
+echo "deb https://packages.sury.org/php/ $VERSION_CODENAME main" | tee /etc/apt/sources.list.d/sury-php.list
 wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/php.gpg  > /dev/null 2>&1
 
-echo "deb https://packages.centreon.com/apt-standard-'${VERSION}'-stable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
-echo "deb https://packages.centreon.com/apt-standard-'${VERSION}'-testing/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
-echo "deb https://packages.centreon.com/apt-standard-'${VERSION}'-unstable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
-echo "deb https://packages.centreon.com/apt-plugins-stable/ '$VERSION_CODENAME' main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
-echo "deb https://packages.centreon.com/apt-plugins-testing/ '$VERSION_CODENAME' main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
-echo "deb https://packages.centreon.com/apt-plugins-unstable/ '$VERSION_CODENAME' main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
+echo "deb https://packages.centreon.com/apt-standard-${VERSION}-stable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
+echo "deb https://packages.centreon.com/apt-standard-${VERSION}-testing/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-testing.list
+echo "deb https://packages.centreon.com/apt-standard-${VERSION}-unstable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+echo "deb https://packages.centreon.com/apt-plugins-stable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
+echo "deb https://packages.centreon.com/apt-plugins-testing/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
+echo "deb https://packages.centreon.com/apt-plugins-unstable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
 wget -O- https://packages.centreon.com/api/security/keypair/Debian/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 
 apt-get update


### PR DESCRIPTION
## Description

Since many perl libs were remove from our repositories because they were already provided by debian official repositories,
they had to be installed before hand in the web dependencies container (since it does not pull them on its own)

**Fixes** #MON-37108

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)
