### PR TITLE
fix(gorgone/mbi): rebuilding centiles truncates mod_bi_metrichourlyvalue

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/mbi/etl/perfdata/main.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/mbi/etl/perfdata/main.pm
@@ -178,7 +178,7 @@ sub purgeTables {
       
         if ($etl->{run}->{etlProperties}->{'perfdata.granularity'} ne "day" && 
             (!defined($etl->{run}->{options}->{month_only}) || $etl->{run}->{options}->{month_only} == 0) && 
-            (!defined($etl->{run}->{options}->{no_centile}) || $etl->{run}->{options}->{no_centile} == 0)) {
+            (!defined($etl->{run}->{options}->{centile_only}) || $etl->{run}->{options}->{centile_only} == 0)) {
             emptyTableForRebuild($etl, name => 'mod_bi_metrichourlyvalue', column => 'time_id', start => $hourly_start, end => $hourly_end);
         }
     }


### PR DESCRIPTION
## Description

When rebuilding MBI centiles data (using `/usr/share/centreon-bi/etl/perfdataStatisticsBuilder.pl -r --centile-only`), Gorgone's MBI module truncates mod_bi_metrichourlyvalue, even though it should not.

This fix just change the condition and put it back to what it was before in `/usr/share/centreon-bi/etl/perfdataStatisticsBuilder.pl` (or in `/usr/share/centreon-bi/etl/perfdataStatisticsBuilder_legacy.pl` now):

```
if ($etlProperties->{'perfdata.granularity'} ne "day" && !defined($options->{'month-only'}) && !defined($options->{'centile-only'})) {
    $logger->writeLog("INFO", "Truncating table ".$hourAgregates->getName());
    $tablesManager->emptyTableForRebuild($hourAgregates->getName(), $dumper->dumpTableStructure($hourAgregates->getName()), $hourAgregates->getTimeColumn(), $hourly_start, $hourly_end);
}
```

**Fixes** # MON-106134

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Have a MBI configured to compute all kinds of statistics, with all granularities and centiles,
2. Launch the rebuild of centiles with `/usr/share/centreon-bi/etl/perfdataStatisticsBuilder.pl -r --centile-only`.

You should not see anything about mod_bi_metrichourlyvalue in the `centreonBIETL.log`, not like this example:

```
2024-03-04 09:36:44 - INFO - [SCHEDULER] >>>>>>> start
2024-03-04 09:36:46 - INFO - [SCHEDULER][PERFDATA] >>>>>>> start
2024-03-04 09:37:47 - INFO - [CREATE] Deleting table [mod_bi_metrichourlyvalue]
2024-03-04 09:37:47 - INFO - [CREATE] Add table [mod_bi_metrichourlyvalue]
2024-03-04 09:37:47 - INFO - [INDEXING] Adding index [idx_mod_bi_metrichourlyvalue_time_id] on table [mod_bi_metrichourlyvalue]
2024-03-04 09:38:17 - INFO - [CREATE] Deleting table [mod_bi_metriccentileweeklyvalue]
2024-03-04 09:38:17 - INFO - [CREATE] Add table [mod_bi_metriccentileweeklyvalue]
2024-03-04 09:38:17 - INFO - [INDEXING] Adding index [idx_mod_bi_metriccentileweeklyvalue_time_id] on table [mod_bi_metriccentileweeklyvalue]
2024-03-04 09:38:23 - INFO - [CREATE] Deleting table [mod_bi_metriccentilemonthlyvalue]
2024-03-04 09:38:23 - INFO - [CREATE] Add table [mod_bi_metriccentilemonthlyvalue]
2024-03-04 09:38:23 - INFO - [INDEXING] Adding index [idx_mod_bi_metriccentilemonthlyvalue_time_id] on table [mod_bi_metriccentilemonthlyvalue]
2024-03-04 09:38:49 - INFO - [CREATE] Deleting table [mod_bi_metriccentiledailyvalue]
2024-03-04 09:38:49 - INFO - [CREATE] Add table [mod_bi_metriccentiledailyvalue]
2024-03-04 09:38:49 - INFO - [INDEXING] Adding index [idx_mod_bi_metriccentiledailyvalue_time_id] on table [mod_bi_metriccentiledailyvalue]
...
```

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
