### PR TITLE
fix(gorgone): During the collect of engine statistics, Gorgone display error messages

### DIFF
--- a/centreon-gorgone/gorgone/class/db.pm
+++ b/centreon-gorgone/gorgone/class/db.pm
@@ -185,17 +185,20 @@ sub transaction_mode {
 sub commit {
     my ($self) = @_;
 
-    if (!defined($self->{instance})) {
+    # Commit only if autocommit isn't enabled
+    if ($self->{instance}->{AutoCommit} != 1) {
+        if (!defined($self->{instance})) {
+            $self->{transaction_begin} = 0;
+            return -1;
+        }
+
+        my $status = $self->{instance}->commit();
         $self->{transaction_begin} = 0;
-        return -1;
-    }
 
-    my $status = $self->{instance}->commit();
-    $self->{transaction_begin} = 0;
-
-    if (!$status) {
-        $self->error($self->{instance}->errstr, 'commit');
-        return -1;
+        if (!$status) {
+            $self->error($self->{instance}->errstr, 'commit');
+            return -1;
+        }
     }
 
     return 0;


### PR DESCRIPTION
## Description

During the collect of engine statistics, Gorgone display error messages:
`ERROR - Already in a transaction`
=> Not reproduced, but now the commits are skipped when the autocommit is activated.

**Fixes** MON-23409

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

