### PR TITLE
feat(resource-access): add mass delete endpoint

### DIFF
--- a/centreon/doc/API/centreon-cloud-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-cloud-api-v24.04.yaml
@@ -49,4 +49,6 @@ paths:
   /administration/resource-access/rules:
     $ref: "./latest/Cloud/ResourceAccessManagement/AddAndFindRules.yaml"
   /administration/resource-access/rules/{rule_id}:
-    $ref: "./latest/Cloud/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml"
+    $ref: "./latest/Cloud/ResourceAccessManagement/FindUpdateAndDeleteRule.yaml"
+  /administration/resource-access/rules/_delete:
+    $ref: "./latest/Cloud/ResourceAccessManagement/DeleteRules.yaml"

--- a/centreon/doc/API/latest/Cloud/ResourceAccessManagement/DeleteRules.yaml
+++ b/centreon/doc/API/latest/Cloud/ResourceAccessManagement/DeleteRules.yaml
@@ -1,0 +1,18 @@
+post:
+  tags:
+    - Resource Access Management
+  summary: 'Delete multiple resource access rule configurations'
+  description: |
+    Delete multiple resource access rule configurations
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "Schema/DeleteRulesRequest.yaml"
+  responses:
+    '207': { $ref: '../../../Common/Response/MultiStatus.yaml' }
+    '400': { $ref: '../../../Common/Response/BadRequest.yaml' }
+    '403': { $ref: '../../../Common/Response/Forbidden.yaml' }
+    '500': { $ref: '../../../Common/Response/InternalServerError.yaml' }
+

--- a/centreon/doc/API/latest/Cloud/ResourceAccessManagement/Schema/DeleteRulesRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/ResourceAccessManagement/Schema/DeleteRulesRequest.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  ids:
+    type: array
+    description: List of resource access rule IDs to delete
+    items:
+      type: integer
+

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRules.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRules.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\ResourceAccess\Application\Exception\RuleException;
+use Core\ResourceAccess\Application\Repository\ReadResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\Repository\WriteResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Domain\Model\ResponseCode;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+
+final class DeleteRules
+{
+    use LoggerTrait;
+    public const AUTHORIZED_ACL_GROUPS = ['customer_admin_acl'];
+
+    /**
+     * @param ReadResourceAccessRepositoryInterface $readRepository
+     * @param WriteResourceAccessRepositoryInterface $writeRepository
+     * @param ContactInterface $user
+     * @param ReadAccessGroupRepositoryInterface $accessGroupRepository
+     * @param DataStorageEngineInterface $dataStorageEngine
+     */
+    public function __construct(
+        private readonly ReadResourceAccessRepositoryInterface $readRepository,
+        private readonly WriteResourceAccessRepositoryInterface $writeRepository,
+        private readonly ContactInterface $user,
+        private readonly ReadAccessGroupRepositoryInterface $accessGroupRepository,
+        private readonly DataStorageEngineInterface $dataStorageEngine
+    ) {
+    }
+
+    /**
+     * @param DeleteRulesRequest $request
+     * @param DeleteRulesPresenterInterface $presenter
+     */
+    public function __invoke(DeleteRulesRequest $request, DeleteRulesPresenterInterface $presenter): void
+    {
+        try {
+            if (! $this->isAuthorized()) {
+                $this->error(
+                    "User doesn't have sufficient rights to delete a resource access rule",
+                    [
+                        'user_id' => $this->user->getId(),
+                    ]
+                );
+                $response = new ForbiddenResponse(RuleException::notAllowed()->getMessage());
+            } else {
+                $this->debug('Starting transaction');
+                $this->dataStorageEngine->startTransaction();
+
+                $response = new DeleteRulesResponse();
+
+                foreach ($request->ids as $ruleId) {
+                    try {
+                        $statusResponse = $this->deleteRule($ruleId);
+                        $response->responseStatuses[] = $this->createResponseStatusDto($ruleId, $statusResponse);
+                    } catch (\Throwable $exception) {
+                        $statusResponse = new ErrorResponse(RuleException::errorWhileDeleting($exception));
+                        $response->responseStatuses[] = $this->createResponseStatusDto($ruleId, $statusResponse);
+                        $this->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
+                    }
+                }
+
+                $this->debug('Commit transaction');
+                $this->dataStorageEngine->commitTransaction();
+            }
+        } catch (\Throwable $exception) {
+            $this->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
+            $response = new ErrorResponse(RuleException::errorWhileDeleting($exception));
+        }
+
+        $presenter->presentResponse($response);
+    }
+
+    /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
+     * @return bool
+     */
+    private function isAuthorized(): bool
+    {
+        $userAccessGroupNames = array_map(
+            static fn (AccessGroup $accessGroup): string => $accessGroup->getName(),
+            $this->accessGroupRepository->findByContact($this->user)
+        );
+
+        /**
+         * User must be
+         *     - An admin (belongs to the centreon_admin_acl ACL group)
+         *     - authorized to reach the Resource Access Management page.
+         */
+        return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+    }
+
+    /**
+     * @param int $ruleId
+     *
+     * @throws \Exception
+     * @throws \Throwable
+     */
+    private function deleteRule(int $ruleId): ResponseStatusInterface
+    {
+        $this->info('Start resource access rule deletion', ['rule_id' => $ruleId]);
+
+        if (! $this->readRepository->exists($ruleId)) {
+            $this->error('Resource access rule not found', ['rule_id' => $ruleId]);
+
+            return new NotFoundResponse('Resource access rule');
+        }
+
+        $this->writeRepository->deleteRuleAndDatasets($ruleId);
+
+        return new NoContentResponse();
+    }
+
+    /**
+     * @param int $ruleId
+     * @param ResponseStatusInterface $statusResponse
+     *
+     * @return DeleteRulesStatusResponse
+     */
+    private function createResponseStatusDto(
+        int $ruleId,
+        ResponseStatusInterface $statusResponse
+    ): DeleteRulesStatusResponse {
+        $dto = new DeleteRulesStatusResponse();
+        $dto->id = $ruleId;
+
+        if ($statusResponse instanceof NotFoundResponse) {
+            $dto->status = ResponseCode::NotFound;
+            $dto->message = $statusResponse->getMessage();
+        } elseif ($statusResponse instanceof NoContentResponse) {
+            $dto->status = ResponseCode::OK;
+            $dto->message = null;
+        } else {
+            $dto->status = ResponseCode::Error;
+            $dto->message = $statusResponse->getMessage();
+        }
+
+        return $dto;
+    }
+}

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesPresenterInterface.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesPresenterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+interface DeleteRulesPresenterInterface
+{
+    /**
+     * @param DeleteRulesResponse|ResponseStatusInterface $data
+     */
+    public function presentResponse(DeleteRulesResponse|ResponseStatusInterface $data): void;
+}

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesRequest.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+final class DeleteRulesRequest
+{
+    /** @var int[] */
+    public array $ids = [];
+}
+

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesResponse.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+final class DeleteRulesResponse
+{
+    /** @var DeleteRulesStatusResponse[] */
+    public array $responseStatuses = [];
+}
+

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesStatusResponse.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesStatusResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+use Core\ResourceAccess\Domain\Model\ResponseCode;
+
+final class DeleteRulesStatusResponse
+{
+    public int $id = 0;
+
+    public ResponseCode $status = ResponseCode::OK;
+
+    public ?string $message = null;
+}

--- a/centreon/src/Core/ResourceAccess/Domain/Model/ResponseCode.php
+++ b/centreon/src/Core/ResourceAccess/Domain/Model/ResponseCode.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Domain\Model;
+
+enum ResponseCode
+{
+    case OK;
+    case NotFound;
+    case Error;
+}
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRule/DeleteRuleRoute.yaml
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRule/DeleteRuleRoute.yaml
@@ -5,5 +5,3 @@ DeleteRule:
   condition: "request.attributes.get('version') >= 24.04 and request.attributes.get('feature.resource_access_management')"
   requirements:
     ruleId: '\d+'
-
-

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesController.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesController.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Infrastructure\API\DeleteRules;
+
+use Centreon\Application\Controller\AbstractController;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRules;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class DeleteRulesController extends AbstractController
+{
+    /**
+     * @param Request $request
+     * @param DeleteRules $useCase
+     * @param DeleteRulesPresenter $presenter
+     *
+     * @return Response
+     */
+    public function __invoke(
+        Request $request,
+        DeleteRules $useCase,
+        DeleteRulesPresenter $presenter
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        /**
+         * @var array{
+         *  ids: int[]
+         * } $data
+         */
+        $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/DeleteRulesSchema.json');
+        $useCase($this->createDtoFromData($data), $presenter);
+
+        return $presenter->show();
+    }
+
+    /**
+     * @param array{
+     *  ids: int[]
+     * } $data
+     *
+     * @return DeleteRulesRequest
+     */
+    private function createDtoFromData(array $data): DeleteRulesRequest
+    {
+        $dto = new DeleteRulesRequest();
+        $dto->ids = $data['ids'];
+
+        return $dto;
+    }
+}
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesPresenter.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesPresenter.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Infrastructure\API\DeleteRules;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\MultiStatusResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Infrastructure\Common\Api\Router;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesPresenterInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesResponse;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesStatusResponse;
+use Core\ResourceAccess\Domain\Model\ResponseCode;
+use Symfony\Component\HttpFoundation\Response;
+
+final class DeleteRulesPresenter extends AbstractPresenter implements DeleteRulesPresenterInterface
+{
+    use LoggerTrait;
+    private const ROUTE_NAME = 'DeleteRule';
+
+    /**
+     * @param PresenterFormatterInterface $presenterFormatter
+     * @param Router $router
+     */
+    public function __construct(
+        protected PresenterFormatterInterface $presenterFormatter,
+        private readonly Router $router
+    ) {
+        parent::__construct($presenterFormatter);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function presentResponse(DeleteRulesResponse|ResponseStatusInterface $response): void
+    {
+        if ($response instanceof DeleteRulesResponse) {
+            $multiStatusResponse = [
+                'results' => array_map(function (DeleteRulesStatusResponse $dto) {
+                    return [
+                        'self' => $this->getDeletedNotificationHref($dto->id),
+                        'status' => $this->enumToIntConverter($dto->status),
+                        'message' => $dto->message,
+                    ];
+                }, $response->responseStatuses),
+            ];
+
+            $this->present(new MultiStatusResponse($multiStatusResponse));
+        } else {
+            $this->setResponseStatus($response);
+        }
+    }
+
+    /**
+     * @param ResponseCode $code
+     *
+     * @return int
+     */
+    private function enumToIntConverter(ResponseCode $code): int
+    {
+        return match ($code) {
+            ResponseCode::OK => Response::HTTP_NO_CONTENT,
+            ResponseCode::NotFound => Response::HTTP_NOT_FOUND,
+            ResponseCode::Error => Response::HTTP_INTERNAL_SERVER_ERROR
+        };
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return string|null
+     */
+    private function getDeletedNotificationHref(int $id): ?string
+    {
+        try {
+            return $this->router->generate(self::ROUTE_NAME, ['ruleId' => $id]);
+        } catch (\Throwable $ex) {
+            $this->error('Impossible to generate the deleted entity route', [
+                'message' => $ex->getMessage(),
+                'trace' => $ex->getTraceAsString(),
+                'route' => self::ROUTE_NAME,
+                'payload' => $id,
+            ]);
+
+            return null;
+        }
+    }
+}

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesRoute.yaml
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesRoute.yaml
@@ -1,0 +1,5 @@
+DeleteRules:
+  methods: POST
+  path: /administration/resource-access/rules/_delete
+  controller: 'Core\ResourceAccess\Infrastructure\API\DeleteRules\DeleteRulesController'
+  condition: "request.attributes.get('version') >= 24.04 and request.attributes.get('feature.resource_access_management')"

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesSchema.json
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesSchema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Delete multiple rules at once",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "ids"
+    ],
+    "properties": {
+        "ids": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
+        }
+    }
+}
+
+

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Tests\Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\MultiStatusResponse;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\ResourceAccess\Application\Exception\RuleException;
+use Core\ResourceAccess\Application\Repository\ReadResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\Repository\WriteResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRules;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesRequest;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Tests\Core\ResourceAccess\Infrastructure\API\DeleteRules\DeleteRulesPresenterStub;
+
+beforeEach(closure: function (): void {
+    $this->useCase = new DeleteRules(
+        readRepository: $this->readRepository = $this->createMock(ReadResourceAccessRepositoryInterface::class),
+        writeRepository: $this->writeRepository = $this->createMock(WriteResourceAccessRepositoryInterface::class),
+        user: $this->user = $this->createMock(ContactInterface::class),
+        accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        dataStorageEngine: $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class)
+    );
+
+    $this->presenter = new DeleteRulesPresenterStub($this->createMock(PresenterFormatterInterface::class));
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (missing page access)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    $request = new DeleteRulesRequest();
+    $request->ids = [1,2];
+
+    ($this->useCase)($request, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (not admin)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'centreon_not_admin', 'not an admin')]
+        );
+
+    $request = new DeleteRulesRequest();
+    $request->ids = [1,2];
+
+    ($this->useCase)($request, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a Multi-Status Response when a bulk delete action is executed', function () {
+    $request = new DeleteRulesRequest();
+    $request->ids = [1,2];
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'customer_admin_acl')]
+        );
+
+    $this->readRepository
+        ->expects($this->exactly(2))
+        ->method('exists')
+        ->willReturnOnConsecutiveCalls(true, false);
+
+    ($this->useCase)($request, $this->presenter);
+
+    $expectedResult = [
+        'results' => [
+            [
+                'self' => 'centreon/api/latest/administration/resource-access/rules/1',
+                'status' => 204,
+                'message' => null
+            ],
+            [
+                'self' => 'centreon/api/latest/administration/resource-access/rules/2',
+                'status' => 404,
+                'message' => 'Resource access rule not found'
+            ],
+        ]
+    ];
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(MultiStatusResponse::class)
+        ->and($this->presenter->response->getPayload())
+        ->toBeArray()
+        ->and($this->presenter->response->getPayload())
+        ->toBe($expectedResult);
+});
+

--- a/centreon/tests/php/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesPresenterStub.php
+++ b/centreon/tests/php/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesPresenterStub.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ResourceAccess\Infrastructure\API\DeleteRules;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\MultiStatusResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesPresenterInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesResponse;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesStatusResponse;
+use Core\ResourceAccess\Domain\Model\ResponseCode;
+use Symfony\Component\HttpFoundation\Response;
+
+class DeleteRulesPresenterStub extends AbstractPresenter implements DeleteRulesPresenterInterface
+{
+    private const HREF = 'centreon/api/latest/administration/resource-access/rules/';
+
+    /** @var ResponseStatusInterface */
+    public ResponseStatusInterface $response;
+
+    public function presentResponse(DeleteRulesResponse|ResponseStatusInterface $response): void
+    {
+        if ($response instanceof DeleteRulesResponse) {
+            $multiStatusResponse = [
+                'results' => array_map(function (DeleteRulesStatusResponse $dto) {
+                    return [
+                        'self' => self::HREF . $dto->id,
+                        'status' => $this->enumToIntConverter($dto->status),
+                        'message' => $dto->message,
+                    ];
+                }, $response->responseStatuses),
+            ];
+
+            $this->response = new MultiStatusResponse($multiStatusResponse);
+        } else {
+            $this->response = $response;
+        }
+    }
+
+    /**
+     * @param ResponseCode $code
+     *
+     * @return int
+     */
+    private function enumToIntConverter(ResponseCode $code): int
+    {
+        return match ($code) {
+            ResponseCode::OK => Response::HTTP_NO_CONTENT,
+            ResponseCode::NotFound => Response::HTTP_NOT_FOUND,
+            ResponseCode::Error => Response::HTTP_INTERNAL_SERVER_ERROR
+        };
+    }
+}


### PR DESCRIPTION
🏷️ MON-37157

This PR intends to add a new endpoint for the Resource Access Management feature. This endpoint allows to delete rules at once.

Here is a video showing the endpoint working

https://github.com/centreon/centreon/assets/31647811/8400f8fd-cb17-4318-865d-1538d32552f3


- PHPStan level 9 ✔️ 
- PHPCSFixer ✔️ 
- Unit tests added ✔️ 

![image](https://github.com/centreon/centreon/assets/31647811/bc6c3520-cb2a-4084-a5d9-ff73ea877c52)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira ticket for this

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
