### PR TITLE
fix(test): do not check metrics data size in dashboard metrics test

### DIFF
--- a/centreon/tests/api/features/DashboardWithOpenApi.feature
+++ b/centreon/tests/api/features/DashboardWithOpenApi.feature
@@ -1799,10 +1799,6 @@ Feature:
       | metrics[0].legend   | "Centreon-Server: Packet Loss"  |
       | metrics[1].metric   | "Centreon-Server: rta"          |
       | metrics[2].metric   | "Centreon-Server: rtmax"        |
-    And the JSON node "metrics[0].data" should have at least 48 elements
-    And the JSON node "metrics[1].data" should have at least 48 elements
-    And the JSON node "metrics[2].data" should have at least 48 elements
-    And the JSON node "times" should have at least 48 elements
 
     When I send a GET request to '/api/latest/monitoring/dashboard/metrics/top?metric_name=rta&search={"$and":[{"hostgroup.id":{"$in":[53]}},{"host.id":{"$in":[14]}},{"service.name":{"$in":["Ping"]}}]}&sort_by={"current_value":"ASC"}&limit=10'
     Then the response code should be "200"


### PR DESCRIPTION
## Description

fix(test): do not check metrics data size in dashboard metrics test

OpenAPI documentation already validates `data` is an array

current rrd/rra configuration does not return same amount of data regarding the date : 
* `< 6 months` : 1 value per 5 minutes
* `> 6 months`: 1 value per hour
* `> 1 year`: 0 value

**Fixes** MON-37334

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)