### PR TITLE
fix(delivery): fix missing inputs for rpm split delivery

### DIFF
--- a/.github/actions/rpm-delivery/action.yml
+++ b/.github/actions/rpm-delivery/action.yml
@@ -78,13 +78,6 @@ runs:
           mv "$FILE" "$ARCH"
         done
 
-        # Custom delivery
-        if [[ "${{ inputs.stability }}" == "pkgtest" ]]; then
-          ROOT_REPO_PATH="installers"
-          jf rt upload "*.deb" "$ROOT_REPO_PATH/${{ inputs.version }}/${{ inputs.distrib }}/${{ inputs.stability }}/" --flat
-          exit 0
-        fi
-
         # Build upload target path based on release_cloud and release_type values
         # if cloud, deliver to testing-<release_type>
         # if non-cloud, delivery to testing as usual

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -150,6 +150,8 @@ jobs:
               ;;
             *)
               echo "release=`date +%s`.`echo ${{ github.sha }} | cut -c -7`" >> $GITHUB_OUTPUT
+              echo "release_cloud=$GITHUB_RELEASE_CLOUD" >> $GITHUB_OUTPUT
+              echo "release_type=$GITHUB_RELEASE_TYPE" >> $GITHUB_OUTPUT
               ;;
           esac
 


### PR DESCRIPTION
## Description

add missing github_outputs for release_type and release_cloud

Fixes #MON-35276

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
