### PR TITLE
enh(log) improve oidc log when received a different value than 200

### DIFF
--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
@@ -127,7 +127,7 @@ final class HttpReadAttributePathRepository implements ReadAttributePathReposito
     {
         $statusCode = $response->getStatusCode();
         if ($statusCode !== Response::HTTP_OK) {
-            throw new InvalidStatusCodeException();
+            throw new InvalidStatusCodeException('Invalid status code received', $statusCode);
         }
     }
 


### PR DESCRIPTION
## Description

Logs returns 0 when a status other than 200 is returned, with this fix we improve OIDC/SAML logs when an invalid status code is received.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Simulate an invalid status code by mocking the response for OIDC and SAML configuration.

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
