### PR TITLE
fix(gorgone): missing dependency in debian packaging

### DIFF
--- a/centreon-gorgone/packaging/debian/control
+++ b/centreon-gorgone/packaging/debian/control
@@ -38,6 +38,7 @@ Depends:
   libssh-session-perl,
   libev-perl,
   libzmq-ffi-perl,
+  libclone-choose-perl,
   sudo,
   ${shlibs:Depends},
   ${misc:Depends}


### PR DESCRIPTION
## Description

The dependency libclone-choose-perl is missing in gorgone packaging for Debian.

**Fixes** MON-37401

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

