### PR TITLE
fix(php): avoid chmod warning on poller config generation

### DIFF
--- a/centreon/www/class/config-generate-remote/Abstracts/AbstractObject.php
+++ b/centreon/www/class/config-generate-remote/Abstracts/AbstractObject.php
@@ -123,7 +123,10 @@ abstract class AbstractObject
         if (!($this->fp = @fopen($fullFile, 'a+'))) {
             throw new Exception("Cannot open file (writing permission) '" . $fullFile . "'");
         }
-        chmod($fullFile, 0660);
+
+        if (posix_getuid() === fileowner($fullFile)) {
+            chmod($fullFile, 0660);
+        }
 
         if ($this->type == 'infile') {
             Manifest::getInstance($this->dependencyInjector)->addFile(

--- a/centreon/www/class/config-generate-remote/Backend.php
+++ b/centreon/www/class/config-generate-remote/Backend.php
@@ -124,11 +124,13 @@ class Backend
                 if (!is_dir($dir)) {
                     throw new Exception("Generation path '" . $dir . "' is not a directory.");
                 }
+                if (posix_getuid() === fileowner($dir)) {
+                    chmod($dir, 0770);
+                }
             } else {
                 if (!mkdir($dir, 0770, true)) {
                     throw new Exception("Cannot create directory '" . $dir . "'");
                 }
-                chmod($dir, 0770);
             }
         }
 

--- a/centreon/www/class/config-generate/abstract/object.class.php
+++ b/centreon/www/class/config-generate/abstract/object.class.php
@@ -172,7 +172,9 @@ abstract class AbstractObject
             throw new Exception("Cannot open file (writing permission) '" . $filePath . "'");
         }
 
-        chmod($filePath, 0660);
+        if (posix_getuid() === fileowner($filePath)) {
+            chmod($filePath, 0660);
+        }
 
         if (! $alreadyExists) {
             $this->setHeader();

--- a/centreon/www/class/config-generate/backend.class.php
+++ b/centreon/www/class/config-generate/backend.class.php
@@ -98,11 +98,13 @@ class Backend
                 if (!is_dir($dir)) {
                     throw new Exception("Generation path '" . $dir . "' is not a directory.");
                 }
+                if (posix_getuid() === fileowner($dir)) {
+                    chmod($dir, 0770);
+                }
             } else {
                 if (!mkdir($dir, 0770, true)) {
                     throw new Exception("Cannot create directory '" . $dir . "'");
                 }
-                chmod($dir, 0770);
             }
         }
 
@@ -132,11 +134,10 @@ class Backend
         }
         $this->tmp_file = basename(tempnam($this->full_path, TMP_DIR_PREFIX));
         $this->tmp_dir = $this->tmp_file . TMP_DIR_SUFFIX;
-        if (!mkdir($this->full_path . '/' . $this->tmp_dir, 0770, true)) {
-            throw new Exception("Cannot create directory '" . $dir . "'");
-        }
-        chmod($this->full_path . '/' . $this->tmp_dir, 0770);
         $this->full_path .= '/' . $this->tmp_dir;
+        if (!mkdir($this->full_path, 0770, true)) {
+            throw new Exception("Cannot create directory '" . $this->full_path . "'");
+        }
     }
 
     public function getPath()


### PR DESCRIPTION
## Description

fix(php): avoid chmod warning on poller config generation

**Fixes** MON-35252

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)