### PR TITLE
fix(autodisco): fix regex to gorgone to execute the save of discovered hosts

### DIFF
--- a/.github/actions/cypress-e2e-testing/action.yml
+++ b/.github/actions/cypress-e2e-testing/action.yml
@@ -35,7 +35,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       with:
         version: 8
         run_install: false
@@ -56,7 +56,7 @@ runs:
         PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
 
     - name: Install Cypress binary
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
       with:
         timeout_seconds: 120
         max_attempts: 10
@@ -65,7 +65,7 @@ runs:
         command: cd ${{ inputs.module }}/tests/e2e && pnpm cypress install --force
 
     - name: Cypress end-to-end testing
-      uses: cypress-io/github-action@v6
+      uses: cypress-io/github-action@1b70233146622b69e789ccdd4f9452adc638d25a # v6.6.1
       with:
         command: pnpm run cypress:run --browser chromium --spec features/**/${{ inputs.feature_file_path }}
         install: false

--- a/.github/actions/frontend-build/action.yml
+++ b/.github/actions/frontend-build/action.yml
@@ -27,7 +27,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       with:
         version: 8
         run_install: false

--- a/.github/actions/frontend-lint/action.yml
+++ b/.github/actions/frontend-lint/action.yml
@@ -19,7 +19,7 @@ runs:
   using: "composite"
 
   steps:
-    - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       with:
         version: 8
         run_install: false

--- a/.github/actions/web-frontend-component-test/action.yml
+++ b/.github/actions/web-frontend-component-test/action.yml
@@ -14,7 +14,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: pnpm/action-setup@d882d12c64e032187b2edb46d3a0d003b7a43598 # v2.4.0
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       with:
         version: 8
         run_install: false
@@ -35,7 +35,7 @@ runs:
         PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
 
     - name: Install Cypress binary
-      uses: nick-fields/retry@v2
+      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
       with:
         timeout_seconds: 120
         max_attempts: 10
@@ -44,7 +44,7 @@ runs:
         command: cd ${{ inputs.module }} && pnpm cypress install --force
 
     - name: Cypress web component testing
-      uses: cypress-io/github-action@v5
+      uses: cypress-io/github-action@248bde77443c376edc45906ede03a1aba9da0462 # v5.8.4
       with:
         browser: chrome
         component: true

--- a/.github/docker/.env
+++ b/.github/docker/.env
@@ -10,4 +10,3 @@ MYSQL_AUTHENTICATION_PLUGIN=mysql_native_password
 MARIADB_ROOT_PASSWORD=centreon
 MARIADB_USER=centreon
 MARIADB_PASSWORD=centreon
-

--- a/.github/docker/centreon-web/alma8/Dockerfile
+++ b/.github/docker/centreon-web/alma8/Dockerfile
@@ -53,6 +53,8 @@ dnf install -y https://github.com/mydumper/mydumper/releases/download/v0.15.2-7/
 mkdir -p /usr/local/src/sql/databases
 mydumper -h localhost -P 3306 -u root -G -o /usr/local/src/sql/databases/centreon -B centreon
 mydumper -h localhost -P 3306 -u root -G -o /usr/local/src/sql/databases/centreon_storage -B centreon_storage
+sed -i -e 's/NO_AUTO_CREATE_USER//g' -e "s#text DEFAULT ''#text DEFAULT ('')#" /usr/local/src/sql/databases/centreon/*
+sed -i -e 's/NO_AUTO_CREATE_USER//g' /usr/local/src/sql/databases/centreon_storage/*
 
 systemctl stop gorgoned
 systemctl stop centengine

--- a/.github/docker/centreon-web/alma8/entrypoint/container.d/20-configuration_files.sh
+++ b/.github/docker/centreon-web/alma8/entrypoint/container.d/20-configuration_files.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-centreon -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1
-centreon -u admin -p Centreon\!2021 -a CFGMOVE -v 1
+su apache -s /bin/bash  -c "centreon -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1"
+su apache -s /bin/bash  -c "centreon -u admin -p Centreon\!2021 -a CFGMOVE -v 1"

--- a/.github/docker/centreon-web/alma8/slim-configuration/exec.txt
+++ b/.github/docker/centreon-web/alma8/slim-configuration/exec.txt
@@ -13,6 +13,8 @@ curl -s -d '{"check":{"is_forced":true},"resources":[{"id":26,"parent":{"id":14}
 dnf search vim
 dnf clean all
 
+lua /usr/share/centreon-broker/lua/centreon-cloud-notifications.lua
+
 systemctl stop gorgoned
 systemctl stop centengine
 systemctl stop cbd

--- a/.github/docker/centreon-web/alma9/Dockerfile
+++ b/.github/docker/centreon-web/alma9/Dockerfile
@@ -53,6 +53,8 @@ dnf install -y https://github.com/mydumper/mydumper/releases/download/v0.15.2-7/
 mkdir -p /usr/local/src/sql/databases
 mydumper -h localhost -P 3306 -u root -G -o /usr/local/src/sql/databases/centreon -B centreon
 mydumper -h localhost -P 3306 -u root -G -o /usr/local/src/sql/databases/centreon_storage -B centreon_storage
+sed -i -e 's/NO_AUTO_CREATE_USER//g' -e "s#text DEFAULT ''#text DEFAULT ('')#" /usr/local/src/sql/databases/centreon/*
+sed -i -e 's/NO_AUTO_CREATE_USER//g' /usr/local/src/sql/databases/centreon_storage/*
 
 systemctl stop gorgoned
 systemctl stop centengine

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/20-configuration_files.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/20-configuration_files.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-centreon -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1
-centreon -u admin -p Centreon\!2021 -a CFGMOVE -v 1
+su apache -s /bin/bash  -c "centreon -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1"
+su apache -s /bin/bash  -c "centreon -u admin -p Centreon\!2021 -a CFGMOVE -v 1"

--- a/.github/docker/centreon-web/alma9/slim-configuration/exec.txt
+++ b/.github/docker/centreon-web/alma9/slim-configuration/exec.txt
@@ -13,6 +13,8 @@ curl -s -d '{"check":{"is_forced":true},"resources":[{"id":26,"parent":{"id":14}
 dnf search vim
 dnf clean all
 
+lua /usr/share/centreon-broker/lua/centreon-cloud-notifications.lua
+
 systemctl stop gorgoned
 systemctl stop centengine
 systemctl stop cbd

--- a/.github/docker/centreon-web/bookworm/Dockerfile
+++ b/.github/docker/centreon-web/bookworm/Dockerfile
@@ -61,6 +61,8 @@ rm -f /tmp/mydumper_*
 mkdir -p /usr/local/src/sql/databases
 mydumper -h localhost -P 3306 -u root -G -o /usr/local/src/sql/databases/centreon -B centreon
 mydumper -h localhost -P 3306 -u root -G -o /usr/local/src/sql/databases/centreon_storage -B centreon_storage
+sed -i -e 's/NO_AUTO_CREATE_USER//g' -e "s#text DEFAULT ''#text DEFAULT ('')#" /usr/local/src/sql/databases/centreon/*
+sed -i -e 's/NO_AUTO_CREATE_USER//g' /usr/local/src/sql/databases/centreon_storage/*
 
 systemctl stop gorgoned
 systemctl stop centengine

--- a/.github/docker/centreon-web/bookworm/entrypoint/container.d/20-configuration_files.sh
+++ b/.github/docker/centreon-web/bookworm/entrypoint/container.d/20-configuration_files.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-centreon -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1
-centreon -u admin -p Centreon\!2021 -a CFGMOVE -v 1
+su www-data -s /bin/bash  -c "centreon -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1"
+su www-data -s /bin/bash  -c "centreon -u admin -p Centreon\!2021 -a CFGMOVE -v 1"

--- a/.github/docker/centreon-web/bookworm/slim-configuration/exec.txt
+++ b/.github/docker/centreon-web/bookworm/slim-configuration/exec.txt
@@ -14,6 +14,8 @@ apt-get update
 apt search centreon
 apt-get clean
 
+lua /usr/share/centreon-broker/lua/centreon-cloud-notifications.lua
+
 systemctl stop gorgoned
 systemctl stop centengine
 systemctl stop cbd

--- a/.github/docker/centreon-web/bullseye/Dockerfile
+++ b/.github/docker/centreon-web/bullseye/Dockerfile
@@ -61,6 +61,8 @@ rm -f /tmp/mydumper_*
 mkdir -p /usr/local/src/sql/databases
 mydumper -h localhost -P 3306 -u root -G -o /usr/local/src/sql/databases/centreon -B centreon
 mydumper -h localhost -P 3306 -u root -G -o /usr/local/src/sql/databases/centreon_storage -B centreon_storage
+sed -i -e 's/NO_AUTO_CREATE_USER//g' -e "s#text DEFAULT ''#text DEFAULT ('')#" /usr/local/src/sql/databases/centreon/*
+sed -i -e 's/NO_AUTO_CREATE_USER//g' /usr/local/src/sql/databases/centreon_storage/*
 
 systemctl stop gorgoned
 systemctl stop centengine

--- a/.github/docker/centreon-web/bullseye/entrypoint/container.d/20-configuration_files.sh
+++ b/.github/docker/centreon-web/bullseye/entrypoint/container.d/20-configuration_files.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-centreon -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1
-centreon -u admin -p Centreon\!2021 -a CFGMOVE -v 1
+su www-data -s /bin/bash  -c "centreon -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1"
+su www-data -s /bin/bash  -c "centreon -u admin -p Centreon\!2021 -a CFGMOVE -v 1"

--- a/.github/docker/centreon-web/bullseye/slim-configuration/exec.txt
+++ b/.github/docker/centreon-web/bullseye/slim-configuration/exec.txt
@@ -14,6 +14,8 @@ apt-get update
 apt search centreon
 apt-get clean
 
+lua /usr/share/centreon-broker/lua/centreon-cloud-notifications.lua
+
 systemctl stop gorgoned
 systemctl stop centengine
 systemctl stop cbd

--- a/.github/docker/centreon-web/jammy/Dockerfile
+++ b/.github/docker/centreon-web/jammy/Dockerfile
@@ -61,6 +61,8 @@ rm -f /tmp/mydumper_*
 mkdir -p /usr/local/src/sql/databases
 mydumper -h localhost -P 3306 -u root -G -o /usr/local/src/sql/databases/centreon -B centreon
 mydumper -h localhost -P 3306 -u root -G -o /usr/local/src/sql/databases/centreon_storage -B centreon_storage
+sed -i -e 's/NO_AUTO_CREATE_USER//g' -e "s#text DEFAULT ''#text DEFAULT ('')#" /usr/local/src/sql/databases/centreon/*
+sed -i -e 's/NO_AUTO_CREATE_USER//g' /usr/local/src/sql/databases/centreon_storage/*
 
 systemctl stop gorgoned
 systemctl stop centengine

--- a/.github/docker/centreon-web/jammy/entrypoint/container.d/20-configuration_files.sh
+++ b/.github/docker/centreon-web/jammy/entrypoint/container.d/20-configuration_files.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-centreon -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1
-centreon -u admin -p Centreon\!2021 -a CFGMOVE -v 1
+su www-data -s /bin/bash  -c "centreon -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1"
+su www-data -s /bin/bash  -c "centreon -u admin -p Centreon\!2021 -a CFGMOVE -v 1"

--- a/.github/docker/centreon-web/jammy/slim-configuration/exec.txt
+++ b/.github/docker/centreon-web/jammy/slim-configuration/exec.txt
@@ -1,8 +1,7 @@
-sleep 5
+timeout 30 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost/centreon/api/latest/platform/versions)" != "200" ]]; do sleep 5; done'
 
 su - www-data -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear"
 
-timeout 20 bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost/centreon/api/latest/platform/versions)" != "200" ]]; do sleep 5; done'
 curl -s http://localhost/centreon/login
 
 centreon -d -u admin -p Centreon\!2021 -a APPLYCFG -v 1
@@ -11,15 +10,16 @@ su - centreon-gorgone -s /bin/bash -c "sudo service centengine reload"
 API_TOKEN=$(curl -s -d '{"security": {"credentials": {"login": "admin","password": "Centreon!2021"}}}' -H "Content-Type: application/json" -X POST http://127.0.0.1/centreon/api/latest/login | jq -r .security.token)
 curl -s -d '{"check":{"is_forced":true},"resources":[{"id":26,"parent":{"id":14},"type":"service"},{"id":14,"parent":null,"type":"host"}]}' -H "X-AUTH-TOKEN:$API_TOKEN" -H "Content-Type: application/json" -X POST 'http://127.0.0.1/centreon/api/latest/monitoring/resources/check'
 
-sleep 5
+apt-get update
+apt search centreon
+apt-get clean
 
-systemctl stop php8.1-fpm
-systemctl stop apache2
+lua /usr/share/centreon-broker/lua/centreon-cloud-notifications.lua
+
 systemctl stop gorgoned
 systemctl stop centengine
 systemctl stop cbd
-timeout 30 service mysql stop
+systemctl stop php8.1-fpm
+systemctl stop apache2
 
 rm -f /tmp/gorgone/*.ipc /var/log/centreon*/*.log /var/lib/centreon-gorgone/history.sdb
-
-sleep 5

--- a/.github/workflows/cypress-component-parallelization.yml
+++ b/.github/workflows/cypress-component-parallelization.yml
@@ -173,7 +173,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        type_of_report: [test-reports, test-coverage]
+        type_of_report: [test-results, test-reports, test-coverage]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
@@ -182,6 +182,6 @@ jobs:
         if: ${{ ( contains(needs.cypress-component-test-run.result, 'failure') && ( matrix.type_of_report == 'test-reports' ) ) || matrix.type_of_report == 'test-coverage' }}
         with:
           target_name: ${{ inputs.name }}-${{ matrix.type_of_report }}
-          source_paths: ${{ inputs.name }}-${{ matrix.type_of_report }}/**/*.json
+          source_paths: ${{ inputs.name }}-${{ matrix.type_of_report }}/**
           source_name_pattern: ${{ inputs.name }}-${{ matrix.type_of_report }}-
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cypress-e2e-parallelization.yml
+++ b/.github/workflows/cypress-e2e-parallelization.yml
@@ -268,6 +268,6 @@ jobs:
         if: ${{ ( contains(needs.cypress-e2e-test-run.result, 'failure') && ( matrix.type_of_report == 'test-results' || matrix.type_of_report == 'test-reports' ) ) || matrix.type_of_report == 'xray-reports' }}
         with:
           target_name: ${{ inputs.name }}-${{ inputs.os }}-${{ matrix.type_of_report }}
-          source_paths: ${{ inputs.name }}-${{ inputs.os }}-${{ matrix.type_of_report }}/**/*.json
+          source_paths: ${{ inputs.name }}-${{ inputs.os }}-${{ matrix.type_of_report }}/**
           source_name_pattern: ${{ inputs.name }}-${{ inputs.os }}-${{ matrix.type_of_report }}-
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -288,7 +288,7 @@ jobs:
           runner: ubuntu-22.04
 
       - name: Install dependencies
-        uses: ramsey/composer-install@83af392bf5f031813d25e6fe4cd626cdba9a2df6 # v2.2.0
+        uses: ramsey/composer-install@57532f8be5bda426838819c5ee9afb8af389d51a # v3.0.0
         with:
           working-directory: centreon
           composer-options: "--optimize-autoloader"

--- a/centreon-gorgone/config/gorgoned-central-ssh.yml
+++ b/centreon-gorgone/config/gorgoned-central-ssh.yml
@@ -43,7 +43,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy

--- a/centreon-gorgone/config/gorgoned-central-zmq.yml
+++ b/centreon-gorgone/config/gorgoned-central-zmq.yml
@@ -67,7 +67,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy

--- a/centreon-gorgone/config/gorgoned-poller.yml
+++ b/centreon-gorgone/config/gorgoned-poller.yml
@@ -25,7 +25,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: engine

--- a/centreon-gorgone/config/gorgoned-remote-ssh.yml
+++ b/centreon-gorgone/config/gorgoned-remote-ssh.yml
@@ -30,7 +30,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy

--- a/centreon-gorgone/config/gorgoned-remote-zmq.yml
+++ b/centreon-gorgone/config/gorgoned-remote-zmq.yml
@@ -35,7 +35,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy

--- a/centreon-gorgone/contrib/gorgone_config_init.pl
+++ b/centreon-gorgone/contrib/gorgone_config_init.pl
@@ -133,7 +133,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy

--- a/centreon-gorgone/docs/migration.md
+++ b/centreon-gorgone/docs/migration.md
@@ -65,7 +65,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: cron

--- a/centreon-gorgone/docs/modules/core/action.md
+++ b/centreon-gorgone/docs/modules/core/action.md
@@ -31,7 +31,7 @@ allowed_cmds:
   - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
   - ^centreon
   - ^mkdir
-  - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+  - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
   - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 ```
 

--- a/centreon-gorgone/docs/poller_pull_configuration.md
+++ b/centreon-gorgone/docs/poller_pull_configuration.md
@@ -50,7 +50,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: engine

--- a/centreon-gorgone/docs/rebound_configuration.md
+++ b/centreon-gorgone/docs/rebound_configuration.md
@@ -54,7 +54,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: engine

--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -414,6 +414,12 @@ paths:
         * name
         * alias
         * is_activated
+        * host.id
+        * host.name
+        * hostgroup.id
+        * hostgroup.name
+        * hostcategory.id
+        * hostcategory.name
       responses:
         "200":
           description: "OK"

--- a/centreon/doc/API/centreon-cloud-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-cloud-api-v24.04.yaml
@@ -49,4 +49,6 @@ paths:
   /administration/resource-access/rules:
     $ref: "./latest/Cloud/ResourceAccessManagement/AddAndFindRules.yaml"
   /administration/resource-access/rules/{rule_id}:
-    $ref: "./latest/Cloud/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml"
+    $ref: "./latest/Cloud/ResourceAccessManagement/FindUpdateAndDeleteRule.yaml"
+  /administration/resource-access/rules/_delete:
+    $ref: "./latest/Cloud/ResourceAccessManagement/DeleteRules.yaml"

--- a/centreon/doc/API/centreon-cloud-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-cloud-api-v24.04.yaml
@@ -49,4 +49,4 @@ paths:
   /administration/resource-access/rules:
     $ref: "./latest/Cloud/ResourceAccessManagement/AddAndFindRules.yaml"
   /administration/resource-access/rules/{rule_id}:
-    $ref: "./latest/Cloud/ResourceAccessManagement/FindUpdateAndDeleteRule.yaml"
+    $ref: "./latest/Cloud/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml"

--- a/centreon/doc/API/latest/Cloud/ResourceAccessManagement/DeleteRules.yaml
+++ b/centreon/doc/API/latest/Cloud/ResourceAccessManagement/DeleteRules.yaml
@@ -1,0 +1,18 @@
+post:
+  tags:
+    - Resource Access Management
+  summary: 'Delete multiple resource access rule configurations'
+  description: |
+    Delete multiple resource access rule configurations
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: "Schema/DeleteRulesRequest.yaml"
+  responses:
+    '207': { $ref: '../../../Common/Response/MultiStatus.yaml' }
+    '400': { $ref: '../../../Common/Response/BadRequest.yaml' }
+    '403': { $ref: '../../../Common/Response/Forbidden.yaml' }
+    '500': { $ref: '../../../Common/Response/InternalServerError.yaml' }
+

--- a/centreon/doc/API/latest/Cloud/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml
+++ b/centreon/doc/API/latest/Cloud/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml
@@ -107,4 +107,36 @@ delete:
       $ref: '../../../Common/Response/NotFound.yaml'
     '500':
       $ref: '../../../Common/Response/InternalServerError.yaml'
+patch:
+  tags:
+    - Resource Access Management
+  summary: "Update partially a resource access rule"
+  description: |
+    Partial update of resource access rule configuration.
+    The available parameters to **update** are:
+
+    * name
+    * description
+    * is_enabled
+  parameters:
+    - $ref: 'QueryParameter/RuleId.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: 'Schema/PartialRuleUpdateRequest.yaml'
+  responses:
+    '204':
+      $ref: '../../../Common/Response/NoContent.yaml'
+    '400':
+      $ref: '../../../Common/Response/BadRequest.yaml'
+    '403':
+      $ref: '../../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../../Common/Response/NotFound.yaml'
+    '409':
+      $ref: '../../../Common/Response/Conflict.yaml'
+    '500':
+      $ref: '../../../Common/Response/InternalServerError.yaml'
 

--- a/centreon/doc/API/latest/Cloud/ResourceAccessManagement/Schema/DeleteRulesRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/ResourceAccessManagement/Schema/DeleteRulesRequest.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  ids:
+    type: array
+    description: List of resource access rule IDs to delete
+    items:
+      type: integer
+

--- a/centreon/doc/API/latest/Cloud/ResourceAccessManagement/Schema/PartialRuleUpdateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/ResourceAccessManagement/Schema/PartialRuleUpdateRequest.yaml
@@ -1,0 +1,15 @@
+type: object
+properties:
+  name:
+    type: string
+    description: "Resource access rule name"
+    example: "Rule for viewers"
+  description:
+    type: string
+    nullable: true
+    description: "Short description of the rule"
+    example: "Rule dedicated for users with limited rights"
+  is_enabled:
+    type: boolean
+    description: "Indicate the status of the rule enabled/disabled"
+    example: true

--- a/centreon/lib/Centreon/Object/Acknowledgement/RtAcknowledgement.php
+++ b/centreon/lib/Centreon/Object/Acknowledgement/RtAcknowledgement.php
@@ -127,7 +127,7 @@ class Centreon_Object_RtAcknowledgement extends Centreon_ObjectRt
                         AND host.host_id = ack.host_id
                     WHERE service.acknowledged = 1
                     %s
-                    GROUP BY host.name, service.description) AS tmp
+                    GROUP BY host.host_id, service.service_id) AS tmp
                     ON tmp.entry_time = ack.entry_time
                     AND tmp.host_id = ack.host_id
                     AND tmp.service_id = ack.service_id

--- a/centreon/lib/Centreon/Object/Dependency/DependencyHostParent.php
+++ b/centreon/lib/Centreon/Object/Dependency/DependencyHostParent.php
@@ -32,14 +32,15 @@ class Centreon_Object_DependencyHostParent extends Centreon_Object
 
     public function removeRelationLastHostDependency(int $hostId): void
     {
-        $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id 
-              FROM dependency_hostParent_relation 
-              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_hostParent_relation 
-                                         WHERE host_host_id = ?)';
+        $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id
+              FROM dependency_hostParent_relation
+              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_hostParent_relation
+                                         WHERE host_host_id = ?)
+              GROUP BY dependency_dep_id';
         $result = $this->getResult($query, array($hostId), "fetch");
 
         //is last parent
-        if ($result['nb_dependency'] == 1) {
+        if (isset($result['nb_dependency']) && $result['nb_dependency'] == 1) {
             $this->db->query("DELETE FROM dependency WHERE dep_id = " . $result['id']);
         }
     }

--- a/centreon/lib/Centreon/Object/Dependency/DependencyHostgroupParent.php
+++ b/centreon/lib/Centreon/Object/Dependency/DependencyHostgroupParent.php
@@ -32,14 +32,15 @@ class Centreon_Object_DependencyHostgroupParent extends Centreon_Object
 
     public function removeRelationLastHostgroupDependency(int $hgId): void
     {
-        $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id 
-              FROM dependency_hostgroupParent_relation 
-              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_hostgroupParent_relation 
-                                         WHERE hostgroup_hg_id = ?)';
+        $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id
+              FROM dependency_hostgroupParent_relation
+              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_hostgroupParent_relation
+                                         WHERE hostgroup_hg_id = ?)
+              GROUP BY dependency_dep_id';
         $result = $this->getResult($query, array($hgId), "fetch");
 
         //is last parent
-        if ($result['nb_dependency'] == 1) {
+        if (isset($result['nb_dependency']) && $result['nb_dependency'] == 1) {
             $this->db->query("DELETE FROM dependency WHERE dep_id = " . $result['id']);
         }
     }

--- a/centreon/lib/Centreon/Object/Dependency/DependencyServiceParent.php
+++ b/centreon/lib/Centreon/Object/Dependency/DependencyServiceParent.php
@@ -32,14 +32,15 @@ class Centreon_Object_DependencyServiceParent extends Centreon_Object
 
     public function removeRelationLastServiceDependency(int $serviceId): void
     {
-        $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id 
-              FROM dependency_serviceParent_relation 
-              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_serviceParent_relation 
-                                         WHERE service_service_id = ?)';
+        $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id
+              FROM dependency_serviceParent_relation
+              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_serviceParent_relation
+                                         WHERE service_service_id = ?)
+              GROUP BY dependency_dep_id';
         $result = $this->getResult($query, array($serviceId), "fetch");
 
         //is last parent
-        if ($result['nb_dependency'] == 1) {
+        if (isset($result['nb_dependency']) && $result['nb_dependency'] == 1) {
             $this->db->query("DELETE FROM dependency WHERE dep_id = " . $result['id']);
         }
     }

--- a/centreon/lib/Centreon/Object/Dependency/DependencyServicegroupParent.php
+++ b/centreon/lib/Centreon/Object/Dependency/DependencyServicegroupParent.php
@@ -32,14 +32,15 @@ class Centreon_Object_DependencyServicegroupParent extends Centreon_Object
 
     public function removeRelationLastServicegroupDependency(int $servicegroupId): void
     {
-        $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id 
-              FROM dependency_servicegroupParent_relation 
-              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_servicegroupParent_relation 
-                                         WHERE servicegroup_sg_id = ?)';
+        $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id
+              FROM dependency_servicegroupParent_relation
+              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_servicegroupParent_relation
+                                         WHERE servicegroup_sg_id = ?)
+              GROUP BY dependency_dep_id';
         $result = $this->getResult($query, array($servicegroupId), "fetch");
 
         //is last parent
-        if ($result['nb_dependency'] == 1) {
+        if (isset($result['nb_dependency']) && $result['nb_dependency'] == 1) {
             $this->db->query("DELETE FROM dependency WHERE dep_id = " . $result['id']);
         }
     }

--- a/centreon/packages/js-config/cypress/e2e/configuration.ts
+++ b/centreon/packages/js-config/cypress/e2e/configuration.ts
@@ -59,7 +59,7 @@ export default ({
     },
     env: {
       ...env,
-      DATABASE_IMAGE: 'bitnami/mariadb:10.5',
+      DATABASE_IMAGE: 'bitnami/mariadb:10.11',
       OPENID_IMAGE_VERSION: process.env.MAJOR || '24.04',
       SAML_IMAGE_VERSION: process.env.MAJOR || '24.04',
       WEB_IMAGE_OS: 'alma9',

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -106,7 +106,7 @@ export default (on: Cypress.PluginEvents): void => {
       const { exitCode, output } = await getContainer(name).exec([
         'bash',
         '-c',
-        command
+        `${command}${command.match(/[\n\r]/) ? '' : ' 2>&1'}`
       ]);
 
       return { exitCode, output };

--- a/centreon/packaging/centreon-web.yaml
+++ b/centreon/packaging/centreon-web.yaml
@@ -511,7 +511,7 @@ overrides:
       - gettext
       - rsync
       - brotli
-      - lua-curl
+      - lua5.3-curl
     provides:
       - centreon-web-apache
       - centreon-web-common

--- a/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsCommand.php
+++ b/centreon/src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsCommand.php
@@ -55,7 +55,7 @@ class MigrateAllCommandsCommand extends AbstractMigrationCommand
         $this->addArgument(
             'target-url',
             InputArgument::REQUIRED,
-            "The target platform base url to connect to the API (ex: 'http://localhost')"
+            "The target platform base url to connect to the API (ex: 'http://localhost/centreon')"
         );
         $this->setHelp(
             "Migrates all commands to the target platform.\r\n"

--- a/centreon/src/Core/Command/Infrastructure/Repository/ApiWriteCommandRepository.php
+++ b/centreon/src/Core/Command/Infrastructure/Repository/ApiWriteCommandRepository.php
@@ -48,7 +48,7 @@ class ApiWriteCommandRepository implements WriteCommandRepositoryInterface
      */
     public function add(NewCommand $command): int
     {
-        $apiEndpoint = $this->url . DIRECTORY_SEPARATOR . 'centreon/api/latest/configuration/commands';
+        $apiEndpoint = $this->url . '/api/latest/configuration/commands';
         $options = [
             'verify_peer' => true,
             'verify_host' => true,

--- a/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardPerformanceMetricRepository.php
@@ -464,7 +464,8 @@ class DbReadDashboardPerformanceMetricRepository extends AbstractRepositoryDRB i
                 SQL;
         }
 
-        $request .= $this->sqlRequestTranslator->translateSortParameterToSql();
+        $sortRequest = $this->sqlRequestTranslator->translateSortParameterToSql();
+        $request .= $sortRequest !== null ? $sortRequest : ' ORDER BY m.metric_id ASC';
         $request .= $this->sqlRequestTranslator->translatePaginationToSql();
 
         return $request;

--- a/centreon/src/Core/Host/Infrastructure/Repository/DbReadHostRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbReadHostRepository.php
@@ -611,7 +611,7 @@ class DbReadHostRepository extends AbstractRepositoryRDB implements ReadHostRepo
         $request .= $search !== null
             ? ' AND h.host_register = \'1\''
             : ' WHERE h.host_register = \'1\'';
-        $request .= ' GROUP BY h.host_id';
+        $request .= ' GROUP BY h.host_id, ns.id, ns.name';
 
         // Sort
         $sortRequest = $sqlTranslator->translateSortParameterToSql();

--- a/centreon/src/Core/Notification/Infrastructure/Repository/DbReadNotificationRepository.php
+++ b/centreon/src/Core/Notification/Infrastructure/Repository/DbReadNotificationRepository.php
@@ -164,6 +164,7 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
                 FROM `:db`.notification_user_relation
                 JOIN contact ON user_id = contact_id
                 WHERE notification_id = :notificationId
+                ORDER BY contact.contact_name ASC
                 SQL
         );
         $statement = $this->db->prepare($request);
@@ -203,6 +204,7 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
             INNER JOIN `:db`.contactgroup cg ON cg.cg_id=cgcr.contactgroup_cg_id
             INNER JOIN `:db`.contact c ON c.contact_id=cgcr.contact_contact_id
             WHERE cg.cg_id IN (:contact_group_ids)
+            ORDER BY c.contact_name ASC
             SQL;
 
         $concatenator = (new SqlConcatenator())
@@ -244,6 +246,7 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
                 FROM `:db`.notification_contactgroup_relation
                 JOIN `:db`.contactgroup ON cg_id = contactgroup_id
                 WHERE notification_id = :notificationId
+                ORDER BY contactgroup.cg_name ASC
                 SQL
         );
         $statement = $this->db->prepare($request);
@@ -280,7 +283,7 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
                         SELECT cg_rel.notification_id, contactgroup_id as user
                         FROM notification_contactgroup_relation cg_rel
                         WHERE cg_rel.notification_id IN ({$bindToken})
-                    ) as subquery GROUP BY notification_id;
+                    ) as subquery GROUP BY notification_id
                     SQL
             )
         );
@@ -309,7 +312,8 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
                         ON ncr.contactgroup_id = cg.cg_id
                     WHERE ccr.contact_contact_id = :userId
                     AND ncr.notification_id = :notificationId
-                    AND cg_activate = '1';
+                    AND cg_activate = '1'
+                    ORDER BY cg_name ASC
                     SQL
             )
         );

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/AddRule/AddRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/AddRule/AddRule.php
@@ -75,11 +75,6 @@ final class AddRule
         AddRulePresenterInterface $presenter
     ): void {
         try {
-            /**
-             * Check if current user is authorized to perform the action.
-             * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
-             * are authorized to add a Resource Access Rule.
-             */
             if (! $this->isAuthorized()) {
                 $this->error(
                     "User doesn't have sufficient rights to create a resource access rule",
@@ -153,6 +148,13 @@ final class AddRule
         }
     }
 
+    /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
+     * @return bool
+     */
     private function isAuthorized(): bool
     {
         $userAccessGroupNames = array_map(

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRules.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRules.php
@@ -1,0 +1,176 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\ResourceAccess\Application\Exception\RuleException;
+use Core\ResourceAccess\Application\Repository\ReadResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\Repository\WriteResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Domain\Model\ResponseCode;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+
+final class DeleteRules
+{
+    use LoggerTrait;
+    public const AUTHORIZED_ACL_GROUPS = ['customer_admin_acl'];
+
+    /**
+     * @param ReadResourceAccessRepositoryInterface $readRepository
+     * @param WriteResourceAccessRepositoryInterface $writeRepository
+     * @param ContactInterface $user
+     * @param ReadAccessGroupRepositoryInterface $accessGroupRepository
+     * @param DataStorageEngineInterface $dataStorageEngine
+     */
+    public function __construct(
+        private readonly ReadResourceAccessRepositoryInterface $readRepository,
+        private readonly WriteResourceAccessRepositoryInterface $writeRepository,
+        private readonly ContactInterface $user,
+        private readonly ReadAccessGroupRepositoryInterface $accessGroupRepository,
+        private readonly DataStorageEngineInterface $dataStorageEngine
+    ) {
+    }
+
+    /**
+     * @param DeleteRulesRequest $request
+     * @param DeleteRulesPresenterInterface $presenter
+     */
+    public function __invoke(DeleteRulesRequest $request, DeleteRulesPresenterInterface $presenter): void
+    {
+        try {
+            if (! $this->isAuthorized()) {
+                $this->error(
+                    "User doesn't have sufficient rights to delete a resource access rule",
+                    [
+                        'user_id' => $this->user->getId(),
+                    ]
+                );
+                $response = new ForbiddenResponse(RuleException::notAllowed()->getMessage());
+            } else {
+                $this->debug('Starting transaction');
+                $this->dataStorageEngine->startTransaction();
+
+                $response = new DeleteRulesResponse();
+
+                foreach ($request->ids as $ruleId) {
+                    try {
+                        $statusResponse = $this->deleteRule($ruleId);
+                        $response->responseStatuses[] = $this->createResponseStatusDto($ruleId, $statusResponse);
+                    } catch (\Throwable $exception) {
+                        $statusResponse = new ErrorResponse(RuleException::errorWhileDeleting($exception));
+                        $response->responseStatuses[] = $this->createResponseStatusDto($ruleId, $statusResponse);
+                        $this->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
+                    }
+                }
+
+                $this->debug('Commit transaction');
+                $this->dataStorageEngine->commitTransaction();
+            }
+        } catch (\Throwable $exception) {
+            $this->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
+            $response = new ErrorResponse(RuleException::errorWhileDeleting($exception));
+        }
+
+        $presenter->presentResponse($response);
+    }
+
+    /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
+     * @return bool
+     */
+    private function isAuthorized(): bool
+    {
+        $userAccessGroupNames = array_map(
+            static fn (AccessGroup $accessGroup): string => $accessGroup->getName(),
+            $this->accessGroupRepository->findByContact($this->user)
+        );
+
+        /**
+         * User must be
+         *     - An admin (belongs to the centreon_admin_acl ACL group)
+         *     - authorized to reach the Resource Access Management page.
+         */
+        return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+    }
+
+    /**
+     * @param int $ruleId
+     *
+     * @throws \Exception
+     * @throws \Throwable
+     */
+    private function deleteRule(int $ruleId): ResponseStatusInterface
+    {
+        $this->info('Start resource access rule deletion', ['rule_id' => $ruleId]);
+
+        if (! $this->readRepository->exists($ruleId)) {
+            $this->error('Resource access rule not found', ['rule_id' => $ruleId]);
+
+            return new NotFoundResponse('Resource access rule');
+        }
+
+        $this->writeRepository->deleteRuleAndDatasets($ruleId);
+
+        return new NoContentResponse();
+    }
+
+    /**
+     * @param int $ruleId
+     * @param ResponseStatusInterface $statusResponse
+     *
+     * @return DeleteRulesStatusResponse
+     */
+    private function createResponseStatusDto(
+        int $ruleId,
+        ResponseStatusInterface $statusResponse
+    ): DeleteRulesStatusResponse {
+        $dto = new DeleteRulesStatusResponse();
+        $dto->id = $ruleId;
+
+        if ($statusResponse instanceof NotFoundResponse) {
+            $dto->status = ResponseCode::NotFound;
+            $dto->message = $statusResponse->getMessage();
+        } elseif ($statusResponse instanceof NoContentResponse) {
+            $dto->status = ResponseCode::OK;
+            $dto->message = null;
+        } else {
+            $dto->status = ResponseCode::Error;
+            $dto->message = $statusResponse->getMessage();
+        }
+
+        return $dto;
+    }
+}

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesPresenterInterface.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesPresenterInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+interface DeleteRulesPresenterInterface
+{
+    /**
+     * @param DeleteRulesResponse|ResponseStatusInterface $data
+     */
+    public function presentResponse(DeleteRulesResponse|ResponseStatusInterface $data): void;
+}

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesRequest.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+final class DeleteRulesRequest
+{
+    /** @var int[] */
+    public array $ids = [];
+}
+

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesResponse.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+final class DeleteRulesResponse
+{
+    /** @var DeleteRulesStatusResponse[] */
+    public array $responseStatuses = [];
+}
+

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesStatusResponse.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesStatusResponse.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+use Core\ResourceAccess\Domain\Model\ResponseCode;
+
+final class DeleteRulesStatusResponse
+{
+    public int $id = 0;
+
+    public ResponseCode $status = ResponseCode::OK;
+
+    public ?string $message = null;
+}

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
@@ -124,6 +124,7 @@ final class FindRule
         $response->id = $rule->getId();
         $response->name = $rule->getName();
         $response->description = $rule->getDescription();
+        $response->isEnabled = $rule->isEnabled();
 
         // retrieve names of linked contact IDs
         $response->contacts = array_values(
@@ -173,6 +174,10 @@ final class FindRule
     }
 
     /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
      * @return bool
      */
     private function isAuthorized(): bool

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRules/FindRules.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRules/FindRules.php
@@ -62,8 +62,6 @@ final class FindRules
     {
         $this->info('Finding resource access rules', ['request_parameters' => $this->requestParameters]);
 
-        // check if current user is authorized to perform the action.
-        // Only users linked to AUTHORIZED_ACL_GROUPS and having access in RW to the page are authorized
         if (! $this->isAuthorized()) {
             $this->error(
                 "User doesn't have sufficient rights to list resource access rules",
@@ -115,6 +113,10 @@ final class FindRules
     }
 
     /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
      * @return bool
      */
     private function isAuthorized(): bool

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdate.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdate.php
@@ -21,51 +21,63 @@
 
 declare(strict_types=1);
 
-namespace Core\ResourceAccess\Application\UseCase\DeleteRule;
+namespace Core\ResourceAccess\Application\UseCase\PartialRuleUpdate;
 
+use Assert\AssertionFailedException;
 use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ConflictResponse;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\PresenterInterface;
+use Core\Common\Application\Type\NoValue;
 use Core\ResourceAccess\Application\Exception\RuleException;
 use Core\ResourceAccess\Application\Repository\ReadResourceAccessRepositoryInterface;
 use Core\ResourceAccess\Application\Repository\WriteResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\UseCase\UpdateRule\UpdateRuleValidation;
+use Core\ResourceAccess\Domain\Model\Rule;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 
-final class DeleteRule
+final class PartialRuleUpdate
 {
     use LoggerTrait;
     public const AUTHORIZED_ACL_GROUPS = ['customer_admin_acl'];
 
     /**
-     * @param ReadResourceAccessRepositoryInterface $readRepository
-     * @param WriteResourceAccessRepositoryInterface $writeRepository
      * @param ContactInterface $user
      * @param ReadAccessGroupRepositoryInterface $accessGroupRepository
+     * @param ReadResourceAccessRepositoryInterface $readRepository
+     * @param WriteResourceAccessRepositoryInterface $writeRepository
+     * @param UpdateRuleValidation $validator
      */
     public function __construct(
-        private readonly ReadResourceAccessRepositoryInterface $readRepository,
-        private readonly WriteResourceAccessRepositoryInterface $writeRepository,
         private readonly ContactInterface $user,
         private readonly ReadAccessGroupRepositoryInterface $accessGroupRepository,
+        private readonly ReadResourceAccessRepositoryInterface $readRepository,
+        private readonly WriteResourceAccessRepositoryInterface $writeRepository,
+        private readonly UpdateRuleValidation $validator,
     ) {
     }
 
     /**
-     * @param int $ruleId
+     * @param PartialRuleUpdateRequest $request
      * @param PresenterInterface $presenter
      */
-    public function __invoke(int $ruleId, PresenterInterface $presenter): void
-    {
+    public function __invoke(
+        PartialRuleUpdateRequest $request,
+        PresenterInterface $presenter
+    ): void {
         try {
+            $this->info('Start resource access rule update process');
+
             if (! $this->isAuthorized()) {
                 $this->error(
-                    "User doesn't have sufficient rights to delete a resource access rule",
+                    "User doesn't have sufficient rights to create a resource access rule",
                     [
                         'user_id' => $this->user->getId(),
                     ]
@@ -77,20 +89,60 @@ final class DeleteRule
                 return;
             }
 
-            $this->info('Starting resource access rule deletion', ['rule_id' => $ruleId]);
-            if (! $this->readRepository->exists($ruleId)) {
-                $this->error('Resource access rule not found', ['rule_id' => $ruleId]);
+            $this->debug('Find resource access rule to partially update', ['id' => $request->id]);
+            $rule = $this->readRepository->findById($request->id);
+
+            if ($rule === null) {
                 $presenter->setResponseStatus(new NotFoundResponse('Resource access rule'));
 
                 return;
             }
 
-            $this->deleteRule($ruleId);
+            $this->updatePropertiesInTransaction($rule, $request);
             $presenter->setResponseStatus(new NoContentResponse());
+        } catch (RuleException $exception) {
+            $presenter->setResponseStatus(
+                match ($exception->getCode()) {
+                    RuleException::CODE_CONFLICT => new ConflictResponse($exception),
+                    default => new ErrorResponse($exception),
+                }
+            );
+            $this->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
+        } catch (AssertionFailedException $ex) {
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
         } catch (\Throwable $exception) {
-            $presenter->setResponseStatus(new ErrorResponse(RuleException::errorWhileDeleting($exception)));
+            $presenter->setResponseStatus(new ErrorResponse(RuleException::addRule()));
             $this->error($exception->getMessage(), ['trace' => $exception->getTraceAsString()]);
         }
+    }
+
+    /**
+     * @param Rule $rule
+     * @param PartialRuleUpdateRequest $request
+     *
+     * @throws RuleException
+     * @throws AssertionFailedException
+     * @throws \Exception
+     */
+    private function updatePropertiesInTransaction(Rule $rule, PartialRuleUpdateRequest $request): void
+    {
+        $this->info('Partial resource access rule update', ['rule_id' => $rule->getId()]);
+
+        if (! $request->name instanceof NoValue) {
+            $this->validator->assertIsValidName($request->name);
+            $rule->setName($request->name);
+        }
+
+        if (! $request->description instanceof NoValue) {
+            $rule->setDescription($request->description ?? '');
+        }
+
+        if (! $request->isEnabled instanceof NoValue) {
+            $rule->setIsEnabled($request->isEnabled);
+        }
+
+        $this->writeRepository->update($rule);
     }
 
     /**
@@ -107,24 +159,7 @@ final class DeleteRule
             $this->accessGroupRepository->findByContact($this->user)
         );
 
-        /**
-         * User must be
-         *     - An admin (belongs to the centreon_admin_acl ACL group)
-         *     - authorized to reach the Resource Access Management page.
-         */
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
             && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
-    }
-
-    /**
-     * @param int $ruleId
-     *
-     * @throws \Exception
-     * @throws \Throwable
-     */
-    private function deleteRule(int $ruleId): void
-    {
-        $this->debug('Starting transaction');
-        $this->writeRepository->deleteRuleAndDatasets($ruleId);
     }
 }

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateRequest.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Application\UseCase\PartialRuleUpdate;
+
+use Core\Common\Application\Type\NoValue;
+
+final class PartialRuleUpdateRequest
+{
+    /**
+     * @param int $id
+     * @param NoValue|string $name
+     * @param NoValue|null|string $description
+     * @param NoValue|bool $isEnabled
+     */
+    public function __construct(
+        public int $id = 0,
+        public NoValue|string $name = new NoValue(),
+        public NoValue|null|string $description = new NoValue(),
+        public NoValue|bool $isEnabled = new NoValue(),
+    ) {
+    }
+}

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
@@ -75,11 +75,6 @@ final class UpdateRule
      */
     public function __invoke(UpdateRuleRequest $request, UpdateRulePresenterInterface $presenter): void
     {
-        /**
-         * Check if current user is authorized to perform the action.
-         * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
-         * are authorized to add a Resource Access Rule.
-         */
         if (! $this->isAuthorized()) {
             $this->error(
                 "User doesn't have sufficient rights to update a resource access rule",
@@ -446,7 +441,7 @@ final class UpdateRule
         sort($current);
         sort($update);
 
-        return array_diff($current, $update) !== [];
+        return $current !== $update;
     }
 
     /**
@@ -464,6 +459,10 @@ final class UpdateRule
     }
 
     /**
+     * Check if current user is authorized to perform the action.
+     * Only users linked to AUTHORIZED_ACL_GROUPS acl_group and having access in Read/Write rights on the page
+     * are authorized to add a Resource Access Rule.
+     *
      * @return bool
      */
     private function isAuthorized(): bool

--- a/centreon/src/Core/ResourceAccess/Domain/Model/ResponseCode.php
+++ b/centreon/src/Core/ResourceAccess/Domain/Model/ResponseCode.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Domain\Model;
+
+enum ResponseCode
+{
+    case OK;
+    case NotFound;
+    case Error;
+}
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRule/DeleteRuleRoute.yaml
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRule/DeleteRuleRoute.yaml
@@ -5,5 +5,3 @@ DeleteRule:
   condition: "request.attributes.get('version') >= 24.04 and request.attributes.get('feature.resource_access_management')"
   requirements:
     ruleId: '\d+'
-
-

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesController.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesController.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Infrastructure\API\DeleteRules;
+
+use Centreon\Application\Controller\AbstractController;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRules;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class DeleteRulesController extends AbstractController
+{
+    /**
+     * @param Request $request
+     * @param DeleteRules $useCase
+     * @param DeleteRulesPresenter $presenter
+     *
+     * @return Response
+     */
+    public function __invoke(
+        Request $request,
+        DeleteRules $useCase,
+        DeleteRulesPresenter $presenter
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        /**
+         * @var array{
+         *  ids: int[]
+         * } $data
+         */
+        $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/DeleteRulesSchema.json');
+        $useCase($this->createDtoFromData($data), $presenter);
+
+        return $presenter->show();
+    }
+
+    /**
+     * @param array{
+     *  ids: int[]
+     * } $data
+     *
+     * @return DeleteRulesRequest
+     */
+    private function createDtoFromData(array $data): DeleteRulesRequest
+    {
+        $dto = new DeleteRulesRequest();
+        $dto->ids = $data['ids'];
+
+        return $dto;
+    }
+}
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesPresenter.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesPresenter.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Infrastructure\API\DeleteRules;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\MultiStatusResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Infrastructure\Common\Api\Router;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesPresenterInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesResponse;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesStatusResponse;
+use Core\ResourceAccess\Domain\Model\ResponseCode;
+use Symfony\Component\HttpFoundation\Response;
+
+final class DeleteRulesPresenter extends AbstractPresenter implements DeleteRulesPresenterInterface
+{
+    use LoggerTrait;
+    private const ROUTE_NAME = 'DeleteRule';
+
+    /**
+     * @param PresenterFormatterInterface $presenterFormatter
+     * @param Router $router
+     */
+    public function __construct(
+        protected PresenterFormatterInterface $presenterFormatter,
+        private readonly Router $router
+    ) {
+        parent::__construct($presenterFormatter);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function presentResponse(DeleteRulesResponse|ResponseStatusInterface $response): void
+    {
+        if ($response instanceof DeleteRulesResponse) {
+            $multiStatusResponse = [
+                'results' => array_map(function (DeleteRulesStatusResponse $dto) {
+                    return [
+                        'self' => $this->getDeletedNotificationHref($dto->id),
+                        'status' => $this->enumToIntConverter($dto->status),
+                        'message' => $dto->message,
+                    ];
+                }, $response->responseStatuses),
+            ];
+
+            $this->present(new MultiStatusResponse($multiStatusResponse));
+        } else {
+            $this->setResponseStatus($response);
+        }
+    }
+
+    /**
+     * @param ResponseCode $code
+     *
+     * @return int
+     */
+    private function enumToIntConverter(ResponseCode $code): int
+    {
+        return match ($code) {
+            ResponseCode::OK => Response::HTTP_NO_CONTENT,
+            ResponseCode::NotFound => Response::HTTP_NOT_FOUND,
+            ResponseCode::Error => Response::HTTP_INTERNAL_SERVER_ERROR
+        };
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return string|null
+     */
+    private function getDeletedNotificationHref(int $id): ?string
+    {
+        try {
+            return $this->router->generate(self::ROUTE_NAME, ['ruleId' => $id]);
+        } catch (\Throwable $ex) {
+            $this->error('Impossible to generate the deleted entity route', [
+                'message' => $ex->getMessage(),
+                'trace' => $ex->getTraceAsString(),
+                'route' => self::ROUTE_NAME,
+                'payload' => $id,
+            ]);
+
+            return null;
+        }
+    }
+}

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesRoute.yaml
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesRoute.yaml
@@ -1,0 +1,5 @@
+DeleteRules:
+  methods: POST
+  path: /administration/resource-access/rules/_delete
+  controller: 'Core\ResourceAccess\Infrastructure\API\DeleteRules\DeleteRulesController'
+  condition: "request.attributes.get('version') >= 24.04 and request.attributes.get('feature.resource_access_management')"

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesSchema.json
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesSchema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Delete multiple rules at once",
+    "type": "object",
+    "additionalProperties": false,
+    "required": [
+        "ids"
+    ],
+    "properties": {
+        "ids": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            }
+        }
+    }
+}
+
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateController.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateController.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ResourceAccess\Infrastructure\API\PartialRuleUpdate;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\ResourceAccess\Application\UseCase\PartialRuleUpdate\PartialRuleUpdate;
+use Core\ResourceAccess\Application\UseCase\PartialRuleUpdate\PartialRuleUpdateRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+final class PartialRuleUpdateController extends AbstractController
+{
+    use LoggerTrait;
+
+    public function __invoke(
+        int $ruleId,
+        Request $request,
+        PartialRuleUpdate $useCase,
+        DefaultPresenter $presenter
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        try {
+            $dto = $this->createDtoFromRequest($ruleId, $request);
+            $useCase($dto, $presenter);
+        } catch (\InvalidArgumentException $ex) {
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+        }
+
+        return $presenter->show();
+    }
+
+    /**
+     * @param int $ruleId
+     * @param Request $request
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return PartialRuleUpdateRequest
+     */
+    private function createDtoFromRequest(int $ruleId, Request $request): PartialRuleUpdateRequest
+    {
+        /**
+         * @var array{
+         *      name?: string,
+         *      description?: string|null,
+         *      is_enabled?: bool
+         * }
+         */
+        $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/PartialRuleUpdateSchema.json');
+
+        $dto = new PartialRuleUpdateRequest();
+        $dto->id = $ruleId;
+
+        if (\array_key_exists('name', $data)) {
+            $dto->name = $data['name'];
+        }
+
+        if (\array_key_exists('description', $data)) {
+            $dto->description = $data['description'];
+        }
+
+        if (\array_key_exists('is_enabled', $data)) {
+            $dto->isEnabled = $data['is_enabled'];
+        }
+
+        return $dto;
+    }
+}

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateRoute.yaml
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateRoute.yaml
@@ -1,0 +1,9 @@
+PartialRuleUpdate:
+  methods: PATCH
+  path: /administration/resource-access/rules/{ruleId}
+  controller: 'Core\ResourceAccess\Infrastructure\API\PartialRuleUpdate\PartialRuleUpdateController'
+  condition: "request.attributes.get('version') >= 24.04 and request.attributes.get('feature.resource_access_management')"
+  requirements:
+    ruleId: '\d+'
+
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateSchema.json
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdateSchema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Update partially the resource access rule",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "name": {
+            "type": "string"
+        },
+        "description": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "is_enabled": {
+            "type": "boolean"
+        }
+    }
+}
+
+

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbWriteResourceAccessRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbWriteResourceAccessRepository.php
@@ -53,10 +53,14 @@ final class DbWriteResourceAccessRepository extends AbstractRepositoryRDB implem
 
     /**
      * @inheritDoc
+     * Here are the deletions (on cascade or not) that will occur on rule deletion
+     *     - Contact relations (ON DELETE CASCADE)
+     *     - Contact Group relations (ON DELETE CASCADE)
+     *     - Datasets relations + datasets (NEED MANUAL DELETION)
+     *     - DatasetFilters (ON DELETE CASCADE).
      */
     public function deleteRuleAndDatasets(int $ruleId): void
     {
-
         $datasetIds = $this->findDatasetIdsByRuleId($ruleId);
         $alreadyInTransaction = $this->db->inTransaction();
 

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbReadServiceCategoryRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbReadServiceCategoryRepository.php
@@ -180,15 +180,9 @@ class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements R
     {
         $this->info('Getting all service categories');
 
-        $concatenator = new SqlConcatenator();
-        $concatenator->withCalcFoundRows(true);
-        $concatenator->defineSelect(<<<'SQL'
-            SELECT sc.sc_id, sc.sc_name, sc.sc_description, sc.sc_activate
-            FROM `:db`.service_categories sc
-            SQL
-        );
+        $concatenators = $this->findServiceCategoriesRequest($requestParameters);
 
-        return $this->retrieveServiceCategories($concatenator, $requestParameters);
+        return $this->retrieveServiceCategories($concatenators, $requestParameters);
     }
 
     /**
@@ -218,24 +212,30 @@ class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements R
             return $this->findByRequestParameter($requestParameters);
         }
 
-        $concatenator = new SqlConcatenator();
-        $concatenator->withCalcFoundRows(true);
-        $concatenator->defineSelect(
-            'SELECT sc.sc_id, sc.sc_name, sc.sc_description, sc.sc_activate
-            FROM `:db`.service_categories sc
-            INNER JOIN `:db`.acl_resources_sc_relations arhr
-                ON sc.sc_id = arhr.sc_id
-            INNER JOIN `:db`.acl_resources res
-                ON arhr.acl_res_id = res.acl_res_id
-            INNER JOIN `:db`.acl_res_group_relations argr
-                ON res.acl_res_id = argr.acl_res_id
-            INNER JOIN `:db`.acl_groups ag
-                ON argr.acl_group_id = ag.acl_group_id'
-        );
-        $concatenator->storeBindValueMultiple(':access_group_ids', $accessGroupIds, \PDO::PARAM_INT)
-            ->appendWhere('ag.acl_group_id IN (:access_group_ids)');
+        $concatenators = $this->findServiceCategoriesRequest($requestParameters, $accessGroupIds);
 
-        return $this->retrieveServiceCategories($concatenator, $requestParameters);
+        foreach ($concatenators as $concatenator) {
+            $concatenator->appendJoins(
+                <<<'SQL'
+                    INNER JOIN `:db`.acl_resources_sc_relations arscr
+                        ON arscr.sc_id = sc.sc_id
+                    INNER JOIN `:db`.acl_resources res
+                        ON res.acl_res_id = arscr.acl_res_id
+                    INNER JOIN `:db`.acl_res_group_relations argr
+                        ON argr.acl_res_id = res.acl_res_id
+                    INNER JOIN `:db`.acl_groups ag
+                        ON ag.acl_group_id = argr.acl_group_id
+                    SQL
+            );
+            $concatenator->storeBindValueMultiple(':access_group_ids', $accessGroupIds, \PDO::PARAM_INT)
+                ->appendWhere(
+                    <<<'SQL'
+                        ag.acl_group_id IN (:access_group_ids)
+                        SQL
+                );
+        }
+
+        return $this->retrieveServiceCategories($concatenators, $requestParameters);
     }
 
     /**
@@ -489,18 +489,215 @@ class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements R
     }
 
     /**
-     * @param SqlConcatenator $concatenator
+     * @param RequestParametersInterface $requestParameters
+     * @param int[] $accessGroupIds
+     *
+     * @return array<SqlConcatenator>
+     */
+    private function findServiceCategoriesRequest(RequestParametersInterface $requestParameters, array $accessGroupIds = []): array
+    {
+        $hostAcls = '';
+        $hostGroupAcls = '';
+        $hostCategoryAcls = '';
+        if ([] !== $accessGroupIds) {
+            if (! $this->hasAccessToAllHosts($accessGroupIds)) {
+                $hostAcls = <<<'SQL'
+                    AND hsr.host_host_id IN (
+                        SELECT arhr.host_host_id
+                        FROM `:db`.acl_resources_host_relations arhr
+                        INNER JOIN `:db`.acl_resources res
+                            ON res.acl_res_id = arhr.acl_res_id
+                        INNER JOIN `:db`.acl_res_group_relations argr
+                            ON argr.acl_res_id = res.acl_res_id
+                        INNER JOIN `:db`.acl_groups ag
+                            ON ag.acl_group_id = argr.acl_group_id
+                        WHERE ag.acl_group_id IN (:access_group_ids)
+                    )
+                    SQL;
+            }
+
+            if (! $this->hasAccessToAllHostGroups($accessGroupIds)) {
+                $hostGroupAcls = <<<'SQL'
+                    AND hr.hostgroup_hg_id IN (
+                        SELECT arhgr.hg_hg_id
+                        FROM `:db`.acl_resources_hg_relations arhgr
+                        INNER JOIN `:db`.acl_resources res
+                            ON res.acl_res_id = arhgr.acl_res_id
+                        INNER JOIN `:db`.acl_res_group_relations argr
+                            ON argr.acl_res_id = res.acl_res_id
+                        INNER JOIN `:db`.acl_groups ag
+                            ON ag.acl_group_id = argr.acl_group_id
+                        WHERE ag.acl_group_id IN (:access_group_ids)
+                    )
+                    SQL;
+            }
+
+            if ($this->hasRestrictedAccessToHostCategories($accessGroupIds)) {
+                $hostCategoryAcls = <<<'SQL'
+                    AND hcr.hostcategories_hc_id IN (
+                        SELECT arhcr.hc_id
+                        FROM `:db`.acl_resources_hc_relations arhcr
+                        INNER JOIN `:db`.acl_resources res
+                            ON res.acl_res_id = arhcr.acl_res_id
+                        INNER JOIN `:db`.acl_res_group_relations argr
+                            ON argr.acl_res_id = res.acl_res_id
+                        INNER JOIN `:db`.acl_groups ag
+                            ON ag.acl_group_id = argr.acl_group_id
+                        WHERE ag.acl_group_id IN (:access_group_ids)
+                    )
+                    SQL;
+            }
+        }
+
+        $searchAsString = $requestParameters->getSearchAsString();
+        \preg_match_all('/\{"(?<object>\w+)\.\w+"/', $searchAsString, $matches);
+
+        $findCategoryByServiceConcatenator = new SqlConcatenator();
+        $findCategoryByServiceConcatenator->defineSelect(
+            <<<'SQL'
+                SELECT sc.sc_id,
+                    sc.sc_name,
+                    sc.sc_description,
+                    sc.sc_activate
+                FROM `:db`.service_categories sc
+                SQL
+        );
+
+        $findCategoryByServiceTemplateConcatenator = new SqlConcatenator();
+        $findCategoryByServiceTemplateConcatenator->defineSelect(
+            <<<'SQL'
+                SELECT sc.sc_id,
+                    sc.sc_name,
+                    sc.sc_description,
+                    sc.sc_activate
+                FROM `:db`.service_categories sc
+                SQL
+        );
+
+        if (\in_array('hostcategory', $matches['object'], true)) {
+            $findCategoryByServiceConcatenator->appendJoins(
+                <<<SQL
+                    LEFT JOIN `:db`.service_categories_relation scr
+                        ON scr.sc_id = sc.sc_id
+                    LEFT JOIN `:db`.host_service_relation hsr
+                        ON hsr.service_service_id = scr.service_service_id
+                        {$hostAcls}
+                    LEFT JOIN `:db`.host
+                        ON host.host_id = hsr.host_host_id
+                    LEFT JOIN `:db`.hostgroup_relation hr
+                        ON hr.host_host_id = host.host_id
+                        {$hostGroupAcls}
+                    LEFT JOIN `:db`.hostgroup
+                        ON hostgroup.hg_id = hr.hostgroup_hg_id
+                    LEFT JOIN `:db`.hostcategories_relation hcr
+                        ON hcr.host_host_id = host.host_id
+                        {$hostCategoryAcls}
+                    LEFT JOIN `:db`.hostcategories
+                        ON hostcategories.hc_id = hcr.hostcategories_hc_id
+                    SQL
+            );
+
+            $findCategoryByServiceTemplateConcatenator->appendJoins(
+                <<<SQL
+                    LEFT JOIN `:db`.service_categories_relation scr
+                        ON scr.sc_id = sc.sc_id
+                    LEFT JOIN `:db`.service s
+                        ON s.service_template_model_stm_id = scr.service_service_id
+                    LEFT JOIN `:db`.host_service_relation hsr
+                        ON hsr.service_service_id = s.service_id
+                        {$hostAcls}
+                    LEFT JOIN `:db`.host
+                        ON host.host_id = hsr.host_host_id
+                    LEFT JOIN `:db`.hostgroup_relation hr
+                        ON hr.host_host_id = host.host_id
+                        {$hostGroupAcls}
+                    LEFT JOIN `:db`.hostgroup
+                        ON hostgroup.hg_id = hr.hostgroup_hg_id
+                    LEFT JOIN `:db`.hostcategories_relation hcr
+                        ON hcr.host_host_id = host.host_id
+                        {$hostCategoryAcls}
+                    LEFT JOIN `:db`.hostcategories
+                        ON hostcategories.hc_id = hcr.hostcategories_hc_id
+                    SQL
+            );
+        } else if (\in_array('hostgroup', $matches['object'], true)) {
+            $findCategoryByServiceConcatenator->appendJoins(
+                <<<SQL
+                    LEFT JOIN `:db`.service_categories_relation scr
+                        ON scr.sc_id = sc.sc_id
+                    LEFT JOIN `:db`.host_service_relation hsr
+                        ON hsr.service_service_id = scr.service_service_id
+                        {$hostAcls}
+                    LEFT JOIN `:db`.host
+                        ON host.host_id = hsr.host_host_id
+                    LEFT JOIN `:db`.hostgroup_relation hr
+                        ON hr.host_host_id = host.host_id
+                        {$hostGroupAcls}
+                    LEFT JOIN `:db`.hostgroup
+                        ON hostgroup.hg_id = hr.hostgroup_hg_id
+                    SQL
+            );
+
+            $findCategoryByServiceTemplateConcatenator->appendJoins(
+                <<<SQL
+                    LEFT JOIN `:db`.service_categories_relation scr
+                        ON scr.sc_id = sc.sc_id
+                    LEFT JOIN `:db`.service s
+                        ON s.service_template_model_stm_id = scr.service_service_id
+                    LEFT JOIN `:db`.host_service_relation hsr
+                        ON hsr.service_service_id = s.service_id
+                        {$hostAcls}
+                    LEFT JOIN `:db`.host
+                        ON host.host_id = hsr.host_host_id
+                    LEFT JOIN `:db`.hostgroup_relation hr
+                        ON hr.host_host_id = host.host_id
+                        {$hostGroupAcls}
+                    LEFT JOIN `:db`.hostgroup
+                        ON hostgroup.hg_id = hr.hostgroup_hg_id
+                    SQL
+            );
+        } else if (\in_array('host', $matches['object'], true)) {
+            $findCategoryByServiceConcatenator->appendJoins(
+                <<<SQL
+                    LEFT JOIN `:db`.service_categories_relation scr
+                        ON scr.sc_id = sc.sc_id
+                    LEFT JOIN `:db`.host_service_relation hsr
+                        ON hsr.service_service_id = scr.service_service_id
+                        {$hostAcls}
+                    LEFT JOIN `:db`.host
+                        ON host.host_id = hsr.host_host_id
+                    SQL
+            );
+
+            $findCategoryByServiceTemplateConcatenator->appendJoins(
+                <<<SQL
+                    LEFT JOIN `:db`.service_categories_relation scr
+                        ON scr.sc_id = sc.sc_id
+                    LEFT JOIN `:db`.service s
+                        ON s.service_template_model_stm_id = scr.service_service_id
+                    LEFT JOIN `:db`.host_service_relation hsr
+                        ON hsr.service_service_id = s.service_id
+                        {$hostAcls}
+                    LEFT JOIN `:db`.host
+                        ON host.host_id = hsr.host_host_id
+                    SQL
+            );
+        }
+
+        return [$findCategoryByServiceConcatenator, $findCategoryByServiceTemplateConcatenator];
+    }
+
+    /**
+     * @param array<SqlConcatenator> $concatenators
      * @param RequestParametersInterface $requestParameters
      *
      * @return ServiceCategory[]
      */
     private function retrieveServiceCategories(
-        SqlConcatenator $concatenator,
+        array $concatenators,
         RequestParametersInterface $requestParameters
     ): array {
-        // Exclude severities from the results
-        $concatenator->appendWhere('sc.level IS NULL');
-
+        $concatenatorsAsString = [];
         // Settup for search, pagination, order
         $sqlTranslator = new SqlRequestParametersTranslator($requestParameters);
         $sqlTranslator->setConcordanceArray([
@@ -508,14 +705,38 @@ class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements R
             'name' => 'sc.sc_name',
             'alias' => 'sc.sc_description',
             'is_activated' => 'sc.sc_activate',
+            'host.id' => 'host.host_id',
+            'host.name' => 'host.host_name',
+            'hostgroup.id' => 'hostgroup.hg_id',
+            'hostgroup.name' => 'hostgroup.hg_name',
+            'hostcategory.id' => 'hostcategories.hc_id',
+            'hostcategory.name' => 'hostcategories.hc_name',
         ]);
-        $sqlTranslator->addNormalizer('is_activated', new BoolToEnumNormalizer());
-        $sqlTranslator->translateForConcatenator($concatenator);
+
+        foreach ($concatenators as $concatenator) {
+            // Exclude severities from the results
+            $concatenator->appendWhere('sc.level IS NULL');
+
+            $sqlTranslator->addNormalizer('is_activated', new BoolToEnumNormalizer());
+            $sqlTranslator->translateForConcatenator($concatenator);
+            $concatenator->withCalcFoundRows(false);
+            $concatenatorsAsString[] = $concatenator->concatForUnion();
+        }
+
+        $concatenator = new SqlConcatenator();
+        $concatenator->withCalcFoundRows(true);
+        $concatenator->defineSelect(
+            <<<'SQL'
+                SELECT *
+                SQL
+        )->defineFrom('(' . \implode(' UNION ', $concatenatorsAsString) . ') AS union_table');
 
         $statement = $this->db->prepare($this->translateDbName($concatenator->__toString()));
 
         $sqlTranslator->bindSearchValues($statement);
-        $concatenator->bindValuesToStatement($statement);
+        foreach ($concatenators as $concatenator) {
+            $concatenator->bindValuesToStatement($statement);
+        }
         $statement->execute();
 
         $sqlTranslator->calculateNumberOfRows($this->db);
@@ -527,6 +748,131 @@ class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements R
         }
 
         return $serviceCategories;
+    }
+
+    /**
+     * Determines if access groups give access to all host groups
+     * true: all host groups are accessible
+     * false: all host groups are NOT accessible.
+     *
+     * @param int[] $accessGroupIds
+     *
+     * @phpstan-param non-empty-array<int> $accessGroupIds
+     *
+     * @return bool
+     */
+    private function hasAccessToAllHostGroups(array $accessGroupIds): bool
+    {
+        $bindValuesArray = [];
+        foreach ($accessGroupIds as $index => $accessGroupId) {
+            $bindValuesArray[':acl_group_id_' . $index] = $accessGroupId;
+        }
+        $bindParamsAsString = \implode(',', \array_keys($bindValuesArray));
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<SQL
+                SELECT res.all_hostgroups
+                FROM `:db`.acl_resources res
+                INNER JOIN `:db`.acl_res_group_relations argr
+                    ON argr.acl_res_id = res.acl_res_id
+                INNER JOIN `:db`.acl_groups ag
+                    ON ag.acl_group_id = argr.acl_group_id
+                WHERE ag.acl_group_id IN ({$bindParamsAsString})
+                SQL
+        ));
+        foreach ($bindValuesArray as $bindParam => $bindValue) {
+            $statement->bindValue($bindParam, $bindValue, \PDO::PARAM_INT);
+        }
+        $statement->execute();
+
+        while (false !== ($hasAccessToAll = $statement->fetchColumn())) {
+            if (true === (bool) $hasAccessToAll) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines if access groups give access to all hosts
+     * true: all hosts are accessible
+     * false: all hosts are NOT accessible.
+     *
+     * @param int[] $accessGroupIds
+     *
+     * @phpstan-param non-empty-array<int> $accessGroupIds
+     *
+     * @return bool
+     */
+    private function hasAccessToAllHosts(array $accessGroupIds): bool
+    {
+        $bindValuesArray = [];
+        foreach ($accessGroupIds as $index => $accessGroupId) {
+            $bindValuesArray[':acl_group_id_' . $index] = $accessGroupId;
+        }
+        $bindParamsAsString = \implode(',', \array_keys($bindValuesArray));
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<SQL
+                SELECT res.all_hosts
+                FROM `:db`.acl_resources res
+                INNER JOIN `:db`.acl_res_group_relations argr
+                    ON argr.acl_res_id = res.acl_res_id
+                INNER JOIN `:db`.acl_groups ag
+                    ON ag.acl_group_id = argr.acl_group_id
+                WHERE ag.acl_group_id IN ({$bindParamsAsString})
+                SQL
+        ));
+        foreach ($bindValuesArray as $bindParam => $bindValue) {
+            $statement->bindValue($bindParam, $bindValue, \PDO::PARAM_INT);
+        }
+        $statement->execute();
+
+        while (false !== ($hasAccessToAll = $statement->fetchColumn())) {
+            if (true === (bool) $hasAccessToAll) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Determines if host categories are filtered for given access group ids
+     * true: accessible host categories are filtered (only specified are accessible)
+     * false: accessible host categories are NOT filtered (all are accessible).
+     *
+     * @param int[] $accessGroupIds
+     *
+     * @phpstan-param non-empty-array<int> $accessGroupIds
+     *
+     * @return bool
+     */
+    private function hasRestrictedAccessToHostCategories(array $accessGroupIds): bool
+    {
+        $bindValuesArray = [];
+        foreach ($accessGroupIds as $index => $accessGroupId) {
+            $bindValuesArray[':acl_group_id_' . $index] = $accessGroupId;
+        }
+        $bindParamsAsString = \implode(',', \array_keys($bindValuesArray));
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<SQL
+                SELECT 1
+                FROM `:db`.acl_resources_hc_relations arhcr
+                INNER JOIN `:db`.acl_resources res
+                    ON res.acl_res_id = arhcr.acl_res_id
+                INNER JOIN `:db`.acl_res_group_relations argr
+                    ON argr.acl_res_id = res.acl_res_id
+                INNER JOIN `:db`.acl_groups ag
+                    ON ag.acl_group_id = argr.acl_group_id
+                WHERE ag.acl_group_id IN ({$bindParamsAsString})
+                SQL
+        ));
+        foreach ($bindValuesArray as $bindParam => $bindValue) {
+            $statement->bindValue($bindParam, $bindValue, \PDO::PARAM_INT);
+        }
+        $statement->execute();
+
+        return (bool) $statement->fetchColumn();
     }
 
     /**

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbReadServiceTemplateRepository.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Repository/DbReadServiceTemplateRepository.php
@@ -159,7 +159,14 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
                     AND host.host_register = '0'
                 WHERE service.service_id = :id
                     AND service.service_register = '0'
-                GROUP BY service.service_id
+                GROUP BY
+                    service.service_id,
+                    esi.esi_action_url,
+                    esi.esi_icon_image,
+                    esi.esi_icon_image_alt,
+                    esi.esi_notes,
+                    esi.esi_notes_url,
+                    esi.graph_id
             SQL;
         $statement = $this->db->prepare($this->translateDbName($request));
         $statement->bindValue(':id', $serviceTemplateId, \PDO::PARAM_INT);
@@ -248,7 +255,15 @@ class DbReadServiceTemplateRepository extends AbstractRepositoryRDB implements R
         $sqlConcatenator = new SqlConcatenator();
         $sqlConcatenator->defineSelect($request);
         $sqlConcatenator->appendWhere("service_register = '0'");
-        $sqlConcatenator->appendGroupBy('service.service_id');
+        $sqlConcatenator->appendGroupBy(
+            'service.service_id',
+            'esi.esi_action_url',
+            'esi.esi_icon_image',
+            'esi.esi_icon_image_alt',
+            'esi.esi_notes',
+            'esi.esi_notes_url',
+            'esi.graph_id'
+        );
         $sqlTranslator->translateForConcatenator($sqlConcatenator);
         $sql = $sqlConcatenator->__toString();
         $statement = $this->db->prepare($this->translateDbName($sql));

--- a/centreon/src/Utility/SqlConcatenator.php
+++ b/centreon/src/Utility/SqlConcatenator.php
@@ -377,6 +377,24 @@ final class SqlConcatenator implements \Stringable
     }
 
     /**
+     * @return string
+     */
+    public function concatForUnion(): string
+    {
+        $sql = rtrim(
+            $this->concatSelect()
+            . $this->concatFrom()
+            . $this->concatJoins()
+            . $this->concatWhere()
+            . $this->concatGroupBy()
+            . $this->concatHaving()
+            . $this->concatOrderBy()
+        );
+
+        return $this->bindArrayReplacements($sql);
+    }
+
+    /**
      * @param string $sql
      *
      * @return string

--- a/centreon/tests/api/features/Clapi.feature
+++ b/centreon/tests/api/features/Clapi.feature
@@ -29,8 +29,8 @@ Feature:
     And the CLAPI export of "STPL" filtered on "addhosttemplate;ServiceTemplate" should be
     """
     STPL;addhosttemplate;ServiceTemplate1;HostTemplate1
-    STPL;addhosttemplate;ServiceTemplate2;HostTemplate1
     STPL;addhosttemplate;ServiceTemplate1;HostTemplate2
+    STPL;addhosttemplate;ServiceTemplate2;HostTemplate1
     STPL;addhosttemplate;ServiceTemplate2;HostTemplate2
     """
 

--- a/centreon/tests/api/features/Notification.feature
+++ b/centreon/tests/api/features/Notification.feature
@@ -61,33 +61,37 @@ Feature:
     And the JSON should be equal to:
     """
     {
-        "notification_id": 1,
-        "channels": {
-            "email": {
-                "subject": "Hello world !",
-                "formatted_message": "a formatted message",
-                "contacts": [
-                    {
-                        "email_address": "user1@mail.com",
-                        "full_name": "user-name1"
-                    }, {
-                        "email_address": "user2@mail.com",
-                        "full_name": "user-name2"
-                    }, {
-                        "email_address": "guest@localhost",
-                        "full_name": "Guest"
-                    }, {
-                        "email_address": "admin@centreon.com",
-                        "full_name": "admin admin"
-                    }, {
-                        "email_address": "user@localhost",
-                        "full_name": "User"
-                    }
-                ]
+      "notification_id": 1,
+      "channels": {
+        "email": {
+          "subject": "Hello world !",
+          "formatted_message": "a formatted message",
+          "contacts": [
+            {
+              "email_address": "user1@mail.com",
+              "full_name": "user-name1"
             },
-            "slack": null,
-            "sms": null
-        }
+            {
+              "email_address": "user2@mail.com",
+              "full_name": "user-name2"
+            },
+            {
+              "email_address": "admin@centreon.com",
+              "full_name": "admin admin"
+            },
+            {
+              "email_address": "guest@localhost",
+              "full_name": "Guest"
+            },
+            {
+              "email_address": "user@localhost",
+              "full_name": "User"
+            }
+          ]
+        },
+        "slack": null,
+        "sms": null
+      }
     }
     """
 

--- a/centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature
+++ b/centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature
@@ -23,6 +23,25 @@ Feature: Creating a Notification Rule
     And the notification refresh_delay has been reached
     Then an email is sent to the configured '<contact_settings>' with the configured format
     Examples:
-      | contact_settings                            | resource_type                           |
-      | a single contact                            | host group                              |
-      | two contacts                                | host group and services for these hosts |
+      | contact_settings | resource_type                           |
+      | a single contact | host group                              |
+      | two contacts     | host group and services for these hosts |
+
+  @ignore
+  Scenario Outline: Creating a large volume Notification Rule for <contact_settings>
+    Given a minimum of 1000 services linked to a host group and <contact_settings>
+    When the user defines a name for the rule
+    And the user selects a host group with its linked services and with associated events on which to notify
+    And the user selects the <contact_settings>
+    And the user defines a mail subject
+    And the user defines a mail body
+    And the user clicks on the "Save" button to confirm
+    Then a success message is displayed and the created Notification Rule is displayed in the listing
+    When changes occur in the configured statuses for the selected host group
+    And the hard state has been reached
+    And the notification refresh_delay has been reached
+    Then an email is sent to the configured <contact_settings> with the configured format
+    Examples:
+      | contact_settings |
+      | a single contact |
+      | two contacts     |

--- a/centreon/tests/e2e/features/Cloud-notifications/01-notification-create/index.ts
+++ b/centreon/tests/e2e/features/Cloud-notifications/01-notification-create/index.ts
@@ -1,23 +1,26 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+
+import {
+  checkHostsAreMonitored,
+  checkServicesAreMonitored
+} from '../../../commons';
 import {
   enableNotificationFeature,
   notificationSentCheck,
   setBrokerNotificationsOutput,
   waitUntilLogFileChange
 } from '../common';
-import { checkHostsAreMonitored, checkServicesAreMonitored } from 'e2e/commons';
-
 import data from '../../../fixtures/notifications/data-for-notification.json';
 
 let globalResourceType = '';
 let globalContactSettings = '';
 
 beforeEach(() => {
-  cy.startContainers({ useSlim: false });
+  cy.startContainers();
   enableNotificationFeature();
   setBrokerNotificationsOutput({
-    name: 'central-cloud-notifications-output',
-    configName: 'central-broker-master'
+    configName: 'central-broker-master',
+    name: 'central-cloud-notifications-output'
   });
 
   cy.intercept({
@@ -60,23 +63,25 @@ Given(
     switch (contactSettings) {
       case 'a single contact':
         cy.addContact({
-          name: data.contacts.contact1.name,
           email: data.contacts.contact1.email,
+          name: data.contacts.contact1.name,
           password: data.contacts.contact1.password
         });
         break;
       case 'two contacts':
         cy.addContact({
-          name: data.contacts.contact1.name,
           email: data.contacts.contact1.email,
+          name: data.contacts.contact1.name,
           password: data.contacts.contact1.password
         });
         cy.addContact({
-          name: data.contacts.contact2.name,
           email: data.contacts.contact2.email,
+          name: data.contacts.contact2.name,
           password: data.contacts.contact2.password
         });
         break;
+      default:
+        throw new Error(`${contactSettings} not managed`);
     }
 
     cy.addHostGroup({
@@ -164,6 +169,8 @@ When(
           cy.wrap($el).click();
         });
         break;
+      default:
+        throw new Error(`${resourceType} not managed`);
     }
   }
 );
@@ -181,6 +188,8 @@ When('the user selects the {string}', (contactSettings: string) => {
       cy.contains(data.contacts.contact1.name).click();
       cy.contains(data.contacts.contact2.name).click();
       break;
+    default:
+      throw new Error(`${contactSettings} not managed`);
   }
 });
 
@@ -256,6 +265,8 @@ When(
           }
         ]);
         break;
+      default:
+        throw new Error(`${resourceType} not managed`);
     }
   }
 );
@@ -280,6 +291,8 @@ When('the hard state has been reached', () => {
         }
       ]);
       break;
+    default:
+      throw new Error(`${globalResourceType} not managed`);
   }
 });
 
@@ -305,6 +318,8 @@ Then(
           log: `[{"email_address":"${data.contacts.contact1.email}","full_name":"${data.contacts.contact1.name}"},{"email_address":"${data.contacts.contact2.email}","full_name":"${data.contacts.contact2.name}"}]`
         });
         break;
+      default:
+        throw new Error(`${contactSettings} not managed`);
     }
   }
 );

--- a/centreon/tests/e2e/features/Cloud-notifications/02-notification-duplicate/index.ts
+++ b/centreon/tests/e2e/features/Cloud-notifications/02-notification-duplicate/index.ts
@@ -1,9 +1,11 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor';
+
 import { createNotification, enableNotificationFeature } from '../common';
-
 import notificationBody from '../../../fixtures/notifications/notification-creation.json';
-import { checkHostsAreMonitored, checkServicesAreMonitored } from 'e2e/commons';
-
+import {
+  checkHostsAreMonitored,
+  checkServicesAreMonitored
+} from '../../../commons';
 import data from '../../../fixtures/notifications/data-for-notification.json';
 
 const duplicatedNotificationName = 'Duplicated Notification';
@@ -17,7 +19,7 @@ const notificationProperties = [
 ];
 
 beforeEach(() => {
-  cy.startContainers({ useSlim: false });
+  cy.startContainers();
   enableNotificationFeature();
   cy.intercept({
     method: 'GET',

--- a/centreon/tests/e2e/features/Cloud-notifications/03-notification-delete/index.ts
+++ b/centreon/tests/e2e/features/Cloud-notifications/03-notification-delete/index.ts
@@ -1,4 +1,5 @@
 import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
+
 import {
   createNotification,
   enableNotificationFeature,
@@ -7,16 +8,18 @@ import {
   waitUntilLogFileChange
 } from '../common';
 import notificationBody from '../../../fixtures/notifications/notification-creation.json';
-import { checkHostsAreMonitored, checkServicesAreMonitored } from 'e2e/commons';
-
+import {
+  checkHostsAreMonitored,
+  checkServicesAreMonitored
+} from '../../../commons';
 import data from '../../../fixtures/notifications/data-for-notification.json';
 
 beforeEach(() => {
-  cy.startContainers({ useSlim: false });
+  cy.startContainers();
   enableNotificationFeature();
   setBrokerNotificationsOutput({
-    name: 'central-cloud-notifications-output',
-    configName: 'central-broker-master'
+    configName: 'central-broker-master',
+    name: 'central-cloud-notifications-output'
   });
 
   cy.intercept({
@@ -124,8 +127,8 @@ Then(
     waitUntilLogFileChange();
 
     notificationSentCheck({
-      log: `<<${data.hosts.host1.name}>>`,
-      contain: false
+      contain: false,
+      log: `<<${data.hosts.host1.name}>>`
     });
   }
 );

--- a/centreon/tests/e2e/features/Cloud-notifications/04-notification-edit/Index.ts
+++ b/centreon/tests/e2e/features/Cloud-notifications/04-notification-edit/Index.ts
@@ -1,4 +1,9 @@
 import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
+
+import {
+  checkHostsAreMonitored,
+  checkServicesAreMonitored
+} from '../../../commons';
 import {
   createNotification,
   editNotification,
@@ -8,7 +13,6 @@ import {
   waitUntilLogFileChange
 } from '../common';
 import notificationBody from '../../../fixtures/notifications/notification-creation.json';
-import { checkHostsAreMonitored, checkServicesAreMonitored } from 'e2e/commons';
 import data from '../../../fixtures/notifications/data-for-notification.json';
 
 const contactAfterEdit = 'Guest';
@@ -19,11 +23,11 @@ let notificationWithServices = true;
 let notificationEnabled = true;
 
 beforeEach(() => {
-  cy.startContainers({ useSlim: false });
+  cy.startContainers();
   enableNotificationFeature();
   setBrokerNotificationsOutput({
-    name: 'central-cloud-notifications-output',
-    configName: 'central-broker-master'
+    configName: 'central-broker-master',
+    name: 'central-cloud-notifications-output'
   });
 
   cy.intercept({
@@ -154,13 +158,14 @@ Then(
   () => {
     if (!notificationEnabled) {
       notificationSentCheck({
-        log: `<<${data.hosts.host1.name}>>`,
-        contain: false
+        contain: false,
+        log: `<<${data.hosts.host1.name}>>`
       });
       notificationSentCheck({
-        log: `<<${data.hosts.host1.name}/${data.services.service1.name}>>`,
-        contain: false
+        contain: false,
+        log: `<<${data.hosts.host1.name}/${data.services.service1.name}>>`
       });
+
       return;
     }
 
@@ -168,9 +173,10 @@ Then(
 
     if (!notificationWithServices) {
       notificationSentCheck({
-        log: `<<${data.hosts.host1.name}/${data.services.service1.name}>>`,
-        contain: false
+        contain: false,
+        log: `<<${data.hosts.host1.name}/${data.services.service1.name}>>`
       });
+
       return;
     }
 
@@ -206,6 +212,8 @@ When(
           cy.wrap($checkbox).click().should('not.be.checked');
           notificationEnabled = false;
           break;
+        default:
+          throw new Error(`${action} not managed`);
       }
     });
   }
@@ -215,8 +223,8 @@ Then(
   'the notifications for status changes are sent only to the updated contact',
   () => {
     notificationSentCheck({
-      log: '[{"email_address":"admin@centreon.com","full_name":"admin admin"}]',
-      contain: false
+      contain: false,
+      log: '[{"email_address":"admin@centreon.com","full_name":"admin admin"}]'
     });
     notificationSentCheck({
       log: '[{"email_address":"guest@localhost","full_name":"Guest"}]'
@@ -227,13 +235,14 @@ Then(
 Then('{string} notification is sent for this rule once', (prefix) => {
   if (!notificationEnabled) {
     notificationSentCheck({
-      log: `<<${data.hosts.host1.name}>>`,
-      contain: false
+      contain: false,
+      log: `<<${data.hosts.host1.name}>>`
     });
     notificationSentCheck({
-      log: `<<${data.hosts.host1.name}/${data.services.service1.name}>>`,
-      contain: false
+      contain: false,
+      log: `<<${data.hosts.host1.name}/${data.services.service1.name}>>`
     });
+
     return;
   }
 
@@ -265,6 +274,8 @@ When('the user {string} the Notification Rule', (action) => {
           cy.wrap($checkbox).click().should('not.be.checked');
           notificationEnabled = false;
           break;
+        default:
+          throw new Error(`${action} not managed`);
       }
     });
 });

--- a/centreon/tests/e2e/features/Cloud-notifications/05-notification-listing/index.ts
+++ b/centreon/tests/e2e/features/Cloud-notifications/05-notification-listing/index.ts
@@ -1,14 +1,15 @@
 import { Given, When, Then } from '@badeball/cypress-cucumber-preprocessor';
+
 import { createNotification, enableNotificationFeature } from '../common';
 import notificationBody from '../../../fixtures/notifications/notification-creation.json';
-import { checkHostsAreMonitored } from 'e2e/commons';
+import { checkHostsAreMonitored } from '../../../commons';
 import data from '../../../fixtures/notifications/data-for-notification.json';
 
 const previousPageLabel = 'Previous page';
 const nextPageLabel = 'Next page';
 
 beforeEach(() => {
-  cy.startContainers({ useSlim: false });
+  cy.startContainers();
   enableNotificationFeature();
   cy.intercept({
     method: 'GET',

--- a/centreon/tests/e2e/features/Cloud-notifications/common.ts
+++ b/centreon/tests/e2e/features/Cloud-notifications/common.ts
@@ -12,9 +12,9 @@ const createNotification = (
 ): Cypress.Chainable => {
   return cy
     .request({
+      body,
       method: 'POST',
-      url: 'centreon/api/latest/configuration/notifications',
-      body: body
+      url: 'centreon/api/latest/configuration/notifications'
     })
     .then((response) => {
       cy.wrap(response);
@@ -24,9 +24,9 @@ const createNotification = (
 const editNotification = (body: typeof notificationBody): Cypress.Chainable => {
   return cy
     .request({
+      body,
       method: 'PUT',
-      url: 'centreon/api/latest/configuration/notifications/1',
-      body: body
+      url: 'centreon/api/latest/configuration/notifications/1'
     })
     .then((response) => {
       cy.wrap(response);
@@ -34,8 +34,8 @@ const editNotification = (body: typeof notificationBody): Cypress.Chainable => {
 };
 
 interface Broker {
-  name: string;
   configName: string;
+  name: string;
 }
 
 const setBrokerNotificationsOutput = ({
@@ -53,7 +53,7 @@ const setBrokerNotificationsOutput = ({
   ];
   modifyLuaFileCommands.forEach((command) => {
     cy.execInContainer({
-      command: command,
+      command,
       name: 'web'
     });
   });
@@ -74,6 +74,7 @@ const setBrokerNotificationsOutput = ({
     object: 'CENTBROKERCFG',
     values: `${configName}`
   };
+
   return cy
     .executeActionViaClapi({
       bodyContent: getBrokerIOIdByNameBody
@@ -113,8 +114,8 @@ const notificationSentCheck = ({
   log,
   contain = true
 }: {
-  log: string;
   contain?: boolean;
+  log: string;
 }): Cypress.Chainable => {
   return cy
     .execInContainer({
@@ -137,7 +138,7 @@ const waitUntilLogFileChange = (): Cypress.Chainable => {
       name: 'web'
     })
     .then((result) => {
-      if (result.output === undefined) {
+      if (result.exitCode) {
         throw new Error('No initial output found in log file');
       }
 
@@ -151,15 +152,16 @@ const waitUntilLogFileChange = (): Cypress.Chainable => {
               name: 'web'
             })
             .then((result) => {
-              if (result.output === undefined) {
+              if (result.exitCode) {
                 throw new Error('No current output found in log file');
               }
 
               const currentContent = result.output.trim();
+
               return cy.wrap(currentContent !== initialContent);
             });
         },
-        { timeout: 40000, interval: 5000 }
+        { interval: 5000, timeout: 40000 }
       );
     });
 };

--- a/centreon/tests/e2e/features/Dashboards/01-dashboard-creation.feature
+++ b/centreon/tests/e2e/features/Dashboards/01-dashboard-creation.feature
@@ -33,10 +33,11 @@ Feature: Creating a new dashboard
     When the user opens the form to create a new dashboard for the second time
     Then the form fields are empty
 
-  @TEST_MON-23634
-  Scenario: Creating a new dashboard while editing an existing one
-    Given a dashboard with existing widgets in the dashboard administrator user's dashboard library
-    When the dashboard administrator user starts to edit the dashboard
-    And creates a new dashboard on the previous dashboard's edition page
-    Then the user is redirected to the newly created dashboard's edition page
-    And the newly created dashboard is empty
+  # uncomment once MON-37265 is fixed
+  # @TEST_MON-23634
+  # Scenario: Creating a new dashboard while editing an existing one
+  #   Given a dashboard with existing widgets in the dashboard administrator user's dashboard library
+  #   When the dashboard administrator user starts to edit the dashboard
+  #   And creates a new dashboard on the previous dashboard's edition page
+  #   Then the user is redirected to the newly created dashboard's edition page
+  #   And the newly created dashboard is empty

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -35,9 +35,7 @@ const getCentreonStableMinorVersions = (
   if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {
     commandResult = cy
       .execInContainer({
-        command: `bash -e <<EOF
-          dnf config-manager --set-disabled 'centreon-*-unstable*' 'centreon-*-testing*' 'mariadb*'
-EOF`,
+        command: `dnf config-manager --set-disabled 'centreon-*-unstable*' 'centreon-*-testing*' 'mariadb*'`,
         name: 'web'
       })
       .execInContainer({
@@ -47,11 +45,11 @@ EOF`,
   } else {
     commandResult = cy
       .execInContainer({
-        command: `bash -e <<EOF
-          mv /etc/apt/sources.list.d/centreon-unstable.list /etc/apt/sources.list.d/centreon-unstable.list.bak
-          mv /etc/apt/sources.list.d/centreon-testing.list /etc/apt/sources.list.d/centreon-testing.list.bak
-          apt-get update
-EOF`,
+        command: [
+          `mv /etc/apt/sources.list.d/centreon-unstable.list /etc/apt/sources.list.d/centreon-unstable.list.bak`,
+          `mv /etc/apt/sources.list.d/centreon-testing.list /etc/apt/sources.list.d/centreon-testing.list.bak`,
+          `apt-get update`
+        ],
         name: 'web'
       })
       .execInContainer({
@@ -72,18 +70,16 @@ EOF`,
 
     if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {
       cy.execInContainer({
-        command: `bash -e <<EOF
-            dnf config-manager --set-enabled 'centreon-*'
-EOF`,
+        command: "dnf config-manager --set-enabled 'centreon-*'",
         name: 'web'
       });
     } else {
       cy.execInContainer({
-        command: `bash -e <<EOF
-            mv /etc/apt/sources.list.d/centreon-unstable.list.bak /etc/apt/sources.list.d/centreon-unstable.list
-            mv /etc/apt/sources.list.d/centreon-testing.list.bak /etc/apt/sources.list.d/centreon-testing.list
-            apt-get update
-EOF`,
+        command: [
+          `mv /etc/apt/sources.list.d/centreon-unstable.list.bak /etc/apt/sources.list.d/centreon-unstable.list`,
+          `mv /etc/apt/sources.list.d/centreon-testing.list.bak /etc/apt/sources.list.d/centreon-testing.list`,
+          `apt-get update`
+        ],
         name: 'web'
       });
     }
@@ -97,44 +93,40 @@ const installCentreon = (version: string): Cypress.Chainable => {
 
   if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {
     cy.execInContainer({
-      command: `bash -e <<EOF
-        dnf config-manager --set-disabled 'centreon-*-unstable*' 'centreon-*-testing*' 'mariadb*'
-        dnf install -y centreon-web-${version}
-        dnf install -y centreon-broker-cbd
-        echo 'date.timezone = Europe/Paris' > /etc/php.d/centreon.ini
-        /etc/init.d/mysql start
-        mkdir -p /run/php-fpm
-        systemctl start php-fpm
-        systemctl start httpd
-        mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"
-        dnf config-manager --set-enabled 'centreon-*'
-EOF`,
+      command: [
+        `dnf config-manager --set-disabled 'centreon-*-unstable*' 'centreon-*-testing*' 'mariadb*'`,
+        `dnf install -y centreon-web-${version}`,
+        `dnf install -y centreon-broker-cbd`,
+        `echo 'date.timezone = Europe/Paris' > /etc/php.d/centreon.ini`,
+        `/etc/init.d/mysql start`,
+        `mkdir -p /run/php-fpm`,
+        `systemctl start php-fpm`,
+        `systemctl start httpd`,
+        `mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"`,
+        `dnf config-manager --set-enabled 'centreon-*'`
+      ],
       name: 'web'
     });
   } else {
     cy.execInContainer({
-      command: `bash -e <<EOF
-        mv /etc/apt/sources.list.d/centreon-unstable.list /etc/apt/sources.list.d/centreon-unstable.list.bak
-        mv /etc/apt/sources.list.d/centreon-testing.list /etc/apt/sources.list.d/centreon-testing.list.bak
-        apt-get update
-        apt-get install -y \\
-          centreon-poller=${version}-${Cypress.env('WEB_IMAGE_OS')} \\
-          centreon-web-apache=${version}-${Cypress.env('WEB_IMAGE_OS')} \\
-          centreon-web=${version}-${Cypress.env('WEB_IMAGE_OS')} \\
-          centreon-common=${version}-${Cypress.env('WEB_IMAGE_OS')}
-        mkdir -p /usr/lib/centreon-connector
-        echo "date.timezone = Europe/Paris" >> /etc/php/8.1/mods-available/centreon.ini
-        sed -i 's#^datadir_set=#datadir_set=1#' /etc/init.d/mysql
-        service mysql start
-        mkdir -p /run/php
-        systemctl start php8.1-fpm
-        systemctl start apache2
-        mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"
-        mv /etc/apt/sources.list.d/centreon-unstable.list.bak /etc/apt/sources.list.d/centreon-unstable.list
-        mv /etc/apt/sources.list.d/centreon-testing.list.bak /etc/apt/sources.list.d/centreon-testing.list
-        apt-get update
-        usermod -a -G centreon-broker www-data # temporary fix (MON-20769)
-EOF`,
+      command: [
+        `mv /etc/apt/sources.list.d/centreon-unstable.list /etc/apt/sources.list.d/centreon-unstable.list.bak`,
+        `mv /etc/apt/sources.list.d/centreon-testing.list /etc/apt/sources.list.d/centreon-testing.list.bak`,
+        `apt-get update`,
+        `apt-get install -y centreon-poller=${version}-${Cypress.env('WEB_IMAGE_OS')} centreon-web-apache=${version}-${Cypress.env('WEB_IMAGE_OS')} centreon-web=${version}-${Cypress.env('WEB_IMAGE_OS')} centreon-common=${version}-${Cypress.env('WEB_IMAGE_OS')}`,
+        `mkdir -p /usr/lib/centreon-connector`,
+        `echo "date.timezone = Europe/Paris" >> /etc/php/8.1/mods-available/centreon.ini`,
+        `sed -i 's#^datadir_set=#datadir_set=1#' /etc/init.d/mysql`,
+        `service mysql start`,
+        `mkdir -p /run/php`,
+        `systemctl start php8.1-fpm`,
+        `systemctl start apache2`,
+        `mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"`,
+        `mv /etc/apt/sources.list.d/centreon-unstable.list.bak /etc/apt/sources.list.d/centreon-unstable.list`,
+        `mv /etc/apt/sources.list.d/centreon-testing.list.bak /etc/apt/sources.list.d/centreon-testing.list`,
+        `apt-get update`,
+        `usermod -a -G centreon-broker www-data` // temporary fix (MON-20769)
+      ],
       name: 'web'
     });
   }
@@ -216,11 +208,11 @@ EOF`,
     .setUserTokenApiV1()
     .applyPollerConfiguration()
     .execInContainer({
-      command: `bash -e <<EOF
-        systemctl restart cbd
-        systemctl restart centengine
-        systemctl restart gorgoned
-EOF`,
+      command: [
+        `systemctl restart cbd`,
+        `systemctl restart centengine`,
+        `systemctl restart gorgoned`
+      ],
       name: 'web'
     });
 };

--- a/centreon/tests/e2e/features/Resources-status/04-timezone/index.ts
+++ b/centreon/tests/e2e/features/Resources-status/04-timezone/index.ts
@@ -289,7 +289,23 @@ When('the user creates a downtime on a resource', () => {
 Then(
   'date and time fields should be based on the custom timezone of the user',
   () => {
-    cy.contains(serviceInDtName).parent().click();
+    cy.waitUntil(() => {
+      cy.contains(serviceInDtName).parent().click();
+      cy.get('button#Close').click();
+      cy.contains(serviceInDtName).parent().click();
+
+      return cy
+        .get('#panel-content :contains("Status information")')
+        .then(($el) => {
+          if ($el.find(':contains("Downtime duration")').length === 0) {
+            cy.get('button#Close').click();
+
+            return false;
+          }
+
+          return true;
+        });
+    });
 
     cy.get('p[data-testid="From_date"]').then(($toDate) => {
       cy.getTimeFromHeader().then((localTime: string) => {

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRuleTest.php
@@ -24,7 +24,6 @@ declare(strict_types = 1);
 namespace Tests\Core\ResourceAccess\Application\UseCase\DeleteRule;
 
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
@@ -44,7 +43,6 @@ beforeEach(closure: function (): void {
         writeRepository: $this->writeRepository = $this->createMock(WriteResourceAccessRepositoryInterface::class),
         user: $this->user = $this->createMock(ContactInterface::class),
         accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
-        dataStorageEngine: $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class)
     );
 
     $this->presenter = new DeleteRulePresenterStub($this->createMock(PresenterFormatterInterface::class));
@@ -131,19 +129,11 @@ it('should present a ErrorResponse when deletion goes wrong', function (): void 
         ->method('exists')
         ->willReturn(true);
 
-    $this->dataStorageEngine
-        ->expects($this->once())
-        ->method('startTransaction');
-
     $this->writeRepository
         ->expects($this->once())
         ->method('deleteRuleAndDatasets')
         ->with(1)
         ->willThrowException(new \Exception());
-
-    $this->dataStorageEngine
-        ->expects($this->once())
-        ->method('rollbackTransaction');
 
     ($this->useCase)(1, $this->presenter);
 
@@ -171,18 +161,10 @@ it('should present a NoContentResponse when deletion goes well', function (): vo
         ->method('exists')
         ->willReturn(true);
 
-    $this->dataStorageEngine
-        ->expects($this->once())
-        ->method('startTransaction');
-
     $this->writeRepository
         ->expects($this->once())
         ->method('deleteRuleAndDatasets')
         ->with(1);
-
-    $this->dataStorageEngine
-        ->expects($this->once())
-        ->method('commitTransaction');
 
     ($this->useCase)(1, $this->presenter);
 

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Tests\Core\ResourceAccess\Application\UseCase\DeleteRules;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\MultiStatusResponse;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\ResourceAccess\Application\Exception\RuleException;
+use Core\ResourceAccess\Application\Repository\ReadResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\Repository\WriteResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRules;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesRequest;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Tests\Core\ResourceAccess\Infrastructure\API\DeleteRules\DeleteRulesPresenterStub;
+
+beforeEach(closure: function (): void {
+    $this->useCase = new DeleteRules(
+        readRepository: $this->readRepository = $this->createMock(ReadResourceAccessRepositoryInterface::class),
+        writeRepository: $this->writeRepository = $this->createMock(WriteResourceAccessRepositoryInterface::class),
+        user: $this->user = $this->createMock(ContactInterface::class),
+        accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        dataStorageEngine: $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class)
+    );
+
+    $this->presenter = new DeleteRulesPresenterStub($this->createMock(PresenterFormatterInterface::class));
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (missing page access)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    $request = new DeleteRulesRequest();
+    $request->ids = [1,2];
+
+    ($this->useCase)($request, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (not admin)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'centreon_not_admin', 'not an admin')]
+        );
+
+    $request = new DeleteRulesRequest();
+    $request->ids = [1,2];
+
+    ($this->useCase)($request, $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->response->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a Multi-Status Response when a bulk delete action is executed', function () {
+    $request = new DeleteRulesRequest();
+    $request->ids = [1,2];
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'customer_admin_acl')]
+        );
+
+    $this->readRepository
+        ->expects($this->exactly(2))
+        ->method('exists')
+        ->willReturnOnConsecutiveCalls(true, false);
+
+    ($this->useCase)($request, $this->presenter);
+
+    $expectedResult = [
+        'results' => [
+            [
+                'self' => 'centreon/api/latest/administration/resource-access/rules/1',
+                'status' => 204,
+                'message' => null
+            ],
+            [
+                'self' => 'centreon/api/latest/administration/resource-access/rules/2',
+                'status' => 404,
+                'message' => 'Resource access rule not found'
+            ],
+        ]
+    ];
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(MultiStatusResponse::class)
+        ->and($this->presenter->response->getPayload())
+        ->toBeArray()
+        ->and($this->presenter->response->getPayload())
+        ->toBe($expectedResult);
+});
+

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateTest.php
@@ -1,0 +1,267 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ResourceAccess\Application\UseCase\PartialRuleUpdate;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ConflictResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\ResourceAccess\Application\Exception\RuleException;
+use Core\ResourceAccess\Application\Repository\ReadResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\Repository\WriteResourceAccessRepositoryInterface;
+use Core\ResourceAccess\Application\UseCase\PartialRuleUpdate\PartialRuleUpdate;
+use Core\ResourceAccess\Application\UseCase\PartialRuleUpdate\PartialRuleUpdateRequest;
+use Core\ResourceAccess\Application\UseCase\UpdateRule\UpdateRuleValidation;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\DatasetFilter;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\DatasetFilterValidator;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\HostCategoryFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\HostFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\HostGroupFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\MetaServiceFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceCategoryFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceFilterType;
+use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceGroupFilterType;
+use Core\ResourceAccess\Domain\Model\NewRule;
+use Core\ResourceAccess\Domain\Model\Rule;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Tests\Core\ResourceAccess\Infrastructure\API\PartialRuleUpdate\PartialRuleUpdatePresenterStub;
+
+beforeEach(closure: function (): void {
+   $this->presenter = new PartialRuleUpdatePresenterStub($this->createMock(PresenterFormatterInterface::class));
+
+    foreach ([
+        HostFilterType::class,
+        HostGroupFilterType::class,
+        HostCategoryFilterType::class,
+        ServiceFilterType::class,
+        ServiceGroupFilterType::class,
+        ServiceCategoryFilterType::class,
+        MetaServiceFilterType::class,
+    ] as $className) {
+        $this->filterTypes[] = new $className();
+    }
+
+    $this->datasetValidator = new DatasetFilterValidator(new \ArrayObject($this->filterTypes));
+
+    $this->useCase = new PartialRuleUpdate(
+        user: $this->user = $this->createMock(ContactInterface::class),
+        accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        readRepository: $this->readRepository = $this->createMock(ReadResourceAccessRepositoryInterface::class),
+        writeRepository: $this->writeRepository = $this->createMock(WriteResourceAccessRepositoryInterface::class),
+        validator: $this->validator = $this->createMock(UpdateRuleValidation::class),
+    );
+
+    $this->request = new PartialRuleUpdateRequest();
+    $this->request->name = 'Rule 1';
+    $this->request->description = 'Description of Rule 1';
+    $this->request->isEnabled = true;
+
+    $datasetFilterData0 = [
+        'type' => 'hostgroup',
+        'resources' => [11, 12],
+        'dataset_filter' => [
+            'type' => 'host',
+            'resources' => [110, 120],
+            'dataset_filter' => null,
+        ],
+    ];
+
+    $datasetFilterData1 = [
+        'type' => 'host',
+        'resources' => [111, 121],
+        'dataset_filter' => null,
+    ];
+
+    $datasetFilter0 = new DatasetFilter(
+        $datasetFilterData0['type'],
+        $datasetFilterData0['resources'],
+        $this->datasetValidator
+    );
+
+    $datasetFilter0->setDatasetFilter(
+        new DatasetFilter(
+            $datasetFilterData0['dataset_filter']['type'],
+            $datasetFilterData0['dataset_filter']['resources'],
+            $this->datasetValidator
+        )
+    );
+
+    $datasetFilter1 = new DatasetFilter(
+        $datasetFilterData1['type'],
+        $datasetFilterData1['resources'],
+        $this->datasetValidator
+    );
+
+    $this->datasetFilters = [$datasetFilter0, $datasetFilter1];
+
+    $this->rule = new Rule(
+        id: 1,
+        name: Rule::formatName($this->request->name),
+        description: $this->request->name,
+        linkedContacts: [1],
+        linkedContactGroups: [2],
+        datasets: $this->datasetFilters,
+        isEnabled: true
+    );
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (missing page access)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+        );
+
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)($this->request, $this->presenter);
+
+    expect($this->presenter->responseStatus)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->responseStatus->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it('should present a Forbidden response when user does not have sufficient rights (not an admin)', function (): void {
+    $this->accessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn(
+            [new AccessGroup(1, 'lame_acl', 'not an admin')]
+        );
+
+    ($this->useCase)($this->request, $this->presenter);
+
+    expect($this->presenter->responseStatus)
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->responseStatus->getMessage())
+        ->toBe(RuleException::notAllowed()->getMessage());
+});
+
+it(
+    'should present a NotFoundResponse when ruleId requested does not exist',
+    function (): void {
+        $this->accessGroupRepository
+            ->expects($this->once())
+            ->method('findByContact')
+            ->willReturn(
+                [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+            );
+
+        $this->user
+            ->expects($this->once())
+            ->method('hasTopologyRole')
+            ->willReturn(true);
+
+        $this->readRepository
+            ->expects($this->once())
+            ->method('findById')
+            ->willReturn(null);
+
+        ($this->useCase)($this->request, $this->presenter);
+
+        expect($this->presenter->responseStatus)->toBeInstanceOf(NotFoundResponse::class);
+    }
+);
+
+it(
+    'should present ConflictResponse when name provided is already used',
+    function (): void {
+        $this->accessGroupRepository
+            ->expects($this->once())
+            ->method('findByContact')
+            ->willReturn(
+                [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+            );
+
+        $this->user
+            ->expects($this->once())
+            ->method('hasTopologyRole')
+            ->willReturn(true);
+
+        $this->readRepository
+            ->expects($this->once())
+            ->method('findById')
+            ->willReturn($this->rule);
+
+        $this->request->name = 'fake-existing-name';
+
+        $this->validator
+            ->expects($this->once())
+            ->method('assertIsValidName')
+            ->willThrowException(
+                RuleException::nameAlreadyExists(
+                    NewRule::formatName($this->request->name),
+                    $this->request->name
+                )
+            );
+
+        ($this->useCase)($this->request, $this->presenter);
+
+        expect($this->presenter->responseStatus)
+            ->toBeInstanceOf(ConflictResponse::class)
+            ->and($this->presenter->responseStatus->getMessage())
+            ->toBe(
+                RuleException::nameAlreadyExists(
+                    NewRule::formatName($this->request->name),
+                    $this->request->name
+                )->getMessage()
+            );
+    }
+);
+
+it(
+    'should present a NoContentResponse when everything goes well',
+    function (): void {
+        $this->accessGroupRepository
+            ->expects($this->once())
+            ->method('findByContact')
+            ->willReturn(
+                [new AccessGroup(1, 'customer_admin_acl', 'not an admin')]
+            );
+
+        $this->user
+            ->expects($this->once())
+            ->method('hasTopologyRole')
+            ->willReturn(true);
+
+        $this->readRepository
+            ->expects($this->once())
+            ->method('findById')
+            ->willReturn($this->rule);
+
+        ($this->useCase)($this->request, $this->presenter);
+
+        expect($this->presenter->responseStatus)
+            ->toBeInstanceOf(NoContentResponse::class);
+    }
+);
+

--- a/centreon/tests/php/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesPresenterStub.php
+++ b/centreon/tests/php/Core/ResourceAccess/Infrastructure/API/DeleteRules/DeleteRulesPresenterStub.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ResourceAccess\Infrastructure\API\DeleteRules;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\MultiStatusResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesPresenterInterface;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesResponse;
+use Core\ResourceAccess\Application\UseCase\DeleteRules\DeleteRulesStatusResponse;
+use Core\ResourceAccess\Domain\Model\ResponseCode;
+use Symfony\Component\HttpFoundation\Response;
+
+class DeleteRulesPresenterStub extends AbstractPresenter implements DeleteRulesPresenterInterface
+{
+    private const HREF = 'centreon/api/latest/administration/resource-access/rules/';
+
+    /** @var ResponseStatusInterface */
+    public ResponseStatusInterface $response;
+
+    public function presentResponse(DeleteRulesResponse|ResponseStatusInterface $response): void
+    {
+        if ($response instanceof DeleteRulesResponse) {
+            $multiStatusResponse = [
+                'results' => array_map(function (DeleteRulesStatusResponse $dto) {
+                    return [
+                        'self' => self::HREF . $dto->id,
+                        'status' => $this->enumToIntConverter($dto->status),
+                        'message' => $dto->message,
+                    ];
+                }, $response->responseStatuses),
+            ];
+
+            $this->response = new MultiStatusResponse($multiStatusResponse);
+        } else {
+            $this->response = $response;
+        }
+    }
+
+    /**
+     * @param ResponseCode $code
+     *
+     * @return int
+     */
+    private function enumToIntConverter(ResponseCode $code): int
+    {
+        return match ($code) {
+            ResponseCode::OK => Response::HTTP_NO_CONTENT,
+            ResponseCode::NotFound => Response::HTTP_NOT_FOUND,
+            ResponseCode::Error => Response::HTTP_INTERNAL_SERVER_ERROR
+        };
+    }
+}

--- a/centreon/tests/php/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdatePresenterStub.php
+++ b/centreon/tests/php/Core/ResourceAccess/Infrastructure/API/PartialRuleUpdate/PartialRuleUpdatePresenterStub.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ResourceAccess\Infrastructure\API\PartialRuleUpdate;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+class PartialRuleUpdatePresenterStub extends AbstractPresenter
+{
+    public ?ResponseStatusInterface $responseStatus;
+
+    public function setResponseStatus(?ResponseStatusInterface $responseStatus): void
+    {
+        $this->responseStatus = $responseStatus;
+    }
+}
+

--- a/centreon/tests/rest_api/behat-collections/realtime_rest_api.postman_collection.json
+++ b/centreon/tests/rest_api/behat-collections/realtime_rest_api.postman_collection.json
@@ -5382,7 +5382,7 @@
 									}
 								],
 								"url": {
-									"raw": "http://{{url}}/centreon/api/index.php?action=list&object=centreon_realtime_services&limit={{my_limit}}&fields=service_id",
+									"raw": "http://{{url}}/centreon/api/index.php?action=list&object=centreon_realtime_services&limit={{my_limit}}&fields=service_id&sortType=service_id",
 									"protocol": "http",
 									"host": [
 										"{{url}}"
@@ -5407,6 +5407,10 @@
 										},
 										{
 											"key": "fields",
+											"value": "service_id"
+										},
+										{
+											"key": "sortType",
 											"value": "service_id"
 										}
 									]

--- a/centreon/www/api/class/centreon_realtime_hosts.class.php
+++ b/centreon/www/api/class/centreon_realtime_hosts.class.php
@@ -1,4 +1,25 @@
 <?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
 /**
  * Copyright 2005-2017 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
@@ -30,36 +51,43 @@
  * do not wish to do so, delete this exception statement from your version.
  *
  * For more information : contact@centreon.com
- *
  */
 
-require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
-require_once dirname(__FILE__) . "/centreon_configuration_objects.class.php";
-require_once dirname(__FILE__) . "/centreon_realtime_base.class.php";
+require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
+require_once __DIR__ . '/centreon_configuration_objects.class.php';
+require_once __DIR__ . '/centreon_realtime_base.class.php';
 
 /**
- * Class Centreon Realtime Host
- *
+ * Class Centreon Realtime Host.
  */
 class CentreonRealtimeHosts extends CentreonRealtimeBase
 {
-    /**
-     * @var CentreonDB
-     */
+    /** @var CentreonDB */
     protected $aclObj;
+
     protected $admin;
 
-    /* parameters */
+    // parameters
     protected $limit;
+
     protected $number;
+
     protected $status;
+
     protected $hostgroup;
+
     protected $search;
+
     protected $searchHost;
+
     protected $viewType;
+
     protected $sortType;
+
     protected $order;
+
     protected $instance;
+
     protected $criticality;
 
     protected $fieldList;
@@ -74,7 +102,7 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
         parent::__construct();
 
         // Init ACL
-        if (!$centreon->user->admin) {
+        if (! $centreon->user->admin) {
             $this->admin = 0;
             $this->aclObj = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
         } else {
@@ -83,12 +111,229 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
     }
 
     /**
-     * Set a list of filters send by the request
+     * @return array
+     */
+    public function getList()
+    {
+        $this->setHostFilters();
+        $this->setHostFieldList();
+
+        return $this->getHostState();
+    }
+
+    /**
+     * @throws RestBadRequestException
+     *
+     * @return array
+     */
+    public function getHostState()
+    {
+        $queryValues = [];
+
+        $tables = 'instances i, '
+            . (! $this->admin ? 'centreon_acl, ' : '')
+            . ($this->hostgroup ? 'hosts_hostgroups hhg, hostgroups hg, ' : '')
+            . ($this->criticality ? 'customvariables cvs, ' : '')
+            . '`hosts` h';
+
+        $criticalityConditions = '';
+        if ($this->criticality) {
+            $criticalityConditions = <<<'SQL'
+                AND h.host_id = cvs.host_id
+                AND cvs.name = 'CRITICALITY_LEVEL'
+                AND (cvs.service_id IS NULL OR cvs.service_id = 0)
+                AND cvs.value = :criticality
+                SQL;
+
+            $queryValues['criticality'] = (string) $this->criticality;
+        }
+
+        $nonAdminConditions = '';
+        if (! $this->admin) {
+            $nonAdminConditions .= ' AND h.host_id = centreon_acl.host_id ';
+            $nonAdminConditions .= $this->aclObj->queryBuilder(
+                'AND',
+                'centreon_acl.group_id',
+                $this->aclObj->getAccessGroupsString()
+            );
+        }
+
+        $viewTypeConditions = '';
+        if ($this->viewType === 'unhandled') {
+            $viewTypeConditions = <<<'SQL'
+                AND h.state = 1
+                AND h.state_type = '1'
+                AND h.acknowledged = 0
+                AND h.scheduled_downtime_depth = 0
+                SQL;
+        } elseif ($this->viewType === 'problems') {
+            $viewTypeConditions = ' AND (h.state <> 0 AND h.state <> 4) ';
+        }
+
+        $statusConditions = '';
+        if ($this->status === 'up') {
+            $statusConditions = ' AND h.state = 0 ';
+        } elseif ($this->status === 'down') {
+            $statusConditions = ' AND h.state = 1 ';
+        } elseif ($this->status === 'unreachable') {
+            $statusConditions = ' AND h.state = 2 ';
+        } elseif ($this->status === 'pending') {
+            $statusConditions = ' AND h.state = 4 ';
+        }
+
+        $hostGroupConditions = '';
+        if ($this->hostgroup) {
+            $explodedValues = '';
+            foreach (explode(',', $this->hostgroup) as $hgId => $hgValue) {
+                if (! is_numeric($hgValue)) {
+                    throw new \RestBadRequestException('Error, host group id must be numerical');
+                }
+                $explodedValues .= ':hostgroup' . $hgId . ',';
+                $queryValues['hostgroup'][$hgId] = (int) $hgValue;
+            }
+            $explodedValues = rtrim($explodedValues, ',');
+
+            $hostGroupConditions = <<<SQL
+                AND h.host_id = hhg.host_id
+                AND hg.hostgroup_id IN ({$explodedValues})
+                AND hhg.hostgroup_id = hg.hostgroup_id
+                SQL;
+        }
+
+        $instanceConditions = '';
+        if ($this->instance !== -1 && ! empty($this->instance)) {
+            if (! is_numeric($this->instance)) {
+                throw new \RestBadRequestException('Error, instance id must be numerical');
+            }
+            $instanceConditions = ' AND h.instance_id = :instanceId ';
+            $queryValues['instanceId'] = (int) $this->instance;
+        }
+
+        $order = '';
+        if (
+            ! isset($this->arguments['fields'])
+            || is_null($this->arguments['fields'])
+            || in_array($this->sortType, explode(',', $this->arguments['fields']), true)
+        ) {
+            $q = 'ASC';
+            if (isset($this->order) && mb_strtoupper($this->order) === 'DESC') {
+                $q = 'DESC';
+            }
+
+            switch ($this->sortType) {
+                case 'id':
+                    $order = " ORDER BY h.host_id {$q}, h.name";
+                    break;
+                case 'alias':
+                    $order = " ORDER BY h.alias {$q}, h.name";
+                    break;
+                case 'address':
+                    $order = " ORDER BY IFNULL(inet_aton(h.address), h.address) {$q}, h.name ";
+                    break;
+                case 'state':
+                    $order = " ORDER BY h.state {$q}, h.name ";
+                    break;
+                case 'last_state_change':
+                    $order = " ORDER BY h.last_state_change {$q}, h.name ";
+                    break;
+                case 'last_hard_state_change':
+                    $order = " ORDER BY h.last_hard_state_change {$q}, h.name ";
+                    break;
+                case 'acknowledged':
+                    $order = "ORDER BY h.acknowledged {$q}, h.name";
+                    break;
+                case 'last_check':
+                    $order = " ORDER BY h.last_check {$q}, h.name ";
+                    break;
+                case 'check_attempt':
+                    $order = " ORDER BY h.check_attempt {$q}, h.name ";
+                    break;
+                case 'max_check_attempts':
+                    $order = " ORDER BY h.max_check_attempts {$q}, h.name";
+                    break;
+                case 'instance_name':
+                    $order = " ORDER BY i.name {$q}, h.name";
+                    break;
+                case 'output':
+                    $order = " ORDER BY h.output {$q}, h.name ";
+                    break;
+                case 'criticality':
+                    $order = " ORDER BY criticality {$q}, h.name ";
+                    break;
+                case 'name':
+                default:
+                    $order = " ORDER BY h.name {$q}";
+                    break;
+            }
+        }
+
+        // Get Host status
+        $query = <<<SQL
+            SELECT SQL_CALC_FOUND_ROWS DISTINCT {$this->fieldList}
+            FROM {$tables}
+            LEFT JOIN hosts_hosts_parents hph
+                ON hph.parent_id = h.host_id
+            LEFT JOIN `customvariables` cv
+                ON (cv.host_id = h.host_id
+                AND (cv.service_id IS NULL OR cv.service_id = 0)
+                AND cv.name = 'CRITICALITY_LEVEL')
+            WHERE h.name NOT LIKE '\_Module\_%'
+                AND h.instance_id = i.instance_id
+                {$criticalityConditions}
+                {$nonAdminConditions}
+                AND (h.name LIKE :searchName OR h.alias LIKE :searchAlias OR h.address LIKE :searchAddress)
+                {$viewTypeConditions}
+                {$statusConditions}
+                {$hostGroupConditions}
+                {$instanceConditions}
+                AND h.enabled = 1
+                {$order}
+                LIMIT :offset,:limit
+            SQL;
+
+        $queryValues['searchName'] = '%' . (string) $this->search . '%';
+        $queryValues['searchAlias'] = '%' . (string) $this->search . '%';
+        $queryValues['searchAddress'] = '%' . (string) $this->search . '%';
+        $queryValues['offset'] = (int) ($this->number * $this->limit);
+        $queryValues['limit'] = (int) $this->limit;
+
+        $stmt = $this->realTimeDb->prepare($query);
+
+        if ($this->criticality) {
+            $stmt->bindParam(':criticality', $queryValues['criticality'], PDO::PARAM_STR);
+        }
+        $stmt->bindParam(':searchName', $queryValues['searchName'], PDO::PARAM_STR);
+        $stmt->bindParam(':searchAlias', $queryValues['searchAlias'], PDO::PARAM_STR);
+        $stmt->bindParam(':searchAddress', $queryValues['searchAddress'], PDO::PARAM_STR);
+        if (isset($queryValues['hostgroup'])) {
+            foreach ($queryValues['hostgroup'] as $hgId => $hgValue) {
+                $stmt->bindValue(':hostgroup' . $hgId, $hgValue, PDO::PARAM_INT);
+            }
+        }
+        if (isset($queryValues['instanceId'])) {
+            $stmt->bindParam(':instanceId', $queryValues['instanceId'], PDO::PARAM_INT);
+        }
+
+        $stmt->bindParam(':offset', $queryValues['offset'], PDO::PARAM_INT);
+        $stmt->bindParam(':limit', $queryValues['limit'], PDO::PARAM_INT);
+        $stmt->execute();
+
+        $dataList = [];
+        while ($data = $stmt->fetch()) {
+            $dataList[] = $data;
+        }
+
+        return $dataList;
+    }
+
+    /**
+     * Set a list of filters send by the request.
+     *
      * @throws RestBadRequestException
      */
-    protected function setHostFilters()
+    protected function setHostFilters(): void
     {
-        /* Pagination Elements */
+        // Pagination Elements
         if (isset($this->arguments['limit'])) {
             $this->limit = $this->arguments['limit'];
         } else {
@@ -99,14 +344,14 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
         } else {
             $this->number = 0;
         }
-        if (!is_numeric($this->number) || !is_numeric($this->limit)) {
+        if (! is_numeric($this->number) || ! is_numeric($this->limit)) {
             throw new \RestBadRequestException('Error, limit must be numerical');
         }
 
-        /* Filters */
+        // Filters
         if (isset($this->arguments['status'])) {
-            $statusList = array('up', 'down', 'unreachable', 'pending', 'all');
-            if (in_array(strtolower($this->arguments['status']), $statusList)) {
+            $statusList = ['up', 'down', 'unreachable', 'pending', 'all'];
+            if (in_array(mb_strtolower($this->arguments['status']), $statusList, true)) {
                 $this->status = $this->arguments['status'];
             } else {
                 throw new \RestBadRequestException('Bad status parameter');
@@ -135,15 +380,17 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
             $this->criticality = null;
         }
 
-        /* view properties */
+        // view properties
         if (isset($this->arguments['viewType'])) {
             $this->viewType = $this->arguments['viewType'];
         } else {
             $this->viewType = null;
         }
         if (isset($this->arguments['order'])) {
-            if (strtolower($this->arguments['order']) === 'asc' ||
-                strtolower($this->arguments['order']) === 'desc') {
+            if (
+                mb_strtolower($this->arguments['order']) === 'asc'
+                || mb_strtolower($this->arguments['order']) === 'desc'
+            ) {
                 $this->order = $this->arguments['order'];
             } else {
                 throw new \RestBadRequestException('Bad order parameter');
@@ -159,17 +406,7 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
     }
 
     /**
-     * @return array
-     */
-    public function getList()
-    {
-        $this->setHostFilters();
-        $this->setHostFieldList();
-        return $this->getHostState();
-    }
-
-    /**
-     * Get selected fields by the request
+     * Get selected fields by the request.
      *
      * @return array
      */
@@ -177,318 +414,129 @@ class CentreonRealtimeHosts extends CentreonRealtimeBase
     {
         $tab = explode(',', $this->arguments['fields']);
 
-        $fieldList = array();
+        $fieldList = [];
         foreach ($tab as $key) {
             $fieldList[trim($key)] = 1;
         }
-        return ($fieldList);
+
+        return $fieldList;
     }
 
     /**
-     * Set Filters
-     *
+     * Set Filters.
      */
-    protected function setHostFieldList()
+    protected function setHostFieldList(): void
     {
-        $fields = array();
-        if (!isset($this->arguments['fields'])) {
-            $fields["h.host_id as id"] = 'host_id';
-            $fields["h.name"] = 'name';
-            $fields["h.alias"] = 'alias';
-            $fields["h.address"] = 'address';
-            $fields["h.state"] = 'state';
-            $fields["h.state_type"] = 'state_type';
-            $fields["h.output"] = 'output';
-            $fields["h.max_check_attempts"] = 'max_check_attempts';
-            $fields["h.check_attempt"] = 'check_attempt';
-            $fields["h.last_check"] = 'last_check';
-            $fields["h.last_state_change"] = 'last_state_change';
-            $fields["h.last_hard_state_change"] = 'last_hard_state_change';
-            $fields["h.acknowledged"] = 'acknowledged';
-            $fields["i.name as instance_name"] = 'instance';
-            $fields["cv.value as criticality"] = 'criticality';
+        $fields = [];
+        if (! isset($this->arguments['fields'])) {
+            $fields['h.host_id as id'] = 'host_id';
+            $fields['h.name'] = 'name';
+            $fields['h.alias'] = 'alias';
+            $fields['h.address'] = 'address';
+            $fields['h.state'] = 'state';
+            $fields['h.state_type'] = 'state_type';
+            $fields['h.output'] = 'output';
+            $fields['h.max_check_attempts'] = 'max_check_attempts';
+            $fields['h.check_attempt'] = 'check_attempt';
+            $fields['h.last_check'] = 'last_check';
+            $fields['h.last_state_change'] = 'last_state_change';
+            $fields['h.last_hard_state_change'] = 'last_hard_state_change';
+            $fields['h.acknowledged'] = 'acknowledged';
+            $fields['i.name as instance_name'] = 'instance';
+            $fields['cv.value as criticality'] = 'criticality';
         } else {
             $fieldList = $this->getFieldContent();
 
             if (isset($fieldList['id'])) {
-                $fields["h.host_id as id"] = 'host_id';
+                $fields['h.host_id as id'] = 'host_id';
             }
             if (isset($fieldList['name'])) {
-                $fields["h.name"] = 'name';
+                $fields['h.name'] = 'name';
             }
             if (isset($fieldList['alias'])) {
-                $fields["h.alias"] = 'alias';
+                $fields['h.alias'] = 'alias';
             }
             if (isset($fieldList['address'])) {
-                $fields["h.address"] = 'address';
+                $fields['h.address'] = 'address';
             }
             if (isset($fieldList['state'])) {
-                $fields["h.state"] = 'state';
+                $fields['h.state'] = 'state';
             }
             if (isset($fieldList['state_type'])) {
-                $fields["h.state_type"] = 'state_type';
+                $fields['h.state_type'] = 'state_type';
             }
             if (isset($fieldList['output'])) {
-                $fields["h.output"] = 'output';
+                $fields['h.output'] = 'output';
             }
             if (isset($fieldList['max_check_attempts'])) {
-                $fields["h.max_check_attempts"] = 'max_check_attempts';
+                $fields['h.max_check_attempts'] = 'max_check_attempts';
             }
             if (isset($fieldList['check_attempt'])) {
-                $fields["h.check_attempt"] = 'check_attempt';
+                $fields['h.check_attempt'] = 'check_attempt';
             }
             if (isset($fieldList['last_check'])) {
-                $fields["h.last_check"] = 'last_check';
+                $fields['h.last_check'] = 'last_check';
             }
             if (isset($fieldList['next_check'])) {
-                $fields["h.next_check"] = 'next_check';
+                $fields['h.next_check'] = 'next_check';
             }
             if (isset($fieldList['last_state_change'])) {
-                $fields["h.last_state_change"] = 'last_state_change';
+                $fields['h.last_state_change'] = 'last_state_change';
             }
             if (isset($fieldList['last_hard_state_change'])) {
-                $fields["h.last_hard_state_change"] = 'last_hard_state_change';
+                $fields['h.last_hard_state_change'] = 'last_hard_state_change';
             }
             if (isset($fieldList['acknowledged'])) {
-                $fields["h.acknowledged"] = 'acknowledged';
+                $fields['h.acknowledged'] = 'acknowledged';
             }
             if (isset($fieldList['instance'])) {
-                $fields["i.name as instance_name"] = 'instance';
+                $fields['i.name as instance_name'] = 'instance';
             }
             if (isset($fieldList['instance_id'])) {
-                $fields["i.instance_id as instance_id"] = 'instance_id';
+                $fields['i.instance_id as instance_id'] = 'instance_id';
             }
             if (isset($fieldList['criticality'])) {
-                $fields["cv.value as criticality"] = 'criticality';
+                $fields['cv.value as criticality'] = 'criticality';
             }
             if (isset($fieldList['passive_checks'])) {
-                $fields["h.passive_checks"] = 'passive_checks';
+                $fields['h.passive_checks'] = 'passive_checks';
             }
             if (isset($fieldList['active_checks'])) {
-                $fields["h.active_checks"] = 'active_checks';
+                $fields['h.active_checks'] = 'active_checks';
             }
             if (isset($fieldList['notify'])) {
-                $fields["h.notify"] = 'notify';
+                $fields['h.notify'] = 'notify';
             }
             if (isset($fieldList['action_url'])) {
-                $fields["h.action_url"] = 'action_url';
+                $fields['h.action_url'] = 'action_url';
             }
             if (isset($fieldList['notes_url'])) {
-                $fields["h.notes_url"] = 'notes_url';
+                $fields['h.notes_url'] = 'notes_url';
             }
             if (isset($fieldList['notes'])) {
-                $fields["h.notes"] = 'notes';
+                $fields['h.notes'] = 'notes';
             }
             if (isset($fieldList['icon_image'])) {
-                $fields["h.icon_image"] = 'icon_image';
+                $fields['h.icon_image'] = 'icon_image';
             }
             if (isset($fieldList['icon_image_alt'])) {
-                $fields["h.icon_image_alt"] = 'icon_image_alt';
+                $fields['h.icon_image_alt'] = 'icon_image_alt';
             }
             if (isset($fieldList['scheduled_downtime_depth'])) {
-                $fields["h.scheduled_downtime_depth"] = 'scheduled_downtime_depth';
+                $fields['h.scheduled_downtime_depth'] = 'scheduled_downtime_depth';
             }
             if (isset($fieldList['flapping'])) {
-                $fields["h.flapping"] = 'flapping';
+                $fields['h.flapping'] = 'flapping';
             }
         }
 
-        /* Build Field List */
-        $this->fieldList = "";
+        // Build Field List
+        $this->fieldList = '';
         foreach ($fields as $key => $value) {
-            if ($this->fieldList != '') {
+            if ($this->fieldList !== '') {
                 $this->fieldList .= ', ';
             }
             $this->fieldList .= $key;
         }
-    }
-
-
-    /**
-     * @return array
-     * @throws RestBadRequestException
-     */
-    public function getHostState()
-    {
-        $queryValues = array();
-
-        /*
-         * Get Host status
-         */
-        $query = " SELECT SQL_CALC_FOUND_ROWS DISTINCT " . $this->fieldList . " ";
-        $query .= " FROM instances i, ";
-        if (!$this->admin) {
-            $query .= " centreon_acl, ";
-        }
-        if ($this->hostgroup) {
-            $query .= " hosts_hostgroups hhg, hostgroups hg, ";
-        }
-        if ($this->criticality) {
-            $query .= "customvariables cvs, ";
-        }
-        $query .= " `hosts` h ";
-        $query .= " LEFT JOIN hosts_hosts_parents hph ";
-        $query .= " ON hph.parent_id = h.host_id ";
-
-        $query .= " LEFT JOIN `customvariables` cv ";
-        $query .= " ON (cv.host_id = h.host_id ";
-        $query .= " AND cv.service_id IS NULL ";
-        $query .= " AND cv.name = 'CRITICALITY_LEVEL') ";
-
-        $query .= " WHERE h.name NOT LIKE '\_Module\_%'";
-        $query .= " AND h.instance_id = i.instance_id ";
-
-        if ($this->criticality) {
-            $query .= " AND h.host_id = cvs.host_id ";
-            $query .= " AND cvs.name = 'CRITICALITY_LEVEL' ";
-            $query .= " AND cvs.service_id IS NULL ";
-            $query .= " AND cvs.value = :criticality ";
-            $queryValues['criticality'] = (string)$this->criticality;
-        }
-
-        if (!$this->admin) {
-            $query .= " AND h.host_id = centreon_acl.host_id ";
-            $query .= $this->aclObj->queryBuilder(
-                "AND",
-                "centreon_acl.group_id",
-                $this->aclObj->getAccessGroupsString()
-            );
-        }
-
-        $query .= " AND (h.name LIKE :searchName ";
-        $queryValues['searchName'] = '%' . (string)$this->search . '%';
-        $query .= " OR h.alias LIKE :searchAlias ";
-        $queryValues['searchAlias'] = '%' . (string)$this->search . '%';
-        $query .= " OR h.address LIKE :searchAddress ) ";
-        $queryValues['searchAddress'] = '%' . (string)$this->search . '%';
-
-        if ($this->viewType == "unhandled") {
-            $query .= " AND h.state = 1 ";
-            $query .= " AND h.state_type = '1'";
-            $query .= " AND h.acknowledged = 0";
-            $query .= " AND h.scheduled_downtime_depth = 0";
-        } elseif ($this->viewType == "problems") {
-            $query .= " AND (h.state <> 0 AND h.state <> 4) ";
-        }
-
-        if ($this->status == "up") {
-            $query .= " AND h.state = 0 ";
-        } elseif ($this->status == "down") {
-            $query .= " AND h.state = 1 ";
-        } elseif ($this->status == "unreachable") {
-            $query .= " AND h.state = 2 ";
-        } elseif ($this->status == "pending") {
-            $query .= " AND h.state = 4 ";
-        }
-
-        if ($this->hostgroup) {
-            $explodedValues = '';
-            foreach (explode(',', $this->hostgroup) as $hgId => $hgValue) {
-                if (!is_numeric($hgValue)) {
-                    throw new \RestBadRequestException('Error, host group id must be numerical');
-                }
-                $explodedValues .= ':hostgroup' . $hgId . ',';
-                $queryValues['hostgroup'][$hgId] = (int)$hgValue;
-            }
-            $explodedValues = rtrim($explodedValues, ',');
-            $query .= " AND h.host_id = hhg.host_id ";
-            $query .= " AND hg.hostgroup_id IN ($explodedValues) ";
-            $query .= " AND hhg.hostgroup_id = hg.hostgroup_id";
-        }
-
-        if ($this->instance != -1 && !empty($this->instance)) {
-            if (!is_numeric($this->instance)) {
-                throw new \RestBadRequestException('Error, instance id must be numerical');
-            }
-            $query .= " AND h.instance_id = :instanceId ";
-            $queryValues['instanceId'] = (int)$this->instance;
-        }
-        $query .= " AND h.enabled = 1 ";
-
-        if (!isset($this->arguments['fields']) ||
-            is_null($this->arguments['fields']) ||
-            in_array($this->sortType, explode(',', $this->arguments['fields']))
-        ) {
-            $q = 'ASC';
-            if (isset($this->order) && strtoupper($this->order) === 'DESC') {
-                $q = 'DESC';
-            }
-
-            switch ($this->sortType) {
-                case 'id':
-                    $query .= "ORDER BY h.host_id $q, h.name";
-                    break;
-                case 'alias':
-                    $query .= "ORDER BY h.alias $q, h.name";
-                    break;
-                case 'address':
-                    $query .= " ORDER BY IFNULL(inet_aton(h.address), h.address) $q, h.name ";
-                    break;
-                case 'state':
-                    $query .= " ORDER BY h.state $q, h.name ";
-                    break;
-                case 'last_state_change':
-                    $query .= " ORDER BY h.last_state_change $q, h.name ";
-                    break;
-                case 'last_hard_state_change':
-                    $query .= " ORDER BY h.last_hard_state_change $q, h.name ";
-                    break;
-                case 'acknowledged':
-                    $query .= "ORDER BY h.acknowledged $q, h.name";
-                    break;
-                case 'last_check':
-                    $query .= " ORDER BY h.last_check $q, h.name ";
-                    break;
-                case 'check_attempt':
-                    $query .= " ORDER BY h.check_attempt $q, h.name ";
-                    break;
-                case 'max_check_attempts':
-                    $query .= "ORDER BY h.max_check_attempts $q, h.name";
-                    break;
-                case 'instance_name':
-                    $query .= "ORDER BY i.name $q, h.name";
-                    break;
-                case 'output':
-                    $query .= " ORDER BY h.output $q, h.name ";
-                    break;
-                case 'criticality':
-                    $query .= " ORDER BY criticality $q, h.name ";
-                    break;
-                case 'name':
-                default:
-                    $query .= " ORDER BY h.name $q";
-                    break;
-            }
-        }
-
-        $query .= " LIMIT :offset,:limit";
-        $queryValues['offset'] = (int)($this->number * $this->limit);
-        $queryValues['limit'] = (int)$this->limit;
-        $stmt = $this->realTimeDb->prepare($query);
-
-        if ($this->criticality) {
-            $stmt->bindParam(':criticality', $queryValues["criticality"], PDO::PARAM_STR);
-        }
-        $stmt->bindParam(':searchName', $queryValues["searchName"], PDO::PARAM_STR);
-        $stmt->bindParam(':searchAlias', $queryValues["searchAlias"], PDO::PARAM_STR);
-        $stmt->bindParam(':searchAddress', $queryValues["searchAddress"], PDO::PARAM_STR);
-        if (isset($queryValues['hostgroup'])) {
-            foreach ($queryValues['hostgroup'] as $hgId => $hgValue) {
-                $stmt->bindValue(':hostgroup' . $hgId, $hgValue, PDO::PARAM_INT);
-            }
-        }
-        if (isset($queryValues['instanceId'])) {
-            $stmt->bindParam(':instanceId', $queryValues['instanceId'], PDO::PARAM_INT);
-        }
-
-        $stmt->bindParam(':offset', $queryValues["offset"], PDO::PARAM_INT);
-        $stmt->bindParam(':limit', $queryValues["limit"], PDO::PARAM_INT);
-        $stmt->execute();
-
-        $dataList = array();
-        while ($data = $stmt->fetch()) {
-            $dataList[] = $data;
-        }
-        return $dataList;
     }
 }

--- a/centreon/www/api/class/centreon_realtime_services.class.php
+++ b/centreon/www/api/class/centreon_realtime_services.class.php
@@ -431,6 +431,7 @@ class CentreonRealtimeServices extends CentreonRealtimeBase
         }
         $tabOrder = array();
         $tabOrder["criticality_id"] = " ORDER BY criticality $q, h.name, s.description ";
+        $tabOrder["service_id"] = " ORDER BY s.service_id $q ";
         $tabOrder["host_name"] = " ORDER BY h.name $q, s.description ";
         $tabOrder["service_description"] = " ORDER BY s.description $q, h.name";
         $tabOrder["current_state"] = " ORDER BY s.state $q, h.name, s.description";

--- a/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php
+++ b/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php
@@ -1255,8 +1255,8 @@ class CentreonServiceTemplate extends CentreonObject
             array('service_description'),
             -1,
             0,
-            null,
-            null,
+            'service_description,host_name',
+            'ASC',
             $filters_hostRel,
             "AND"
         );

--- a/centreon/www/class/centreonCustomView.class.php
+++ b/centreon/www/class/centreonCustomView.class.php
@@ -1274,12 +1274,12 @@ class CentreonCustomView
             $queryValue[] = (int)$k;
         }
         $cgString = rtrim($cgString, ',');
-        $query = 'SELECT c1.custom_view_id, c1.user_id as owner_id, c2.usergroup_id ' .
+        $query = 'SELECT c1.custom_view_id, c1.user_id as owner_id ' .
             'FROM custom_view_user_relation c1, custom_view_user_relation c2 ' .
             'WHERE c1.custom_view_id = c2.custom_view_id ' .
             'AND c1.is_owner = 1 ' .
             'AND c2.usergroup_id in (' . $cgString . ') ' .
-            'GROUP BY custom_view_id';
+            'GROUP BY c1.custom_view_id, c1.user_id';
         $stmt = $db->prepare($query);
         $dbResult = $stmt->execute($queryValue);
         if (!$dbResult) {

--- a/centreon/www/class/centreonDB.class.php
+++ b/centreon/www/class/centreonDB.class.php
@@ -426,7 +426,9 @@ class CentreonDB extends \PDO
          */
         if ($res = $this->query("SELECT VERSION() AS mysql_version")) {
             $row = $res->fetch();
-            $info['version'] = $row['mysql_version'];
+            $versionInformation = explode('-', $row['mysql_version']);
+            $info["version"] = $versionInformation[0];
+            $info["engine"] = $versionInformation[1] ?? 'MySQL';
             if ($dbResult = $this->query("SHOW TABLE STATUS FROM `" . $this->dsn['database'] . "`")) {
                 while ($data = $dbResult->fetch()) {
                     $info['dbsize'] += $data['Data_length'] + $data['Index_length'];
@@ -440,13 +442,9 @@ class CentreonDB extends \PDO
                 if ($key != "rows" && $key != "version" && $key != "engine") {
                     $info[$key] = round($value / $unitMultiple, 2);
                 }
-                if ($key == "version") {
-                    $tab = explode('-', $value);
-                    $info["version"] = $tab[0];
-                    $info["engine"] = $tab[1];
-                }
             }
         }
+
         return $info;
     }
 

--- a/centreon/www/include/configuration/configObject/command/formCommand.php
+++ b/centreon/www/include/configuration/configObject/command/formCommand.php
@@ -113,7 +113,7 @@ if (count($aMacroDescription) > 0) {
  * Resource Macro
  */
 $resource = array();
-$query = "SELECT DISTINCT `resource_name`, `resource_comment` FROM `cfg_resource` ORDER BY `resource_line`";
+$query = "SELECT DISTINCT `resource_name`, `resource_comment` FROM `cfg_resource` ORDER BY `resource_name`";
 $DBRESULT = $pearDB->query($query);
 while ($row = $DBRESULT->fetchRow()) {
     $resource[$row["resource_name"]] = $row["resource_name"];

--- a/centreon/www/include/configuration/configObject/connector/formConnector.php
+++ b/centreon/www/include/configuration/configObject/connector/formConnector.php
@@ -62,9 +62,9 @@ try {
      * Resource Macro
      */
     $resource = array();
-    $DBRESULT = $pearDB->query("SELECT DISTINCT `resource_name`, `resource_comment` 
-                                FROM `cfg_resource` 
-                                ORDER BY `resource_line`");
+    $DBRESULT = $pearDB->query("SELECT DISTINCT `resource_name`, `resource_comment`
+                                FROM `cfg_resource`
+                                ORDER BY `resource_name`");
     while ($row = $DBRESULT->fetchRow()) {
         $resource[$row["resource_name"]] = $row["resource_name"];
         if (isset($row["resource_comment"]) && $row["resource_comment"] != "") {

--- a/centreon/www/include/configuration/configObject/hostgroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/DB-Func.php
@@ -141,12 +141,13 @@ function removeRelationLastHostgroupDependency(int $hgId): void
     $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id
               FROM dependency_hostgroupParent_relation
               WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_hostgroupParent_relation
-                                         WHERE hostgroup_hg_id =  ' . $hgId . ')';
+                                         WHERE hostgroup_hg_id =  ' . $hgId . ')
+              GROUP BY dependency_dep_id';
     $dbResult = $pearDB->query($query);
     $result = $dbResult->fetch();
 
     //is last parent
-    if ($result['nb_dependency'] == 1) {
+    if (isset($result['nb_dependency']) && $result['nb_dependency'] == 1) {
         $pearDB->query("DELETE FROM dependency WHERE dep_id = " . $result['id']);
     }
 }

--- a/centreon/www/include/configuration/configObject/meta_service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/meta_service/DB-Func.php
@@ -89,15 +89,16 @@ function removeRelationLastMetaServiceDependency(int $serviceId): void
 {
     global $pearDB;
 
-    $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id 
-              FROM dependency_metaserviceParent_relation 
-              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_metaserviceParent_relation 
-                                         WHERE meta_service_meta_id =  ' . $serviceId . ')';
+    $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id
+              FROM dependency_metaserviceParent_relation
+              WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_metaserviceParent_relation
+                                         WHERE meta_service_meta_id =  ' . $serviceId . ')
+              GROUP BY dependency_dep_id';
     $dbResult = $pearDB->query($query);
     $result = $dbResult->fetch();
 
     //is last parent
-    if ($result['nb_dependency'] == 1) {
+    if (isset($result['nb_dependency']) && $result['nb_dependency'] == 1) {
         $pearDB->query("DELETE FROM dependency WHERE dep_id = " . $result['id']);
     }
 }

--- a/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/DB-Func.php
@@ -114,12 +114,13 @@ function removeRelationLastServicegroupDependency(int $servicegroupId): void
     $query = 'SELECT count(dependency_dep_id) AS nb_dependency , dependency_dep_id AS id
               FROM dependency_servicegroupParent_relation
               WHERE dependency_dep_id = (SELECT dependency_dep_id FROM dependency_servicegroupParent_relation
-                                         WHERE servicegroup_sg_id =  ' . $servicegroupId . ')';
+                                         WHERE servicegroup_sg_id =  ' . $servicegroupId . ')
+              GROUP BY dependency_dep_id';
     $dbResult = $pearDB->query($query);
     $result = $dbResult->fetch();
 
     //is last parent
-    if ($result['nb_dependency'] == 1) {
+    if (isset($result['nb_dependency']) && $result['nb_dependency'] == 1) {
         $pearDB->query("DELETE FROM dependency WHERE dep_id = " . $result['id']);
     }
 }

--- a/centreon/www/include/configuration/configServers/popup/central.yaml
+++ b/centreon/www/include/configuration/configServers/popup/central.yaml
@@ -33,7 +33,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
     - name: cron
       package: "gorgone::modules::core::cron::hooks"

--- a/centreon/www/include/configuration/configServers/popup/poller.yaml
+++ b/centreon/www/include/configuration/configServers/popup/poller.yaml
@@ -23,7 +23,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: engine

--- a/centreon/www/include/configuration/configServers/popup/remote.yaml
+++ b/centreon/www/include/configuration/configServers/popup/remote.yaml
@@ -24,7 +24,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: cron

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -583,7 +583,7 @@ CREATE TABLE `cfg_nagios` (
   `cfg_file` varchar(255) NOT NULL DEFAULT 'centengine.cfg',
   `log_pid` enum('0','1') DEFAULT '1',
   `enable_macros_filter` enum('0', '1') DEFAULT '0',
-  `macros_filter` TEXT DEFAULT '',
+  `macros_filter` TEXT DEFAULT (''),
   `logger_version` enum('log_v2_enabled', 'log_legacy_enabled') DEFAULT 'log_v2_enabled',
   PRIMARY KEY (`nagios_id`),
   KEY `cmd1_index` (`global_host_event_handler`),

--- a/centreon/www/install/php/Update-19.04.0.php
+++ b/centreon/www/install/php/Update-19.04.0.php
@@ -36,7 +36,7 @@ try {
     }
     if (!$pearDB->isColumnExist('cfg_nagios', 'macros_filter')) {
         $pearDB->query(
-            "ALTER TABLE `cfg_nagios` ADD COLUMN `macros_filter` TEXT DEFAULT ''"
+            "ALTER TABLE `cfg_nagios` ADD COLUMN `macros_filter` TEXT DEFAULT ('')"
         );
     }
 } catch (\PDOException $e) {

--- a/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
+++ b/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
@@ -33,7 +33,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: cron


### PR DESCRIPTION
## Description

The initial regex did not allow execution of the `run_save_discovered_host` command for discovered hosts, due to the options

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
