### PR TITLE
Fix(UI): Fix unsynced statuses display on group monitoring

### DIFF
--- a/centreon/www/widgets/src/centreon-widget-groupmonitoring/src/Columns/Statuses/Statuses.tsx
+++ b/centreon/www/widgets/src/centreon-widget-groupmonitoring/src/Columns/Statuses/Statuses.tsx
@@ -1,9 +1,7 @@
 import { equals, flatten, pluck, project } from 'ramda';
-import { useAtomValue } from 'jotai';
 
 import { Group, RowProps } from '../../models';
 import { getStatusesCountFromResources } from '../../utils';
-import { statusesAtom } from '../../atoms';
 import { useStatusesColumnStyles } from '../Columns.styles';
 
 import Status from './Status';
@@ -35,7 +33,7 @@ const Statuses = ({
 }: { resourceType: string } & RowProps): JSX.Element => {
   const { classes } = useStatusesColumnStyles();
 
-  const statuses = useAtomValue(statusesAtom);
+  const { statuses } = row;
 
   const resources = getResources({ resourceType, row });
 

--- a/centreon/www/widgets/src/centreon-widget-groupmonitoring/src/GroupMonitoring.tsx
+++ b/centreon/www/widgets/src/centreon-widget-groupmonitoring/src/GroupMonitoring.tsx
@@ -1,14 +1,12 @@
-import { useSetAtom } from 'jotai';
 import { includes, isNotNil } from 'ramda';
 
 import { MemoizedListing } from '@centreon/ui';
 
 import NoResources from '../../NoResources';
 
-import { WidgetProps } from './models';
+import { FormattedGroup, WidgetProps } from './models';
 import { useGroupMonitoring } from './useGroupMonitoring';
 import { useColumns } from './Columns/useColumns';
-import { statusesAtom } from './atoms';
 
 const GroupMonitoring = ({
   panelData,
@@ -18,8 +16,6 @@ const GroupMonitoring = ({
   isFromPreview,
   setPanelOptions
 }: Omit<WidgetProps, 'store'>): JSX.Element => {
-  const setStatuses = useSetAtom(statusesAtom);
-
   const {
     hasResourceTypeDefined,
     changeLimit,
@@ -48,8 +44,6 @@ const GroupMonitoring = ({
     isFromPreview
   });
 
-  setStatuses(panelOptions.statuses || []);
-
   if (!hasResourceTypeDefined) {
     return <NoResources />;
   }
@@ -61,7 +55,7 @@ const GroupMonitoring = ({
   ].filter(isNotNil);
 
   return (
-    <MemoizedListing
+    <MemoizedListing<FormattedGroup>
       isResponsive
       columnConfiguration={{
         selectedColumnIds: columnsToDisplay,
@@ -71,7 +65,6 @@ const GroupMonitoring = ({
       currentPage={page}
       limit={limit}
       loading={isLoading}
-      memoProps={[panelOptions.statuses]}
       rows={listing?.result || []}
       sortField={sortField}
       sortOrder={sortOrder}

--- a/centreon/www/widgets/src/centreon-widget-groupmonitoring/src/atoms.ts
+++ b/centreon/www/widgets/src/centreon-widget-groupmonitoring/src/atoms.ts
@@ -1,3 +1,0 @@
-import { atom } from 'jotai';
-
-export const statusesAtom = atom<Array<string>>([]);

--- a/centreon/www/widgets/src/centreon-widget-groupmonitoring/src/models.ts
+++ b/centreon/www/widgets/src/centreon-widget-groupmonitoring/src/models.ts
@@ -36,8 +36,13 @@ export interface Group extends NamedEntity {
   hosts: Array<Host>;
 }
 
+export interface FormattedGroup extends NamedEntity {
+  hosts: Array<Host>;
+  statuses: Array<string>;
+}
+
 export interface RowProps {
   groupType: string;
   isFromPreview?: boolean;
-  row: Group;
+  row: FormattedGroup;
 }


### PR DESCRIPTION
## Description

This fixes the sync issue when displaying several statuses with multiple group monitoring in the dashboard.

https://github.com/centreon/centreon/assets/12515407/700ba7b0-faab-48be-a20b-053d3bb90af7

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
