### PR TITLE
enh(log) log invalid http status code

### DIFF
--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Repository/HttpReadAttributePathRepository.php
@@ -127,7 +127,7 @@ final class HttpReadAttributePathRepository implements ReadAttributePathReposito
     {
         $statusCode = $response->getStatusCode();
         if ($statusCode !== Response::HTTP_OK) {
-            throw new InvalidStatusCodeException();
+            throw new InvalidStatusCodeException('Invalid status code received', $statusCode);
         }
     }
 


### PR DESCRIPTION
## Description
**Backport of MON-37392**

Logs returns 0 when a status code other than 200 is returned for conditions.

`invalid status code return by external provider, [404] returned, [200] expected `
instead of 
`invalid status code return by external provider, [0] returned, [200] expected` 


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Configure your OIDC / SAML conditions and be sur to return another status code than 200 and check your logs

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
