### PR TITLE
fix(autodiscovery): fix regex for gorgone to execute run_save_discovered_host script for discovered hosts

### DIFF
--- a/centreon-gorgone/config/gorgoned-central-ssh.yml
+++ b/centreon-gorgone/config/gorgoned-central-ssh.yml
@@ -43,7 +43,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy

--- a/centreon-gorgone/config/gorgoned-central-zmq.yml
+++ b/centreon-gorgone/config/gorgoned-central-zmq.yml
@@ -67,7 +67,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy

--- a/centreon-gorgone/config/gorgoned-poller.yml
+++ b/centreon-gorgone/config/gorgoned-poller.yml
@@ -25,7 +25,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: engine

--- a/centreon-gorgone/config/gorgoned-remote-ssh.yml
+++ b/centreon-gorgone/config/gorgoned-remote-ssh.yml
@@ -30,7 +30,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy

--- a/centreon-gorgone/config/gorgoned-remote-zmq.yml
+++ b/centreon-gorgone/config/gorgoned-remote-zmq.yml
@@ -35,7 +35,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy

--- a/centreon-gorgone/contrib/gorgone_config_init.pl
+++ b/centreon-gorgone/contrib/gorgone_config_init.pl
@@ -133,7 +133,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: proxy

--- a/centreon-gorgone/docs/migration.md
+++ b/centreon-gorgone/docs/migration.md
@@ -65,7 +65,7 @@ configuration:
           - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
           - ^centreon
           - ^mkdir
-          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+          - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
           - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
       - name: cron

--- a/centreon-gorgone/docs/modules/core/action.md
+++ b/centreon-gorgone/docs/modules/core/action.md
@@ -31,7 +31,7 @@ allowed_cmds:
   - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
   - ^centreon
   - ^mkdir
-  - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+  - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
   - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 ```
 

--- a/centreon-gorgone/docs/poller_pull_configuration.md
+++ b/centreon-gorgone/docs/poller_pull_configuration.md
@@ -50,7 +50,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: engine

--- a/centreon-gorgone/docs/rebound_configuration.md
+++ b/centreon-gorgone/docs/rebound_configuration.md
@@ -54,7 +54,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: engine

--- a/centreon/www/include/configuration/configServers/popup/central.yaml
+++ b/centreon/www/include/configuration/configServers/popup/central.yaml
@@ -33,7 +33,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
     - name: cron
       package: "gorgone::modules::core::cron::hooks"

--- a/centreon/www/include/configuration/configServers/popup/poller.yaml
+++ b/centreon/www/include/configuration/configServers/popup/poller.yaml
@@ -23,7 +23,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: engine

--- a/centreon/www/include/configuration/configServers/popup/remote.yaml
+++ b/centreon/www/include/configuration/configServers/popup/remote.yaml
@@ -24,7 +24,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: cron

--- a/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
+++ b/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
@@ -33,7 +33,7 @@ gorgone:
         - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
         - ^centreon
         - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --all --job-id=\d+ --export-conf --token=\S+$
+        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
         - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
 
     - name: cron


### PR DESCRIPTION
## Description

Following the implementation of a command whitelist, the execution of the discovered hosts registration script no longer worked.
```
2024-03-08 15:38:19 - DEBUG - [action] Create sub-process
2024-03-08 15:38:19 - INFO - [action] command not allowed (whitelist): /usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host --job-id=1 --ids=9
2024-03-08 15:38:19 - DEBUG - [action] internal message: [PUTLOG] [851d485f9df669e5024a0b31b2cac23b393e7057f9ffcdf25b5411539cc280ecb9b0a6cb5c1eefd175aeceaf6c80034a07a23cd314c096fd4e570c3a4ef9ef83] [] {"token":"851d485f9df669e5024a0b31b2cac23b393e7057f9ffcdf25b5411539cc280ecb9b0a6cb5c1eefd175aeceaf6c80034a07a23cd314c096fd4e570c3a4ef9ef83","data":{"message":"command not allowed (whitelist) at array index '0'"},"etime":1709912299,"instant":null,"code":1}
2024-03-08 15:38:19 - DEBUG - [core] Message received internal - [PUTLOG] [851d485f9df669e5024a0b31b2cac23b393e7057f9ffcdf25b5411539cc280ecb9b0a6cb5c1eefd175aeceaf6c80034a07a23cd314c096fd4e570c3a4ef9ef83] [] {"token":"851d485f9df669e5024a0b31b2cac23b393e7057f9ffcdf25b5411539cc280ecb9b0a6cb5c1eefd175aeceaf6c80034a07a23cd314c096fd4e570c3a4ef9ef83","data":{"message":"command not allowed (whitelist) at array index '0'"},"etime":1709912299,"instant":null,"code":1}
```

The initial regex did not allow execution of the `run_save_discovered_host` command for discovered hosts, due to the options

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
