### PR TITLE
fix(UI): Fix the edit mode when a dashboard is created

### DIFF
--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/PanelHeader.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Layout/Panel/PanelHeader.tsx
@@ -49,7 +49,7 @@ const PanelHeader = ({
 
   const duplicate = (event): void => {
     event.preventDefault();
-    setIsEditing(true);
+    setIsEditing(() => true);
     duplicatePanel(id);
   };
 

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/atoms.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/atoms.ts
@@ -48,7 +48,7 @@ export const dashboardRefreshIntervalAtom = atom<
 export const setLayoutModeDerivedAtom = atom(
   null,
   (get, setAtom, isEditing: boolean) => {
-    setAtom(isEditingAtom, isEditing);
+    setAtom(isEditingAtom, () => isEditing);
 
     const dashboard = get(dashboardAtom);
 
@@ -275,7 +275,7 @@ export const duplicatePanelDerivedAtom = atom(
 export const switchPanelsEditionModeDerivedAtom = atom(
   null,
   (_, setAtom, isEditing: boolean) => {
-    setAtom(isEditingAtom, isEditing);
+    setAtom(isEditingAtom, () => isEditing);
     setAtom(dashboardAtom, (currentDashboard): Dashboard => {
       const newLayout = map<Panel, Panel>(
         set(lensProp('static'), !isEditing),

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/hooks/useDashboardDetails.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/hooks/useDashboardDetails.ts
@@ -17,7 +17,6 @@ import {
   dashboardAtom,
   dashboardRefreshIntervalAtom,
   hasEditPermissionAtom,
-  isEditingAtom,
   panelsLengthAtom
 } from '../atoms';
 
@@ -82,7 +81,6 @@ const useDashboardDetails = ({
   const setPanelsLength = useSetAtom(panelsLengthAtom);
   const setHasEditPermission = useSetAtom(hasEditPermissionAtom);
   const setDashboardRefreshInterval = useSetAtom(dashboardRefreshIntervalAtom);
-  const setIsEditing = useSetAtom(isEditingAtom);
 
   const { data: dashboard } = useFetchQuery({
     decoder: dashboardDecoder,
@@ -119,7 +117,6 @@ const useDashboardDetails = ({
 
   useEffect(() => {
     return () => {
-      setIsEditing(false);
       setDashboardRefreshInterval(undefined);
     };
   }, []);

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/hooks/useDeleteWidget.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/hooks/useDeleteWidget.ts
@@ -11,7 +11,7 @@ const useDeleteWidget = (): UseDeleteWidgetState => {
   const setIsEditing = useSetAtom(isEditingAtom);
 
   const deleteWidget = (id: string) => (): void => {
-    setIsEditing(true);
+    setIsEditing(() => true);
     removePanel(id);
   };
 

--- a/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardsQuickAccess/DashboardsQuickAccessMenu.tsx
+++ b/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardsQuickAccess/DashboardsQuickAccessMenu.tsx
@@ -2,6 +2,7 @@ import { ReactElement } from 'react';
 
 import { generatePath, useNavigate } from 'react-router-dom';
 import { equals } from 'ramda';
+import { useSetAtom } from 'jotai';
 
 import { PageLayout } from '@centreon/ui/components';
 
@@ -13,6 +14,7 @@ import {
 } from '../../../translatedLabels';
 import { useDashboardConfig } from '../DashboardConfig/useDashboardConfig';
 import { DashboardLayout } from '../../../models';
+import { isEditingAtom } from '../../../SingleInstancePage/Dashboard/atoms';
 
 import { useDashboardsQuickAccess } from './useDashboardsQuickAccess';
 
@@ -27,6 +29,8 @@ const DashboardsQuickAccessMenu = ({
 
   const { createDashboard } = useDashboardConfig();
 
+  const setIsEditing = useSetAtom(isEditingAtom);
+
   const navigate = useNavigate();
   const navigateToDashboard = (dashboardId: string | number) => (): void =>
     navigate(
@@ -36,10 +40,12 @@ const DashboardsQuickAccessMenu = ({
       })
     );
 
-  const navigateToDashboardLibrary = (): void =>
+  const navigateToDashboardLibrary = (): void => {
+    setIsEditing(false);
     navigate(
       generatePath(routeMap.dashboards, { layout: DashboardLayout.Library })
     );
+  };
 
   return (
     <PageLayout.QuickAccess


### PR DESCRIPTION
## Description

This fixes a random bug about the edit mode when a dashboard is created via the dashboard page.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
