### PR TITLE
enh(resources) handle filter by status on status endpoints

### DIFF
--- a/centreon/src/Core/Resources/Domain/Model/HostsStatusCount.php
+++ b/centreon/src/Core/Resources/Domain/Model/HostsStatusCount.php
@@ -31,7 +31,6 @@ final class HostsStatusCount
         private readonly UpStatusCount $upStatusCount,
         private readonly PendingStatusCount $pendingStatusCount
     ) {
-
     }
 
     public function getDownStatusCount(): DownStatusCount

--- a/centreon/src/Core/Resources/Domain/Model/ServicesStatusCount.php
+++ b/centreon/src/Core/Resources/Domain/Model/ServicesStatusCount.php
@@ -32,7 +32,6 @@ final class ServicesStatusCount
         private readonly OkStatusCount $okStatusCount,
         private readonly PendingStatusCount $pendingStatusCount
     ) {
-
     }
 
     public function getCriticalStatusCount(): CriticalStatusCount

--- a/centreon/src/Core/Resources/Infrastructure/API/FindHostsStatusCount/FindHostsStatusCountController.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindHostsStatusCount/FindHostsStatusCountController.php
@@ -70,6 +70,7 @@ final class FindHostsStatusCountController extends AbstractController
 
         return (new ResourceFilter())
             ->setHostgroupNames($filter[FindHostsStatusCountRequestValidator::PARAM_HOSTGROUP_NAMES])
-            ->setHostCategoryNames($filter[FindHostsStatusCountRequestValidator::PARAM_HOST_CATEGORY_NAMES]);
+            ->setHostCategoryNames($filter[FindHostsStatusCountRequestValidator::PARAM_HOST_CATEGORY_NAMES])
+            ->setStatuses($filter[FindHostsStatusCountRequestValidator::PARAM_STATUSES]);
     }
 }

--- a/centreon/src/Core/Resources/Infrastructure/API/FindHostsStatusCount/FindHostsStatusCountRequestValidator.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindHostsStatusCount/FindHostsStatusCountRequestValidator.php
@@ -30,6 +30,7 @@ use Centreon\Domain\RequestParameters\RequestParameters;
  * @phpstan-type _RequestParameters array{
  *      hostgroup_names: list<string>,
  *      host_category_names: list<string>,
+ *      statuses: list<string>
  * }
  */
 final class FindHostsStatusCountRequestValidator

--- a/centreon/src/Core/Resources/Infrastructure/API/FindHostsStatusCount/FindHostsStatusCountRequestValidator.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindHostsStatusCount/FindHostsStatusCountRequestValidator.php
@@ -46,7 +46,6 @@ final class FindHostsStatusCountRequestValidator
         'UP',
         'DOWN',
     ];
-
     private const EMPTY_FILTERS = [
         self::PARAM_HOSTGROUP_NAMES => [],
         self::PARAM_HOST_CATEGORY_NAMES => [],
@@ -76,7 +75,7 @@ final class FindHostsStatusCountRequestValidator
 
             $value = $this->tryJsonDecodeParameterValue($parameterValue);
 
-            if($parameterName === self::PARAM_STATUSES) {
+            if ($parameterName === self::PARAM_STATUSES) {
                 $filterData[$parameterName] = $this->ensureStatusesFilter($parameterName, $value);
             }
 

--- a/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountController.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountController.php
@@ -72,6 +72,7 @@ final class FindServicesStatusCountController extends AbstractController
             ->setHostgroupNames($filter[FindServicesStatusCountRequestValidator::PARAM_HOSTGROUP_NAMES])
             ->setHostCategoryNames($filter[FindServicesStatusCountRequestValidator::PARAM_HOST_CATEGORY_NAMES])
             ->setServicegroupNames($filter[FindServicesStatusCountRequestValidator::PARAM_SERVICEGROUP_NAMES])
-            ->setServiceCategoryNames($filter[FindServicesStatusCountRequestValidator::PARAM_SERVICE_CATEGORY_NAMES]);
+            ->setServiceCategoryNames($filter[FindServicesStatusCountRequestValidator::PARAM_SERVICE_CATEGORY_NAMES])
+            ->setStatuses($filter[FindServicesStatusCountRequestValidator::PARAM_STATUSES]);;
     }
 }

--- a/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountController.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountController.php
@@ -73,6 +73,6 @@ final class FindServicesStatusCountController extends AbstractController
             ->setHostCategoryNames($filter[FindServicesStatusCountRequestValidator::PARAM_HOST_CATEGORY_NAMES])
             ->setServicegroupNames($filter[FindServicesStatusCountRequestValidator::PARAM_SERVICEGROUP_NAMES])
             ->setServiceCategoryNames($filter[FindServicesStatusCountRequestValidator::PARAM_SERVICE_CATEGORY_NAMES])
-            ->setStatuses($filter[FindServicesStatusCountRequestValidator::PARAM_STATUSES]);;
+            ->setStatuses($filter[FindServicesStatusCountRequestValidator::PARAM_STATUSES]);
     }
 }

--- a/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountRequestValidator.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountRequestValidator.php
@@ -33,6 +33,7 @@ use Core\Resources\Infrastructure\API\FindHostsStatusCount\_RequestParameters;
  *      host_category_names: list<string>,
  *      servicegroup_names: list<string>,
  *      service_category_names: list<string>,
+ *      statuses: list<string>
  * }
  */
 final class FindServicesStatusCountRequestValidator

--- a/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountRequestValidator.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountRequestValidator.php
@@ -42,11 +42,22 @@ final class FindServicesStatusCountRequestValidator
     public const PARAM_HOST_CATEGORY_NAMES = 'host_category_names';
     public const PARAM_SERVICEGROUP_NAMES = 'servicegroup_names';
     public const PARAM_SERVICE_CATEGORY_NAMES = 'service_category_names';
+    public const PARAM_STATUSES = 'statuses';
     private const EMPTY_FILTERS = [
         self::PARAM_HOSTGROUP_NAMES => [],
         self::PARAM_HOST_CATEGORY_NAMES => [],
         self::PARAM_SERVICEGROUP_NAMES => [],
         self::PARAM_SERVICE_CATEGORY_NAMES => [],
+        self::PARAM_STATUSES => [],
+    ];
+
+    /** Allowed values for statuses. */
+    public const ALLOWED_STATUSES = [
+        'OK',
+        'WARNING',
+        'CRITICAL',
+        'UNKNOWN',
+        'PENDING',
     ];
 
     /**
@@ -71,6 +82,11 @@ final class FindServicesStatusCountRequestValidator
             }
 
             $value = $this->tryJsonDecodeParameterValue($parameterValue);
+
+            if($parameterName === self::PARAM_STATUSES) {
+                $this->ensureStatusesFilter($parameterName, $value);
+            }
+
             $filterData[$parameterName] = $this->ensureArrayOfString($parameterName, $value);
         }
 
@@ -142,5 +158,30 @@ final class FindServicesStatusCountRequestValidator
         }
 
         return $value;
+    }
+
+    /**
+     * Ensures that statuses filter provided in the payload are supported.
+     *
+     * @param string $parameterName
+     * @param mixed $values
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return list<value-of<self::ALLOWED_STATUSES>>
+     */
+    private function ensureStatusesFilter(string $parameterName, mixed $values): array
+    {
+        $statuses = [];
+        foreach ($this->ensureArrayOfString($parameterName, $values) as $string) {
+            if (! \in_array($string, self::ALLOWED_STATUSES, true)) {
+                $message = sprintf('Value provided for %s parameter is not supported (was: %s)', $parameterName, $string);
+
+                throw new \InvalidArgumentException($message);
+            }
+            $statuses[] = $string;
+        }
+
+        return $statuses;
     }
 }

--- a/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountRequestValidator.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountRequestValidator.php
@@ -43,14 +43,6 @@ final class FindServicesStatusCountRequestValidator
     public const PARAM_SERVICEGROUP_NAMES = 'servicegroup_names';
     public const PARAM_SERVICE_CATEGORY_NAMES = 'service_category_names';
     public const PARAM_STATUSES = 'statuses';
-    private const EMPTY_FILTERS = [
-        self::PARAM_HOSTGROUP_NAMES => [],
-        self::PARAM_HOST_CATEGORY_NAMES => [],
-        self::PARAM_SERVICEGROUP_NAMES => [],
-        self::PARAM_SERVICE_CATEGORY_NAMES => [],
-        self::PARAM_STATUSES => [],
-    ];
-
     /** Allowed values for statuses. */
     public const ALLOWED_STATUSES = [
         'OK',
@@ -58,6 +50,13 @@ final class FindServicesStatusCountRequestValidator
         'CRITICAL',
         'UNKNOWN',
         'PENDING',
+    ];
+    private const EMPTY_FILTERS = [
+        self::PARAM_HOSTGROUP_NAMES => [],
+        self::PARAM_HOST_CATEGORY_NAMES => [],
+        self::PARAM_SERVICEGROUP_NAMES => [],
+        self::PARAM_SERVICE_CATEGORY_NAMES => [],
+        self::PARAM_STATUSES => [],
     ];
 
     /**
@@ -83,7 +82,7 @@ final class FindServicesStatusCountRequestValidator
 
             $value = $this->tryJsonDecodeParameterValue($parameterValue);
 
-            if($parameterName === self::PARAM_STATUSES) {
+            if ($parameterName === self::PARAM_STATUSES) {
                 $this->ensureStatusesFilter($parameterName, $value);
             }
 

--- a/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountRequestValidator.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindServicesStatusCount/FindServicesStatusCountRequestValidator.php
@@ -43,6 +43,7 @@ final class FindServicesStatusCountRequestValidator
     public const PARAM_SERVICEGROUP_NAMES = 'servicegroup_names';
     public const PARAM_SERVICE_CATEGORY_NAMES = 'service_category_names';
     public const PARAM_STATUSES = 'statuses';
+
     /** Allowed values for statuses. */
     public const ALLOWED_STATUSES = [
         'OK',

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -552,7 +552,6 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
 
         $query .= ' AND ' . (new HostACLProvider())->buildACLSubRequest($accessGroupIds);
 
-
         return $this->fetchHostsStatusCount($query, $collector);
     }
 

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -437,6 +437,11 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
             resources.type=1 AND resources.name NOT LIKE "_Module_%"
             SQL;
 
+        /**
+         * Resource filter by status
+         */
+        $query .= $this->addResourceStatusSubRequest($filter);
+
         return $this->fetchHostsStatusCount($query, $collector);
     }
 
@@ -486,6 +491,11 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
             resources.type=0 AND resources.name NOT LIKE "_Module_%"
             SQL;
 
+        /**
+         * Resource filter by status
+         */
+        $query .= $this->addResourceStatusSubRequest($filter);
+
         return $this->fetchServicesStatusCount($query, $collector);
     }
 
@@ -534,7 +544,14 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         $query .= <<<'SQL'
             resources.type=1 AND resources.name NOT LIKE "_Module_%"
             SQL;
+
+        /**
+         * Resource filter by status
+         */
+        $query .= $this->addResourceStatusSubRequest($filter);
+
         $query .= ' AND ' . (new HostACLProvider())->buildACLSubRequest($accessGroupIds);
+
 
         return $this->fetchHostsStatusCount($query, $collector);
     }
@@ -584,6 +601,12 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         $query .= <<<'SQL'
             resources.type=0 AND resources.name NOT LIKE "_Module_%"
             SQL;
+
+        /**
+         * Resource filter by status
+         */
+        $query .= $this->addResourceStatusSubRequest($filter);
+
         $query .= ' AND ' . (new ServiceACLProvider())->buildACLSubRequest($accessGroupIds);
 
         return $this->fetchServicesStatusCount($query, $collector);

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -438,7 +438,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
             SQL;
 
         /**
-         * Resource filter by status
+         * Resource filter by status.
          */
         $query .= $this->addResourceStatusSubRequest($filter);
 
@@ -492,7 +492,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
             SQL;
 
         /**
-         * Resource filter by status
+         * Resource filter by status.
          */
         $query .= $this->addResourceStatusSubRequest($filter);
 
@@ -546,7 +546,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
             SQL;
 
         /**
-         * Resource filter by status
+         * Resource filter by status.
          */
         $query .= $this->addResourceStatusSubRequest($filter);
 
@@ -602,7 +602,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
             SQL;
 
         /**
-         * Resource filter by status
+         * Resource filter by status.
          */
         $query .= $this->addResourceStatusSubRequest($filter);
 


### PR DESCRIPTION
## Description

This PR intends to add status filter on hosts/services status endpoints

```json
/monitoring/services/status?statuses=["OK","UNKNOWN"]

{
  "critical": {
    "total": 0
  },
  "warning": {
    "total": 0
  },
  "unknown": {
    "total": 30
  },
  "ok": {
    "total": 10
  },
  "pending": {
    "total": 0
  },
  "total": 40
}
```

```json
/monitoring/hosts/status?statuses=["UP","DOWN"]

{
  "up": {
    "total": 1
  },
  "down": {
    "total": 1
  },
  "unreachable": {
    "total": 0
  },
  "pending": {
    "total": 0
  },
  "total": 2
}
```

**Fixes** # MON-37218

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
