### PR TITLE
fix(packaging): fix path of systemd configuration for mysql

### DIFF
--- a/centreon/packaging/centreon-mysql.yaml
+++ b/centreon/packaging/centreon-mysql.yaml
@@ -22,7 +22,7 @@ contents:
       mode: 0600
     packager: rpm
   - src: "./src/centreon-database.cnf"
-    dst: "/etc/mysql/mysqld.conf.d/80-centreon.cnf"
+    dst: "/etc/mysql/mysql.conf.d/80-centreon.cnf"
     type: config|noreplace
     file_info:
       mode: 0600
@@ -33,6 +33,13 @@ contents:
     type: config|noreplace
     file_info:
       mode: 0600
+    packager: rpm
+  - src: "./src/database-systemd.conf"
+    dst: "/etc/systemd/system/mysql.service.d/centreon.conf"
+    type: config|noreplace
+    file_info:
+      mode: 0600
+    packager: deb
 
 overrides:
   rpm:

--- a/centreon/packaging/centreon-mysql.yaml
+++ b/centreon/packaging/centreon-mysql.yaml
@@ -22,14 +22,14 @@ contents:
       mode: 0600
     packager: rpm
   - src: "./src/centreon-database.cnf"
-    dst: "/etc/mysql/mysql.conf.d/80-centreon.cnf"
+    dst: "/etc/mysql/mysqld.conf.d/80-centreon.cnf"
     type: config|noreplace
     file_info:
       mode: 0600
     packager: deb
 
   - src: "./src/database-systemd.conf"
-    dst: "/etc/systemd/system/mysql.service.d/centreon.conf"
+    dst: "/etc/systemd/system/mysqld.service.d/centreon.conf"
     type: config|noreplace
     file_info:
       mode: 0600

--- a/centreon/www/install/steps/process/installConfigurationDb.php
+++ b/centreon/www/install/steps/process/installConfigurationDb.php
@@ -73,10 +73,9 @@ if (is_null($open_files_limit)) {
     $open_files_limit = 0;
 }
 if ($open_files_limit < 32000) {
-    $return['msg'] = 'If your operating system is based on systemd (CentOS 7, Debian Jessie), add LimitNOFILE=32000 value on the ' .
-        'service file /etc/systemd/system/mariadb.service and reload systemd (systemctl daemon-reload).<br/>' .
-        'If your operating system is based on SystemV, ' .
-        'add open_files_limit=32000 in my.cnf file under the [mysqld] section and restart MySQL Server.';
+    $return['msg'] = 'Add LimitNOFILE=32000 value in the service file ' .
+        '/etc/systemd/system/mariadb.service.d/centreon.conf or /etc/systemd/system/mysqld.service.d/centreon.conf ' .
+        'and reload systemd : systemctl daemon-reload';
     echo json_encode($return);
     exit;
 }

--- a/centreon/www/install/steps/process/installConfigurationDb.php
+++ b/centreon/www/install/steps/process/installConfigurationDb.php
@@ -74,7 +74,8 @@ if (is_null($open_files_limit)) {
 }
 if ($open_files_limit < 32000) {
     $return['msg'] = 'Add LimitNOFILE=32000 value in the service file ' .
-        '/etc/systemd/system/mariadb.service.d/centreon.conf or /etc/systemd/system/mysqld.service.d/centreon.conf ' .
+        '/etc/systemd/system/<database_service_name>.service.d/centreon.conf ' .
+        '(replace <database_service_name> by mysql, mysqld or mariadb depending on the systemd service name) ' .
         'and reload systemd : systemctl daemon-reload';
     echo json_encode($return);
     exit;


### PR DESCRIPTION
## Description

fix(packaging): fix path of systemd configuration for mysql

**Fixes** MON-37933

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)