### PR TITLE
fix(configuration): Fix Export/Import Remote Server configuration with MariaDB 10.11 (

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/legacycmd/class.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/legacycmd/class.pm
@@ -554,8 +554,11 @@ sub action_addimporttaskwithparent {
         return -1;
     }
 
+    my ($sec,$min,$hour,$mday,$mon,$year,$wday,$yday,$isdst) = localtime(time());
+    my $datetime = sprintf('%04d-%02d-%02d %02d:%02d:%02d', $year+1900, $mon+1, $mday, $hour, $min, $sec);
+
     my ($status, $datas) = $self->{class_object_centreon}->custom_execute(
-        request => "INSERT INTO task (`type`, `status`, `parent_id`) VALUES ('import', 'pending', '" . $options{data}->{content}->{parent_id} . "')"
+        request => "INSERT INTO task (`type`, `status`, `parent_id`, `created_at`) VALUES ('import', 'pending', '" . $options{data}->{content}->{parent_id} . "', '" . $datetime . "')"
     );
     if ($status == -1) {
         $self->send_log(

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2322,7 +2322,7 @@ CREATE TABLE IF NOT EXISTS `task` (
   `status` VARCHAR(40) NOT NULL,
   `parent_id` INT(11) NULL,
   `params` BLOB NULL,
-  `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Create user_filter table

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2322,7 +2322,7 @@ CREATE TABLE IF NOT EXISTS `task` (
   `status` VARCHAR(40) NOT NULL,
   `parent_id` INT(11) NULL,
   `params` BLOB NULL,
-  `created_at` TIMESTAMP NOT NULL
+  `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- Create user_filter table

--- a/centreon/www/install/php/Update-24.04.0.php
+++ b/centreon/www/install/php/Update-24.04.0.php
@@ -202,6 +202,11 @@ $insertGroupMonitoringWidget = function(CentreonDB $pearDB) use(&$errorMessage):
     }
 };
 
+$addDefaultValueforTaskTable = function(CentreonDB $pearDB) use(&$errorMessage): void {
+    $errorMessage = 'Unable to alter created_at for task table';
+    $pearDB->query("ALTER TABLE task MODIFY COLUMN `created_at` timestamp DEFAULT CURRENT_TIMESTAMP");
+};
+
 try {
     $updateWidgetModelsTable($pearDB);
 
@@ -214,6 +219,8 @@ try {
     $addCloudDescriptionToAclGroups($pearDB);
     $addCloudSpecificToAclResources($pearDB);
     $createDatasetFiltersTable($pearDB);
+
+    $addDefaultValueforTaskTable($pearDB);
 
     // Tansactional queries
     if (! $pearDB->inTransaction()) {

--- a/centreon/www/install/php/Update-24.04.0.php
+++ b/centreon/www/install/php/Update-24.04.0.php
@@ -204,7 +204,7 @@ $insertGroupMonitoringWidget = function(CentreonDB $pearDB) use(&$errorMessage):
 
 $addDefaultValueforTaskTable = function(CentreonDB $pearDB) use(&$errorMessage): void {
     $errorMessage = 'Unable to alter created_at for task table';
-    $pearDB->query("ALTER TABLE task MODIFY COLUMN `created_at` timestamp DEFAULT CURRENT_TIMESTAMP");
+    $pearDB->query("ALTER TABLE task MODIFY COLUMN `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP");
 };
 
 $insertStatusChartWidget = function(CentreonDB $pearDB) use(&$errorMessage): void {


### PR DESCRIPTION
## Description

When gorgone try to insert a task in centreon.task table, there is an SQL error because gorgone doesn't define created_at column and this one is not null:

`2024-03-14 11:10:05 - ERROR - Field 'created_at' doesn't have a default value`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced tracking of task creation time in the system for better management and auditing.
- **Refactor**
	- Updated the database schema to automatically capture the creation timestamp of tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->