### PR TITLE
enh(api): add hostgroup filter to the FindHostCategoriesEndpoint

### DIFF
--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -293,6 +293,8 @@ paths:
         * name
         * alias
         * is_activated
+        * hostgroup.name
+        * hostgroup.id
       responses:
         "200":
           description: "OK"

--- a/centreon/src/Core/HostCategory/Application/Repository/ReadHostCategoryRepositoryInterface.php
+++ b/centreon/src/Core/HostCategory/Application/Repository/ReadHostCategoryRepositoryInterface.php
@@ -45,14 +45,14 @@ interface ReadHostCategoryRepositoryInterface
     /**
      * Find all host categories by access groups.
      *
-     * @param AccessGroup[] $accessGroups
+     * @param int[] $accessGroupIds
      * @param RequestParametersInterface|null $requestParameters
      *
      * @throws \Throwable
      *
      * @return HostCategory[]
      */
-    public function findAllByAccessGroups(array $accessGroups, ?RequestParametersInterface $requestParameters): array;
+    public function findAllByAccessGroupIds(array $accessGroupIds, ?RequestParametersInterface $requestParameters): array;
 
     /**
      * Check existence of a host category.
@@ -166,4 +166,15 @@ interface ReadHostCategoryRepositoryInterface
      * @return HostCategoryNamesById
      */
     public function findNames(array $hostCategoryIds): HostCategoryNamesById;
+
+    /**
+     * Determine if host categories are filtered for given access group ids.
+     *
+     * @param int[] $accessGroupIds
+     *
+     * @phpstan-param non-empty-array<int> $accessGroupIds
+     *
+     * @return bool
+     */
+    public function hasAclFilterOnHostCategories(array $accessGroupIds): bool;
 }

--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadHostCategoryRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadHostCategoryRepository.php
@@ -31,6 +31,7 @@ use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 use Core\Common\Domain\TrimmedString;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Core\Common\Infrastructure\Repository\SqlMultipleBindTrait;
 use Core\Common\Infrastructure\RequestParameters\Normalizer\BoolToEnumNormalizer;
 use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
 use Core\HostCategory\Domain\Model\HostCategory;
@@ -48,7 +49,7 @@ use Utility\SqlConcatenator;
  */
 class DbReadHostCategoryRepository extends AbstractRepositoryRDB implements ReadHostCategoryRepositoryInterface
 {
-    use LoggerTrait;
+    use LoggerTrait, SqlMultipleBindTrait;
 
     /**
      * @param DatabaseConnection $db
@@ -99,61 +100,166 @@ class DbReadHostCategoryRepository extends AbstractRepositoryRDB implements Read
      */
     public function findAll(?RequestParametersInterface $requestParameters): array
     {
-        $this->info('Getting all host categories');
+        $request = <<<'SQL'
+                SELECT SQL_CALC_FOUND_ROWS * FROM `:db`.hostcategories hc
+            SQL;
 
-        $concatenator = new SqlConcatenator();
-        $concatenator->withCalcFoundRows(true);
-        $concatenator->defineSelect(
-            'SELECT hc.hc_id, hc.hc_name, hc.hc_alias, hc.hc_activate, hc.hc_comment
-            FROM `:db`.hostcategories hc'
-        );
+        $search = $requestParameters?->getSearchAsString();
 
-        return $this->retrieveHostCategories($concatenator, $requestParameters);
+        if ($search !== null && \str_contains($search, 'hostgroup')) {
+            $request .= $this->prepareHostGroupSearchSubRequest();
+        }
+
+        // Setup for search, pagination and order
+        $sqlTranslator = $requestParameters ? new SqlRequestParametersTranslator($requestParameters) : null;
+        $sqlTranslator?->getRequestParameters()->setConcordanceStrictMode(RequestParameters::CONCORDANCE_MODE_STRICT);
+        $sqlTranslator?->setConcordanceArray([
+            'id' => 'hc.hc_id',
+            'name' => 'hc.hc_name',
+            'alias' => 'hc.hc_alias',
+            'is_activated' => 'hc.hc_activate',
+            'hostgroup.id' => 'hg.hg_id',
+            'hostgroup.name' => 'hg.hg_name',
+        ]);
+        $sqlTranslator?->addNormalizer('is_activated', new BoolToEnumNormalizer());
+
+        $searchRequest = $sqlTranslator?->translateSearchParameterToSql();
+
+        $request .= $searchRequest !== null
+            ? $searchRequest . ' AND '
+            : ' WHERE ';
+
+        // avoid severities
+        $request .= 'hc.level IS NULL';
+
+        // handle sort
+        $request .= $sqlTranslator?->translateSortParameterToSql();
+
+        // handle pagination
+        $request .= $sqlTranslator?->translatePaginationToSql();
+
+        $statement = $this->db->prepare($this->translateDbName($request));
+
+        $sqlTranslator?->bindSearchValues($statement);
+
+        $statement->setFetchMode(\PDO::FETCH_ASSOC);
+        $statement->execute();
+
+        // handle total
+        $result = $this->db->query('SELECT FOUND_ROWS()');
+        if ($result !== false && ($total = $result->fetchColumn()) !== false) {
+            $sqlTranslator?->getRequestParameters()->setTotal((int) $total);
+        }
+
+        $hostCategories = [];
+        while (is_array($result = $statement->fetch())) {
+            /** @var array{hc_id:int,hc_name:string,hc_alias:string,hc_activate:'0'|'1',hc_comment:string|null} $result */
+            $hostCategories[] = $this->createHostCategoryFromArray($result);
+        }
+
+        return $hostCategories;
     }
 
     /**
      * @inheritDoc
      */
-    public function findAllByAccessGroups(array $accessGroups, ?RequestParametersInterface $requestParameters): array
+    public function findAllByAccessGroupIds(array $accessGroupIds, ?RequestParametersInterface $requestParameters): array
     {
-        $this->info('Getting all host categories by access groups');
-
-        if ($accessGroups === []) {
-            $this->debug('No access group for this user, return empty');
-
+        if ($accessGroupIds === []) {
             return [];
         }
 
-        $accessGroupIds = array_map(
-            fn ($accessGroup) => $accessGroup->getId(),
-            $accessGroups
-        );
+        [$bindValues, $bindQuery] = $this->createMultipleBindQuery($accessGroupIds, ':access_group_id_');
 
-        // if host categories are not filtered in ACLs, then user has access to ALL host categories
-        if (! $this->hasRestrictedAccessToHostCategories($accessGroupIds)) {
-            $this->info('Host categories access not filtered');
+        $request = <<<'SQL'
+                SELECT SQL_CALC_FOUND_ROWS * FROM `:db`.hostcategories hc
+            SQL;
 
-            return $this->findAll($requestParameters);
+        $search = $requestParameters?->getSearchAsString();
+
+        if ($search !== null && \str_contains($search, 'hostgroup')) {
+            $request .= $this->prepareHostGroupSearchSubRequest();
+
+            if (! $this->hasAccessToAllHostGroups($accessGroupIds)) {
+                $request .= <<<SQL
+                        AND hgr.hostgroup_hg_id IN (
+                            SELECT arhgr.hg_hg_id
+                            FROM `:db`.acl_resources_hg_relations arhgr
+                            INNER JOIN `:db`.acl_resources res
+                                ON arhgr.acl_res_id = res.acl_res_id
+                            INNER JOIN `:db`.acl_res_group_relations argr
+                                ON res.acl_res_id = argr.acl_res_id
+                            INNER JOIN `:db`.acl_groups ag
+                                ON argr.acl_group_id = ag.acl_group_id
+                            WHERE ag.acl_group_id IN ({$bindQuery})
+                        )
+                    SQL;
+            }
         }
 
-        $concatenator = new SqlConcatenator();
-        $concatenator->withCalcFoundRows(true);
-        $concatenator->defineSelect(
-            'SELECT hc.hc_id, hc.hc_name, hc.hc_alias, hc.hc_activate, hc.hc_comment
-            FROM `:db`.hostcategories hc
-            INNER JOIN `:db`.acl_resources_hc_relations arhr
-                ON hc.hc_id = arhr.hc_id
-            INNER JOIN `:db`.acl_resources res
-                ON arhr.acl_res_id = res.acl_res_id
-            INNER JOIN `:db`.acl_res_group_relations argr
-                ON res.acl_res_id = argr.acl_res_id
-            INNER JOIN `:db`.acl_groups ag
-                ON argr.acl_group_id = ag.acl_group_id'
-        );
-        $concatenator->storeBindValueMultiple(':access_group_ids', $accessGroupIds, \PDO::PARAM_INT)
-            ->appendWhere('ag.acl_group_id IN (:access_group_ids)');
+        $request .= <<<'SQL'
+                INNER JOIN `:db`.acl_resources_hc_relations arhr
+                    ON hc.hc_id = arhr.hc_id
+                INNER JOIN `:db`.acl_resources res
+                    ON arhr.acl_res_id = res.acl_res_id
+                INNER JOIN `:db`.acl_res_group_relations argr
+                    ON res.acl_res_id = argr.acl_res_id
+                INNER JOIN `:db`.acl_groups ag
+                    ON argr.acl_group_id = ag.acl_group_id
+            SQL;
 
-        return $this->retrieveHostCategories($concatenator, $requestParameters);
+        // Setup for search, pagination and order
+        $sqlTranslator = $requestParameters ? new SqlRequestParametersTranslator($requestParameters) : null;
+        $sqlTranslator?->getRequestParameters()->setConcordanceStrictMode(RequestParameters::CONCORDANCE_MODE_STRICT);
+        $sqlTranslator?->setConcordanceArray([
+            'id' => 'hc.hc_id',
+            'name' => 'hc.hc_name',
+            'alias' => 'hc.hc_alias',
+            'is_activated' => 'hc.hc_activate',
+            'hostgroup.id' => 'hg.hg_id',
+            'hostgroup.name' => 'hg.hg_name',
+        ]);
+        $sqlTranslator?->addNormalizer('is_activated', new BoolToEnumNormalizer());
+
+        $searchRequest = $sqlTranslator?->translateSearchParameterToSql();
+
+        $request .= $searchRequest !== null
+            ? $searchRequest . ' AND '
+            : ' WHERE ';
+
+        // avoid severities
+        $request .= "hc.level IS NULL AND ag.acl_group_id IN ({$bindQuery})";
+
+        // handle sort
+        $request .= $sqlTranslator?->translateSortParameterToSql();
+
+        // handle pagination
+        $request .= $sqlTranslator?->translatePaginationToSql();
+
+        $statement = $this->db->prepare($this->translateDbName($request));
+
+        $sqlTranslator?->bindSearchValues($statement);
+
+        foreach ($bindValues as $key => $value) {
+            $statement->bindValue($key, $value, \PDO::PARAM_INT);
+        }
+
+        $statement->setFetchMode(\PDO::FETCH_ASSOC);
+        $statement->execute();
+
+        // handle total
+        $result = $this->db->query('SELECT FOUND_ROWS()');
+        if ($result !== false && ($total = $result->fetchColumn()) !== false) {
+            $sqlTranslator?->getRequestParameters()->setTotal((int) $total);
+        }
+
+        $hostCategories = [];
+        while (is_array($result = $statement->fetch())) {
+            /** @var array{hc_id:int,hc_name:string,hc_alias:string,hc_activate:'0'|'1',hc_comment:string|null} $result */
+            $hostCategories[] = $this->createHostCategoryFromArray($result);
+        }
+
+        return $hostCategories;
     }
 
     /**
@@ -197,7 +303,7 @@ class DbReadHostCategoryRepository extends AbstractRepositoryRDB implements Read
         );
 
         // if host categories are not filtered in ACLs, then user has access to ALL host categories
-        if (! $this->hasRestrictedAccessToHostCategories($accessGroupIds)) {
+        if (! $this->hasAclFilterOnHostCategories($accessGroupIds)) {
             $this->info('Host categories access not filtered');
 
             return $this->exists($hostCategoryId);
@@ -287,7 +393,7 @@ class DbReadHostCategoryRepository extends AbstractRepositoryRDB implements Read
         );
 
         // if host categories are not filtered in ACLs, then user has access to ALL host categories
-        if (! $this->hasRestrictedAccessToHostCategories($accessGroupIds)) {
+        if (! $this->hasAclFilterOnHostCategories($accessGroupIds)) {
             $this->info('Host categories access not filtered');
 
             return $this->exist($hostCategoryIds);
@@ -455,7 +561,7 @@ class DbReadHostCategoryRepository extends AbstractRepositoryRDB implements Read
         );
 
         // if host categories are not filtered in ACLs, then user has access to ALL host categories
-        if (! $this->hasRestrictedAccessToHostCategories($accessGroupIds)) {
+        if (! $this->hasAclFilterOnHostCategories($accessGroupIds)) {
             $this->info('Host categories access not filtered');
 
             return $this->findByHost($hostId);
@@ -485,6 +591,83 @@ class DbReadHostCategoryRepository extends AbstractRepositoryRDB implements Read
             ->storeBindValueMultiple(':access_group_ids', $accessGroupIds, \PDO::PARAM_INT);
 
         return $this->retrieveHostCategories($concatenator, null);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hasAclFilterOnHostCategories(array $accessGroupIds): bool
+    {
+        [$bindValues, $bindQuery] = $this->createMultipleBindQuery($accessGroupIds, ':access_group_id_');
+
+        $request = <<<SQL
+            SELECT 1
+            FROM `:db`.acl_resources_hc_relations arhr
+            INNER JOIN `:db`.acl_resources res
+                ON arhr.acl_res_id = res.acl_res_id
+            INNER JOIN `:db`.acl_res_group_relations argr
+                ON res.acl_res_id = argr.acl_res_id
+            INNER JOIN `:db`.acl_groups ag
+                ON argr.acl_group_id = ag.acl_group_id
+            WHERE ag.acl_group_id IN ({$bindQuery})
+            SQL;
+
+        $statement = $this->db->prepare($this->translateDbName($request));
+
+        foreach ($bindValues as $key => $value) {
+            $statement->bindValue($key, $value, \PDO::PARAM_INT);
+        }
+
+        $statement->setFetchMode(\PDO::FETCH_ASSOC);
+        $statement->execute();
+
+        return (bool) $statement->fetchColumn();
+    }
+
+    /**
+     * @param int[] $accessGroupIds
+     *
+     * @return bool
+     */
+    private function hasAccessToAllHostGroups(array $accessGroupIds): bool
+    {
+        [$bindValues, $bindQuery] = $this->createMultipleBindQuery($accessGroupIds, ':access_group_id_');
+
+        $request = <<<SQL
+                SELECT res.all_hostgroups
+                FROM `:db`.acl_resources res
+                INNER JOIN `:db`.acl_res_group_relations argr
+                    ON argr.acl_res_id = res.acl_res_id
+                INNER JOIN `:db`.acl_groups ag
+                    ON ag.acl_group_id = argr.acl_group_id
+                WHERE ag.acl_group_id IN ({$bindQuery})
+            SQL;
+
+        $statement = $this->db->prepare($this->translateDbName($request));
+
+        foreach ($bindValues as $key => $value) {
+            $statement->bindValue($key, $value, \PDO::PARAM_INT);
+        }
+
+        $statement->setFetchMode(\PDO::FETCH_ASSOC);
+        $statement->execute();
+
+        return (bool) $statement->fetchColumn();
+    }
+
+    /**
+     * @return string
+     */
+    private function prepareHostGroupSearchSubRequest(): string
+    {
+        return <<<'SQL'
+             INNER JOIN `:db`.hostcategories_relation hcr
+                ON hc.hc_id = hcr.hostcategories_hc_id
+            INNER JOIN `:db`.hostgroup_relation hgr
+                ON hcr.host_host_id = hgr.host_host_id
+            INNER JOIN `:db`.hostgroup hg
+                ON hgr.hostgroup_hg_id = hg.hg_id
+            SQL;
     }
 
     /**
@@ -545,42 +728,5 @@ class DbReadHostCategoryRepository extends AbstractRepositoryRDB implements Read
         $hostCategory->setComment($result['hc_comment']);
 
         return $hostCategory;
-    }
-
-    /**
-     * Determine if host categories are filtered for given access group ids
-     * true: accessible host categories are filtered
-     * false: accessible host categories are not filtered.
-     *
-     * @param int[] $accessGroupIds
-     *
-     * @phpstan-param non-empty-array<int> $accessGroupIds
-     *
-     * @return bool
-     */
-    private function hasRestrictedAccessToHostCategories(array $accessGroupIds): bool
-    {
-        $concatenator = new SqlConcatenator();
-
-        $concatenator->defineSelect(
-            'SELECT 1
-            FROM `:db`.acl_resources_hc_relations arhr
-            INNER JOIN `:db`.acl_resources res
-                ON arhr.acl_res_id = res.acl_res_id
-            INNER JOIN `:db`.acl_res_group_relations argr
-                ON res.acl_res_id = argr.acl_res_id
-            INNER JOIN `:db`.acl_groups ag
-                ON argr.acl_group_id = ag.acl_group_id'
-        );
-
-        $concatenator->storeBindValueMultiple(':access_group_ids', $accessGroupIds, \PDO::PARAM_INT)
-            ->appendWhere('ag.acl_group_id IN (:access_group_ids)');
-
-        $statement = $this->db->prepare($this->translateDbName($concatenator->__toString()));
-
-        $concatenator->bindValuesToStatement($statement);
-        $statement->execute();
-
-        return (bool) $statement->fetchColumn();
     }
 }


### PR DESCRIPTION
This PR intends to do several things
- Cleanup the repository from logs
- Cleanup the repository from Business logic
- Add new possibility of filtering (/hostgroup.name /hostgroup.id)

**Code**
- Unit tests ✔️ 
- PHPStan LEVEL 9 ✔️ 
- PHPCSFixer ✔️ 

**Jira** MON-34389

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
