### PR TITLE
fix(gorgone/pull) remove infinite loop in pull module using 100% cpu

### DIFF
--- a/centreon-gorgone/gorgone/modules/core/pull/class.pm
+++ b/centreon-gorgone/gorgone/modules/core/pull/class.pm
@@ -161,7 +161,7 @@ sub read_message_client {
 sub event {
     while (1) {
         my $message = transmit_back(message => $connector->read_message());
-        next if (!defined($message));
+        last if (!defined($message));
 
         # Only send back SETLOGS and PONG
         $connector->{logger}->writeLogDebug("[pull] read message from internal: $message");


### PR DESCRIPTION
REFS:MON-38020

## Description

fix regression induced by https://centreon.atlassian.net/browse/MON-23884, an infinite loop will draw 100% cpu on one core.



- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [X] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

To test you can configure a 22.10 poller in pull mode, when you start gorgone on the poller without this fix you will see cpu at 100% on one core.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
