### PR TITLE
fix(API): Endpoint search filter shows duplicate resources

### DIFF
--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -326,7 +326,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
         $concatenator = (new SqlConcatenator())
             ->defineSelect(
                 <<<'SQL'
-                    SELECT
+                    SELECT DISTINCT
                         hg.hg_id,
                         hg.hg_name,
                         hg.hg_alias,


### PR DESCRIPTION
## Description

Fixed enpoint `configuration/hosts/groups` returning duplicate results with some search filters

**Fixes** # MON-38229

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
