### PR TITLE
Mon 38242 dev 23 04 x discovery only the services associated to one host are created

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -1040,7 +1040,7 @@ sub action_servicediscoverylistener {
         %options
     );
 
-    if ($self->{service_discoveries}->{ $uuid }->is_finished()) {
+    if (defined($self->{service_discoveries}->{ $uuid }) && $self->{service_discoveries}->{ $uuid }->is_finished()) {
         delete $self->{service_discoveries}->{ $uuid };
     }
 }
@@ -1060,8 +1060,11 @@ sub action_launchservicediscovery {
         config_core => $self->{config_core},
         service_number => $self->{service_number},
         class_object_centreon => $self->{class_object_centreon},
-        class_object_centstorage => $self->{class_object_centstorage}
+        class_object_centstorage => $self->{class_object_centstorage},
+        class_autodiscovery => $self
     );
+
+    $self->{service_discoveries}->{ $svc_discovery->get_uuid() } = $svc_discovery;
     my $status = $svc_discovery->launchdiscovery(
         token => $options{token},
         frame => $options{frame}
@@ -1072,8 +1075,7 @@ sub action_launchservicediscovery {
             token => $options{token},
             data => { message => 'cannot launch discovery' }
         );
-    } elsif ($status == 0) {
-        $self->{service_discoveries}->{ $svc_discovery->get_uuid() } = $svc_discovery;
+        delete $self->{service_discoveries}->{ $svc_discovery->get_uuid() };
     }
 }
 

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -1041,6 +1041,8 @@ sub action_servicediscoverylistener {
     );
 
     if (defined($self->{service_discoveries}->{ $uuid }) && $self->{service_discoveries}->{ $uuid }->is_finished()) {
+        return 0 if ($self->{service_discoveries}->{ $uuid }->is_post_execution());
+        $self->{service_discoveries}->{ $uuid }->service_discovery_post_exec();
         delete $self->{service_discoveries}->{ $uuid };
     }
 }

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -40,6 +40,7 @@ sub new {
     $connector->{internal_socket} = $options{internal_socket};
     $connector->{class_object_centreon} = $options{class_object_centreon};
     $connector->{class_object_centstorage} = $options{class_object_centstorage};
+    $connector->{class_autodiscovery} = $options{class_autodiscovery};
     $connector->{tpapi_clapi} = $options{tpapi_clapi};
     $connector->{mail_subject} = defined($connector->{config}->{mail_subject}) ? $connector->{config}->{mail_subject} : 'Centreon Auto Discovery';
     $connector->{mail_from} = defined($connector->{config}->{mail_from}) ? $connector->{config}->{mail_from} : 'centreon-autodisco';
@@ -937,6 +938,12 @@ sub launchdiscovery {
     $self->service_execute_commands(vault_count => $vault_count);
 
     return 0;
+}
+
+sub event {
+    my ($self, %options) = @_;
+
+    $self->{class_autodiscovery}->event();
 }
 
 1;

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -50,6 +50,7 @@ sub new {
     $connector->{service_parrallel_commands_poller} = 8;
     $connector->{service_current_commands_poller} = {};
     $connector->{finished} = 0;
+    $connector->{post_execution} = 0;
 
     $connector->{safe_display} = Safe->new();
     $connector->{safe_display}->share('$values');
@@ -116,6 +117,12 @@ sub is_finished {
     my ($self, %options) = @_;
 
     return $self->{finished};
+}
+
+sub is_post_execution {
+    my ($self, %options) = @_;
+
+    return $self->{post_execution};
 }
 
 sub send_email {
@@ -722,13 +729,21 @@ sub discoverylistener {
                 manual => $self->{discovery}->{manual}
             }
         );
-
-        if ($self->{discovery}->{is_manual} == 0) {
-            $self->restart_pollers();
-            $self->send_email();
-        }
     }
 
+    return 0;
+}
+
+sub service_discovery_post_exec {
+    my ($self, %options) = @_;
+
+    $self->{post_execution} = 1;
+
+    if ($self->{discovery}->{is_manual} == 0) {
+        $self->restart_pollers();
+        $self->send_email();
+    }
+    
     return 0;
 }
 


### PR DESCRIPTION
## Description

backport PR for autodiscovery only creating half of the services.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [X] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

launch a service discovery with multiples hosts, every service should be created

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
