### PR TITLE
Fix(Dashboards) : error when filtring by service groups on display by host

### DIFF
--- a/centreon/www/widgets/src/centreon-widget-statuschart/src/api/endpoint.ts
+++ b/centreon/www/widgets/src/centreon-widget-statuschart/src/api/endpoint.ts
@@ -20,6 +20,8 @@ const resourceTypesCustomParameters = [
   'service-category'
 ];
 
+const hostTypesCustomParameters = ['host-group', 'host-category'];
+
 const resourceTypesSearchParameters = ['host', 'service'];
 
 const categories = ['host-category', 'service-category'];
@@ -38,12 +40,15 @@ export const buildResourcesEndpoint = ({
     : serviceStatusesEndpoint;
 
   const resourcesToApplyToCustomParameters = resources.filter(
-    ({ resourceType }) => includes(resourceType, resourceTypesCustomParameters)
+    ({ resourceType }) =>
+      equals(type, 'host')
+        ? includes(resourceType, hostTypesCustomParameters)
+        : includes(resourceType, resourceTypesCustomParameters)
   );
+
   const resourcesToApplyToSearchParameters = resources.filter(
     ({ resourceType }) => includes(resourceType, resourceTypesSearchParameters)
   );
-
   const searchConditions = resourcesToApplyToSearchParameters.map(
     ({ resourceType, resources: resourcesToApply }) => {
       return resourcesToApply.map((resource) => ({


### PR DESCRIPTION
## Description

What: when I select the 'host' display type and then choose 'service group' or 'service categories' as the resource type, I receive an error message.

Where: dataset of the Status Chart widget

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
