### PR TITLE
fix(api) hide macros of type password in response

### DIFF
--- a/centreon/src/Core/Host/Infrastructure/API/AddHost/AddHostOnPremPresenter.php
+++ b/centreon/src/Core/Host/Infrastructure/API/AddHost/AddHostOnPremPresenter.php
@@ -116,6 +116,7 @@ class AddHostOnPremPresenter extends AbstractPresenter implements AddHostPresent
                             function (array $macro) {
                                 return [
                                     'name' => $macro['name'],
+                                    // Note: do not handle vault storage at the moment
                                     'value' => $macro['isPassword'] ? null : $macro['value'],
                                     'is_password' => $macro['isPassword'],
                                     'description' => $this->emptyStringAsNull($macro['description']),

--- a/centreon/src/Core/Host/Infrastructure/API/AddHost/AddHostSaasPresenter.php
+++ b/centreon/src/Core/Host/Infrastructure/API/AddHost/AddHostSaasPresenter.php
@@ -96,6 +96,7 @@ class AddHostSaasPresenter extends AbstractPresenter implements AddHostPresenter
                             function (array $macro) {
                                 return [
                                     'name' => $macro['name'],
+                                    // Note: do not handle vault storage at the moment
                                     'value' => $macro['isPassword'] ? null : $macro['value'],
                                     'is_password' => $macro['isPassword'],
                                     'description' => $this->emptyStringAsNull($macro['description']),

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateOnPremPresenter.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateOnPremPresenter.php
@@ -91,6 +91,7 @@ class AddHostTemplateOnPremPresenter extends AbstractPresenter implements AddHos
                             function ($macro) {
                                 return [
                                     'name' => $macro['name'],
+                                    // Note: do not handle vault storage at the moment
                                     'value' => $macro['isPassword'] ? null : $macro['value'],
                                     'is_password' => $macro['isPassword'],
                                     'description' => $this->emptyStringAsNull($macro['description']),

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateSaasPresenter.php
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/AddHostTemplate/AddHostTemplateSaasPresenter.php
@@ -69,6 +69,7 @@ class AddHostTemplateSaasPresenter extends AbstractPresenter implements AddHostT
                             function ($macro) {
                                 return [
                                     'name' => $macro['name'],
+                                    // Note: do not handle vault storage at the moment
                                     'value' => $macro['isPassword'] ? null : $macro['value'],
                                     'is_password' => $macro['isPassword'],
                                     'description' => $this->emptyStringAsNull($macro['description']),

--- a/centreon/src/Core/Service/Infrastructure/API/AddService/AddServiceOnPremPresenter.php
+++ b/centreon/src/Core/Service/Infrastructure/API/AddService/AddServiceOnPremPresenter.php
@@ -85,7 +85,7 @@ class AddServiceOnPremPresenter extends AbstractPresenter implements AddServiceP
                         'is_activated' => $response->isActivated,
                         'macros' => array_map(fn(MacroDto $macro): array => [
                             'name' => $macro->name,
-                            'value' => $macro->value,
+                            'value' => $macro->isPassword ? null : $macro->value,
                             'is_password' => $macro->isPassword,
                             'description' => $macro->description,
                         ], $response->macros),

--- a/centreon/src/Core/Service/Infrastructure/API/AddService/AddServiceOnPremPresenter.php
+++ b/centreon/src/Core/Service/Infrastructure/API/AddService/AddServiceOnPremPresenter.php
@@ -85,6 +85,7 @@ class AddServiceOnPremPresenter extends AbstractPresenter implements AddServiceP
                         'is_activated' => $response->isActivated,
                         'macros' => array_map(fn(MacroDto $macro): array => [
                             'name' => $macro->name,
+                            // Note: do not handle vault storage at the moment
                             'value' => $macro->isPassword ? null : $macro->value,
                             'is_password' => $macro->isPassword,
                             'description' => $macro->description,

--- a/centreon/src/Core/Service/Infrastructure/API/AddService/AddServiceSaasPresenter.php
+++ b/centreon/src/Core/Service/Infrastructure/API/AddService/AddServiceSaasPresenter.php
@@ -71,7 +71,7 @@ class AddServiceSaasPresenter extends AbstractPresenter implements AddServicePre
                         ], $response->groups),
                         'macros' => array_map(fn(MacroDto $macro): array => [
                             'name' => $macro->name,
-                            'value' => $macro->value,
+                            'value' => $macro->isPassword ? null : $macro->value,
                             'is_password' => $macro->isPassword,
                             'description' => $macro->description,
                         ], $response->macros),

--- a/centreon/src/Core/Service/Infrastructure/API/AddService/AddServiceSaasPresenter.php
+++ b/centreon/src/Core/Service/Infrastructure/API/AddService/AddServiceSaasPresenter.php
@@ -71,6 +71,7 @@ class AddServiceSaasPresenter extends AbstractPresenter implements AddServicePre
                         ], $response->groups),
                         'macros' => array_map(fn(MacroDto $macro): array => [
                             'name' => $macro->name,
+                            // Note: do not handle vault storage at the moment
                             'value' => $macro->isPassword ? null : $macro->value,
                             'is_password' => $macro->isPassword,
                             'description' => $macro->description,

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateOnPremPresenter.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateOnPremPresenter.php
@@ -85,7 +85,7 @@ class AddServiceTemplateOnPremPresenter extends AbstractPresenter implements Add
                         'is_locked' => $response->isLocked,
                         'macros' => array_map(fn(MacroDto $macro): array => [
                             'name' => $macro->name,
-                            'value' => $macro->value,
+                            'value' => $macro->isPassword ? null : $macro->value,
                             'is_password' => $macro->isPassword,
                             'description' => $macro->description,
                         ], $response->macros),

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateOnPremPresenter.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateOnPremPresenter.php
@@ -85,6 +85,7 @@ class AddServiceTemplateOnPremPresenter extends AbstractPresenter implements Add
                         'is_locked' => $response->isLocked,
                         'macros' => array_map(fn(MacroDto $macro): array => [
                             'name' => $macro->name,
+                            // Note: do not handle vault storage at the moment
                             'value' => $macro->isPassword ? null : $macro->value,
                             'is_password' => $macro->isPassword,
                             'description' => $macro->description,

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateSaasPresenter.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateSaasPresenter.php
@@ -68,7 +68,7 @@ class AddServiceTemplateSaasPresenter extends AbstractPresenter implements AddSe
                         ], $response->categories),
                         'macros' => array_map(fn(MacroDto $macro): array => [
                             'name' => $macro->name,
-                            'value' => $macro->value,
+                            'value' => $macro->isPassword ? null : $macro->value,
                             'is_password' => $macro->isPassword,
                             'description' => $macro->description,
                         ], $response->macros),

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateSaasPresenter.php
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/API/AddServiceTemplate/AddServiceTemplateSaasPresenter.php
@@ -68,6 +68,7 @@ class AddServiceTemplateSaasPresenter extends AbstractPresenter implements AddSe
                         ], $response->categories),
                         'macros' => array_map(fn(MacroDto $macro): array => [
                             'name' => $macro->name,
+                            // Note: do not handle vault storage at the moment
                             'value' => $macro->isPassword ? null : $macro->value,
                             'is_password' => $macro->isPassword,
                             'description' => $macro->description,


### PR DESCRIPTION
## Description

Return null instead of value for macros of type password in AddService and AddServiceTemplate endpoints responses

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)
