### PR TITLE
fix(gorgone): install default whitelists in a separate file (#3671)

### DIFF
--- a/centreon-gorgone/packaging/centreon-gorgone.yaml
+++ b/centreon-gorgone/packaging/centreon-gorgone.yaml
@@ -36,8 +36,29 @@ contents:
       group: centreon-gorgone
       mode: 0770
 
+  - dst: "/etc/centreon-gorgone/config.d/whitelist.conf.d"
+    type: dir
+    file_info:
+      owner: centreon-gorgone
+      group: centreon-gorgone
+      mode: 0770
+
   - src: "./configuration/config.yaml"
     dst: "/etc/centreon-gorgone/config.yaml"
+    file_info:
+      owner: centreon-gorgone
+      group: centreon-gorgone
+      mode: 0640
+
+  - src: "./configuration/action.yaml"
+    dst: "/etc/centreon-gorgone/config.d/41-action.yaml"
+    file_info:
+      owner: centreon-gorgone
+      group: centreon-gorgone
+      mode: 0640
+
+  - src: "./configuration/whitelist.conf.d/centreon.yaml"
+    dst: "/etc/centreon-gorgone/config.d/whitelist.conf.d/centreon.yaml"
     file_info:
       owner: centreon-gorgone
       group: centreon-gorgone

--- a/centreon-gorgone/packaging/configuration/action.yaml
+++ b/centreon-gorgone/packaging/configuration/action.yaml
@@ -1,0 +1,8 @@
+gorgone:
+  modules:
+    - name: action
+      package: "gorgone::modules::core::action::hooks"
+      enable: true
+      command_timeout: 30
+      whitelist_cmds: true
+      allowed_cmds: !include /etc/centreon-gorgone/config.d/whitelist.conf.d/*.yaml

--- a/centreon-gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
+++ b/centreon-gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
@@ -1,0 +1,13 @@
+# Configuration brought by Centreon Gorgone package.
+# SHOULD NOT BE EDITED! CREATE YOUR OWN FILE IN WHITELIST.CONF.D DIRECTORY!
+- ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+- ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
+- ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/+centengine\.cfg\s*$
+- ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats\.json\s*$
+- ^/usr/lib/centreon/plugins/.*$
+- ^/bin/perl /usr/share/centreon/bin/anomaly_detection --seasonality >> /var/log/centreon/anomaly_detection\.log 2>&1\s*$
+- ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
+- ^centreon
+- ^mkdir
+- ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
+- ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$


### PR DESCRIPTION
## Description

fix(gorgone): install default whitelists in a separate file

**Fixes** MON-38362

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)