### PR TITLE
fix(gorgone): install default whitelists in a separate file

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -122,6 +122,13 @@ jobs:
           path: ./*.${{ inputs.package_extension }}
           key: ${{ inputs.cache_key }}
 
+      - if: ${{ inputs.package_extension == 'deb' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: packages-${{ inputs.package_extension }}
+          path: ./*.${{ inputs.package_extension }}
+          retention-days: 1
+
   sign:
     if: ${{ inputs.package_extension == 'rpm' }}
     needs: [package]
@@ -156,3 +163,9 @@ jobs:
         with:
           path: ./*.${{ inputs.package_extension }}
           key: ${{ inputs.cache_key }}
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: packages-${{ inputs.package_extension }}
+          path: ./*.${{ inputs.package_extension }}
+          retention-days: 1

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -122,13 +122,6 @@ jobs:
           path: ./*.${{ inputs.package_extension }}
           key: ${{ inputs.cache_key }}
 
-      - if: ${{ inputs.package_extension == 'deb' }}
-        uses: actions/upload-artifact@v3
-        with:
-          name: packages-${{ inputs.package_extension }}
-          path: ./*.${{ inputs.package_extension }}
-          retention-days: 1
-
   sign:
     if: ${{ inputs.package_extension == 'rpm' }}
     needs: [package]
@@ -163,9 +156,3 @@ jobs:
         with:
           path: ./*.${{ inputs.package_extension }}
           key: ${{ inputs.cache_key }}
-
-      - uses: actions/upload-artifact@v3
-        with:
-          name: packages-${{ inputs.package_extension }}
-          path: ./*.${{ inputs.package_extension }}
-          retention-days: 1

--- a/centreon-gorgone/packaging/action.yaml
+++ b/centreon-gorgone/packaging/action.yaml
@@ -1,0 +1,8 @@
+gorgone:
+  modules:
+    - name: action
+      package: "gorgone::modules::core::action::hooks"
+      enable: true
+      command_timeout: 30
+      whitelist_cmds: true
+      allowed_cmds: !include /etc/centreon-gorgone/config.d/whitelist.conf.d/*.yaml

--- a/centreon-gorgone/packaging/centreon-gorgone.spectemplate
+++ b/centreon-gorgone/packaging/centreon-gorgone.spectemplate
@@ -103,11 +103,14 @@ mkdir -p %{buildroot}/%{perl_vendorlib}/gorgone
 %{__install} -d %{buildroot}%{_sysconfdir}/centreon-gorgone
 %{__install} -d %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/
 %{__install} -d %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/cron.d/
+%{__install} -d %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/whitelist.conf.d/
 %{__install} -d %buildroot%{_localstatedir}/cache/centreon-gorgone/autodiscovery
 %{__cp} centreon-gorgone/packaging/config.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/
 %{__cp} centreon-gorgone/packaging/centreon.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/30-centreon.yaml
 %{__cp} centreon-gorgone/packaging/centreon-api.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/31-centreon-api.yaml
+%{__cp} centreon-gorgone/packaging/action.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/41-action.yaml
 %{__cp} centreon-gorgone/packaging/centreon-audit.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/50-centreon-audit.yaml
+%{__cp} centreon-gorgone/packaging/whitelist.conf.d/centreon.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/whitelist.conf.d/centreon.yaml
 
 %{__install} -d %buildroot%{_sysconfdir}/sudoers.d/
 %{__cp} centreon-gorgone/packaging/sudoers.d/centreon-gorgone %buildroot%{_sysconfdir}/sudoers.d/centreon-gorgone
@@ -138,7 +141,11 @@ rm -rf %{buildroot}
 %dir %{_sysconfdir}/centreon-gorgone
 %dir %{_sysconfdir}/centreon-gorgone/config.d
 %dir %{_sysconfdir}/centreon-gorgone/config.d/cron.d
+%dir %{_sysconfdir}/centreon-gorgone/config.d/whitelist.conf.d
 %{_sysconfdir}/centreon-gorgone/config.yaml
+%{_sysconfdir}/centreon-gorgone/config.d/41-action.yaml
+%{_sysconfdir}/centreon-gorgone/config.d/whitelist.conf.d/centreon.yaml
+
 %defattr(-, centreon-gorgone, centreon-gorgone, -)
 %{_localstatedir}/lib/centreon-gorgone
 %{_localstatedir}/log/centreon-gorgone

--- a/centreon-gorgone/packaging/debian/centreon-gorgone.dirs
+++ b/centreon-gorgone/packaging/debian/centreon-gorgone.dirs
@@ -1,4 +1,5 @@
 etc/centreon-gorgone/config.d
+etc/centreon-gorgone/config.d/whitelist.conf.d
 etc/centreon-gorgone/config.d/cron.d
 var/cache/centreon-gorgone
 var/cache/centreon-gorgone/autodiscovery

--- a/centreon-gorgone/packaging/debian/centreon-gorgone.install
+++ b/centreon-gorgone/packaging/debian/centreon-gorgone.install
@@ -1,14 +1,16 @@
 #!/usr/bin/dh-exec
 
-gorgoned                                usr/bin
-contrib/*                               usr/local/bin
-packaging/config.yaml                   etc/centreon-gorgone
-packaging/centreon-api.yaml             etc/centreon-gorgone/config.d
-packaging/sudoers.d/centreon-gorgone    etc/sudoers.d
-gorgone/class/*                         usr/share/perl5/gorgone/class
-gorgone/modules/*                       usr/share/perl5/gorgone/modules
-gorgone/standard/*                      usr/share/perl5/gorgone/standard
+gorgoned                                 usr/bin
+contrib/*                                usr/local/bin
+packaging/config.yaml                    etc/centreon-gorgone
+packaging/centreon-api.yaml              etc/centreon-gorgone/config.d
+packaging/whitelist.conf.d/centreon.yaml etc/centreon-gorgone/config.d/whitelist.conf.d
+packaging/sudoers.d/centreon-gorgone     etc/sudoers.d
+gorgone/class/*                          usr/share/perl5/gorgone/class
+gorgone/modules/*                        usr/share/perl5/gorgone/modules
+gorgone/standard/*                       usr/share/perl5/gorgone/standard
 
+packaging/action.yaml => etc/centreon-gorgone/config.d/41-action.yaml
 packaging/centreon.yaml => etc/centreon-gorgone/config.d/30-centreon.yaml
 packaging/centreon-audit.yaml => etc/centreon-gorgone/config.d/50-centreon-audit.yaml
 config/systemd/gorgoned-service => lib/systemd/system/gorgoned.service

--- a/centreon-gorgone/packaging/whitelist.conf.d/centreon.yaml
+++ b/centreon-gorgone/packaging/whitelist.conf.d/centreon.yaml
@@ -1,0 +1,13 @@
+# Configuration brought by Centreon Gorgone package.
+# SHOULD NOT BE EDITED! CREATE YOUR OWN FILE IN WHITELIST.CONF.D DIRECTORY!
+- ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+- ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
+- ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/+centengine\.cfg\s*$
+- ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats\.json\s*$
+- ^/usr/lib/centreon/plugins/.*$
+- ^/bin/perl /usr/share/centreon/bin/anomaly_detection --seasonality >> /var/log/centreon/anomaly_detection\.log 2>&1\s*$
+- ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
+- ^centreon
+- ^mkdir
+- ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
+- ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$


### PR DESCRIPTION
## Description

fix(gorgone): install default whitelists in a separate file

**Fixes** MON-38363

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)