### PR TITLE
fix(gorgone): install default whitelists in a separate file

### DIFF
--- a/.github/docker/Dockerfile.packaging-alma8
+++ b/.github/docker/Dockerfile.packaging-alma8
@@ -1,6 +1,10 @@
-FROM almalinux:8.5
+FROM almalinux:8
 
-RUN <<EOF
+RUN bash -e <<EOF
+
+dnf module reset -y ruby
+dnf module enable -y ruby:3.0
+dnf install -y ruby
 
 dnf install -y rpm-build rpm-sign zstd perl-devel
 dnf clean all

--- a/centreon-gorgone/packaging/action.yaml
+++ b/centreon-gorgone/packaging/action.yaml
@@ -1,0 +1,8 @@
+gorgone:
+  modules:
+    - name: action
+      package: "gorgone::modules::core::action::hooks"
+      enable: true
+      command_timeout: 30
+      whitelist_cmds: true
+      allowed_cmds: !include /etc/centreon-gorgone/config.d/whitelist.conf.d/*.yaml

--- a/centreon-gorgone/packaging/centreon-gorgone.spectemplate
+++ b/centreon-gorgone/packaging/centreon-gorgone.spectemplate
@@ -83,11 +83,14 @@ mkdir -p %{buildroot}/%{perl_vendorlib}/gorgone
 %{__install} -d %{buildroot}%{_sysconfdir}/centreon-gorgone
 %{__install} -d %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/
 %{__install} -d %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/cron.d/
+%{__install} -d %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/whitelist.conf.d/
 %{__install} -d %buildroot%{_localstatedir}/cache/centreon-gorgone/autodiscovery
 %{__cp} centreon-gorgone/packaging/config.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/
 %{__cp} centreon-gorgone/packaging/centreon.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/30-centreon.yaml
 %{__cp} centreon-gorgone/packaging/centreon-api.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/31-centreon-api.yaml
+%{__cp} centreon-gorgone/packaging/action.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/41-action.yaml
 %{__cp} centreon-gorgone/packaging/centreon-audit.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/50-centreon-audit.yaml
+%{__cp} centreon-gorgone/packaging/whitelist.conf.d/centreon.yaml %{buildroot}%{_sysconfdir}/centreon-gorgone/config.d/whitelist.conf.d/centreon.yaml
 
 %{__install} -d %buildroot%{_sysconfdir}/sudoers.d/
 %{__cp} centreon-gorgone/packaging/sudoers.d/centreon-gorgone %buildroot%{_sysconfdir}/sudoers.d/centreon-gorgone
@@ -114,7 +117,11 @@ rm -rf %{buildroot}
 %dir %{_sysconfdir}/centreon-gorgone
 %dir %{_sysconfdir}/centreon-gorgone/config.d
 %dir %{_sysconfdir}/centreon-gorgone/config.d/cron.d
+%dir %{_sysconfdir}/centreon-gorgone/config.d/whitelist.conf.d
 %{_sysconfdir}/centreon-gorgone/config.yaml
+%{_sysconfdir}/centreon-gorgone/config.d/41-action.yaml
+%{_sysconfdir}/centreon-gorgone/config.d/whitelist.conf.d/centreon.yaml
+
 %defattr(-, centreon-gorgone, centreon-gorgone, -)
 %{_localstatedir}/lib/centreon-gorgone
 %{_localstatedir}/log/centreon-gorgone

--- a/centreon-gorgone/packaging/debian/centreon-gorgone.dirs
+++ b/centreon-gorgone/packaging/debian/centreon-gorgone.dirs
@@ -1,4 +1,5 @@
 etc/centreon-gorgone/config.d
+etc/centreon-gorgone/config.d/whitelist.conf.d
 etc/centreon-gorgone/config.d/cron.d
 var/cache/centreon-gorgone
 var/cache/centreon-gorgone/autodiscovery

--- a/centreon-gorgone/packaging/debian/centreon-gorgone.install
+++ b/centreon-gorgone/packaging/debian/centreon-gorgone.install
@@ -1,15 +1,17 @@
 #!/usr/bin/dh-exec
 
-gorgoned                                usr/bin
-contrib/*                               usr/local/bin
-packaging/config.yaml                   etc/centreon-gorgone
-packaging/centreon.yaml                 etc/centreon-gorgone/config.d
-packaging/centreon-api.yaml             etc/centreon-gorgone/config.d
-packaging/centreon-audit.yaml           etc/centreon-gorgone/config.d
-packaging/sudoers.d/centreon-gorgone    etc/sudoers.d
-gorgone/class/*                         usr/share/perl5/gorgone/class
-gorgone/modules/*                       usr/share/perl5/gorgone/modules
-gorgone/standard/*                      usr/share/perl5/gorgone/standard
+gorgoned                                 usr/bin
+contrib/*                                usr/local/bin
+packaging/config.yaml                    etc/centreon-gorgone
+packaging/centreon.yaml                  etc/centreon-gorgone/config.d
+packaging/centreon-api.yaml              etc/centreon-gorgone/config.d
+packaging/centreon-audit.yaml            etc/centreon-gorgone/config.d
+packaging/whitelist.conf.d/centreon.yaml etc/centreon-gorgone/config.d/whitelist.conf.d
+packaging/sudoers.d/centreon-gorgone     etc/sudoers.d
+gorgone/class/*                          usr/share/perl5/gorgone/class
+gorgone/modules/*                        usr/share/perl5/gorgone/modules
+gorgone/standard/*                       usr/share/perl5/gorgone/standard
 
+packaging/action.yaml => etc/centreon-gorgone/config.d/41-action.yaml
 config/systemd/gorgoned-service => lib/systemd/system/gorgoned.service
 config/systemd/gorgoned-sysconfig => etc/default/gorgoned

--- a/centreon-gorgone/packaging/whitelist.conf.d/centreon.yaml
+++ b/centreon-gorgone/packaging/whitelist.conf.d/centreon.yaml
@@ -1,0 +1,13 @@
+# Configuration brought by Centreon Gorgone package.
+# SHOULD NOT BE EDITED! CREATE YOUR OWN FILE IN WHITELIST.CONF.D DIRECTORY!
+- ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+- ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
+- ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/+centengine\.cfg\s*$
+- ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats\.json\s*$
+- ^/usr/lib/centreon/plugins/.*$
+- ^/bin/perl /usr/share/centreon/bin/anomaly_detection --seasonality >> /var/log/centreon/anomaly_detection\.log 2>&1\s*$
+- ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
+- ^centreon
+- ^mkdir
+- ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
+- ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$


### PR DESCRIPTION
## Description

fix(gorgone): install default whitelists in a separate file

**Fixes** MON-38361 MON-38367

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)