### PR TITLE
fix(ci): install ruby 3.0 on alma8 packaging image

### DIFF
--- a/.github/docker/Dockerfile.packaging-alma8
+++ b/.github/docker/Dockerfile.packaging-alma8
@@ -2,6 +2,10 @@ FROM almalinux:8
 
 RUN bash -e <<EOF
 
+dnf module reset -y ruby
+dnf module enable -y ruby:3.0
+dnf install -y ruby
+
 echo '[goreleaser]
 name=GoReleaser
 baseurl=https://repo.goreleaser.com/yum/


### PR DESCRIPTION
## Description

fix(ci): install ruby 3.0 on alma8 packaging image

**Fixes** MON-38367

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)