### PR TITLE
enh(CEIP): add playlists to CEIP Statistics

### DIFF
--- a/centreon/www/class/centreonStatistics.class.php
+++ b/centreon/www/class/centreonStatistics.class.php
@@ -464,18 +464,18 @@ class CentreonStatistics
         );
         while (false !== ($record = $statement->fetch(\PDO::FETCH_ASSOC))) {
             $dashboardsCount = $record['dashboards'] !== null
-                ? count(explode(',',$record['dashboards']))
+                ? count(explode(',', $record['dashboards']))
                 : 0;
             $contactsCount = $record['contacts'] !== null
-                ? count(explode(',',$record['contacts']))
+                ? count(explode(',', $record['contacts']))
                 : 0;
             $contactGroupsCount = $record['contactgroups'] !== null
-                ? count(explode(',',$record['contactgroups']))
+                ? count(explode(',', $record['contactgroups']))
                 : 0;
             $data[$record['playlist_name']] = [
                     'rotation_time' => $record['rotation_time'],
                     'dashboards_count' => $dashboardsCount,
-                    'shared_users_groups_count' => $contactsCount + $contactGroupsCount
+                    'shared_users_groups_count' => $contactsCount + $contactGroupsCount,
             ];
         }
 

--- a/centreon/www/class/centreonStatistics.class.php
+++ b/centreon/www/class/centreonStatistics.class.php
@@ -440,6 +440,9 @@ class CentreonStatistics
         return $data;
     }
 
+    /**
+     * @return array<string,array{rotation_time: int, dashboards_count: int, shared_users_groups_count: int}>
+     */
     private function getAdditionalDashboardPlaylistsInformation(): array
     {
         $data = [];

--- a/centreon/www/class/centreonStatistics.class.php
+++ b/centreon/www/class/centreonStatistics.class.php
@@ -473,9 +473,9 @@ class CentreonStatistics
                 ? count(explode(',', $record['contactgroups']))
                 : 0;
             $data[$record['playlist_name']] = [
-                    'rotation_time' => $record['rotation_time'],
-                    'dashboards_count' => $dashboardsCount,
-                    'shared_users_groups_count' => $contactsCount + $contactGroupsCount,
+                'rotation_time' => $record['rotation_time'],
+                'dashboards_count' => $dashboardsCount,
+                'shared_users_groups_count' => $contactsCount + $contactGroupsCount,
             ];
         }
 

--- a/centreon/www/class/centreonStatistics.class.php
+++ b/centreon/www/class/centreonStatistics.class.php
@@ -349,6 +349,10 @@ class CentreonStatistics
             $data['dashboards'] = $this->getAdditionalDashboardsInformation();
         }
 
+        if ($this->featureFlags?->isEnabled('dashboard_playlist')) {
+            $data['playlists'] = $this->getAdditionalDashboardPlaylistsInformation();
+        }
+
         $data['user_filter'] = $this->getAdditionalUserFiltersInformation();
 
         return $data;
@@ -431,6 +435,45 @@ class CentreonStatistics
                     ? null
                     : \count($widgetSettings['data']['metrics']);
             }
+        }
+
+        return $data;
+    }
+
+    private function getAdditionalDashboardPlaylistsInformation(): array
+    {
+        $data = [];
+        $statement = $this->dbConfig->query(
+            <<<SQL
+                SELECT dp.name as playlist_name, dp.rotation_time,
+                    GROUP_CONCAT(dplr.dashboard_id) as dashboards,
+                    GROUP_CONCAT(dpcr.contact_id) as contacts,
+                    GROUP_CONCAT(dpcgr.contactgroup_id) as contactgroups
+                FROM dashboard_playlist dp
+                    LEFT JOIN dashboard_playlist_relation dplr
+                        ON dplr.playlist_id = dp.id
+                    LEFT JOIN dashboard_playlist_contact_relation dpcr
+                        ON dpcr.playlist_id = dp.id
+                    LEFT JOIN dashboard_playlist_contactgroup_relation dpcgr
+                        ON dpcgr.playlist_id = dp.id
+                GROUP BY dp.name
+                SQL
+        );
+        while (false !== ($record = $statement->fetch(\PDO::FETCH_ASSOC))) {
+            $dashboardsCount = $record['dashboards'] !== null
+                ? count(explode(',',$record['dashboards']))
+                : 0;
+            $contactsCount = $record['contacts'] !== null
+                ? count(explode(',',$record['contacts']))
+                : 0;
+            $contactGroupsCount = $record['contactgroups'] !== null
+                ? count(explode(',',$record['contactgroups']))
+                : 0;
+            $data[$record['playlist_name']] = [
+                    'rotation_time' => $record['rotation_time'],
+                    'dashboards_count' => $dashboardsCount,
+                    'shared_users_groups_count' => $contactsCount + $contactGroupsCount
+            ];
         }
 
         return $data;


### PR DESCRIPTION
## Description

This PR intends to add Playlists to CEIP Statistics

**Fixes** # MON-33952

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced additional insights for dashboard playlists, including rotation time, dashboard count, and shared users/groups count, available when the `dashboard_playlist` feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->