### PR TITLE
fix(gorgone/pullwss) escape character before sending http message

### DIFF
--- a/centreon-gorgone/gorgone/modules/core/proxy/httpserver.pm
+++ b/centreon-gorgone/gorgone/modules/core/proxy/httpserver.pm
@@ -34,6 +34,7 @@ use IO::Handle;
 use JSON::XS;
 use IO::Poll qw(POLLIN POLLPRI);
 use EV;
+use HTML::Entities;
 
 my %handlers = (TERM => {}, HUP => {});
 my ($connector);
@@ -52,6 +53,8 @@ websocket '/' => sub {
 
     $mojo->on(message => sub {
         my ($mojo, $msg) = @_;
+
+        $msg =  HTML::Entities::decode_entities($msg);
 
         $connector->{ws_clients}->{ $mojo->tx->connection }->{last_update} = time();
 

--- a/centreon-gorgone/gorgone/modules/core/pullwss/class.pm
+++ b/centreon-gorgone/gorgone/modules/core/pullwss/class.pm
@@ -32,6 +32,7 @@ use IO::Socket::SSL;
 use IO::Handle;
 use JSON::XS;
 use EV;
+use HTML::Entities;
 
 my %handlers = (TERM => {}, HUP => {});
 my ($connector);
@@ -103,8 +104,8 @@ sub class_handle_HUP {
 
 sub send_message {
     my ($self, %options) = @_;
-
-    $self->{tx}->send({text => $options{message} });
+    my $message = HTML::Entities::encode_entities($options{message});
+    $self->{tx}->send({text => $message });
 }
 
 sub ping {


### PR DESCRIPTION
as wide space was not correctly interpreted.

REF:MON-37293

## Description

backport to 24.04 march cloud release.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>
Add a poller in pulwss configuration to a central centreon, and check all gorgone dependant fonctionnality work.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
