### PR TITLE
fix(clapi) fix downtime creation on services linked to a service group

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonRtDowntime.class.php
+++ b/centreon/www/class/centreon-clapi/centreonRtDowntime.class.php
@@ -633,28 +633,29 @@ class CentreonRtDowntime extends CentreonObject
     }
 
     /**
-     * @param $resource
-     * @param $start
-     * @param $end
-     * @param $fixed
-     * @param $duration
-     * @param $comment
+     * @param string $resource
+     * @param string $start
+     * @param string $end
+     * @param int $fixed
+     * @param ?int $duration
+     * @param string $comment
+     *
      * @throws CentreonClapiException
      */
     private function addSgDowntime(
-        $resource,
-        $start,
-        $end,
-        $fixed,
-        $duration,
-        $comment
-    ) {
-        if ($resource === "") {
+        string $resource,
+        string $start,
+        string $end,
+        int $fixed,
+        ?int $duration,
+        string $comment
+    ): void {
+        if ($resource === '') {
             throw new CentreonClapiException(self::MISSINGPARAMETER);
         }
 
-        $existingSg = array();
-        $unknownSg = array();
+        $existingSg = [];
+        $unknownSg = [];
         $listSg = explode('|', $resource);
 
         // check if service exist
@@ -668,7 +669,10 @@ class CentreonRtDowntime extends CentreonObject
 
         if (count($existingSg)) {
             foreach ($existingSg as $sg) {
-                $serviceList = $this->sgObject->getServicesByServicegroupName($sg);
+                $serviceList = [
+                    ...$this->sgObject->getServicesByServicegroupName($sg),
+                    ...$this->sgObject->getServicesThroughtServiceTemplatesByServicegroupName($sg),
+                ];
                 foreach ($serviceList as $service) {
                     $this->externalCmdObj->addSvcDowntime(
                         $service['host'],


### PR DESCRIPTION
## Description

When creating a dowtime with CLAPI (or API v1 using clapi), services linked to a service group through their template where not put in downtime like it is the case when doing the same action via UI + a bit of code style (on the updated methods)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved parameter type definitions and return types in downtime management methods for enhanced reliability.
	- Enhanced service group functionality with stricter parameter types and more comprehensive data retrieval methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->