### PR TITLE
fix(ci): fix ha packaging with old package action

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -10,6 +10,9 @@ inputs:
   package_extension:
     description: The package extension (deb or rpm)
     required: true
+  distrib:
+    description: The distribution
+    required: true
   frontend_index_cache_key:
     description: The index.html cache key
   frontend_index_file:
@@ -168,7 +171,7 @@ runs:
     - name: Upload package artifacts
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
-        name: packages-${{ inputs.package_extension }}
+        name: packages-${{ inputs.package_extension }}-${{ inputs.distrib }}
         path: ./*.${{ inputs.package_extension }}
         retention-days: 1
 

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -158,7 +158,7 @@ runs:
 
         fi
 
-        debmake -f "Centreon" -e "contact@centreon.com" -u "$VERSION" -y -r "bullseye"
+        debmake -f "Centreon" -e "contact@centreon.com" -u "$VERSION" -y -r "${{ inputs.distrib }}"
         debuild-pbuilder --no-lintian
 
         # This makes shure that widget pkgs end up in the same dir as non widgets

--- a/.github/workflows/ha.yml
+++ b/.github/workflows/ha.yml
@@ -60,6 +60,7 @@ jobs:
       release: ${{ needs.get-version.outputs.release }}
       commit_hash: ${{ github.sha }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      distrib: ${{ matrix.distrib }}
     secrets:
       registry_username: ${{ secrets.DOCKER_REGISTRY_ID }}
       registry_password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,6 +13,10 @@ on:
         type: string
         description: The package extension (deb or rpm)
         required: true
+      distrib:
+        type: string
+        description: The package distribution
+        required: true
       frontend_index_cache_key:
         type: string
         description: The index.html cache key
@@ -98,6 +102,7 @@ jobs:
           base_directory: ${{ inputs.base_directory }}
           spec_file: ${{ inputs.spec_file }}
           package_extension: ${{ inputs.package_extension }}
+          distrib: ${{ inputs.distrib }}
           frontend_index_cache_key: ${{ inputs.frontend_index_cache_key }}
           frontend_index_file: ${{ inputs.frontend_index_file }}
           frontend_static_cache_key: ${{ inputs.frontend_static_cache_key }}


### PR DESCRIPTION
## Description

Fixed HA builds that relied on old package action, to avoid having multiple artifacts with the same name which would prevent the action upload-artifact v4 from uploading them.

**Fixes** #MON-38512

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new input parameter for specifying package distribution in GitHub Actions workflows, enhancing artifact management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->