### PR TITLE
Systemctl is under /usr/bin

### DIFF
--- a/centreon-gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
+++ b/centreon-gorgone/packaging/configuration/whitelist.conf.d/centreon.yaml
@@ -1,6 +1,6 @@
 # Configuration brought by Centreon Gorgone package.
 # SHOULD NOT BE EDITED! CREATE YOUR OWN FILE IN WHITELIST.CONF.D DIRECTORY!
-- ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+- ^sudo\s+(/bin/|/usr/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
 - ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
 - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/+centengine\.cfg\s*$
 - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats\.json\s*$


### PR DESCRIPTION
Hello,

## Description
At least under RedHat Linux, starting from 7, the default path for systemctl is /usr/bin (/bin is a symbolic link to /usr/bin)

So it’s must be allowed is the Whitelist.

**Fixes** # (issue)
reload/restart do not works if we use the real path in the Poller configuration.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

- on a Poller, edit "/etc/centreon-gorgone/config.d $ vim whitelist.conf.d/centreon.yaml" and put the new content
- Restart «gorgoned»
- In Centreon UI go to : Configuration > Poller
- Edit one Poller
- in "Monitoring Engine Information"
- use the real and absolute path for every  Monitoring Engine" command
- Try to reload/restart a Poller for the UI 

## Checklist
Look for the restart in Centreon Engine's logs.

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
