### PR TITLE
enh(cloud): add required rule on host form for hg selection

### DIFF
--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -798,6 +798,10 @@ $form->addElement('textarea', 'host_comment', _('Comments'), $attrsTextarea);
 
 $form->addElement('select2', 'host_hgs', _('Host Groups'), [], $attributes['host_groups']);
 
+if ($isCloudPlatform) {
+    $form->addRule('host_hgs', _('Mandatory field for ACL purpose.'), 'required');
+}
+
 if ($o === HOST_MASSIVE_CHANGE) {
     $mc_mod_hhg = [];
     $mc_mod_hhg[] = $form->createElement('radio', 'mc_mod_hhg', null, _('Incremental'), '0');


### PR DESCRIPTION
This PR intends to make the hostgroup link mandatory for host creation / update for Cloud environnement.


https://github.com/centreon/centreon/assets/31647811/78144276-3a90-4a6d-8099-0f6a732b10a9


**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Host configuration now requires 'Host Groups' to be specified for enhanced access control, specifically for cloud platform deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->