### PR TITLE
fix(acl): allow to link host with hg when all_hostgroups is set to 1

### DIFF
--- a/centreon/www/api/class/centreon_configuration_hostgroup.class.php
+++ b/centreon/www/api/class/centreon_configuration_hostgroup.class.php
@@ -34,14 +34,12 @@
  *
  */
 
-require_once _CENTREON_PATH_ . "/www/class/centreonDB.class.php";
-require_once __DIR__ . "/centreon_configuration_objects.class.php";
+require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
+require_once __DIR__ . '/centreon_configuration_objects.class.php';
 
 class CentreonConfigurationHostgroup extends CentreonConfigurationObjects
 {
-    /**
-     * @var CentreonDB
-     */
+    /** @var CentreonDB */
     protected $pearDBMonitoring;
 
     /**
@@ -54,8 +52,9 @@ class CentreonConfigurationHostgroup extends CentreonConfigurationObjects
     }
 
     /**
-     * @return array
      * @throws Exception
+     *
+     * @return array
      */
     public function getList()
     {
@@ -64,67 +63,92 @@ class CentreonConfigurationHostgroup extends CentreonConfigurationObjects
         $userId = $centreon->user->user_id;
         $isAdmin = $centreon->user->admin;
         $aclHostGroups = '';
-        $queryValues = array();
+        $queryValues = [];
 
-        /* Get ACL if user is not admin */
-        if (!$isAdmin && $centreon->user->access->hasAccessToAllHostGroups === false) {
+        // Get ACL if user is not admin
+        if (
+            ! $isAdmin
+            && $centreon->user->access->hasAccessToAllHostGroups === false
+        ) {
             $acl = new CentreonACL($userId, $isAdmin);
-            $aclHostGroups .= 'AND hg.hg_id IN (' . $acl->getHostGroupsString('ID') . ') ';
+            $aclHostGroups .= ' AND hg.hg_id IN (' . $acl->getHostGroupsString() . ') ';
         }
 
-        // Check for select2 'q' argument
-        if (isset($this->arguments['q'])) {
-            $queryValues['hgName'] = '%' . (string)$this->arguments['q'] . '%';
-        } else {
-            $queryValues['hgName'] = '%%';
+        $query = filter_var(
+            $this->arguments['q'] ?? '',
+            FILTER_SANITIZE_FULL_SPECIAL_CHARS
+        );
+
+        $limit = array_key_exists('page_limit', $this->arguments)
+            ? filter_var($this->arguments['page_limit'], FILTER_VALIDATE_INT)
+            : null;
+
+        $page = array_key_exists('page', $this->arguments)
+            ? filter_var($this->arguments['page'], FILTER_VALIDATE_INT)
+            : null;
+
+        if ($limit === false) {
+            throw new RestBadRequestException('Error, limit must be an integer greater than zero');
         }
 
-        $queryHostGroup = "SELECT SQL_CALC_FOUND_ROWS DISTINCT "
-            . "hg.hg_name, hg.hg_id, hg.hg_activate FROM hostgroup hg "
-            . "WHERE hg.hg_name LIKE :hgName " . $aclHostGroups . "ORDER BY hg.hg_name ";
-
-        if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
-            if (
-                !is_numeric($this->arguments['page'])
-                || !is_numeric($this->arguments['page_limit'])
-                || $this->arguments['page_limit'] < 1
-            ) {
-                throw new \RestBadRequestException('Error, limit must be an integer greater than zero');
-            }
-            $offset = ($this->arguments['page'] - 1) * $this->arguments['page_limit'];
-            $queryHostGroup .= 'LIMIT :offset, :limit';
-            $queryValues['offset'] = (int)$offset;
-            $queryValues['limit'] = (int)$this->arguments['page_limit'];
+        if ($page === false) {
+            throw new RestBadRequestException('Error, page must be an integer greater than zero');
         }
-        $stmt = $this->pearDB->prepare($queryHostGroup);
-        $stmt->bindParam(':hgName', $queryValues["hgName"], PDO::PARAM_STR);
+
+        $queryValues['hostGroupName'] = $query !== '' ? '%' . $query . '%' : '%%';
+
+        $range = '';
+        if (
+            $page !== null
+            && $limit !== null
+        ) {
+            $range = ' LIMIT :offset, :limit';
+            $queryValues['offset'] = (int) (($page - 1) * $limit);
+            $queryValues['limit'] = $limit;
+        }
+
+        $request = <<<SQL
+            SELECT SQL_CALC_FOUND_ROWS DISTINCT
+                hg.hg_name,
+                hg.hg_id,
+                hg.hg_activate
+            FROM hostgroup hg
+            WHERE hg.hg_name LIKE :hostGroupName $aclHostGroups
+            ORDER BY hg.hg_name
+            $range
+        SQL;
+
+        $statement = $this->pearDB->prepare($request);
+
+        $statement->bindValue(':hostGroupName', $queryValues['hostGroupName'], PDO::PARAM_STR);
+
         if (isset($queryValues['offset'])) {
-            $stmt->bindParam(':offset', $queryValues["offset"], PDO::PARAM_INT);
-            $stmt->bindParam(':limit', $queryValues["limit"], PDO::PARAM_INT);
-        }
-        $dbResult = $stmt->execute();
-        if (!$dbResult) {
-            throw new \Exception("An error occured");
+            $statement->bindValue(':offset', $queryValues['offset'], PDO::PARAM_INT);
+            $statement->bindValue(':limit', $queryValues['limit'], PDO::PARAM_INT);
         }
 
-        $hostGroupList = array();
-        while ($data = $stmt->fetch()) {
+        $statement->execute();
+
+        $hostGroupList = [];
+
+        while ($record = $statement->fetch()) {
             $hostGroupList[] = [
-                'id' => htmlentities($data['hg_id']),
-                'text' => $data['hg_name'],
-                'status' => (bool) $data['hg_activate'],
+                'id' => htmlentities($record['hg_id']),
+                'text' => $record['hg_name'],
+                'status' => (bool) $record['hg_activate'],
             ];
         }
 
-        return array(
+        return [
             'items' => $hostGroupList,
-            'total' => (int) $this->pearDB->numberRows()
-        );
+            'total' => (int) $this->pearDB->numberRows(),
+        ];
     }
 
     /**
-     * @return array
      * @throws RestBadRequestException
+     *
+     * @return array
      */
     public function getHostList()
     {
@@ -132,76 +156,99 @@ class CentreonConfigurationHostgroup extends CentreonConfigurationObjects
 
         $userId = $centreon->user->user_id;
         $isAdmin = $centreon->user->admin;
-        $aclHostGroups = '';
-        $aclHosts = '';
-        $queryValues = array();
-        $hgIdList = '';
+        $queryValues = [];
 
-        /* Get ACL if user is not admin */
-
-        if (!$isAdmin && $centreon->user->access->hasAccessToAllHostGroups === false) {
+        // Get ACL if user is not admin
+        if (
+            ! $isAdmin
+                && $centreon->user->access->hasAccessToAllHostGroups === false
+        ) {
             $acl = new CentreonACL($userId, $isAdmin);
-            $aclHostGroups .= ' AND hg.hg_id IN (' . $acl->getHostGroupsString('ID') . ') ';
-            $aclHosts .= ' AND h.host_id IN (' . $acl->getHostsString('ID', $this->pearDBMonitoring) . ') ';
+            $filters[] = ' hg.hg_id IN (' . $acl->getHostGroupsString() . ') ';
+            $filters[] = ' h.host_id IN (' . $acl->getHostsString($this->pearDBMonitoring) . ') ';
         }
 
-        // Check for select2 'q' argument
-        if (isset($this->arguments['hgid'])) {
-            $listId = explode(',', $this->arguments['hgid']);
-            foreach ($listId as $key => $idHg) {
-                if (!is_numeric($idHg)) {
-                    throw new \RestBadRequestException('Error, host group id must be numerical');
+        // Handle search by host group ids
+        $hostGroupIdsString = filter_var($this->arguments['hgid'] ?? '', FILTER_SANITIZE_FULL_SPECIAL_CHARS);
+
+        $whereCondition = '';
+        if ($hostGroupIdsString !== '') {
+            $hostGroupIds = array_values(explode(',', $hostGroupIdsString));
+
+            foreach ($hostGroupIds as $key => $hostGroupId) {
+                if (! is_numeric($hostGroupId)) {
+                    throw new RestBadRequestException('Error, host group id must be numerical');
                 }
-                $hgIdList .= ':hgid' . $idHg . ',';
-                $queryValues['hgid'][$idHg] = (int)$idHg;
+                $queryValues[':hostGroupId' . $key] = (int) $hostGroupId;
             }
-            $hgIdList = rtrim($hgIdList, ',');
-        } else {
-            $queryValues['hgid'][0] = '""';
-            $hgIdList .= ':hgid0';
+
+            $whereCondition .= ' WHERE hg.hg_id IN (' . implode(',', $queryValues) . ')';
         }
 
-        $queryHostGroup = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT h.host_name , h.host_id FROM hostgroup hg ' .
-            'INNER JOIN hostgroup_relation hgr ON hg.hg_id = hgr.hostgroup_hg_id ' .
-            'INNER JOIN host h ON  h.host_id = hgr.host_host_id ' .
-            'WHERE hg.hg_id IN (' . $hgIdList . ') ' .
-            $aclHostGroups .
-            $aclHosts;
+        // Handle pagination and limit
+        $limit = array_key_exists('page_limit', $this->arguments)
+            ? filter_var($this->arguments['page_limit'], FILTER_VALIDATE_INT)
+            : null;
 
-        if (isset($this->arguments['page_limit']) && isset($this->arguments['page'])) {
-            if (
-                !is_numeric($this->arguments['page'])
-                || !is_numeric($this->arguments['page_limit'])
-                || $this->arguments['page_limit'] < 1
-            ) {
-                throw new \RestBadRequestException('Error, limit must be an integer greater than zero');
-            }
-            $offset = ($this->arguments['page'] - 1) * $this->arguments['page_limit'];
-            $queryHostGroup .= 'LIMIT :offset, :limit';
-            $queryValues['offset'] = (int)$offset;
-            $queryValues['limit'] = (int)$this->arguments['page_limit'];
-        }
-        $stmt = $this->pearDB->prepare($queryHostGroup);
+        $page = array_key_exists('page', $this->arguments)
+            ? filter_var($this->arguments['page'], FILTER_VALIDATE_INT)
+            : null;
 
-        foreach ($queryValues["hgid"] as $k => $v) {
-            $stmt->bindValue(':hgid' . $k, $v, PDO::PARAM_INT);
-        }
-        if (isset($queryValues['offset'])) {
-            $stmt->bindParam(':offset', $queryValues["offset"], PDO::PARAM_INT);
-            $stmt->bindParam(':limit', $queryValues["limit"], PDO::PARAM_INT);
-        }
-        $stmt->execute();
-        $hostList = array();
-        while ($data = $stmt->fetch()) {
-            $hostList[] = array(
-                'id' => htmlentities($data['host_id']),
-                'text' => $data['host_name']
-            );
+        if ($limit === false) {
+            throw new RestBadRequestException('Error, limit must be an integer greater than zero');
         }
 
-        return array(
+        if ($page === false) {
+            throw new RestBadRequestException('Error, page must be an integer greater than zero');
+        }
+
+        $range = '';
+        if (
+            $page !== null
+            && $limit !== null
+        ) {
+            $range = ' LIMIT :offset, :limit';
+            $queryValues['offset'] = (int) (($page - 1) * $limit);
+            $queryValues['limit'] = $limit;
+        }
+
+        $request = <<<'SQL'
+            SELECT SQL_CALC_FOUND_ROWS DISTINCT
+                h.host_name,
+                h.host_id
+            FROM hostgroup hg
+            INNER JOIN hostgroup_relation hgr
+                ON hg.hg_id = hgr.hostgroup_hg_id
+            INNER JOIN host h
+                ON h.host_id = hgr.host_host_id
+        SQL;
+
+        if ($filters !== []) {
+            $whereCondition .= empty($whereCondition) ? ' WHERE ' : ' AND ';
+            $whereCondition .= implode(' AND ', $filters);
+        }
+
+        $request .= $whereCondition . $range;
+
+        $statement = $this->pearDB->prepare($request);
+
+        foreach ($queryValues as $key => $value) {
+            $statement->bindValue($key, $value, \PDO::PARAM_INT);
+        }
+
+        $statement->execute();
+
+        $hostList = [];
+        while ($record = $statement->fetch()) {
+            $hostList[] = [
+                'id' => htmlentities($record['host_id']),
+                'text' => $record['host_name'],
+            ];
+        }
+
+        return [
             'items' => $hostList,
-            'total' => (int) $this->pearDB->numberRows()
-        );
+            'total' => (int) $this->pearDB->numberRows(),
+        ];
     }
 }

--- a/centreon/www/api/class/centreon_configuration_hostgroup.class.php
+++ b/centreon/www/api/class/centreon_configuration_hostgroup.class.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005-2020 Centreon
+ * Copyright 2005-2024 Centreon
  * Centreon is developed by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -67,7 +67,7 @@ class CentreonConfigurationHostgroup extends CentreonConfigurationObjects
         $queryValues = array();
 
         /* Get ACL if user is not admin */
-        if (!$isAdmin) {
+        if (!$isAdmin && $centreon->user->access->hasAccessToAllHostGroups === false) {
             $acl = new CentreonACL($userId, $isAdmin);
             $aclHostGroups .= 'AND hg.hg_id IN (' . $acl->getHostGroupsString('ID') . ') ';
         }
@@ -139,7 +139,7 @@ class CentreonConfigurationHostgroup extends CentreonConfigurationObjects
 
         /* Get ACL if user is not admin */
 
-        if (!$isAdmin) {
+        if (!$isAdmin && $centreon->user->access->hasAccessToAllHostGroups === false) {
             $acl = new CentreonACL($userId, $isAdmin);
             $aclHostGroups .= ' AND hg.hg_id IN (' . $acl->getHostGroupsString('ID') . ') ';
             $aclHosts .= ' AND h.host_id IN (' . $acl->getHostsString('ID', $this->pearDBMonitoring) . ') ';

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -90,10 +90,10 @@ class CentreonACL
             $this->admin = $isAdmin;
         }
 
-        if (!$this->admin) {
+        if (! $this->admin) {
             $this->setAccessGroups();
             $this->setResourceGroups();
-            $this->checkAllhostGroupsAccess();
+            $this->hasAccessToAllHostGroups = $this->hasAccessToAllHostGroups();
             $this->setHostGroups();
             $this->setPollers();
             $this->setServiceGroups();
@@ -204,36 +204,57 @@ class CentreonACL
     }
 
     /**
-     * Check is all_hostgroups is activated at least of one ACL Group which this user is linked
+     * @param array<int|string, int|string> $list
+     * @param string $prefix
+     *
+     * @return array{0: array<string, mixed>, 1: string}
      */
-    private function checkAllhostGroupsAccess()
+    private function createMultipleBindQuery(array $list, string $prefix): array
     {
-        $aclGroups = $this->getAccessGroupsString();
-        $aclGroupsExploded = explode(',', $aclGroups);
-        $aclGroupsQueryBinds = [];
-        foreach ($aclGroupsExploded as $key => $value) {
-            $aclGroupsQueryBinds[':acl_group_' . $key] = str_replace("'","",$value);
+        $bindValues = [];
+        foreach ($list as $index => $id) {
+            $bindValues[$prefix . $index] = $id;
         }
-        $aclGroupBinds = implode(',', array_keys($aclGroupsQueryBinds));
 
-        $query = "SELECT COUNT(*) AS countAcl "
-            . "FROM acl_resources acl, acl_res_group_relations argr "
-            . "WHERE acl.acl_res_id = argr.acl_res_id "
-            . "AND acl.acl_res_activate = '1' "
-            . "AND acl.all_hostgroups = '1' "
-            . "AND argr.acl_group_id IN (" . $aclGroupBinds . ") ";
+        return [$bindValues, implode(', ', array_keys($bindValues))];
+    }
 
-        $statement = \CentreonDBInstance::getConfInstance()->prepare($query);
-        foreach ($aclGroupsQueryBinds as $key => $value) {
-            $statement->bindValue($key, (int) $value, \PDO::PARAM_INT);
+    /**
+     * Check is all_hostgroups is activated at least of one ACL Group which this user is linked
+     * @return bool
+     */
+    private function hasAccessToAllHostGroups(): bool
+    {
+        [$bindValues, $bindQuery] = $this->createMultipleBindQuery(
+            list: explode(',', $this->getAccessGroupsString()),
+            prefix: ':access_group_id_'
+        );
+
+        $request = <<<SQL
+            SELECT res.all_hostgroups
+            FROM acl_resources res
+            INNER JOIN acl_res_group_relations argr
+                ON argr.acl_res_id = res.acl_res_id
+            INNER JOIN acl_groups ag
+                ON ag.acl_group_id = argr.acl_group_id
+            WHERE res.acl_res_activate = '1' AND ag.acl_group_id IN ({$bindQuery})
+            SQL;
+
+        $statement = \CentreonDBInstance::getConfInstance()->prepare($request);
+
+        foreach ($bindValues as $key => $value) {
+            $statement->bindValue($key, $value, \PDO::PARAM_INT);
         }
+
         $statement->execute();
 
-        $row = $statement->fetchRow();
-        if ((int)$row['countAcl'] > 0) {
-            $this->hasAccessToAllHostGroups = true;
+        while (false !== ($hasAccessToAll = $statement->fetchColumn())) {
+            if (true === (bool) $hasAccessToAll) {
+                return true;
+            }
         }
-        $statement->closeCursor();
+
+        return false;
     }
 
     /**
@@ -259,39 +280,42 @@ class CentreonACL
      */
     private function setHostGroups()
     {
+        $aclSubRequest = '';
         if ($this->hasAccessToAllHostGroups === false) {
-            $aclGroups = $this->getAccessGroupsString();
-            $aclGroupsExploded = explode(',', $aclGroups);
-            $aclGroupsQueryBinds = [];
-            foreach ($aclGroupsExploded as $key => $value) {
-                $aclGroupsQueryBinds[':acl_group_' . $key] = str_replace("'", "", $value);
-            }
-            $aclGroupBinds = implode(',', array_keys($aclGroupsQueryBinds));
+            [$bindValues, $bindQuery] = $this->createMultipleBindQuery(
+                list: explode(',', $this->getAccessGroupsString()),
+                prefix: ':access_group_id_'
+            );
+
+            $aclSubRequest .= ' AND arhr.acl_res_id IN (' . $bindQuery . ')';
         }
 
-        $query = "SELECT hg.hg_id, hg.hg_name, hg.hg_alias, arhr.acl_res_id "
-            . "FROM hostgroup hg, acl_resources_hg_relations arhr "
-            . "WHERE hg.hg_id = arhr.hg_hg_id "
-            . "AND hg.hg_activate = '1' ";
-        if ($this->hasAccessToAllHostGroups === false) {
-            $query.= "AND arhr.acl_res_id IN (" . $aclGroupBinds . ") ";
-        }
-        $query.= "ORDER BY hg.hg_name ASC ";
+        $request = <<<SQL
+            SELECT
+                hg.hg_id,
+                hg.hg_name,
+                hg.hg_alias
+            FROM hostgroup hg
+            INNER JOIN acl_resources_hg_relations arhr
+                ON hg.hg_id = arhr.hg_hg_id
+            WHERE hg.hg_activate = '1'
+            $aclSubRequest
+            ORDER BY hg.hg_name ASC
+        SQL;
 
-        $statement = \CentreonDBInstance::getConfInstance()->prepare($query);
-        if ($this->hasAccessToAllHostGroups === false) {
-            foreach ($aclGroupsQueryBinds as $key => $value) {
-                $statement->bindValue($key, (int) $value, \PDO::PARAM_INT);
-            }
+        $statement = \CentreonDBInstance::getConfInstance()->prepare($request);
+
+        foreach ($bindValues as $key => $value) {
+            $statement->bindValue($key, $value, \PDO::PARAM_INT);
         }
+
         $statement->execute();
 
-        while ($row = $statement->fetchRow()) {
-            $this->hostGroups[$row['hg_id']] = $row['hg_name'];
-            $this->hostGroupsAlias[$row['hg_id']] = $row['hg_alias'];
-            $this->hostGroupsFilter[$row['acl_res_id']][$row['hg_id']] = $row['hg_id'];
+        while($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
+            $this->hostGroups[$record['hg_id']] = $record['hg_name'];
+            $this->hostGroupsAlias[$record['hg_id']] = $record['hg_alias'];
+            $this->hostGroupsFilter[$record['acl_res_id']][$record['hg_id']] = $record['hg_id'];
         }
-        $statement->closeCursor();
     }
 
     /**

--- a/centreon/www/class/centreonHostgroups.class.php
+++ b/centreon/www/class/centreonHostgroups.class.php
@@ -342,7 +342,9 @@ class CentreonHostgroups
         }
 
         // get list of authorized hostgroups
-        if (!$centreon->user->access->admin && $centreon->user->access->hasAccessToAllHostGroups === false) {
+        if (! $centreon->user->access->admin
+            && $centreon->user->access->hasAccessToAllHostGroups === false
+        ) {
             $hgAcl = $centreon->user->access->getHostGroupAclConf(
                 null,
                 'broker',
@@ -385,9 +387,9 @@ class CentreonHostgroups
             // hide unauthorized hostgroups
             $hide = false;
             if (
-                !$centreon->user->access->admin
+                ! $centreon->user->access->admin
                 && $centreon->user->access->hasAccessToAllHostGroups === false
-                && !in_array($row['hg_id'], $hgAcl)
+                && ! in_array($row['hg_id'], $hgAcl)
             ) {
                 $hide = true;
             }

--- a/centreon/www/class/centreonHostgroups.class.php
+++ b/centreon/www/class/centreonHostgroups.class.php
@@ -1,6 +1,6 @@
 <?php
 /*
- * Copyright 2005-2015 Centreon
+ * Copyright 2005-2024 Centreon
  * Centreon is developped by : Julien Mathis and Romain Le Merlus under
  * GPL Licence 2.0.
  *
@@ -342,7 +342,7 @@ class CentreonHostgroups
         }
 
         // get list of authorized hostgroups
-        if (!$centreon->user->access->admin) {
+        if (!$centreon->user->access->admin && $centreon->user->access->hasAccessToAllHostGroups === false) {
             $hgAcl = $centreon->user->access->getHostGroupAclConf(
                 null,
                 'broker',
@@ -384,7 +384,11 @@ class CentreonHostgroups
         while ($row = $stmt->fetch()) {
             // hide unauthorized hostgroups
             $hide = false;
-            if (!$centreon->user->access->admin && !in_array($row['hg_id'], $hgAcl)) {
+            if (
+                !$centreon->user->access->admin
+                && $centreon->user->access->hasAccessToAllHostGroups === false
+                && !in_array($row['hg_id'], $hgAcl)
+            ) {
                 $hide = true;
             }
 


### PR DESCRIPTION
## Description

Allow to list all hostgroups in "Configuration > Hosts > Hostgroups" menu and when user try to link a host (create.edit form) when he is linked to an ACL Resources where all hostgroups is checked

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced access control for host groups in the application, ensuring users only see host groups they are authorized to access.

- **Documentation**
	- Updated copyright year to 2024 in relevant files.

- **Refactor**
	- Improved logic for checking user access to all host groups across various functionalities, streamlining user experience and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->