### PR TITLE
fix(ci): filter out existing tags to only use new release tags

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -81,7 +81,7 @@ runs:
           fi
         done
 
-        echo "Tags present in previous releases but not in new releases:"
+        echo "New tags to be published from new release that were not in previous releases:"
         printf '%s\n' "${NEW_STABLE_TAGS[@]}"
 
         # Make NEW_STABLE_TAGS available for other steps

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -70,7 +70,7 @@ runs:
           # Iterate over elements of PREVIOUS_STABLE_TAGS
           for old_tag in "${PREVIOUS_STABLE_TAGS[@]}"; do
             # Compare elements
-            if [ "$new_tag" == "old_tag" ]; then
+            if [ "$new_tag" == "$old_tag" ]; then
               found=true
               break
             fi

--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -30,13 +30,20 @@ runs:
         # Variables
         COMPONENTS_OSS=("centreon-awie" "centreon-dsm" "centreon-gorgone" "centreon-ha" "centreon-open-tickets" "centreon-web")
         CURRENT_STABLE_BRANCH_MAJOR_VERSION=""
+        declare -a TMP_STABLE_TAGS=()
         declare -a NEW_STABLE_TAGS=()
         declare -a PREVIOUS_STABLE_TAGS=()
         SCOPE_VERSION="OSS"
         MINOR_VERSION_FILE_PATH=".version"
 
         # Get current stable branch name
-        CURRENT_STABLE_BRANCH_MAJOR_VERSION=$(echo ${{ inputs.github_ref_name }} | cut -d '.' -f1,2)
+        # If MASTER, use root .version
+        # Else use branch name
+        if [[ "${{ inputs.github_ref_name }}" == "master" ]]; then
+          CURRENT_STABLE_BRANCH_MAJOR_VERSION=$(grep -E "MAJOR" .version | cut -d '=' -f2)
+        else
+          CURRENT_STABLE_BRANCH_MAJOR_VERSION=$(echo ${{ inputs.github_ref_name }} | cut -d '.' -f1,2)
+        fi
         echo "Current stable branch major version: $CURRENT_STABLE_BRANCH_MAJOR_VERSION"
 
         # Get previous and new version tags for components
@@ -51,14 +58,31 @@ runs:
           # Previous stable tags array
           PREVIOUS_STABLE_TAGS+=($(git tag -l --sort=-version:refname "$component-$CURRENT_STABLE_BRANCH_MAJOR_VERSION*" | head -n 1))
           # New stable tags array
-          NEW_STABLE_TAGS+=("$component-$MAJOR_VERSION.$MINOR_VERSION")
+          TMP_STABLE_TAGS+=("$component-$MAJOR_VERSION.$MINOR_VERSION")
         done
         echo "Previous releases were: ${PREVIOUS_STABLE_TAGS[*]}"
-        echo "New releases are: ${NEW_STABLE_TAGS[*]}"
+        echo "Temporary new releases are: ${TMP_STABLE_TAGS[*]}"
 
-        # TODO: Check that NEW_STABLE_TAGS are fully different from PREVIOUS_STABLE_TAGS
-        # re use the part from check version ??
-        # or use the check-version action after turning this release action into a real workflow ?
+        # Building final NEW_STABLE_TAGS with the new version tags only
+        # Iterate over elements of TMP_STABLE_TAGS
+        for new_tag in "${TMP_STABLE_TAGS[@]}"; do
+          found=false
+          # Iterate over elements of PREVIOUS_STABLE_TAGS
+          for old_tag in "${PREVIOUS_STABLE_TAGS[@]}"; do
+            # Compare elements
+            if [ "$new_tag" == "old_tag" ]; then
+              found=true
+              break
+            fi
+          done
+          # If element not found in PREVIOUS_STABLE_TAGS, add it to NEW_STABLE_TAGS
+          if ! $found; then
+            NEW_STABLE_TAGS+=("$new_tag")
+          fi
+        done
+
+        echo "Tags present in previous releases but not in new releases:"
+        printf '%s\n' "${NEW_STABLE_TAGS[@]}"
 
         # Make NEW_STABLE_TAGS available for other steps
         echo "NEW_STABLE_TAGS=${NEW_STABLE_TAGS[*]}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Description

Release action changes
* handle master branch or maintenance branch
* only attempt to publish new tags

**Fixes** #MON-34069

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
