### PR TITLE
fix(gorgone): systemctl path in whitelist - backport 23.10

### DIFF
--- a/centreon-gorgone/packaging/whitelist.conf.d/centreon.yaml
+++ b/centreon-gorgone/packaging/whitelist.conf.d/centreon.yaml
@@ -1,6 +1,6 @@
 # Configuration brought by Centreon Gorgone package.
 # SHOULD NOT BE EDITED! CREATE YOUR OWN FILE IN WHITELIST.CONF.D DIRECTORY!
-- ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
+- ^sudo\s+(/bin/|/usr/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
 - ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
 - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/+centengine\.cfg\s*$
 - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats\.json\s*$


### PR DESCRIPTION
## Description

Backport of #3780 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)
