### PR TITLE
fix (symfony): disabled the log for deprecated warning messages in the prod environment

### DIFF
--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -11,7 +11,7 @@ jms_serializer:
                 namespace_prefix: "Core\\"
                 path: '%kernel.project_dir%/config/packages/serializer/Core'
 parameters:
-    debug_log_file: '%log_path%/centreon-web.log'
+    log_file: '%log_path%/centreon-web.log'
     env(DEBUG_LEVEL): !php/const Monolog\Logger::WARNING
     curl.timeout: 60
     debug_level: "%env(int:DEBUG_LEVEL)%"
@@ -441,17 +441,13 @@ services:
         public: true
 
     # Log configuration
-    monolog.error.formater:
-        class: Monolog\Formatter\LineFormatter
-        arguments: [ "%%level_name%%: %%message%% %%context%%\n" ]
-
-    monolog.debug.formater:
+    monolog.formater:
         class: Monolog\Formatter\LineFormatter
         arguments: [ "[%%datetime%%] [%%level_name%%] %%message%% %%context%%\n", !php/const DateTimeInterface::ISO8601, false, true ]
 
-    monolog.debug.handler:
-        class: Centreon\Domain\Log\DebugFileHandler
-        arguments: [ '@monolog.debug.formater', '%debug_log_file%', 664, '%debug_level%' ]
+    monolog.handler:
+        class: Centreon\Domain\Log\ErrorFileHandler
+        arguments: [ '@monolog.formater', '%log_file%', 432, '%debug_level%' ]
 
     Centreon\Domain\Log\ContactForDebug:
         class: Centreon\Domain\Log\ContactForDebug

--- a/centreon/config/packages/monolog.yaml
+++ b/centreon/config/packages/monolog.yaml
@@ -1,19 +1,34 @@
 # Monolog Bundle configuration
 # https://github.com/symfony/monolog-bundle/blob/master/DependencyInjection/Configuration.php#L25
-monolog:
-    channels: ['centreon', 'deprecation']
+when@prod:
+  monolog:
+    channels: [ 'centreon']
     handlers:
-        system:
-            type: error_log
-            level: warning
-            formatter: monolog.error.formater
-            channels: ['!centreon']
-        centreon:
-            type: service
-            id: monolog.debug.handler
-            channels: ['centreon']
-        deprecation:
-            type: rotating_file
-            path: "%log_path%/%kernel.environment%.deprecations.log"
-            max_files: 2
-            channels: [ deprecation ]
+      system:
+        type: error_log
+        level: warning
+        formatter: monolog.error.formater
+        channels: [ '!centreon' ]
+      centreon:
+        type: service
+        id: monolog.debug.handler
+        channels: [ 'centreon' ]
+when@dev:
+  monolog:
+    channels: [ 'centreon', 'deprecation' ]
+    handlers:
+      system:
+        type: error_log
+        level: warning
+        formatter: monolog.error.formater
+        channels: [ '!centreon' ]
+      centreon:
+        type: service
+        id: monolog.debug.handler
+        channels: [ 'centreon' ]
+      deprecation:
+        type: rotating_file
+        path: "%log_path%/%kernel.environment%.deprecations.log"
+        max_files: 2
+        channels: [ deprecation ]
+        file_permission: 662

--- a/centreon/config/packages/monolog.yaml
+++ b/centreon/config/packages/monolog.yaml
@@ -7,11 +7,11 @@ when@prod:
       system:
         type: error_log
         level: warning
-        formatter: monolog.error.formater
+        formatter: monolog.formater
         channels: [ '!centreon' ]
       centreon:
         type: service
-        id: monolog.debug.handler
+        id: monolog.handler
         channels: [ 'centreon' ]
 when@dev:
   monolog:
@@ -20,15 +20,15 @@ when@dev:
       system:
         type: error_log
         level: warning
-        formatter: monolog.error.formater
+        formatter: monolog.formater
         channels: [ '!centreon' ]
       centreon:
         type: service
-        id: monolog.debug.handler
+        id: monolog.handler
         channels: [ 'centreon' ]
       deprecation:
         type: rotating_file
         path: "%log_path%/%kernel.environment%.deprecations.log"
         max_files: 2
-        channels: [ deprecation ]
-        file_permission: 662
+        channels: [ 'deprecation' ]
+        file_permission: 0660

--- a/centreon/src/Centreon/Domain/Log/ErrorFileHandler.php
+++ b/centreon/src/Centreon/Domain/Log/ErrorFileHandler.php
@@ -31,7 +31,7 @@ use Monolog\Logger;
  *
  * @package Centreon\Domain\Log
  */
-class DebugFileHandler extends StreamHandler
+class ErrorFileHandler extends StreamHandler
 {
     /**
      * @param FormatterInterface $formatter Monolog formatter


### PR DESCRIPTION
## Description

Fixed bad configuration concerning the centreon log file permission.

1. Rename Symfony services for log handlers and formatters.
2. Centreon log file (centreon-web.log) has new file permission (660 instead of 230, which was the octal representation of 660 as an integer)
3. Separate dev/prod configurations for log handlers.
4. Moved the deprecation log handlers to the development environment to avoid generating deprecation log messages in the production environment.
5. Depreciation log file has new file permissions (660)
6. Renamed DebugFileHandler to ErrorFileHandler.

Fixe: MON-46496

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
