### PR TITLE
fix (resource status): Fixed warning message concerning metric parameter in resource status

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/API/FindResources/FindResourcesPresenter.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindResources/FindResourcesPresenter.php
@@ -127,7 +127,7 @@ class FindResourcesPresenter extends AbstractPresenter implements FindResourcesP
                         'downtime' => $endpoints['downtime'],
                         'check' => $endpoints['check'],
                         'forced_check' => $endpoints['forced_check'],
-                        'metrics' => $endpoints['metrics'],
+                        'metrics' => $endpoints['metrics'] ?? null,
                     ],
                     'uris' => $this->hypermediaCreator->createInternalUris($parameters),
                     'externals' => [


### PR DESCRIPTION
## Description

Fixed warning message concerning metric parameter in resource status.
`Warning: Undefined array key "metrics"`

**Fixes** # MON-48484

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)


## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
