### PR TITLE
fix(hostgroup): update host group form Alias

### DIFF
--- a/centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
@@ -185,7 +185,7 @@ for ($i = 0; $hg = $dbResult->fetch(); $i++) {
         "RowMenu_link" => "main.php?p=" . $p . "&o=c&hg_id=" . $hg['hg_id'],
         "RowMenu_desc" => ($hg["hg_alias"] == ''
             ? '-'
-            : CentreonUtils::escapeSecure(html_entity_decode($hg["hg_alias"]))),
+            : CentreonUtils::escapeSecure(html_entity_decode($hg["hg_alias"]), CentreonUtils::ESCAPE_ALL)),
         "RowMenu_status" => $hg["hg_activate"] ? _("Enabled") : _("Disabled"),
         "RowMenu_badge" => $hg["hg_activate"] ? "service_ok" : "service_critical",
         "RowMenu_hostAct" => $nbrhostAct,


### PR DESCRIPTION
## Description

update affichage d'alias au niveau de hostgroup

**Fixes** # (MON-49519)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Create or edit a hostgroup and set `<a href=”foo”>foo</a>` for alias and save

You should see

`<a href=”foo”>foo</a>`

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
