### PR TITLE
fix(conf) fix service category listing query with non admin user and no search parameters

### DIFF
--- a/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+++ b/centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
@@ -56,7 +56,7 @@ if (isset($_POST['searchSC']) || isset($_GET['searchSC'])) {
     $search = $centreon->historySearch[$url]["search"] ?? null;
 }
 
-$searchTool = '';
+$searchTool = null;
 if ($search) {
     $searchTool .= "WHERE (sc_name LIKE '%" . $search . "%' " .
     "OR sc_description LIKE '%" . $search . "%') ";


### PR DESCRIPTION
## Description

Having a non admin user with filtered access to service categories, when trying to list the sSC, a blanck page whas displayed due to an SQL error

```
2024-04-09 11:04|0|0|SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'AND  sc_id IN (1) ORDER BY sc_name LIMIT 0, 30' at line 1 QUERY : SELECT SQL_CALC_FOUND_ROWS \\* FROM service_categories   AND  sc_id IN (1) ORDER BY sc_name LIMIT 0, 30
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x (master)

