### PR TITLE
Some clapi/REST v1 output fixes (MON-53495)

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonCommand.class.php
+++ b/centreon/www/class/centreon-clapi/centreonCommand.class.php
@@ -251,7 +251,7 @@ class CentreonCommand extends CentreonObject
                     }
 
                     if (!isset($exportedFields[$paramSearch])) {
-                        $resultString .= $ret . $this->delim;
+                        $resultString .= $this->csv_escape($ret) . $this->delim;
                         $exportedFields[$paramSearch] = 1;
                     }
                 }

--- a/centreon/www/class/centreon-clapi/centreonHost.class.php
+++ b/centreon/www/class/centreon-clapi/centreonHost.class.php
@@ -667,7 +667,7 @@ class CentreonHost extends CentreonObject
                             break;
                     }
                     if (!isset($exportedFields[$paramSearch])) {
-                        $resultString .= $ret . $this->delim;
+                        $resultString .= $this->csv_escape($ret) . $this->delim;
                         $exportedFields[$paramSearch] = 1;
                     }
                 }
@@ -914,10 +914,10 @@ class CentreonHost extends CentreonObject
             if ($macro["source"] == "fromTpl") {
                 $source = $macro["macroTpl"];
             }
-            echo $macro['host_macro_name'] . $this->delim
-                . $macro['host_macro_value'] . $this->delim
+            echo $this->csv_escape($macro['host_macro_name']) . $this->delim
+                . $this->csv_escape($macro['host_macro_value']) . $this->delim
                 . $macro['is_password'] . $this->delim
-                . $macro['description'] . $this->delim
+                . $this->csv_escape($macro['description']) . $this->delim
                 . $source . "\n";
         }
     }

--- a/centreon/www/class/centreon-clapi/centreonHostGroup.class.php
+++ b/centreon/www/class/centreon-clapi/centreonHostGroup.class.php
@@ -289,7 +289,7 @@ class CentreonHostGroup extends CentreonObject
                     $ret = $ret[$field];
 
                     if (!isset($exportedFields[$paramSearch])) {
-                        $resultString .= $ret . $this->delim;
+                        $resultString .= $this->csv_escape($ret) . $this->delim;
                         $exportedFields[$paramSearch] = 1;
                     }
                 }

--- a/centreon/www/class/centreon-clapi/centreonHostGroupService.class.php
+++ b/centreon/www/class/centreon-clapi/centreonHostGroupService.class.php
@@ -531,7 +531,8 @@ class CentreonHostGroupService extends CentreonObject
         );
         echo "macro name;macro value\n";
         foreach ($macroList as $macro) {
-            echo $macro['svc_macro_name'] . $this->delim . $macro['svc_macro_value'] . "\n";
+            echo $this->csv_escape($macro['svc_macro_name']) . $this->delim
+                . $this->csv_escape($macro['svc_macro_value']) . "\n";
         }
     }
 

--- a/centreon/www/class/centreon-clapi/centreonObject.class.php
+++ b/centreon/www/class/centreon-clapi/centreonObject.class.php
@@ -663,4 +663,20 @@ abstract class CentreonObject
 
         return self::$instances[$class];
     }
+
+    /**
+     * Escape a value for CSV output
+     *
+     * @param string $text The string to escape
+     * @return string The string sanitized
+     */
+    protected function csv_escape($text)
+    {
+        $escape_required = $text[0] == '"' || strpos($text, $this->delim) !== false || strpos($text, "\n") !== false;
+        if ($escape_required) {
+            $text = '"' . str_replace('"', '""', $text) . '"';
+        }
+        return $text;
+    }
+
 }

--- a/centreon/www/class/centreon-clapi/centreonObject.class.php
+++ b/centreon/www/class/centreon-clapi/centreonObject.class.php
@@ -349,7 +349,7 @@ abstract class CentreonObject
             throw new CentreonClapiException(self::MISSINGPARAMETER);
         }
         $p = $this->object->getParameters($params[0], $params[1]);
-        print $p[$params[1]] . "\n";
+        print $this->csv_escape($p[$params[1]]) . "\n";
     }
 
     /**

--- a/centreon/www/class/centreon-clapi/centreonService.class.php
+++ b/centreon/www/class/centreon-clapi/centreonService.class.php
@@ -669,7 +669,7 @@ class CentreonService extends CentreonObject
                     }
                 }
                 if (!isset($exportedFields[$paramSearch])) {
-                    $resultString .= $ret . $this->delim;
+                    $resultString .= $this->csv_escape($ret) . $this->delim;
                     $exportedFields[$paramSearch] = 1;
                 }
             }
@@ -903,10 +903,10 @@ class CentreonService extends CentreonObject
             if ($macro["source"] == "fromTpl") {
                 $source = $macro["macroTpl"];
             }
-            echo $macro['svc_macro_name'] . $this->delim
-                . $macro['svc_macro_value'] . $this->delim
+            echo $this->csv_escape($macro['svc_macro_name']) . $this->delim
+                . $this->csv_escape($macro['svc_macro_value']) . $this->delim
                 . $macro['is_password'] . $this->delim
-                . $macro['description'] . $this->delim
+                . $this->csv_escape($macro['description']) . $this->delim
                 . $source . "\n";
         }
     }

--- a/centreon/www/class/centreon-clapi/centreonServiceGroup.class.php
+++ b/centreon/www/class/centreon-clapi/centreonServiceGroup.class.php
@@ -174,7 +174,7 @@ class CentreonServiceGroup extends CentreonObject
                     $ret = $ret[$field];
 
                     if (!isset($exportedFields[$paramSearch])) {
-                        $resultString .= $ret . $this->delim;
+                        $resultString .= $this->csv_escape($ret) . $this->delim;
                         $exportedFields[$paramSearch] = 1;
                     }
                 }

--- a/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php
+++ b/centreon/www/class/centreon-clapi/centreonServiceTemplate.class.php
@@ -338,7 +338,7 @@ class CentreonServiceTemplate extends CentreonObject
                             break;
                     }
                     if (!isset($exportedFields[$paramSearch])) {
-                        $resultString .= $ret . $this->delim;
+                        $resultString .= $this->csv_escape($ret) . $this->delim;
                         $exportedFields[$paramSearch] = 1;
                     }
                 }
@@ -665,9 +665,9 @@ class CentreonServiceTemplate extends CentreonObject
         echo "macro name;macro value;description;is_password\n";
         foreach ($macroList as $macro) {
             $password = !empty($macro['is_password']) ? (int)$macro['is_password'] : 0;
-            echo $this->extractMacroName($macro['svc_macro_name']) . $this->delim
-            . $macro['svc_macro_value'] . $this->delim
-            . $macro['description'] . $this->delim
+            echo $this->csv_escape($this->extractMacroName($macro['svc_macro_name'])) . $this->delim
+            . $this->csv_escape($macro['svc_macro_value']) . $this->delim
+            . $this->csv_escape($macro['description']) . $this->delim
             . $password . "\n";
         }
     }

--- a/centreon/www/include/common/common-Func.php
+++ b/centreon/www/include/common/common-Func.php
@@ -2092,3 +2092,114 @@ function signalConfigurationChange(
 
     definePollersToUpdated(array_merge($pollerIds, $previousPollers));
 }
+
+
+/**
+ * Transform plain CSV data in an associative array (first line acts as headers)
+ *
+ * @param array $records
+ */
+function csv_to_associative_array(&$records)
+{
+    $headers = array_shift($records);
+    foreach ($records as &$record) {
+        $record = array_combine($headers, $record);
+    }
+}
+
+/**
+ * Return array of parsed CSV
+ *
+ * @param string $text
+ * @param string $delim (default ';')
+ * @param bool $ignore_empty_lines (default true)
+ * @return bool|array False if there was a problem, otherwise the records
+ */
+function parse_csv(&$text, $delim=';', $ignore_empty_lines=true)
+{
+    $records = array();
+    $record = array();
+
+    $pos_field_start = 0;
+    $pos_cur = 0;
+    $rec_nr = 0;
+    $prev_char_is_dq = false;
+    $inside_dq = 0; // 0: to determine, 1: no, 2: yes
+
+    $enders_field = array(
+        $delim => $delim,
+        "\n" => "\n",
+        '' => '',
+    );
+    $enders_record = array(
+        "\n" => "\n",
+        '' => '',
+    );
+
+    $text_len = strlen($text) + ($text[-1] == "\n" ? 0 : 1);
+    while ($pos_cur < $text_len) {
+        $c = $text[$pos_cur] ?? '';
+
+        switch ($inside_dq) {
+            case 0:
+                if ($c == '"') {
+                    $inside_dq = 2;
+                    $pos_field_start = $pos_cur + 1;
+                    break;
+                } else
+                     $inside_dq = 1;
+                // fall through
+
+            case 1:
+                if (array_key_exists($c, $enders_field)) {
+                    $inside_dq = 0;
+                    $is_end_rec = array_key_exists($c, $enders_record);
+                    if ($is_end_rec && $pos_field_start == $pos_cur && $ignore_empty_lines && !$record) {
+                    } else
+                        $record[] = substr($text, $pos_field_start, $pos_cur - $pos_field_start);
+                    $pos_field_start = $pos_cur + 1;
+
+                    if ($is_end_rec && $record) {
+                        $records[$rec_nr] = $record;
+                        $record = array();
+                        $rec_nr++;
+                    }
+                }
+                break;
+
+            case 2:
+                if ($prev_char_is_dq) {
+                    if ($c == '"') {
+                        $prev_char_is_dq = false;
+                    } elseif (array_key_exists($c, $enders_field)) {
+                        $prev_char_is_dq = false;
+                        $is_end_rec = array_key_exists($c, $enders_record);
+                        if ($is_end_rec && $pos_field_start == $pos_cur && $ignore_empty_lines && !$record) {
+                        } else
+                            $record[] = str_replace('""', '"', substr($text, $pos_field_start, $pos_cur - $pos_field_start - 1));
+                        $pos_field_start = $pos_cur + 1;
+
+                        if ($is_end_rec && $record) {
+                            $records[$rec_nr] = $record;
+                            $record = array();
+                            $rec_nr++;
+                        }
+                        $inside_dq = 0;
+                    } else {
+                        return false; // malformed csv
+                    }
+                    break;
+                }
+                if ($c == '"') {
+                    $prev_char_is_dq = true;
+                } elseif ($c == '') {
+                    return false; // malformed csv
+                }
+                break;
+        }
+
+        $pos_cur++;
+    }
+
+    return $records;
+}


### PR DESCRIPTION
## Description

These patches affect clapi and REST v1. They fix issues regarding 1/ delimiters not escaped and 2/ multiline values.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

The cases below show REST v1 output for commands equivalent to short clapi params in first row of tables. The output with patches is the correct result.

**Semi colon case**
<table>
<tr><td colspan="2">-o HTPL -a GETPARAM -v "htp-test;alias|notes|check_period|active_checks_enabled"</td></tr>
<tr><td>original output</td><td>output with patches</td></tr>
<tr>
<td><pre>{
    "result": [
        {
            "alias": "htp-test",
            "notes": "note 1",
            "check_period": " note 2",
            "active_checks_enabled": "24x7;2"
        }
    ]
}</pre></td>
<td><pre>{
    "result": [
        {
            "alias": "htp-test",
            "notes": "note 1; note 2",
            "check_period": "24x7",
            "active_checks_enabled": "2"
        }
    ]
}</pre></td>
</tr>
</table>

**Multiline case**
<table>
<tr><td colspan="2">-o HTPL -a GETPARAM -v "htp-test;alias|comment|check_period"</td></tr>
<tr><td>original output</td><td>output with patches</td></tr>
<tr>
<td><pre>Error HTTP 500</pre></td>
<td><pre>{
    "result": [
        {
            "alias": "htp-test",
            "comment": "line 1\r\nline 2|\r\nline 3",
            "check_period": "24x7"
        }
    ]
}</pre></td>
</tr>
</table>

If we change the parameters order, it's broken in a different way.
<table>
<tr><td colspan="2">-o HTPL -a GETPARAM -v "htp-test;comment|alias|check_period"</td></tr>
<tr><td>original output</td><td>output with patches</td></tr>
<tr>
<td><pre>{
    "result": [
        "line 1",
        "line 2|",
        {
            "comment": "line 3",
            "alias": "htp-test",
            "check_period": "24x7"
        }
    ]
}</pre></td>
<td><pre>{
    "result": [
        {
            "comment": "line 1\r\nline 2|\r\nline 3",
            "alias": "htp-test",
            "check_period": "24x7"
        }
   ]
}</pre></td>
</tr>
</table>

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced CSV data parsing and handling across multiple PHP class files for improved reliability and output consistency.
- **New Features**
	- Introduced new functions for transforming and parsing CSV data, ensuring more robust data management.
- **Bug Fixes**
	- Implemented CSV escape methods in various functions to correct CSV formatting issues, enhancing the accuracy of data outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->