### PR TITLE
fix(docker): update debian dockerfiles with new apt gpg key url

### DIFF
--- a/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
@@ -40,7 +40,7 @@ echo "deb https://packages.centreon.com/apt-standard-${VERSION}-unstable/ $VERSI
 echo "deb https://packages.centreon.com/apt-plugins-stable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-stable.list
 echo "deb https://packages.centreon.com/apt-plugins-testing/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-testing.list
 echo "deb https://packages.centreon.com/apt-plugins-unstable/ $VERSION_CODENAME main" | tee -a /etc/apt/sources.list.d/centreon-plugins-unstable.list
-wget -O- https://packages.centreon.com/api/security/keypair/Debian/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
+wget -O- https://packages.centreon.com/api/security/keypair/APT-GPG-KEY/public | gpg --dearmor | tee /etc/apt/trusted.gpg.d/centreon.gpg > /dev/null 2>&1
 
 apt-get update
 


### PR DESCRIPTION
## Description

update docker files for debian with new gpg key

Fixes #MON-22355

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x (master)
