### PR TITLE
fix(contactGroups): correctly check users rights for cloud

### DIFF
--- a/centreon/tests/php/Core/Contact/Application/UseCase/FindContactGroups/FindContactGroupsTest.php
+++ b/centreon/tests/php/Core/Contact/Application/UseCase/FindContactGroups/FindContactGroupsTest.php
@@ -1,13 +1,13 @@
 <?php
 
 /*
- * Copyright 2005 - 2022 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -24,23 +24,25 @@ declare(strict_types=1);
 namespace Tests\Core\Contact\Application\UseCase\FindContactGroups;
 
 use Centreon\Domain\Contact\Contact;
-use Core\Application\Common\UseCase\ErrorResponse;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
-use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
-use Core\Contact\Application\UseCase\FindContactGroups\FindContactGroups;
 use Core\Contact\Application\Repository\ReadContactGroupRepositoryInterface;
+use Core\Contact\Application\UseCase\FindContactGroups\FindContactGroups;
 use Core\Contact\Application\UseCase\FindContactGroups\FindContactGroupsResponse;
 use Core\Contact\Domain\Model\ContactGroup;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
 
-beforeEach(function () {
+beforeEach(function (): void {
     $this->repository = $this->createMock(ReadContactGroupRepositoryInterface::class);
     $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
     $this->user = $this->createMock(ContactInterface::class);
+    $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
 });
 
-it('should present an ErrorResponse while an exception occured', function () {
-    $useCase = new FindContactGroups($this->repository, $this->user);
+it('should present an ErrorResponse while an exception occured', function (): void {
+    $useCase = new FindContactGroups($this->accessGroupRepository, $this->repository, $this->user, false);
     $this->user
         ->expects($this->once())
         ->method('isAdmin')
@@ -60,8 +62,8 @@ it('should present an ErrorResponse while an exception occured', function () {
     );
 });
 
-it('should present an ForbiddenResponse if the user doesnt have the read menu access to contact group', function () {
-    $useCase = new FindContactGroups($this->repository, $this->user);
+it('should present an ForbiddenResponse if the user doesnt have the read menu access to contact group', function (): void {
+    $useCase = new FindContactGroups($this->accessGroupRepository, $this->repository, $this->user, false);
     $this->user
         ->expects($this->once())
         ->method('isAdmin')
@@ -85,9 +87,8 @@ it('should present an ForbiddenResponse if the user doesnt have the read menu ac
     );
 });
 
-
-it('should call the method findAll if the user is admin', function () {
-    $useCase = new FindContactGroups($this->repository, $this->user);
+it('should call the method findAll if the user is admin', function (): void {
+    $useCase = new FindContactGroups($this->accessGroupRepository, $this->repository, $this->user, false);
     $this->user
         ->expects($this->once())
         ->method('isAdmin')
@@ -101,10 +102,10 @@ it('should call the method findAll if the user is admin', function () {
     $useCase($presenter);
 });
 
-it('should call the method FindAllByUserId if the user is not admin', function () {
-    $useCase = new FindContactGroups($this->repository, $this->user);
+it('should call the method FindAllByUserId if the user is not admin', function (): void {
+    $useCase = new FindContactGroups($this->accessGroupRepository, $this->repository, $this->user, false);
     $this->user
-        ->expects($this->once())
+        ->expects($this->any())
         ->method('getId')
         ->willReturn(1);
 
@@ -128,8 +129,8 @@ it('should call the method FindAllByUserId if the user is not admin', function (
     $useCase($presenter);
 });
 
-it('should present a FindContactGroupsResponse when no error occured', function () {
-    $useCase = new FindContactGroups($this->repository, $this->user);
+it('should present a FindContactGroupsResponse when no error occured', function (): void {
+    $useCase = new FindContactGroups($this->accessGroupRepository, $this->repository, $this->user, false);
 
     $contactGroup = new ContactGroup(1, 'contact_group');
     $this->repository
@@ -148,7 +149,7 @@ it('should present a FindContactGroupsResponse when no error occured', function 
     expect($presenter->response->contactGroups[0])->toBe(
         [
             'id' => 1,
-            'name' => 'contact_group'
+            'name' => 'contact_group',
         ]
     );
 });


### PR DESCRIPTION
🏷️ MON-52742

This PR intends to fix an issue in Cloud Context.
A user, is considered as admin in cloud context when he belongs to the `customer_admin_acl`
Therefore in this condition he should be able to see all contacts and all contact groups (like onPrem admin user)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the contact group search functionality to better respect user roles and access permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->