### PR TITLE
enh(gorgone/servicediscovery): use rest api instead of clapi and map options

### DIFF
--- a/centreon-gorgone/docs/modules/centreon/autodiscovery.md
+++ b/centreon-gorgone/docs/modules/centreon/autodiscovery.md
@@ -6,10 +6,13 @@ This module aims to extend Centreon Autodiscovery server functionalities.
 
 ## Configuration
 
-| Directive       | Description                                                            | Default value |
-| :-------------- | :--------------------------------------------------------------------- | :------------ |
-| global\_timeout | Time in seconds before a discovery command is considered timed out     | `300`         |
-| check\_interval | Time in seconds defining frequency at which results will be search for | `15`          |
+| Directive                            | Description                                                                                       | Default value |
+| :----------------------------------- | :------------------------------------------------------------------------------------------------ | :------------ |
+| global\_timeout                      | Time in seconds before a discovery command is considered timed out                                | `300`         |
+| check\_interval                      | Time in seconds defining frequency at which results will be search for                            | `15`          |
+| service\_parrallel\_commands\_poller | Number of commands run simultaneously on each Poller                                              | `8`           |
+| service\_check\_interval             | Time in seconds defining frequency at which results will be search for (for services discoveries) | `15`          |
+| service\_timeout                     | Time in seconds before a service discovery command is considered timed out                        | `90`          |
 
 #### Example
 
@@ -19,6 +22,9 @@ package: "gorgone::modules::centreon::autodiscovery::hooks"
 enable: true
 global_timeout: 60
 check_interval: 10
+service_parrallel_commands_poller: 15
+service_check_interval: 5
+service_timeout: 60
 ```
 
 ## Events

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/class.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/class.pm
@@ -27,7 +27,6 @@ use warnings;
 use gorgone::standard::library;
 use gorgone::standard::constants qw(:all);
 use gorgone::modules::centreon::autodiscovery::services::discovery;
-use gorgone::class::tpapi::clapi;
 use gorgone::class::tpapi::centreonv2;
 use gorgone::class::sqlquery;
 use gorgone::class::frame;
@@ -69,7 +68,6 @@ sub new {
         $options{config}->{global_timeout} =~ /(\d+)/) ? $1 : 300;
     $connector->{check_interval} = (defined($options{config}->{check_interval}) &&
         $options{config}->{check_interval} =~ /(\d+)/) ? $1 : 15;
-    $connector->{tpapi_clapi_name} = defined($options{config}->{tpapi_clapi}) && $options{config}->{tpapi_clapi} ne '' ? $options{config}->{tpapi_clapi} : 'clapi';
     $connector->{tpapi_centreonv2_name} = defined($options{config}->{tpapi_centreonv2}) && $options{config}->{tpapi_centreonv2} ne '' ? 
         $options{config}->{tpapi_centreonv2} : 'centreonv2';
 
@@ -1056,7 +1054,7 @@ sub action_launchservicediscovery {
     my $svc_discovery = gorgone::modules::centreon::autodiscovery::services::discovery->new(
         module_id => $self->{module_id},
         logger => $self->{logger},
-        tpapi_clapi => $self->{tpapi_clapi},
+        tpapi_centreonv2 => $self->{tpapi_centreonv2},
         internal_socket => $self->{internal_socket},
         config => $self->{config},
         config_core => $self->{config_core},
@@ -1144,10 +1142,6 @@ sub periodic_exec {
 sub run {
     my ($self, %options) = @_;
 
-    $self->{tpapi_clapi} = gorgone::class::tpapi::clapi->new();
-    $self->{tpapi_clapi}->set_configuration(
-        config => $self->{tpapi}->get_configuration(name => $self->{tpapi_clapi_name})
-    );
     $self->{tpapi_centreonv2} = gorgone::class::tpapi::centreonv2->new();
     my ($status) = $self->{tpapi_centreonv2}->set_configuration(
         config => $self->{tpapi}->get_configuration(name => $self->{tpapi_centreonv2_name}),

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -41,7 +41,7 @@ sub new {
     $connector->{class_object_centreon} = $options{class_object_centreon};
     $connector->{class_object_centstorage} = $options{class_object_centstorage};
     $connector->{class_autodiscovery} = $options{class_autodiscovery};
-    $connector->{tpapi_clapi} = $options{tpapi_clapi};
+    $connector->{tpapi_centreonv2} = $options{tpapi_centreonv2};
     $connector->{mail_subject} = defined($connector->{config}->{mail_subject}) ? $connector->{config}->{mail_subject} : 'Centreon Auto Discovery';
     $connector->{mail_from} = defined($connector->{config}->{mail_from}) ? $connector->{config}->{mail_from} : 'centreon-autodisco';
 
@@ -188,17 +188,11 @@ sub restart_pollers {
     my $poller_ids = {};
     foreach my $poller_id (keys %{$self->{discovery}->{pollers_reload}}) {
         $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} generate poller config '" . $poller_id . "'");
-        $self->send_internal_action({
-            action => 'COMMAND',
-            token => $self->{discovery}->{token} . ':config',
-            data => {
-                content => [
-                    {
-                        command => $self->{tpapi_clapi}->get_applycfg_command(poller_id => $poller_id)
-                    }
-                ]
-            }
-        });
+
+        my ($status, $results) = $self->{tpapi_centreonv2}->monitoring_server_generate_reload(monitoring_server_id => $poller_id);
+        if ($status != 0) {
+            $self->{logger}->writeLogError("[autodiscovery] -servicediscovery- $self->{uuid} cannot generate poller config - " . $self->{tpapi_centreonv2}->error());
+        }
     }
 }
 
@@ -850,13 +844,18 @@ sub launchdiscovery {
         return -1;
     }
 
-    if (!defined($self->{tpapi_clapi}->get_username())) {
-        $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => 'clapi ' . $self->{tpapi_clapi}->error());
+    if (!defined($self->{tpapi_centreonv2}->get_username())) {
+        $self->send_log_msg_error(
+            token => $options{token},
+            subname => 'servicediscovery',
+            number => $self->{uuid},
+            message => 'cannot get api user: ' . $self->{tpapi_centreonv2}->error()
+        );
         return -1;
     }
     ($status, $message, my $user_id) = gorgone::modules::centreon::autodiscovery::services::resources::get_audit_user_id(
         class_object_centreon => $self->{class_object_centreon},
-        clapi_user => $self->{tpapi_clapi}->get_username()
+        user => $self->{tpapi_centreonv2}->get_username()
     );
     if ($status < 0) {
         $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -44,10 +44,15 @@ sub new {
     $connector->{tpapi_centreonv2} = $options{tpapi_centreonv2};
     $connector->{mail_subject} = defined($connector->{config}->{mail_subject}) ? $connector->{config}->{mail_subject} : 'Centreon Auto Discovery';
     $connector->{mail_from} = defined($connector->{config}->{mail_from}) ? $connector->{config}->{mail_from} : 'centreon-autodisco';
+    $connector->{service_parrallel_commands_poller} = (defined($options{config}->{service_parrallel_commands_poller}) &&
+        $options{config}->{service_parrallel_commands_poller} =~ /(\d+)/) ? $1 : 8;
+    $connector->{service_check_interval} = (defined($options{config}->{service_check_interval}) &&
+        $options{config}->{service_check_interval} =~ /(\d+)/) ? $1 : 15;
+    $connector->{service_timeout} = (defined($options{config}->{service_timeout}) &&
+        $options{config}->{service_timeout} =~ /(\d+)/) ? $1 : 90;
 
     $connector->{service_pollers} = {};
     $connector->{audit_user_id} = undef;
-    $connector->{service_parrallel_commands_poller} = 8;
     $connector->{service_current_commands_poller} = {};
     $connector->{finished} = 0;
     $connector->{post_execution} = 0;
@@ -779,8 +784,8 @@ sub service_execute_commands {
                             event => 'SERVICEDISCOVERYLISTENER',
                             target => $poller_id,
                             token => 'svc-disco-' . $self->{uuid} . '-' . $rule_id . '-' . $host_id,
-                            timeout => 120,
-                            log_pace => 15
+                            timeout => $self->{service_timeout} + $self->{service_check_interval} + 15,
+                            log_pace => $self->{service_check_interval}
                         }
                     ]
                 });
@@ -794,7 +799,7 @@ sub service_execute_commands {
                         content => [
                             {
                                 command => $command,
-                                timeout => 90
+                                timeout => $self->{service_timeout}
                             }
                         ]
                     }

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -85,7 +85,7 @@ sub get_audit_user_id {
 
     my ($status, $contacts) = $options{class_object_centreon}->custom_execute(
         request => 'SELECT contact_id FROM contact WHERE contact_alias = ?',
-        bind_values => [$options{clapi_user}],
+        bind_values => [$options{user}],
         mode => 2
     );
     if ($status == -1) {


### PR DESCRIPTION
## Description

Removes the use of CLAPI in the service discovery part of the autodiscovery module that can be painful to use with complicated passwords. It's also the aim of all Gorgone's modules.
Also maps settings in configuration file to be able to change the frequency of the discoveries.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

1. Have some discovery rules configured and enabled,
2. Make sure to have something to be discovered and added to configuration,
3. Look at the logs for configuration generation:

```
2024-04-16 13:48:50 - INFO - [autodiscovery] -servicediscovery- 005cfc72:41 generate poller config '8'
2024-04-16 13:48:50 - DEBUG - == Info: Found bundle for host mycentral.domain.com: 0x558400333ec0 [can pipeline]
2024-04-16 13:48:50 - DEBUG - == Info: Re-using existing connection! (#746) with host mycentral.domain.com
2024-04-16 13:48:50 - DEBUG - == Info: Connected to mycentral.domain.com (10.2.3.4) port 443 (#746)
2024-04-16 13:48:50 - DEBUG - == Info: TLSv1.3 (OUT), TLS app data, [no content] (0):
2024-04-16 13:48:50 - DEBUG - => Send header: GET /centreon/api/latest/configuration/monitoring-servers/8/generate-and-reload?limit=10000&page=1 HTTP/1.1
Host: mycentral.domain.com
Accept: */*
Accept-Type: application/json; charset=utf-8
Content-Type: application/json; charset=utf-8
X-AUTH-TOKEN: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
2024-04-16 13:48:54 - DEBUG - == Info: TLSv1.3 (IN), TLS app data, [no content] (0):
2024-04-16 13:48:54 - DEBUG - => Recv header: HTTP/1.1 204 No Content
2024-04-16 13:48:54 - DEBUG - => Recv header: Date: Tue, 16 Apr 2024 11:48:53 GMT
2024-04-16 13:48:54 - DEBUG - => Recv header: Server: Apache
2024-04-16 13:48:54 - DEBUG - => Recv header: Cache-Control: no-cache, private
2024-04-16 13:48:54 - DEBUG - => Recv header: Api-Version: 23.04
2024-04-16 13:48:54 - DEBUG - => Recv header: X-Robots-Tag: noindex
2024-04-16 13:48:54 - DEBUG - => Recv header: Strict-Transport-Security: max-age=31536000; includeSubDomains
2024-04-16 13:48:54 - DEBUG - => Recv header: X-Frame-Options: sameorigin
2024-04-16 13:48:54 - DEBUG - => Recv header:
2024-04-16 13:48:54 - DEBUG - == Info: Connection #746 to host mycentral.domain.com left intact
```

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the Autodiscovery module with new configuration directives for service discovery.
	- Introduced a method to trigger a reload for a monitoring server.

- **Bug Fixes**
	- Resolved a formatting issue in the `get_platform_versions` method.
	- Adjusted timeouts in service command executions to align with new configurations.

- **Documentation**
	- Updated documentation for the Autodiscovery module with new configuration directives and default values.

- **Refactor**
	- Updated the usage of internal APIs and methods across several modules for improved robustness and efficiency.
	- Renamed and refactored code for clearer understanding and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->