### PR TITLE
MON-23408-gorgone-discovery-during-service-discovery-gorgone-display-vault-error-messages

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -458,7 +458,7 @@ sub get_macros_host {
             my $macro_value = $_->[1];
             my $is_password = $_->[2];
             # Replace macro value if a vault is used
-            if ($options{vault_count} > 0 && defined($is_password) && $is_password == 1) {
+            if (defined($options{vault_count}) && $options{vault_count} > 0 && defined($is_password) && $is_password == 1) {
                 set_macro(\%macros, $macro_name, "{" . $macro_name . "::secret::" . $macro_value . "}");
             } else {
                 set_macro(\%macros, $macro_name, $macro_value);
@@ -498,7 +498,7 @@ sub substitute_service_discovery_command {
     $command =~ s/\$HOSTADDRESS\$/$options{host}->{host_address}/g;
     $command =~ s/\$HOSTNAME\$/$options{host}->{host_name}/g;
 
-    if ($options{vault_count} > 0) {
+    if (defined($options{vault_count}) && $options{vault_count} > 0) {
         $command .= ' --pass-manager="centreonvault"';
     }
     


### PR DESCRIPTION
## Description

community PR https://github.com/centreon/centreon/pull/3285
error is raised by discovery in some case where vault_count is undefined, this change silence the error in the logs.


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of password macros to ensure secure operations in service discovery features.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->