### PR TITLE
fix(dashboards): correctly check admin rights on contact/contactgroup listing

### DIFF
--- a/centreon/src/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroups.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroups.php
@@ -51,7 +51,7 @@ final class FindDashboardContactGroups
         try {
             if ($this->rights->canAccess()) {
                 $this->info('Find dashboard contact groups', ['request' => $this->requestParameters->toArray()]);
-                $users = $this->contact->isAdmin()
+                $users = $this->rights->hasAdminRole()
                     ? $this->findContactGroupsAsAdmin()
                     : $this->findContactGroupsAsContact();
 

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContacts.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContacts.php
@@ -68,7 +68,7 @@ final class FindDashboardContacts
         try {
             if ($this->rights->canAccess()) {
                 $this->info('Find dashboard contacts', ['request' => $this->requestParameters->toArray()]);
-                $users = $this->contact->isAdmin()
+                $users = $this->rights->hasAdminRole()
                     ? $this->findContactAsAdmin()
                     : $this->findContactsAsNonAdmin();
                 $presenter->presentResponse($this->createResponse($users));

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroupsTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroupsTest.php
@@ -73,8 +73,8 @@ it(
     function (): void {
         $this->rights->expects($this->once())->method('canAccess')->willReturn(true);
 
-        $this->contact->expects($this->once())
-            ->method('isAdmin')
+        $this->rights->expects($this->once())
+            ->method('hasAdminRole')
             ->willReturn(false);
 
         $this->readDashboardShareRepository

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContactsTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContactsTest.php
@@ -77,7 +77,7 @@ it(
 it(
     'should present a FindDashboardContactsResponse if the contact is allowed',
     function (): void {
-        $this->contact->expects($this->once())->method('isAdmin')->willReturn(true);
+        $this->rights->expects($this->once())->method('hasAdminRole')->willReturn(true);
         $this->rights->expects($this->once())->method('canAccess')->willReturn(true);
         $this->readDashboardShareRepository->expects($this->once())->method(
             'findContactsWithAccessRightByRequestParameters'
@@ -93,7 +93,7 @@ it(
     'should present a FindDashboardContactsResponse if the contact is allowed and non admin',
     function (): void {
         $this->rights->expects($this->once())->method('canAccess')->willReturn(true);
-        $this->contact->expects($this->once())->method('isAdmin')->willReturn(false);
+        $this->rights->expects($this->once())->method('hasAdminRole')->willReturn(false);
         $this->readDashboardShareRepository->expects($this->once())->method(
             'findContactsWithAccessRightByACLGroupsAndRequestParameters'
         )->willReturn([]);


### PR DESCRIPTION
## Description

This PR intends to correctly Admin rights on dashboards for the contact and contactgroup listing.

Previously only the main "admin" role was checked instead of the Dashboard "admin"

**Fixes** # MON-55677

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.10.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced user role determination logic across various dashboard functionalities to improve security and access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->