### PR TITLE
fix(acl): allow to link service with service group when all_servicegroups is set to 1

### DIFF
--- a/centreon/www/api/class/centreon_configuration_hostgroup.class.php
+++ b/centreon/www/api/class/centreon_configuration_hostgroup.class.php
@@ -159,12 +159,12 @@ class CentreonConfigurationHostgroup extends CentreonConfigurationObjects
         $queryValues = [];
 
         // Get ACL if user is not admin
-        if (
-            ! $isAdmin
-                && $centreon->user->access->hasAccessToAllHostGroups === false
-        ) {
+        if (! $isAdmin) {
             $acl = new CentreonACL($userId, $isAdmin);
-            $filters[] = ' hg.hg_id IN (' . $acl->getHostGroupsString() . ') ';
+            if ($centreon->user->access->hasAccessToAllHostGroups === false) {
+                $filters[] = ' hg.hg_id IN (' . $acl->getHostGroupsString() . ') ';
+            }
+
             $filters[] = ' h.host_id IN (' . $acl->getHostsString($this->pearDBMonitoring) . ') ';
         }
 

--- a/centreon/www/class/centreonServicegroups.class.php
+++ b/centreon/www/class/centreonServicegroups.class.php
@@ -208,17 +208,36 @@ class CentreonServicegroups
     }
 
     /**
+     * @param array<int|string, int|string> $list
+     * @param string $prefix
+     *
+     * @return array{0: array<string, mixed>, 1: string}
+     */
+    private function createMultipleBindQuery(array $list, string $prefix): array
+    {
+        $bindValues = [];
+        foreach ($list as $index => $id) {
+            $bindValues[$prefix . $index] = $id;
+        }
+
+        return [$bindValues, implode(', ', array_keys($bindValues))];
+    }
+
+    /**
      * @param array $values
      * @param array $options
      * @return array
      */
-    public function getObjectForSelect2($values = array(), $options = array())
+    public function getObjectForSelect2($values = [], $options = [])
     {
         global $centreon;
-        $items = array();
+        $items = [];
 
         # get list of authorized servicegroups
-        if (!$centreon->user->access->admin) {
+        if (
+            ! $centreon->user->access->admin
+            && $centreon->user->access->hasAccessToAllServiceGroups === false
+        ) {
             $sgAcl = $centreon->user->access->getServiceGroupAclConf(
                 null,
                 'broker',
@@ -239,38 +258,49 @@ class CentreonServicegroups
         }
 
         $queryValues = [];
-        if (!empty($values)) {
-            foreach ($values as $k => $v) {
-                $multiValues = explode(',', $v);
-                foreach ($multiValues as $item) {
-                    $queryValues[':sg_' . $item] = (int) $item;
+        $whereCondition = '';
+        if (! empty($values)) {
+            foreach ($values as $key => $value) {
+                $serviceGroupIds = explode(',', $value);
+                foreach ($serviceGroupIds as $serviceGroupId) {
+                    $queryValues[':sg_' . $serviceGroupId] = (int) $serviceGroupId;
                 }
             }
+
+            $whereCondition = ' WHERE sg_id IN (' . implode(',', array_keys($queryValues)) . ')';
         }
 
-        # get list of selected servicegroups
-        $query = 'SELECT sg_id, sg_name FROM servicegroup '
-            . 'WHERE sg_id IN ('
-            . (count($queryValues) ? implode(',', array_keys($queryValues)) : '""')
-            . ') ORDER BY sg_name ';
+        $request = <<<SQL
+            SELECT
+                sg_id,
+                sg_name
+            FROM servicegroup
+            $whereCondition
+            ORDER BY sg_name
+        SQL;
 
-        $stmt = $this->DB->prepare($query);
-        foreach ($queryValues as $key => $id) {
-            $stmt->bindValue($key, $id, PDO::PARAM_INT);
+        $statement = $this->DB->prepare($request);
+
+        foreach ($queryValues as $key => $value) {
+            $statement->bindValue($key, $value, \PDO::PARAM_INT);
         }
-        $stmt->execute();
+        $statement->execute();
 
-        while ($row = $stmt->fetch()) {
+        while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
             # hide unauthorized servicegroups
             $hide = false;
-            if (!$centreon->user->access->admin && !in_array($row['sg_id'], $sgAcl)) {
+            if (
+                ! $centreon->user->access->admin
+                && !in_array($record['sg_id'], $sgAcl)
+                && $centreon->user->access->hasAccessToAllServiceGroups === false
+            ) {
                 $hide = true;
             }
-            $items[] = array(
-                'id' => $row['sg_id'],
-                'text' => $row['sg_name'],
+            $items[] = [
+                'id' => $record['sg_id'],
+                'text' => $record['sg_name'],
                 'hide' => $hide
-            );
+            ];
         }
         return $items;
     }


### PR DESCRIPTION
🏷️ MON-36989

Allow to list all service groups in "Configuration > Services > Servicegroups" menu and when user try to link a service (create/edit form) when he is linked to an ACL Resources where all servicegroups is checked

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

See Jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced ACL checks for admin users, streamlining access controls for host groups.
	- Introduced efficient pagination and refined ACL management for service group listings.

- **Refactor**
	- Improved query handling for service groups, including more robust parameter processing and query construction.
	- Updated methods in `CentreonACL` and `CentreonServicegroups` classes for better management of service group access and query efficiency.

- **Bug Fixes**
	- Adjusted access logic to correctly hide unauthorized service groups from users without full access rights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->