### PR TITLE
feat(api): add StringGeneratorInterface to DI

### DIFF
--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -469,6 +469,10 @@ services:
         class: Utility\UUIDGenerator
         public: true
 
+    Utility\Interfaces\StringGeneratorInterface:
+        class: Utility\ULIDGenerator
+        public: true
+
     Centreon\Domain\Repository\ImagesRepository:
         class: Centreon\Domain\Repository\ImagesRepository
         public: true

--- a/centreon/src/Utility/Interfaces/StringGeneratorInterface.php
+++ b/centreon/src/Utility/Interfaces/StringGeneratorInterface.php
@@ -19,6 +19,8 @@
  *
  */
 
+declare(strict_types=1);
+
 namespace Utility\Interfaces;
 
 interface StringGeneratorInterface

--- a/centreon/src/Utility/ULIDGenerator.php
+++ b/centreon/src/Utility/ULIDGenerator.php
@@ -19,6 +19,8 @@
  *
  */
 
+declare(strict_types=1);
+
 namespace Utility;
 
 use Symfony\Component\Uid\Ulid;


### PR DESCRIPTION
## Description

this PR intends to add StringGeneratorInterface in Dependency Injection, as it is in Utility namespace it is not automatically injected
**Fixes** # MON-54984

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced system reliability with the introduction of a new unique identifier generation method.
- **Refactor**
	- Enforced strict typing in utility components to improve code robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->