### PR TITLE
fix(install): fix erronous gpg key name in check-centreon-gpg-key script

### DIFF
--- a/centreon/check-centreon-gpg-key.sh
+++ b/centreon/check-centreon-gpg-key.sh
@@ -17,7 +17,7 @@ fi
 OLDKEY_NAME="gpg-pubkey-8a7652bc-4cb6f1f6"
 OLDKEY_ID="1024D/8A7652BC"
 
-NEWKEY_NAME="gpg-pubkey-3fc49c1b-6166eb52"
+NEWKEY_NAME="gpg-pubkey-3fc49c1b-651d4c25"
 
 rpm -q gpg-pubkey --qf '%{NAME}-%{VERSION}-%{RELEASE}\t%{SUMMARY}\n' | grep -q "${OLDKEY_NAME}"
 


### PR DESCRIPTION
## Description

* fix check-centreon-gpg-key script to use the correct RELEASE in new gpg key name

**Fixes** #MON-57396

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
