### PR TITLE
fix(web): fix rights of tmp dirs during config export

### DIFF
--- a/centreon/packaging/scripts/centreon-common-postinstall.sh
+++ b/centreon/packaging/scripts/centreon-common-postinstall.sh
@@ -7,6 +7,10 @@ fixCacheConfigRights() {
   chmod 2775 /var/cache/centreon/config/engine
   chmod 2775 /var/cache/centreon/config/broker
   chmod 2775 /var/cache/centreon/config/export
+
+  # MON-38165
+  chmod 0770 /var/cache/centreon/config/engine/*
+  chmod 0770 /var/cache/centreon/config/broker/*
 }
 
 startCentreon() {

--- a/centreon/www/class/config-generate/backend.class.php
+++ b/centreon/www/class/config-generate/backend.class.php
@@ -135,9 +135,11 @@ class Backend
         $this->tmp_file = basename(tempnam($this->full_path, TMP_DIR_PREFIX));
         $this->tmp_dir = $this->tmp_file . TMP_DIR_SUFFIX;
         $this->full_path .= '/' . $this->tmp_dir;
-        if (!mkdir($this->full_path, 0770, true)) {
+        if (! mkdir($this->full_path)) {
             throw new Exception("Cannot create directory '" . $this->full_path . "'");
         }
+        // rights cannot be set in mkdir function (2nd argument) because current sgid bit on parent directory override it
+        chmod($this->full_path, 0770);
     }
 
     public function getPath()


### PR DESCRIPTION
## Description

fix(web): fix rights of tmp dirs during config export

**Fixes** MON-38165

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced security by setting specific permissions for critical directories.
- **Refactor**
	- Improved the directory creation process to enhance security by separating the creation and permission setting steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->