### PR TITLE
enh(resource-access): handle dynamically all_* filters

### DIFF
--- a/centreon/src/Core/ResourceAccess/Application/Repository/WriteDatasetRepositoryInterface.php
+++ b/centreon/src/Core/ResourceAccess/Application/Repository/WriteDatasetRepositoryInterface.php
@@ -38,4 +38,11 @@ interface WriteDatasetRepositoryInterface
      * @return bool
      */
     public function isValidFor(string $type): bool;
+
+    /**
+     * @param int $ruleId
+     * @param int $datasetId
+     * @param bool $fullAccess
+     */
+    public function updateDatasetAccess(int $ruleId, int $datasetId, bool $fullAccess): void;
 }

--- a/centreon/src/Core/ResourceAccess/Application/Repository/WriteResourceAccessRepositoryInterface.php
+++ b/centreon/src/Core/ResourceAccess/Application/Repository/WriteResourceAccessRepositoryInterface.php
@@ -79,11 +79,12 @@ interface WriteResourceAccessRepositoryInterface
     ): int;
 
     /**
+     * @param int $ruleId
      * @param int $datasetId
      * @param string $resourceType (possible values: hostgroups, servicegroups, hosts)
      * @param bool $fullAccess
      */
-    public function updateDatasetAccess(int $datasetId, string $resourceType, bool $fullAccess): void;
+    public function updateDatasetAccess(int $ruleId, int $datasetId, string $resourceType, bool $fullAccess): void;
 
     /**
      * @param int $ruleId

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
@@ -55,6 +55,7 @@ final class FindRule
      * @param ReadContactRepositoryInterface $contactRepository
      * @param ReadContactGroupRepositoryInterface $contactGroupRepository
      * @param \Traversable<DatasetProviderInterface> $repositoryProviders
+     * @param DatasetFilterValidator $datasetFilterValidator
      */
     public function __construct(
         private readonly ContactInterface $user,
@@ -62,6 +63,7 @@ final class FindRule
         private readonly ReadResourceAccessRepositoryInterface $repository,
         private readonly ReadContactRepositoryInterface $contactRepository,
         private readonly ReadContactGroupRepositoryInterface $contactGroupRepository,
+        private readonly DatasetFilterValidator $datasetFilterValidator,
         \Traversable $repositoryProviders
     ) {
         $this->repositoryProviders = iterator_to_array($repositoryProviders);
@@ -146,7 +148,7 @@ final class FindRule
 
             if (
                 $datasetFilter->getResourceIds() === []
-                && DatasetFilter::canResourceIdsBeEmpty($data['type'])
+                && $this->datasetFilterValidator->canResourceIdsBeEmpty($data['type'])
             ) {
                 $data['resources'] = [];
 

--- a/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/AbstractDatasetFilterType.php
+++ b/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/AbstractDatasetFilterType.php
@@ -53,5 +53,13 @@ abstract class AbstractDatasetFilterType implements DatasetFilterTypeInterface
     {
         return $this->possibleChildren;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function canResourceIdsBeEmpty(): bool
+    {
+        return false;
+    }
 }
 

--- a/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/DatasetFilter.php
+++ b/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/DatasetFilter.php
@@ -27,7 +27,6 @@ use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\HostCategoryFilterType;
-use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\HostFilterType;
 use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\HostGroupFilterType;
 use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceCategoryFilterType;
 use Core\ResourceAccess\Domain\Model\DatasetFilter\Providers\ServiceGroupFilterType;
@@ -59,7 +58,7 @@ class DatasetFilter
 
         // if it can be empty it does not mean that it is empty.
         // So we need to check if not empty that we do receive an array of ints.
-        if ($this->canResourceIdsBeEmpty($type)) {
+        if ($this->validator->canResourceIdsBeEmpty($type)) {
             if ($resourceIds !== []) {
                 Assertion::arrayOfTypeOrNull('int', $this->resourceIds, "{$shortName}::resourceIds");
             }
@@ -158,27 +157,6 @@ class DatasetFilter
             ],
             true
         );
-    }
-
-    /**
-     * This method indicates for a given type if the resourceIds array can be empty.
-     * If it is empty is means 'ALL' (of the given resource type).
-     *
-     * @param string $type
-     *
-     * @return bool
-     */
-    public static function canResourceIdsBeEmpty(string $type): bool
-    {
-        return $type === DatasetFilterValidator::ALL_RESOURCES_FILTER
-            || in_array(
-                $type,
-                [
-                    HostGroupFilterType::TYPE_NAME,
-                    HostFilterType::TYPE_NAME,
-                    ServiceGroupFilterType::TYPE_NAME,
-                ], true
-            );
     }
 
     /**

--- a/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/DatasetFilterTypeInterface.php
+++ b/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/DatasetFilterTypeInterface.php
@@ -41,5 +41,10 @@ interface DatasetFilterTypeInterface
      * @return string[]|array{}
      */
     public function getPossibleChildren(): array;
+
+    /**
+     * @return bool
+     */
+    public function canResourceIdsBeEmpty(): bool;
 }
 

--- a/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/DatasetFilterValidator.php
+++ b/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/DatasetFilterValidator.php
@@ -27,6 +27,9 @@ class DatasetFilterValidator
 {
     public const ALL_RESOURCES_FILTER = 'all';
 
+    /** @var DatasetFilterTypeInterface[] */
+    private array $filterTypes = [];
+
     /** @var array<string, array<string>> */
     private array $hiearchy = [];
 
@@ -35,8 +38,10 @@ class DatasetFilterValidator
      */
     public function __construct(\Traversable $datasetFilterTypes)
     {
-        foreach (iterator_to_array($datasetFilterTypes) as $datasetFilterType) {
-            $this->hiearchy[$datasetFilterType->getName()] = $datasetFilterType->getPossibleChildren();
+        $this->filterTypes = iterator_to_array($datasetFilterTypes);
+
+        foreach ($this->filterTypes as $filterType) {
+            $this->hiearchy[$filterType->getName()] = $filterType->getPossibleChildren();
         }
 
         if ([] === $this->hiearchy) {
@@ -45,6 +50,29 @@ class DatasetFilterValidator
 
         // Add special case of all resources filter type
         $this->hiearchy[self::ALL_RESOURCES_FILTER] = [];
+    }
+
+    /**
+     * This method indicates for a given type if the resourceIds array can be empty.
+     * If it is empty is means 'ALL' (of the given resource type that is allowed to).
+     *
+     * @param string $type
+     *
+     * @return bool
+     */
+    public function canResourceIdsBeEmpty(string $type): bool
+    {
+        if ($type === self::ALL_RESOURCES_FILTER) {
+            return true;
+        }
+
+        foreach ($this->filterTypes as $filterType) {
+            if ($filterType->isValidFor($type)) {
+                return $filterType->canResourceIdsBeEmpty();
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/Providers/HostFilterType.php
+++ b/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/Providers/HostFilterType.php
@@ -36,5 +36,13 @@ class HostFilterType extends AbstractDatasetFilterType
         ServiceCategoryFilterType::TYPE_NAME,
         ServiceFilterType::TYPE_NAME,
     ];
+
+    /**
+     * @inheritDoc
+     */
+    public function canResourceIdsBeEmpty(): bool
+    {
+        return true;
+    }
 }
 

--- a/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/Providers/HostGroupFilterType.php
+++ b/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/Providers/HostGroupFilterType.php
@@ -38,5 +38,13 @@ class HostGroupFilterType extends AbstractDatasetFilterType
         ServiceCategoryFilterType::TYPE_NAME,
         ServiceFilterType::TYPE_NAME,
     ];
+
+    /**
+     * @inheritDoc
+     */
+    public function canResourceIdsBeEmpty(): bool
+    {
+        return true;
+    }
 }
 

--- a/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/Providers/ServiceGroupFilterType.php
+++ b/centreon/src/Core/ResourceAccess/Domain/Model/DatasetFilter/Providers/ServiceGroupFilterType.php
@@ -35,5 +35,13 @@ class ServiceGroupFilterType extends AbstractDatasetFilterType
         ServiceCategoryFilterType::TYPE_NAME,
         ServiceFilterType::TYPE_NAME,
     ];
+
+    /**
+     * @inheritDoc
+     */
+    public function canResourceIdsBeEmpty(): bool
+    {
+        return true;
+    }
 }
 

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteHostCategoryRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteHostCategoryRepository.php
@@ -79,4 +79,12 @@ class DbWriteHostCategoryRepository extends AbstractRepositoryRDB implements Wri
 
         $statement->execute();
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateDatasetAccess(int $ruleId, int $datasetId, bool $fullAccess): void
+    {
+        return;
+    }
 }

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteHostGroupRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteHostGroupRepository.php
@@ -87,4 +87,20 @@ class DbWriteHostGroupRepository extends AbstractRepositoryRDB implements WriteD
 
         $statement->execute();
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateDatasetAccess(int $ruleId, int $datasetId, bool $fullAccess): void
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<'SQL'
+                    UPDATE `:db`.acl_resources SET all_hostgroups = :access WHERE acl_res_id = :datasetId
+                SQL
+        ));
+
+        $statement->bindValue(':datasetId', $datasetId, \PDO::PARAM_INT);
+        $statement->bindValue(':access', $fullAccess ? '1' : '0', \PDO::PARAM_STR);
+        $statement->execute();
+    }
 }

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteHostRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteHostRepository.php
@@ -87,4 +87,20 @@ class DbWriteHostRepository extends AbstractRepositoryRDB implements WriteDatase
 
         $statement->execute();
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateDatasetAccess(int $ruleId, int $datasetId, bool $fullAccess): void
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<'SQL'
+                    UPDATE `:db`.acl_resources SET all_hosts = :access WHERE acl_res_id = :datasetId
+                SQL
+        ));
+
+        $statement->bindValue(':datasetId', $datasetId, \PDO::PARAM_INT);
+        $statement->bindValue(':access', $fullAccess ? '1' : '0', \PDO::PARAM_STR);
+        $statement->execute();
+    }
 }

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteMetaServiceRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteMetaServiceRepository.php
@@ -87,4 +87,12 @@ class DbWriteMetaServiceRepository extends AbstractRepositoryRDB implements Writ
 
         $statement->execute();
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateDatasetAccess(int $ruleId, int $datasetId, bool $fullAccess): void
+    {
+        return;
+    }
 }

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteServiceCategoryRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteServiceCategoryRepository.php
@@ -87,4 +87,12 @@ class DbWriteServiceCategoryRepository extends AbstractRepositoryRDB implements 
 
         $statement->execute();
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateDatasetAccess(int $ruleId, int $datasetId, bool $fullAccess): void
+    {
+        return;
+    }
 }

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteServiceGroupRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/Dataset/DbWriteServiceGroupRepository.php
@@ -87,4 +87,20 @@ class DbWriteServiceGroupRepository extends AbstractRepositoryRDB implements Wri
 
         $statement->execute();
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateDatasetAccess(int $ruleId, int $datasetId, bool $fullAccess): void
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<'SQL'
+                    UPDATE `:db`.acl_resources SET all_servicegroups = :access WHERE acl_res_id = :datasetId
+                SQL
+        ));
+
+        $statement->bindValue(':datasetId', $datasetId, \PDO::PARAM_INT);
+        $statement->bindValue(':access', $fullAccess ? '1' : '0', \PDO::PARAM_STR);
+        $statement->execute();
+    }
 }

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbWriteResourceAccessRepository.php
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Repository/DbWriteResourceAccessRepository.php
@@ -54,17 +54,13 @@ final class DbWriteResourceAccessRepository extends AbstractRepositoryRDB implem
     /**
      * @inheritDoc
      */
-    public function updateDatasetAccess(int $datasetId, string $resourceType, bool $fullAccess): void
+    public function updateDatasetAccess(int $ruleId, int $datasetId, string $resourceType, bool $fullAccess): void
     {
-        $statement = $this->db->prepare($this->translateDbName(
-            <<<SQL
-                    UPDATE `:db`.acl_resources SET all_{$resourceType} = :access WHERE acl_res_id = :datasetId
-                SQL
-        ));
-
-        $statement->bindValue(':datasetId', $datasetId, \PDO::PARAM_INT);
-        $statement->bindValue(':access', $fullAccess ? '1' : '0', \PDO::PARAM_STR);
-        $statement->execute();
+        foreach ($this->repositoryProviders as $repositoryProvider) {
+            if ($repositoryProvider->isValidFor($resourceType) === true) {
+                $repositoryProvider->updateDatasetAccess(ruleId: $ruleId, datasetId: $datasetId, fullAccess: $fullAccess);
+            }
+        }
     }
 
     /**

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
@@ -108,6 +108,7 @@ beforeEach(closure: function (): void {
         repository: $this->repository,
         contactRepository: $this->contactRepository,
         contactGroupRepository: $this->contactGroupRepository,
+        datasetFilterValidator: $datasetValidator,
         repositoryProviders: $providers
     );
 });


### PR DESCRIPTION
This PR intends to handle dynamically filters that can have a all_* capacity. Main reason of this change is to integrate the all_business_view filter.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

see jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced dataset access control with additional parameter requirements for updating access rules.
  - Introduced validation for whether resource IDs can be empty in various dataset filters.

- **Refactor**
  - Streamlined the process of updating dataset access across multiple repository interfaces and use cases.
  - Updated rule finding functionality to incorporate new dataset filter validations.

- **Documentation**
  - No visible changes for end-users.

- **Bug Fixes**
  - Corrected dataset access updating methods to align with new interface requirements.

- **Tests**
  - Updated tests to accommodate new parameters and validation methods in rule finding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->