### PR TITLE
Fix(UI): Fix resources delete button

### DIFF
--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.cypress.spec.tsx
@@ -174,7 +174,6 @@ describe('Resources', () => {
     initialize({ singleResourceType: true });
 
     cy.contains(labelAddFilter).should('not.exist');
-    cy.findByLabelText(labelDelete).should('not.exist');
 
     cy.makeSnapshot();
   });

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.cypress.spec.tsx
@@ -174,6 +174,7 @@ describe('Resources', () => {
     initialize({ singleResourceType: true });
 
     cy.contains(labelAddFilter).should('not.exist');
+    cy.findByLabelText(labelDelete).should('not.be.visible');
 
     cy.makeSnapshot();
   });

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.cypress.spec.tsx
@@ -11,6 +11,7 @@ import { widgetPropertiesAtom } from '../../../atoms';
 import { WidgetResourceType } from '../../../models';
 import {
   labelAddFilter,
+  labelDelete,
   labelResourceType,
   labelSelectAResource
 } from '../../../../translatedLabels';
@@ -173,6 +174,7 @@ describe('Resources', () => {
     initialize({ singleResourceType: true });
 
     cy.contains(labelAddFilter).should('not.exist');
+    cy.findByLabelText(labelDelete).should('not.exist');
 
     cy.makeSnapshot();
   });

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.tsx
@@ -65,7 +65,7 @@ const Resources = ({
   const deleteButtonHidden =
     !canEditField ||
     (value.length <= 1 && (required || isNil(required))) ||
-    (singleResourceType && equals(value.length, 1));
+    equals(value.length, 1);
 
   return (
     <div className={classes.resourcesContainer}>

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/Resources.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import { useTranslation } from 'react-i18next';
-import { isNil } from 'ramda';
+import { equals, isNil } from 'ramda';
 
 import { Divider, FormHelperText, Typography } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
@@ -63,7 +63,9 @@ const Resources = ({
   const { canEditField } = useCanEditProperties();
 
   const deleteButtonHidden =
-    !canEditField || (value.length <= 1 && (required || isNil(required)));
+    !canEditField ||
+    (value.length <= 1 && (required || isNil(required))) ||
+    (singleResourceType && equals(value.length, 1));
 
   return (
     <div className={classes.resourcesContainer}>

--- a/centreon/www/widgets/src/centreon-widget-statuschart/src/spec/StatusChart.cypress.spec.tsx
+++ b/centreon/www/widgets/src/centreon-widget-statuschart/src/spec/StatusChart.cypress.spec.tsx
@@ -83,7 +83,7 @@ const interceptRequests = (): void => {
       method: Method.GET,
       path: `./api/latest${getPublicWidgetEndpoint({
         dashboardId: 1,
-        extraQueryParameters: '?&resource_type=host',
+        extraQueryParameters: '?&resource_type=%22host%22',
         playlistHash: 'hash',
         widgetId: '1'
       })}`,


### PR DESCRIPTION
## Description

This fixes the delete button in resources dataset

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved logic for hiding the delete button in the Resources section of Widget Properties for a more intuitive user interface.
- **Tests**
	- Added a new test to verify the absence of the delete label based on specific conditions in the Resources section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->