### PR TITLE
enh(hosts): Handle new filters by hostgroup/hostcategory on monitoring endpoint

### DIFF
--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -16,7 +16,7 @@ info:
     + Added metrics by service listing endpoint to service resource type
     + Handle new filters for the /configuration/hosts/groups endpoint
     + Handle new filters for the /configuration/services/groups endpoint
-    +
+    + Handle new filters for the /monitoring/hosts endpoint
     +
     # Information
     All dates are in **ISO 8601** format
@@ -1944,6 +1944,9 @@ paths:
         * poller.id
         * service.display_name
         * host_group.id
+        * host_group.name
+        * host_category.id
+        * host_category.name
         * host.is_acknowledged
         * host.downtime
         * host.criticality

--- a/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -115,7 +115,10 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             'host.state' => 'h.state',
             'poller.id' => 'h.instance_id',
             'service.display_name' => 'srv.display_name',
-            'host_group.id' => 'hg.hostgroup_id',
+            'host_group.id' => 'hhg.hostgroup_id',
+            'host_group.name' => 'hg.name',
+            'host_category.id' => 'hc.hc_id',
+            'host_category.name' => 'hc.hc_name',
             'host.is_acknowledged' => 'h.acknowledged',
             'host.downtime' => 'h.scheduled_downtime_depth',
             'host.criticality' => 'cv.value',
@@ -239,8 +242,14 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             LEFT JOIN `:dbstg`.`services` srv
                 ON srv.host_id = h.host_id
                 AND srv.enabled = '1'
-            LEFT JOIN `:dbstg`.`hosts_hostgroups` hg
-                ON hg.host_id = h.host_id
+            LEFT JOIN `:dbstg`.`hosts_hostgroups` hhg
+                ON hhg.host_id = h.host_id
+            LEFT JOIN `:dbstg`.`hostgroups` hg
+                ON hhg.hostgroup_id = hg.hostgroup_id
+            LEFT JOIN `:db`.`hostcategories_relation` hcr
+                ON hcr.host_host_id = h.host_id
+            LEFT JOIN `:db`.`hostcategories` hc
+                ON hcr.hostcategories_hc_id = hc.hc_id
             LEFT JOIN `:dbstg`.`customvariables` cv
                 ON cv.host_id = h.host_id
                 AND (cv.service_id = 0 OR cv.service_id IS NULL)


### PR DESCRIPTION
## Description

This PR intends to add new filters by hostgroup name and hostcategory id/name on /monitoring/hosts endpoint

**Fixes** # MON-33475

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
