### PR TITLE
enh(Administration): Remove autofill for credentials in forms (#3963) [dev-24.04.x]

### DIFF
--- a/centreon/www/include/Administration/parameters/general/form.php
+++ b/centreon/www/include/Administration/parameters/general/form.php
@@ -66,14 +66,15 @@ while ($opt = $dbResult->fetch()) {
         $gopt[$opt["key"]] = myDecode($opt["value"]);
     }
 }
-$gopt['proxy_password'] = CentreonAuth::PWS_OCCULTATION;
 
 /*
  * Style
  */
-$attrsText = array("size" => "40");
-$attrsText2 = array("size" => "5");
+$attrsText = ['size' => '40'];
+$attrsText2 = ['size' => '5'];
 $attrsAdvSelect = null;
+
+$autocompleteOff = ['autocomplete' => 'new-password'];
 
 /*
  * Form begin
@@ -193,8 +194,8 @@ $form->addElement(
     array("class" => "btc bt_success", "onClick" => "javascript:checkProxyConf()")
 );
 $form->addElement('text', 'proxy_port', _("Proxy port"), $attrsText2);
-$form->addElement('text', 'proxy_user', _("Proxy user"), $attrsText);
-$form->addElement('password', 'proxy_password', _("Proxy password"), $attrsText);
+$form->addElement('text', 'proxy_user', _("Proxy user"), array_merge($attrsText, $autocompleteOff));
+$form->addElement('password', 'proxy_password', _("Proxy password"), array_merge($attrsText, $autocompleteOff));
 
 /**
  * Charts options

--- a/centreon/www/include/Administration/parameters/gorgone/gorgone.php
+++ b/centreon/www/include/Administration/parameters/gorgone/gorgone.php
@@ -43,9 +43,11 @@ while ($opt = $DBRESULT->fetchRow()) {
 }
 $DBRESULT->closeCursor();
 
-$attrsText = array("size" => "40");
-$attrsText2 = array("size" => "5");
+$attrsText = ['size' => '40'];
+$attrsText2 = ['size' => '5'];
 $attrsAdvSelect = null;
+
+$autocompleteOff = ['autocomplete' => 'new-password'];
 
 // Form begin
 $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
@@ -61,8 +63,8 @@ $form->addElement('text', 'gorgone_illegal_characters', _("Illegal characters fo
 $form->addElement('text', 'gorgone_api_address', _("IP address or hostname"), $attrsText);
 $form->addElement('text', 'gorgone_api_port', _("Port"), $attrsText2);
 $form->addRule('gorgone_api_port', _('Must be a number'), 'numeric');
-$form->addElement('text', 'gorgone_api_username', _("Username"), $attrsText);
-$form->addElement('password', 'gorgone_api_password', _("Password"), $attrsText);
+$form->addElement('text', 'gorgone_api_username', _("Username"), array_merge($attrsText, $autocompleteOff));
+$form->addElement('password', 'gorgone_api_password', _("Password"), array_merge($attrsText, $autocompleteOff));
 $form->addElement(
     'checkbox',
     'gorgone_api_ssl',

--- a/centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+++ b/centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
@@ -51,6 +51,8 @@ $DBRESULT->closeCursor();
 
 $attrsAdvSelect = null;
 
+$autocompleteOff = ['autocomplete' => 'new-password'];
+
 /*
  * Form begin
  */
@@ -61,9 +63,9 @@ $form = new HTML_QuickFormCustom('Form', 'post', "?p=" . $p);
  */
 $form->addElement('text', 'kb_wiki_url', _("Knowledge base url"));
 $form->addRule('kb_wiki_url', _("Mandatory field"), 'required');
-$form->addElement('text', 'kb_wiki_account', _("Knowledge wiki account (with delete right)"));
+$form->addElement('text', 'kb_wiki_account', _("Knowledge wiki account (with delete right)"), $autocompleteOff);
 $form->addRule('kb_wiki_account', _("Mandatory field"), 'required');
-$form->addElement('password', 'kb_wiki_password', _("Knowledge wiki account password"));
+$form->addElement('password', 'kb_wiki_password', _("Knowledge wiki account password"), $autocompleteOff);
 $form->addRule('kb_wiki_password', _("Mandatory field"), 'required');
 $form->addElement('checkbox', 'kb_wiki_certificate', 'ssl certificate', _("Ignore ssl certificate"));
 


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/3963

**Fixes** # MON-62131

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
