### PR TITLE
MON-51684-gorgone-add-whitelist-error-in-first-level-logs

### DIFF
--- a/centreon-gorgone/gorgone/modules/core/action/class.pm
+++ b/centreon-gorgone/gorgone/modules/core/action/class.pm
@@ -387,14 +387,14 @@ sub action_command {
         }
 
         if ($self->is_command_authorized(command => $command->{command})) {
-            $self->{logger}->writeLogInfo("[action] command not allowed (whitelist): " . $command->{command});
+            $self->{logger}->writeLogError("[action] command not allowed (whitelist): " . $command->{command});
             $self->send_log(
                 socket => $options{socket_log},
                 code => GORGONE_ACTION_FINISH_KO,
                 token => $options{token},
                 logging => $options{data}->{logging},
                 data => {
-                    message => "command not allowed (whitelist) at array index '" . $index . "'"
+                    message => "command not allowed (whitelist) at array index '$index' : $command->{command}"
                 }
             );
             return -1;
@@ -679,14 +679,14 @@ sub action_actionengine {
     }
 
     if ($self->is_command_authorized(command => $options{data}->{content}->{command})) {
-        $self->{logger}->writeLogInfo("[action] command not allowed (whitelist): " . $options{data}->{content}->{command});
+        $self->{logger}->writeLogError("[action] command not allowed (whitelist): " . $options{data}->{content}->{command});
         $self->send_log(
             socket => $options{socket_log},
             code => GORGONE_ACTION_FINISH_KO,
             token => $options{token},
             logging => $options{data}->{logging},
             data => {
-                message => 'command not allowed (whitelist)'
+                message => 'command not allowed (whitelist)' . $options{data}->{content}->{command}
             }
         );
         return -1;


### PR DESCRIPTION
REF:MON-51684

## Description
in gorgone action module, command not allowed by the whitelist are now displayed as error logs.

**Fixes** # MON-51684

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.
launch gorgone with default configuration, and use curl to launch an action : 
`curl --request POST "http://127.0.0.1:8085/api/core/action/command" --header "Accept: application/json" --header "Content-Type: application/json" --data "[{\"command\": \"echo 'Test command' >> /tmp/here.log\"}]"`
## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
