### PR TITLE
fix(ci): fix faild e2e test R.A.M

### DIFF
--- a/centreon/tests/e2e/features/Resources-Access-Management/commands.ts
+++ b/centreon/tests/e2e/features/Resources-Access-Management/commands.ts
@@ -16,7 +16,7 @@ Cypress.Commands.add(
       cy.request({
         body: payload,
         method: 'POST',
-        url: `/centreon/api/v${major_version}/administration/resource-access/rules?*`
+        url: `/centreon/api/v24.04/administration/resource-access/rules?*`
       });
     }
   }


### PR DESCRIPTION
## Description

The e2e test for  Resources-Access-Management, rules listing feature is failing due to Web version being dynamic v24.05, it needs to be 24.04 for now.
```
Body: {
          "code": 404,
          "message": "No route found for \"POST [http://127.0.0.1:4000/centreon/api/v24.05/administration/resource-access/rules\](http://127.0.0.1:4000/centreon/api/v24.05/administration/resource-access/rules/)""
        }
```

**Fixes** # MON-72030

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
