### PR TITLE
fix(api) Fix check non-admin user action rights on post and delete platform/topology endpoint

### DIFF
--- a/centreon/config/routes/Centreon/platform.yaml
+++ b/centreon/config/routes/Centreon/platform.yaml
@@ -18,9 +18,9 @@ centreon_application_platformtopology_getcompleteplatformtopology:
 
 centreon_application_platformtopology_deleteplatform:
   methods: DELETE
-  path: /platform/topology/{serverId}
+  path: /platform/topology/{platformId}
   requirements:
-    serverId: '\d+'
+    platformId: '\d+'
   controller: 'Centreon\Application\Controller\PlatformTopologyController::deletePlatform'
   condition: "request.attributes.get('version') >= 21.10"
 

--- a/centreon/src/Centreon/Application/Controller/PlatformTopologyController.php
+++ b/centreon/src/Centreon/Application/Controller/PlatformTopologyController.php
@@ -106,8 +106,11 @@ class PlatformTopologyController extends AbstractController
 
         // Check Topology access to Configuration > Pollers page
         if (
-            ! $contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
-            && ($contact->isAdmin() || $contact->hasRole(Contact::ROLE_CREATE_EDIT_POLLER_CFG))
+            ! $contact->isAdmin()
+            && ! (
+                $contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
+                && $contact->hasRole(Contact::ROLE_CREATE_EDIT_POLLER_CFG)
+            )
         ) {
             return $this->view(null, Response::HTTP_FORBIDDEN);
         }

--- a/centreon/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyReadRepositoryInterface.php
+++ b/centreon/src/Centreon/Domain/PlatformTopology/Interfaces/PlatformTopologyReadRepositoryInterface.php
@@ -88,11 +88,11 @@ interface PlatformTopologyReadRepositoryInterface
     /**
      * Search for the address of a topology using its Id.
      *
-     * @param int $serverId
+     * @param int $platformId
      *
      * @return PlatformInterface|null
      */
-    public function findPlatform(int $serverId): ?PlatformInterface;
+    public function findPlatform(int $platformId): ?PlatformInterface;
 
     /**
      * Find the Top Level Platform.

--- a/centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/PlatformTopologyRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/PlatformTopologyRepositoryRDB.php
@@ -246,10 +246,10 @@ class PlatformTopologyRepositoryRDB extends AbstractRepositoryDRB implements Pla
     /**
      * @inheritDoc
      */
-    public function findPlatform(int $serverId): ?PlatformInterface
+    public function findPlatform(int $platformId): ?PlatformInterface
     {
-        $statement = $this->db->prepare('SELECT * FROM `platform_topology` WHERE id = :serverId');
-        $statement->bindValue(':serverId', $serverId, \PDO::PARAM_INT);
+        $statement = $this->db->prepare('SELECT * FROM `platform_topology` WHERE id = :platformId');
+        $statement->bindValue(':platformId', $platformId, \PDO::PARAM_INT);
         $statement->execute();
 
         $platform = null;

--- a/centreon/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
+++ b/centreon/tests/php/Centreon/Application/Controller/PlatformTopologyControllerTest.php
@@ -21,25 +21,25 @@
 
 namespace Tests\Centreon\Application\Controller;
 
-use FOS\RestBundle\View\View;
-use PHPUnit\Framework\TestCase;
-use FOS\RestBundle\Context\Context;
+use Centreon\Application\Controller\PlatformTopologyController;
 use Centreon\Domain\Contact\Contact;
-use Psr\Container\ContainerInterface;
-use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
+use Centreon\Domain\PlatformTopology\Exception\PlatformTopologyException;
+use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyServiceInterface;
 use Centreon\Domain\PlatformTopology\Model\PlatformPending;
+use Centreon\Domain\PlatformTopology\Model\PlatformRegistered;
 use Centreon\Domain\PlatformTopology\Model\PlatformRelation;
 use Centreon\Domain\PlatformTopology\PlatformTopologyService;
-use Centreon\Domain\PlatformTopology\Model\PlatformRegistered;
-use Centreon\Application\Controller\PlatformTopologyController;
-use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Centreon\Domain\PlatformTopology\Exception\PlatformTopologyException;
 use Centreon\Infrastructure\PlatformTopology\Repository\Model\PlatformJsonGraph;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
-use Centreon\Domain\PlatformTopology\Interfaces\PlatformTopologyServiceInterface;
+use FOS\RestBundle\Context\Context;
+use FOS\RestBundle\View\View;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 class PlatformTopologyControllerTest extends TestCase
 {
@@ -313,11 +313,15 @@ class PlatformTopologyControllerTest extends TestCase
         $platformTopologyController = new PlatformTopologyController($this->platformTopologyService);
         $platformTopologyController->setContainer($this->container);
 
+        $this->platformTopologyService->expects($this->once())
+            ->method('isValidPlatform')
+            ->willReturn(true);
+
         $view = $platformTopologyController->deletePlatform($this->pollerPlatform->getId());
 
         $this->assertEquals(
+            View::create(null, Response::HTTP_NO_CONTENT),
             $view,
-            View::create(null, Response::HTTP_NO_CONTENT)
         );
     }
 }


### PR DESCRIPTION
## Description

A non-admin user should not be able to create or delete a poller instance without appropriate rights (action, resource & topology rights)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)
