### PR TITLE
fix(packaging) Do not replace conf.pm and centreontrapd.pm files

### DIFF
--- a/centreon/packaging/centreon-poller.yaml
+++ b/centreon/packaging/centreon-poller.yaml
@@ -51,6 +51,7 @@ contents:
 
   - src: ./src/conf.pm
     dst: /etc/centreon/conf.pm
+    type: config|noreplace
     file_info:
       owner: "centreon"
       group: "centreon"
@@ -58,6 +59,7 @@ contents:
 
   - src: ./src/centreontrapd.pm
     dst: /etc/centreon/centreontrapd.pm
+    type: config|noreplace
     file_info:
       owner: "centreon"
       group: "centreon"


### PR DESCRIPTION
## Description

fix(packaging) Do not replace conf.pm and centreontrapd.pm files (#4094)

**Fixes** MON-7559

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)