### PR TITLE
fix(gorgone-api) http response is now 400 in case of error

### DIFF
--- a/.github/docker/Dockerfile.gorgone-testing-alma8
+++ b/.github/docker/Dockerfile.gorgone-testing-alma8
@@ -10,6 +10,7 @@ dnf -y clean all --enablerepo=*
 dnf install -y python3.11 python3.11-pip
 pip3.11 install robotframework robotframework-examples robotframework-databaselibrary pymysql robotframework-requests
 
+
 dnf clean all
 
 EOF

--- a/centreon-gorgone/gorgone/standard/api.pm
+++ b/centreon-gorgone/gorgone/standard/api.pm
@@ -83,7 +83,7 @@ sub root {
             module => $options{module}
         );
     } else {
-        $response = '{"error":"method_unknown","message":"Method not implemented"}';
+        $response = '{"error":"method_unknown","message":"Method not implemented","http_response_code":"404"}';
     }
 
     return $response;
@@ -166,14 +166,14 @@ sub call_internal {
             $content = JSON::XS->new->decode($options{module}->{tokens}->{$action_token}->{data});
         };
         if ($@) {
-            $response = '{"error":"decode_error","message":"Cannot decode response"}';
+            $response = '{"error":"decode_error","message":"Cannot decode response","http_response_code":"400"}';
         } else {
             if (defined($content->{data})) {
                 eval {
                     $response = JSON::XS->new->encode($content->{data});
                 };
                 if ($@) {
-                    $response = '{"error":"encode_error","message":"Cannot encode response"}';
+                    $response = '{"error":"encode_error","message":"Cannot encode response","http_response_code":"400"}';
                 }
             } else {
                 $response = '';

--- a/centreon-gorgone/tests/robot/resources/import.resource
+++ b/centreon-gorgone/tests/robot/resources/import.resource
@@ -3,5 +3,6 @@ Documentation    This is the documentation for the import resource file.
 Library             Examples
 Library             OperatingSystem
 Library             String
+Library             Collections
 Resource            resources.resource
 Library             DatabaseLibrary

--- a/centreon-gorgone/tests/robot/resources/resources.resource
+++ b/centreon-gorgone/tests/robot/resources/resources.resource
@@ -5,6 +5,7 @@ Library            Process
 Library            RequestsLibrary
 
 *** Variables ***
+${gorgone_binary}           /usr/bin/gorgoned
 ${ROOT_CONFIG}              ${CURDIR}${/}..${/}config${/}
 ${pull_central_config}      ${ROOT_CONFIG}pull_central_config.yaml
 ${pull_poller_config}       ${ROOT_CONFIG}pull_poller_config.yaml
@@ -21,7 +22,7 @@ Start Gorgone
     [Arguments]    ${CONFIG_FILE}    ${SEVERITY}    ${ALIAS}
     ${process}    Start Process
     ...    /usr/bin/perl
-    ...    /usr/bin/gorgoned
+    ...    ${gorgone_binary}
     ...    --config
     ...    ${CONFIG_FILE}
     ...    --logfile

--- a/centreon-gorgone/tests/robot/tests/core/httpserver.robot
+++ b/centreon-gorgone/tests/robot/tests/core/httpserver.robot
@@ -48,5 +48,5 @@ Setup Gorgone
     Start Gorgone    /etc/centreon-gorgone/httpserver_api_statuscode/includer.yaml    debug    httpserver_api_statuscode
 
     Log To Console    \nGorgone Started. We have to wait for it to be ready to respond.
-    Sleep    5
+    Sleep    10
     Log To Console    Gorgone should be ready. \n

--- a/centreon-gorgone/tests/robot/tests/core/httpserver.robot
+++ b/centreon-gorgone/tests/robot/tests/core/httpserver.robot
@@ -1,0 +1,52 @@
+*** Settings ***
+Documentation       check gorgone api response
+Suite Setup         Setup Gorgone
+Suite Teardown      Stop Gorgone And Remove Gorgone Config    httpserver_api_statuscode
+Resource            ${CURDIR}${/}..${/}..${/}resources${/}import.resource
+Test Timeout        220s
+
+*** Variables ***
+
+
+*** Test Cases ***
+check http api get status code ${tc}
+    ${expected_code}=    Convert To Integer    ${http_status_code}
+    ${api_response}=    GET  http://127.0.0.1:8085${endpoint}    expected_status=anything
+
+    Log To Console    \nendpoint code is : ${api_response.status_code} output is : ${api_response.text}
+
+    Should Be Equal    ${api_response.status_code}    ${expected_code}
+    ${expected_json}=    evaluate    json.loads('''${expected_response}''')    json
+    Dictionaries Should Be Equal    ${api_response.json()}    ${expected_json}
+
+    Examples:        tc    http_status_code    endpoint    expected_response    --
+            ...      forbidden     403    /bad/endpoint     {"error":"http_error_403","message":"forbidden"}
+            ...      constatus Ok     200    /api/internal/constatus    {"data":{},"action":"constatus","message":"ok"}
+            ...      method not found     404    /api/internal/wrongendpoint    {"error":"method_unknown","message":"Method not implemented"}
+        
+check http api post api ${tc}
+    ${expected_code}=    Convert To Integer    ${http_status_code}
+    ${api_response}=    POST  http://127.0.0.1:8085${endpoint}    expected_status=anything    data=${body}
+
+    Log To Console    \nendpoint code is : ${api_response.status_code} output is : ${api_response.text}
+
+    Should Be Equal    ${api_response.status_code}    ${expected_code}
+    IF    len("""${expected_response}""") > 0
+        ${expected}=    evaluate    json.loads('''${expected_response}''')    json
+        Dictionaries Should Be Equal    ${api_response.json()}    ${expected}
+    END
+
+    Examples:        tc    http_status_code    endpoint    body    expected_response    --
+            ...      body is not json     400    /api/centreon/nodes/sync     {    {"error":"decode_error","message":"POST content must be JSON-formated"}
+            ...      body is valid json     200    /api/centreon/nodes/sync     {}    ${EMPTY}        # api send back a random token.
+
+
+*** Keywords ***
+
+Setup Gorgone
+    Setup Gorgone Config    httpserver_api_statuscode    ${push_central_config}
+    Start Gorgone    /etc/centreon-gorgone/httpserver_api_statuscode/includer.yaml    debug    httpserver_api_statuscode
+
+    Log To Console    \nGorgone Started. We have to wait for it to be ready to respond.
+    Sleep    5
+    Log To Console    Gorgone should be ready. \n

--- a/centreon-gorgone/tests/robot/tests/core/push.robot
+++ b/centreon-gorgone/tests/robot/tests/core/push.robot
@@ -8,7 +8,7 @@ Test Timeout        220s
 @{process_list}    gorgone_central    gorgone_poller_2
 
 *** Test Cases ***
-test Evan
+connect 1 poller to a central
     [Teardown]    Stop Gorgone And Remove Gorgone Config    @{process_list}    sql_file=${ROOT_CONFIG}push_db_1_poller_delete.sql
 
     Log To Console    \nStarting the gorgone setup


### PR DESCRIPTION
## Description

the gorgone api did not implement http error code for most applicative error (there was already some for unauthorized case) This pr add a way to specify http code to send back along the json response. This will add a new property in the json '

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [X] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>
see robot tests.
When the api send back an error property in the json the http response is now 400

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
