### PR TITLE
enh(dashboard): move WidgetDataProviderInterface from module to Core

### DIFF
--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -318,6 +318,8 @@ services:
             tags: ['configuration.notification.resource.repositories']
         Core\Notification\Application\Repository\NotifiableResourceRequestProviderInterface:
             tags: ['configuration.notification.notifiable.resource.request.provider']
+        Core\Dashboard\Application\Repository\WidgetDataProviderInterface:
+            tags: ['dashboard.playlist.widget.data.providers']
         Symfony\Component\Console\Command\Command:
             tags: ['script.command']
 

--- a/centreon/config/packages/security.yaml
+++ b/centreon/config/packages/security.yaml
@@ -15,7 +15,7 @@ security:
             pattern: ^.*/api/(?:latest|beta|v[0-9]+|v[0-9]+\.[0-9]+)(/it-edition-extensions/login_page|/platform/(?:versions|features|installation/status))$
             security: false
         publicPlaylist:
-            pattern: ^.*/api/(?:latest|beta|v[0-9]+|v[0-9]+\.[0-9]+)(/it-edition-extensions/monitoring/dashboards/playlists/[1-9A-HJ-NP-TV-Za-km-z]{22}(?:/dashboards/\d+(?:/widgets/\d+)?)?)$
+            pattern: ^.*/api/(?:latest|beta|v[0-9]+|v[0-9]+\.[0-9]+)(/it-edition-extensions/monitoring/dashboards/playlists/[1-9A-HJ-NP-Za-km-z]{22}(?:/dashboards/\d+(?:/widgets/\d+)?)?)$
             security: false
         authentication:
             pattern: ^.*(?<!administration)/authentication/(providers/configurations|users)(.*)$

--- a/centreon/src/Core/Dashboard/Application/Repository/WidgetDataProviderInterface.php
+++ b/centreon/src/Core/Dashboard/Application/Repository/WidgetDataProviderInterface.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Application\Repository;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Dashboard\Domain\Model\DashboardPanel;
+
+interface WidgetDataProviderInterface
+{
+    /**
+     * @param string $widgetName
+     *
+     * @return bool
+     */
+    public function isValidFor(string $widgetName): bool;
+
+    /**
+     * @param DashboardPanel $panel
+     * @param ContactInterface $user
+     *
+     * @throws \Throwable
+     *
+     * @return ResponseStatusInterface|mixed
+     */
+    public function getData(DashboardPanel $panel, ContactInterface $user): mixed;
+}


### PR DESCRIPTION
This PR intends to move the WidgetDataProviderInterface from the centreon-it-edition-extensions module to Core.
**Why?**

Because this interface needs to be implemented by a CentreonBam class, which requires the interface to be always available to be implemented. BAM cannot be used without centreon-web while BAM can be used without centreon-it-edition-extensions.

The centreon-it-edition-extension source code will be adapted in a dedicated PR (opened on centreon-modules)

This PR also brings a patch regarding the public playlists and the detection of the public playlist ID (ULID base 58)

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] develop

<h2> How this pull request can be tested ? </h2>

See Jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
