### PR TITLE
fix: Empty red snackbar appears after loading or refresh a page with ACL User

### DIFF
--- a/centreon/www/front_src/src/App/useApp.ts
+++ b/centreon/www/front_src/src/App/useApp.ts
@@ -50,6 +50,7 @@ const useApp = (): UseAppState => {
     request: getData
   });
   const { sendRequest: getParameters } = useRequest<DefaultParameters>({
+    httpCodesBypassErrorSnackbar: [403],
     request: getData
   });
   const { sendRequest: getAcl } = useRequest<Actions>({


### PR DESCRIPTION
**Description**: empty red snackbar appears after loading or refresh a page with ACL User