### PR TITLE
fix (update_centreon_storage_logs): Rename $path variable

### DIFF
--- a/centreon/tools/update_centreon_storage_logs.php
+++ b/centreon/tools/update_centreon_storage_logs.php
@@ -60,18 +60,19 @@ $temporaryPath = null;
 /**
  * Check if the directory exist and add the character / at the end if it not exist
  *
- * @param string &$path Path to check
+ * @param string &$temporaryPath Path to check
+ *
  * @throws \Exception
  */
-function checkTemporaryDirectory(&$path)
+function checkTemporaryDirectory(&$temporaryPath)
 {
-    if (is_dir($path) === false) {
+    if (is_dir($temporaryPath) === false) {
         throw new \Exception(
-            'This path for temporary files (' . $path . ') does not exist'
+            'This path for temporary files (' . $temporaryPath . ') does not exist'
         );
     }
-    if (substr($path, -1, 1) != '/') {
-        $path .= '/';
+    if (substr($temporaryPath, -1, 1) != '/') {
+        $temporaryPath .= '/';
     }
 }
 
@@ -309,11 +310,11 @@ try {
         if (is_dir(TEMP_DIRECTORY) === false) {
             $temporaryPath = __DIR__;
         }
-        $path = askQuestion(
+        $pathDirectory = askQuestion(
             "Please to give the directory for temporary files [$temporaryPath]\n",
             false
         );
-        $temporaryPath = empty($path) ? $temporaryPath : $path;
+        $temporaryPath = empty($pathDirectory) ? $temporaryPath : $pathDirectory;
     }
 
     checkTemporaryDirectory($temporaryPath);


### PR DESCRIPTION
## Description

Rename the $path variable in an attempt to reduce its potential scope in other php files.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x (master)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
