### PR TITLE
fix(gorgone): Add mbi legacy function to manage host template recursivity

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/mbi/libs/centreon/Host.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/mbi/libs/centreon/Host.pm
@@ -30,75 +30,77 @@ use Data::Dumper;
 # $centreon: Instance of centreonDB class for connection to Centreon database
 # $centstorage: (optionnal) Instance of centreonDB class for connection to Centstorage database
 sub new {
-	my $class = shift;
-	my $self  = {};
-	$self->{logger}	= shift;
-	$self->{centreon} = shift;
-	$self->{etlProperties} = undef;
+    my $class = shift;
+    my $self  = {};
+    $self->{logger}    = shift;
+    $self->{centreon} = shift;
+    $self->{etlProperties} = undef;
 
-	if (@_) {
-		$self->{centstorage}  = shift;
-	}
-	bless $self, $class;
-	return $self;
+    if (@_) {
+        $self->{centstorage}  = shift;
+    }
+    bless $self, $class;
+    return $self;
 }
 
 #Set the etl properties as a variable of the class
 sub setEtlProperties{
-	my $self = shift;
-	$self->{etlProperties} = shift;
+    my $self = shift;
+    $self->{etlProperties} = shift;
 }
 
 # returns two references to two hash tables => hosts indexed by id and hosts indexed by name
 sub getAllHosts {
-	my $self = shift;
-	my $centreon = $self->{centreon};
-	my $activated = 1;
-	if (@_) {
-		$activated  = 0;
-	}
-	my (%host_ids, %host_names);
-	
-	my $query = "SELECT `host_id`, `host_name`".
-        " FROM `host`".
-        " WHERE `host_register`='1'";
+    my $self = shift;
+    my $centreon = $self->{centreon};
+    my $activated = 1;
+    if (@_) {
+        $activated  = 0;
+    }
+    my (%host_ids, %host_names);
+
+    my $query = "SELECT `host_id`, `host_name`" .
+                " FROM `host`" .
+                " WHERE `host_register`='1'";
     if ($activated == 1) {
         $query .= " AND `host_activate` ='1'";
     }
-	my $sth = $centreon->query({ query => $query });
-	while (my $row = $sth->fetchrow_hashref()) {
-		$host_ids{ $row->{host_name} } = $row->{host_id};
-		$host_names{ $row->{host_id} } = $row->{host_name};
-	}
-	return (\%host_ids, \%host_names);
+    my $sth                            = $centreon->query({ query => $query });
+    while (my $row                     = $sth->fetchrow_hashref()) {
+        $host_ids{ $row->{host_name} } = $row->{host_id};
+        $host_names{ $row->{host_id} } = $row->{host_name};
+    }
+    return (\%host_ids, \%host_names);
 }
 
 # Get all hosts, keys are IDs
 sub getAllHostsByID {
-	my $self = shift;
-	my ($host_ids, $host_names) = $self->getAllHosts();	
-	return ($host_ids);
+    my $self                    = shift;
+    my ($host_ids, $host_names) = $self->getAllHosts();
+    return ($host_ids);
 }
 
 # Get all hosts, keys are names
 sub getAllHostsByName {
-	my $self = shift;
-	my ($host_ids, $host_names) = $self->getAllHosts();	
-	return ($host_names);
+    my $self                    = shift;
+    my ($host_ids, $host_names) = $self->getAllHosts();
+    return ($host_names);
 }
 
 sub loadAllCategories {
     my $self = shift;
 
-    $self->{hc} = {};
+    $self->{hc}                = {};
     $self->{host_hc_relations} = {};
-    my $query = "SELECT hc.hc_id as category_id, hc.hc_name as category_name, host_host_id
+    my $query                  = "SELECT hc.hc_id as category_id, hc.hc_name as category_name, host_host_id
         FROM hostcategories hc, hostcategories_relation hr
         WHERE hc.hc_activate = '1' AND hc.hc_id = hr.hostcategories_hc_id";
-    my $sth = $self->{centreon}->query({ query => $query });
-    while (my $row = $sth->fetchrow_hashref()) {
-        $self->{hc}->{ $row->{category_id} } = $row->{category_name} if (!defined($self->{hc}->{ $row->{category_id} }));
-        $self->{host_hc_relations}->{ $row->{host_host_id} } = [] if (!defined($self->{host_hc_relations}->{ $row->{host_host_id} }));
+    my $sth                                                  = $self->{centreon}->query({ query => $query });
+    while (my $row                                           = $sth->fetchrow_hashref()) {
+        $self->{hc}->{ $row->{category_id} }                 = $row->{category_name} if (!defined($self->{hc}->{ $row
+            ->{category_id} }));
+        $self->{host_hc_relations}->{ $row->{host_host_id} } = [] if (!defined($self->{host_hc_relations}->{ $row
+            ->{host_host_id} }));
         push @{$self->{host_hc_relations}->{ $row->{host_host_id} }}, $row->{category_id};
     }
 }
@@ -106,15 +108,17 @@ sub loadAllCategories {
 sub loadAllHosts {
     my $self = shift;
 
-    $self->{hosts} = {};
+    $self->{hosts}               = {};
     $self->{host_htpl_relations} = {};
-    my $query = "SELECT h.host_id, h.host_name, host_tpl_id
+    my $query                    = "SELECT h.host_id, h.host_name, host_tpl_id
         FROM host h, host_template_relation htr
         WHERE h.host_activate = '1' AND h.host_id = htr.host_host_id";
-    my $sth = $self->{centreon}->query({ query => $query });
-    while (my $row = $sth->fetchrow_hashref()) {
-        $self->{hosts}->{ $row->{host_id} } = $row->{host_name} if (!defined($self->{hosts}->{ $row->{host_id} }));
-        $self->{host_htpl_relations}->{ $row->{host_id} } = [] if (!defined($self->{host_htpl_relations}->{ $row->{host_id} }));
+    my $sth                                               = $self->{centreon}->query({ query => $query });
+    while (my $row                                        = $sth->fetchrow_hashref()) {
+        $self->{hosts}->{ $row->{host_id} }               = $row->{host_name} if (!defined($self->{hosts}->{ $row
+            ->{host_id} }));
+        $self->{host_htpl_relations}->{ $row->{host_id} } = [] if (!defined($self->{host_htpl_relations}->{ $row
+            ->{host_id} }));
         push @{$self->{host_htpl_relations}->{ $row->{host_id} }}, $row->{host_tpl_id};
     }
 }
@@ -124,201 +128,201 @@ sub loadAllHosts {
 # each key of the hash table is a host id
 # each key is linked to a table containing entries like : "hostgroup_id;hostgroup_name"
 sub getHostGroups {
-	my $self = shift;
-	my $centreon = $self->{"centreon"};
-	my $activated = 1;
-	my $etlProperties = $self->{'etlProperties'};
-	if (@_) {
-		$activated  = 0;
-	}
-	my %result = ();
-	
-	my $query = "SELECT `host_id`, `host_name`, `hg_id`, `hg_name`".
-        " FROM `host`, `hostgroup_relation`, `hostgroup`".
-        " WHERE `host_register`='1'".
-        " AND `hostgroup_hg_id` = `hg_id`".
-        " AND `host_id`= `host_host_id`";
+    my $self          = shift;
+    my $centreon      = $self->{"centreon"};
+    my $activated     = 1;
+    my $etlProperties = $self->{'etlProperties'};
+    if (@_) {
+        $activated = 0;
+    }
+    my %result = ();
+
+    my $query = "SELECT `host_id`, `host_name`, `hg_id`, `hg_name`" .
+                " FROM `host`, `hostgroup_relation`, `hostgroup`" .
+                " WHERE `host_register`='1'" .
+                " AND `hostgroup_hg_id` = `hg_id`" .
+                " AND `host_id`= `host_host_id`";
     if ($activated == 1) {
         $query .= " AND `host_activate` ='1'";
     }
     if (!defined($etlProperties->{'dimension.all.hostgroups'}) && $etlProperties->{'dimension.hostgroups'} ne '') {
-        $query .= " AND `hg_id` IN (".$etlProperties->{'dimension.hostgroups'}.")"; 
+        $query .= " AND `hg_id` IN (" . $etlProperties->{'dimension.hostgroups'} . ")";
     }
-	my $sth = $centreon->query({ query => $query });
-	while (my $row = $sth->fetchrow_hashref()) {
-		my $new_entry = $row->{"hg_id"}.";".$row->{"hg_name"};
-		if (defined($result{$row->{"host_id"}})) {
-			my $tab_ref = $result{$row->{"host_id"}};
-			my @tab = @$tab_ref;
-			my $exists = 0;
-			foreach(@tab) {
-				if ($_ eq $new_entry) {
-					$exists = 1;
-					last;
-				}
-			}
-			if (!$exists) {
-				push @tab, $new_entry;
-			}
-			$result{$row->{"host_id"}} = \@tab;
-		}else {
-			my @tab = ($new_entry);
-			$result{$row->{"host_id"}} = \@tab;
-		}
-	}
-	$sth->finish();
-	return (\%result);
+    my $sth           = $centreon->query({ query => $query });
+    while (my $row    = $sth->fetchrow_hashref()) {
+        my $new_entry = $row->{"hg_id"} . ";" . $row->{"hg_name"};
+        if (defined($result{$row->{"host_id"}})) {
+            my $tab_ref = $result{$row->{"host_id"}};
+            my @tab     = @$tab_ref;
+            my $exists  = 0;
+            foreach (@tab) {
+                if ($_ eq $new_entry) {
+                    $exists = 1;
+                    last;
+                }
+            }
+            if (!$exists) {
+                push @tab, $new_entry;
+            }
+            $result{$row->{"host_id"}} = \@tab;
+        } else {
+            my @tab                    = ($new_entry);
+            $result{$row->{"host_id"}} = \@tab;
+        }
+    }
+    $sth->finish();
+    return (\%result);
 }
 
 #Fill a class Hash table that contains the relation between host_id and table[hc_id,hc_name]
 sub getHostCategoriesWithTemplate {
-	my $self	  = shift;
-	my $centreon  = $self->{"centreon"};
-	my $activated = 1;
+    my $self      = shift;
+    my $centreon  = $self->{"centreon"};
+    my $activated = 1;
 
-	#Hash : each key of the hash table is a host id
-	#each key is linked to a table containing entries like : "hc_id,hc_name"
-	my $hostCategoriesWithTemplate = $self->{'hostCategoriesWithTemplates'};
-	if (@_) {
-		$activated = 0;
-	}
+    #Hash : each key of the hash table is a host id
+    #each key is linked to a table containing entries like : "hc_id,hc_name"
+    my $hostCategoriesWithTemplate = $self->{'hostCategoriesWithTemplates'};
+    if (@_) {
+        $activated = 0;
+    }
 
-	my $query = "SELECT   `host_id` FROM `host` WHERE `host_activate` ='1'";
+    my $query = "SELECT   `host_id` FROM `host` WHERE `host_activate` ='1'";
 
-	my $sth		 = $centreon->query({ query => $query });
-	while (my $row  = $sth->fetchrow_hashref()) {
-		my @tab	 = ();
-		my $host_id = $row->{"host_id"};
-		$self->getRecursiveCategoriesForOneHost($host_id, \@tab);
-		$self->getDirectLinkedCategories($host_id, \@tab);
-		$hostCategoriesWithTemplate->{$row->{"host_id"}} = [@tab];
-		undef @tab;
-	}
-	$self->{'hostCategoriesWithTemplates'} = $hostCategoriesWithTemplate;
-	$sth->finish();
+    my $sth         = $centreon->query({ query => $query });
+    while (my $row  = $sth->fetchrow_hashref()) {
+        my @tab     = ();
+        my $host_id = $row->{"host_id"};
+        $self->getRecursiveCategoriesForOneHost($host_id, \@tab);
+        $self->getDirectLinkedCategories($host_id, \@tab);
+        $hostCategoriesWithTemplate->{$row->{"host_id"}} = [@tab];
+        undef @tab;
+    }
+    $self->{'hostCategoriesWithTemplates'} = $hostCategoriesWithTemplate;
+    $sth->finish();
 }
 
 #Get the link between host and categories using direct link hc <> host
 sub getDirectLinkedCategories {
-	my $self		  = shift;
-	my $host_id	   = shift;
-	my $ref_hostCat   = shift;
-	my $centreon	  = $self->{"centreon"};
-	my $etlProperties = $self->{"etlProperties"};
-	my @tab		   = ();
+    my $self          = shift;
+    my $host_id       = shift;
+    my $ref_hostCat   = shift;
+    my $centreon      = $self->{"centreon"};
+    my $etlProperties = $self->{"etlProperties"};
+    my @tab           = ();
 
-	my $query = "SELECT `host_id`, `host_name`, `hc_id`, `hc_name`" .
-				" FROM `host`, `hostcategories_relation`, `hostcategories`" .
-				" WHERE `host_register`='1'" .
-				" AND `hostcategories_hc_id` = `hc_id`" .
-				" AND `host_id`= `host_host_id`" .
-				" AND `host_id`= " . $host_id . " " .
-				" AND `host_activate` ='1' AND hostcategories.hc_activate = '1' ";
+    my $query = "SELECT `host_id`, `host_name`, `hc_id`, `hc_name`" .
+                " FROM `host`, `hostcategories_relation`, `hostcategories`" .
+                " WHERE `host_register`='1'" .
+                " AND `hostcategories_hc_id` = `hc_id`" .
+                " AND `host_id`= `host_host_id`" .
+                " AND `host_id`= " . $host_id . " " .
+                " AND `host_activate` ='1' AND hostcategories.hc_activate = '1' ";
 
-	if (!defined($etlProperties->{'dimension.all.hostcategories'}) && $etlProperties->{'dimension.hostcategories'}
-																	  ne '') {
-		$query .= " AND `hc_id` IN (" . $etlProperties->{'dimension.hostcategories'} . ")";
-	}
+    if (!defined($etlProperties->{'dimension.all.hostcategories'}) && $etlProperties->{'dimension.hostcategories'}
+                                                                      ne '') {
+        $query .= " AND `hc_id` IN (" . $etlProperties->{'dimension.hostcategories'} . ")";
+    }
 
-	my $sth		   = $centreon->query({ query => $query });
-	while (my $row	= $sth->fetchrow_hashref()) {
-		my $new_entry = $row->{"hc_id"} . ";" . $row->{"hc_name"};
-		if (!scalar(@$ref_hostCat)) {
-			@$ref_hostCat = ($new_entry);
-		} else {
-			@tab	   = @$ref_hostCat;
-			my $exists = 0;
-			foreach (@$ref_hostCat) {
-				if ($_ eq $new_entry) {
-					$exists = 1;
-					last;
-				}
-			}
-			if (!$exists) {
-				push @$ref_hostCat, $new_entry;
-			}
-		}
-	}
-	$sth->finish();
+    my $sth           = $centreon->query({ query => $query });
+    while (my $row    = $sth->fetchrow_hashref()) {
+        my $new_entry = $row->{"hc_id"} . ";" . $row->{"hc_name"};
+        if (!scalar(@$ref_hostCat)) {
+            @$ref_hostCat = ($new_entry);
+        } else {
+            @tab       = @$ref_hostCat;
+            my $exists = 0;
+            foreach (@$ref_hostCat) {
+                if ($_ eq $new_entry) {
+                    $exists = 1;
+                    last;
+                }
+            }
+            if (!$exists) {
+                push @$ref_hostCat, $new_entry;
+            }
+        }
+    }
+    $sth->finish();
 }
 
 #Get the link between host and categories using templates
 sub getRecursiveCategoriesForOneHost {
-	my $self		  = shift;
-	my $host_id	   = shift;
-	my $ref_hostCat   = shift;
-	my $centreon	  = $self->{"centreon"};
-	my $etlProperties = $self->{"etlProperties"};
+    my $self          = shift;
+    my $host_id       = shift;
+    my $ref_hostCat   = shift;
+    my $centreon      = $self->{"centreon"};
+    my $etlProperties = $self->{"etlProperties"};
 
 
-	#Get all categories linked to the templates associated with the host or just template associated with host to be able to call the method recursively
+    #Get all categories linked to the templates associated with the host or just template associated with host to be able to call the method recursively
 
-	my $query
-		= "SELECT host_id, host_name, template_id,template_name,  categories.hc_id as category_id, categories.hc_activate as hc_activate," .
-		  " categories.hc_name as category_name " .
-		  " FROM ( SELECT t1.host_id,t1.host_name,templates.host_id as template_id,templates.host_name as template_name " .
-		  " FROM host t1, host_template_relation t2, host templates " .
-		  " WHERE t1.host_id = t2.host_host_id AND t2.host_tpl_id = templates.host_id AND t1.host_activate ='1' AND t1.host_id = " . $host_id . " ) r1 " .
-		  " LEFT JOIN hostcategories_relation t3 ON t3.host_host_id = r1.template_id LEFT JOIN hostcategories categories ON t3.hostcategories_hc_id = categories.hc_id ";
+    my $query
+        = "SELECT host_id, host_name, template_id,template_name,  categories.hc_id as category_id, categories.hc_activate as hc_activate," .
+          " categories.hc_name as category_name " .
+          " FROM ( SELECT t1.host_id,t1.host_name,templates.host_id as template_id,templates.host_name as template_name " .
+          " FROM host t1, host_template_relation t2, host templates " .
+          " WHERE t1.host_id = t2.host_host_id AND t2.host_tpl_id = templates.host_id AND t1.host_activate ='1' AND t1.host_id = " . $host_id . " ) r1 " .
+          " LEFT JOIN hostcategories_relation t3 ON t3.host_host_id = r1.template_id LEFT JOIN hostcategories categories ON t3.hostcategories_hc_id = categories.hc_id ";
 
-	my @hostCategoriesAllowed = split /,/, $etlProperties->{'dimension.hostcategories'};
+    my @hostCategoriesAllowed = split /,/, $etlProperties->{'dimension.hostcategories'};
 
-	my $sth		= $centreon->query({ query => $query });
-	while (my $row = $sth->fetchrow_hashref()) {
-		my @tab	= ();
-		my $new_entry;
-		my $categoryId	   = $row->{"category_id"};
-		my $categoryName	 = $row->{"category_name"};
-		my $categoryActivate = $row->{"hc_activate"};
+    my $sth        = $centreon->query({ query => $query });
+    while (my $row = $sth->fetchrow_hashref()) {
+        my @tab    = ();
+        my $new_entry;
+        my $categoryId       = $row->{"category_id"};
+        my $categoryName     = $row->{"category_name"};
+        my $categoryActivate = $row->{"hc_activate"};
 
-		#If current category is in allowed categories in ETL configuration
-		#add it to the categories link to the host,
-		#Then check for templates categories recursively
-		if (defined($categoryId) && defined($categoryName) && $categoryActivate == '1') {
-			if ((grep { $_ eq $categoryId } @hostCategoriesAllowed) || (defined($etlProperties
-				->{'dimension.all.hostcategories'})					 &&										$etlProperties
-																													  ->{'dimension.all.hostcategories'}
-																												  ne '')) {
-				$new_entry = $categoryId . ";" . $categoryName;
-				#If no hostcat has been found for the host, create the line
-				if (!scalar(@$ref_hostCat)) {
-					@$ref_hostCat = ($new_entry);
-				} else {
-					#If the tab is not empty, check wether the combination already exists in the tab
-					@tab	   = @$ref_hostCat;
-					my $exists = 0;
-					foreach (@$ref_hostCat) {
-						if ($_ eq $new_entry) {
-							$exists = 1;
-							last;
-						}
-					}
-					#If the host category did not exist, add it to the table @$ref_hostCat
-					if (!$exists) {
-						push @$ref_hostCat, $new_entry;
-					}
-				}
-			}
-		}
-		$self->getRecursiveCategoriesForOneHost($row->{"template_id"}, $ref_hostCat);
-	}
-	$sth->finish();
+        #If current category is in allowed categories in ETL configuration
+        #add it to the categories link to the host,
+        #Then check for templates categories recursively
+        if (defined($categoryId) && defined($categoryName) && $categoryActivate == '1') {
+            if ((grep { $_ eq $categoryId } @hostCategoriesAllowed) || (defined($etlProperties
+                ->{'dimension.all.hostcategories'})                     &&                                        $etlProperties
+                                                                                                                      ->{'dimension.all.hostcategories'}
+                                                                                                                  ne '')) {
+                $new_entry = $categoryId . ";" . $categoryName;
+                #If no hostcat has been found for the host, create the line
+                if (!scalar(@$ref_hostCat)) {
+                    @$ref_hostCat = ($new_entry);
+                } else {
+                    #If the tab is not empty, check wether the combination already exists in the tab
+                    @tab       = @$ref_hostCat;
+                    my $exists = 0;
+                    foreach (@$ref_hostCat) {
+                        if ($_ eq $new_entry) {
+                            $exists = 1;
+                            last;
+                        }
+                    }
+                    #If the host category did not exist, add it to the table @$ref_hostCat
+                    if (!$exists) {
+                        push @$ref_hostCat, $new_entry;
+                    }
+                }
+            }
+        }
+        $self->getRecursiveCategoriesForOneHost($row->{"template_id"}, $ref_hostCat);
+    }
+    $sth->finish();
 }
 
 sub getHostGroupAndCategories {
     my $self = shift;
-	
+
     my $hostGroups = $self->getHostGroups();
 
-	$self->loadAllCategories();
-	$self->loadAllHosts();
-	$self->getHostCategoriesWithTemplate();
-	my $hostCategories = $self->{"hostCategoriesWithTemplates"};
-	my @results;
+    $self->loadAllCategories();
+    $self->loadAllHosts();
+    $self->getHostCategoriesWithTemplate();
+    my $hostCategories = $self->{"hostCategoriesWithTemplates"};
+    my @results;
 
-    while (my ($hostId, $groups) = each (%$hostGroups)) {
-        my $categories_ref = $hostCategories->{$hostId};
-        my @categoriesTab = ();
+    while (my ($hostId, $groups) = each(%$hostGroups)) {
+        my $categories_ref       = $hostCategories->{$hostId};
+        my @categoriesTab        = ();
         if (defined($categories_ref) && scalar(@$categories_ref)) {
             @categoriesTab = @$categories_ref;
         }
@@ -326,12 +330,12 @@ sub getHostGroupAndCategories {
         foreach (@$groups) {
             my $group = $_;
             if (scalar(@categoriesTab)) {
-                foreach(@categoriesTab) {
-                    push @results, $hostId . ';' .$hostName . ';' . $group . ';' . $_;
+                foreach (@categoriesTab) {
+                    push @results, $hostId . ';' . $hostName . ';' . $group . ';' . $_;
                 }
-    		} else {
+            } else {
                 #If there is no category
-                push @results, $hostId . ";" . $hostName . ";" .  $group . ";0;NoCategory";
+                push @results, $hostId . ";" . $hostName . ";" . $group . ";0;NoCategory";
             }
         }
     }

--- a/centreon-gorgone/gorgone/modules/centreon/mbi/libs/centreon/Host.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/mbi/libs/centreon/Host.pm
@@ -187,7 +187,7 @@ sub getHostCategoriesWithTemplate {
         $activated = 0;
     }
 
-    my $query = "SELECT   `host_id` FROM `host` WHERE `host_activate` ='1'";
+    my $query = "SELECT `host_id` FROM `host` WHERE `host_activate` ='1' AND `host_register` ='1'";
 
     my $sth         = $centreon->query({ query => $query });
     while (my $row  = $sth->fetchrow_hashref()) {
@@ -246,31 +246,67 @@ sub getDirectLinkedCategories {
     $sth->finish();
 }
 
+sub GetHostTemplateAndCategoryForOneHost {
+    my $self = shift;
+    my $host_id = shift;
+
+        my $query = << "EOQ";
+SELECT
+    hhtemplates.host_id,
+    hhtemplates.host_name,
+    hhtemplates.template_id,
+    hhtemplates.template_name,
+    categories.hc_id as category_id,
+    categories.hc_activate as hc_activate,
+    categories.hc_name as category_name
+FROM (
+    SELECT
+        hst.host_id,
+        hst.host_name,
+        htpls.host_id as template_id,
+        htpls.host_name as template_name
+    FROM
+        host hst
+    JOIN
+        host_template_relation hst_htpl_rel
+        ON
+            hst.host_id = hst_htpl_rel.host_host_id
+    JOIN
+        host htpls
+        ON
+            hst_htpl_rel.host_tpl_id = htpls.host_id
+    WHERE
+        hst.host_activate ='1'
+        AND hst.host_id = $host_id
+) hhtemplates
+LEFT JOIN
+    hostcategories_relation hcs_rel
+    ON
+        hcs_rel.host_host_id = hhtemplates.template_id
+LEFT JOIN
+    hostcategories categories
+    ON
+        hcs_rel.hostcategories_hc_id = categories.hc_id
+EOQ
+
+    return $self->{centreon}->query({ query => $query });
+
+}
+
 #Get the link between host and categories using templates
 sub getRecursiveCategoriesForOneHost {
     my $self          = shift;
     my $host_id       = shift;
     my $ref_hostCat   = shift;
-    my $centreon      = $self->{"centreon"};
     my $etlProperties = $self->{"etlProperties"};
 
-
     #Get all categories linked to the templates associated with the host or just template associated with host to be able to call the method recursively
-
-    my $query
-        = "SELECT host_id, host_name, template_id,template_name,  categories.hc_id as category_id, categories.hc_activate as hc_activate," .
-          " categories.hc_name as category_name " .
-          " FROM ( SELECT t1.host_id,t1.host_name,templates.host_id as template_id,templates.host_name as template_name " .
-          " FROM host t1, host_template_relation t2, host templates " .
-          " WHERE t1.host_id = t2.host_host_id AND t2.host_tpl_id = templates.host_id AND t1.host_activate ='1' AND t1.host_id = " . $host_id . " ) r1 " .
-          " LEFT JOIN hostcategories_relation t3 ON t3.host_host_id = r1.template_id LEFT JOIN hostcategories categories ON t3.hostcategories_hc_id = categories.hc_id ";
+    my $sth = $self->GetHostTemplateAndCategoryForOneHost($host_id);
 
     my @hostCategoriesAllowed = split /,/, $etlProperties->{'dimension.hostcategories'};
-
-    my $sth        = $centreon->query({ query => $query });
     while (my $row = $sth->fetchrow_hashref()) {
-        my @tab    = ();
         my $new_entry;
+        my @tab              = ();
         my $categoryId       = $row->{"category_id"};
         my $categoryName     = $row->{"category_name"};
         my $categoryActivate = $row->{"hc_activate"};
@@ -279,10 +315,9 @@ sub getRecursiveCategoriesForOneHost {
         #add it to the categories link to the host,
         #Then check for templates categories recursively
         if (defined($categoryId) && defined($categoryName) && $categoryActivate == '1') {
-            if ((grep { $_ eq $categoryId } @hostCategoriesAllowed) || (defined($etlProperties
-                ->{'dimension.all.hostcategories'})                     &&                                        $etlProperties
-                                                                                                                      ->{'dimension.all.hostcategories'}
-                                                                                                                  ne '')) {
+            if ((grep {$_ eq $categoryId} @hostCategoriesAllowed)
+            || (defined($etlProperties->{'dimension.all.hostcategories'})
+            && $etlProperties->{'dimension.all.hostcategories'} ne '')) {
                 $new_entry = $categoryId . ";" . $categoryName;
                 #If no hostcat has been found for the host, create the line
                 if (!scalar(@$ref_hostCat)) {


### PR DESCRIPTION
## Description

host category can be added to host template.
As host template are recursive (a host template can be a parent of another host template) we need to recursivly check every parent for category when adding host in mbi database.

**Fixes** # Refs:MON-37036


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x 
- [X] 24.10.x (master)

<h2> How this pull request can be tested ? </h2>

see jira, need to have a centreon db with one host using a host template, with a host category on the host template
launch /usr/share/centreon-bi/bin/centreonBIETL -r
host category should be present in mbi db.


## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
