### PR TITLE
chore: Cut off public routes manager

### DIFF
--- a/centreon/www/front_src/src/Main/Main.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Main/Main.cypress.spec.tsx
@@ -83,17 +83,17 @@ const initialize = ({ page = '/' }): void => {
 };
 
 describe('Main', () => {
-  it('displays the public page when a public url is entered', () => {
-    initialize({ page: '/public/dashboards/playlists/hash' });
+  // it('displays the public page when a public url is entered', () => {
+  //   initialize({ page: '/public/dashboards/playlists/hash' });
 
-    cy.waitForRequest('@platformVersions');
-    cy.waitForRequest('@translations');
+  //   cy.waitForRequest('@platformVersions');
+  //   cy.waitForRequest('@translations');
 
-    cy.contains(labelLogin).should('not.exist');
-    cy.contains('Cannot load module').should('be.visible');
+  //   cy.contains(labelLogin).should('not.exist');
+  //   cy.contains('Cannot load module').should('be.visible');
 
-    cy.makeSnapshot();
-  });
+  //   cy.makeSnapshot();
+  // });
 
   it('displays the login page by default', () => {
     initialize({});

--- a/centreon/www/front_src/src/Main/Provider.tsx
+++ b/centreon/www/front_src/src/Main/Provider.tsx
@@ -12,9 +12,9 @@ import AuthenticationDenied from '../FallbackPages/AuthenticationDenied';
 const LoginPage = lazy(() => import('../Login'));
 const ResetPasswordPage = lazy(() => import('../ResetPassword'));
 const AppPage = lazy(() => import('./InitializationPage'));
-const PublicPagesManager = lazy(
-  () => import('../publicPages/PublicPagesManager')
-);
+// const PublicPagesManager = lazy(
+//   () => import('../publicPages/PublicPagesManager')
+// );
 const Main = lazy(() => import('.'));
 
 export const store = createStore();
@@ -53,10 +53,10 @@ const Provider = (): JSX.Element | null => {
             Component: ResetPasswordPage,
             path: routeMap.resetPassword
           },
-          {
-            Component: PublicPagesManager,
-            path: routeMap.publicPages
-          },
+          // {
+          //   Component: PublicPagesManager,
+          //   path: routeMap.publicPages
+          // },
           {
             Component: AppPage,
             path: '*'


### PR DESCRIPTION
## Description

This removes the public routes manager for the 24.05

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x (master)

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
