### PR TITLE
fix(gorgone): test vault_count option before using it

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -458,7 +458,7 @@ sub get_macros_host {
             my $macro_value = $_->[1];
             my $is_password = $_->[2];
             # Replace macro value if a vault is used
-            if ($options{vault_count} > 0 && defined($is_password) && $is_password == 1) {
+            if (defined($options{vault_count}) && $options{vault_count} > 0 && defined($is_password) && $is_password == 1) {
                 set_macro(\%macros, $macro_name, "{" . $macro_name . "::secret::" . $macro_value . "}");
             } else {
                 set_macro(\%macros, $macro_name, $macro_value);
@@ -498,7 +498,7 @@ sub substitute_service_discovery_command {
     $command =~ s/\$HOSTADDRESS\$/$options{host}->{host_address}/g;
     $command =~ s/\$HOSTNAME\$/$options{host}->{host_name}/g;
 
-    if ($options{vault_count} > 0) {
+    if (defined($options{vault_count}) && $options{vault_count} > 0) {
         $command .= ' --pass-manager="centreonvault"';
     }
     


### PR DESCRIPTION
## Description

check vault_count value taken from database is not empty before using it.

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [X] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>
See initial ticket https://github.com/centreon/centreon/pull/3883

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
