### PR TITLE
enh(service_groups): add search capabilities to host categories endpoint

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -8,6 +8,7 @@ info:
     + Added host_category filter to /monitoring/hostgroups endpoint
     + Added new filters for the /monitoring/hosts/categories endpoint
     + Added new filters for the /monitoring/services/categories endpoint
+    + Added new filters to the /monitoring/servicegroups endpoint
     +
     # Information
     All dates are in **ISO 8601** format
@@ -2266,8 +2267,13 @@ paths:
         * host.display_name
         * host.state
         * poller.id
+        * service.id
+        * service.name
         * service.display_name
         * host_group.id
+        * host_group.name
+        * host_categories.id
+        * host_categories.name
 
       parameters:
         - $ref: '#/components/parameters/ShowService'

--- a/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1519,7 +1519,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         $shouldJoinHostCategory = false;
         if (count(array_intersect($searchParameters, array_keys($hostCategoryConcordanceArray))) > 0) {
             $shouldJoinHostCategory = true;
-            $serviceCategoryConcordanceArray = array_merge($serviceGroupConcordanceArray, $serviceCategoryConcordanceArray);
+            $serviceGroupConcordanceArray = array_merge($serviceGroupConcordanceArray, $hostCategoryConcordanceArray);
         }
 
         $this->sqlRequestTranslator->setConcordanceArray($serviceGroupConcordanceArray);

--- a/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1479,8 +1479,20 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             'poller.id' => 'h.instance_id'
         ];
 
+        $hostGroupConcordanceArray = [
+            'host_group.id' => 'host_groups.id',
+            'host_group.name' => 'host_groups.name'
+        ];
+
+        $hostCategoryConcordanceArray = [
+            'host_category.id' => 'host_categories.id',
+            'host_category.name' => 'host_categories.name'
+        ];
+
         // To allow to find service groups relating to Service information
         $serviceConcordanceArray = [
+            'service.id' => 'srv.service_id',
+            'service.name' => 'srv.description',
             'service.display_name' => 'srv.display_name',
         ];
 
@@ -1496,6 +1508,18 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         if (count(array_intersect($searchParameters, array_keys($serviceConcordanceArray))) > 0) {
             $shouldJoinService = true;
             $serviceGroupConcordanceArray = array_merge($serviceGroupConcordanceArray, $serviceConcordanceArray);
+        }
+
+        $shouldJoinHostGroup = false;
+        if (count(array_intersect($searchParameters, array_keys($hostGroupConcordanceArray))) > 0) {
+            $shouldJoinHostGroup = true;
+            $serviceGroupConcordanceArray = array_merge($serviceGroupConcordanceArray, $hostGroupConcordanceArray);
+        }
+
+        $shouldJoinHostCategory = false;
+        if (count(array_intersect($searchParameters, array_keys($hostCategoryConcordanceArray))) > 0) {
+            $shouldJoinHostCategory = true;
+            $serviceCategoryConcordanceArray = array_merge($serviceGroupConcordanceArray, $serviceCategoryConcordanceArray);
         }
 
         $this->sqlRequestTranslator->setConcordanceArray($serviceGroupConcordanceArray);
@@ -1530,23 +1554,54 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
         }
 
         // This join will only be added if a search parameter corresponding to one of the host or Service parameter
-        if ($shouldJoinHost || $shouldJoinService) {
+        /**
+         * 0 = service groups,
+         * 1 = host groups,
+         * 2 = service categories.
+         * 3 = host categories.
+         */
+        if (
+            $shouldJoinHost
+            || $shouldJoinService
+            || $shouldJoinHostGroup
+            || $shouldJoinHostCategory
+        ) {
             $subRequest .=
                 ' INNER JOIN `:dbstg`.services_servicegroups ssg
                     ON ssg.servicegroup_id = sg.servicegroup_id
-                    INNER JOIN `:dbstg`.hosts h
+                INNER JOIN `:dbstg`.hosts h
                     ON h.host_id = ssg.host_id
-                    AND h.enabled = \'1\'';
+                    AND h.enabled = \'1\'
+                INNER JOIN `:dbstg`.resources
+                    ON resources.id = h.host_id';
 
             if ($shouldJoinService) {
                 $subRequest .=
                 ' LEFT JOIN `:dbstg`.`services` srv
-                            ON srv.service_id = ssg.service_id
-                            AND srv.host_id = h.host_id
-                            AND srv.enabled = \'1\'';
+                    ON srv.service_id = ssg.service_id
+                    AND srv.host_id = h.host_id
+                    AND srv.enabled = \'1\'';
             }
 
-            if (!$this->isAdmin()) {
+            if ($shouldJoinHostGroup) {
+                $subRequest .=
+                    ' INNER JOIN `:dbstg`.resources_tags AS rtags_host_groups
+                        ON rtags_host_groups.resource_id = resources.resource_id
+                    INNER JOIN `:dbstg`.tags host_groups
+                        ON host_groups.tag_id = rtags_host_groups.tag_id
+                        AND host_groups.`type` = 1';
+            }
+
+            if ($shouldJoinHostCategory) {
+                $subRequest .=
+                    ' INNER JOIN `:dbstg`.resources_tags AS rtags_host_categories
+                        ON rtags_host_categories.resource_id = resources.resource_id
+                    INNER JOIN `:dbstg`.tags host_categories
+                        ON host_categories.tag_id = rtags_host_categories.tag_id
+                        AND host_categories.`type` = 3';
+            }
+
+            if (! $this->isAdmin()) {
                 $subRequest .=
                     ' INNER JOIN `:dbstg`.`centreon_acl` acl
                         ON acl.host_id = h.host_id

--- a/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1572,6 +1572,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 INNER JOIN `:dbstg`.hosts h
                     ON h.host_id = ssg.host_id
                     AND h.enabled = \'1\'
+                    AND h.host_register = \'1\'
                 INNER JOIN `:dbstg`.resources
                     ON resources.id = h.host_id';
 
@@ -1580,7 +1581,8 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 ' LEFT JOIN `:dbstg`.`services` srv
                     ON srv.service_id = ssg.service_id
                     AND srv.host_id = h.host_id
-                    AND srv.enabled = \'1\'';
+                    AND srv.enabled = \'1\'
+                    AND srv.service_register = \'1\'';
             }
 
             if ($shouldJoinHostGroup) {


### PR DESCRIPTION
This PR intends to add a host_group search capability to the realtime servicegroups endpoint.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
