### PR TITLE
chore(vault): move vault configuration from /usr/share/centreon/config to var/lib/centreon

### DIFF
--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -18,7 +18,7 @@ parameters:
     validation_path: "%env(_CENTREON_PATH_)%config/packages/validator"
     centreon_path: "%env(_CENTREON_PATH_)%"
     centreon_etc_path: "%env(_CENTREON_ETC_)%"
-    vault_conf_path: "%env(_CENTREON_PATH_)%config/vault/vault.yaml"
+    vault_conf_path: "%centreon_var_lib%/vault/vault.yaml"
     centreon_install_path: "%centreon_path%/www/install"
     translation_path: "%centreon_path%/www/locale"
     log_path: "%env(_CENTREON_LOG_)%"

--- a/centreon/packaging/centreon-web.yaml
+++ b/centreon/packaging/centreon-web.yaml
@@ -260,13 +260,6 @@ contents:
     file_info:
       mode: 0664
 
-  - dst: "/var/lib/centreon/vault"
-    type: dir
-    file_info:
-      owner: "centreon"
-      group: "centreon"
-      mode: 0775
-
   - src: "../cron"
     dst: "/usr/share/centreon/cron"
     file_info:
@@ -339,6 +332,14 @@ contents:
     file_info:
       owner: "centreon-broker"
       group: "centreon-broker"
+
+
+  - dst: "/var/lib/centreon/vault"
+    type: dir
+    file_info:
+      owner: "centreon"
+      group: "centreon"
+      mode: 0775
 
   - dst: "/var/lib/centreon/installs"
     type: dir

--- a/centreon/packaging/centreon-web.yaml
+++ b/centreon/packaging/centreon-web.yaml
@@ -260,7 +260,7 @@ contents:
     file_info:
       mode: 0664
 
-  - dst: "/usr/share/centreon/config/vault"
+  - dst: "/var/lib/centreon/vault"
     type: dir
     file_info:
       owner: "centreon"


### PR DESCRIPTION
this PR intends to move vault configuration from /usr/share/centreon/config to var/lib/centreon as it is a more suitable folder for this file.

**Fixes** # MON-88909

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
