### PR TITLE
ci(codeowners) remove php team from Gorgone ownership and add robot team for robot tests.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,54 +1,59 @@
-*.sh                    @centreon/owners-bash
+*.sh                                    @centreon/owners-bash
 
-*.po                    @centreon/owners-doc
-*.md                    @centreon/owners-doc
-*.mdx                   @centreon/owners-doc
+*.po                                    @centreon/owners-doc
+*.md                                    @centreon/owners-doc
+*.mdx                                   @centreon/owners-doc
 
-**/config/              @centreon/owners-php
-**/composer.*           @centreon/owners-php
-**/tests/api/           @centreon/owners-php
-**/tests/php/           @centreon/owners-php
-**/tests/clapi_export/  @centreon/owners-php
-**/www/                 @centreon/owners-php
-**/tmpl/                @centreon/owners-php
-**/bin/                 @centreon/owners-php
-*.xml                   @centreon/owners-php
-**/phpstan.neon         @centreon/owners-php
-*.php                   @centreon/owners-php
-*.xsl                   @centreon/owners-php
+**/config/                              @centreon/owners-php
+**/composer.*                           @centreon/owners-php
+**/tests/api/                           @centreon/owners-php
+**/tests/php/                           @centreon/owners-php
+**/tests/clapi_export/                  @centreon/owners-php
+**/www/                                 @centreon/owners-php
+**/tmpl/                                @centreon/owners-php
+**/bin/                                 @centreon/owners-php
+*.xml                                   @centreon/owners-php
+**/phpstan.neon                         @centreon/owners-php
+*.php                                   @centreon/owners-php
+*.xsl                                   @centreon/owners-php
 
-**/www/front_src/       @centreon/owners-react
-**/www/widgets/         @centreon/owners-react
-**/cypress/**           @centreon/owners-react
-centreon/cypress        @centreon/owners-react
-package.json            @centreon/owners-react
-package-lock.json       @centreon/owners-react
-webpack*                @centreon/owners-react
-babel.config.js         @centreon/owners-react
-tsconfig.json           @centreon/owners-react
-.prettierrc.js          @centreon/owners-react
-.eslint*                @centreon/owners-react
-.csslintrc              @centreon/owners-react
-*.ts                    @centreon/owners-react
-*.tsx                   @centreon/owners-react
-*.jsx                   @centreon/owners-react
-**/cypress/**           @centreon/owners-react
+**/www/front_src/                       @centreon/owners-react
+**/www/widgets/                         @centreon/owners-react
+**/cypress/**                           @centreon/owners-react
+centreon/cypress                        @centreon/owners-react
+package.json                            @centreon/owners-react
+package-lock.json                       @centreon/owners-react
+webpack*                                @centreon/owners-react
+babel.config.js                         @centreon/owners-react
+tsconfig.json                           @centreon/owners-react
+.prettierrc.js                          @centreon/owners-react
+.eslint*                                @centreon/owners-react
+.csslintrc                              @centreon/owners-react
+*.ts                                    @centreon/owners-react
+*.tsx                                   @centreon/owners-react
+*.jsx                                   @centreon/owners-react
+**/cypress/**                           @centreon/owners-react
 
-*.pm                    @centreon/owners-perl
-*.pl                    @centreon/owners-perl
+centreon-gorgone/                       @centreon/owners-perl
+centreon-gorgone/docs/                  @centreon/owners-doc
+centreon-gorgone/tests/                 @centreon/owners-robot-e2e
 
-**/tests/e2e/**         @centreon/owners-cypress-e2e
-**/cypress/e2e/**       @centreon/owners-cypress-e2e
+centreon-gorgone/tests/robot/config/    @centreon/owners-perl
+*.pm                                    @centreon/owners-perl
+*.pl                                    @centreon/owners-perl
 
-*.feature               @centreon/owners-gherkin
+**/tests/e2e/**                         @centreon/owners-cypress-e2e
+**/cypress/e2e/**                       @centreon/owners-cypress-e2e
 
-*.py                    @centreon/owners-python
+*.feature                               @centreon/owners-gherkin
 
-.github/**              @centreon/owners-pipelines
-**/.project             @centreon/owners-pipelines
-**/selinux/             @centreon/owners-pipelines
-**/project/             @centreon/owners-pipelines
-**/packaging/           @centreon/owners-pipelines
-dependencies/**         @centreon/owners-pipelines
+*.py                                    @centreon/owners-python
+
+.github/**                              @centreon/owners-pipelines
+**/.project                             @centreon/owners-pipelines
+**/selinux/                             @centreon/owners-pipelines
+**/project/                             @centreon/owners-pipelines
+**/packaging/                           @centreon/owners-pipelines
+dependencies/**                         @centreon/owners-pipelines
 
 **/config/features.json @centreon/release-management


### PR DESCRIPTION
## Description

Due to CODEOWNERS file, php team was added as reviewer on gorgone pr when config/ folder where changed.
This PR aim to remove php team from gorgone review, and add robot-e2e team for robot tests in gorgone.


**Fixes** # (MON-78779)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>
make a pr change specific file in centreon-gorgone and check what team is set for review by github.
(https://github.com/snyk/github-codeowners is a good test in local before pushing)
## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
