### PR TITLE
fix(config-generate): service categories fix the export configuration

### DIFF
--- a/centreon/www/class/config-generate/severity.class.php
+++ b/centreon/www/class/config-generate/severity.class.php
@@ -274,6 +274,7 @@ class Severity extends AbstractObject
     public function getServiceSeverityMappingHostSeverityByName($hc_name)
     {
         if (isset($this->service_severity_by_name_cache[$hc_name])) {
+            $this->service_severities[$this->service_severity_by_name_cache[$hc_name]['sc_id']] = $this->service_severity_by_name_cache[$hc_name];
             return $this->service_severity_by_name_cache[$hc_name];
         }
         if ($this->done_cache == 1) {
@@ -298,8 +299,9 @@ class Severity extends AbstractObject
         }
 
         $this->service_severity_by_name_cache[$hc_name] = &$severity;
-        $this->service_severity_cache[$hc_name] = &$severity;
-        return $severity['sc_id'];
+        $this->service_severity_cache[$severity['sc_id']] = &$severity;
+        $this->service_severities[$severity['sc_id']] = $this->service_severity_cache[$severity['sc_id']];
+        return $severity;
     }
 
     /**


### PR DESCRIPTION
## Description

A feature is not working anymore (since the severities.cfg engine file). When we export the configuration, we have the following error:

`Could not add the severity (xy, 0) to the service on export of configuration`

The feature is: applied the host category to all services. To do that, you need to create a service category with the same name that the host category used on your host.

**Fixes** # (MON-92657)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

> Create a host category prod with a severity level 1
> Create a service category prod with a severity level 1
> Link the host category severity prod on a host

If we export the configuration, we have errors.

**Warning: if your service category severity ````prod``` is linked to any services, you won't have the error (because the service category will be exported. It's a workaround to make it work without the patch)

Checklist

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
