### PR TITLE
enh(conf): call API to save a new host template

### DIFF
--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -7083,12 +7083,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "48ea4267a6e477b043642e88b147fbe45599ff72"
+                "reference": "d686936d55f7d2d20ee3ebcece13c12c6e6001db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/48ea4267a6e477b043642e88b147fbe45599ff72",
-                "reference": "48ea4267a6e477b043642e88b147fbe45599ff72",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/d686936d55f7d2d20ee3ebcece13c12c6e6001db",
+                "reference": "d686936d55f7d2d20ee3ebcece13c12c6e6001db",
                 "shasum": ""
             },
             "require": {
@@ -7138,7 +7138,7 @@
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
                 "source": "https://github.com/centreon/centreon-test-lib/tree/master"
             },
-            "time": "2024-05-21T09:15:29+00:00"
+            "time": "2024-06-03T09:51:01+00:00"
         },
         {
             "name": "composer/pcre",
@@ -12165,5 +12165,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -77,10 +77,13 @@ services:
     Core\Infrastructure\Common\Api\Router:
         decorates: router
         arguments: ['@.inner']
+        public: true
 
     Symfony\Component\Finder\Finder:
         shared: false
 
+    Symfony\Component\HttpClient\CurlHttpClient:
+        public: true
 
     # Security
     Security\Domain\Authentication\Interfaces\AuthenticationRepositoryInterface:

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -82,8 +82,6 @@ services:
     Symfony\Component\Finder\Finder:
         shared: false
 
-    Symfony\Component\HttpClient\CurlHttpClient:
-        public: true
 
     # Security
     Security\Domain\Authentication\Interfaces\AuthenticationRepositoryInterface:

--- a/centreon/features/bootstrap/DisableFieldsOnBlockedObjectsContext.php
+++ b/centreon/features/bootstrap/DisableFieldsOnBlockedObjectsContext.php
@@ -1,8 +1,8 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\HostTemplateConfigurationPage;
 use Centreon\Test\Behat\Configuration\HostTemplateConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\HostTemplateConfigurationPage;
 
 class DisableFieldsOnBlockedObjectsContext extends CentreonContext
 {
@@ -15,7 +15,6 @@ class DisableFieldsOnBlockedObjectsContext extends CentreonContext
         $newHostTemplate->setProperties(array(
             'name' => 'myHostTemplate',
             'alias' => 'myAlias',
-            'address' => '127.0.0.1',
             'macros' => array('macro1' => '001')
         ));
 

--- a/centreon/features/bootstrap/HostConfigurationContext.php
+++ b/centreon/features/bootstrap/HostConfigurationContext.php
@@ -1,10 +1,10 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\HostConfigurationPage;
-use Centreon\Test\Behat\Configuration\HostConfigurationListingPage;
-use Centreon\Test\Behat\Configuration\HostGroupConfigurationPage;
 use Centreon\Test\Behat\Configuration\HostCategoryConfigurationPage;
+use Centreon\Test\Behat\Configuration\HostConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\HostConfigurationPage;
+use Centreon\Test\Behat\Configuration\HostGroupConfigurationPage;
 use Centreon\Test\Behat\Configuration\HostTemplateConfigurationPage;
 
 class HostConfigurationContext extends CentreonContext
@@ -92,18 +92,12 @@ class HostConfigurationContext extends CentreonContext
         'parent_host_categories' => 'hostCategoryName2',
         'parent_hosts' => 'Centreon-Server',
         'child_hosts' => 'hostName2',
-        'obsess_over_host' => 2,
         'acknowledgement_timeout' => 2,
         'check_freshness' => 1,
         'freshness_threshold' => 34,
         'flap_detection_enabled' => 1,
         'low_flap_threshold' => 67,
         'high_flap_threshold' => 85,
-        'retain_status_information' => 2,
-        'retain_non_status_information' => 0,
-        'stalking_option_on_up' => 1,
-        'stalking_option_on_down' => 0,
-        'stalking_option_on_unreachable' => 1,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
         'event_handler_arguments' => 'event_handler_arguments',
@@ -112,10 +106,7 @@ class HostConfigurationContext extends CentreonContext
         'action_url' => 'hostMassiveChangeActionUrl',
         'icon' => 'centreon (png)',
         'alt_icon' => 'hostMassiveChangeIcon',
-        'status_map_image' => '',
         'geo_coordinates' => '2.3522219,48.856614',
-        '2d_coords' => '15,84',
-        '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategoryName1 (2)',
         'comments' => 'hostMassiveChangeComments'
     );
@@ -155,18 +146,12 @@ class HostConfigurationContext extends CentreonContext
         'parent_host_categories' => 'hostCategoryName2',
         'parent_hosts' => 'Centreon-Server',
         'child_hosts' => 'hostName2',
-        'obsess_over_host' => 2,
         'acknowledgement_timeout' => 2,
         'check_freshness' => 1,
         'freshness_threshold' => 34,
         'flap_detection_enabled' => 1,
         'low_flap_threshold' => 67,
         'high_flap_threshold' => 85,
-        'retain_status_information' => 2,
-        'retain_non_status_information' => 0,
-        'stalking_option_on_up' => 1,
-        'stalking_option_on_down' => 0,
-        'stalking_option_on_unreachable' => 1,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
         'event_handler_arguments' => 'event_handler_arguments',
@@ -175,10 +160,7 @@ class HostConfigurationContext extends CentreonContext
         'action_url' => 'hostMassiveChangeActionUrl',
         'icon' => 'centreon (png)',
         'alt_icon' => 'hostMassiveChangeIcon',
-        'status_map_image' => '',
         'geo_coordinates' => '2.3522219,48.856614',
-        '2d_coords' => '15,84',
-        '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategoryName1 (2)',
         'comments' => 'hostMassiveChangeComments'
     );
@@ -221,18 +203,12 @@ class HostConfigurationContext extends CentreonContext
         'parent_host_categories' => 'hostCategoryName3',
         'parent_hosts' => 'hostName3',
         'child_hosts' => 'Centreon-Server',
-        'obsess_over_host' => 1,
         'acknowledgement_timeout' => 0,
         'check_freshness' => 2,
         'freshness_threshold' => 65,
         'flap_detection_enabled' => 0,
         'low_flap_threshold' => 38,
         'high_flap_threshold' => 51,
-        'retain_status_information' => 1,
-        'retain_non_status_information' => 1,
-        'stalking_option_on_up' => 0,
-        'stalking_option_on_down' => 1,
-        'stalking_option_on_unreachable' => 0,
         'event_handler_enabled' => 1,
         'event_handler' => 'check_http',
         'event_handler_arguments' => 'eventHandlerArgumentsChanged',
@@ -241,10 +217,7 @@ class HostConfigurationContext extends CentreonContext
         'action_url' => 'hostMassiveChangeActionUrlChanged',
         'icon' => '',
         'alt_icon' => 'hostMassiveChangeIconChanged',
-        'status_map_image' => 'centreon (png)',
         'geo_coordinates' => '2.3522219,48.856614',
-        '2d_coords' => '2,3',
-        '3d_coords' => '42,24,66',
         'severity_level' => '',
         'comments' => 'hostMassiveChangeCommentsChanged'
     );

--- a/centreon/features/bootstrap/HostTemplateBasicsOperationsContext.php
+++ b/centreon/features/bootstrap/HostTemplateBasicsOperationsContext.php
@@ -1,9 +1,9 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\HostTemplateConfigurationPage;
-use Centreon\Test\Behat\Configuration\HostTemplateConfigurationListingPage;
 use Centreon\Test\Behat\Configuration\HostCategoryConfigurationPage;
+use Centreon\Test\Behat\Configuration\HostTemplateConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\HostTemplateConfigurationPage;
 
 class HostTemplateBasicsOperationsContext extends CentreonContext
 {
@@ -39,7 +39,6 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
     protected $initialProperties = array(
         'name' => 'hostTemplateName',
         'alias' => 'hostTemplateAlias',
-        'address' => 'hostTemplate@localhost',
         'snmp_community' => 'snmp',
         'snmp_version' => '2c',
         'location' => 'Europe/Paris',
@@ -47,7 +46,7 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
             'generic-host'
         ),
         'check_command' => 'check_http',
-        'command_arguments' => 'hostTemplateCommandArgument',
+        'command_arguments' => '!hostTemplateCommandArgument',
         'macros' => array(
             'HOSTTEMPLATEMACRONAME' => '22'
         ),
@@ -72,29 +71,20 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
         'recovery_notification_delay' => 3,
         'service_templates' => 'generic-service',
         'parent_host_categories' => 'hostCategory3Name',
-        'obsess_over_host' => 2,
         'acknowledgement_timeout' => 2,
         'check_freshness' => 0,
         'freshness_threshold' => 34,
         'flap_detection_enabled' => 1,
         'low_flap_threshold' => 67,
         'high_flap_threshold' => 85,
-        'retain_status_information' => 2,
-        'retain_non_status_information' => 0,
-        'stalking_option_on_up' => 1,
-        'stalking_option_on_down' => 0,
-        'stalking_option_on_unreachable' => 1,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
-        'event_handler_arguments' => 'event_handler_arguments',
+        'event_handler_arguments' => '!event_handler_arguments',
         'url' => 'hostTemplateChangeUrl',
         'notes' => 'hostTemplateChangeNotes',
         'action_url' => 'hostTemplateChangeActionUrl',
         'icon' => 'centreon (png)',
         'alt_icon' => 'hostTemplateChangeIcon',
-        'status_map_image' => '',
-        '2d_coords' => '15,84',
-        '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategory1Name (2)',
         'comments' => 'hostTemplateChangeComments'
     );
@@ -102,7 +92,6 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
     protected $duplicatedProperties = array(
         'name' => 'hostTemplateName_1',
         'alias' => 'hostTemplateAlias',
-        'address' => 'hostTemplate@localhost',
         'snmp_community' => self::PASSWORD_REPLACEMENT_VALUE,
         'snmp_version' => '2c',
         'location' => 'Europe/Paris',
@@ -110,7 +99,7 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
             'generic-host'
         ),
         'check_command' => 'check_http',
-        'command_arguments' => 'hostTemplateCommandArgument',
+        'command_arguments' => '!hostTemplateCommandArgument',
         'macros' => array(
             'HOSTTEMPLATEMACRONAME' => '22'
         ),
@@ -135,29 +124,20 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
         'recovery_notification_delay' => 3,
         'service_templates' => 'generic-service',
         'parent_host_categories' => 'hostCategory3Name',
-        'obsess_over_host' => 2,
         'acknowledgement_timeout' => 2,
         'check_freshness' => 0,
         'freshness_threshold' => 34,
         'flap_detection_enabled' => 1,
         'low_flap_threshold' => 67,
         'high_flap_threshold' => 85,
-        'retain_status_information' => 2,
-        'retain_non_status_information' => 0,
-        'stalking_option_on_up' => 1,
-        'stalking_option_on_down' => 0,
-        'stalking_option_on_unreachable' => 1,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
-        'event_handler_arguments' => 'event_handler_arguments',
+        'event_handler_arguments' => '!event_handler_arguments',
         'url' => 'hostTemplateChangeUrl',
         'notes' => 'hostTemplateChangeNotes',
         'action_url' => 'hostTemplateChangeActionUrl',
         'icon' => 'centreon (png)',
         'alt_icon' => 'hostTemplateChangeIcon',
-        'status_map_image' => '',
-        '2d_coords' => '15,84',
-        '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategory1Name (2)',
         'comments' => 'hostTemplateChangeComments'
     );
@@ -165,7 +145,6 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
     protected $update = array(
         'name' => 'hostTemplateNameChanged',
         'alias' => 'hostTemplateAliasChanged',
-        'address' => 'hostTemplate@localhostChanged',
         'snmp_community' => 'snmpChanged',
         'snmp_version' => '3',
         'location' => 'Europe/Paris',
@@ -173,7 +152,7 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
             'Printers'
         ),
         'check_command' => 'check_https',
-        'command_arguments' => 'hostTemplateCommandArgumentChanged',
+        'command_arguments' => '!hostTemplateCommandArgumentChanged',
         'macros' => array(
             'HOSTTEMPLATEMACRONAMECHANGED' => '11'
         ),
@@ -198,29 +177,20 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
         'recovery_notification_delay' => 8,
         'service_templates' => 'Ping-LAN',
         'parent_host_categories' => 'hostCategory4Name',
-        'obsess_over_host' => 1,
         'acknowledgement_timeout' => 0,
         'check_freshness' => 1,
         'freshness_threshold' => 15,
         'flap_detection_enabled' => 0,
         'low_flap_threshold' => 25,
         'high_flap_threshold' => 34,
-        'retain_status_information' => 1,
-        'retain_non_status_information' => 1,
-        'stalking_option_on_up' => 0,
-        'stalking_option_on_down' => 1,
-        'stalking_option_on_unreachable' => 0,
         'event_handler_enabled' => 1,
         'event_handler' => 'check_http',
-        'event_handler_arguments' => 'event_handler_argumentsChanged',
+        'event_handler_arguments' => '!event_handler_argumentsChanged',
         'url' => 'hostTemplateChangeUrlChanged',
         'notes' => 'hostTemplateChangeNotesChanged',
         'action_url' => 'hostTemplateChangeActionUrlChanged',
         'icon' => '',
         'alt_icon' => 'hostTemplateChangeIconChanged',
-        'status_map_image' => 'centreon (png)',
-        '2d_coords' => '48,29',
-        '3d_coords' => '09,25,27',
         'severity_level' => 'hostCategory2Name (13)',
         'comments' => 'hostTemplateChangeCommentsChanged'
     );
@@ -228,7 +198,6 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
     protected $updatedProperties = array(
         'name' => 'hostTemplateNameChanged',
         'alias' => 'hostTemplateAliasChanged',
-        'address' => 'hostTemplate@localhostChanged',
         'snmp_community' => self::PASSWORD_REPLACEMENT_VALUE,
         'snmp_version' => '3',
         'location' => 'Europe/Paris',
@@ -236,7 +205,7 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
             'Printers'
         ),
         'check_command' => 'check_https',
-        'command_arguments' => 'hostTemplateCommandArgumentChanged',
+        'command_arguments' => '!hostTemplateCommandArgumentChanged',
         'macros' => array(
             'HOSTTEMPLATEMACRONAME' => '22',
             'HOSTTEMPLATEMACRONAMECHANGED' => '11'
@@ -262,29 +231,20 @@ class HostTemplateBasicsOperationsContext extends CentreonContext
         'recovery_notification_delay' => 8,
         'service_templates' => 'Ping-LAN',
         'parent_host_categories' => 'hostCategory4Name',
-        'obsess_over_host' => 1,
         'acknowledgement_timeout' => 0,
         'check_freshness' => 1,
         'freshness_threshold' => 15,
         'flap_detection_enabled' => 0,
         'low_flap_threshold' => 25,
         'high_flap_threshold' => 34,
-        'retain_status_information' => 1,
-        'retain_non_status_information' => 1,
-        'stalking_option_on_up' => 0,
-        'stalking_option_on_down' => 1,
-        'stalking_option_on_unreachable' => 0,
         'event_handler_enabled' => 1,
         'event_handler' => 'check_http',
-        'event_handler_arguments' => 'event_handler_argumentsChanged',
+        'event_handler_arguments' => '!event_handler_argumentsChanged',
         'url' => 'hostTemplateChangeUrlChanged',
         'notes' => 'hostTemplateChangeNotesChanged',
         'action_url' => 'hostTemplateChangeActionUrlChanged',
         'icon' => '',
         'alt_icon' => 'hostTemplateChangeIconChanged',
-        'status_map_image' => 'centreon (png)',
-        '2d_coords' => '48,29',
-        '3d_coords' => '09,25,27',
         'severity_level' => 'hostCategory2Name (13)',
         'comments' => 'hostTemplateChangeCommentsChanged'
     );

--- a/centreon/features/bootstrap/MassiveChangeHostsContext.php
+++ b/centreon/features/bootstrap/MassiveChangeHostsContext.php
@@ -1,11 +1,11 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\MassiveChangeHostConfigurationPage;
-use Centreon\Test\Behat\Configuration\HostConfigurationPage;
-use Centreon\Test\Behat\Configuration\HostConfigurationListingPage;
-use Centreon\Test\Behat\Configuration\HostGroupConfigurationPage;
 use Centreon\Test\Behat\Configuration\HostCategoryConfigurationPage;
+use Centreon\Test\Behat\Configuration\HostConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\HostConfigurationPage;
+use Centreon\Test\Behat\Configuration\HostGroupConfigurationPage;
+use Centreon\Test\Behat\Configuration\MassiveChangeHostConfigurationPage;
 
 class MassiveChangeHostsContext extends CentreonContext
 {
@@ -95,18 +95,12 @@ class MassiveChangeHostsContext extends CentreonContext
         'parent_hosts' => 'Centreon-Server',
         'update_mode_hch' => 0,
         'child_hosts' => 'host3Name',
-        'obsess_over_host' => 2,
         'acknowledgement_timeout' => 2,
         'check_freshness' => 0,
         'freshness_threshold' => 34,
         'flap_detection_enabled' => 1,
         'low_flap_threshold' => 67,
         'high_flap_threshold' => 85,
-        'retain_status_information' => 2,
-        'retain_non_status_information' => 0,
-        'stalking_option_on_up' => 1,
-        'stalking_option_on_down' => 0,
-        'stalking_option_on_unreachable' => 1,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
         'event_handler_arguments' => 'event_handler_arguments',
@@ -115,10 +109,7 @@ class MassiveChangeHostsContext extends CentreonContext
         'action_url' => 'hostMassiveChangeActionUrl',
         'icon' => 'centreon (png)',
         'alt_icon' => 'hostMassiveChangeIcon',
-        'status_map_image' => 'centreon (png)',
         'geo_coordinates' => '2.3522219,48.856614',
-        '2d_coords' => '15,84',
-        '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategoryName1 (2)',
         'comments' => 'hostMassiveChangeComments'
     );
@@ -163,18 +154,12 @@ class MassiveChangeHostsContext extends CentreonContext
         'parent_host_categories' => 'hostCategoryName2',
         'parent_hosts' => 'Centreon-Server',
         'child_hosts' => 'host3Name',
-        'obsess_over_host' => 2,
         'acknowledgement_timeout' => 2,
         'check_freshness' => 0,
         'freshness_threshold' => 34,
         'flap_detection_enabled' => 1,
         'low_flap_threshold' => 67,
         'high_flap_threshold' => 85,
-        'retain_status_information' => 2,
-        'retain_non_status_information' => 0,
-        'stalking_option_on_up' => 1,
-        'stalking_option_on_down' => 0,
-        'stalking_option_on_unreachable' => 1,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
         'event_handler_arguments' => 'event_handler_arguments',
@@ -183,10 +168,7 @@ class MassiveChangeHostsContext extends CentreonContext
         'action_url' => 'hostMassiveChangeActionUrl',
         'icon' => 'centreon (png)',
         'alt_icon' => 'hostMassiveChangeIcon',
-        'status_map_image' => 'centreon (png)',
         'geo_coordinates' => '2.3522219,48.856614',
-        '2d_coords' => '15,84',
-        '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategoryName1 (2)',
         'comments' => 'hostMassiveChangeComments'
     );
@@ -231,18 +213,12 @@ class MassiveChangeHostsContext extends CentreonContext
         'parent_host_categories' => 'hostCategoryName2',
         'parent_hosts' => 'Centreon-Server',
         'child_hosts' => 'host3Name',
-        'obsess_over_host' => 2,
         'acknowledgement_timeout' => 2,
         'check_freshness' => 0,
         'freshness_threshold' => 34,
         'flap_detection_enabled' => 1,
         'low_flap_threshold' => 67,
         'high_flap_threshold' => 85,
-        'retain_status_information' => 2,
-        'retain_non_status_information' => 0,
-        'stalking_option_on_up' => 1,
-        'stalking_option_on_down' => 0,
-        'stalking_option_on_unreachable' => 1,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
         'event_handler_arguments' => 'event_handler_arguments',
@@ -251,10 +227,7 @@ class MassiveChangeHostsContext extends CentreonContext
         'action_url' => 'hostMassiveChangeActionUrl',
         'icon' => 'centreon (png)',
         'alt_icon' => 'hostMassiveChangeIcon',
-        'status_map_image' => 'centreon (png)',
         'geo_coordinates' => '2.3522219,48.856614',
-        '2d_coords' => '15,84',
-        '3d_coords' => '15,84,76',
         'severity_level' => 'hostCategoryName1 (2)',
         'comments' => 'hostMassiveChangeComments'
     );

--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -78,7 +78,7 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
      */
     public function generate(string $name, array $parameters = [], int $referenceType = self::ABSOLUTE_PATH): string
     {
-        $parameters['base_uri'] = $this->getBaseUri();
+        $parameters['base_uri'] ??= $this->getBaseUri();
         if (! empty($parameters['base_uri'])) {
             $parameters['base_uri'] .= '/';
         }

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3196,9 +3196,7 @@ function insertHostByApi(array $formData, bool $isCloudPlatform, string $basePat
     /** @var Core\Infrastructure\Common\Api\Router $router */
     $router = $kernel->getContainer()->get(Core\Infrastructure\Common\Api\Router::class)
         ?? throw new LogicException('Router not found in container');
-    /** @var Symfony\Component\HttpClient\CurlHttpClient */
-    $client = $kernel->getContainer()->get(Symfony\Component\HttpClient\CurlHttpClient::class)
-        ?? throw new LogicException('CurlHttpClient not found in container');
+    $client = new Symfony\Component\HttpClient\CurlHttpClient();
 
 
     $payload = getPayloadForHostTemplate($isCloudPlatform, $formData);

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -43,6 +43,8 @@ require_once _CENTREON_PATH_ . 'www/class/centreonContactgroup.class.php';
 require_once _CENTREON_PATH_ . 'www/class/centreonACL.class.php';
 require_once _CENTREON_PATH_ . 'www/include/common/vault-functions.php';
 
+use Core\Host\Application\Converter\HostEventConverter;
+
 /**
  * Quickform rule that checks whether or not monitoring server can be set
  *
@@ -2970,7 +2972,6 @@ function testCg($list)
     return CentreonContactgroup::verifiedExists($list);
 }
 
-
 /**
  * Apply template in order to deploy services
  *
@@ -3111,4 +3112,277 @@ function sanitizeFormHostParameters(array $ret): array
         }
     }
     return $bindParams;
+}
+
+/**
+ * Create a new host from formData.
+ *
+ * @param array<mixed> $ret
+ *
+ * @return int|null
+ */
+function insertHostInAPI(array $ret = []): int|null
+{
+    global $centreon, $form, $isCloudPlatform, $basePath;
+
+    /** @var array<string,int|string|null> $formData */
+    $formData = !count($ret) ? $form->getSubmitValues() : $ret;
+
+    try {
+        $hostId = insertHostByApi($formData, $isCloudPlatform, $basePath);
+
+        if ((int) $formData['host_register'] === 0) {
+            updateHostTemplateService($hostId);
+        }
+
+        if (! $isCloudPlatform) {
+            if ((int) $formData['host_register'] !== 0) {
+                updateHostHostParent($hostId, $formData);
+                updateHostHostChild($hostId);
+            }
+            updateHostContactGroup($hostId, $formData);
+            updateHostContact($hostId, $formData);
+        }
+
+        if (
+            ! empty($formData['dupSvTplAssoc']['dupSvTplAssoc'])
+            || $isCloudPlatform === true
+        ) {
+            createHostTemplateService($hostId);
+        }
+
+        // Update conf change flag for poller
+        signalConfigurationChange('host', $hostId);
+        // Update host ACLs
+        $centreon->user->access->updateACL([
+            'type' => 'HOST',
+            'id' => $hostId,
+            'action' => 'ADD',
+            'access_grp_id' => (isset($formData['acl_groups']) ? $formData['acl_groups'] : null),
+        ]);
+        // Insert change logs
+        $fields = CentreonLogAction::prepareChanges($formData);
+        $centreon->CentreonLogAction->insertLog(
+            "host",
+            $hostId,
+            CentreonDB::escape($formData["host_name"]),
+            "a",
+            $fields
+        );
+
+        return ($hostId);
+    } catch (\Throwable $th) {
+        echo "<div class='msg' align='center'>" . _($th->getMessage()) . "</div>";
+
+        return (null);
+    }
+}
+
+/**
+ * Make the API request to create a new host and return the new ID.
+ *
+ * @param array $formData
+ * @param bool $isCloudPlatform
+ * @param string $basePath
+ *
+ * @throws \LogicException
+ * @throws \Exception
+ *
+ * @return int
+ */
+function insertHostByApi(array $formData, bool $isCloudPlatform, string $basePath): int
+{
+    $kernel = \App\Kernel::createForWeb();
+    /** @var Core\Infrastructure\Common\Api\Router $router */
+    $router = $kernel->getContainer()->get(Core\Infrastructure\Common\Api\Router::class)
+        ?? throw new LogicException('Router not found in container');
+    /** @var Symfony\Component\HttpClient\CurlHttpClient */
+    $client = $kernel->getContainer()->get(Symfony\Component\HttpClient\CurlHttpClient::class)
+        ?? throw new LogicException('CurlHttpClient not found in container');
+
+
+    $payload = getPayloadForHostTemplate($isCloudPlatform, $formData);
+
+    $url = $router->generate(
+        'AddHostTemplate',
+        $basePath ? ['base_uri' => $basePath] : [],
+        Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL,
+    );
+
+    $headers = [
+        'Content-Type' => 'application/json',
+        'X-AUTH-TOKEN' => $_COOKIE['PHPSESSID'],
+    ];
+    $response = $client->request(
+        'POST',
+        $url,
+        [
+            'headers' => $headers,
+            'body' => json_encode($payload),
+        ],
+    );
+
+    if ($response->getStatusCode() !== 201) {
+        $content = json_decode($response->getContent(false));
+
+        throw new \Exception($content->message ?? 'Unexpected return status');
+    }
+
+    $data = $response->toArray();
+
+    /** @var array{id:int} $data */
+    return $data['id'];
+}
+
+/**
+ * @param bool $isCloudPlatform
+ * @param array<mixed> $formData
+ * @return array<string,mixed>
+ */
+function getPayloadForHostTemplate(bool $isCloudPlatform, array $formData): array
+{
+    if ($isCloudPlatform === true) {
+        return [
+            'name' => $formData['host_name'],
+            'alias' => $formData['host_alias'] ?: null,
+            'snmp_version' => $formData['host_snmp_version'] ?: null,
+            'snmp_community' => $formData['host_snmp_community'] ?: null,
+            'note_url' => $formData['ehi_notes_url'] ?: null,
+            'note' => $formData['ehi_notes'] ?: null,
+            'action_url' => $formData['ehi_action_url'] ?: null,
+            'icon_id' => '' !== $formData['ehi_icon_image']
+                ? (int) $formData['ehi_icon_image']
+                : null,
+            'timezone_id' => '' !== $formData['host_location']
+                ? (int) $formData['host_location']
+                : null,
+            'severity_id' => '' !== $formData['criticality_id']
+                ? (int) $formData['criticality_id']
+                : null,
+            'check_timeperiod_id' => '' !== $formData['timeperiod_tp_id']
+                ? (int) $formData['timeperiod_tp_id']
+                : null,
+            'max_check_attempts' => '' !== $formData['host_max_check_attempts']
+                ? (int) $formData['host_max_check_attempts']
+                : null,
+            'normal_check_interval' => '' !== $formData['host_check_interval']
+                ? (int) $formData['host_check_interval']
+                : null,
+            'retry_check_interval' => '' !== $formData['host_retry_check_interval']
+                ? (int) $formData['host_retry_check_interval']
+                : null,
+            'templates' => array_map(static fn(string $id): int => (int) $id, $formData['tpSelect'] ?? []),
+            'categories' => array_map(static fn(string $id): int => (int) $id, $formData['host_hcs'] ?? []),
+            'macros' => array_map(
+                static function (int $key, string $name, string $value) use ($formData): array {
+                    return [
+                        'name' => $name,
+                        'value' => $value,
+                        'is_password' => (bool) ($formData['macroPassword'][$key] ?? false),
+                        'description' => $formData["macroDescription_{$key}"],
+                    ];
+                },
+                array_keys($formData['macroInput'] ?? []),
+                $formData['macroInput'] ?? [],
+                $formData['macroValue'] ?? []
+            ),
+        ];
+    } else {
+        return [
+            'name' => $formData['host_name'],
+            'alias' => $formData['host_alias'] ?: null,
+            'snmp_version' => $formData['host_snmp_version'] ?: null,
+            'snmp_community' => $formData['host_snmp_community'] ?: null,
+            'note_url' => $formData['ehi_notes_url'] ?: null,
+            'note' => $formData['ehi_notes'] ?: null,
+            'action_url' => $formData['ehi_action_url'] ?: null,
+            'icon_id' => '' !== $formData['ehi_icon_image']
+                ? (int) $formData['ehi_icon_image']
+                : null,
+            'icon_alternative' => $formData['ehi_icon_image_alt'] ?: null,
+            'comment' => $formData['host_comment'] ?: null,
+            'timezone_id' => '' !== $formData['host_location']
+                ? (int) $formData['host_location']
+                : null,
+            'severity_id' => '' !== $formData['criticality_id']
+                ? (int) $formData['criticality_id']
+                : null,
+            'check_command_id' => '' !== $formData['command_command_id']
+                ? (int) $formData['command_command_id']
+                : null,
+            'check_command_args' => array_values(array_filter(
+                explode('!', $formData['command_command_id_arg1']),
+                static fn(string $elem): bool => $elem !== ""
+            )),
+            'check_timeperiod_id' => '' !== $formData['timeperiod_tp_id']
+                ? (int) $formData['timeperiod_tp_id']
+                : null,
+            'max_check_attempts' => '' !== $formData['host_max_check_attempts']
+                ? (int) $formData['host_max_check_attempts']
+                : null,
+            'normal_check_interval' => '' !== $formData['host_check_interval']
+                ? (int) $formData['host_check_interval']
+                : null,
+            'retry_check_interval' => '' !== $formData['host_retry_check_interval']
+                ? (int) $formData['host_retry_check_interval']
+                : null,
+            'active_check_enabled' => (int) $formData['host_active_checks_enabled']['host_active_checks_enabled'],
+            'passive_check_enabled' => (int) $formData['host_passive_checks_enabled']['host_passive_checks_enabled'],
+            'low_flap_threshold' => $formData['host_low_flap_threshold']
+                ? (int) $formData['host_low_flap_threshold']
+                : null,
+            'high_flap_threshold' => '' !== $formData['host_high_flap_threshold']
+                ? (int) $formData['host_high_flap_threshold']
+                : null,
+            'freshness_checked' => (int) $formData['host_check_freshness']['host_check_freshness'],
+            'freshness_threshold' => '' !== $formData['host_freshness_threshold']
+                ? (int) $formData['host_freshness_threshold']
+                : null,
+            'acknowledgement_timeout' => '' !== $formData['host_acknowledgement_timeout']
+                ? (int) $formData['host_acknowledgement_timeout']
+                : null,
+            'flap_detection_enabled' => (int) $formData['host_flap_detection_enabled']['host_flap_detection_enabled'],
+            'event_handler_enabled' => (int) $formData['host_event_handler_enabled']['host_event_handler_enabled'],
+            'event_handler_command_id' => '' !== $formData['command_command_id2']
+                ? (int) $formData['command_command_id2']
+                : null,
+            'event_handler_command_args' => array_values(array_filter(
+                explode('!', $formData['command_command_id_arg2']),
+                static fn(string $elem): bool => $elem !== ""
+            )),
+            'notification_enabled' => (int) $formData['host_notifications_enabled']['host_notifications_enabled'],
+            'notification_interval' => '' !== $formData['host_notification_interval'] ?
+                 (int) $formData['host_notification_interval']
+                 : null,
+            'notification_timeperiod_id' => '' !== $formData['timeperiod_tp_id2']
+                ? (int) $formData['timeperiod_tp_id2']
+                : null,
+            'notification_options' => HostEventConverter::toBitFlag(HostEventConverter::fromString(
+                implode(',', array_keys($formData['host_notifOpts'] ?? []))
+            )),
+            'first_notification_delay' => '' !== $formData['host_first_notification_delay']
+                ? (int) $formData['host_first_notification_delay']
+                : null,
+            'recovery_notification_delay' => '' !== $formData['host_recovery_notification_delay']
+                ? (int) $formData['host_recovery_notification_delay']
+                : null,
+            'add_inherited_contact_group' => (bool) ($formData['cg_additive_inheritance'] ?? false),
+            'add_inherited_contact' => (bool) ($formData['contact_additive_inheritance'] ?? false),
+            'templates' => array_map(static fn(string $id): int => (int) $id, $formData['tpSelect'] ?? []),
+            'categories' => array_map(static fn(string $id): int => (int) $id, $formData['host_hcs'] ?? []),
+            'macros' => array_map(
+                static function (int $key, string $name, string $value) use ($formData): array {
+                    return [
+                        'name' => $name,
+                        'value' => $value,
+                        'is_password' => (bool) ($formData['macroPassword'][$key] ?? false),
+                        'description' => $formData["macroDescription_{$key}"],
+                    ];
+                },
+                array_keys($formData['macroInput'] ?? []),
+                $formData['macroInput'] ?? [],
+                $formData['macroValue'] ?? []
+            ),
+        ];
+    }
 }

--- a/centreon/www/include/configuration/configObject/host/formHostOnPrem.ihtml
+++ b/centreon/www/include/configuration/configObject/host/formHostOnPrem.ihtml
@@ -66,15 +66,17 @@
 			    <td class="FormRowField"><img class="helpTooltip" name="alias"> {$form.host_alias.label}</td>
 			    <td class="FormRowValue">{$form.host_alias.html}</td>
 			</tr>
-	        <tr class="list_one">
-	            <td class="FormRowField"><img class="helpTooltip" name="address"> {$form.host_address.label}</td>
-	            <td class="FormRowValue">
-					{$form.host_address.html}&nbsp;&nbsp;
-					{if isset($form.host_resolve)}
-						{$form.host_resolve.html}
-					{/if}
-				</td>
-	        </tr>
+				{if !$msg.isHostTemplate}
+				<tr class="list_one">
+					<td class="FormRowField"><img class="helpTooltip" name="address"> {$form.host_address.label}</td>
+					<td class="FormRowValue">
+						{$form.host_address.html}&nbsp;&nbsp;
+						{if isset($form.host_resolve)}
+							{$form.host_resolve.html}
+						{/if}
+					</td>
+				</tr>
+				{/if}
 			{/if}
 		    <tr class="list_two">
 		        <td class="FormRowField"><img class="helpTooltip" name="snmp_options"> {$form.host_snmp_community.label} & {$form.host_snmp_version.label}</td>
@@ -432,8 +434,7 @@
             <h4>{$form.header.treatment}</h4>
         </td>
     </tr>
-    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="obsess_over_host"> {$form.host_obsess_over_host.label}</td><td class="FormRowValue">{$form.host_obsess_over_host.html}</td></tr>
-    <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="host_acknowledgement_timeout"> {$form.host_acknowledgement_timeout.label}</td><td class="FormRowValue">{$form.host_acknowledgement_timeout.html}&nbsp;{$time_unit}</td></tr>
+    <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="host_acknowledgement_timeout"> {$form.host_acknowledgement_timeout.label}</td><td class="FormRowValue">{$form.host_acknowledgement_timeout.html}&nbsp;{$time_unit}</td></tr>
     <tr class="list_lvl_1">
         <td class="ListColLvl1_name" colspan="2">
             <h4>{$Freshness_Control_options}</h4>
@@ -450,38 +451,6 @@
 	<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="low_flap_threshold"> {$form.host_low_flap_threshold.label}</td><td class="FormRowValue">{$form.host_low_flap_threshold.html}&nbsp;%</td></tr>
 	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="high_flap_threshold"> {$form.host_high_flap_threshold.label}</td><td class="FormRowValue">{$form.host_high_flap_threshold.html}&nbsp;%</td></tr>
 
-	<tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
-      <h4>{$History_Options}</h4>
-    </td></tr>
-	<tr class="list_one">
-		<td class="FormRowField">
-			<div class="formRowLabel">
-				<div>
-					<img class="helpTooltip" name="retain_status_information">
-				</div>
-				<div>
-					<p class="fieldLabel">
-						{$form.host_retain_status_information.label}
-					</p>
-				</div>
-			</div>
-		</td>
-		<td class="FormRowValue">{$form.host_retain_status_information.html}</td></tr>
-	<tr class="list_two">
-		<td class="FormRowField">
-		<div class="formRowLabel">
-			<div>
-				<img class="helpTooltip" name="retain_nonstatus_information">
-			</div>
-			<div>
-				<p class="fieldLabel">
-					{$form.host_retain_nonstatus_information.label}
-				</p>
-			</div>
-		</div>
-		</td>
-		<td class="FormRowValue">{$form.host_retain_nonstatus_information.html}</td></tr>
-	<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="stalking_options"> {$form.host_stalOpts.label}</td><td class="FormRowValue">{$form.host_stalOpts.html}</td></tr>
 	<tr class="list_lvl_1"><td class="ListColLvl1_name" colspan="2">
       <h4>{$Event_Handler}</h4>
     </td></tr>
@@ -526,15 +495,10 @@
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="action_url"> {$form.ehi_action_url.label}</td><td class="FormRowValue">{$form.ehi_action_url.html}</td></tr>
 		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="icon_image"> {$form.ehi_icon_image.label}</td><td class="FormRowValue">{$form.ehi_icon_image.html}&nbsp;&nbsp;<img id='ehi_icon_image_img' class="img_box" src='./img/blank.gif'></td></tr>
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="icon_image_alt"> {$form.ehi_icon_image_alt.label}</td><td class="FormRowValue">{$form.ehi_icon_image_alt.html}</td></tr>
-		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="statusmap_image"> {$form.ehi_statusmap_image.label}</td><td class="FormRowValue">{$form.ehi_statusmap_image.html}&nbsp;&nbsp;<img id='ehi_statusmap_image_img' class="img_box" src='./img/blank.gif'></td></tr>
 		{if isset($form.geo_coords.label)}
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="geo_coords"> {$form.geo_coords.label}</td><td class="FormRowValue">{$form.geo_coords.html}</td></tr>
-		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="2d_coords"> {$form.ehi_2d_coords.label}</td><td class="FormRowValue">{$form.ehi_2d_coords.html}</td></tr>
-		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="3d_coords"> {$form.ehi_3d_coords.label}</td><td class="FormRowValue">{$form.ehi_3d_coords.html}</td></tr>
 		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="criticality_id"> {$form.criticality_id.label}</td><td class="FormRowValue">{$form.criticality_id.html}</td></tr>
 		{else}
-		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="2d_coords"> {$form.ehi_2d_coords.label}</td><td class="FormRowValue">{$form.ehi_2d_coords.html}</td></tr>
-		<tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="3d_coords"> {$form.ehi_3d_coords.label}</td><td class="FormRowValue">{$form.ehi_3d_coords.html}</td></tr>
 		<tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="criticality_id"> {$form.criticality_id.label}</td><td class="FormRowValue">{$form.criticality_id.html}</td></tr>
 		{/if}
 		<tr class="list_lvl_1">

--- a/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
@@ -49,24 +49,24 @@ const BASE_ROUTE = './include/common/webServices/rest/internal.php';
 $datasetRoutes = [
     'timeperiods' => BASE_ROUTE . '?object=centreon_configuration_timeperiod&action=list',
     'default_check_periods' => BASE_ROUTE . '?object=centreon_configuration_timeperiod&action=defaultValues&target=host&field=timeperiod_tp_id&id=' . $hostId,
-    'default_notification_periods' => BASE_ROUTE . '?object=centreon_configuration_timeperiod&action=defaultValues&target=host&field=timeperiod_tp_id2&id=' . $hostId, 
+    'default_notification_periods' => BASE_ROUTE . '?object=centreon_configuration_timeperiod&action=defaultValues&target=host&field=timeperiod_tp_id2&id=' . $hostId,
     'hosts' => BASE_ROUTE . '?object=centreon_configuration_host&action=list',
-    'default_host_parents' => BASE_ROUTE . '?object=centreon_configuration_host&action=defaultValues&target=host&field=host_parents&id=' . $hostId, 
+    'default_host_parents' => BASE_ROUTE . '?object=centreon_configuration_host&action=defaultValues&target=host&field=host_parents&id=' . $hostId,
     'default_host_child' => BASE_ROUTE . '?object=centreon_configuration_host&action=defaultValues&target=host&field=host_childs&id=' . $hostId,
     'host_groups' => BASE_ROUTE . '?object=centreon_configuration_hostgroup&action=list',
     'default_host_groups' => BASE_ROUTE . '?object=centreon_configuration_hostgroup&action=defaultValues&target=host&field=host_hgs&id=' . $hostId,
     'host_categories' => BASE_ROUTE . '?object=centreon_configuration_hostcategory&action=list&t=c',
     'default_host_categories' => BASE_ROUTE . '?object=centreon_configuration_hostcategory&action=defaultValues&target=host&field=host_hcs&id=' . $hostId,
-    'default_contacts' => BASE_ROUTE . '?object=centreon_configuration_contact&action=defaultValues&target=host&field=host_cs&id=' . $hostId, 
+    'default_contacts' => BASE_ROUTE . '?object=centreon_configuration_contact&action=defaultValues&target=host&field=host_cs&id=' . $hostId,
     'contacts' => BASE_ROUTE . '?object=centreon_configuration_contact&action=list',
     'default_contact_groups' => BASE_ROUTE . '?object=centreon_configuration_contactgroup&action=defaultValues&target=host&field=host_cgs&id=' . $hostId,
     'contact_groups' => BASE_ROUTE . '?object=centreon_configuration_contactgroup&action=list',
     'default_timezones' => BASE_ROUTE . '?object=centreon_configuration_timezone&action=defaultValues&target=host&field=host_location&id=' . $hostId,
-    'timezones' => BASE_ROUTE . '?object=centreon_configuration_timezone&action=list', 
+    'timezones' => BASE_ROUTE . '?object=centreon_configuration_timezone&action=list',
     'default_commands' => BASE_ROUTE . '?object=centreon_configuration_comman&action=defaultValues&target=host&field=command_command_id&id=' . $hostId,
     'check_commands' => BASE_ROUTE . '?object=centreon_configuration_command&action=list&t=2',
     'event_handlers' => BASE_ROUTE . '?object=centreon_configuration_command&action=list',
-    'default_event_handlers' => BASE_ROUTE . '?object=centreon_configuration_command&action=defaultValues&target=host&field=command_command_id2&id=' . $hostId, 
+    'default_event_handlers' => BASE_ROUTE . '?object=centreon_configuration_command&action=defaultValues&target=host&field=command_command_id2&id=' . $hostId,
     'default_acl_groups' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=defaultValues&target=host&field=acl_groups&id=' . $hostId,
     'acl_groups' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=list',
     'service_templates' => BASE_ROUTE . '?object=centreon_configuration_servicetemplate&action=list',
@@ -202,12 +202,6 @@ if (($o === HOST_TEMPLATE_MODIFY || $o === HOST_TEMPLATE_WATCH) && isset($hostId
         $tmp = explode(',', $host['host_notification_options']);
         foreach ($tmp as $key => $value) {
             $host['host_notifOpts'][trim($value)] = 1;
-        }
-
-        // Set Stalking Options
-        $tmp = explode(',', $host['host_stalking_options']);
-        foreach ($tmp as $key => $value) {
-            $host['host_stalOpts'][trim($value)] = 1;
         }
 
         // Set criticality
@@ -348,10 +342,6 @@ if ($o !== HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->addElement('text', 'host_alias', _('Alias'), $attrsText);
 }
 
-if (! $isCloudPlatform) {
-    $form->addElement('text', 'host_address', _('Address'), $attrsText);
-}
-
 $form->addElement('select', 'host_snmp_version', _('Version'), [null => null, 1 => '1', '2c' => '2c', 3 => '3']);
 switch ($o) {
     case HOST_TEMPLATE_ADD:
@@ -468,7 +458,7 @@ if (! $isCloudPlatform) {
         $form->setDefaults(['host_event_handler_enabled' => '2']);
     }
 
-    $eventHandlerSelect = $form->addElement('select2', 'command_command_id2', _('Event Handler'), [], $attributes['event_handlers']); 
+    $eventHandlerSelect = $form->addElement('select2', 'command_command_id2', _('Event Handler'), [], $attributes['event_handlers']);
     $eventHandlerSelect->addJsCallback(
         'change',
         'setArgument(jQuery(this).closest("form").get(0),"command_command_id2","example2");'
@@ -780,16 +770,6 @@ if ($o === HOST_TEMPLATE_ADD) {
 
 $form->addElement('header', 'treatment', _('Data Processing'));
 
-$hostOOH = [
-    $form->createElement('radio', 'host_obsess_over_host', null, _('Yes'), '1'),
-    $form->createElement('radio', 'host_obsess_over_host', null, _('No'), '0'),
-    $form->createElement('radio', 'host_obsess_over_host', null, _('Default'), '2'),
-];
-$form->addGroup($hostOOH, 'host_obsess_over_host', _('Obsess Over Host'), '&nbsp;');
-if ($o !== HOST_TEMPLATE_MASSIVE_CHANGE) {
-    $form->setDefaults(['host_obsess_over_host' => '2']);
-}
-
 $hostCF = [
     $form->createElement('radio', 'host_check_freshness', null, _('Yes'), '1'),
     $form->createElement('radio', 'host_check_freshness', null, _('No'), '0'),
@@ -826,26 +806,6 @@ if ($o !== HOST_TEMPLATE_MASSIVE_CHANGE) {
     $form->setDefaults(['host_process_perf_data' => '2']);
 }
 
-$hostRSI = [
-    $form->createElement('radio', 'host_retain_status_information', null, _('Yes'), '1'),
-    $form->createElement('radio', 'host_retain_status_information', null, _('No'), '0'),
-    $form->createElement('radio', 'host_retain_status_information', null, _('Default'), '2'),
-];
-$form->addGroup($hostRSI, 'host_retain_status_information', _('Retain Status Information'), '&nbsp;');
-if ($o !== HOST_TEMPLATE_MASSIVE_CHANGE) {
-    $form->setDefaults(['host_retain_status_information' => '2']);
-}
-
-$hostRNI = [
-    $form->createElement('radio', 'host_retain_nonstatus_information', null, _('Yes'), '1'),
-    $form->createElement('radio', 'host_retain_nonstatus_information', null, _('No'), '0'),
-    $form->createElement('radio', 'host_retain_nonstatus_information', null, _('Default'), '2'),
-];
-$form->addGroup($hostRNI, 'host_retain_nonstatus_information', _('Retain Non Status Information'), '&nbsp;');
-if ($o !== HOST_TEMPLATE_MASSIVE_CHANGE) {
-    $form->setDefaults(['host_retain_nonstatus_information' => '2']);
-}
-
 //
 // # Sort 4 - Extended Infos
 //
@@ -872,8 +832,6 @@ $form->addElement('select', 'ehi_statusmap_image', _('Status Map Image'), $extIm
     'onChange' => "showLogo('ehi_statusmap_image_img',this.value)",
     'onkeyup' => 'this.blur();this.focus();',
 ]);
-$form->addElement('text', 'ehi_2d_coords', _('2d Coords'), $attrsText2);
-$form->addElement('text', 'ehi_3d_coords', _('3d Coords'), $attrsText2);
 
 // Criticality
 $criticality = new CentreonCriticality($pearDB);
@@ -1024,7 +982,11 @@ $valid = false;
 if ($form->validate() && $from_list_menu === false) {
     $hostObj = $form->getElement('host_id');
     if ($form->getSubmitValue('submitA')) {
-        $hostObj->setValue(insertHostInDB());
+        if (null !== $hostTplId = insertHostInAPI()) {
+            $hostObj->setValue($hostTplId);
+            $o = null;
+            $valid = true;
+        }
     } elseif ($form->getSubmitValue('submitC')) {
         /*
          * Before saving, we check if a password macro has changed its name to be able to give it the right password
@@ -1050,13 +1012,15 @@ if ($form->validate() && $from_list_menu === false) {
             }
         }
         updateHostInDB($hostObj->getValue());
+        $o = null;
+        $valid = true;
     } elseif ($form->getSubmitValue('submitMC')) {
         foreach (array_keys($select) as $hostTemplateIdToUpdate) {
             updateHostInDB($hostTemplateIdToUpdate, true);
         }
+        $o = null;
+        $valid = true;
     }
-    $o = null;
-    $valid = true;
 }
 
 // add specific header for cloud
@@ -1101,7 +1065,6 @@ if ($valid) {
     ?>
     <script type="text/javascript">
         showLogo('ehi_icon_image_img', document.getElementById('ehi_icon_image').value);
-        showLogo('ehi_statusmap_image_img', document.getElementById('ehi_statusmap_image').value);
 
         function uncheckNotifOption(object) {
             if (object.id == "notifN" && object.checked) {


### PR DESCRIPTION
## Description

Replace legacy code by API call to save a new host template
Remove the following outdated inputs from the form:
- Address
- Obsess Over Host
- Retain Status Information
- Retain Non Status Information
- Stalking Options
- 2D Coords
- 3D Coords
- StatusMap Image

The fulll removal and clean up of those inputs in the DB and rest of the code will be handled in another PR.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master
