### PR TITLE
fix(ci): force ubuntu 22.04 runner usage in all (mostly veracode) pipelines

### DIFF
--- a/.github/workflows/synchronize-jira-xray.yml
+++ b/.github/workflows/synchronize-jira-xray.yml
@@ -14,7 +14,7 @@ jobs:
 
   synchronize-jira-xray:
     needs: [get-version]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/veracode-analysis.yml
+++ b/.github/workflows/veracode-analysis.yml
@@ -248,7 +248,7 @@ jobs:
     needs: [pipeline-scan]
     name: Clean artifact
     if: success() || failure()
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: geekyeggo/delete-artifact@24928e75e6e6590170563b8ddae9fac674508aa1 # v5.0.0
@@ -260,7 +260,7 @@ jobs:
     name: Run a sandbox scan
     # only stable and unstable maintenances branches will produce a report
     if: needs.build.outputs.development_stage != 'Development'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Get build binary
@@ -308,7 +308,7 @@ jobs:
     name: Run a SCA scan
     # only stable and unstable maintenance branches will produce a report
     if: needs.build.outputs.development_stage != 'Development'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: ${{ vars.VERACODE_CONTINUE_ON_ERROR == 'true' }}
 
     steps:


### PR DESCRIPTION
## Description

fix ubuntu 22.04 runner usage in all (mostly veracode) pipelines to prevent unexpected behaviors using ubuntu latest or 24-04 runners

**Fixes** # MON-93851

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
