### PR TITLE
enh(conf): call API to save a new host

### DIFF
--- a/centreon/features/bootstrap/DowntimeRecurrentContext.php
+++ b/centreon/features/bootstrap/DowntimeRecurrentContext.php
@@ -1,11 +1,11 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\ServiceConfigurationPage;
 use Centreon\Test\Behat\Configuration\DowntimeConfigurationListingPage;
 use Centreon\Test\Behat\Configuration\HostConfigurationPage;
 use Centreon\Test\Behat\Configuration\HostGroupConfigurationPage;
 use Centreon\Test\Behat\Configuration\RecurrentDowntimeConfigurationPage;
+use Centreon\Test\Behat\Configuration\ServiceConfigurationPage;
 
 /**
  * Defines application features from the specific context.
@@ -19,7 +19,7 @@ class DowntimeRecurrentContext extends CentreonContext
     protected $host = array(
         'name' => 'host',
         'alias' => 'host',
-        'address' => 'host2@localhost',
+        'address' => '1.2.3.4',
         'check_command' => 'check_centreon_dummy',
         'location' => 'Europe/Paris'
     );

--- a/centreon/features/bootstrap/EscalationConfigurationContext.php
+++ b/centreon/features/bootstrap/EscalationConfigurationContext.php
@@ -1,11 +1,11 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\EscalationConfigurationPage;
 use Centreon\Test\Behat\Configuration\EscalationConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\EscalationConfigurationPage;
 use Centreon\Test\Behat\Configuration\HostConfigurationPage;
-use Centreon\Test\Behat\Configuration\ServiceGroupConfigurationPage;
 use Centreon\Test\Behat\Configuration\MetaServiceConfigurationPage;
+use Centreon\Test\Behat\Configuration\ServiceGroupConfigurationPage;
 
 class EscalationConfigurationContext extends CentreonContext
 {
@@ -14,7 +14,7 @@ class EscalationConfigurationContext extends CentreonContext
     protected $host = array(
         'name' => 'hostName',
         'alias' => 'hostAlias',
-        'address' => 'host@localhost'
+        'address' => '1.2.3.4'
     );
 
     protected $metaService1 = array(

--- a/centreon/features/bootstrap/HostCategoryConfigurationContext.php
+++ b/centreon/features/bootstrap/HostCategoryConfigurationContext.php
@@ -1,8 +1,8 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\HostCategoryConfigurationPage;
 use Centreon\Test\Behat\Configuration\HostCategoryConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\HostCategoryConfigurationPage;
 use Centreon\Test\Behat\Configuration\HostConfigurationPage;
 use Centreon\Test\Behat\Configuration\HostTemplateConfigurationPage;
 
@@ -13,13 +13,13 @@ class HostCategoryConfigurationContext extends CentreonContext
     protected $host1 = array(
         'name' => 'host1Name',
         'alias' => 'host1Alias',
-        'address' => 'host1@localhost'
+        'address' => '1.2.3.4'
     );
 
     protected $host2 = array(
         'name' => 'host2Name',
         'alias' => 'host2Alias',
-        'address' => 'host2@localhost'
+        'address' => '2.3.4.5'
     );
 
     protected $hostTemplate1 = array(

--- a/centreon/features/bootstrap/HostConfigurationContext.php
+++ b/centreon/features/bootstrap/HostConfigurationContext.php
@@ -15,13 +15,13 @@ class HostConfigurationContext extends CentreonContext
     protected $host2 = array(
         'name' => 'hostName2',
         'alias' => 'hostAlias2',
-        'address' => 'host2@localhost'
+        'address' => '2.3.4.5'
     );
 
     protected $host3 = array(
         'name' => 'hostName3',
         'alias' => 'hostAlias3',
-        'address' => 'host3@localhost'
+        'address' => '3.4.5.6'
     );
 
     protected $hostGroup1 = array(
@@ -60,7 +60,7 @@ class HostConfigurationContext extends CentreonContext
     protected $initialProperties = array(
         'name' => 'hostName',
         'alias' => 'hostAlias',
-        'address' => 'host@localhost',
+        'address' => '1.2.3.4',
         'snmp_community' => 'hostSnmpCommunity',
         'snmp_version' => '1',
         'location' => 'America/Caracas',
@@ -68,7 +68,7 @@ class HostConfigurationContext extends CentreonContext
             'generic-host'
         ),
         'check_command' => 'check_http',
-        'command_arguments' => 'hostCommandArgument',
+        'command_arguments' => '!hostCommandArgument',
         'check_period' => 'workhours',
         'max_check_attempts' => 34,
         'normal_check_interval' => 5,
@@ -100,7 +100,7 @@ class HostConfigurationContext extends CentreonContext
         'high_flap_threshold' => 85,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
-        'event_handler_arguments' => 'event_handler_arguments',
+        'event_handler_arguments' => '!event_handler_arguments',
         'url' => 'hostMassiveChangeUrl',
         'notes' => 'hostMassiveChangeNotes',
         'action_url' => 'hostMassiveChangeActionUrl',
@@ -114,7 +114,7 @@ class HostConfigurationContext extends CentreonContext
     protected $duplicatedProperties = array(
         'name' => 'hostName_1',
         'alias' => 'hostAlias',
-        'address' => 'host@localhost',
+        'address' => '1.2.3.4',
         'snmp_community' => self::PASSWORD_REPLACEMENT_VALUE,
         'snmp_version' => '1',
         'location' => 'America/Caracas',
@@ -122,7 +122,7 @@ class HostConfigurationContext extends CentreonContext
             'generic-host'
         ),
         'check_command' => 'check_http',
-        'command_arguments' => 'hostCommandArgument',
+        'command_arguments' => '!hostCommandArgument',
         'check_period' => 'workhours',
         'max_check_attempts' => 34,
         'normal_check_interval' => 5,
@@ -154,7 +154,7 @@ class HostConfigurationContext extends CentreonContext
         'high_flap_threshold' => 85,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
-        'event_handler_arguments' => 'event_handler_arguments',
+        'event_handler_arguments' => '!event_handler_arguments',
         'url' => 'hostMassiveChangeUrl',
         'notes' => 'hostMassiveChangeNotes',
         'action_url' => 'hostMassiveChangeActionUrl',
@@ -168,7 +168,7 @@ class HostConfigurationContext extends CentreonContext
     protected $updatedProperties = array(
         'name' => 'hostNameChanged',
         'alias' => 'hostAliasChanged',
-        'address' => 'hostChanged@localhost',
+        'address' => '4.3.2.1',
         'snmp_community' => self::PASSWORD_REPLACEMENT_VALUE,
         'snmp_version' => '3',
         'macros' => array(
@@ -179,7 +179,7 @@ class HostConfigurationContext extends CentreonContext
             'hostTemplateName'
         ),
         'check_command' => 'check_https',
-        'command_arguments' => 'hostCommandArgumentChanged',
+        'command_arguments' => '!hostCommandArgumentChanged',
         'check_period' => 'none',
         'max_check_attempts' => 43,
         'normal_check_interval' => 4,
@@ -211,7 +211,7 @@ class HostConfigurationContext extends CentreonContext
         'high_flap_threshold' => 51,
         'event_handler_enabled' => 1,
         'event_handler' => 'check_http',
-        'event_handler_arguments' => 'eventHandlerArgumentsChanged',
+        'event_handler_arguments' => '!eventHandlerArgumentsChanged',
         'url' => 'hostMassiveChangeUrlChanged',
         'notes' => 'hostMassiveChangeNotesChanged',
         'action_url' => 'hostMassiveChangeActionUrlChanged',

--- a/centreon/features/bootstrap/HostDependencyConfigurationContext.php
+++ b/centreon/features/bootstrap/HostDependencyConfigurationContext.php
@@ -1,9 +1,9 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\HostDependencyConfigurationPage;
-use Centreon\Test\Behat\Configuration\HostDependencyConfigurationListingPage;
 use Centreon\Test\Behat\Configuration\HostConfigurationPage;
+use Centreon\Test\Behat\Configuration\HostDependencyConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\HostDependencyConfigurationPage;
 
 class HostDependencyConfigurationContext extends CentreonContext
 {
@@ -12,19 +12,19 @@ class HostDependencyConfigurationContext extends CentreonContext
     protected $host1 = array(
         'name' => 'host1Name',
         'alias' => 'host1Alias',
-        'address' => 'host1@localhost'
+        'address' => '1.2.3.4'
     );
 
     protected $host2 = array(
         'name' => 'host2Name',
         'alias' => 'host2Alias',
-        'address' => 'host2@localhost'
+        'address' => '2.3.4.5'
     );
 
     protected $host3 = array(
         'name' => 'host3Name',
         'alias' => 'host3Alias',
-        'address' => 'host3@localhost'
+        'address' => '3.4.5.6'
     );
 
     protected $initialProperties = array(

--- a/centreon/features/bootstrap/HostGroupConfigurationContext.php
+++ b/centreon/features/bootstrap/HostGroupConfigurationContext.php
@@ -1,9 +1,9 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\HostGroupConfigurationPage;
-use Centreon\Test\Behat\Configuration\HostGroupConfigurationListingPage;
 use Centreon\Test\Behat\Configuration\HostConfigurationPage;
+use Centreon\Test\Behat\Configuration\HostGroupConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\HostGroupConfigurationPage;
 
 class HostGroupConfigurationContext extends CentreonContext
 {
@@ -12,13 +12,13 @@ class HostGroupConfigurationContext extends CentreonContext
     protected $host1 = array(
         'name' => 'host1Name',
         'alias' => 'host1Alias',
-        'address' => 'host1@localhost'
+        'address' => '1.2.3.4'
     );
 
     protected $host2 = array(
         'name' => 'host2Name',
         'alias' => 'host2Alias',
-        'address' => 'host2@localhost'
+        'address' => '2.3.4.5'
     );
 
     protected $initialProperties = array(

--- a/centreon/features/bootstrap/MassiveChangeHostsContext.php
+++ b/centreon/features/bootstrap/MassiveChangeHostsContext.php
@@ -15,19 +15,19 @@ class MassiveChangeHostsContext extends CentreonContext
     protected $host1 = array(
         'name' => 'host1Name',
         'alias' => 'host1Alias',
-        'address' => 'host1@localhost'
+        'address' => '1.2.3.4'
     );
 
     protected $host2 = array(
         'name' => 'host2Name',
         'alias' => 'host2Alias',
-        'address' => 'host2@localhost'
+        'address' => '2.3.4.5'
     );
 
     protected $host3 = array(
         'name' => 'host3Name',
         'alias' => 'host3Alias',
-        'address' => 'host3@localhost'
+        'address' => '3.4.5.6'
     );
 
     protected $hostGroup = array(
@@ -59,7 +59,7 @@ class MassiveChangeHostsContext extends CentreonContext
             'generic-host'
         ),
         'service_linked_to_template' => 0,
-        'command_arguments' => 'hostCommandArgument',
+        'command_arguments' => '!hostCommandArgument',
         'macros' => array(
             'HOSTMACRONAME' => '22'
         ),
@@ -103,7 +103,7 @@ class MassiveChangeHostsContext extends CentreonContext
         'high_flap_threshold' => 85,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
-        'event_handler_arguments' => 'event_handler_arguments',
+        'event_handler_arguments' => '!event_handler_arguments',
         'url' => 'hostMassiveChangeUrl',
         'notes' => 'hostMassiveChangeNotes',
         'action_url' => 'hostMassiveChangeActionUrl',
@@ -117,7 +117,7 @@ class MassiveChangeHostsContext extends CentreonContext
     protected $updatedHost1 = array(
         'name' => 'host1Name',
         'alias' => 'host1Alias',
-        'address' => 'host1@localhost',
+        'address' => '1.2.3.4',
         'snmp_community' => 'snmp',
         'snmp_version' => '2c',
         'monitored_from' => 'Central',
@@ -127,7 +127,7 @@ class MassiveChangeHostsContext extends CentreonContext
         ),
         'service_linked_to_template' => 0,
         'check_command' => 'check_http',
-        'command_arguments' => 'hostCommandArgument',
+        'command_arguments' => '!hostCommandArgument',
         'macros' => array(
             'HOSTMACRONAME' => '22'
         ),
@@ -162,7 +162,7 @@ class MassiveChangeHostsContext extends CentreonContext
         'high_flap_threshold' => 85,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
-        'event_handler_arguments' => 'event_handler_arguments',
+        'event_handler_arguments' => '!event_handler_arguments',
         'url' => 'hostMassiveChangeUrl',
         'notes' => 'hostMassiveChangeNotes',
         'action_url' => 'hostMassiveChangeActionUrl',
@@ -176,7 +176,7 @@ class MassiveChangeHostsContext extends CentreonContext
     protected $updatedHost2 = array(
         'name' => 'host2Name',
         'alias' => 'host2Alias',
-        'address' => 'host2@localhost',
+        'address' => '2.3.4.5',
         'snmp_community' => 'snmp',
         'snmp_version' => '2c',
         'monitored_from' => 'Central',
@@ -186,7 +186,7 @@ class MassiveChangeHostsContext extends CentreonContext
         ),
         'service_linked_to_template' => 0,
         'check_command' => 'check_http',
-        'command_arguments' => 'hostCommandArgument',
+        'command_arguments' => '!hostCommandArgument',
         'macros' => array(
             'HOSTMACRONAME' => '22'
         ),
@@ -221,7 +221,7 @@ class MassiveChangeHostsContext extends CentreonContext
         'high_flap_threshold' => 85,
         'event_handler_enabled' => 2,
         'event_handler' => 'check_https',
-        'event_handler_arguments' => 'event_handler_arguments',
+        'event_handler_arguments' => '!event_handler_arguments',
         'url' => 'hostMassiveChangeUrl',
         'notes' => 'hostMassiveChangeNotes',
         'action_url' => 'hostMassiveChangeActionUrl',

--- a/centreon/features/bootstrap/MassiveChangeServicesContext.php
+++ b/centreon/features/bootstrap/MassiveChangeServicesContext.php
@@ -1,14 +1,14 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\MassiveChangeServiceConfigurationPage;
-use Centreon\Test\Behat\Configuration\ServiceConfigurationPage;
-use Centreon\Test\Behat\Configuration\ServiceConfigurationListingPage;
-use Centreon\Test\Behat\Configuration\ServiceTemplateConfigurationPage;
 use Centreon\Test\Behat\Configuration\ContactConfigurationPage;
 use Centreon\Test\Behat\Configuration\HostConfigurationPage;
+use Centreon\Test\Behat\Configuration\MassiveChangeServiceConfigurationPage;
 use Centreon\Test\Behat\Configuration\ServiceCategoryConfigurationPage;
+use Centreon\Test\Behat\Configuration\ServiceConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\ServiceConfigurationPage;
 use Centreon\Test\Behat\Configuration\ServiceGroupConfigurationPage;
+use Centreon\Test\Behat\Configuration\ServiceTemplateConfigurationPage;
 use Centreon\Test\Behat\Configuration\SnmpTrapsConfigurationPage;
 
 class MassiveChangeServicesContext extends CentreonContext
@@ -24,19 +24,19 @@ class MassiveChangeServicesContext extends CentreonContext
     protected $host1 = array(
         'name' => 'host1Name',
         'alias' => 'host1Alias',
-        'address' => 'host1@localhost'
+        'address' => '1.2.3.4'
     );
 
     protected $host2 = array(
         'name' => 'host2Name',
         'alias' => 'host2Alias',
-        'address' => 'host2@localhost'
+        'address' => '2.3.4.5'
     );
 
     protected $host3 = array(
         'name' => 'host3Name',
         'alias' => 'host3Alias',
-        'address' => 'host3@localhost'
+        'address' => '3.4.5.6'
     );
 
     protected $service1 = array(

--- a/centreon/features/bootstrap/ServiceConfigurationContext.php
+++ b/centreon/features/bootstrap/ServiceConfigurationContext.php
@@ -1,10 +1,10 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\ServiceConfigurationPage;
-use Centreon\Test\Behat\Configuration\ServiceConfigurationListingPage;
 use Centreon\Test\Behat\Configuration\HostConfigurationPage;
 use Centreon\Test\Behat\Configuration\ServiceCategoryConfigurationPage;
+use Centreon\Test\Behat\Configuration\ServiceConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\ServiceConfigurationPage;
 use Centreon\Test\Behat\Configuration\ServiceGroupConfigurationPage;
 
 class ServiceConfigurationContext extends CentreonContext
@@ -14,7 +14,7 @@ class ServiceConfigurationContext extends CentreonContext
     protected $host = array(
         'name' => 'hostName',
         'alias' => 'hostAlias',
-        'address' => 'host@localhost'
+        'address' => '1.2.3.4'
     );
 
     protected $serviceCategory1 = array(

--- a/centreon/features/bootstrap/ServiceDependencyConfigurationContext.php
+++ b/centreon/features/bootstrap/ServiceDependencyConfigurationContext.php
@@ -1,9 +1,9 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\ServiceDependencyConfigurationPage;
-use Centreon\Test\Behat\Configuration\ServiceDependencyConfigurationListingPage;
 use Centreon\Test\Behat\Configuration\HostConfigurationPage;
+use Centreon\Test\Behat\Configuration\ServiceDependencyConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\ServiceDependencyConfigurationPage;
 
 class ServiceDependencyConfigurationContext extends CentreonContext
 {
@@ -12,7 +12,7 @@ class ServiceDependencyConfigurationContext extends CentreonContext
     protected $host = array(
         'name' => 'hostName',
         'alias' => 'hostAlias',
-        'address' => 'host@localhost'
+        'address' => '1.2.3.4'
     );
 
     protected $initialProperties = array(

--- a/centreon/features/bootstrap/ServiceTemplateConfigurationContext.php
+++ b/centreon/features/bootstrap/ServiceTemplateConfigurationContext.php
@@ -1,10 +1,10 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\ServiceTemplateConfigurationPage;
-use Centreon\Test\Behat\Configuration\ServiceTemplateConfigurationListingPage;
 use Centreon\Test\Behat\Configuration\HostConfigurationPage;
 use Centreon\Test\Behat\Configuration\ServiceCategoryConfigurationPage;
+use Centreon\Test\Behat\Configuration\ServiceTemplateConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\ServiceTemplateConfigurationPage;
 
 class ServiceTemplateConfigurationContext extends CentreonContext
 {
@@ -13,7 +13,7 @@ class ServiceTemplateConfigurationContext extends CentreonContext
     protected $host = array(
         'name' => 'hostName',
         'alias' => 'hostAlias',
-        'address' => 'host@localhost'
+        'address' => '1.2.3.4'
     );
 
     protected $serviceCategory1 = array(

--- a/centreon/features/bootstrap/TrapsSNMPConfigurationContext.php
+++ b/centreon/features/bootstrap/TrapsSNMPConfigurationContext.php
@@ -1,14 +1,14 @@
 <?php
 
 use Centreon\Test\Behat\CentreonContext;
-use Centreon\Test\Behat\Configuration\SnmpTrapsConfigurationPage;
-use Centreon\Test\Behat\Configuration\SnmpTrapsConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\CommandConfigurationPage;
+use Centreon\Test\Behat\Configuration\HostConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\HostConfigurationPage;
+use Centreon\Test\Behat\Configuration\ServiceCategoryConfigurationPage;
 use Centreon\Test\Behat\Configuration\ServiceConfigurationPage;
 use Centreon\Test\Behat\Configuration\ServiceTemplateConfigurationPage;
-use Centreon\Test\Behat\Configuration\ServiceCategoryConfigurationPage;
-use Centreon\Test\Behat\Configuration\HostConfigurationPage;
-use Centreon\Test\Behat\Configuration\HostConfigurationListingPage;
-use Centreon\Test\Behat\Configuration\CommandConfigurationPage;
+use Centreon\Test\Behat\Configuration\SnmpTrapsConfigurationListingPage;
+use Centreon\Test\Behat\Configuration\SnmpTrapsConfigurationPage;
 
 class TrapsSNMPConfigurationContext extends CentreonContext
 {
@@ -106,7 +106,7 @@ class TrapsSNMPConfigurationContext extends CentreonContext
         $this->currentPage->setProperties(array(
             'name' => 'hostName',
             'alias' => 'hostName',
-            'address' => 'host@localhost'
+            'address' => '1.2.3.4'
         ));
         $this->currentPage->save();
         $this->currentPage = new CommandConfigurationPage($this);
@@ -200,7 +200,7 @@ class TrapsSNMPConfigurationContext extends CentreonContext
         $this->currentPage->setProperties(array(
             'name' => 'hostName',
             'alias' => 'hostName',
-            'address' => 'host@localhost'
+            'address' => '1.2.3.4'
         ));
         $this->currentPage->save();
         $this->currentPage = new CommandConfigurationPage($this);
@@ -291,7 +291,7 @@ class TrapsSNMPConfigurationContext extends CentreonContext
         $this->currentPage->setProperties(array(
             'name' => 'hostName',
             'alias' => 'hostName',
-            'address' => 'host@localhost'
+            'address' => '1.2.3.4'
         ));
         $this->currentPage->save();
         $this->currentPage = new CommandConfigurationPage($this);

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -1054,55 +1054,6 @@ function updateHostInDB($hostId = null, $isMassiveChange = false, $configuration
     return ($hostId);
 }
 
-function insertHostInDB($ret = array(), $onDemandMacro = null)
-{
-    global $centreon, $form, $isCloudPlatform;
-
-    isset($ret["nagios_server_id"])
-        ? $nagiosServerId = $ret["nagios_server_id"]
-        : $nagiosServerId = $form->getSubmitValue("nagios_server_id");
-    if (!isset($nagiosServerId) || $nagiosServerId == "" || $nagiosServerId == 0) {
-        $nagiosServerId = null;
-    }
-
-    $hostId = insertHost($ret, $onDemandMacro, $nagiosServerId);
-
-    if (! $isCloudPlatform) {
-        updateHostHostParent($hostId, $ret);
-        updateHostHostChild($hostId);
-        updateHostContactGroup($hostId, $ret);
-        updateHostContact($hostId, $ret);
-        updateHostNotifs($hostId, $ret);
-        updateHostNotifOptionInterval($hostId, $ret);
-        updateHostNotifOptionTimeperiod($hostId, $ret);
-        updateHostNotifOptionFirstNotificationDelay($hostId, $ret);
-    }
-
-    updateHostHostGroup($hostId, $ret);
-    updateHostHostCategory($hostId, $ret);
-    updateHostTemplateService($hostId);
-    updateNagiosServerRelation($hostId, $ret);
-
-    $ret = $form->getSubmitValues();
-
-    if (
-        ! empty($ret['dupSvTplAssoc']['dupSvTplAssoc'])
-        || $isCloudPlatform === true
-    ) {
-        createHostTemplateService($hostId);
-    }
-
-    signalConfigurationChange('host', $hostId);
-    $centreon->user->access->updateACL([
-        'type' => 'HOST',
-        'id' => $hostId,
-        'action' => 'ADD',
-        'access_grp_id' => (isset($ret['acl_groups']) ? $ret['acl_groups'] : null),
-    ]);
-    insertHostExtInfos($hostId, $ret);
-    return ($hostId);
-}
-
 /**
  * @param array<string,<int,string|int|null>> $bindParams
  * @param bool $isTemplate
@@ -1184,295 +1135,6 @@ function resetUnwantedParameters(array $bindParams): array
     }
 
     return $bindParams;
-}
-
-function insertHost($ret, $macro_on_demand = null, $server_id = null)
-{
-    global $form, $pearDB, $centreon, $is_admin, $isCloudPlatform;
-
-    $hostObj = new CentreonHost($pearDB);
-    if (!count($ret)) {
-        $ret = $form->getSubmitValues();
-    }
-
-    $host = new CentreonHost($pearDB);
-
-    if (! $isCloudPlatform) {
-        if (isset($ret['command_command_id_arg1']) && $ret['command_command_id_arg1'] != null) {
-            $ret['command_command_id_arg1'] = str_replace('\n', '#BR#', $ret['command_command_id_arg1']);
-            $ret['command_command_id_arg1'] = str_replace('\t', '#T#', $ret['command_command_id_arg1']);
-            $ret['command_command_id_arg1'] = str_replace('\r', '#R#', $ret['command_command_id_arg1']);
-        }
-        if (isset($ret['command_command_id_arg2']) && $ret['command_command_id_arg2'] != null) {
-            $ret['command_command_id_arg2'] = str_replace('\n', '#BR#', $ret['command_command_id_arg2']);
-            $ret['command_command_id_arg2'] = str_replace('\t', '#T#', $ret['command_command_id_arg2']);
-            $ret['command_command_id_arg2'] = str_replace('\r', '#R#', $ret['command_command_id_arg2']);
-        }
-    }
-
-    // For Centreon 2, we no longer need "host_template_model_htm_id" in Nagios 3
-    // but we try to keep it compatible with Nagios 2 which needs "host_template_model_htm_id"
-    if (isset($_POST['nbOfSelect'])) {
-        $dbResult = $pearDB->query("SELECT host_id FROM `host` WHERE host_register='0' LIMIT 1");
-        $result = $dbResult->fetch();
-        $ret["host_template_model_htm_id"] = $result["host_id"];
-        $dbResult->closeCursor();
-    }
-
-    $ret["host_name"] = $host->checkIllegalChar($ret["host_name"], $server_id);
-
-    $bindParams = sanitizeFormHostParameters($ret);
-
-    if ($isCloudPlatform) {
-        $bindParams = resetUnwantedParameters($bindParams);
-        $bindParams = resetHostTypeSpecificParams(
-            $bindParams,
-            isset($ret['host_register']) && $ret['host_register'] === '0' ? true : false
-        );
-    }
-
-    $params = [];
-    foreach (array_keys($bindParams) as $token) {
-        $params[] = ltrim($token, ':');
-    }
-
-    $rq = "INSERT INTO `host` ( " . implode(', ', $params) . ")
-           VALUES (" . implode(", ", array_keys($bindParams)) . " )";
-    $stmt = $pearDB->prepare($rq);
-    foreach ($bindParams as $token => $bindValues) {
-        foreach ($bindValues as $paramType => $value) {
-            $stmt->bindValue($token, $value, $paramType);
-        }
-    }
-
-    $stmt->execute();
-    $dbResult = $pearDB->query("SELECT MAX(host_id) FROM host");
-    $host_id = $dbResult->fetch();
-
-    /*
-     *  Insert multiple templates
-     */
-    $multiTP_logStr = "";
-    if (isset($ret["use"]) && $ret["use"]) {
-        $already_stored = array();
-        $tplTab = preg_split("/\,/", $ret["use"]);
-        $j = 0;
-        $rq = "INSERT INTO host_template_relation (`host_host_id`, `host_tpl_id`, `order`)
-               VALUES (:host_host_id, :host_tpl_id, :order)";
-        $statement = $pearDB->prepare($rq);
-        foreach ($tplTab as $val) {
-            $tplId = getMyHostID($val);
-            if (
-                !isset($already_stored[$tplId])
-                && $tplId && hasNoInfiniteLoop($host_id['MAX(host_id)'], $tplId) === true
-            ) {
-                $statement->bindValue(':host_host_id', (int) $host_id['MAX(host_id)'], \PDO::PARAM_INT);
-                $statement->bindValue(':host_tpl_id', (int) $tplId, \PDO::PARAM_INT);
-                $statement->bindValue(':order', $j, \PDO::PARAM_INT);
-                $statement->execute();
-                $multiTP_logStr .= $tplId . ",";
-                $j++;
-                $already_stored[$tplId] = 1;
-            }
-        }
-    } elseif (isset($_REQUEST['tpSelect'])) {
-        $hostObj->setTemplates($host_id['MAX(host_id)'], $_REQUEST['tpSelect']);
-    }
-
-    /*
-     * Insert on demand macros
-     * Keeping it just in case it could used somewhere else
-     */
-
-    if (isset($macro_on_demand)) {
-        $my_tab = $macro_on_demand;
-        if (isset($my_tab['nbOfMacro'])) {
-            $already_stored = array();
-            $rq = "INSERT INTO on_demand_macro_host (`host_macro_name`, `host_macro_value`, `description`,
-                                                     `host_host_id`, `macro_order`)
-                   VALUES (:host_macro_name, :host_macro_value, :host_host_id, :macro_order)";
-            $statement = $pearDB->prepare($rq);
-            for ($i = 0; $i <= $my_tab['nbOfMacro']; $i++) {
-                $macInput = "macroInput_" . $i;
-                $macValue = "macroValue_" . $i;
-                if (
-                    isset($my_tab[$macInput])
-                    && !isset($already_stored[strtolower($my_tab[$macInput])]) && $my_tab[$macInput]
-                ) {
-                    $my_tab[$macInput] = str_replace("\$_HOST", "", $my_tab[$macInput]);
-                    $my_tab[$macInput] = str_replace("\$", "", $my_tab[$macInput]);
-                    $macName = $my_tab[$macInput];
-                    $macVal = $my_tab[$macValue];
-                    $statement->bindValue(':host_macro_name', '$_HOST' . strtoupper($macName) . '$', \PDO::PARAM_STR);
-                    $statement->bindValue(':host_macro_value', $macVal, \PDO::PARAM_STR);
-                    $statement->bindValue(':host_host_id', (int) $host_id['MAX(host_id)'], \PDO::PARAM_INT);
-                    $statement->bindValue(':macro_order', $i, \PDO::PARAM_INT);
-                    $statement->execute();
-                    $fields["_" . strtoupper($my_tab[$macInput]) . "_"] = $my_tab[$macValue];
-                    $already_stored[strtolower($my_tab[$macInput])] = 1;
-                }
-            }
-        }
-    } elseif (
-        isset($_REQUEST['macroInput'])
-        && isset($_REQUEST['macroValue'])
-    ) {
-        $macroDescription = array();
-        foreach ($_REQUEST as $nam => $ele) {
-            if (preg_match_all("/macroDescription_(\w+)$/", $nam, $matches, PREG_SET_ORDER)) {
-                foreach ($matches as $match) {
-                    $macroDescription[$match[1]] = $ele;
-                }
-            }
-        }
-        $hostObj->insertMacro(
-            $host_id['MAX(host_id)'],
-            $_REQUEST['macroInput'],
-            $_REQUEST['macroValue'],
-            $_REQUEST['macroPassword'] ?? [],
-            $macroDescription,
-            false,
-            $ret["command_command_id"] ?? false
-        );
-    }
-
-    $kernel = \App\Kernel::createForWeb();
-    /** @var \Utility\Interfaces\UUIDGeneratorInterface $uuidGenerator */
-    $uuidGenerator = $kernel->getContainer()->get(Utility\Interfaces\UUIDGeneratorInterface::class);
-    /** @var \Centreon\Domain\Log\Logger $logger */
-    $logger = $kernel->getContainer()->get(\Centreon\Domain\Log\Logger::class);
-    $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface::class
-    );
-    $vaultConfiguration = $readVaultConfigurationRepository->find();
-    if ($vaultConfiguration !== null) {
-        try {
-            insertHostSecretsInVault(
-                $vaultConfiguration,
-                $uuidGenerator,
-                $logger,
-                $bindParams[':host_snmp_community'][\PDO::PARAM_STR],
-                $hostObj->getFormattedMacros(),
-                (int) $host_id['MAX(host_id)']
-            );
-        } catch (\Throwable $ex) {
-            $logger->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
-            error_log((string) $ex);
-        }
-    }
-
-    if (isset($ret['criticality_id'])) {
-        setHostCriticality($host_id['MAX(host_id)'], $ret['criticality_id']);
-    }
-
-    if ($isCloudPlatform) {
-        $stmt = $pearDB->prepare("DELETE FROM acl_resources_host_relations where host_host_id = :hostId");
-        $stmt->bindValue(':hostId', $host_id['MAX(host_id)'], \PDO::PARAM_INT);
-        $stmt->execute();
-    } else {
-        if (isset($ret['acl_groups']) && count($ret['acl_groups'])) {
-            foreach ($ret['acl_groups'] as $groupId) {
-                $sql = "SELECT acl_res_id FROM acl_res_group_relations WHERE acl_group_id = " . $groupId;
-                $res = $pearDB->query($sql);
-
-                $query = "INSERT INTO acl_resources_host_relations (acl_res_id, host_host_id) VALUES ";
-                $first = true;
-
-                while ($aclRes = $res->fetch()) {
-                    if (!$first) {
-                        $query .= ", ";
-                    } else {
-                        $first = false;
-                    }
-                    $query .= "(" . $aclRes['acl_res_id'] . ", " . $pearDB->escape($host_id['MAX(host_id)']) . ")";
-                }
-
-                if (!$first) {
-                    $pearDB->query($query);
-                }
-            }
-        }
-    }
-    /*
-     *  Logs
-     */
-
-    /* Prepare value for changelog */
-    $fields = CentreonLogAction::prepareChanges($ret);
-    $centreon->CentreonLogAction->insertLog(
-        "host",
-        $host_id["MAX(host_id)"],
-        CentreonDB::escape($ret["host_name"]),
-        "a",
-        $fields
-    );
-
-    return ($host_id["MAX(host_id)"]);
-}
-
-/**
- * @global HTML_QuickFormCustom $form
- * @global CentreonDB $pearDB
- * @param int $host_id
- * @param array $ret
- */
-function insertHostExtInfos($host_id, $ret)
-{
-    global $form, $pearDB;
-
-    if (!$host_id) {
-        return;
-    }
-
-    if (empty($ret)) {
-        $ret = $form->getSubmitValues();
-    }
-
-    /*
-     * Check if image selected isn't a directory
-     */
-    if (isset($ret["ehi_icon_image"]) && strrchr("REP_", $ret["ehi_icon_image"])) {
-        $ret["ehi_icon_image"] = null;
-    }
-    if (isset($ret["ehi_statusmap_image"]) && strrchr("REP_", $ret["ehi_statusmap_image"])) {
-        $ret["ehi_statusmap_image"] = null;
-    }
-    /*
-     *
-     */
-    $rq = "INSERT INTO `extended_host_information` " .
-        "( `ehi_id` , `host_host_id` , `ehi_notes` , `ehi_notes_url` , " .
-        "`ehi_action_url` , `ehi_icon_image` , `ehi_icon_image_alt` , " .
-        "`ehi_statusmap_image` , `ehi_2d_coords` , " .
-        "`ehi_3d_coords` )" .
-        "VALUES ( ";
-    $rq .= "NULL, " . $host_id . ", ";
-    isset($ret["ehi_notes"]) && $ret["ehi_notes"] != null
-        ? $rq .= "'" . CentreonDB::escape($ret["ehi_notes"]) . "', "
-        : $rq .= "NULL, ";
-    isset($ret["ehi_notes_url"]) && $ret["ehi_notes_url"] != null
-        ? $rq .= "'" . CentreonDB::escape($ret["ehi_notes_url"]) . "', "
-        : $rq .= "NULL, ";
-    isset($ret["ehi_action_url"]) && $ret["ehi_action_url"] != null
-        ? $rq .= "'" . CentreonDB::escape($ret["ehi_action_url"]) . "', "
-        : $rq .= "NULL, ";
-    isset($ret["ehi_icon_image"]) && $ret["ehi_icon_image"] != null
-        ? $rq .= "'" . CentreonDB::escape($ret["ehi_icon_image"]) . "', "
-        : $rq .= "NULL, ";
-    isset($ret["ehi_icon_image_alt"]) && $ret["ehi_icon_image_alt"] != null
-        ? $rq .= "'" . CentreonDB::escape($ret["ehi_icon_image_alt"]) . "', "
-        : $rq .= "NULL, ";
-    isset($ret["ehi_statusmap_image"]) && $ret["ehi_statusmap_image"] != null
-        ? $rq .= "'" . CentreonDB::escape($ret["ehi_statusmap_image"]) . "', "
-        : $rq .= "NULL, ";
-    isset($ret["ehi_2d_coords"]) && $ret["ehi_2d_coords"] != null
-        ? $rq .= "'" . CentreonDB::escape($ret["ehi_2d_coords"]) . "', "
-        : $rq .= "NULL, ";
-    isset($ret["ehi_3d_coords"]) && $ret["ehi_3d_coords"] != null
-        ? $rq .= "'" . CentreonDB::escape($ret["ehi_3d_coords"]) . "' "
-        : $rq .= "NULL ";
-    $rq .= ")";
-    $dbResult = $pearDB->query($rq);
 }
 
 /*
@@ -3198,14 +2860,25 @@ function insertHostByApi(array $formData, bool $isCloudPlatform, string $basePat
         ?? throw new LogicException('Router not found in container');
     $client = new Symfony\Component\HttpClient\CurlHttpClient();
 
+    if ((int) $formData['host_register'] === 0) {
+        // is template
+        $payload = getPayloadForHostTemplate($isCloudPlatform, $formData);
 
-    $payload = getPayloadForHostTemplate($isCloudPlatform, $formData);
+        $url = $router->generate(
+            'AddHostTemplate',
+            $basePath ? ['base_uri' => $basePath] : [],
+            Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+    } else {
+        // is regular host
+        $payload = getPayloadForHost($isCloudPlatform, $formData);
 
-    $url = $router->generate(
-        'AddHostTemplate',
-        $basePath ? ['base_uri' => $basePath] : [],
-        Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL,
-    );
+        $url = $router->generate(
+            'AddHost',
+            $basePath ? ['base_uri' => $basePath] : [],
+            Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL,
+        );
+    }
 
     $headers = [
         'Content-Type' => 'application/json',
@@ -3326,7 +2999,7 @@ function getPayloadForHostTemplate(bool $isCloudPlatform, array $formData): arra
                 : null,
             'active_check_enabled' => (int) $formData['host_active_checks_enabled']['host_active_checks_enabled'],
             'passive_check_enabled' => (int) $formData['host_passive_checks_enabled']['host_passive_checks_enabled'],
-            'low_flap_threshold' => $formData['host_low_flap_threshold']
+            'low_flap_threshold' => '' !== $formData['host_low_flap_threshold']
                 ? (int) $formData['host_low_flap_threshold']
                 : null,
             'high_flap_threshold' => '' !== $formData['host_high_flap_threshold']
@@ -3370,6 +3043,169 @@ function getPayloadForHostTemplate(bool $isCloudPlatform, array $formData): arra
             'categories' => array_map(static fn(string $id): int => (int) $id, $formData['host_hcs'] ?? []),
             'macros' => array_map(
                 static function (int $key, string $name, string $value) use ($formData): array {
+                    return [
+                        'name' => $name,
+                        'value' => $value,
+                        'is_password' => (bool) ($formData['macroPassword'][$key] ?? false),
+                        'description' => $formData["macroDescription_{$key}"],
+                    ];
+                },
+                array_keys($formData['macroInput'] ?? []),
+                $formData['macroInput'] ?? [],
+                $formData['macroValue'] ?? []
+            ),
+        ];
+    }
+}
+
+/**
+ * @param bool $isCloudPlatform
+ * @param array $formData
+ * @return array<string,mixed>
+ */
+function getPayloadForHost(bool $isCloudPlatform, array $formData): array
+{
+    if ($isCloudPlatform === true) {
+        return [
+            'name' => $formData['host_name'],
+            'address' => $formData['host_address'],
+            'monitoring_server_id' => (int) $formData['nagios_server_id'] ?: null,
+            'alias' => $formData['host_alias'] ?: null,
+            'snmp_version' => $formData['host_snmp_version'] ?: null,
+            'snmp_community' => $formData['host_snmp_community'] ?: null,
+            'note_url' => $formData['ehi_notes_url'] ?: null,
+            'note' => $formData['ehi_notes'] ?: null,
+            'action_url' => $formData['ehi_action_url'] ?: null,
+            'icon_id' => '' !== $formData['ehi_icon_image']
+                ? (int) $formData['ehi_icon_image']
+                : null,
+            'geo_coords' => $formData['geo_coords'] ?: null,
+            'timezone_id' => '' !== $formData['host_location']
+                ? (int) $formData['host_location']
+                : null,
+            'severity_id' => '' !== $formData['criticality_id']
+                ? (int) $formData['criticality_id']
+                : null,
+            'check_timeperiod_id' => '' !== $formData['timeperiod_tp_id']
+                ? (int) $formData['timeperiod_tp_id']
+                : null,
+            'max_check_attempts' => '' !== $formData['host_max_check_attempts']
+                ? (int) $formData['host_max_check_attempts']
+                : null,
+            'normal_check_interval' => '' !== $formData['host_check_interval']
+                ? (int) $formData['host_check_interval']
+                : null,
+            'retry_check_interval' => '' !== $formData['host_retry_check_interval']
+                ? (int) $formData['host_retry_check_interval']
+                : null,
+            'is_activated' => (bool) ($formData['host_activate']['host_activate'] ?: false),
+            'templates' => array_map(static fn(string $id): int => (int) $id, $formData['tpSelect'] ?? []),
+            'categories' => array_map(static fn(string $id): int => (int) $id, $formData['host_hcs'] ?? []),
+            'groups' => array_map(static fn(string $id): int => (int) $id, $formData['host_hgs'] ?? []),
+            'macros' => array_map(
+                static function (int|string $key, string $name, string $value) use ($formData): array {
+                    return [
+                        'name' => $name,
+                        'value' => $value,
+                        'is_password' => (bool) ($formData['macroPassword'][$key] ?? false),
+                        'description' => $formData["macroDescription_{$key}"],
+                    ];
+                },
+                array_keys($formData['macroInput'] ?? []),
+                $formData['macroInput'] ?? [],
+                $formData['macroValue'] ?? []
+            ),
+        ];
+    } else {
+        return [
+            'name' => $formData['host_name'],
+            'address' => $formData['host_address'],
+            'monitoring_server_id' => (int) $formData['nagios_server_id'] ?: null,
+            'alias' => $formData['host_alias'] ?: null,
+            'snmp_version' => $formData['host_snmp_version'] ?: null,
+            'snmp_community' => $formData['host_snmp_community'] ?: null,
+            'note_url' => $formData['ehi_notes_url'] ?: null,
+            'note' => $formData['ehi_notes'] ?: null,
+            'action_url' => $formData['ehi_action_url'] ?: null,
+            'icon_id' => '' !== $formData['ehi_icon_image']
+                ? (int) $formData['ehi_icon_image']
+                : null,
+            'icon_alternative' => $formData['ehi_icon_image_alt'] ?: null,
+            'comment' => $formData['host_comment'] ?: null,
+            'geo_coords' => $formData['geo_coords'] ?: null,
+            'timezone_id' => '' !== $formData['host_location']
+                ? (int) $formData['host_location']
+                : null,
+            'severity_id' => '' !== $formData['criticality_id']
+                ? (int) $formData['criticality_id']
+                : null,
+            'check_command_id' => '' !== $formData['command_command_id']
+                ? (int) $formData['command_command_id']
+                : null,
+            'check_command_args' => array_values(array_filter(
+                explode('!', $formData['command_command_id_arg1']),
+                static fn(string $elem): bool => $elem !== ""
+            )),
+            'check_timeperiod_id' => '' !== $formData['timeperiod_tp_id']
+                ? (int) $formData['timeperiod_tp_id']
+                : null,
+            'max_check_attempts' => '' !== $formData['host_max_check_attempts']
+                ? (int) $formData['host_max_check_attempts']
+                : null,
+            'normal_check_interval' => '' !== $formData['host_check_interval']
+                ? (int) $formData['host_check_interval']
+                : null,
+            'retry_check_interval' => '' !== $formData['host_retry_check_interval']
+                ? (int) $formData['host_retry_check_interval']
+                : null,
+            'active_check_enabled' => (int) $formData['host_active_checks_enabled']['host_active_checks_enabled'],
+            'passive_check_enabled' => (int) $formData['host_passive_checks_enabled']['host_passive_checks_enabled'],
+            'low_flap_threshold' => '' !== $formData['host_low_flap_threshold']
+                ? (int) $formData['host_low_flap_threshold']
+                : null,
+            'high_flap_threshold' => '' !== $formData['host_high_flap_threshold']
+                ? (int) $formData['host_high_flap_threshold']
+                : null,
+            'freshness_checked' => (int) $formData['host_check_freshness']['host_check_freshness'],
+            'freshness_threshold' => '' !== $formData['host_freshness_threshold']
+                ? (int) $formData['host_freshness_threshold']
+                : null,
+            'acknowledgement_timeout' => '' !== $formData['host_acknowledgement_timeout']
+                ? (int) $formData['host_acknowledgement_timeout']
+                : null,
+            'flap_detection_enabled' => (int) $formData['host_flap_detection_enabled']['host_flap_detection_enabled'],
+            'event_handler_enabled' => (int) $formData['host_event_handler_enabled']['host_event_handler_enabled'],
+            'event_handler_command_id' => '' !== $formData['command_command_id2']
+                ? (int) $formData['command_command_id2']
+                : null,
+            'event_handler_command_args' => array_values(array_filter(
+                explode('!', $formData['command_command_id_arg2']),
+                static fn(string $elem): bool => $elem !== ""
+            )),
+            'notification_enabled' => (int) $formData['host_notifications_enabled']['host_notifications_enabled'],
+            'notification_interval' => '' !== $formData['host_notification_interval']
+                ? (int) $formData['host_notification_interval']
+                : null,
+            'notification_timeperiod_id' => '' !== $formData['timeperiod_tp_id2']
+                ? (int) $formData['timeperiod_tp_id2']
+                : null,
+            'notification_options' => HostEventConverter::toBitFlag(HostEventConverter::fromString(
+                implode(',', array_keys($formData['host_notifOpts'] ?? []))
+            )),
+            'first_notification_delay' => '' !== $formData['host_first_notification_delay']
+                ? (int) $formData['host_first_notification_delay']
+                : null,
+            'recovery_notification_delay' => '' !== $formData['host_recovery_notification_delay']
+                ? (int) $formData['host_recovery_notification_delay']
+                : null,
+            'add_inherited_contact_group' => (bool) ($formData['cg_additive_inheritance'] ?? false),
+            'add_inherited_contact' => (bool) ($formData['contact_additive_inheritance'] ?? false),
+            'is_activated' => (bool) ($formData['host_activate']['host_activate'] ?: false),
+            'templates' => array_map(static fn(string $id): int => (int) $id, $formData['tpSelect'] ?? []),
+            'categories' => array_map(static fn(string $id): int => (int) $id, $formData['host_hcs'] ?? []),
+            'groups' => array_map(static fn(string $id): int => (int) $id, $formData['host_hgs'] ?? []),
+            'macros' => array_map(
+                static function (int|string $key, string $name, string $value) use ($formData): array {
                     return [
                         'name' => $name,
                         'value' => $value,

--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -54,26 +54,26 @@ const BASE_ROUTE = './include/common/webServices/rest/internal.php';
 $datasetRoutes = [
     'timeperiods' => BASE_ROUTE . '?object=centreon_configuration_timeperiod&action=list',
     'default_check_periods' => BASE_ROUTE . '?object=centreon_configuration_timeperiod&action=defaultValues&target=host&field=timeperiod_tp_id&id=' . $host_id,
-    'default_notification_periods' => BASE_ROUTE . '?object=centreon_configuration_timeperiod&action=defaultValues&target=host&field=timeperiod_tp_id2&id=' . $host_id, 
+    'default_notification_periods' => BASE_ROUTE . '?object=centreon_configuration_timeperiod&action=defaultValues&target=host&field=timeperiod_tp_id2&id=' . $host_id,
     'hosts' => BASE_ROUTE . '?object=centreon_configuration_host&action=list',
-    'default_host_parents' => BASE_ROUTE . '?object=centreon_configuration_host&action=defaultValues&target=host&field=host_parents&id=' . $host_id, 
+    'default_host_parents' => BASE_ROUTE . '?object=centreon_configuration_host&action=defaultValues&target=host&field=host_parents&id=' . $host_id,
     'default_host_child' => BASE_ROUTE . '?object=centreon_configuration_host&action=defaultValues&target=host&field=host_childs&id=' . $host_id,
     'host_groups' => BASE_ROUTE . '?object=centreon_configuration_hostgroup&action=list',
     'default_host_groups' => BASE_ROUTE . '?object=centreon_configuration_hostgroup&action=defaultValues&target=host&field=host_hgs&id=' . $host_id,
     'host_categories' => BASE_ROUTE . '?object=centreon_configuration_hostcategory&action=list&t=c',
     'default_host_categories' => BASE_ROUTE . '?object=centreon_configuration_hostcategory&action=defaultValues&target=host&field=host_hcs&id=' . $host_id,
-    'default_contacts' => BASE_ROUTE . '?object=centreon_configuration_contact&action=defaultValues&target=host&field=host_cs&id=' . $host_id, 
+    'default_contacts' => BASE_ROUTE . '?object=centreon_configuration_contact&action=defaultValues&target=host&field=host_cs&id=' . $host_id,
     'contacts' => BASE_ROUTE . '?object=centreon_configuration_contact&action=list',
     'default_contact_groups' => BASE_ROUTE . '?object=centreon_configuration_contactgroup&action=defaultValues&target=host&field=host_cgs&id=' . $host_id,
     'contact_groups' => BASE_ROUTE . '?object=centreon_configuration_contactgroup&action=list',
     'default_timezones' => BASE_ROUTE . '?object=centreon_configuration_timezone&action=defaultValues&target=host&field=host_location&id=' . $host_id,
-    'timezones' => BASE_ROUTE . '?object=centreon_configuration_timezone&action=list', 
+    'timezones' => BASE_ROUTE . '?object=centreon_configuration_timezone&action=list',
     'default_commands' => BASE_ROUTE . '?object=centreon_configuration_comman&action=defaultValues&target=host&field=command_command_id&id=' . $host_id,
     'check_commands' => BASE_ROUTE . '?object=centreon_configuration_command&action=list&t=2',
     'event_handlers' => BASE_ROUTE . '?object=centreon_configuration_command&action=list',
-    'default_event_handlers' => BASE_ROUTE . '?object=centreon_configuration_command&action=defaultValues&target=host&field=command_command_id2&id=' . $host_id, 
+    'default_event_handlers' => BASE_ROUTE . '?object=centreon_configuration_command&action=defaultValues&target=host&field=command_command_id2&id=' . $host_id,
     'default_acl_groups' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=defaultValues&target=host&field=acl_groups&id=' . $host_id,
-    'acl_groups' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=list' 
+    'acl_groups' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=list'
 ];
 
 $attributes = [
@@ -231,12 +231,6 @@ if (
         $tmp = explode(',', $host['host_notification_options'] ?? '');
         foreach ($tmp as $key => $value) {
             $host['host_notifOpts'][trim($value)] = 1;
-        }
-
-        // Set Stalking Options
-        $tmp = explode(',', $host['host_stalking_options'] ?? '');
-        foreach ($tmp as $key => $value) {
-            $host['host_stalOpts'][trim($value)] = 1;
         }
     }
 
@@ -647,7 +641,7 @@ if ($o === HOST_MASSIVE_CHANGE) {
 $dbResult = $pearDB->query('SELECT `value` FROM options WHERE `key` = "inheritance_mode"');
 $inheritanceMode = $dbResult->fetch();
 
-if (! $isCloudPlatform) { 
+if (! $isCloudPlatform) {
     if ($o === HOST_MASSIVE_CHANGE) {
         $contactAdditive[] = $form->createElement('radio', 'mc_contact_additive_inheritance', null, _('Yes'), '1');
         $contactAdditive[] = $form->createElement('radio', 'mc_contact_additive_inheritance', null, _('No'), '0');
@@ -790,11 +784,6 @@ if (! $isCloudPlatform) {
         ),
     ];
     $form->addGroup($hostNotifOpt, 'host_notifOpts', _('Notification Options'), '&nbsp;&nbsp;');
-
-    $hostStalOpt[] = $form->createElement('checkbox', 'o', '&nbsp;', _('Up'));
-    $hostStalOpt[] = $form->createElement('checkbox', 'd', '&nbsp;', _('Down'));
-    $hostStalOpt[] = $form->createElement('checkbox', 'u', '&nbsp;', _('Unreachable'));
-    $form->addGroup($hostStalOpt, 'host_stalOpts', _('Stalking Options'), '&nbsp;&nbsp;');
 }
 
 //
@@ -890,14 +879,6 @@ if (! $isCloudPlatform) {
 
     $form->addElement('header', 'treatment', _('Data Processing'));
 
-    $hostOOH[] = $form->createElement('radio', 'host_obsess_over_host', null, _('Yes'), '1');
-    $hostOOH[] = $form->createElement('radio', 'host_obsess_over_host', null, _('No'), '0');
-    $hostOOH[] = $form->createElement('radio', 'host_obsess_over_host', null, _('Default'), '2');
-    $form->addGroup($hostOOH, 'host_obsess_over_host', _('Obsess Over Host'), '&nbsp;');
-    if ($o !== HOST_MASSIVE_CHANGE) {
-        $form->setDefaults(['host_obsess_over_host' => '2']);
-    }
-
     $hostCF[] = $form->createElement('radio', 'host_check_freshness', null, _('Yes'), '1');
     $hostCF[] = $form->createElement('radio', 'host_check_freshness', null, _('No'), '0');
     $hostCF[] = $form->createElement('radio', 'host_check_freshness', null, _('Default'), '2');
@@ -918,21 +899,6 @@ if (! $isCloudPlatform) {
     $form->addElement('text', 'host_low_flap_threshold', _('Low Flap Threshold'), $attrsText2);
     $form->addElement('text', 'host_high_flap_threshold', _('High Flap Threshold'), $attrsText2);
 
-    $hostRSI[] = $form->createElement('radio', 'host_retain_status_information', null, _('Yes'), '1');
-    $hostRSI[] = $form->createElement('radio', 'host_retain_status_information', null, _('No'), '0');
-    $hostRSI[] = $form->createElement('radio', 'host_retain_status_information', null, _('Default'), '2');
-    $form->addGroup($hostRSI, 'host_retain_status_information', _('Retain Status Information'), '&nbsp;');
-    if ($o !== HOST_MASSIVE_CHANGE) {
-        $form->setDefaults(['host_retain_status_information' => '2']);
-    }
-
-    $hostRNI[] = $form->createElement('radio', 'host_retain_nonstatus_information', null, _('Yes'), '1');
-    $hostRNI[] = $form->createElement('radio', 'host_retain_nonstatus_information', null, _('No'), '0');
-    $hostRNI[] = $form->createElement('radio', 'host_retain_nonstatus_information', null, _('Default'), '2');
-    $form->addGroup($hostRNI, 'host_retain_nonstatus_information', _('Retain Non Status Information'), '&nbsp;');
-    if ($o !== HOST_MASSIVE_CHANGE) {
-        $form->setDefaults(['host_retain_nonstatus_information' => '2']);
-    }
 }
 
 $form->addElement('select', 'ehi_icon_image', _('Icon'), $extImg, [
@@ -960,8 +926,6 @@ if (! $isCloudPlatform) {
         'onChange' => "showLogo('ehi_statusmap_image_img',this.value)",
         'onkeyup' => 'this.blur();this.focus();',
     ]);
-    $form->addElement('text', 'ehi_2d_coords', _('2d Coords'), $attrsText2);
-    $form->addElement('text', 'ehi_3d_coords', _('3d Coords'), $attrsText2);
 }
 
 $form->addElement('text', 'ehi_notes', _('Note'), $attrsText);
@@ -1185,7 +1149,11 @@ $valid = false;
 if ($form->validate() && $from_list_menu === false) {
     $hostObj = $form->getElement('host_id');
     if ($form->getSubmitValue('submitA')) {
-        $hostObj->setValue(insertHostInDB());
+        if (null !== $hostId = insertHostInAPI()) {
+            $hostObj->setValue($hostId);
+            $o = HOST_WATCH;
+            $valid = true;
+        }
     } elseif ($form->getSubmitValue('submitC')) {
         /*
          * Before saving, we check if a password macro has changed its name to be able to give it the right password
@@ -1211,13 +1179,15 @@ if ($form->validate() && $from_list_menu === false) {
             }
         }
         updateHostInDB($hostObj->getValue());
+        $o = HOST_WATCH;
+        $valid = true;
     } elseif ($form->getSubmitValue('submitMC')) {
         foreach (array_keys($select) as $hostIdToUpdate) {
             updateHostInDB($hostIdToUpdate, true);
         }
+        $o = HOST_WATCH;
+        $valid = true;
     }
-    $o = HOST_WATCH;
-    $valid = true;
 } elseif ($form->isSubmitted()) {
     $tpl->assign('macChecker', "<i style='color:red;'>" . $form->getElementError('macChecker') . '</i>');
 }
@@ -1265,7 +1235,6 @@ if ($valid) {
     ?>
     <script type="text/javascript">
         showLogo('ehi_icon_image_img', document.getElementById('ehi_icon_image').value);
-        showLogo('ehi_statusmap_image_img', document.getElementById('ehi_statusmap_image').value);
 
         function uncheckNotifOption(object) {
             if (object.id == "notifN" && object.checked) {


### PR DESCRIPTION
## Description

Replace legacy code by API call to save a new host
Remove the following outdated inputs from the form:
- Obsess Over Host
- Retain Status Information
- Retain Non Status Information
- Stalking Options
- 2D Coords
- 3D Coords
- StatusMap Image
The fulll removal and clean up of those inputs in the DB and rest of the code will be handled in another PR.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master
