### PR TITLE
fix(RAM): Cannot link hostgroup to a host (#4224)

### DIFF
--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -216,7 +216,7 @@ class CentreonACL
     {
         $bindValues = [];
         foreach ($list as $index => $id) {
-            $bindValues[$prefix . $index] = $id;
+            $bindValues[$prefix . $index] = trim($id, '"\'');
         }
 
         return [$bindValues, implode(', ', array_keys($bindValues))];


### PR DESCRIPTION
## Description

Fixed issue when it is impossible to link hostgroup when creating a host for cloud users.

**Fixes** # MON-98798

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
