### PR TITLE
enh (veracode): Exclude install php scripts from veracode analysis

### DIFF
--- a/centreon/.veracode-exclusions
+++ b/centreon/.veracode-exclusions
@@ -6,6 +6,7 @@ node_modules
 www/include/common/javascript/marked.js
 www/include/common/javascript/jquery
 www/lib/wz_tooltip/wz_tooltip.js
+www/install/php
 www/install/sql
 www/include/Administration/parameters/backup/formBackup.js
 bin/changeRrdDsName.pl


### PR DESCRIPTION
## Description

Exclude an install php script directory from Veracode analysis.

**Fixes** [MON-92752](https://centreon.atlassian.net/browse/MON-92752)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Wait for next Veracode sandbox analysis.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-92752]: https://centreon.atlassian.net/browse/MON-92752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ