### PR TITLE
fix(RAM): Error when creating a rule with all hostgroups (#4301)

### DIFF
--- a/centreon/www/include/configuration/configObject/hostgroup/hostGroup.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/hostGroup.php
@@ -153,7 +153,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            deleteHostGroupInDB($select ?? []);
+            deleteHostGroupInDB($isCloudPlatform, $select ?? []);
         } else {
             unvalidFormMessage();
         }


### PR DESCRIPTION
## Description

1. Fixed error when a rule is created with all hostgroups and creating a new hostgroup generates an error when editing previously created rule.

New behavoir:

- When a new hostgroup is linked to a RA rule having only all hostgroups dataset - no new dataset created
- When a hew hostgroup is linked to a RA rule having a specific hostgroup dataset configured and doesn't have neither a parent nor a child filter - hostgroup is added to said filter
- When a hew hostgroup is linked to a RA rule having a specific hostgroup dataset configured and it has either a child or a parent filter - a new filter is created

2. Fixed error when deleting a hostgroup linked to a RA rule doesn't delete the hostgroup from a rule.

**Fixes** # MON-106080

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
