### PR TITLE
fix([Ressource Status]): No check icon for passive services but for active services yes

### DIFF
--- a/centreon/www/front_src/src/Resources/ChecksIcon.tsx
+++ b/centreon/www/front_src/src/Resources/ChecksIcon.tsx
@@ -43,7 +43,7 @@ const ChecksIcon = ({
     return <Icon Component={SyncDisabledIcon} title={labelChecksDisabled} />;
   }
 
-  if (equals(has_passive_checks_enabled, false)) {
+  if (equals(has_active_checks_enabled, false)) {
     return (
       <Icon Component={SyncProblemIcon} title={labelOnlyPassiveChecksEnabled} />
     );


### PR DESCRIPTION
Description: fix the checks condition

**video**:

[screen-capture (31).webm](https://github.com/centreon/centreon/assets/97687698/192c5128-5ddc-49fd-bcb8-ac74340808a5)
