### PR TITLE
fix(cloud): remove limitation on all_servicegroups all_hostgroups for creation

### DIFF
--- a/centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
@@ -164,7 +164,7 @@ if (
         [],
         [
             'datasourceOrigin' => 'ajax',
-            'availableDatasetRoute' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=list&use_ram=true&all_hostgroups_filter=true',
+            'availableDatasetRoute' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=list&use_ram=true',
             'defaultDataset' => [],
             'multiple' => true,
         ]

--- a/centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+++ b/centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
@@ -163,7 +163,7 @@ if (
         [],
         [
             'datasourceOrigin' => 'ajax',
-            'availableDatasetRoute' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=list&use_ram=true&all_servicegroups_filter=true',
+            'availableDatasetRoute' => BASE_ROUTE . '?object=centreon_administration_aclgroup&action=list&use_ram=true',
             'defaultDataset' => [],
             'multiple' => true,
         ]


### PR DESCRIPTION
This PR intends to remove the limitation regarding the listing of the resource access rules when creating a hostgroup or a servicegroup

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Tested live on platform

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
