### PR TITLE
fix(api): correct endpoint filters and ACLs

### DIFF
--- a/centreon/.veracode-exclusions
+++ b/centreon/.veracode-exclusions
@@ -6,6 +6,7 @@ node_modules
 www/include/common/javascript/marked.js
 www/include/common/javascript/jquery
 www/lib/wz_tooltip/wz_tooltip.js
+www/install/php
 www/install/sql
 www/include/Administration/parameters/backup/formBackup.js
 bin/changeRrdDsName.pl

--- a/centreon/doc/API/centreon-api-v24.04.yaml
+++ b/centreon/doc/API/centreon-api-v24.04.yaml
@@ -416,6 +416,8 @@ paths:
         * hostgroup.name
         * hostcategory.id
         * hostcategory.name
+        * servicegroup.id
+        * servicegroup.name
       responses:
         "200":
           description: "OK"

--- a/centreon/src/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategories.php
+++ b/centreon/src/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategories.php
@@ -39,18 +39,21 @@ use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 final class FindHostCategories
 {
     use LoggerTrait;
+    public const AUTHORIZED_ACL_GROUPS = ['customer_admin_acl'];
 
     /**
      * @param ReadHostCategoryRepositoryInterface $readHostCategoryRepository
      * @param ReadAccessGroupRepositoryInterface $readAccessGroupRepository
      * @param RequestParametersInterface $requestParameters
      * @param ContactInterface $user
+     * @param bool $isCloudPlatform
      */
     public function __construct(
         private readonly ReadHostCategoryRepositoryInterface $readHostCategoryRepository,
         private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
         private readonly RequestParametersInterface $requestParameters,
-        private readonly ContactInterface $user
+        private readonly ContactInterface $user,
+        private readonly bool $isCloudPlatform,
     ) {
     }
 
@@ -75,7 +78,7 @@ final class FindHostCategories
 
             $this->info('Finding host categories');
             $presenter->present(
-                $this->createResponse($this->user->isAdmin() ? $this->findAllAsAdmin() : $this->findAllAsUser())
+                $this->createResponse($this->isUserAdmin() ? $this->findAllAsAdmin() : $this->findAllAsUser())
             );
         } catch (\Throwable $ex) {
             $presenter->setResponseStatus(
@@ -83,6 +86,26 @@ final class FindHostCategories
             );
             $this->error($ex->getMessage());
         }
+    }
+
+    /**
+     * Indicates if the current user is admin or not (cloud + onPremise context).
+     *
+     * @return bool
+     */
+    private function isUserAdmin(): bool
+    {
+        if ($this->user->isAdmin()) {
+            return true;
+        }
+
+        $userAccessGroupNames = array_map(
+            static fn (AccessGroup $accessGroup): string => $accessGroup->getName(),
+            $this->readAccessGroupRepository->findByContact($this->user)
+        );
+
+        return ! empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS))
+            && $this->isCloudPlatform;
     }
 
     /**

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/AddRule/AddRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/AddRule/AddRule.php
@@ -54,6 +54,7 @@ final class AddRule
      * @param AddRuleValidation $validator
      * @param ReadAccessGroupRepositoryInterface $accessGroupRepository
      * @param DatasetFilterValidator $datasetValidator
+     * @param bool $isCloudPlatform
      */
     public function __construct(
         private readonly ReadResourceAccessRepositoryInterface $readRepository,
@@ -62,7 +63,8 @@ final class AddRule
         private readonly DataStorageEngineInterface $dataStorageEngine,
         private readonly AddRuleValidation $validator,
         private readonly ReadAccessGroupRepositoryInterface $accessGroupRepository,
-        private readonly DatasetFilterValidator $datasetValidator
+        private readonly DatasetFilterValidator $datasetValidator,
+        private readonly bool $isCloudPlatform
     ) {
     }
 
@@ -184,7 +186,8 @@ final class AddRule
         );
 
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
+            && $this->isCloudPlatform;
     }
 
     /**

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRule.php
@@ -47,12 +47,14 @@ final class DeleteRule
      * @param WriteResourceAccessRepositoryInterface $writeRepository
      * @param ContactInterface $user
      * @param ReadAccessGroupRepositoryInterface $accessGroupRepository
+     * @param bool $isCloudPlatform
      */
     public function __construct(
         private readonly ReadResourceAccessRepositoryInterface $readRepository,
         private readonly WriteResourceAccessRepositoryInterface $writeRepository,
         private readonly ContactInterface $user,
         private readonly ReadAccessGroupRepositoryInterface $accessGroupRepository,
+        private readonly bool $isCloudPlatform
     ) {
     }
 
@@ -117,7 +119,8 @@ final class DeleteRule
          *     - authorized to reach the Resource Access Management page.
          */
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
+            && $this->isCloudPlatform;
     }
 
     /**

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRules.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRules.php
@@ -50,13 +50,15 @@ final class DeleteRules
      * @param ContactInterface $user
      * @param ReadAccessGroupRepositoryInterface $accessGroupRepository
      * @param DataStorageEngineInterface $dataStorageEngine
+     * @param bool $isCloudPlatform
      */
     public function __construct(
         private readonly ReadResourceAccessRepositoryInterface $readRepository,
         private readonly WriteResourceAccessRepositoryInterface $writeRepository,
         private readonly ContactInterface $user,
         private readonly ReadAccessGroupRepositoryInterface $accessGroupRepository,
-        private readonly DataStorageEngineInterface $dataStorageEngine
+        private readonly DataStorageEngineInterface $dataStorageEngine,
+        private readonly bool $isCloudPlatform
     ) {
     }
 
@@ -127,7 +129,8 @@ final class DeleteRules
          *     - authorized to reach the Resource Access Management page.
          */
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
+            && $this->isCloudPlatform;
     }
 
     /**

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
@@ -54,8 +54,9 @@ final class FindRule
      * @param ReadResourceAccessRepositoryInterface $repository
      * @param ReadContactRepositoryInterface $contactRepository
      * @param ReadContactGroupRepositoryInterface $contactGroupRepository
-     * @param \Traversable<DatasetProviderInterface> $repositoryProviders
      * @param DatasetFilterValidator $datasetFilterValidator
+     * @param bool $isCloudPlatform
+     * @param \Traversable<DatasetProviderInterface> $repositoryProviders
      */
     public function __construct(
         private readonly ContactInterface $user,
@@ -64,6 +65,7 @@ final class FindRule
         private readonly ReadContactRepositoryInterface $contactRepository,
         private readonly ReadContactGroupRepositoryInterface $contactGroupRepository,
         private readonly DatasetFilterValidator $datasetFilterValidator,
+        private readonly bool $isCloudPlatform,
         \Traversable $repositoryProviders
     ) {
         $this->repositoryProviders = iterator_to_array($repositoryProviders);
@@ -216,6 +218,7 @@ final class FindRule
          *     - authorized to reach the Resource Access Management page.
          */
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
+            && $this->isCloudPlatform;
     }
 }

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRules/FindRules.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRules/FindRules.php
@@ -46,12 +46,14 @@ final class FindRules
      * @param ReadResourceAccessRepositoryInterface $repository
      * @param RequestParametersInterface $requestParameters
      * @param ReadAccessGroupRepositoryInterface $accessGroupRepository
+     * @param bool $isCloudPlatform
      */
     public function __construct(
         private readonly ContactInterface $user,
         private readonly ReadResourceAccessRepositoryInterface $repository,
         private readonly RequestParametersInterface $requestParameters,
-        private readonly ReadAccessGroupRepositoryInterface $accessGroupRepository
+        private readonly ReadAccessGroupRepositoryInterface $accessGroupRepository,
+        private readonly bool $isCloudPlatform
     ) {
     }
 
@@ -131,6 +133,7 @@ final class FindRules
         );
 
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
+            && $this->isCloudPlatform;
     }
 }

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdate.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdate.php
@@ -54,6 +54,7 @@ final class PartialRuleUpdate
      * @param ReadResourceAccessRepositoryInterface $readRepository
      * @param WriteResourceAccessRepositoryInterface $writeRepository
      * @param UpdateRuleValidation $validator
+     * @param bool $isCloudPlatform
      */
     public function __construct(
         private readonly ContactInterface $user,
@@ -61,6 +62,7 @@ final class PartialRuleUpdate
         private readonly ReadResourceAccessRepositoryInterface $readRepository,
         private readonly WriteResourceAccessRepositoryInterface $writeRepository,
         private readonly UpdateRuleValidation $validator,
+        private readonly bool $isCloudPlatform
     ) {
     }
 
@@ -164,6 +166,7 @@ final class PartialRuleUpdate
         );
 
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
+            && $this->isCloudPlatform;
     }
 }

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRule.php
@@ -57,6 +57,7 @@ final class UpdateRule
      * @param UpdateRuleValidation $validator
      * @param DatasetFilterValidator $datasetValidator
      * @param DataStorageEngineInterface $dataStorageEngine
+     * @param bool $isCloudPlatform
      */
     public function __construct(
         private readonly ContactInterface $user,
@@ -65,7 +66,8 @@ final class UpdateRule
         private readonly WriteResourceAccessRepositoryInterface $writeRepository,
         private readonly UpdateRuleValidation $validator,
         private readonly DatasetFilterValidator $datasetValidator,
-        private readonly DataStorageEngineInterface $dataStorageEngine
+        private readonly DataStorageEngineInterface $dataStorageEngine,
+        private readonly bool $isCloudPlatform
     ) {
     }
 
@@ -572,6 +574,7 @@ final class UpdateRule
         );
 
         return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
-            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW);
+            && $this->user->hasTopologyRole(Contact::ROLE_ADMINISTRATION_ACL_RESOURCE_ACCESS_MANAGEMENT_RW)
+            && $this->isCloudPlatform;
     }
 }

--- a/centreon/src/Core/ResourceAccess/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Configuration/symfony.yaml
@@ -6,6 +6,8 @@ services:
 
     Core\ResourceAccess\:
         resource: '../../../../Core/ResourceAccess/*'
+        bind:
+            $isCloudPlatform: '%env(bool:IS_CLOUD_PLATFORM)%'
 
     _instanceof:
         Core\ResourceAccess\Domain\Model\DatasetFilter\DatasetFilterTypeInterface:

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbReadServiceCategoryRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbReadServiceCategoryRepository.php
@@ -29,10 +29,12 @@ use Centreon\Infrastructure\DatabaseConnection;
 use Centreon\Infrastructure\RequestParameters\SqlRequestParametersTranslator;
 use Core\Common\Domain\TrimmedString;
 use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Core\Common\Infrastructure\Repository\SqlMultipleBindTrait;
 use Core\Common\Infrastructure\RequestParameters\Normalizer\BoolToEnumNormalizer;
 use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\ServiceCategory;
 use Core\ServiceCategory\Domain\Model\ServiceCategoryNamesById;
+use Core\ServiceGroup\Infrastructure\Repository\ServiceGroupRepositoryTrait;
 use Utility\SqlConcatenator;
 
 /**
@@ -45,7 +47,7 @@ use Utility\SqlConcatenator;
  */
 class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements ReadServiceCategoryRepositoryInterface
 {
-    use LoggerTrait;
+    use LoggerTrait, ServiceGroupRepositoryTrait, SqlMultipleBindTrait;
 
     public function __construct(DatabaseConnection $db)
     {
@@ -506,6 +508,7 @@ class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements R
         $hostAcls = '';
         $hostGroupAcls = '';
         $hostCategoryAcls = '';
+        $serviceGroupAcls = '';
         if ([] !== $accessGroupIds) {
             if (! $this->hasAccessToAllHosts($accessGroupIds)) {
                 $hostAcls = <<<'SQL'
@@ -552,6 +555,23 @@ class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements R
                             ON ag.acl_group_id = argr.acl_group_id
                         WHERE ag.acl_group_id IN (:access_group_ids)
                     )
+                    SQL;
+            }
+
+            if (! $this->hasAccessToAllServiceGroups($accessGroupIds)) {
+                $serviceGroupAcls = <<<'SQL'
+                        AND sgr.servicegroup_sg_id IN (
+                            SELECT arsgr.sg_id
+                            FROM `:db`.acl_resources_sg_relations arsgr
+                            INNER JOIN `:db`.acl_resources res
+                                ON res.acl_res_id = arsgr.acl_res_id
+                            INNER JOIN `:db`.acl_res_group_relations argr
+                                ON arsgr.acl_res_id = res.acl_res_id
+                            INNER JOIN `:db`.acl_groups ag
+                                ON ag.acl_group_id = argr.acl_group_id
+                            WHERE ag.acl_group_id IN (:access_group_ids)
+
+                        )
                     SQL;
             }
         }
@@ -689,6 +709,34 @@ class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements R
                         ON host.host_id = hsr.host_host_id
                     SQL
             );
+        } else if (\in_array('servicegroup', $matches['object'], true)) {
+            $findCategoryByServiceConcatenator->appendJoins(
+                <<<SQL
+                        LEFT JOIN `:db`.service_categories_relation scr
+                            ON scr.sc_id = sc.sc_id
+                        LEFT JOIN `:db`.service s
+                            ON s.service_id = scr.service_service_id
+                        LEFT JOIN `:db`.servicegroup_relation sgr
+                            ON sgr.service_service_id = s.service_id
+                            {$serviceGroupAcls}
+                        LEFT JOIN `:db`.servicegroup
+                            ON sgr.servicegroup_sg_id = servicegroup.sg_id
+                    SQL
+            );
+
+            $findCategoryByServiceTemplateConcatenator->appendJoins(
+                <<<SQL
+                    LEFT JOIN `:db`.service_categories_relation scr
+                        ON scr.sc_id = sc.sc_id
+                    LEFT JOIN `:db`.service s
+                        ON s.service_template_model_stm_id = scr.service_service_id
+                    LEFT JOIN `:db`.servicegroup_relation sgr
+                        ON sgr.service_service_id = s.service_id
+                        {$serviceGroupAcls}
+                    LEFT JOIN `:db`.servicegroup
+                        ON sgr.servicegroup_sg_id = servicegroup.sg_id
+                    SQL
+            );
         }
 
         return [$findCategoryByServiceConcatenator, $findCategoryByServiceTemplateConcatenator];
@@ -718,6 +766,8 @@ class DbReadServiceCategoryRepository extends AbstractRepositoryRDB implements R
             'hostgroup.name' => 'hostgroup.hg_name',
             'hostcategory.id' => 'hostcategories.hc_id',
             'hostcategory.name' => 'hostcategories.hc_name',
+            'servicegroup.id' => 'servicegroup.sg_id',
+            'servicegroup.name' => 'servicegroup.sg_name',
         ]);
 
         foreach ($concatenators as $concatenator) {

--- a/centreon/tests/php/Centreon/Domain/MetaServiceConfiguration/UseCase/V21/FindMetaServicesConfigurationsTest.php
+++ b/centreon/tests/php/Centreon/Domain/MetaServiceConfiguration/UseCase/V21/FindMetaServicesConfigurationsTest.php
@@ -24,7 +24,9 @@ namespace Tests\Centreon\Domain\MetaServiceConfiguration\UseCase\V21;
 
 use Centreon\Domain\Contact\Contact;
 use Centreon\Domain\MetaServiceConfiguration\MetaServiceConfigurationService;
+use Centreon\Domain\MetaServiceConfiguration\Model\MetaServiceConfiguration;
 use Centreon\Domain\MetaServiceConfiguration\UseCase\V2110\FindMetaServicesConfigurations;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 use Tests\Centreon\Domain\MetaServiceConfiguration\Model\MetaServiceConfigurationTest;
 
@@ -33,19 +35,17 @@ use Tests\Centreon\Domain\MetaServiceConfiguration\Model\MetaServiceConfiguratio
  */
 class FindMetaServicesConfigurationsTest extends TestCase
 {
-    /**
-     * @var MetaServiceConfigurationService&\PHPUnit\Framework\MockObject\MockObject
-     */
-    private $metaServiceConfigurationService;
-    /**
-     * @var \Centreon\Domain\MetaServiceConfiguration\Model\MetaServiceConfiguration
-     */
-    private $metaServiceConfiguration;
+    private MetaServiceConfigurationService&\PHPUnit\Framework\MockObject\MockObject $metaServiceConfigurationService;
+
+    private MetaServiceConfiguration $metaServiceConfiguration;
+
+    private ReadAccessGroupRepositoryInterface $accessGroupRepository;
 
     protected function setUp(): void
     {
         $this->metaServiceConfigurationService = $this->createMock(MetaServiceConfigurationService::class);
         $this->metaServiceConfiguration = MetaServiceConfigurationTest::createEntity();
+        $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
     }
 
     /**
@@ -62,7 +62,9 @@ class FindMetaServicesConfigurationsTest extends TestCase
         $contact->setAdmin(true);
         $findMetaServiceConfigurations = new FindMetaServicesConfigurations(
             $this->metaServiceConfigurationService,
-            $contact
+            $contact,
+            $this->accessGroupRepository,
+            false
         );
         $response = $findMetaServiceConfigurations->execute();
         $this->assertCount(1, $response->getMetaServicesConfigurations());
@@ -82,7 +84,9 @@ class FindMetaServicesConfigurationsTest extends TestCase
         $contact->setAdmin(false);
         $findMetaServiceConfigurations = new FindMetaServicesConfigurations(
             $this->metaServiceConfigurationService,
-            $contact
+            $contact,
+            $this->accessGroupRepository,
+            false
         );
         $response = $findMetaServiceConfigurations->execute();
         $this->assertCount(1, $response->getMetaServicesConfigurations());

--- a/centreon/tests/php/Core/Host/Application/UseCase/FindHosts/FindHostsTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/FindHosts/FindHostsTest.php
@@ -65,6 +65,7 @@ beforeEach(closure: function (): void {
        $this->hostCategoryRepository,
        $this->hostTemplateRepository,
        $this->hostGroupRepository,
+       false
    );
 });
 

--- a/centreon/tests/php/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategoriesTest.php
+++ b/centreon/tests/php/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategoriesTest.php
@@ -48,7 +48,8 @@ beforeEach(function () {
         $this->hostCategoryRepository,
         $this->accessGroupRepository,
         $this->requestParameters,
-        $this->user
+        $this->user,
+        false
     );
     $this->presenter = new DefaultPresenter($this->presenterFormatter);
     $this->hostCategoryName = 'hc-name';
@@ -125,7 +126,7 @@ it('should present a FindHostGroupsResponse when a non-admin user has read only 
         );
 
     $this->accessGroupRepository
-        ->expects($this->once())
+        ->expects($this->any())
         ->method('findByContact')
         ->willReturn($this->accessGroups);
 
@@ -163,7 +164,7 @@ it('should present a FindHostGroupsResponse when a non-admin user has read/write
         );
 
     $this->accessGroupRepository
-        ->expects($this->once())
+        ->expects($this->any())
         ->method('findByContact')
         ->willReturn($this->accessGroups);
 

--- a/centreon/tests/php/Core/HostGroup/Application/UseCase/FindHostGroups/FindHostGroupsTest.php
+++ b/centreon/tests/php/Core/HostGroup/Application/UseCase/FindHostGroups/FindHostGroupsTest.php
@@ -48,7 +48,8 @@ beforeEach(function (): void {
         $this->readHostGroupRepository,
         $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
         $this->createMock(RequestParametersInterface::class),
-        $this->contact
+        $this->contact,
+        false
     );
 
     $this->testedHostGroup = new HostGroup(
@@ -166,7 +167,7 @@ it(
                 ]
             );
         $this->readAccessGroupRepository
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('findByContact')
             ->willReturn([new AccessGroup(id: 1, name: 'testName', alias: 'testAlias')]);
         $this->readHostGroupRepository
@@ -204,7 +205,7 @@ it(
                 ]
             );
         $this->readAccessGroupRepository
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('findByContact')
             ->willReturn([new AccessGroup(id: 1, name: 'testName', alias: 'testAlias')]);
         $this->readHostGroupRepository

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/AddRule/AddRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/AddRule/AddRuleTest.php
@@ -74,7 +74,8 @@ beforeEach(closure: function (): void {
         dataStorageEngine: $this->createMock(DataStorageEngineInterface::class),
         validator: $this->validator = $this->createMock(AddRuleValidation::class),
         accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
-        datasetValidator: $this->datasetValidator
+        datasetValidator: $this->datasetValidator,
+        isCloudPlatform: true
     );
 
     $this->request = new AddRuleRequest();

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRule/DeleteRuleTest.php
@@ -43,6 +43,7 @@ beforeEach(closure: function (): void {
         writeRepository: $this->writeRepository = $this->createMock(WriteResourceAccessRepositoryInterface::class),
         user: $this->user = $this->createMock(ContactInterface::class),
         accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        isCloudPlatform: true
     );
 
     $this->presenter = new DeleteRulePresenterStub($this->createMock(PresenterFormatterInterface::class));

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/DeleteRules/DeleteRulesTest.php
@@ -43,7 +43,8 @@ beforeEach(closure: function (): void {
         writeRepository: $this->writeRepository = $this->createMock(WriteResourceAccessRepositoryInterface::class),
         user: $this->user = $this->createMock(ContactInterface::class),
         accessGroupRepository: $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
-        dataStorageEngine: $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class)
+        dataStorageEngine: $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class),
+        isCloudPlatform: true
     );
 
     $this->presenter = new DeleteRulesPresenterStub($this->createMock(PresenterFormatterInterface::class));

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
@@ -109,7 +109,8 @@ beforeEach(closure: function (): void {
         contactRepository: $this->contactRepository,
         contactGroupRepository: $this->contactGroupRepository,
         datasetFilterValidator: $datasetValidator,
-        repositoryProviders: $providers
+        repositoryProviders: $providers,
+        isCloudPlatform: true
     );
 });
 

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRules/FindRulesTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRules/FindRulesTest.php
@@ -68,7 +68,7 @@ beforeEach(closure: function (): void {
     $this->presenter = new FindRulesPresenterStub($this->createMock(PresenterFormatterInterface::class));
     $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
 
-    $this->useCase = new FindRules($this->user, $this->repository, $this->requestParameters, $this->accessGroupRepository);
+    $this->useCase = new FindRules($this->user, $this->repository, $this->requestParameters, $this->accessGroupRepository, true);
 });
 
 it('should present a Forbidden response when user does not have sufficient rights (missing page access)', function (): void {

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/PartialRuleUpdate/PartialRuleUpdateTest.php
@@ -73,6 +73,7 @@ beforeEach(closure: function (): void {
         readRepository: $this->readRepository = $this->createMock(ReadResourceAccessRepositoryInterface::class),
         writeRepository: $this->writeRepository = $this->createMock(WriteResourceAccessRepositoryInterface::class),
         validator: $this->validator = $this->createMock(UpdateRuleValidation::class),
+        isCloudPlatform: true
     );
 
     $this->request = new PartialRuleUpdateRequest();

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/UpdateRule/UpdateRuleTest.php
@@ -80,6 +80,7 @@ beforeEach(closure: function (): void {
         validator: $this->validator = $this->createMock(UpdateRuleValidation::class),
         datasetValidator: $this->datasetValidator,
         dataStorageEngine: $this->createMock(DataStorageEngineInterface::class),
+        isCloudPlatform: true
     );
 
     $this->request = new UpdateRuleRequest();

--- a/centreon/tests/php/Core/ServiceCategory/Application/UseCase/FindServiceCategories/FindServiceCategoriesTest.php
+++ b/centreon/tests/php/Core/ServiceCategory/Application/UseCase/FindServiceCategories/FindServiceCategoriesTest.php
@@ -48,7 +48,8 @@ beforeEach(function () {
         $this->serviceCategoryRepository,
         $this->accessGroupRepository,
         $this->requestParameters,
-        $this->user
+        $this->user,
+        false
     );
     $this->presenter = new DefaultPresenter($this->presenterFormatter);
     $this->serviceCategoryName = 'sc-name';

--- a/centreon/tests/php/Core/ServiceGroup/Application/FindServiceGroups/FindServiceGroupsTest.php
+++ b/centreon/tests/php/Core/ServiceGroup/Application/FindServiceGroups/FindServiceGroupsTest.php
@@ -46,7 +46,8 @@ beforeEach(function (): void {
         readServiceGroupRepository: $this->readServiceGroupRepository = $this->createMock(ReadServiceGroupRepositoryInterface::class),
         readAccessGroupRepository: $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class),
         requestParameters: $this->createMock(RequestParametersInterface::class),
-        contact: $this->contact = $this->createMock(ContactInterface::class)
+        contact: $this->contact = $this->createMock(ContactInterface::class),
+        isCloudPlatform: false
     );
 
     $this->testedServiceGroup = new ServiceGroup(
@@ -154,7 +155,7 @@ it(
             );
 
         $this->readAccessGroupRepository
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('findByContact')
             ->willReturn([new AccessGroup(id: 1, name: 'TestName', alias: 'TestAlias')]);
 
@@ -196,7 +197,7 @@ it(
             );
 
         $this->readAccessGroupRepository
-            ->expects($this->once())
+            ->expects($this->any())
             ->method('findByContact')
             ->willReturn([new AccessGroup(id: 1, name: 'TestName', alias: 'TestAlias')]);
 


### PR DESCRIPTION
This PR intends to
- Add the "Admin Cloud" notion to the endpoints used to filter on RAM
- Add the servicegroup filter on service categories endpoint that was not implemented.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
