### PR TITLE
fix (notification): fixed use of feature flag for engine notification

### DIFF
--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -323,7 +323,8 @@ class Engine extends AbstractObject
         }
     }
 
-    private function setEngineNotificationState() {
+    private function setEngineNotificationState(): void
+    {
         $kernel = \App\Kernel::createForWeb();
         $featureFlags = $kernel->getContainer()->get(Core\Common\Infrastructure\FeatureFlags::class);
 

--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -334,7 +334,7 @@ class Engine extends AbstractObject
         if ($featureFlags->isCloudPlatform()) {
             $this->engine['enable_notifications'] = $featureFlags->isEnabled('notification') ? '1' : '0';
         } else {
-            $this->engine['enable_notifications'] = ($featureFlags->isEnabled('notification') && $this->engine['enable_notifications'] == '1') ? '1' : '0';
+            $this->engine['enable_notifications'] = ($featureFlags->isEnabled('notification') && $this->engine['enable_notifications'] === '1') ? '1' : '0';
         }
     }
 

--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -323,19 +323,15 @@ class Engine extends AbstractObject
         }
     }
 
-    /**
-     * This method indicates if engine notifications needs to be disabled according to feature flags and engine conf in the database.
-     * conditions: "notification" feature flag AND isCloudPlatform must be true OR feature flag and enabled in the database
-     */
     private function setEngineNotificationState() {
         $kernel = \App\Kernel::createForWeb();
         $featureFlags = $kernel->getContainer()->get(Core\Common\Infrastructure\FeatureFlags::class);
 
-        if ($featureFlags->isCloudPlatform()) {
-            $this->engine['enable_notifications'] = $featureFlags->isEnabled('notification') ? '1' : '0';
-        } else {
-            $this->engine['enable_notifications'] = ($featureFlags->isEnabled('notification') && $this->engine['enable_notifications'] === '1') ? '1' : '0';
-        }
+        $this->engine['enable_notifications'] =
+            $featureFlags->isEnabled('notification') === false
+            && $this->engine['enable_notifications'] === '1'
+                ? '1'
+                : '0';
     }
 
     private function generate($poller_id)

--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -327,7 +327,7 @@ class Engine extends AbstractObject
      * This method indicates if engine notifications needs to be disabled according to feature flags and engine conf in the database.
      * conditions: "notification" feature flag AND isCloudPlatform must be true OR feature flag and enabled in the database
      */
-    private function getEngineNotificationState() {
+    private function setEngineNotificationState() {
         $kernel = \App\Kernel::createForWeb();
         $featureFlags = $kernel->getContainer()->get(Core\Common\Infrastructure\FeatureFlags::class);
 
@@ -352,7 +352,7 @@ class Engine extends AbstractObject
         $result = $this->stmt_engine->fetchAll(PDO::FETCH_ASSOC);
 
         $this->engine = array_pop($result);
-        $this->getEngineNotificationState();
+        $this->setEngineNotificationState();
 
         if (is_null($this->engine)) {
             throw new Exception(


### PR DESCRIPTION
## Description

Notification activation/deactivation is taken into account from the engine configuration form only if the notification feature flag is deactivated on the platform (notification feature flag set to 0).
Otherwise, notifications will be disabled (enable_notifications=0 in /etc/centreon-engine/centengine.cfg).

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
