### PR TITLE
fix(acl): warning when user is not linked to an ACL resource

### DIFF
--- a/centreon/.veracode-exclusions
+++ b/centreon/.veracode-exclusions
@@ -6,6 +6,7 @@ node_modules
 www/include/common/javascript/marked.js
 www/include/common/javascript/jquery
 www/lib/wz_tooltip/wz_tooltip.js
+www/install/php
 www/install/sql
 www/include/Administration/parameters/backup/formBackup.js
 bin/changeRrdDsName.pl

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -322,6 +322,8 @@ class CentreonACL
     private function setHostGroups()
     {
         $aclSubRequest = '';
+        $bindValues = [];
+
         if ($this->hasAccessToAllHostGroups === false) {
             [$bindValues, $bindQuery] = $this->createMultipleBindQuery(
                 list: explode(',', $this->getAccessGroupsString()),
@@ -355,7 +357,11 @@ class CentreonACL
         while($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
             $this->hostGroups[$record['hg_id']] = $record['hg_name'];
             $this->hostGroupsAlias[$record['hg_id']] = $record['hg_alias'];
-            $this->hostGroupsFilter[$record['acl_res_id']][$record['hg_id']] = $record['hg_id'];
+
+            // INNER JOIN might not give anything is the user is not linked to ACL resources...
+            if (isset($record['acl_res_id'])) {
+                $this->hostGroupsFilter[$record['acl_res_id']][$record['hg_id']] = $record['hg_id'];
+            }
         }
     }
 
@@ -395,6 +401,7 @@ class CentreonACL
     private function setServiceGroups()
     {
         $aclSubRequest = '';
+        $bindValues = [];
 
         if ($this->hasAccessToAllServiceGroups === false) {
             [$bindValues, $bindQuery] = $this->createMultipleBindQuery(
@@ -429,7 +436,11 @@ class CentreonACL
         while ($record = $statement->fetch(\PDO::FETCH_ASSOC)) {
             $this->serviceGroups[$record['sg_id']] = $record['sg_name'];
             $this->serviceGroupsAlias[$record['sg_id']] = $record['sg_alias'];
-            $this->serviceGroupsFilter[$record['acl_res_id']][$record['sg_id']] = $record['sg_id'];
+
+            // INNER JOIN might not give anything is the user is not linked to ACL resources...
+            if (isset($record['acl_res_id'])) {
+                $this->serviceGroupsFilter[$record['acl_res_id']][$record['sg_id']] = $record['sg_id'];
+            }
         }
     }
 


### PR DESCRIPTION
This PR intends to fix warnings due to a possible non set variable bindValues and due to the fact that a user might not be linked to a ACL resource.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
