### PR TITLE
fix(RAM): Add filter when editing a rule with All Resources is not diabled

### DIFF
--- a/centreon/.veracode-exclusions
+++ b/centreon/.veracode-exclusions
@@ -6,6 +6,7 @@ node_modules
 www/include/common/javascript/marked.js
 www/include/common/javascript/jquery
 www/lib/wz_tooltip/wz_tooltip.js
+www/install/php
 www/install/sql
 www/include/Administration/parameters/backup/formBackup.js
 bin/changeRrdDsName.pl

--- a/centreon/www/front_src/src/ResourceAccessManagement/AddEditResourceAccessRule/FormInputs/components/DatasetFilter.tsx
+++ b/centreon/www/front_src/src/ResourceAccessManagement/AddEditResourceAccessRule/FormInputs/components/DatasetFilter.tsx
@@ -57,7 +57,9 @@ const DatasetFilter = ({
       <ItemComposition
         IconAdd={<AddIcon />}
         addbuttonDisabled={
-          !areResourcesFilled(datasetFilter) || lowestResourceTypeReached()
+          !areResourcesFilled(datasetFilter) ||
+          lowestResourceTypeReached() ||
+          equals(datasetFilter[0].resourceType, ResourceTypeEnum.All)
         }
         labelAdd={t(labelAddFilter)}
         onAddItem={addResource}

--- a/centreon/www/front_src/src/ResourceAccessManagement/AddEditResourceAccessRule/FormInputs/components/DatasetFilters.tsx
+++ b/centreon/www/front_src/src/ResourceAccessManagement/AddEditResourceAccessRule/FormInputs/components/DatasetFilters.tsx
@@ -6,7 +6,7 @@ import { equals, flatten, isEmpty, last } from 'ramda';
 import { Divider } from '@mui/material';
 
 import useDatasetFilters from '../hooks/useDatasetFilters';
-import { Dataset } from '../../../models';
+import { Dataset, ResourceTypeEnum } from '../../../models';
 import { useDatasetFiltersStyles } from '../styles/DatasetFilters.styles';
 
 import DatasetFilter from './DatasetFilter';
@@ -53,8 +53,9 @@ const DatasetFilters = (): ReactElement => {
           !isEmpty(
             flatten(datasetFilters).filter(
               (dataset) =>
-                !dataset.allOfResourceType &&
-                (isEmpty(dataset.resourceType) || isEmpty(dataset.resources))
+                equals(dataset.resourceType, ResourceTypeEnum.All) ||
+                (!dataset.allOfResourceType &&
+                  (isEmpty(dataset.resourceType) || isEmpty(dataset.resources)))
             )
           )
         }


### PR DESCRIPTION
## Description

Fixed filter not being diabled when editing a rule with All Resources selected.

**Fixes** # MON-108054

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
