### PR TITLE
fix(ram): force isCloudPlatform argument in class definition

### DIFF
--- a/centreon/src/Core/ResourceAccess/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/ResourceAccess/Infrastructure/Configuration/symfony.yaml
@@ -27,6 +27,7 @@ services:
 
     Core\ResourceAccess\Application\UseCase\FindRule\FindRule:
         arguments:
+          $isCloudPlatform: '%env(bool:IS_CLOUD_PLATFORM)%'
           $repositoryProviders: !tagged_iterator 'resource.access.dataset.providers'
 
     Core\ResourceAccess\Domain\Model\DatasetFilter\DatasetFilterValidator:


### PR DESCRIPTION
It seems that providing the arguments instruction in FindRule definition breaks the binding.