### PR TITLE
fix(vault): correctly update macros in database while migrating macros to vault

### DIFF
--- a/centreon/src/Core/Macro/Domain/Model/Macro.php
+++ b/centreon/src/Core/Macro/Domain/Model/Macro.php
@@ -50,7 +50,7 @@ class Macro
     public function __construct(
         private readonly int $ownerId,
         private string $name,
-        private readonly string $value,
+        private string $value,
     ) {
         $this->shortName = (new \ReflectionClass($this))->getShortName();
 
@@ -74,6 +74,13 @@ class Macro
     public function getValue(): string
     {
         return $this->value;
+    }
+
+    public function setValue(string $value): self
+    {
+        $this->value = $value;
+
+        return $this;
     }
 
     public function isPassword(): bool

--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
@@ -36,6 +36,7 @@ use Core\Macro\Application\Repository\ReadHostMacroRepositoryInterface;
 use Core\Macro\Application\Repository\ReadServiceMacroRepositoryInterface;
 use Core\Macro\Application\Repository\WriteHostMacroRepositoryInterface;
 use Core\Macro\Application\Repository\WriteServiceMacroRepositoryInterface;
+use Core\Macro\Domain\Model\Macro;
 use Core\Security\Vault\Application\Exceptions\VaultException;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 
@@ -132,7 +133,14 @@ final class MigrateAllCredentials
                 }
             }
 
-            $this->migrateCredentials($credentials, $this->response, $hosts, $hostTemplates);
+            $this->migrateCredentials(
+                $credentials,
+                $this->response,
+                $hosts,
+                $hostTemplates,
+                $hostMacros,
+                $serviceMacros
+            );
             $presenter->presentResponse($this->response);
         } catch (\Throwable $ex) {
             $this->error((string) $ex);
@@ -145,12 +153,16 @@ final class MigrateAllCredentials
      * @param MigrateAllCredentialsResponse $response
      * @param Host[] $hosts
      * @param HostTemplate[] $hostTemplates
+     * @param Macro[] $hostMacros
+     * @param Macro[] $serviceMacros
      */
     private function migrateCredentials(
         \Traversable&\Countable $credentials,
         MigrateAllCredentialsResponse $response,
         array $hosts,
-        array $hostTemplates
+        array $hostTemplates,
+        array $hostMacros,
+        array $serviceMacros,
     ): void {
 
         $response->results = new CredentialMigrator(
@@ -162,6 +174,8 @@ final class MigrateAllCredentials
             $this->writeServiceMacroRepository,
             $hosts,
             $hostTemplates,
+            $hostMacros,
+            $serviceMacros,
         );
     }
 }

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigratorTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigratorTest.php
@@ -30,6 +30,7 @@ use Core\HostTemplate\Application\Repository\WriteHostTemplateRepositoryInterfac
 use Core\HostTemplate\Domain\Model\HostTemplate;
 use Core\Macro\Application\Repository\WriteHostMacroRepositoryInterface;
 use Core\Macro\Application\Repository\WriteServiceMacroRepositoryInterface;
+use Core\Macro\Domain\Model\Macro;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\CredentialDto;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\CredentialErrorDto;
 use Core\Security\Vault\Application\UseCase\MigrateAllCredentials\CredentialMigrator;
@@ -73,6 +74,14 @@ it('tests getIterator method with hosts, hostTemplates and service macros', func
         new HostTemplate(2, 'HostTemplate1', 'HostTemplate1'),
     ];
 
+    $hostMacro = new Macro(1,'_MACRO_HOST1','value');
+    $hostMacro->setIsPassword(true);
+    $hostMacros = [$hostMacro];
+
+    $serviceMacro = new Macro(1,'_MACRO_SERVICE1','value');
+    $serviceMacro->setIsPassword(true);
+    $serviceMacros = [$serviceMacro];
+
     $credentialMigrator = new CredentialMigrator(
         credentials: $credentials,
         writeVaultRepository: $writeVaultRepository,
@@ -81,7 +90,9 @@ it('tests getIterator method with hosts, hostTemplates and service macros', func
         writeHostMacroRepository: $writeHostMacroRepository,
         writeServiceMacroRepository: $writeServiceMacroRepository,
         hosts: $hosts,
-        hostTemplates: $hostTemplates
+        hostTemplates: $hostTemplates,
+        hostMacros: $hostMacros,
+        serviceMacros: $serviceMacros
     );
 
     foreach ($credentialMigrator as $status) {
@@ -119,6 +130,14 @@ it('tests getIterator method with exception', function (): void {
         new HostTemplate(2, 'HostTemplate1', 'HostTemplate1'),
     ];
 
+    $hostMacro = new Macro(1,'_MACRO_HOST1','value');
+    $hostMacro->setIsPassword(true);
+    $hostMacros = [$hostMacro];
+
+    $serviceMacro = new Macro(1,'_MACRO_SERVICE1','value');
+    $serviceMacro->setIsPassword(true);
+    $serviceMacros = [$serviceMacro];
+
     $credentialMigrator = new CredentialMigrator(
         credentials: $credentials,
         writeVaultRepository: $writeVaultRepository,
@@ -127,7 +146,9 @@ it('tests getIterator method with exception', function (): void {
         writeHostMacroRepository: $writeHostMacroRepository,
         writeServiceMacroRepository: $writeServiceMacroRepository,
         hosts: $hosts,
-        hostTemplates: $hostTemplates
+        hostTemplates: $hostTemplates,
+        hostMacros: $hostMacros,
+        serviceMacros: $serviceMacros
     );
 
     foreach ($credentialMigrator as $status) {


### PR DESCRIPTION
## Description

This PR intends to correctly update the macros when using the migration command. Previously some informations were override by empty values while updating the macro in database after successful migration.

**Fixes** # MON-116321

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- Create a password custom macro for service/host/hosttemplate/servicetemplate
- Add a Vault configuration
- Use the migration command
- in database the macro value should be updated with the vault path, and other informations shouldn't be changed.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
