### PR TITLE
fix(dashboards): correctly check admin rights on contact/contactgroup listing (#3887)

### DIFF
--- a/centreon/src/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroups.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroups.php
@@ -51,7 +51,7 @@ final class FindDashboardContactGroups
         try {
             if ($this->rights->canAccess()) {
                 $this->info('Find dashboard contact groups', ['request' => $this->requestParameters->toArray()]);
-                $users = $this->contact->isAdmin()
+                $users = $this->rights->hasAdminRole()
                     ? $this->findContactGroupsAsAdmin()
                     : $this->findContactGroupsAsContact();
 

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContacts.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContacts.php
@@ -68,7 +68,7 @@ final class FindDashboardContacts
         try {
             if ($this->rights->canAccess()) {
                 $this->info('Find dashboard contacts', ['request' => $this->requestParameters->toArray()]);
-                $users = $this->contact->isAdmin()
+                $users = $this->rights->hasAdminRole()
                     ? $this->findContactAsAdmin()
                     : $this->findContactsAsNonAdmin();
                 $presenter->presentResponse($this->createResponse($users));

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroupsTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboardContactGroups/FindDashboardContactGroupsTest.php
@@ -73,8 +73,8 @@ it(
     function (): void {
         $this->rights->expects($this->once())->method('canAccess')->willReturn(true);
 
-        $this->contact->expects($this->once())
-            ->method('isAdmin')
+        $this->rights->expects($this->once())
+            ->method('hasAdminRole')
             ->willReturn(false);
 
         $this->readDashboardShareRepository

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContactsTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindDashboardContacts/FindDashboardContactsTest.php
@@ -77,7 +77,7 @@ it(
 it(
     'should present a FindDashboardContactsResponse if the contact is allowed',
     function (): void {
-        $this->contact->expects($this->once())->method('isAdmin')->willReturn(true);
+        $this->rights->expects($this->once())->method('hasAdminRole')->willReturn(true);
         $this->rights->expects($this->once())->method('canAccess')->willReturn(true);
         $this->readDashboardShareRepository->expects($this->once())->method(
             'findContactsWithAccessRightByRequestParameters'
@@ -93,7 +93,7 @@ it(
     'should present a FindDashboardContactsResponse if the contact is allowed and non admin',
     function (): void {
         $this->rights->expects($this->once())->method('canAccess')->willReturn(true);
-        $this->contact->expects($this->once())->method('isAdmin')->willReturn(false);
+        $this->rights->expects($this->once())->method('hasAdminRole')->willReturn(false);
         $this->readDashboardShareRepository->expects($this->once())->method(
             'findContactsWithAccessRightByACLGroupsAndRequestParameters'
         )->willReturn([]);


### PR DESCRIPTION
🏷️ MON-88937
ℹ️ dev-24.04.x backport of https://github.com/centreon/centreon/pull/3887