### PR TITLE
enh(install): improve vault steps style in wizard

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2684,7 +2684,7 @@ msgstr "Mot de passe de l'utilisateur de la base de données"
 msgid "Confirm user password"
 msgstr "Confirmer le mot de passe de l'utilisateur"
 
-msgid "Use vault to store sensitive data"
+msgid "Use a vault to store sensitive data"
 msgstr "Utiliser un coffre fort pour stocker les données sensibles"
 
 #: centreon-web/www/install/steps/functions.php:140

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -2684,6 +2684,9 @@ msgstr "Mot de passe de l'utilisateur de la base de données"
 msgid "Confirm user password"
 msgstr "Confirmer le mot de passe de l'utilisateur"
 
+msgid "Use vault to store sensitive data"
+msgstr "Utiliser un coffre fort pour stocker les données sensibles"
+
 #: centreon-web/www/install/steps/functions.php:140
 msgid "File not found"
 msgstr "Fichier non trouvé"

--- a/centreon/www/install/steps/process/getFeatureFlags.php
+++ b/centreon/www/install/steps/process/getFeatureFlags.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright 2005-2024 Centreon
+ * Centreon is developped by : Julien Mathis and Romain Le Merlus under
+ * GPL Licence 2.0.
+ *
+ * This program is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License as published by the Free Software
+ * Foundation ; either version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along with
+ * this program; if not, see <http://www.gnu.org/licenses>.
+ *
+ * Linking this program statically or dynamically with other modules is making a
+ * combined work based on this program. Thus, the terms and conditions of the GNU
+ * General Public License cover the whole combination.
+ *
+ * As a special exception, the copyright holders of this program give Centreon
+ * permission to link this program with independent modules to produce an executable,
+ * regardless of the license terms of these independent modules, and to copy and
+ * distribute the resulting executable under terms of Centreon choice, provided that
+ * Centreon also meet, for each linked independent module, the terms  and conditions
+ * of the license of that module. An independent module is a module which is not
+ * derived from this program. If you modify this program, you may extend this
+ * exception to your version of the program, but you are not obliged to do so. If you
+ * do not wish to do so, delete this exception statement from your version.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../../../bootstrap.php';
+
+use Core\Common\Infrastructure\FeatureFlags;
+use Symfony\Component\Dotenv\Dotenv;
+
+(new Dotenv())->bootEnv('/usr/share/centreon/.env');
+$isCloudPlatform = false;
+if (array_key_exists("IS_CLOUD_PLATFORM", $_ENV) && $_ENV["IS_CLOUD_PLATFORM"]) {
+    $isCloudPlatform = true;
+}
+$featuresFileContent = file_get_contents(__DIR__ . '/../../../../config/features.json');
+$featureFlagManager = new FeatureFlags($isCloudPlatform, $featuresFileContent);
+
+echo json_encode($featureFlagManager->getAll());

--- a/centreon/www/install/steps/process/process_step6.php
+++ b/centreon/www/install/steps/process/process_step6.php
@@ -39,6 +39,10 @@ require_once __DIR__ . '/../../../../bootstrap.php';
 require_once __DIR__ . '/../functions.php';
 require __DIR__ . '/../../../include/common/common-Func.php';
 
+use Symfony\Component\Dotenv\Dotenv;
+use Core\Common\Infrastructure\FeatureFlags;
+use CentreonLegacy\Core\Install\Step\Step6;
+
 define('SQL_ERROR_CODE_ACCESS_DENIED', 1698);
 
 $requiredParameters = [
@@ -65,19 +69,8 @@ foreach ($parameters as $name => $value) {
     }
 }
 
-// If the vault checkbox is checked, validate that the feature is enabled
 if (array_key_exists('use_vault', $parameters)) {
-    (new \Symfony\Component\Dotenv\Dotenv())->bootEnv('/usr/share/centreon/.env');
-    $isCloudPlatform = false;
-    if (array_key_exists("IS_CLOUD_PLATFORM", $_ENV) && $_ENV["IS_CLOUD_PLATFORM"]) {
-        $isCloudPlatform = true;
-    }
-    $featuresFileContent = file_get_contents(__DIR__ . '/../../../../config/features.json');
-    $featureFlagManager = new \Core\Common\Infrastructure\FeatureFlags($isCloudPlatform, $featuresFileContent);
-    $err['use_vault'] = in_array('vault', $featureFlagManager->getEnabled());
-    if (! $err['use_vault']) {
-        $err['vault_error'] = 'Vault feature is disabled';
-
+    $err['use_vault'] = true;
 }
 
 if (!in_array('db_password', $err['required']) && !in_array('db_password_confirm', $err['required']) &&
@@ -116,7 +109,7 @@ try {
 }
 
 if (!count($err['required']) && $err['password'] && trim($err['connection']) == '') {
-    $step = new \CentreonLegacy\Core\Install\Step\Step6($dependencyInjector);
+    $step = new Step6($dependencyInjector);
     $step->setDatabaseConfiguration($parameters);
 }
 

--- a/centreon/www/install/steps/templates/step6.1.tpl
+++ b/centreon/www/install/steps/templates/step6.1.tpl
@@ -9,7 +9,7 @@
         <tr>
             <td class='formlabel'>{t}Vault Address{/t} <span style='color:#e00b3d'> *</span></td>
             <td class='formvalue'>
-                <input type='text' name='address' value='{$parameters.address}' />
+                <input type='text' name='address' value='{$parameters.address}' size="35"/>
                 <label class='field_msg'></label>
             </td>
         </tr>
@@ -21,7 +21,7 @@
             </td>
         </tr>
         <tr>
-            <td class='formlabel'>{t}Storage Root Path (default: root){/t} <span style='color:#e00b3d'> *</span></td>
+            <td class='formlabel'>{t}Centreon Storage Path{/t} <span style='color:#e00b3d'> *</span></td>
             <td class='formvalue'>
                 <input type='text' name='root_path' value='{$parameters.root_path}' />
                 <label class='field_msg'></label>
@@ -30,14 +30,14 @@
         <tr>
             <td class='formlabel'>{t}Role Id{/t} <span style='color:#e00b3d'> *</span></td>
             <td class='formvalue'>
-                <input type='text' name='role_id' value='{$parameters.role_id}' />
+                <input type='text' name='role_id' value='{$parameters.role_id}' size="35"/>
                 <label class='field_msg'></label>
             </td>
         </tr>
         <tr>
             <td class='formlabel'>{t}Secret Id{/t}<span style='color:#e00b3d'> *</span></td>
             <td class='formvalue'>
-                <input type='text' name='secret_id' value='{$parameters.secret_id}' />
+                <input type='text' name='secret_id' value='{$parameters.secret_id}' size="35"/>
                 <label class='field_msg'></label>
             </td>
         </tr>

--- a/centreon/www/install/steps/templates/step6.1.tpl
+++ b/centreon/www/install/steps/templates/step6.1.tpl
@@ -2,7 +2,7 @@
     <table cellpadding='0' cellspacing='0' border='0' width='100%' class='StyleDottedHr' align='center'>
         <thead>
         <tr>
-            <th colspan='2'>{t}VAULT INFO{/t}</th>
+            <th colspan='2'>{t}VAULT INFORMATION{/t}</th>
         </tr>
         </thead>
         <tbody>
@@ -16,14 +16,14 @@
         <tr>
             <td class='formlabel'>{t}Vault Port (default: 443){/t} <span style='color:#e00b3d'> *</span></td>
             <td class='formvalue'>
-                <input type='text' name='port' value='{$parameters.port}' />
+                <input type='text' name='port' value='{$parameters.port}' size="35"/>
                 <label class='field_msg'></label>
             </td>
         </tr>
         <tr>
             <td class='formlabel'>{t}Centreon Storage Path{/t} <span style='color:#e00b3d'> *</span></td>
             <td class='formvalue'>
-                <input type='text' name='root_path' value='{$parameters.root_path}' />
+                <input type='text' name='root_path' value='{$parameters.root_path}' size="35"/>
                 <label class='field_msg'></label>
             </td>
         </tr>

--- a/centreon/www/install/steps/templates/step6.tpl
+++ b/centreon/www/install/steps/templates/step6.tpl
@@ -87,7 +87,7 @@
                     <tr>
                         <td class='formlabel'>
                             {/literal}{t}{literal}
-                                Use vault to store sensitive data
+                                Use a vault to store sensitive data
                             {/literal}{/t}{literal}
                         </td>
                         <td class='formvalue'>

--- a/centreon/www/install/steps/templates/step6.tpl
+++ b/centreon/www/install/steps/templates/step6.tpl
@@ -5,7 +5,7 @@
             <th colspan='2'>{t}Database information{/t}</th>
         </tr>
         </thead>
-        <tbody>
+        <tbody id ="database_information_form_body">
         <tr>
             <td class='formlabel'>{t}Database Host Address (default: localhost){/t}</td>
             <td class='formvalue'>
@@ -69,13 +69,6 @@
                 <label class='field_msg'></label>
             </td>
         </tr>
-        <tr>
-            <td class='formlabel'>{t}Use vault to store sensitive data{/t}</td>
-            <td class='formvalue'>
-                <input type='checkbox' name='use_vault' value="{$parameters.use_vault}"/>
-                <label class='field_msg'></label>
-            </td>
-        </tr>
         </tbody>
     </table>
 </form>
@@ -83,6 +76,30 @@
 <script type="text/javascript">
 
     {literal}
+
+    jQuery.ajax({
+        type: 'GET',
+        url: './steps/process/getFeatureFlags.php',
+        success: (data) => {
+            const result = JSON.parse(data);
+            if (result.vault === true) {
+                jQuery('#database_information_form_body').append(`
+                    <tr>
+                        <td class='formlabel'>
+                            {/literal}{t}{literal}
+                                Use vault to store sensitive data
+                            {/literal}{/t}{literal}
+                        </td>
+                        <td class='formvalue'>
+                            <input type='checkbox' name='use_vault' value="{$parameters.use_vault}"/>
+                            <label class='field_msg'></label>
+                        </td>
+                    </tr>
+                `);
+            }
+        }
+    });
+
 
     function validation() {
         jQuery('.field_msg').empty();


### PR DESCRIPTION
## Description

This PR intends to add little improvement on the wizard:
- On Step6 the vault checkbox now appears dinamically depending of the activation of the vault feature flags
- Vault Step input have a increased width
- Correct a little typo saying that default path is root.

**Fixes** # MON-113489

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
