### PR TITLE
chore(ci): disable dependabot PR except for GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,27 @@ updates:
     labels:
       - 'dependencies'
       - 'gha'
+
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
+    labels:
+      - 'dependencies'
+      - 'javascript'
+    allow:
+      - dependency-type: "direct"
+      - dependency-type: "production"
+
+  - package-ecosystem: composer
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 0
+    labels:
+      - 'dependencies'
+      - 'php'
+    allow:
+      - dependency-type: "direct"
+      - dependency-type: "production"


### PR DESCRIPTION
## Description

Disable dependabot PR except for GH actions

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master
