### PR TITLE
fix(servicegroups): error when creating a service with user cloud

### DIFF
--- a/centreon/www/class/centreonServicegroups.class.php
+++ b/centreon/www/class/centreonServicegroups.class.php
@@ -232,6 +232,7 @@ class CentreonServicegroups
     {
         global $centreon;
         $items = [];
+        $sgAcl = [];
 
         # get list of authorized servicegroups
         if (
@@ -291,8 +292,8 @@ class CentreonServicegroups
             $hide = false;
             if (
                 ! $centreon->user->access->admin
-                && !in_array($record['sg_id'], $sgAcl)
                 && $centreon->user->access->hasAccessToAllServiceGroups === false
+                && ! in_array($record['sg_id'], $sgAcl)
             ) {
                 $hide = true;
             }

--- a/centreon/www/include/configuration/configObject/service/formService.php
+++ b/centreon/www/include/configuration/configObject/service/formService.php
@@ -793,11 +793,12 @@ if ($o === SERVICE_MASSIVE_CHANGE) {
 $sgReadOnly = false;
 if ($form_service_type === 'BYHOST') {
     if ($isCloudPlatform) {
+        $defaultDataset = [];
         if ($service_id !== false) {
             $hostsBounded = findHostsOfService($service_id);
             $defaultDataset = (! empty($hostsBounded))
-            ? ['0' => $hostsBounded[0]]
-            : [];
+                ? ['0' => $hostsBounded[0]]
+                : [];
         };
         $form->addElement(
             'select2',


### PR DESCRIPTION
This PR intends to patch an issue when creating a service in the cloud context and linking it to a servicegroup during the creation proccess. When user has access to all servicegroups the variable $sgAcl was not defined and then there was a fatal error.

This patches also a PHP warning

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

See jira ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
