### PR TITLE
ci(gorgone-docker): use md5 hash for docker tag instead of centreon major version

### DIFF
--- a/.github/workflows/docker-gorgone-testing.yml
+++ b/.github/workflows/docker-gorgone-testing.yml
@@ -48,4 +48,4 @@ jobs:
           context: .
           pull: true
           push: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.distrib }}:${{ needs.get-version.outputs.major_version }}
+          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/gorgone-testing-${{ matrix.distrib }}:${{ needs.get-version.outputs.gorgone_docker_version }}

--- a/.github/workflows/docker-gorgone-testing.yml
+++ b/.github/workflows/docker-gorgone-testing.yml
@@ -12,9 +12,11 @@ on:
       - dev-[2-9][0-9].[0-9][0-9].x
     paths:
       - ".github/docker/Dockerfile.gorgone-testing-*"
+      - ".github/workflows/docker-gorgone-testing.yml"
   pull_request:
     paths:
       - ".github/docker/Dockerfile.gorgone-testing-*"
+      - ".github/workflows/docker-gorgone-testing.yml"
 
 jobs:
   get-version:

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -42,6 +42,7 @@ jobs:
       os_and_database_matrix: ${{ steps.get_os_database_matrix.outputs.result }}
       release_type: ${{ steps.get_version.outputs.release_type }}
       release_cloud: ${{ steps.get_version.outputs.release_cloud}}
+      gorgone_docker_version: ${{ steps.get_version.outputs.gorgone_docker_version}}
 
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -72,7 +73,7 @@ jobs:
         run: |
           set -x
           GORGONE_DOCKER_VERSION=$(cat .github/docker/Dockerfile.gorgone-testing-* | md5sum | cut -c1-8)
-          echo "gorgone_docker_version=GORGONE_DOCKER_VERSION" >> $GITHUB_OUTPUT
+          echo "gorgone_docker_version=$GORGONE_DOCKER_VERSION" >> $GITHUB_OUTPUT
 
           if [[ "${{ inputs.version_file }}" == */.version ]]; then
             . .version

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -29,6 +29,9 @@ on:
       release_cloud:
         description: "context of release (cloud or not cloud)"
         value: ${{ jobs.get-version.outputs.release_cloud }}
+      gorgone_docker_version:
+        description: "md5 of gorgone dockerfile"
+        value: ${{ jobs.get-version.outputs.gorgone_docker_version }}
 
 jobs:
   get-version:

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -71,6 +71,9 @@ jobs:
       - id: get_version
         run: |
           set -x
+          GORGONE_DOCKER_VERSION=$(cat .github/docker/Dockerfile.gorgone-testing-* | md5sum | cut -c1-8)
+          echo "gorgone_docker_version=GORGONE_DOCKER_VERSION" >> $GITHUB_OUTPUT
+
           if [[ "${{ inputs.version_file }}" == */.version ]]; then
             . .version
             . ${{ inputs.version_file }}

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -16,6 +16,7 @@ on:
       - "centreon-gorgone/**"
       - "!centreon-gorgone/veracode.json"
       - "!centreon-gorgone/.veracode-exclusions"
+      - ".github/workflows/gorgone.yml"
   push:
     branches:
       - develop
@@ -26,6 +27,7 @@ on:
       - "centreon-gorgone/**"
       - "!centreon-gorgone/veracode.json"
       - "!centreon-gorgone/.veracode-exclusions"
+      - ".github/workflows/gorgone.yml"
 
 env:
   base_directory: centreon-gorgone

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -149,7 +149,7 @@ jobs:
             distrib: bullseye
     runs-on: ubuntu-22.04
     container:
-      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-version.outputs.major_version }}
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}:${{ needs.get-version.outputs.gorgone_docker_version }}
       credentials:
         username: ${{ secrets.DOCKER_REGISTRY_ID }}
         password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}


### PR DESCRIPTION
## Description
This allows to be sure the docker configuration is the one expected when starting to build/test docker.


**Fixes** # MON-125335

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>
All gorgone tests should have the correct dependancy when running.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
