### PR TITLE
fix(unattended): add missing RPM repositories for redhat-release

### DIFF
--- a/centreon/unattended.sh
+++ b/centreon/unattended.sh
@@ -442,9 +442,10 @@ function set_required_prerequisite() {
 
 			case "$detected_os_release" in
 			redhat-release*)
-				BASE_PACKAGES=(dnf-plugins-core epel-release)
+				BASE_PACKAGES=(dnf-plugins-core)
 				subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 				$PKG_MGR config-manager --set-enabled codeready-builder-for-rhel-8-rhui-rpms
+				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 				;;
 
 			centos-release-8.[3-9]* | centos-linux-release* | centos-stream-release* | almalinux-release* | rocky-release*)
@@ -493,9 +494,10 @@ function set_required_prerequisite() {
 
 			case "$detected_os_release" in
 			redhat-release*)
-				BASE_PACKAGES=(dnf-plugins-core epel-release)
+				BASE_PACKAGES=(dnf-plugins-core)
 				subscription-manager repos --enable codeready-builder-for-rhel-9-x86_64-rpms
 				$PKG_MGR config-manager --set-enabled codeready-builder-for-rhel-9-rhui-rpms
+				dnf install -y http://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 				;;
 
 			centos-release* | centos-linux-release* | centos-stream-release* | almalinux-release* | rocky-release*)


### PR DESCRIPTION
## Description

* fix missing repository configuration for redhat-release case installations, this should bring EPEL repositories to the platform

REFS: #MON-127462

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
