### PR TITLE
fix (pendo): replace cdn.eu.pendo.io by guide.centreon.com for snippet

### DIFF
--- a/centreon/tests/e2e/features/ACLs/01-acl-access-groups/index.ts
+++ b/centreon/tests/e2e/features/ACLs/01-acl-access-groups/index.ts
@@ -33,7 +33,7 @@ beforeEach(() => {
   }).as('getTimeZone');
   cy.intercept(
     'HEAD',
-    'https://cdn.eu.pendo.io/agent/static/b06b875d-4a10-4365-7edf-8efeaf53dfdd/pendo.js'
+    'https://guide.centreon.com/agent/static/b06b875d-4a10-4365-7edf-8efeaf53dfdd/pendo.js'
   ).as('pendoRequest');
 });
 

--- a/centreon/www/front_src/src/App/initPendo.js
+++ b/centreon/www/front_src/src/App/initPendo.js
@@ -22,7 +22,7 @@ const initPendo = (data) => {
         })(v[w]);
       y = e.createElement(n);
       y.async = !0;
-      y.src = `https://cdn.eu.pendo.io/agent/static/${apiKey}/pendo.js`;
+      y.src = `https://guide.centreon.com/agent/static/${apiKey}/pendo.js`;
       z = e.getElementsByTagName(n)[0];
       z.parentNode.insertBefore(y, z);
     })(window, document, 'script', 'pendo');

--- a/centreon/www/include/common/javascript/pendo.js
+++ b/centreon/www/include/common/javascript/pendo.js
@@ -19,7 +19,7 @@ function checkConnection(url) {
 const apiKey = 'b06b875d-4a10-4365-7edf-8efeaf53dfdd';
 // Pendo.io
 if (navigator.onLine ) {
-  checkConnection('https://cdn.eu.pendo.io/agent/static/'+apiKey+'/pendo.js').then(function() {
+  checkConnection('https://guide.centreon.com/agent/static/'+apiKey+'/pendo.js').then(function() {
 
       const initPendo = (data) => {
         (function (apiKey, platformData) {
@@ -35,7 +35,7 @@ if (navigator.onLine ) {
             })(v[w]);
             y = e.createElement(n);
             y.async = !0;
-            y.src = 'https://cdn.eu.pendo.io/agent/static/' + apiKey + '/pendo.js';
+            y.src = 'https://guide.centreon.com/agent/static/' + apiKey + '/pendo.js';
             z = e.getElementsByTagName(n)[0];
             z.parentNode.insertBefore(y, z);
           })(window, document, 'script', 'pendo');


### PR DESCRIPTION
## Description

Replace cdn.eu.pendo.io by guide.centreon.com for snippet

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
