### PR TITLE
fix(dashboard): exclude disabled resources from status grid/chart widget

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -542,7 +542,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
 
         $query .= ! empty($searchSubRequest) ? $searchSubRequest . ' AND ' : ' WHERE ';
         $query .= <<<'SQL'
-            resources.enabled = 1 AND resources.type=1 AND resources.name NOT LIKE "_Module_%"
+            resources.enabled = 1 AND resources.type=1 AND resources.name NOT LIKE "\_Module\_%"
             SQL;
 
         /**

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -434,7 +434,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         $query .= ! empty($searchSubRequest) ? $searchSubRequest . ' AND ' : ' WHERE ';
 
         $query .= <<<'SQL'
-            resources.enabled = 1 AND resources.type=1 AND resources.name NOT LIKE "_Module_%"
+            resources.enabled = 1 AND resources.type=1 AND resources.name NOT LIKE "\_Module\_%"
             SQL;
 
         /**

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -598,7 +598,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
 
         $query .= ! empty($searchSubRequest) ? $searchSubRequest . ' AND ' : ' WHERE ';
         $query .= <<<'SQL'
-            resources.enabled = 1 AND resources.type=0 AND resources.name NOT LIKE "_Module_%"
+            resources.enabled = 1 AND resources.type=0 AND resources.name NOT LIKE "\_Module\_%"
             SQL;
 
         /**

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -488,7 +488,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         $query .= ! empty($searchSubRequest) ? $searchSubRequest . ' AND ' : ' WHERE ';
 
         $query .= <<<'SQL'
-            resources.enabled = 1 AND resources.type=0 AND resources.name NOT LIKE "_Module_%"
+            resources.enabled = 1 AND resources.type=0 AND resources.name NOT LIKE "\_Module\_%"
             SQL;
 
         /**

--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -434,7 +434,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         $query .= ! empty($searchSubRequest) ? $searchSubRequest . ' AND ' : ' WHERE ';
 
         $query .= <<<'SQL'
-            resources.type=1 AND resources.name NOT LIKE "_Module_%"
+            resources.enabled = 1 AND resources.type=1 AND resources.name NOT LIKE "_Module_%"
             SQL;
 
         /**
@@ -488,7 +488,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
         $query .= ! empty($searchSubRequest) ? $searchSubRequest . ' AND ' : ' WHERE ';
 
         $query .= <<<'SQL'
-            resources.type=0 AND resources.name NOT LIKE "_Module_%"
+            resources.enabled = 1 AND resources.type=0 AND resources.name NOT LIKE "_Module_%"
             SQL;
 
         /**
@@ -542,7 +542,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
 
         $query .= ! empty($searchSubRequest) ? $searchSubRequest . ' AND ' : ' WHERE ';
         $query .= <<<'SQL'
-            resources.type=1 AND resources.name NOT LIKE "_Module_%"
+            resources.enabled = 1 AND resources.type=1 AND resources.name NOT LIKE "_Module_%"
             SQL;
 
         /**
@@ -598,7 +598,7 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
 
         $query .= ! empty($searchSubRequest) ? $searchSubRequest . ' AND ' : ' WHERE ';
         $query .= <<<'SQL'
-            resources.type=0 AND resources.name NOT LIKE "_Module_%"
+            resources.enabled = 1 AND resources.type=0 AND resources.name NOT LIKE "_Module_%"
             SQL;
 
         /**


### PR DESCRIPTION
🏷️ MON-93393
📃 This PR intends to patch an issue regarding status chart/grid widgets that does not exclude the disabled resources.
Patch has been already applied and validated by community https://thewatch.centreon.com/platform-7/display-issue-of-service-states-in-the-centreon-dashboard-3387?tid=3387&postid=12345#post12345

Only applicable in 24.04.x as those endpoints were refactored on **develop**

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

See Jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
