### PR TITLE
fix(dashboard): update dashboard name with empty description

### DIFF
--- a/centreon/src/Core/Dashboard/Application/UseCase/PartialUpdateDashboard/PartialUpdateDashboard.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/PartialUpdateDashboard/PartialUpdateDashboard.php
@@ -225,7 +225,12 @@ final class PartialUpdateDashboard
                     $dashboard->getRefresh()->getRefreshInterval()
                 )
                 : new Refresh($request->refresh->refreshType, $request->refresh->refreshInterval)
-        ))->setDescription(NoValue::coalesce($request->description, $dashboard->getDescription()));
+        ))->setDescription(
+            NoValue::coalesce(
+                $request->description !== '' ? $request->description : null,
+                $dashboard->getDescription(),
+            ),
+        );
     }
 
     /**


### PR DESCRIPTION
🏷️ MON-88893
📃 This PR intends to patch an issue regarding dashboard partial update. Updating dashboards name with empty description caused an error because the partialUpdateRequest object always provides a empty string which results in a setDescription with empty string (which is not possible with the actual Dashboard entity).

This is the least-impact solution.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>
- Create a dashboard with a name1 and empty description.
- Update the dashboard with name2 -> should work.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
