### PR TITLE
fix(graph): do not parse title to get the hostname

### DIFF
--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
@@ -81,7 +81,8 @@ use Core\Metric\Domain\Model\MetricInformation\ThresholdInformation;
  * @phpstan-type _MetricData array{
  *     global: array{
  *         base: int,
- *         title: string
+ *         title: string,
+ *         host_name: string
  *     },
  *     metrics: array<_Metrics>,
  *     times: string[]
@@ -124,9 +125,7 @@ class PerformanceMetricsDataFactory
         $times = [];
         foreach ($metricsData as $index => $metricData) {
             $metricBases[] = $metricData['global']['base'];
-            \preg_match('/^[[:ascii:]]+ graph on ([[:ascii:]]+)$/', $metricData['global']['title'], $matches);
-            $hostName = $matches[1];
-            $metrics['index:' . $index . ';host_name:' . $hostName] = $metricData['metrics'];
+            $metrics['index:' . $index . ';host_name:' . $metricData['global']['host_name']] = $metricData['metrics'];
             $times[] = $metricData['times'];
         }
 

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/FindPerformanceMetricsDataTest.php
@@ -230,7 +230,8 @@ it('should present a FindPerformanceMetricsDataResponse when metrics are correct
             [
                 'global' => [
                     'base' => 1000,
-                    'title' => 'Ping graph on myHost'
+                    'title' => 'Ping graph on myHost',
+                    'host_name' => 'myHost'
                 ],
                 'metrics' => [
                     [

--- a/centreon/www/class/centreonGraphNg.class.php
+++ b/centreon/www/class/centreonGraphNg.class.php
@@ -997,9 +997,13 @@ class CentreonGraphNg
         }
 
         if ($this->indexData["host_name"] != "_Module_Meta") {
+            $this->extraDatas['host_name'] = $this->indexData['host_name'];
+            $this->extraDatas['service_description'] = $this->indexData['service_description'];
             $this->extraDatas['title'] = $this->indexData['service_description'] . " " . _("graph on") . " "
                 . $this->indexData['host_name'];
         } else {
+            $this->extraDatas['service_description'] = $this->indexData['service_description'];
+            $this->extraDatas['host_name'] = '';
             $this->extraDatas['title'] = _("Graph") . " " . $this->indexData["service_description"];
         }
     }


### PR DESCRIPTION
🏷️ MON-118558
📃 This PR intends to change the way the host name is computed when creating the metric legend. It was initially done by parsing the tile "serviceName graph on hostName". The issue here is that this doesn't work when user sets the locale to fr_FR for instance. As we can't / do not want to handle all locales for such thing then get directly the host name from the MetricRepository and use it. There will be not impact on other api(s) using this repository.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Set the locale to french.
Create a dashboard and add a widget metic graph on it.
=> Should work

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
