### PR TITLE
enh(conf/broker) handle vault in inputs/outputs broker configuration

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -246,8 +246,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '500':
           $ref: '#/components/responses/InternalServerError'
-  /configuration/broker/{brokerId}/outputs:
-    $ref: "./latest/onPremise/Configuration/Broker/AddBrokerOutput.yaml"
+  /configuration/broker/{brokerId}/{tag}:
+    $ref: "./latest/onPremise/Configuration/Broker/AddBrokerInputOutput.yaml"
   /configuration/broker/{brokerId}/outputs/{outputId}/file:
     $ref: "./latest/onPremise/Configuration/Broker/UpdateStreamConnectorFile.yaml"
   /configuration/commands:

--- a/centreon/doc/API/latest/onPremise/Configuration/Broker/AddBrokerInputOutput.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Broker/AddBrokerInputOutput.yaml
@@ -1,16 +1,23 @@
 post:
   tags:
     - Broker
-  summary: "Add a broker output"
-  description: "Add a broker output configuration"
+  summary: "Add a Broker input/output"
+  description: "Add a Broker input/output configuration"
   parameters:
     - $ref: 'QueryParameter/BrokerId.yaml'
+    - in: path
+      name: tag
+      description: "The configuration tag"
+      required: true
+      schema:
+        type: string
+        enum: [inputs, outputs]
   requestBody:
     required: true
     content:
       application/json:
         schema:
-          $ref: 'Schema/AddBrokerOutputRequest.yaml'
+          $ref: 'Schema/AddBrokerInputOutputRequest.yaml'
   responses:
     '201':
       description: "Object created"
@@ -18,7 +25,7 @@ post:
         application/json:
           schema:
             type: object
-            $ref: 'Schema/AddBrokerOutputResponse.yaml'
+            $ref: 'Schema/AddBrokerInputOutputResponse.yaml'
     '400':
       $ref: '../../Common/Response/BadRequest.yaml'
     '403':

--- a/centreon/doc/API/latest/onPremise/Configuration/Broker/Schema/AddBrokerInputOutputRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Broker/Schema/AddBrokerInputOutputRequest.yaml
@@ -3,14 +3,14 @@ required: ["name", "typeId", "parameters"]
 properties:
   name:
     type: string
-    description: "output name"
+    description: "input/output name"
     example: "central-broker-master-unified-sql"
   type:
     type: integer
     description: |
-      Output type ID
+      Input/Output type ID
 
-      Must be one of the following:
+      Must be one of the following for outputs:
         *  3 - IPv4 (ipv4)
         * 10 - IPv6 (ipv6)
         * 11 - File (file)
@@ -23,6 +23,13 @@ properties:
         * 31 - Storage - InfluxDB (influxdb)
         * 33 - Stream connector (lua)
         * 34 - Unified SQL (unified_sql)
+        * 35 - BBDO Server (bbdo_server)
+        * 36 - BBDO Client (bbdo_client)
+
+      Must be one of the following for inputs:
+        *  3 - IPv4 (ipv4)
+        * 10 - IPv6 (ipv6)
+        * 11 - File (file)
         * 35 - BBDO Server (bbdo_server)
         * 36 - BBDO Client (bbdo_client)
     example: "33"
@@ -39,7 +46,7 @@ properties:
     example: |
       {
         "path": "some/test/path",
-        "filters.category": ["storage", "neb"],
+        "filters_category": ["storage", "neb"],
         "lua_parameter": [
           {
             "type": "string",

--- a/centreon/doc/API/latest/onPremise/Configuration/Broker/Schema/AddBrokerInputOutputResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Broker/Schema/AddBrokerInputOutputResponse.yaml
@@ -6,31 +6,31 @@ properties:
     example: 1
   name:
     type: string
-    description: "output name"
+    description: "input/output name"
     example: "central-broker-master-unified-sql"
   type:
     type: object
-    description: "output type"
+    description: "input/output type"
     properties:
       id:
         type: integer
-        description: "output type ID"
+        description: "input/output type ID"
         example: 33
       name:
         type: string
-        description: "output type name"
+        description: "input/output type name"
         example: "lua"
   parameters:
     type: object
     description: |
-      Output parameters specific to the output type.
+      Input/Output parameters specific to its type.
 
-      For multiselect fields, the property name is a combination of the group field name and the sub field name (ex: "filters.category")
+      For multiselect fields, the property name is a combination of the group field name and the sub field name (ex: "filters_category")
 
     example: |
       {
         "path": "some/test/path",
-        "filters.category": ["storage", "neb"],
+        "filters_category": ["storage", "neb"],
         "lua_parameter": [
           {
             "type": "string",

--- a/centreon/src/Core/Broker/Application/Repository/ReadBrokerInputOutputRepositoryInterface.php
+++ b/centreon/src/Core/Broker/Application/Repository/ReadBrokerInputOutputRepositoryInterface.php
@@ -77,4 +77,12 @@ interface ReadBrokerInputOutputRepositoryInterface
      */
     public function findVaultPathByBrokerId(int $brokerId): ?string;
 
+    /**
+     * Return all the broker inputs and outputs ordered by broker configuration ID.
+     *
+     * @throws \Throwable
+     *
+     * @return array<int,BrokerInputOutput[]>
+     */
+    public function findAll(): array;
 }

--- a/centreon/src/Core/Broker/Application/Repository/ReadBrokerInputOutputRepositoryInterface.php
+++ b/centreon/src/Core/Broker/Application/Repository/ReadBrokerInputOutputRepositoryInterface.php
@@ -65,4 +65,16 @@ interface ReadBrokerInputOutputRepositoryInterface
      * @return null|BrokerInputOutput
      */
     public function findByIdAndBrokerId(string $tag, int $outputId, int $brokerId): ?BrokerInputOutput;
+
+    /**
+     * Return the vault path corresponding to a broker configuration ID.
+     *
+     * @param int $brokerId
+     *
+     * @throws \Throwable
+     *
+     * @return string|null
+     */
+    public function findVaultPathByBrokerId(int $brokerId): ?string;
+
 }

--- a/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
+++ b/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
@@ -194,7 +194,8 @@ final class AddBrokerInputOutput
                     }
                 }
             } elseif (
-                $inputOutputFields[$paramName]->getType() === 'password'
+                array_key_exists($paramName, $inputOutputFields)
+                && $inputOutputFields[$paramName]->getType() === 'password'
             ) {
                 if (! is_string($paramValue) && ! is_int($paramValue)) {
                     // for phpstan, should not happen.

--- a/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
+++ b/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
@@ -35,21 +35,27 @@ use Core\Broker\Application\Exception\BrokerException;
 use Core\Broker\Application\Repository\ReadBrokerInputOutputRepositoryInterface;
 use Core\Broker\Application\Repository\WriteBrokerInputOutputRepositoryInterface;
 use Core\Broker\Domain\Model\BrokerInputOutput;
+use Core\Broker\Domain\Model\BrokerInputOutputField;
 use Core\Broker\Domain\Model\NewBrokerInputOutput;
+use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Application\UseCase\VaultTrait;
+use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 
 /**
  * @phpstan-import-type _BrokerInputOutputParameter from \Core\Broker\Domain\Model\BrokerInputOutput
  */
 final class AddBrokerInputOutput
 {
-    use LoggerTrait;
+    use LoggerTrait, VaultTrait;
 
     public function __construct(
         private readonly WriteBrokerInputOutputRepositoryInterface $writeOutputRepository,
         private readonly ReadBrokerInputOutputRepositoryInterface $readOutputRepository,
         private readonly ContactInterface $user,
         private readonly BrokerInputOutputValidator $validator,
+        private readonly WriteVaultRepositoryInterface $writeVaultRepository,
     ) {
+        $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::BROKER_VAULT_PATH);
     }
 
     /**
@@ -85,13 +91,20 @@ final class AddBrokerInputOutput
             /** @var _BrokerInputOutputParameter[] $validatedParameters */
             $validatedParameters = $request->parameters;
 
+            $newOutput = new NewBrokerInputOutput(
+                tag: $request->tag,
+                type: $type,
+                name: $request->name,
+                parameters: $validatedParameters
+            );
+
+            if ($this->writeVaultRepository->isVaultConfigured() === true) {
+                $this->uuid = $this->getBrokerVaultUuid($request->brokerId);
+                $newOutput = $this->saveInVault($newOutput, $outputFields);
+            }
+
             $outputId = $this->writeOutputRepository->add(
-                new NewBrokerInputOutput(
-                    tag: $request->tag,
-                    type: $type,
-                    name: $request->name,
-                    parameters: $validatedParameters
-                ),
+                $newOutput,
                 $request->brokerId,
                 $outputFields
             );
@@ -135,6 +148,70 @@ final class AddBrokerInputOutput
             name: $output->getName(),
             type: new TypeDto($output->getType()->id, $output->getType()->name),
             parameters: $output->getParameters()
+        );
+    }
+
+    private function getBrokerVaultUuid(int $configId): ?string
+    {
+        $vaultPath = $this->readOutputRepository->findVaultPathByBrokerId($configId);
+        if ($vaultPath === null) {
+
+            return null;
+        }
+        $vaultParts = explode('/', $vaultPath);
+
+        return end($vaultParts);
+    }
+
+    /**
+     * @param NewBrokerInputOutput $inputOutput
+     * @param array<string,BrokerInputOutputField|array<string,BrokerInputOutputField>> $inputOutputFields
+     *
+     * @return NewBrokerInputOutput
+     */
+    private function saveInVault(NewBrokerInputOutput $inputOutput, array $inputOutputFields): NewBrokerInputOutput
+    {
+        $updatedParameters = $inputOutput->getParameters();
+
+        foreach ($updatedParameters as $paramName => $paramValue) {
+            if (is_array($inputOutputFields[$paramName])) {
+                if (! is_array($paramValue)) {
+                    // for phpstan, should not happen.
+                    continue;
+                }
+                foreach ($paramValue as $groupIndex => $groupedParams) {
+                    if (isset($groupedParams['type']) && $groupedParams['type'] === 'password') {
+                        /** @var array{type:string,name:string,value:string|int} $groupedParams */
+                        $vaultKey = implode('_', [$inputOutput->getName(), $paramName, $groupedParams['name']]);
+                        $vaultPath = $this->writeVaultRepository->upsert(
+                            $this->uuid,
+                            [$vaultKey => $groupedParams['value']],
+                            []
+                        );
+                        $this->uuid ??= $this->getUuidFromPath($vaultPath);
+                        /** @var array<array<array{value:string}>> $updatedParameters */
+                        $updatedParameters[$paramName][$groupIndex]['value'] = $vaultPath;
+                    }
+                }
+            } elseif (
+                $inputOutputFields[$paramName]->getType() === 'password'
+            ) {
+                if (! is_string($paramValue) && ! is_int($paramValue)) {
+                    // for phpstan, should not happen.
+                    continue;
+                }
+                $vaultKey = implode('_', [$inputOutput->getName(), $paramName]);
+                $vaultPath = $this->writeVaultRepository->upsert($this->uuid, [$vaultKey => $paramValue], []);
+                $this->uuid ??= $this->getUuidFromPath($vaultPath);
+                $updatedParameters[$paramName] = $vaultPath;
+            }
+        }
+
+        return new NewBrokerInputOutput(
+            tag: $inputOutput->getTag(),
+            type: $inputOutput->getType(),
+            name: $inputOutput->getName(),
+            parameters: $updatedParameters,
         );
     }
 }

--- a/centreon/src/Core/Broker/Domain/Model/BrokerInputOutput.php
+++ b/centreon/src/Core/Broker/Domain/Model/BrokerInputOutput.php
@@ -49,7 +49,7 @@ class BrokerInputOutput
         private string $name,
         private array $parameters,
     ) {
-        Assertion::positiveInt($id, 'BrokerInputOutput::id');
+        Assertion::min($id, 0, 'BrokerInputOutput::id');
         Assertion::inArray($tag, ['input', 'output'], 'BrokerInputOutput::tag');
 
         $this->name = trim($name);

--- a/centreon/src/Core/Broker/Infrastructure/Repository/DbReadBrokerInputOutputRepository.php
+++ b/centreon/src/Core/Broker/Infrastructure/Repository/DbReadBrokerInputOutputRepository.php
@@ -39,6 +39,16 @@ use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
  *      parent_grp_id:null|int,
  *      fieldIndex:null|int
  * }
+ * @phpstan-type _ExtendedInputOutput array{
+ *      config_id:int,
+ *      config_group:string,
+ *      config_group_id:int,
+ *      config_key:string,
+ *      config_value:string,
+ *      subgrp_id:null|int,
+ *      parent_grp_id:null|int,
+ *      fieldIndex:null|int
+ * }
  */
 class DbReadBrokerInputOutputRepository extends AbstractRepositoryRDB implements ReadBrokerInputOutputRepositoryInterface
 {
@@ -259,10 +269,11 @@ class DbReadBrokerInputOutputRepository extends AbstractRepositoryRDB implements
     /**
      * @param _InputOutput[] $result
      * @param string $tag
+     * @param bool $withPasswords
      *
      * @return BrokerInputOutput|null
      */
-    private function createFromArray(array $result, string $tag): ?BrokerInputOutput
+    private function createFromArray(array $result, string $tag, bool $withPasswords = false): ?BrokerInputOutput
     {
         $parameters = [];
         $groupedFields = [];
@@ -316,12 +327,14 @@ class DbReadBrokerInputOutputRepository extends AbstractRepositoryRDB implements
             }
         }
 
-        // removing password values
-        foreach (array_keys($groupedFields) as $groupedFieldName) {
-            $parameters[$groupedFieldName] = array_map(
-                $this->removePasswordValue(...),
-                array_values($parameters[$groupedFieldName])
-            );
+        if (false === $withPasswords) {
+            // removing password values
+            foreach (array_keys($groupedFields) as $groupedFieldName) {
+                $parameters[$groupedFieldName] = array_map(
+                    $this->removePasswordValue(...),
+                    array_values($parameters[$groupedFieldName])
+                );
+            }
         }
 
         // for phpstan, should never happen

--- a/centreon/src/Core/Common/Infrastructure/Repository/AbstractVaultRepository.php
+++ b/centreon/src/Core/Common/Infrastructure/Repository/AbstractVaultRepository.php
@@ -37,6 +37,7 @@ abstract class AbstractVaultRepository
     public const KNOWLEDGE_BASE_PATH = 'configuration/knowledge_base';
     public const POLLER_MACRO_VAULT_PATH = 'monitoring/pollerMacros';
     public const OPEN_ID_CREDENTIALS_VAULT_PATH = 'configuration/openid';
+    public const BROKER_VAULT_PATH = 'configuration/broker';
     protected const DEFAULT_SCHEME = 'https';
 
     /** @var string[] */
@@ -46,6 +47,7 @@ abstract class AbstractVaultRepository
         self::KNOWLEDGE_BASE_PATH,
         self::POLLER_MACRO_VAULT_PATH,
         self::OPEN_ID_CREDENTIALS_VAULT_PATH,
+        self::BROKER_VAULT_PATH,
     ];
 
     protected ?VaultConfiguration $vaultConfiguration;

--- a/centreon/src/Core/Security/Vault/Application/Repository/ReadVaultConfigurationRepositoryInterface.php
+++ b/centreon/src/Core/Security/Vault/Application/Repository/ReadVaultConfigurationRepositoryInterface.php
@@ -40,4 +40,11 @@ interface ReadVaultConfigurationRepositoryInterface
      * @return VaultConfiguration|null
      */
     public function find(): ?VaultConfiguration;
+
+    /**
+     * @throws \Throwable
+     *
+     * @return string|null
+     */
+    public function getLocation(): ?string;
 }

--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigrator.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigrator.php
@@ -24,6 +24,9 @@ declare(strict_types=1);
 namespace Core\Security\Vault\Application\UseCase\MigrateAllCredentials;
 
 use Centreon\Domain\Log\LoggerTrait;
+use Core\Broker\Application\Repository\ReadBrokerInputOutputRepositoryInterface;
+use Core\Broker\Application\Repository\WriteBrokerInputOutputRepositoryInterface;
+use Core\Broker\Domain\Model\BrokerInputOutput;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
@@ -45,10 +48,11 @@ use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
  * @implements \IteratorAggregate<CredentialRecordedDto|CredentialErrorDto>
  *
  * @phpstan-type _ExistingUuids array{
- *      hosts: string[],
+ *      hosts:string[],
  *      services:string[],
- *      pollerMacro: ?string,
- *      openId: ?string
+ *      pollerMacro:?string,
+ *      openId:?string,
+ *      brokerConfigs:string[],
  * }
  */
 class CredentialMigrator implements \IteratorAggregate, \Countable
@@ -63,14 +67,17 @@ class CredentialMigrator implements \IteratorAggregate, \Countable
      * @param WriteHostMacroRepositoryInterface $writeHostMacroRepository
      * @param WriteServiceMacroRepositoryInterface $writeServiceMacroRepository
      * @param WriteOptionRepositoryInterface $writeOptionRepository
-     * @param WritePollerMacroRepositoryInterface $writePollerMacroRepository,
-     * @param Host[] $hosts,
-     * @param HostTemplate[] $hostTemplates,
+     * @param WritePollerMacroRepositoryInterface $writePollerMacroRepository
+     * @param ReadBrokerInputOutputRepositoryInterface $readBrokerInputOutputRepository
+     * @param WriteBrokerInputOutputRepositoryInterface $writeBrokerInputOutputRepository
+     * @param Host[] $hosts
+     * @param HostTemplate[] $hostTemplates
      * @param Macro[] $hostMacros
      * @param Macro[] $serviceMacros
      * @param PollerMacro[] $pollerMacros,
      * @param WriteOpenIdConfigurationRepositoryInterface $writeOpenIdConfigurationRepository
      * @param Configuration $openIdProviderConfiguration
+     * @param array<int,BrokerInputOutput[]> $brokerInputOutputs
      */
     public function __construct(
         private readonly \Traversable&\Countable $credentials,
@@ -82,12 +89,15 @@ class CredentialMigrator implements \IteratorAggregate, \Countable
         private readonly WriteOptionRepositoryInterface $writeOptionRepository,
         private readonly WritePollerMacroRepositoryInterface $writePollerMacroRepository,
         private readonly WriteOpenIdConfigurationRepositoryInterface $writeOpenIdConfigurationRepository,
+        private readonly ReadBrokerInputOutputRepositoryInterface $readBrokerInputOutputRepository,
+        private readonly WriteBrokerInputOutputRepositoryInterface $writeBrokerInputOutputRepository,
         private readonly array $hosts,
         private readonly array $hostTemplates,
         private readonly array $hostMacros,
         private readonly array $serviceMacros,
         private readonly array $pollerMacros,
         private readonly Configuration $openIdProviderConfiguration,
+        private readonly array $brokerInputOutputs,
     ) {
     }
 
@@ -98,6 +108,7 @@ class CredentialMigrator implements \IteratorAggregate, \Countable
             'services' => [],
             'pollerMacro' => null,
             'openId' => null,
+            'brokerConfigs' => [],
         ];
         /**
          * @var CredentialDto $credential
@@ -122,6 +133,10 @@ class CredentialMigrator implements \IteratorAggregate, \Countable
                         $credential
                     ),
                     CredentialTypeEnum::TYPE_OPEN_ID => $this->migrateOpenIdCredentials(
+                        $credential,
+                        $existingUuids
+                    ),
+                    CredentialTypeEnum::TYPE_BROKER_INPUT_OUTPUT => $this->migrateBrokerInputOutputPasswords(
                         $credential,
                         $existingUuids
                     ),
@@ -344,6 +359,75 @@ class CredentialMigrator implements \IteratorAggregate, \Countable
 
         return [
             'uuid' => $existingUuids['openId'],
+            'path' => $vaultPath,
+        ];
+    }
+
+    /**
+     * @param CredentialDto $credential
+     * @param _ExistingUuids $existingUuids
+     *
+     * @throws \Throwable
+     *
+     * @return array{uuid: string, path: string}
+     */
+    private function migrateBrokerInputOutputPasswords(
+        CredentialDto $credential,
+        array &$existingUuids
+    ): array {
+        if ($credential->resourceId === null) {
+            throw new \Exception('Resource ID should not be null');
+        }
+        $uuid = null;
+        if (array_key_exists($credential->resourceId, $existingUuids['brokerConfigs'])) {
+            $uuid = $existingUuids['brokerConfigs'][$credential->resourceId];
+        }
+        $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::BROKER_VAULT_PATH);
+
+        $vaultPath = $this->writeVaultRepository->upsert(
+            $uuid,
+            [
+                $credential->name => $credential->value,
+            ]
+        );
+        $vaultPathPart = explode('/', $vaultPath);
+        $existingUuids['brokerConfigs'][$credential->resourceId] = end($vaultPathPart);
+        $inputOutputs = $this->brokerInputOutputs[$credential->resourceId];
+        foreach ($inputOutputs as $inputOutput) {
+            if (str_starts_with($credential->name, $inputOutput->getName())) {
+                $credentialNamePart = str_replace($inputOutput->getName() . '_', '', $credential->name);
+                $params = $inputOutput->getParameters();
+                foreach ($params as $paramName => $param) {
+                    if (is_array($param)) {
+                        foreach ($param as $index => $groupedParams) {
+                            if (
+                                is_array($groupedParams)
+                                && isset($groupedParams['type'])
+                                && ($paramName . '_' . $groupedParams['name']) === $credentialNamePart
+                            ) {
+                                if (! isset($params[$paramName][$index]) || ! is_array($params[$paramName][$index])) {
+                                    // for phpstan, should never happen.
+                                    throw new \Exception('Unexpected error');
+                                }
+                                $params[$paramName][$index]['value'] = $vaultPath;
+                            }
+                        }
+                    } elseif ($paramName === $credentialNamePart) {
+                        $params[$paramName] = $vaultPath;
+                    }
+                }
+
+                $inputOutput->setParameters($params);
+                $this->writeBrokerInputOutputRepository->update(
+                    $inputOutput,
+                    $credential->resourceId,
+                    $this->readBrokerInputOutputRepository->findParametersByType($inputOutput->getType()->id),
+                );
+            }
+        }
+
+        return [
+            'uuid' => $existingUuids['brokerConfigs'][$credential->resourceId],
             'path' => $vaultPath,
         ];
     }

--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialTypeEnum.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialTypeEnum.php
@@ -31,4 +31,5 @@ enum CredentialTypeEnum
     case TYPE_KNOWLEDGE_BASE_PASSWORD;
     case TYPE_POLLER_MACRO;
     case TYPE_OPEN_ID;
+    case TYPE_BROKER_INPUT_OUTPUT;
 }

--- a/centreon/src/Core/Security/Vault/Infrastructure/Command/MigrateAllCredentials/MigrateAllCredentialsPresenter.php
+++ b/centreon/src/Core/Security/Vault/Infrastructure/Command/MigrateAllCredentials/MigrateAllCredentialsPresenter.php
@@ -74,6 +74,7 @@ class MigrateAllCredentialsPresenter extends CliAbstractPresenter implements Mig
             CredentialTypeEnum::TYPE_KNOWLEDGE_BASE_PASSWORD => 'knowledge_base',
             CredentialTypeEnum::TYPE_POLLER_MACRO => 'poller_macro',
             CredentialTypeEnum::TYPE_OPEN_ID => 'open_id',
+            CredentialTypeEnum::TYPE_BROKER_INPUT_OUTPUT => 'broker_input_output',
         };
     }
 
@@ -93,9 +94,7 @@ class MigrateAllCredentialsPresenter extends CliAbstractPresenter implements Mig
         return match ($dto->type) {
             CredentialTypeEnum::TYPE_HOST, CredentialTypeEnum::TYPE_HOST_TEMPLATE => '_HOST' . $dto->credentialName,
             CredentialTypeEnum::TYPE_SERVICE => '_SERVICE' . $dto->credentialName,
-            CredentialTypeEnum::TYPE_POLLER_MACRO,
-            CredentialTypeEnum::TYPE_KNOWLEDGE_BASE_PASSWORD,
-            CredentialTypeEnum::TYPE_OPEN_ID => $dto->credentialName
+            default => $dto->credentialName
         };
 
     }

--- a/centreon/src/Core/Security/Vault/Infrastructure/Repository/FsReadVaultConfigurationRepository.php
+++ b/centreon/src/Core/Security/Vault/Infrastructure/Repository/FsReadVaultConfigurationRepository.php
@@ -77,4 +77,19 @@ class FsReadVaultConfigurationRepository implements ReadVaultConfigurationReposi
          */
         return $this->factory->createFromRecord($record);
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function getLocation(): ?string
+    {
+        if (
+            ! file_exists($this->configurationFile)
+            || ! $vaultConfiguration = file_get_contents($this->configurationFile, true)
+        ) {
+            return null;
+        }
+
+        return $this->configurationFile;
+    }
 }

--- a/centreon/tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
+++ b/centreon/tests/php/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutputTest.php
@@ -36,6 +36,7 @@ use Core\Broker\Application\UseCase\AddBrokerInputOutput\BrokerInputOutputValida
 use Core\Broker\Domain\Model\BrokerInputOutput;
 use Core\Broker\Domain\Model\BrokerInputOutputField;
 use Core\Broker\Domain\Model\Type;
+use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 use Tests\Core\Broker\Infrastructure\API\AddBrokerInputOutput\AddBrokerInputOutputPresenterStub;
 
@@ -71,6 +72,7 @@ beforeEach(function (): void {
         $this->readOutputRepository = $this->createMock(ReadBrokerInputOutputRepositoryInterface::class),
         $this->user = $this->createMock(ContactInterface::class),
         $this->validator = $this->createMock(BrokerInputOutputValidator::class),
+        $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
     );
 });
 

--- a/centreon/tests/php/Core/Broker/Domain/Model/BrokerInputOutputTest.php
+++ b/centreon/tests/php/Core/Broker/Domain/Model/BrokerInputOutputTest.php
@@ -45,10 +45,10 @@ it('should return properly set broker output instance', function (): void {
 });
 
 it('should throw an exception when broker output ID is invalid', function (): void {
-    new BrokerInputOutput(0, 'output', $this->type, $this->name, $this->parameters);
+    new BrokerInputOutput(-1, 'output', $this->type, $this->name, $this->parameters);
 })->throws(
     \Assert\InvalidArgumentException::class,
-    AssertionException::positiveInt(0, 'BrokerInputOutput::id')->getMessage()
+    AssertionException::min(-1, 0, 'BrokerInputOutput::id')->getMessage()
 );
 
 it('should throw an exception when broker output name is empty', function (): void {

--- a/centreon/tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
+++ b/centreon/tests/php/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentialsTest.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace Tests\Core\Security\Vault\Application\UseCase\MigrateAllCredentials;
 
 use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Broker\Application\Repository\ReadBrokerInputOutputRepositoryInterface;
+use Core\Broker\Application\Repository\WriteBrokerInputOutputRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Contact\Domain\Model\ContactTemplate;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
@@ -74,6 +76,8 @@ beforeEach(function (): void {
         $this->writeOptionRepository = $this->createMock(WriteOptionRepositoryInterface::class),
         $this->writePollerMacroRepository = $this->createMock(WritePollerMacroRepositoryInterface::class),
         $this->writeOpenIdConfigurationRepository = $this->createMock(WriteOpenIdConfigurationRepositoryInterface::class),
+        $this->readBrokerInputOutputRepository = $this->createMock(ReadBrokerInputOutputRepositoryInterface::class),
+        $this->writeBrokerInputOutputRepository = $this->createMock(WriteBrokerInputOutputRepositoryInterface::class),
     );
 });
 

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -41,6 +41,7 @@
  */
 
 require_once _CENTREON_PATH_ . "www/class/centreon-config/centreonMainCfg.class.php";
+require_once _CENTREON_PATH_ . 'www/include/common/vault-functions.php';
 
 class CentreonConfigCentreonBroker
 {
@@ -850,7 +851,15 @@ class CentreonConfigCentreonBroker
         } catch (\PDOException $e) {
             return false;
         }
-        $this->updateCentreonBrokerInfos($id, $values);
+
+        try {
+            $this->updateCentreonBrokerInfosByAPI($id, $values);
+        } catch (\Throwable $th) {
+            error_log((string) $th);
+            echo "<div class='msg' align='center'>" . _($th->getMessage()) . "</div>";
+
+            return false;
+        }
         return true;
     }
 
@@ -950,7 +959,16 @@ class CentreonConfigCentreonBroker
         } catch (\PDOException $e) {
             return false;
         }
-        $this->updateCentreonBrokerInfos($id, $values);
+
+        try {
+            $this->updateCentreonBrokerInfosByAPI($id, $values);
+        } catch (\Throwable $th) {
+            error_log((string) $th);
+            echo "<div class='msg' align='center'>" . _($th->getMessage()) . "</div>";
+
+            return false;
+        }
+
         return true;
     }
 
@@ -1047,174 +1065,6 @@ class CentreonConfigCentreonBroker
                 }
             }
         }
-    }
-
-    /**
-     * Update the information for a configuration
-     *
-     * @param int $id The configuration id
-     * @param array $values The post array
-     * @return bool
-     */
-    public function updateCentreonBrokerInfos($id, $values)
-    {
-        // exclude multiple parameters load with broker js hook
-        $keepLuaParameters = false;
-        if (isset($values['output'])) {
-            foreach ($values['output'] as $key => $output) {
-                if ($output['type'] === 'lua') {
-                    if ($this->removeUnindexedLuaParameters($values, $key)) {
-                        $keepLuaParameters = true;
-                    }
-                    $this->removeEmptyLuaParameters($values, $key);
-                }
-            }
-        }
-
-        $this->revealLuaPasswords($id, $values);
-        $this->revealPasswords($id, $values);
-
-        // Clean the informations for this id
-        $query = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = '
-            . (int) $id
-            . ($keepLuaParameters ? ' AND config_key NOT LIKE "lua\_parameter\_%"' : '');
-        $this->db->query($query);
-
-        $groups_infos = array();
-        $groups_infos_multiple = array();
-        foreach ($this->getTags() as $group) {
-            // Resort array
-            if (isset($values[$group])) {
-                foreach ($values[$group] as $infos) {
-                    if (!isset($groups_infos[$group])) {
-                        $groups_infos[$group] = array();
-                    }
-                    $newArray = array();
-                    foreach ($infos as $key => $info) {
-                        $is_multiple = preg_match('/(.+?)_(\d+)$/', $key, $result);
-                        if ($is_multiple) {
-                            if (!isset($newArray[$result[2]])) {
-                                $newArray[$result[2]] = array();
-                            }
-                            $newArray[$result[2]][$result[1]] = $infos[$key];
-
-                            unset($infos[$key]);
-                        }
-                    }
-                    if (!empty($newArray)) {
-                        $groups_infos_multiple[] = $newArray;
-                        $infos['multiple_fields'] = $newArray;
-                    }
-                    $groups_infos[$group][] = $infos;
-                }
-            }
-        }
-
-        foreach ($groups_infos as $group => $groups) {
-            foreach ($groups as $gid => $infos) {
-                if (isset($infos['blockId'])) {
-                    list($tagId, $typeId) = explode('_', $infos['blockId']);
-                    $fieldtype = $this->getFieldtypes((int) $typeId);
-                    foreach ($infos as $fieldname => $fieldvalue) {
-                        $lvl = 0;
-                        $grp_id = null;
-                        $parent_id = null;
-
-                        if ($fieldname == 'multiple_fields' && is_array($fieldvalue)) {
-                            $index = 0;
-                            foreach ($fieldvalue as $key => $value) {
-                                if (isset($fieldtype[$fieldname]) && $fieldtype[$fieldname] == 'radio') {
-                                    $value = $value[$fieldname];
-                                }
-                                if (false === is_array($value)) {
-                                    $value = array($value);
-                                }
-                                foreach ($value as $fieldname2 => $value2) {
-                                    if (is_array($value2)) {
-                                        $explodedFieldname2 = explode('__', $fieldname2);
-                                        if (
-                                            isset($fieldtype[$explodedFieldname2[1]]) &&
-                                            $fieldtype[$explodedFieldname2[1]] === 'radio'
-                                        ) {
-                                            $value2 = $value2[$explodedFieldname2[1]];
-                                        }
-                                    }
-                                    $query = "INSERT INTO cfg_centreonbroker_info "
-                                        . "(config_id, config_key, config_value, config_group, config_group_id, "
-                                        . "grp_level, subgrp_id, parent_grp_id, fieldIndex) "
-                                        . "VALUES (:config_id, :config_key, :config_value, :config_group, "
-                                        . ":config_group_id, :grp_level, :subgrp_id, :parent_grp_id, :fieldIndex) ";
-                                    $stmt = $this->db->prepare($query);
-                                    $stmt->bindValue(':config_id', $id, \PDO::PARAM_INT);
-                                    $stmt->bindValue(':config_key', $fieldname2, \PDO::PARAM_STR);
-                                    $stmt->bindValue(':config_value', $value2, \PDO::PARAM_STR);
-                                    $stmt->bindValue(':config_group', $group, \PDO::PARAM_STR);
-                                    $stmt->bindValue(':config_group_id', $gid, \PDO::PARAM_INT);
-                                    $stmt->bindValue(':grp_level', $lvl, \PDO::PARAM_INT);
-                                    $stmt->bindValue(':subgrp_id', $grp_id, \PDO::PARAM_INT);
-                                    $stmt->bindValue(':parent_grp_id', $parent_id, \PDO::PARAM_INT);
-                                    $stmt->bindValue(':fieldIndex', $index, \PDO::PARAM_INT);
-                                    $stmt->execute();
-                                }
-                                $index++;
-                            }
-                            continue;
-                        }
-
-                        if (isset($fieldtype[$fieldname]) && $fieldtype[$fieldname] == 'radio') {
-                            $fieldvalue = $fieldvalue[$fieldname];
-                        }
-                        if (false === is_array($fieldvalue)) {
-                            $fieldvalue = array($fieldvalue);
-                        }
-                        // Construct xml tree
-                        while (preg_match('/.+__\d+__.+/', $fieldname)) {
-                            $info = explode('__', $fieldname, 3);
-                            $grp_name = $info[0];
-                            $grp_id = $info[1];
-                            $query = 'INSERT INTO cfg_centreonbroker_info (config_id, config_key, config_value,'
-                                . 'config_group, config_group_id, grp_level, subgrp_id, parent_grp_id)  VALUES ('
-                                . ':config_id, :config_key, :config_value, :config_group, :config_group_id, '
-                                . ':grp_level, :subgrp_id, :parent_grp_id)';
-
-                            $stmt = $this->db->prepare($query);
-                            $stmt->bindValue(':config_id', $id, \PDO::PARAM_INT);
-                            $stmt->bindValue(':config_key', $grp_name, \PDO::PARAM_STR);
-                            $stmt->bindValue(':config_value', "", \PDO::PARAM_STR);
-                            $stmt->bindValue(':config_group', $group, \PDO::PARAM_STR);
-                            $stmt->bindValue(':config_group_id', $gid, \PDO::PARAM_INT);
-                            $stmt->bindValue(':grp_level', $lvl, \PDO::PARAM_INT);
-                            $stmt->bindValue(':subgrp_id', $grp_id, \PDO::PARAM_INT);
-                            $stmt->bindValue(':parent_grp_id', $parent_id, \PDO::PARAM_INT);
-                            $stmt->execute();
-
-                            $lvl++;
-                            $parent_id = $grp_id;
-                            $fieldname = $info[2];
-                        }
-                        $grp_id = null;
-                        foreach ($fieldvalue as $value) {
-                            $query = 'INSERT INTO cfg_centreonbroker_info (config_id, config_key, config_value, '
-                                . 'config_group, config_group_id, grp_level, subgrp_id, parent_grp_id) VALUES ('
-                                . ':config_id, :config_key, :config_value, :config_group, '
-                                . ':config_group_id, :grp_level, :subgrp_id, :parent_grp_id) ';
-                            $stmt = $this->db->prepare($query);
-                            $stmt->bindValue(':config_id', $id, \PDO::PARAM_INT);
-                            $stmt->bindValue(':config_key', $fieldname, \PDO::PARAM_STR);
-                            $stmt->bindValue(':config_value', $value, \PDO::PARAM_STR);
-                            $stmt->bindValue(':config_group', $group, \PDO::PARAM_STR);
-                            $stmt->bindValue(':config_group_id', $gid, \PDO::PARAM_INT);
-                            $stmt->bindValue(':grp_level', $lvl, \PDO::PARAM_INT);
-                            $stmt->bindValue(':subgrp_id', $grp_id, \PDO::PARAM_INT);
-                            $stmt->bindValue(':parent_grp_id', $parent_id, \PDO::PARAM_INT);
-                            $stmt->execute();
-                        }
-                    }
-                }
-            }
-        }
-
-        return true;
     }
 
     /**
@@ -1844,4 +1694,251 @@ class CentreonConfigCentreonBroker
         }
         return $bExist;
     }
+
+    /**
+     * Replace a Broker config inputs and outputs configurations.
+     *
+     * @param int $configId
+     * @param array<string|int|array> $values
+     *
+     * @throws \LogicException
+     * @throws \Exception
+     */
+    public function updateCentreonBrokerInfosByAPI(int $configId, array $values): void
+    {
+        global $basePath;
+
+        // exclude multiple parameters load with broker js hook
+        $keepLuaParameters = false;
+        if (isset($values['output'])) {
+            foreach ($values['output'] as $key => $output) {
+                if ($output['type'] === 'lua') {
+                    if ($this->removeUnindexedLuaParameters($values, $key)) {
+                        $keepLuaParameters = true;
+                    }
+                    $this->removeEmptyLuaParameters($values, $key);
+                }
+            }
+        }
+
+        $this->revealLuaPasswords($configId, $values);
+        $this->revealPasswords($configId, $values);
+
+        // Clean the informations for this id
+         $kernel = \App\Kernel::createForWeb();
+        /** @var \Centreon\Domain\Log\Logger $logger */
+        $logger = $kernel->getContainer()->get(\Centreon\Domain\Log\Logger::class);
+        $readVaultConfigurationRepository = $kernel->getContainer()->get(
+            Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface::class
+        );
+        $vaultConfiguration = $readVaultConfigurationRepository->find();
+        if ($vaultConfiguration !== null) {
+            deleteBrokerConfigsFromVault($vaultConfiguration, $logger, [$configId]);
+        }
+
+        $query = 'DELETE FROM cfg_centreonbroker_info WHERE config_id = '
+            . $configId
+            . ($keepLuaParameters ? ' AND config_key NOT LIKE "lua\_parameter\_%"' : '');
+        $this->db->query($query);
+
+        [$groups_infos, ] = $this->getGroupsInfos($values);
+
+        /** @var Core\Infrastructure\Common\Api\Router $router */
+        $router = $kernel->getContainer()->get(Core\Infrastructure\Common\Api\Router::class)
+        ?? throw new LogicException('Router not found in container');
+        $client = new Symfony\Component\HttpClient\CurlHttpClient();
+        $headers = [
+            'Content-Type' => 'application/json',
+            'X-AUTH-TOKEN' => $_COOKIE['PHPSESSID'],
+        ];
+        $parameters = ['brokerId' => $configId];
+        $basePath ? $parameters['base_uri'] = $basePath : null;
+
+        foreach($groups_infos as $tag => $groups) {
+            $parameters['tag'] = $tag === 'input' ? 'inputs' : 'outputs';
+            $url = $router->generate(
+                'AddBrokerInputOutput',
+                $parameters,
+                Symfony\Component\Routing\Generator\UrlGeneratorInterface::ABSOLUTE_URL,
+            );
+
+            foreach($groups as $group) {
+                $payload = $this->buildPayload($group);
+                $response = $client->request(
+                    'POST',
+                    $url,
+                    [
+                        'headers' => $headers,
+                        'body' => json_encode($payload),
+                    ],
+                );
+                if ($response->getStatusCode() !== 201) {
+                    $content = json_decode($response->getContent(false));
+                    throw new \Exception($content->message ?? 'Unexpected return status');
+                }
+            }
+        }
+    }
+
+    /**
+     * @param array<string|int|null|array<string|int|null|array<string|int|null>>> $inputOutput
+     *
+     * @return array
+     */
+    private function buildPayload(array $inputOutput): array
+    {
+        /** @var string $blockId */
+        $blockId = $inputOutput['blockId'];
+        [, $typeId] = explode('_', $blockId);
+        $fieldTypes = $this->getFieldtypesWithGroup((int) $typeId);
+
+        $payload = [
+            'name' => $inputOutput['name'],
+            'type' => (int) $typeId,
+            'parameters' => [],
+        ];
+
+        foreach($inputOutput as $fieldName => $fieldValue) {
+            if ($fieldName === 'multiple_fields') {
+                foreach($fieldValue as $index => $groups) {
+                    foreach($groups as $subName => $subValue) {
+                        [$groupName, $name] = explode('__', $subName);
+
+                        $fieldType = $fieldTypes[$groupName][$name];
+                        $payload['parameters'][$groupName][$index] ??= [];
+                        $this->addToPayload($payload['parameters'][$groupName][$index], $fieldType, $name, $subValue);
+                    }
+                }
+            } else {
+                if (is_array($fieldValue)) {
+                    if (str_contains($fieldName, '__')) {
+                        [, , $name] = explode('__', $fieldName);
+                    } else {
+                        $name = $fieldName;
+                    }
+                    $fieldType = $fieldTypes[$name] ?? null;
+                } else {
+                    $fieldType = $fieldTypes[$fieldName] ?? null;
+                }
+                if ($fieldType !== null) {
+                    $this->addToPayload($payload['parameters'], $fieldType, $fieldName, $fieldValue);
+                }
+            }
+        }
+
+        foreach($fieldTypes as $name => $type) {
+            if ($type == 'multiselect') {
+                $name = "filters_{$name}";
+            } elseif (is_array($type)) {
+                $type = 'grouped';
+            }
+            if (! array_key_exists($name, $payload['parameters'])) {
+                $payload['parameters'][$name] = match ($type) {
+                    'select', 'text', 'password', 'int', 'radio' => null,
+                    'multiselect', 'grouped' => [],
+                };
+            }
+        }
+
+        return $payload;
+    }
+
+    /**
+     * Summary of addToPayload
+     * @param array<mixed> $payload
+     * @param string $fieldType
+     * @param string $fieldName
+     * @param string|array<mixed> $fieldValue
+     *
+     * @return void
+     */
+    private function addToPayload(
+        array &$payload,
+        string $fieldType,
+        string $fieldName,
+        string|array $fieldValue
+    ): void {
+        switch ($fieldType) {
+            case 'select':
+            case 'text':
+                $payload[$fieldName] = $fieldValue === "" ? null : $fieldValue;
+                break;
+            case 'int':
+                $payload[$fieldName] = $fieldValue === "" ? null : (int) $fieldValue;
+                break;
+            case 'radio':
+                $payload[$fieldName] = $fieldValue[$fieldName];
+                break;
+            case 'multiselect':
+                [$category, , $name] = explode('__', $fieldName);
+                $payload["{$category}_{$name}"] = $fieldValue;
+                break;
+            case 'password':
+                $payload[$fieldName] = $fieldValue;
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * @param array<mixed> $values
+     *
+     * @return array{array<mixed>,array<mixed>}
+     */
+    private function getGroupsInfos(array $values): array
+    {
+        $groups_infos = [];
+        $groups_infos_multiple = [];
+        foreach ($this->getTags() as $group) {
+            // Resort array
+            if (isset($values[$group])) {
+                foreach ($values[$group] as $infos) {
+                    if (!isset($groups_infos[$group])) {
+                        $groups_infos[$group] = [];
+                    }
+                    $newArray = [];
+                    foreach ($infos as $key => $info) {
+                        $is_multiple = preg_match('/(.+?)_(\d+)$/', $key, $result);
+                        if ($is_multiple) {
+                            if (!isset($newArray[$result[2]])) {
+                                $newArray[$result[2]] = [];
+                            }
+                            $newArray[$result[2]][$result[1]] = $info;
+
+                            unset($infos[$key]);
+                        }
+                    }
+                    if (!empty($newArray)) {
+                        $groups_infos_multiple[] = $newArray;
+                        $infos['multiple_fields'] = $newArray;
+                    }
+                    $groups_infos[$group][] = $infos;
+                }
+            }
+        }
+
+        return [$groups_infos, $groups_infos_multiple];
+    }
+
+    /**
+     * Generate fieldtype array.
+     *
+     * @param int $typeId The type id
+     * @return array
+     */
+    public function getFieldtypesWithGroup($typeId)
+    {
+        $fieldTypes = [];
+        $block = $this->getBlockInfos($typeId);
+        foreach ($block as $fieldInfos) {
+            if ($fieldInfos['group_name'] !== null) {
+                $fieldTypes[$fieldInfos['group_name']][$fieldInfos['fieldname']] = $fieldInfos['fieldtype'];
+            } else {
+                $fieldTypes[$fieldInfos['fieldname']] = $fieldInfos['fieldtype'];
+            }
+        }
+        return $fieldTypes;
+    }
+
 }

--- a/centreon/www/class/config-generate/broker.class.php
+++ b/centreon/www/class/config-generate/broker.class.php
@@ -92,6 +92,18 @@ class Broker extends AbstractObjectJSON
     protected $stmt_engine_parameters = null;
     protected $cacheExternalValue = null;
     protected $cacheLogValue = null;
+    protected $readVaultConfigurationRepository = null;
+
+    public function __construct(\Pimple\Container $dependencyInjector)
+    {
+        parent::__construct($dependencyInjector);
+
+        // Get Centeron Vault Storage configuration
+        $kernel = \App\Kernel::createForWeb();
+        $this->readVaultConfigurationRepository = $kernel->getContainer()->get(
+            Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface::class
+        );
+    }
 
     private function getExternalValues()
     {
@@ -356,6 +368,11 @@ class Broker extends AbstractObjectJSON
 
             // Remove unnecessary element form inputs and output for stream types bbdo
             $object = $this->cleanBbdoStreams($object);
+
+            // Add vault path if vault if defined
+            if ($this->readVaultConfigurationRepository->exists()) {
+                $object['vault_configuration'] = $this->readVaultConfigurationRepository->getLocation();
+            }
 
             // Generate file
             $this->generateFile($object);

--- a/centreon/www/include/configuration/configCentreonBroker/DB-Func.php
+++ b/centreon/www/include/configuration/configCentreonBroker/DB-Func.php
@@ -33,6 +33,8 @@
  *
  */
 
+require_once _CENTREON_PATH_ . 'www/include/common/vault-functions.php';
+
 /**
  *
  * Test broker file config existance
@@ -108,9 +110,22 @@ function deleteCentreonBrokerInDB($ids = array())
 {
     global $pearDB;
 
+    $brokerIds = array_keys($ids);
+
+    $kernel = \App\Kernel::createForWeb();
+    /** @var \Centreon\Domain\Log\Logger $logger */
+    $logger = $kernel->getContainer()->get(\Centreon\Domain\Log\Logger::class);
+    $readVaultConfigurationRepository = $kernel->getContainer()->get(
+        Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface::class
+    );
+    $vaultConfiguration = $readVaultConfigurationRepository->find();
+    if ($vaultConfiguration !== null) {
+        deleteBrokerConfigsFromVault($vaultConfiguration, $logger, $brokerIds);
+    }
+
     $statement = $pearDB->prepare("DELETE FROM cfg_centreonbroker WHERE config_id = :config_id");
-    foreach ($ids as $key => $value) {
-        $statement->bindValue(':config_id', (int) $key, \PDO::PARAM_INT);
+    foreach ($brokerIds as $id) {
+        $statement->bindValue(':config_id', $id, \PDO::PARAM_INT);
         $statement->execute();
     }
 }
@@ -206,26 +221,32 @@ function multipleCentreonBrokerInDB($ids, $nbrDup)
         $row = getCfgBrokerData((int) $id);
 
         # Prepare values
-        $values = array();
+        $values = [];
         $values['activate_watchdog']['activate_watchdog'] = '0';
         $values['activate']['activate'] = '0';
         $values['ns_nagios_server'] = $row['ns_nagios_server'];
         $values['event_queue_max_size'] = $row['event_queue_max_size'];
         $values['cache_directory'] = $row['cache_directory'];
         $values['activate_watchdog']['activate_watchdog'] = $row['daemon'];
-        $values['output'] = array();
-        $values['input'] = array();
+        $values['output'] = [];
+        $values['input'] = [];
         $brokerCfgInfoData = getCfgBrokerInfoData((int) $id);
+
         foreach ($brokerCfgInfoData as $rowOpt) {
             if ($rowOpt['config_key'] == 'filters') {
                 continue;
             } elseif ($rowOpt['config_key'] == 'category') {
-                $config_key = 'filters__' . $rowOpt['config_group_id'] . '__category';
-                $values[$rowOpt['config_group']][$rowOpt['config_group_id']][$config_key] = $rowOpt['config_value'];
+                $configKey = 'filters__' . $rowOpt['config_group_id'] . '__category';
+                $values[$rowOpt['config_group']][$rowOpt['config_group_id']][$configKey][] =
+                    $rowOpt['config_value'];
+            } elseif ($rowOpt['fieldIndex'] !== null) {
+                $configKey = $rowOpt['config_key'] . '_' . $rowOpt['fieldIndex'];
+                $values[$rowOpt['config_group']][$rowOpt['config_group_id']][$configKey] = $rowOpt['config_value'];
             } else {
                 $values[$rowOpt['config_group']][$rowOpt['config_group_id']][$rowOpt['config_key']] =
                     $rowOpt['config_value'];
             }
+
         }
 
         # Convert values radio button
@@ -236,7 +257,7 @@ function multipleCentreonBrokerInDB($ids, $nbrDup)
                         list($tagId, $typeId) = explode('_', $infos['blockId']);
                         $fieldtype = $cbObj->getFieldtypes($typeId);
                     } else {
-                        $fieldtype = array();
+                        $fieldtype = [];
                     }
 
                     if (is_array($infos)) {
@@ -271,6 +292,9 @@ function multipleCentreonBrokerInDB($ids, $nbrDup)
             }
             $values['name'] = $newname;
             $values['filename'] = $newfilename;
+
+            retrieveOriginalPasswordValuesFromVault($values);
+
             $cbObj->insertConfig($values);
         }
     }
@@ -330,9 +354,11 @@ function getCfgBrokerInfoData(int $configId): array
 {
     global $pearDB;
 
-    $query = "SELECT config_key, config_value, config_group, config_group_id "
-             . "FROM cfg_centreonbroker_info "
-             . "WHERE config_id = :config_id";
+    $query = <<<SQL
+        SELECT config_key, config_value, config_group, config_group_id, fieldIndex
+        FROM cfg_centreonbroker_info
+        WHERE config_id = :config_id
+        SQL;
     try {
         $statement = $pearDB->prepare($query);
         $statement->bindValue(':config_id', $configId, \PDO::PARAM_INT);
@@ -343,4 +369,53 @@ function getCfgBrokerInfoData(int $configId): array
     }
     $statement->closeCursor();
     return $cfgBrokerInfoData;
+}
+
+/**
+ * Replace the vaultPath by the actual value in the values array.
+ *
+ * @param array{
+ *  name:string,
+ *  output:array<string,array>,
+ *  input:array<string,array>
+ * } $values
+ *
+ */
+function retrieveOriginalPasswordValuesFromVault(array &$values): void
+{
+    $kernel = \App\Kernel::createForWeb();
+    /** @var \Centreon\Domain\Log\Logger $logger */
+    $logger = $kernel->getContainer()->get(\Centreon\Domain\Log\Logger::class);
+    $readVaultConfigurationRepository = $kernel->getContainer()->get(
+        Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface::class
+    );
+    $vaultConfiguration = $readVaultConfigurationRepository->find();
+
+    foreach (['input', 'output'] as $tag) {
+        foreach ($values[$tag] as $key => $inputOutput) {
+            foreach ($inputOutput as $name => $value) {
+                if (is_string($value) && str_starts_with($value, 'secret::')) {
+                    [$groupName, $subName] = explode('__', $name);
+                    [$subName, $subKey] = explode('_', $subName);
+                    if ($subName === 'value') {
+                        $vaultKey = implode(
+                            '_',
+                            [$inputOutput['name'], $groupName, $inputOutput["{$groupName}__name_{$subKey}"]]
+                        );
+                    } else {
+                        $vaultKey = $inputOutput['name'] . '_' . $name;
+                    }
+
+                    $passwordValue = findBrokerConfigValueFromVault(
+                        $vaultConfiguration,
+                        $logger,
+                        $vaultKey,
+                        $value,
+                    );
+                    $values[$tag][$key][$name] = $passwordValue;
+                }
+            }
+        }
+    }
+
 }

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -622,7 +622,6 @@ INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`
 (84, 'certificate','Certificate path','Full path to the file containing the certificate in PEM format (required for encryption)','text', NULL),
 (85, 'compression','Compression','Enable data compression','radio', NULL),
 (86, 'retention','Enable retention','Enable data retention until the client is connected','radio', NULL),
-(87, 'category','Filter on event categories','Broker event categories to filter. If none is selected, all categories of events will be processed','multiselect', NULL),
 (88, 'host','Server address','Address of the server to which the client should connect','text', NULL),
 (89, 'port','Server port','TCP port of the server to which the client should connect','int', NULL),
 (90, 'retry_interval','Retry interval (seconds)','Number of seconds between a lost or failed connection and the next try','int', NULL),
@@ -632,7 +631,6 @@ INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`
 (94, 'ca_certificate',"Trusted CA's certificate path (optional)","If the server's certificate is signed by an untrusted Certification Authority (CA), then specify the certificate's path.\nIf the server\s certificate is self-signed, then specify its path.\nYou can also add the certificate to the store of certificates trusted by the operating system.\nThe file must be in PEM format.",'text', NULL),
 (95, 'ca_name','Certificate Common Name (optional)','If the Common Name (CN) of the certificate is different from the value in the "Server address" field, the CN must be provided here','text', NULL),
 (96, 'compression','Compression','Enable data compression','radio', NULL),
-(97, 'category','Filter on event categories','Broker event categories to filter. If none is selected, all categories of events will be processed','multiselect', NULL);
 
 INSERT INTO `cb_fieldgroup` (`cb_fieldgroup_id`, `groupname`, `displayname`, `multiple`, `group_parent_id`) VALUES
 (1, 'filters', '', 0, NULL),
@@ -655,6 +653,8 @@ INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`
 (71, 'name', 'Name', 'Name of the metric.', 'text', NULL, 4),
 (72, 'value', 'Value', 'Value of the metric.', 'text', NULL, 4),
 (73, 'type', 'Type', 'Type of the metric.', 'select', NULL, 4);
+(87, 'category','Filter on event categories','Broker event categories to filter. If none is selected, all categories of events will be processed','multiselect', NULL, 1),
+(97, 'category','Filter on event categories','Broker event categories to filter. If none is selected, all categories of events will be processed','multiselect', NULL, 1);
 
 --
 -- Contenu de la table `cb_list`

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -630,7 +630,7 @@ INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`
 (93, 'encryption','Enable TLS encryption','Enable TLS 1.3 encryption','radio', NULL),
 (94, 'ca_certificate',"Trusted CA's certificate path (optional)","If the server's certificate is signed by an untrusted Certification Authority (CA), then specify the certificate's path.\nIf the server\s certificate is self-signed, then specify its path.\nYou can also add the certificate to the store of certificates trusted by the operating system.\nThe file must be in PEM format.",'text', NULL),
 (95, 'ca_name','Certificate Common Name (optional)','If the Common Name (CN) of the certificate is different from the value in the "Server address" field, the CN must be provided here','text', NULL),
-(96, 'compression','Compression','Enable data compression','radio', NULL),
+(96, 'compression','Compression','Enable data compression','radio', NULL);
 
 INSERT INTO `cb_fieldgroup` (`cb_fieldgroup_id`, `groupname`, `displayname`, `multiple`, `group_parent_id`) VALUES
 (1, 'filters', '', 0, NULL),
@@ -652,7 +652,7 @@ INSERT INTO `cb_field` (`cb_field_id`, `fieldname`, `displayname`, `description`
 (62, 'is_tag', 'Tag', 'Whether or not this column is a tag', 'radio', NULL, 3),
 (71, 'name', 'Name', 'Name of the metric.', 'text', NULL, 4),
 (72, 'value', 'Value', 'Value of the metric.', 'text', NULL, 4),
-(73, 'type', 'Type', 'Type of the metric.', 'select', NULL, 4);
+(73, 'type', 'Type', 'Type of the metric.', 'select', NULL, 4),
 (87, 'category','Filter on event categories','Broker event categories to filter. If none is selected, all categories of events will be processed','multiselect', NULL, 1),
 (97, 'category','Filter on event categories','Broker event categories to filter. If none is selected, all categories of events will be processed','multiselect', NULL, 1);
 


### PR DESCRIPTION
## Description
- Call API instead of legacy when possible (creation/duplication/update of inputs/outputs) in broker configuration form
- Handle vault for fields of type password in the broker configuration (inputs and outputs) (API + legacy)
- Update vault migration script to handle broker configuration inputs/outputs
- Update API documentation for AddBorkerInputOutput
- Add vault path in broker configuration export file 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master
