### PR TITLE
fix(release): use pcre to get jira_release_id

### DIFF
--- a/.github/actions/release/action.yml
+++ b/.github/actions/release/action.yml
@@ -189,7 +189,7 @@ runs:
         JIRA_RELEASE_NAME=""
         JIRA_PROJECT_ID="${{ inputs.jira_project_id }}"
         JIRA_RELEASE_RELEASED="false"
-        JIRA_RELEASE_ID="$(git log |grep -E "^\s+Centreon.*#[0-9]{5,}#)" |grep -Eo "([0-9]{5,})" |head -n 1)"
+        JIRA_RELEASE_ID="$(git log |grep -E "Centreon\ next.*\#[0-9]{5,}\#\)" |grep -o -P "(?<=#)[0-9]{5,}(?=#)" |head -n 1)"
 
         # Create JIRA version for each released component
         echo "Creating JIRA releases."


### PR DESCRIPTION
## Description

* use pcre pattern search to properly identify jira_release_id (since using ERE caused unexpected non jira_release_id values to be used instead)

REF: #MON-131624

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
