### PR TITLE
fix(dashboard): update dashboard name with empty description (#4476)

### DIFF
--- a/centreon/src/Core/Dashboard/Application/UseCase/PartialUpdateDashboard/PartialUpdateDashboard.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/PartialUpdateDashboard/PartialUpdateDashboard.php
@@ -220,6 +220,11 @@ final class PartialUpdateDashboard
                     $dashboard->getRefresh()->getRefreshInterval()
                 )
                 : new Refresh($request->refresh->refreshType, $request->refresh->refreshInterval)
-        ))->setDescription(NoValue::coalesce($request->description, $dashboard->getDescription()));
+        ))->setDescription(
+            NoValue::coalesce(
+                $request->description !== '' ? $request->description : null,
+                $dashboard->getDescription(),
+            ),
+        );
     }
 }


### PR DESCRIPTION
🏷️ MON-132564
📃 dev-24.04.x backport of the following patch https://github.com/centreon/centreon/pull/4476