### PR TITLE
enh(API): Added ACL check on topology, actions & monitoring server in Generate and Reload Conf Endpoint 

### DIFF
--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/ReloadConfiguration.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/ReloadConfiguration.php
@@ -22,12 +22,16 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\MonitoringServer\UseCase;
 
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Exception\TimeoutException;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\Exception\EntityNotFoundException;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
 use Centreon\Domain\MonitoringServer\Exception\ConfigurationMonitoringServerException;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerConfigurationRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * This class is designed to represent a use case to reload a monitoring server configuration.
@@ -38,25 +42,17 @@ class ReloadConfiguration
     use LoggerTrait;
 
     /**
-     * @var MonitoringServerRepositoryInterface
-     */
-    private $monitoringServerRepository;
-
-    /**
-     * @var MonitoringServerConfigurationRepositoryInterface
-     */
-    private $configurationRepository;
-
-    /**
      * @param MonitoringServerRepositoryInterface $monitoringServerRepository
      * @param MonitoringServerConfigurationRepositoryInterface $configurationRepository
+     * @param ReadAccessGroupRepositoryInterface $readAccessGroupRepositoryInterface
+     * @param ContactInterface $contact
      */
     public function __construct(
-        MonitoringServerRepositoryInterface $monitoringServerRepository,
-        MonitoringServerConfigurationRepositoryInterface $configurationRepository
+        private readonly MonitoringServerRepositoryInterface $monitoringServerRepository,
+        private readonly MonitoringServerConfigurationRepositoryInterface $configurationRepository,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepositoryInterface,
+        private readonly ContactInterface $contact
     ) {
-        $this->monitoringServerRepository = $monitoringServerRepository;
-        $this->configurationRepository = $configurationRepository;
     }
 
     /**
@@ -68,7 +64,26 @@ class ReloadConfiguration
     public function execute(int $monitoringServerId): void
     {
         try {
-            $monitoringServer = $this->monitoringServerRepository->findServer($monitoringServerId);
+            if (
+                ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
+                && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
+            ) {
+                throw new AccessDeniedException(
+                    'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
+                );
+            }
+
+            if (! $this->contact->isAdmin()) {
+                $accessGroups = $this->readAccessGroupRepositoryInterface->findByContact($this->contact);
+
+                $monitoringServer = $this->monitoringServerRepository->findByIdAndAccessGroups(
+                    $monitoringServerId,
+                    $accessGroups
+                );
+            } else {
+                $monitoringServer = $this->monitoringServerRepository->findServer($monitoringServerId);
+            }
+
             if ($monitoringServer === null) {
                 throw ConfigurationMonitoringServerException::notFound($monitoringServerId);
             }


### PR DESCRIPTION
## Description

Endpoint: `GET: /configuration/monitoring-servers/{monitoring_server_id}/generate-and-reload`
Added ACL checks on topology, actions & monitoring servers.

**Fixes** # MON-123341

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
