### PR TITLE
enh(API): Added ACL check on topology, actions & monitoring server in Generate Conf All Servers Endpoint

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -1109,8 +1109,6 @@ paths:
           description: "Generation OK"
         '403':
           $ref: '#/components/responses/Forbidden'
-        '404':
-          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
   /configuration/monitoring-servers/reload:

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
@@ -22,11 +22,15 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\MonitoringServer\UseCase;
 
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Exception\TimeoutException;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\MonitoringServer\Exception\ConfigurationMonitoringServerException;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerConfigurationRepositoryInterface;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 /**
  * This class is designed to represent a use case to generate the monitoring server configurations.
@@ -38,25 +42,17 @@ class GenerateAllConfigurations
     use LoggerTrait;
 
     /**
-     * @var MonitoringServerConfigurationRepositoryInterface
-     */
-    private $configurationRepository;
-
-    /**
-     * @var MonitoringServerRepositoryInterface
-     */
-    private $monitoringServerRepository;
-
-    /**
      * @param MonitoringServerRepositoryInterface $monitoringServerRepository
      * @param MonitoringServerConfigurationRepositoryInterface $configurationRepository
+     * @param ReadAccessGroupRepositoryInterface $readAccessGroupRepositoryInterface
+     * @param ContactInterface $contact
      */
     public function __construct(
-        MonitoringServerRepositoryInterface $monitoringServerRepository,
-        MonitoringServerConfigurationRepositoryInterface $configurationRepository
+        private readonly MonitoringServerRepositoryInterface $monitoringServerRepository,
+        private readonly MonitoringServerConfigurationRepositoryInterface $configurationRepository,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepositoryInterface,
+        private readonly ContactInterface $contact
     ) {
-        $this->monitoringServerRepository = $monitoringServerRepository;
-        $this->configurationRepository = $configurationRepository;
     }
 
     /**
@@ -66,7 +62,26 @@ class GenerateAllConfigurations
     public function execute(): void
     {
         try {
-            $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParameters();
+            if (
+                ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
+                && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
+            ) {
+                throw new AccessDeniedException(
+                    'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
+                );
+            }
+
+            if (! $this->contact->isAdmin()) {
+                $accessGroups = $this->readAccessGroupRepositoryInterface->findByContact($this->contact);
+
+                $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParametersAndAccessGroups(
+                    $accessGroups
+                );
+            } else {
+                $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParameters();
+            }
+        } catch(AccessDeniedException $ex) {
+            throw new AccessDeniedException($ex->getMessage());
         } catch (\Throwable $ex) {
             throw ConfigurationMonitoringServerException::errorRetrievingMonitoringServers($ex);
         }

--- a/centreon/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
@@ -183,19 +183,21 @@ class MonitoringServerRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 $accessGroups
             );
 
-            [$bindValues, $bindQuery] = $this->createMultipleBindQuery($accessGroupIds, ':acl_group_id_');
+            if ($this->hasRestrictedAccessToMonitoringServers($accessGroupIds)) {
+                [$bindValues, $bindQuery] = $this->createMultipleBindQuery($accessGroupIds, ':acl_group_id_');
 
-            $aclMonitoringServersRequest = <<<SQL
-                INNER JOIN `:db`.acl_resources_poller_relations arpr
-                    ON arpr.poller_id = id
-                INNER JOIN `:db`.acl_resources res
-                    ON res.acl_res_id = arpr.acl_res_id
-                INNER JOIN `:db`.acl_res_group_relations argr
-                    ON argr.acl_res_id = res.acl_res_id
-                WHERE argr.acl_group_id IN ({$bindQuery})
-                SQL;
+                $aclMonitoringServersRequest = <<<SQL
+                    INNER JOIN `:db`.acl_resources_poller_relations arpr
+                        ON arpr.poller_id = id
+                    INNER JOIN `:db`.acl_resources res
+                        ON res.acl_res_id = arpr.acl_res_id
+                    INNER JOIN `:db`.acl_res_group_relations argr
+                        ON argr.acl_res_id = res.acl_res_id
+                    WHERE argr.acl_group_id IN ({$bindQuery})
+                    SQL;
 
-            $searchRequest = str_replace('WHERE', 'AND', $searchRequest);
+                $searchRequest = str_replace('WHERE', 'AND', $searchRequest);
+            }
         }
 
         $request = $this->translateDbName(

--- a/centreon/tests/php/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurationsTest.php
+++ b/centreon/tests/php/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurationsTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace Tests\Centreon\Domain\MonitoringServer\UseCase;
 
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\MockObject\MockObject;
 use Centreon\Domain\MonitoringServer\MonitoringServer;
@@ -30,28 +31,44 @@ use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterf
 use Centreon\Domain\MonitoringServer\Exception\ConfigurationMonitoringServerException;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerConfigurationRepositoryInterface;
 use Centreon\Domain\Repository\RepositoryException;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class GenerateAllConfigurationsTest extends TestCase
 {
-    /**
-     * @var MonitoringServerRepositoryInterface&MockObject
-     */
+    /** @var MonitoringServerRepositoryInterface&MockObject */
     private $monitoringServerRepository;
 
-    /**
-     * @var MonitoringServerConfigurationRepositoryInterface&MockObject
-     */
+    /** @var MonitoringServerConfigurationRepositoryInterface&MockObject */
     private $monitoringServerConfigurationRepository;
+
+    /** @var ReadAccessGroupRepositoryInterface&MockObject */
+    private $readAccessGroupRepository;
+
+    /** @var ContactInterface&MockObject */
+    private $contact;
 
     protected function setUp(): void
     {
         $this->monitoringServerRepository = $this->createMock(MonitoringServerRepositoryInterface::class);
         $this->monitoringServerConfigurationRepository =
             $this->createMock(MonitoringServerConfigurationRepositoryInterface::class);
+        $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
+        $this->contact = $this->createMock(ContactInterface::class);
     }
 
     public function testErrorRetrievingMonitoringServersException(): void
     {
+        $this->contact
+            ->expects($this->any())
+            ->method('hasTopologyRole')
+            ->willReturn(true);
+
+        $this->contact
+            ->expects($this->any())
+            ->method('isAdmin')
+            ->willReturn(true);
+
         $exception = new \Exception();
         $this->monitoringServerRepository
             ->expects($this->once())
@@ -64,13 +81,49 @@ class GenerateAllConfigurationsTest extends TestCase
         );
         $useCase = new GenerateAllConfigurations(
             $this->monitoringServerRepository,
-            $this->monitoringServerConfigurationRepository
+            $this->monitoringServerConfigurationRepository,
+            $this->readAccessGroupRepository,
+            $this->contact
+        );
+        $useCase->execute();
+    }
+
+    public function testErrorAccessDeniedException(): void
+    {
+        $this->contact
+            ->expects($this->any())
+            ->method('hasTopologyRole')
+            ->willReturn(false);
+
+        $exception = new AccessDeniedException(
+            'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
+        );
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionMessage(
+            $exception->getMessage()
+        );
+        $useCase = new GenerateAllConfigurations(
+            $this->monitoringServerRepository,
+            $this->monitoringServerConfigurationRepository,
+            $this->readAccessGroupRepository,
+            $this->contact
         );
         $useCase->execute();
     }
 
     public function testErrorOnGeneration(): void
     {
+        $this->contact
+            ->expects($this->any())
+            ->method('hasTopologyRole')
+            ->willReturn(true);
+
+        $this->contact
+            ->expects($this->any())
+            ->method('isAdmin')
+            ->willReturn(true);
+
         $monitoringServers = [
             (new MonitoringServer())->setId(1)
         ];
@@ -89,7 +142,9 @@ class GenerateAllConfigurationsTest extends TestCase
 
         $useCase = new GenerateAllConfigurations(
             $this->monitoringServerRepository,
-            $this->monitoringServerConfigurationRepository
+            $this->monitoringServerConfigurationRepository,
+            $this->readAccessGroupRepository,
+            $this->contact
         );
 
         $this->expectException(ConfigurationMonitoringServerException::class);
@@ -102,6 +157,16 @@ class GenerateAllConfigurationsTest extends TestCase
 
     public function testSuccess(): void
     {
+        $this->contact
+            ->expects($this->any())
+            ->method('hasTopologyRole')
+            ->willReturn(true);
+
+        $this->contact
+            ->expects($this->any())
+            ->method('isAdmin')
+            ->willReturn(true);
+
         $monitoringServer = (new MonitoringServer())->setId(1);
         $monitoringServers = [$monitoringServer];
         $this->monitoringServerRepository
@@ -121,7 +186,48 @@ class GenerateAllConfigurationsTest extends TestCase
 
         $useCase = new GenerateAllConfigurations(
             $this->monitoringServerRepository,
-            $this->monitoringServerConfigurationRepository
+            $this->monitoringServerConfigurationRepository,
+            $this->readAccessGroupRepository,
+            $this->contact
+        );
+
+        $useCase->execute();
+    }
+
+    public function testSuccessNonAdmin(): void
+    {
+        $this->contact
+            ->expects($this->any())
+            ->method('hasTopologyRole')
+            ->willReturn(true);
+
+        $this->contact
+            ->expects($this->any())
+            ->method('isAdmin')
+            ->willReturn(false);
+
+        $monitoringServer = (new MonitoringServer())->setId(1);
+        $monitoringServers = [$monitoringServer];
+        $this->monitoringServerRepository
+            ->expects($this->once())
+            ->method('findServersWithRequestParametersAndAccessGroups')
+            ->willReturn($monitoringServers);
+
+        $this->monitoringServerConfigurationRepository
+            ->expects($this->once())
+            ->method('generateConfiguration')
+            ->with($monitoringServer->getId());
+
+        $this->monitoringServerConfigurationRepository
+            ->expects($this->once())
+            ->method('moveExportFiles')
+            ->with($monitoringServer->getId());
+
+        $useCase = new GenerateAllConfigurations(
+            $this->monitoringServerRepository,
+            $this->monitoringServerConfigurationRepository,
+            $this->readAccessGroupRepository,
+            $this->contact
         );
 
         $useCase->execute();


### PR DESCRIPTION
## Description

Endpoint: `GET: /configuration/monitoring-servers/generate`
Added ACL checks on topology, actions & monitoring servers.

**Fixes** # MON-123343

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
