### PR TITLE
fix(conf/engine) check if notifications sould be diasble (via feature flags) only if notifications are enabled already

### DIFF
--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -351,7 +351,9 @@ class Engine extends AbstractObject
         $result = $this->stmt_engine->fetchAll(PDO::FETCH_ASSOC);
 
         $this->engine = array_pop($result);
-        $this->engine['enable_notifications'] = $this->shouldEngineNotificationsBeDisabled() ? '0' : '1'; 
+        if ($this->shouldEngineNotificationsBeDisabled() && $this->engine['enable_notifications'] == 1) {
+            $this->engine['enable_notifications'] = 0;
+         }
 
         if (is_null($this->engine)) {
             throw new Exception(


### PR DESCRIPTION
## Description

Check if notifications sould be diasble (via feature flags) only if notifications are enabled already

**Fixes** #MON-137158

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- Go to Configuration  >  Pollers  >  Engine configuration > Misc Options > Notification Option
- Set 'Notification Option' to No.
- Export.
- grep "enable_notification" /etc/centreon-engine/centengine.cfg