### PR TITLE
fix (host category): fix SQL query and ACL

### DIFF
--- a/centreon/src/Core/HostCategory/Application/Repository/ReadHostCategoryRepositoryInterface.php
+++ b/centreon/src/Core/HostCategory/Application/Repository/ReadHostCategoryRepositoryInterface.php
@@ -172,9 +172,7 @@ interface ReadHostCategoryRepositoryInterface
      *
      * @param int[] $accessGroupIds
      *
-     * @phpstan-param non-empty-array<int> $accessGroupIds
-     *
      * @return bool
      */
-    public function hasAclFilterOnHostCategories(array $accessGroupIds): bool;
+    public function hasRestrictedAccessToHostCategories(array $accessGroupIds): bool;
 }

--- a/centreon/src/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategories.php
+++ b/centreon/src/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategories.php
@@ -145,7 +145,7 @@ final class FindHostCategories
 
         // If the current user has ACL filter on Host Categories it means that not all categories are visible so
         // we need to apply the ACL
-        if ($this->readHostCategoryRepository->hasAclFilterOnHostCategories($accessGroupIds)) {
+        if ($this->readHostCategoryRepository->hasRestrictedAccessToHostCategories($accessGroupIds)) {
             $categories = $this->readHostCategoryRepository->findAllByAccessGroupIds(
                 $accessGroupIds,
                 $this->requestParameters

--- a/centreon/src/Core/HostCategory/Application/UseCase/FindRealTimeHostCategories/FindRealTimeHostCategories.php
+++ b/centreon/src/Core/HostCategory/Application/UseCase/FindRealTimeHostCategories/FindRealTimeHostCategories.php
@@ -108,7 +108,7 @@ final class FindRealTimeHostCategories
 
         // If the current user has ACL filter on Host Categories it means that not all categories are visible so
         // we need to apply the ACL
-        if ($this->configurationRepository->hasAclFilterOnHostCategories($accessGroupIds)) {
+        if ($this->configurationRepository->hasRestrictedAccessToHostCategories($accessGroupIds)) {
             return $this->repository->findAllByAccessGroupIds(
                 $this->requestParameters,
                 $accessGroupIds,

--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadRealTimeHostCategoryRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadRealTimeHostCategoryRepository.php
@@ -164,7 +164,7 @@ class DbReadRealTimeHostCategoryRepository extends AbstractRepositoryRDB impleme
                     ON host_categories.tag_id  = rtags.tag_id
                     AND host_categories.`type` = 3
                 INNER JOIN `:db`.acl_resources_hc_relations arhr
-                    ON host_categories.id = arhr.sc_id
+                    ON host_categories.id = arhr.hc_id
                 INNER JOIN `:db`.acl_resources res
                     ON arhr.acl_res_id = res.acl_res_id
                 INNER JOIN `:db`.acl_res_group_relations argr

--- a/centreon/tests/php/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategoriesTest.php
+++ b/centreon/tests/php/Core/HostCategory/Application/UseCase/FindHostCategories/FindHostCategoriesTest.php
@@ -132,7 +132,7 @@ it('should present a FindHostGroupsResponse when a non-admin user has read only 
 
     $this->hostCategoryRepository
         ->expects($this->once())
-        ->method('hasAclFilterOnHostCategories')
+        ->method('hasRestrictedAccessToHostCategories')
         ->willReturn(true);
 
     $this->hostCategoryRepository
@@ -170,7 +170,7 @@ it('should present a FindHostGroupsResponse when a non-admin user has read/write
 
     $this->hostCategoryRepository
         ->expects($this->once())
-        ->method('hasAclFilterOnHostCategories')
+        ->method('hasRestrictedAccessToHostCategories')
         ->willReturn(true);
 
     $this->hostCategoryRepository

--- a/centreon/tests/php/Core/HostCategory/Application/UseCase/FindRealTimeHostCategories/FindRealTimeHostCategoriesTest.php
+++ b/centreon/tests/php/Core/HostCategory/Application/UseCase/FindRealTimeHostCategories/FindRealTimeHostCategoriesTest.php
@@ -76,7 +76,7 @@ it('should find all categories as user with no filters on categories', function 
 
     $this->configurationRepository
         ->expects($this->once())
-        ->method('hasAclFilterOnHostCategories')
+        ->method('hasRestrictedAccessToHostCategories')
         ->willReturn(false);
 
     $this->repository->expects($this->once())
@@ -103,7 +103,7 @@ it('should find all categories as user with filters on categories', function ():
 
     $this->configurationRepository
         ->expects($this->once())
-        ->method('hasAclFilterOnHostCategories')
+        ->method('hasRestrictedAccessToHostCategories')
         ->willReturn(true);
 
     $this->repository->expects($this->once())


### PR DESCRIPTION
## Description

- Replaces the **hasAclFilterOnHostCategories** method in **DbReadHostCategoryRepository.php** with the **hasRestrictedAccessToHostCategories** method available in **HostCategoryRepositoryTrait.php**.
- Modified SQL join from `arhr.sc_id` to `arhr.hc_id`.
- Deletion of the **hasAccessToAllHostGroups** method previously available in the **DbReadHostCategoryRepository.php** file, leaving the one available in the trait **HostGroupRepositoryTrait.php**.


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
