### PR TITLE
enh(vault): manage suffix vault path with credential key for openid

### DIFF
--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -46,6 +46,7 @@ use Core\Security\ProviderConfiguration\Domain\SecurityAccess\AttributePath\Attr
 use Core\Security\ProviderConfiguration\Domain\SecurityAccess\Conditions;
 use Core\Security\ProviderConfiguration\Domain\SecurityAccess\GroupsMapping as GroupsMappingSecurityAccess;
 use Core\Security\ProviderConfiguration\Domain\SecurityAccess\RolesMapping;
+use Core\Security\Vault\Domain\Model\VaultConfiguration;
 use DateInterval;
 use Exception;
 use Pimple\Container;
@@ -558,24 +559,28 @@ class OpenIdProvider implements OpenIdProviderInterface
 
         if (
             $customConfiguration->getClientId() !== null
-            && str_starts_with($customConfiguration->getClientId(), 'secret::')
+            && str_starts_with($customConfiguration->getClientId(), VaultConfiguration::VAULT_PATH_PATTERN)
         ) {
             $vaultData = $this->readVaultRepository->findFromPath($customConfiguration->getClientId());
-            if (! array_key_exists('_OPENID_CLIENT_ID', $vaultData)) {
-                throw OpenIdConfigurationException::unableToRetrieveCredentialFromVault('_OPENID_CLIENT_ID');
+            if (! array_key_exists(VaultConfiguration::OPENID_CLIENT_ID_KEY, $vaultData)) {
+                throw OpenIdConfigurationException::unableToRetrieveCredentialFromVault(
+                    VaultConfiguration::OPENID_CLIENT_ID_KEY
+                );
             }
-            $customConfiguration->setClientId($vaultData['_OPENID_CLIENT_ID']);
+            $customConfiguration->setClientId($vaultData[VaultConfiguration::OPENID_CLIENT_ID_KEY]);
         }
 
         if (
             $customConfiguration->getClientSecret() !== null
-            && str_starts_with($customConfiguration->getClientSecret(), 'secret::')
+            && str_starts_with($customConfiguration->getClientSecret(), VaultConfiguration::VAULT_PATH_PATTERN)
         ) {
             $vaultData = $this->readVaultRepository->findFromPath($customConfiguration->getClientSecret());
-            if (! array_key_exists('_OPENID_CLIENT_SECRET', $vaultData)) {
-                throw OpenIdConfigurationException::unableToRetrieveCredentialFromVault('_OPENID_CLIENT_SECRET');
+            if (! array_key_exists(VaultConfiguration::OPENID_CLIENT_SECRET_KEY, $vaultData)) {
+                throw OpenIdConfigurationException::unableToRetrieveCredentialFromVault(
+                    VaultConfiguration::OPENID_CLIENT_SECRET_KEY
+                );
             }
-            $customConfiguration->setClientSecret($vaultData['_OPENID_CLIENT_SECRET']);
+            $customConfiguration->setClientSecret($vaultData[VaultConfiguration::OPENID_CLIENT_SECRET_KEY]);
         }
 
         // Define parameters for the request
@@ -849,24 +854,28 @@ class OpenIdProvider implements OpenIdProviderInterface
         $customConfiguration = $this->configuration->getCustomConfiguration();
         if (
             $customConfiguration->getClientId() !== null
-            && str_starts_with($customConfiguration->getClientId(), 'secret::')
+            && str_starts_with($customConfiguration->getClientId(), VaultConfiguration::VAULT_PATH_PATTERN)
         ) {
             $vaultData = $this->readVaultRepository->findFromPath($customConfiguration->getClientId());
-            if (! array_key_exists('_OPENID_CLIENT_ID', $vaultData)) {
-                throw OpenIdConfigurationException::unableToRetrieveCredentialFromVault('_OPENID_CLIENT_ID');
+            if (! array_key_exists(VaultConfiguration::OPENID_CLIENT_ID_KEY, $vaultData)) {
+                throw OpenIdConfigurationException::unableToRetrieveCredentialFromVault(
+                    VaultConfiguration::OPENID_CLIENT_ID_KEY
+                );
             }
-            $customConfiguration->setClientId($vaultData['_OPENID_CLIENT_ID']);
+            $customConfiguration->setClientId($vaultData[VaultConfiguration::OPENID_CLIENT_ID_KEY]);
         }
 
         if (
             $customConfiguration->getClientSecret() !== null
-            && str_starts_with($customConfiguration->getClientSecret(), 'secret::')
+            && str_starts_with($customConfiguration->getClientSecret(), VaultConfiguration::VAULT_PATH_PATTERN)
         ) {
             $vaultData = $this->readVaultRepository->findFromPath($customConfiguration->getClientSecret());
-            if (! array_key_exists('_OPENID_CLIENT_SECRET', $vaultData)) {
-                throw OpenIdConfigurationException::unableToRetrieveCredentialFromVault('_OPENID_CLIENT_SECRET');
+            if (! array_key_exists(VaultConfiguration::OPENID_CLIENT_SECRET_KEY, $vaultData)) {
+                throw OpenIdConfigurationException::unableToRetrieveCredentialFromVault(
+                    VaultConfiguration::OPENID_CLIENT_SECRET_KEY
+                );
             }
-            $customConfiguration->setClientSecret($vaultData['_OPENID_CLIENT_SECRET']);
+            $customConfiguration->setClientSecret($vaultData[VaultConfiguration::OPENID_CLIENT_SECRET_KEY]);
         }
         if ($customConfiguration->getAuthenticationType() === CustomConfiguration::AUTHENTICATION_BASIC) {
             $headers['Authorization'] = 'Basic ' . base64_encode(

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/PartialUpdateOpenIdConfiguration/PartialUpdateOpenIdConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/OpenId/UseCase/PartialUpdateOpenIdConfiguration/PartialUpdateOpenIdConfiguration.php
@@ -30,6 +30,7 @@ use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\NoContentResponse;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Application\Type\NoValue;
+use Core\Common\Application\UseCase\VaultTrait;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Contact\Application\Repository\ReadContactGroupRepositoryInterface;
 use Core\Contact\Application\Repository\ReadContactTemplateRepositoryInterface;
@@ -51,6 +52,7 @@ use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Model\Configuration;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+use Core\Security\Vault\Domain\Model\VaultConfiguration;
 
 /**
  * @phpstan-import-type _RoleMapping from PartialUpdateOpenIdConfigurationRequest
@@ -62,7 +64,7 @@ use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryI
  */
 final class PartialUpdateOpenIdConfiguration
 {
-    use LoggerTrait;
+    use LoggerTrait, VaultTrait;
 
     /**
      * @param WriteOpenIdConfigurationRepositoryInterface $repository
@@ -184,7 +186,10 @@ final class PartialUpdateOpenIdConfiguration
             }
         }
 
-        $customConfigurationAsArray = $this->manageClientIdAndClientSecretIntoVault($customConfigurationAsArray, $customConfig);
+        $customConfigurationAsArray = $this->manageClientIdAndClientSecretIntoVault(
+            $customConfigurationAsArray,
+            $customConfig
+        );
 
         return new CustomConfiguration($customConfigurationAsArray);
     }
@@ -516,32 +521,36 @@ final class PartialUpdateOpenIdConfiguration
         $clientId = $customConfiguration->getClientId();
         $clientSecret = $customConfiguration->getClientSecret();
 
-        if ($clientId !== null && str_starts_with($clientId, 'secret::')) {
-            $vaultPathPart = explode('/', $clientId);
-            $uuid = end($vaultPathPart);
-        } elseif ($clientSecret !== null && str_starts_with($clientSecret, 'secret::')) {
-            $vaultPathPart = explode('/', $clientSecret);
-            $uuid = end($vaultPathPart);
+        if ($clientId !== null && str_starts_with($clientId, VaultConfiguration::VAULT_PATH_PATTERN)) {
+            $uuid = $this->getUuidFromPath($clientId);
+        } elseif ($clientSecret !== null && str_starts_with($clientSecret, VaultConfiguration::VAULT_PATH_PATTERN)) {
+            $uuid = $this->getUuidFromPath($clientSecret);
         }
 
         // Update the vault with the new client id and client secret if the value are not a vault path.
         $data = [];
-        if ($requestArray['client_id'] !== null && ! str_starts_with($requestArray['client_id'], 'secret::')) {
-            $data['_OPENID_CLIENT_ID'] = $requestArray['client_id'];
+        if (
+            $requestArray['client_id'] !== null
+            && ! str_starts_with($requestArray['client_id'], VaultConfiguration::VAULT_PATH_PATTERN)
+        ) {
+            $data[VaultConfiguration::OPENID_CLIENT_ID_KEY] = $requestArray['client_id'];
         }
-        if ($requestArray['client_secret'] !== null && ! str_starts_with($requestArray['client_secret'], 'secret::')) {
-            $data['_OPENID_CLIENT_SECRET'] = $requestArray['client_secret'];
+        if (
+            $requestArray['client_secret'] !== null
+            && ! str_starts_with($requestArray['client_secret'], VaultConfiguration::VAULT_PATH_PATTERN)
+        ) {
+            $data[VaultConfiguration::OPENID_CLIENT_SECRET_KEY] = $requestArray['client_secret'];
         }
 
         if (! empty($data)) {
-            $vaultPath = $this->writeVaultRepository->upsert(
+            $vaultPaths = $this->writeVaultRepository->upsert(
                 $uuid,
                 $data
             );
 
             // Assign new values to the request array
-            $requestArray['client_id'] = $vaultPath;
-            $requestArray['client_secret'] = $vaultPath;
+            $requestArray['client_id'] = $vaultPaths[VaultConfiguration::OPENID_CLIENT_ID_KEY];
+            $requestArray['client_secret'] = $vaultPaths[VaultConfiguration::OPENID_CLIENT_SECRET_KEY];
         }
 
         return $requestArray;

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/Factory/OpenIdProviderDtoFactory.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/Api/FindProviderConfigurations/Factory/OpenIdProviderDtoFactory.php
@@ -31,6 +31,7 @@ use Core\Security\ProviderConfiguration\Domain\Model\Provider;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Exceptions\OpenIdConfigurationException;
 use Core\Security\ProviderConfiguration\Domain\OpenId\Model\CustomConfiguration;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+use Core\Security\Vault\Domain\Model\VaultConfiguration;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class OpenIdProviderDtoFactory implements ProviderConfigurationDtoFactoryInterface
@@ -101,13 +102,15 @@ class OpenIdProviderDtoFactory implements ProviderConfigurationDtoFactoryInterfa
 
         if (
             $this->readVaultConfigurationRepository->exists()
-            && str_starts_with($customConfiguration->getClientId(), 'secret::')
+            && str_starts_with($customConfiguration->getClientId(), VaultConfiguration::VAULT_PATH_PATTERN)
         ) {
             $openIDCredentialsFromVault = $this->readVaultRepository->findFromPath($customConfiguration->getClientId());
-            if (! array_key_exists('_OPENID_CLIENT_ID', $openIDCredentialsFromVault)) {
-                throw OpenIdConfigurationException::unableToRetrieveCredentialFromVault('_OPENID_CLIENT_ID');
+            if (! array_key_exists(VaultConfiguration::OPENID_CLIENT_ID_KEY, $openIDCredentialsFromVault)) {
+                throw OpenIdConfigurationException::unableToRetrieveCredentialFromVault(
+                    VaultConfiguration::OPENID_CLIENT_ID_KEY
+                );
             }
-            $customConfiguration->setClientId($openIDCredentialsFromVault['_OPENID_CLIENT_ID']);
+            $customConfiguration->setClientId($openIDCredentialsFromVault[VaultConfiguration::OPENID_CLIENT_ID_KEY]);
         }
 
         $authenticationUriParts = [

--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigrator.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigrator.php
@@ -341,7 +341,11 @@ class CredentialMigrator implements \IteratorAggregate, \Countable
             [$credential->name => $credential->value]
         );
         $vaultPath = $vaultPaths[$credential->name];
-        $existingUuids['openId'] ??= $this->getUuidFromPath($vaultPath);
+        $uuid = $this->getUuidFromPath($vaultPath);
+        if ($uuid === null) {
+            throw new \Exception('UUID not found in the vault path');
+        }
+        $existingUuids['openId'] ??= $uuid;
 
         /**
          * @var CustomConfiguration $customConfiguration

--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigrator.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigrator.php
@@ -341,8 +341,7 @@ class CredentialMigrator implements \IteratorAggregate, \Countable
             [$credential->name => $credential->value]
         );
         $vaultPath = $vaultPaths[$credential->name];
-        $vaultPathPart = explode('/', $vaultPath);
-        $existingUuids['openId'] ??= end($vaultPathPart);
+        $existingUuids['openId'] ??= $this->getUuidFromPath($vaultPath);
 
         /**
          * @var CustomConfiguration $customConfiguration

--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
@@ -234,7 +234,7 @@ final class MigrateAllCredentials
     {
         $credentials = [];
         foreach ($hosts as $host) {
-            if ($host->getSnmpCommunity() === '' || str_starts_with($host->getSnmpCommunity(), 'secret::')) {
+            if ($host->getSnmpCommunity() === '' || str_starts_with($host->getSnmpCommunity(), VaultConfiguration::VAULT_PATH_PATTERN)) {
                 continue;
             }
             $credential = new CredentialDto();
@@ -259,7 +259,7 @@ final class MigrateAllCredentials
         foreach ($hostTemplates as $hostTemplate) {
             if (
                 $hostTemplate->getSnmpCommunity() === ''
-                || str_starts_with($hostTemplate->getSnmpCommunity(), 'secret::'))
+                || str_starts_with($hostTemplate->getSnmpCommunity(), VaultConfiguration::VAULT_PATH_PATTERN))
             {
                 continue;
             }
@@ -283,7 +283,7 @@ final class MigrateAllCredentials
     {
         $credentials = [];
         foreach ($hostMacros as $hostMacro) {
-            if ($hostMacro->getValue() === '' || str_starts_with($hostMacro->getValue(), 'secret::')) {
+            if ($hostMacro->getValue() === '' || str_starts_with($hostMacro->getValue(), VaultConfiguration::VAULT_PATH_PATTERN)) {
                 continue;
             }
             $credential = new CredentialDto();
@@ -306,7 +306,7 @@ final class MigrateAllCredentials
     {
         $credentials = [];
         foreach ($serviceMacros as $serviceMacro) {
-            if ($serviceMacro->getValue() === '' || str_starts_with($serviceMacro->getValue(), 'secret::')) {
+            if ($serviceMacro->getValue() === '' || str_starts_with($serviceMacro->getValue(), VaultConfiguration::VAULT_PATH_PATTERN)) {
                 continue;
             }
             $credential = new CredentialDto();
@@ -329,7 +329,7 @@ final class MigrateAllCredentials
     {
         $credentials = [];
         foreach ($pollerMacros as $pollerMacro) {
-            if ($pollerMacro->getValue() === '' || str_starts_with($pollerMacro->getValue(), 'secret::')) {
+            if ($pollerMacro->getValue() === '' || str_starts_with($pollerMacro->getValue(), VaultConfiguration::VAULT_PATH_PATTERN)) {
                 continue;
             }
             $credential = new CredentialDto();
@@ -354,7 +354,7 @@ final class MigrateAllCredentials
         if (
             $knowledgeBasePasswordOption === null
             || $knowledgeBasePasswordOption->getValue() === null
-            || str_starts_with($knowledgeBasePasswordOption->getValue(), 'secret::')
+            || str_starts_with($knowledgeBasePasswordOption->getValue(), VaultConfiguration::VAULT_PATH_PATTERN)
         ){
             return $credentials;
         }
@@ -384,22 +384,22 @@ final class MigrateAllCredentials
 
         if (
             $customConfiguration->getClientId() !== null
-            && ! str_starts_with($customConfiguration->getClientId(), 'secret::')
+            && ! str_starts_with($customConfiguration->getClientId(), VaultConfiguration::VAULT_PATH_PATTERN)
         ) {
             $credential = new CredentialDto();
             $credential->type = CredentialTypeEnum::TYPE_OPEN_ID;
-            $credential->name = '_OPENID_CLIENT_ID';
+            $credential->name = VaultConfiguration::OPENID_CLIENT_ID_KEY;
             $credential->value = $customConfiguration->getClientId();
             $credentials[] = $credential;
         }
 
         if (
             $customConfiguration->getClientSecret() !== null
-            && ! str_starts_with($customConfiguration->getClientSecret(), 'secret::')
+            && ! str_starts_with($customConfiguration->getClientSecret(), VaultConfiguration::VAULT_PATH_PATTERN)
         ) {
             $credential = new CredentialDto();
             $credential->type = CredentialTypeEnum::TYPE_OPEN_ID;
-            $credential->name = '_OPENID_CLIENT_SECRET';
+            $credential->name = VaultConfiguration::OPENID_CLIENT_SECRET_KEY;
             $credential->value = $customConfiguration->getClientSecret();
             $credentials[] = $credential;
         }

--- a/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
@@ -42,6 +42,8 @@ class VaultConfiguration
 
     /** Static Vault Key Constants */
     public const HOST_SNMP_COMMUNITY_KEY = '_HOSTSNMPCOMMUNITY';
+    public const OPENID_CLIENT_ID_KEY = '_OPENID_CLIENT_ID';
+    public const OPENID_CLIENT_SECRET_KEY = '_OPENID_CLIENT_SECRET';
 
     /** Patterns Constants */
     public const VAULT_PATH_PATTERN = 'secret::';


### PR DESCRIPTION
## Description

This PR intends to suffix vault path with credential key for Open ID

**Fixes** # MON-139716

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
