### PR TITLE
fix(api): total result found fixed for service names API

### DIFF
--- a/centreon/src/Core/Service/Infrastructure/API/FindRealTimeUniqueServiceNames/FindRealTimeUniqueServiceNamesController.php
+++ b/centreon/src/Core/Service/Infrastructure/API/FindRealTimeUniqueServiceNames/FindRealTimeUniqueServiceNamesController.php
@@ -36,8 +36,10 @@ final class FindRealTimeUniqueServiceNamesController extends AbstractController
      *
      * @return Response
      */
-    public function __invoke(FindRealTimeUniqueServiceNames $useCase, FindRealTimeUniqueServiceNamesPresenterInterface $presenter): Response
-    {
+    public function __invoke(
+        FindRealTimeUniqueServiceNames $useCase,
+        FindRealTimeUniqueServiceNamesPresenterInterface $presenter,
+    ): Response {
         $this->denyAccessUnlessGrantedForApiRealtime();
 
         $useCase($presenter);

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository.php
@@ -206,7 +206,7 @@ class DbReadRealTimeServiceRepository extends AbstractRepositoryRDB implements R
     {
         // tags 0=servicegroup, 1=hostgroup, 2=servicecategory, 3=hostcategory
         return <<<'SQL'
-                SELECT
+                SELECT SQL_CALC_FOUND_ROWS
                     services.id AS `id`,
                     services.name AS `name`,
                     services.status AS `status`


### PR DESCRIPTION
🏷️ MON-142828
📃 This PR intends to patch an issue regarding the calculation of the total service names found.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

See Jira

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Reformatted the parameter list in `__invoke` method for better readability.

- **Performance Improvement**
  - Enhanced SQL query with `SQL_CALC_FOUND_ROWS` for more efficient data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->