### PR TITLE
enh(vault): manage suffix vault path with credential key for kb

### DIFF
--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigrator.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/CredentialMigrator.php
@@ -314,8 +314,10 @@ class CredentialMigrator implements \IteratorAggregate, \Countable
             [$credential->name => $credential->value]
         );
         $vaultPath = $vaultPaths[$credential->name];
-        $vaultPathPart = explode('/', $vaultPath);
-        $uuid = end($vaultPathPart);
+        $uuid = $this->getUuidFromPath($vaultPath);
+        if ($uuid === null) {
+            throw new \Exception('UUID not found in the vault path');
+        }
         $option = new Option('kb_wiki_password', $vaultPath);
         $this->writeOptionRepository->update($option);
 

--- a/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/MigrateAllCredentials/MigrateAllCredentials.php
@@ -370,7 +370,7 @@ final class MigrateAllCredentials
 
         $credential = new CredentialDto();
         $credential->type = CredentialTypeEnum::TYPE_KNOWLEDGE_BASE_PASSWORD;
-        $credential->name = '_KBPASSWORD';
+        $credential->name = VaultConfiguration::KNOWLEDGE_BASE_KEY;
         $credential->value = $knowledgeBasePasswordOption->getValue();
         $credentials[] = $credential;
 

--- a/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Domain/Model/VaultConfiguration.php
@@ -42,6 +42,7 @@ class VaultConfiguration
 
     /** Static Vault Key Constants */
     public const HOST_SNMP_COMMUNITY_KEY = '_HOSTSNMPCOMMUNITY';
+    public const KNOWLEDGE_BASE_KEY = '_KBPASSWORD';
 
     /** Patterns Constants */
     public const VAULT_PATH_PATTERN = 'secret::';

--- a/centreon/www/include/Administration/parameters/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/DB-Func.php
@@ -37,6 +37,12 @@
 require_once __DIR__ . '/../../../../bootstrap.php';
 require __DIR__ . '/../../common/vault-functions.php';
 
+use App\Kernel;
+use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
+use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+use Core\Security\Vault\Domain\Model\VaultConfiguration;
+
 /**
  * Used to update fields in the 'centreon.options' table
  *
@@ -933,9 +939,9 @@ function updateKnowledgeBaseData($db, $form, $centreon, ?string $originalPasswor
  */
 function saveKnowledgeBasePasswordInVault(string $password, ?string $originalPassword): ?string
 {
-    $kernel = \App\Kernel::createForWeb();
+    $kernel = Kernel::createForWeb();
     $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface::class
+        ReadVaultConfigurationRepositoryInterface::class
     );
     $vaultConfiguration = $readVaultConfigurationRepository->find();
     if ($vaultConfiguration === null) {
@@ -943,18 +949,19 @@ function saveKnowledgeBasePasswordInVault(string $password, ?string $originalPas
     }
 
     $uuid = null;
-    if ($originalPassword !== null && str_starts_with($originalPassword, "secret::")) {
-        $vaultPathPart = explode("/", $originalPassword);
-        $uuid = end($vaultPathPart);
+    if ($originalPassword !== null && str_starts_with($originalPassword, VaultConfiguration::VAULT_PATH_PATTERN)) {
+        $uuid = preg_match(
+            '/' . VaultConfiguration::UUID_EXTRACTION_REGEX . '/',
+            $value,
+            $matches
+        )
+        && isset($matches[2]) ? $matches[2] : null;
     }
 
-    /**
-     * @var \Centreon\Domain\Log\Logger $logger
-     */
-    $logger = $kernel->getContainer()->get(\Centreon\Domain\Log\Logger::class);
-    /** @var \Utility\Interfaces\UUIDGeneratorInterface $uuidGenerator */
-    $uuidGenerator = $kernel->getContainer()->get(Utility\Interfaces\UUIDGeneratorInterface::class);
-    return upsertKnowledgeBasePasswordInVault($password, $vaultConfiguration, $logger, $uuid, $uuidGenerator);
+    /** @var WriteVaultRepositoryInterface $writeVaultRepository */
+    $writeVaultRepository = $kernel->getContainer()->get(WriteVaultRepositoryInterface::class);
+    $writeVaultRepository->setCustomPath(AbstractVaultRepository::KNOWLEDGE_BASE_PATH);
+    return upsertKnowledgeBasePasswordInVault($writeVaultRepository, $password, $uuid);
 }
 
 /**

--- a/centreon/www/include/Administration/parameters/DB-Func.php
+++ b/centreon/www/include/Administration/parameters/DB-Func.php
@@ -952,7 +952,7 @@ function saveKnowledgeBasePasswordInVault(string $password, ?string $originalPas
     if ($originalPassword !== null && str_starts_with($originalPassword, VaultConfiguration::VAULT_PATH_PATTERN)) {
         $uuid = preg_match(
             '/' . VaultConfiguration::UUID_EXTRACTION_REGEX . '/',
-            $value,
+            $originalPassword,
             $matches
         )
         && isset($matches[2]) ? $matches[2] : null;

--- a/centreon/www/include/common/vault-functions.php
+++ b/centreon/www/include/common/vault-functions.php
@@ -1056,7 +1056,7 @@ function prepareServiceUpdateMCPayload(array $macros, array $serviceSecretsFromV
  *
  * @throws Throwable
  */
-function SecretsInVault(
+function updateServiceSecretsInVault(
     ReadVaultRepositoryInterface $readVaultRepository,
     WriteVaultRepositoryInterface $writeVaultRepository,
     Logger $logger,


### PR DESCRIPTION
## Description

This PR intends to suffix vault path with credential key for Knowledge base password

**Fixes** # MON-139716

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
