### PR TITLE
fix(gorgone/mbi): rebuilding centiles truncates mod_bi_metrichourlyvalue

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/mbi/etl/perfdata/main.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/mbi/etl/perfdata/main.pm
@@ -178,7 +178,7 @@ sub purgeTables {
       
         if ($etl->{run}->{etlProperties}->{'perfdata.granularity'} ne "day" && 
             (!defined($etl->{run}->{options}->{month_only}) || $etl->{run}->{options}->{month_only} == 0) && 
-            (!defined($etl->{run}->{options}->{no_centile}) || $etl->{run}->{options}->{no_centile} == 0)) {
+            (!defined($etl->{run}->{options}->{centile_only}) || $etl->{run}->{options}->{centile_only} == 0)) {
             emptyTableForRebuild($etl, name => 'mod_bi_metrichourlyvalue', column => 'time_id', start => $hourly_start, end => $hourly_end);
         }
     }


### PR DESCRIPTION
## Description
backport of #4396 in 23.10

**Fixes** # (issue)

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>
launch this command multiples times to rebuild only the centiles on mbi : `/usr/share/centreon-bi/etl/perfdataStatisticsBuilder.pl -r --centile-only` output should always be the same with no mention of mod_bi_metrichourlyvalue.


## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
