### PR TITLE
fix(gorgone/mbi): add weekly and monthly centiles partitioning

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/mbi/etl/perfdata/main.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/mbi/etl/perfdata/main.pm
@@ -346,6 +346,30 @@ sub dailyProcessing {
             ]
         };
     }
+    if (defined($etl->{run}->{etlProperties}->{'centile.week'}) && $etl->{run}->{etlProperties}->{'centile.week'} eq '1') {
+        push @{$etl->{run}->{schedule}->{perfdata}->{stages}->[0]}, {
+            type => 'sql',
+            db => 'centstorage',
+            sql => [
+                [
+                    '[PARTITIONS] Add partition [p' . $partName . '] on table [mod_bi_metriccentileweeklyvalue]',
+                    "ALTER TABLE `mod_bi_metriccentileweeklyvalue` ADD PARTITION (PARTITION `p$partName` VALUES LESS THAN(" . $epoch . "))"
+                ]
+            ]
+        };
+    }
+    if (defined($etl->{run}->{etlProperties}->{'centile.month'}) && $etl->{run}->{etlProperties}->{'centile.month'} eq '1') {
+        push @{$etl->{run}->{schedule}->{perfdata}->{stages}->[0]}, {
+            type => 'sql',
+            db => 'centstorage',
+            sql => [
+                [
+                    '[PARTITIONS] Add partition [p' . $partName . '] on table [mod_bi_metriccentilemonthlyvalue]',
+                    "ALTER TABLE `mod_bi_metriccentilemonthlyvalue` ADD PARTITION (PARTITION `p$partName` VALUES LESS THAN(" . $epoch . "))"
+                ]
+            ]
+        };
+    }
 
     # processing agregation by month. If the day is the first day of the month, also processing agregation by month
     processDayAndMonthAgregation($etl, $liveServices, $start, $end);


### PR DESCRIPTION
## Description

community contribution from @cgagnaire to add partition for weekly and montly table in mbi in 23.10 version.

**Fixes** #3763

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>


## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
