### PR TITLE
fix(test): check versions during update

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
@@ -115,6 +115,12 @@ Given(
             switch (version_from_expression) {
               case 'last stable':
                 minor_version_index = stable_minor_versions.length - 1;
+                if (
+                  stable_minor_versions[minor_version_index] ===
+                  Cypress.env('lastStableMinorVersion')
+                ) {
+                  return cy.stopContainer({ name: 'web' }).wrap('skipped');
+                }
                 break;
               case 'penultimate stable':
                 minor_version_index = stable_minor_versions.length - 2;

--- a/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
@@ -139,15 +139,17 @@ Given(
           }
 
           cy.log(
-            `${version_from_expression} version is ${minor_version_index}`
+            `${version_from_expression} version is ${stable_minor_versions[minor_version_index]}`
           );
 
-          return installCentreon(
-            `${major_version}.${stable_minor_versions[minor_version_index]}`
-          ).then(() => {
-            return checkPlatformVersion(
-              `${major_version}.${stable_minor_versions[minor_version_index]}`
-            ).then(() => cy.visit('/'));
+          const installed_version = `${major_version}.${stable_minor_versions[minor_version_index]}`;
+          Cypress.env('installed_version', installed_version);
+          cy.log('installed_version', installed_version);
+
+          return installCentreon(installed_version).then(() => {
+            return checkPlatformVersion(installed_version).then(() =>
+              cy.visit('/')
+            );
           });
         }
       );

--- a/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade/index.ts
@@ -129,12 +129,13 @@ Given(
                 }
 
                 cy.log(
-                  `${version_from_expression} version is ${minor_version_index}`
+                  `${version_from_expression} version is ${stable_minor_versions[minor_version_index]}`
                 );
+                const installed_version = `${major_version_from}.${stable_minor_versions[minor_version_index]}`;
+                Cypress.env('installed_version', installed_version);
+                cy.log('installed_version', installed_version);
 
-                return installCentreon(
-                  `${major_version_from}.${stable_minor_versions[minor_version_index]}`
-                )
+                return installCentreon(installed_version)
                   .then(() => {
                     if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {
                       const distrib =

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -83,6 +83,11 @@ const getCentreonStableMinorVersions = (
         name: 'web'
       });
     }
+    const lastStableMinorVersion = [...new Set(stableVersions)]
+      .sort((a, b) => a - b)
+      .pop();
+    cy.log('lastStableMinorVersion', lastStableMinorVersion);
+    Cypress.env('lastStableMinorVersion', lastStableMinorVersion);
 
     return cy.wrap([...new Set(stableVersions)].sort((a, b) => a - b)); // remove duplicates and order
   });

--- a/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/common.ts
@@ -322,6 +322,14 @@ When('administrator runs the update procedure', () => {
 
   cy.wait('@getStep3');
   cy.contains('Release notes');
+  // check correct updated version
+  const installed_version = Cypress.env('installed_version');
+  cy.log(`installed_version : ${installed_version}`);
+  cy.getWebVersion().then(({ major_version, minor_version }) => {
+    cy.contains(
+      `upgraded from version ${installed_version} to ${major_version}.${minor_version}`
+    ).should('be.visible');
+  });
   cy.get('#next', { timeout: 15000 }).should('not.be.enabled');
   // button is disabled during 3s in order to read documentation
   cy.get('#next', { timeout: 15000 }).should('be.enabled').click();
@@ -373,7 +381,10 @@ Then(
         template: 'serviceTemplate1'
       })
       .applyPollerConfiguration();
-
+    cy.visit('/');
+    cy.getWebVersion().then(({ major_version, minor_version }) => {
+      cy.contains(`${major_version}.${minor_version}`).should('be.visible');
+    });
     cy.loginByTypeOfUser({
       jsonName: 'admin'
     }).wait('@getLastestUserFilters');


### PR DESCRIPTION
## Description

Enable you to check in the wizard (at step 3 ) that the start and finish versions are correctly quoted in the interface.
checking that the Login page also contains the correct target version.

**Fixes** # MON-143234

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced end-to-end tests for platform upgrades to include version comparison logic, improved logging, and environment variable settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->