### PR TITLE
fix(doc): fix example display in doc API

### DIFF
--- a/centreon/doc/API/latest/onPremise/Configuration/Broker/AddBrokerInputOutput.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Broker/AddBrokerInputOutput.yaml
@@ -24,7 +24,6 @@ post:
       content:
         application/json:
           schema:
-            type: object
             $ref: 'Schema/AddBrokerInputOutputResponse.yaml'
     '400':
       $ref: '../../Common/Response/BadRequest.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/Broker/Schema/AddBrokerInputOutputRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Broker/Schema/AddBrokerInputOutputRequest.yaml
@@ -32,7 +32,7 @@ properties:
         * 11 - File (file)
         * 35 - BBDO Server (bbdo_server)
         * 36 - BBDO Client (bbdo_client)
-    example: "33"
+    example: 33
   parameters:
     type: object
     description: |
@@ -43,20 +43,18 @@ properties:
 
       All fields must be provided, but can be null/empty if they are optional.
 
-    example: |
-      {
-        "path": "some/test/path",
-        "filters_category": ["storage", "neb"],
-        "lua_parameter": [
-          {
-            "type": "string",
-            "name": "my-lua-param-1",
-            "value": "azerty"
-          },
-          {
-            "type": "string",
-            "name": "my-lua-param-2",
-            "value": "qwerty"
-          }
-        ]
-      }
+    example:
+      path: "some/test/path"
+      filters_category: ["storage", "neb"]
+      lua_parameter: [
+        {
+          "type": "string",
+          "name": "my-lua-param-1",
+          "value": "azerty"
+        },
+        {
+          "type": "string",
+          "name": "my-lua-param-2",
+          "value": "qwerty"
+        }
+      ]

--- a/centreon/doc/API/latest/onPremise/Configuration/Broker/Schema/AddBrokerInputOutputResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Broker/Schema/AddBrokerInputOutputResponse.yaml
@@ -27,20 +27,18 @@ properties:
 
       For multiselect fields, the property name is a combination of the group field name and the sub field name (ex: "filters_category")
 
-    example: |
-      {
-        "path": "some/test/path",
-        "filters_category": ["storage", "neb"],
-        "lua_parameter": [
-          {
-            "type": "string",
-            "name": "my-lua-param-1",
-            "value": "azerty"
-          },
-          {
-            "type": "string",
-            "name": "my-lua-param-2",
-            "value": "qwerty"
-          }
-        ]
-      }
+    example:
+      path: "some/test/path"
+      filters_category: ["storage", "neb"]
+      lua_parameter: [
+        {
+          "type": "string",
+          "name": "my-lua-param-1",
+          "value": "azerty"
+        },
+        {
+          "type": "string",
+          "name": "my-lua-param-2",
+          "value": "qwerty"
+        }
+      ]


### PR DESCRIPTION
## Description

Fix example display in API documentation, examples where displayed as string instead of integer or object.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved clarity and structure in API documentation by referencing external schema files and using a more concise format for examples.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->