### PR TITLE
fix(graph): fixed modify of curves definition

### DIFF
--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/useResources.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/useResources.ts
@@ -390,7 +390,7 @@ const useResources = ({
 
   const getSearchField = (resourceType: string): string =>
     cond([
-      [equals('host'), always('h.name')],
+      [equals('host'), always('host.name')],
       [T, always('name')]
     ])(resourceType);
 

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/useResources.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/Resources/useResources.ts
@@ -390,7 +390,7 @@ const useResources = ({
 
   const getSearchField = (resourceType: string): string =>
     cond([
-      [equals('host'), always('host.name')],
+      [equals('host'), always('h.name')],
       [T, always('name')]
     ])(resourceType);
 

--- a/centreon/www/include/views/componentTemplates/DB-Func.php
+++ b/centreon/www/include/views/componentTemplates/DB-Func.php
@@ -81,9 +81,9 @@ function DsHsrTestExistence($name = null)
 
     $stmt->execute();
     $compo = $stmt->fetch();
-    if ($stmt->rowCount() >= 1 && $compo['compo_id'] === $formValues['compo_id']) {
+    if ($stmt->rowCount() >= 1 && $compo['compo_id'] === (int) $formValues['compo_id']) {
         return true;
-    } elseif ($stmt->rowCount() >= 1 && $compo['compo_id'] !== $formValues['compo_id']) {
+    } elseif ($stmt->rowCount() >= 1 && $compo['compo_id'] !== (int) $formValues['compo_id']) {
         return false;
     } else {
         return true;
@@ -131,9 +131,9 @@ function NameHsrTestExistence($name = null)
 
     $stmt->execute();
     $compo = $stmt->fetch();
-    if ($stmt->rowCount() >= 1 && $compo['compo_id'] === $formValues['compo_id']) {
+    if ($stmt->rowCount() >= 1 && $compo['compo_id'] === (int) $formValues['compo_id']) {
         return true;
-    } elseif ($stmt->rowCount() >= 1 && $compo['compo_id'] !== $formValues['compo_id']) {
+    } elseif ($stmt->rowCount() >= 1 && $compo['compo_id'] !== (int) $formValues['compo_id']) {
         return false;
     } else {
         return true;

--- a/centreon/www/include/views/componentTemplates/formComponentTemplate.php
+++ b/centreon/www/include/views/componentTemplates/formComponentTemplate.php
@@ -463,7 +463,9 @@ if ($o === MODIFY_COMPONENT_TEMPLATE || $o === WATCH_COMPONENT_TEMPLATE) {
             colorPickerInput.addEventListener('change', function (e){
                 let newColor = e.target.value;
                 let nameColorPickerblock = `${e.target.name}_color`;
-                document.querySelector(`input[name=${nameColorPickerblock}]`).style.backgroundColor = newColor;
+                let divColorPickerBlock = document.querySelector(`input[name=${nameColorPickerblock}]`)
+                let oldColor = divColorPickerBlock.style.backgroundColor;
+                divColorPickerBlock.style.backgroundColor = (newColor !== '') ? newColor : oldColor;
             })
         });
     });

--- a/centreon/www/include/views/componentTemplates/formComponentTemplate.php
+++ b/centreon/www/include/views/componentTemplates/formComponentTemplate.php
@@ -178,7 +178,8 @@ foreach ($l_dsColorList as $l_dsColor => $l_dCData) {
         'value' => $l_hxColor,
         'size' => 7,
         'maxlength' => 7,
-        'style' => 'text-align: center;'
+        'style' => 'text-align: center;',
+        'class' => 'js-input-colorpicker'
     ];
     $form->addElement('text', $l_dsColor, $l_dCData["label"], $attColText);
 
@@ -456,6 +457,14 @@ if ($o === MODIFY_COMPONENT_TEMPLATE || $o === WATCH_COMPONENT_TEMPLATE) {
             additionnalFilters: {
                 id: '#host_id',
             }
+        });
+        // color picker change event in form
+        document.querySelectorAll('.formTable .js-input-colorpicker').forEach(function (colorPickerInput){
+            colorPickerInput.addEventListener('change', function (e){
+                let newColor = e.target.value;
+                let nameColorPickerblock = `${e.target.name}_color`;
+                document.querySelector(`input[name=${nameColorPickerblock}]`).style.backgroundColor = newColor;
+            })
         });
     });
 </script>

--- a/centreon/www/include/views/componentTemplates/formComponentTemplate.php
+++ b/centreon/www/include/views/componentTemplates/formComponentTemplate.php
@@ -43,7 +43,7 @@ if (!isset($centreon)) {
  */
 $l_general_opt = [];
 
-$stmt = $pearDB->query("SELECT * FROM options WHERE `key` RLIKE '^color_(warn|crit)'");
+$stmt = $pearDB->query("SELECT * FROM options");
 while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
     $l_general_opt[$row['key']] = $row['value'];
 }
@@ -160,11 +160,11 @@ $l_dsColorList = [
     ],
     'ds_color_area_warn' => [
         'label' => _('Warning Area color'),
-        'color' => $l_general_opt['color_warning']
+        'color' => '#FFFFFF'
     ],
     'ds_color_area_crit' => [
         'label' => _('Critical Area color'),
-        'color' => $l_general_opt['color_critical']
+        'color' => '#FFFFFF'
     ],
 ];
 

--- a/centreon/www/include/views/componentTemplates/formComponentTemplate.php
+++ b/centreon/www/include/views/componentTemplates/formComponentTemplate.php
@@ -317,7 +317,6 @@ if ($o === WATCH_COMPONENT_TEMPLATE) {
         'reset',
         _('Reset'),
         [
-            'onClick' => 'javascript:resetLists(' . ($compo["host_id"] ?? 0) . ',' . ($compo["service_id"] ?? 0) . ')',
             'class' => 'btc bt_default'
         ]
     );
@@ -335,7 +334,6 @@ if ($o === WATCH_COMPONENT_TEMPLATE) {
         'reset',
         _('Reset'),
         [
-            'onClick' => 'javascript:resetLists(0,0)',
             'class' => 'btc bt_default'
         ]
     );

--- a/centreon/www/include/views/componentTemplates/formComponentTemplate.php
+++ b/centreon/www/include/views/componentTemplates/formComponentTemplate.php
@@ -461,9 +461,10 @@ if ($o === MODIFY_COMPONENT_TEMPLATE || $o === WATCH_COMPONENT_TEMPLATE) {
         // color picker change event in form
         document.querySelectorAll('.formTable .js-input-colorpicker').forEach(function (colorPickerInput){
             colorPickerInput.addEventListener('change', function (e){
+                e.stopPropagation();
                 let newColor = e.target.value;
                 let nameColorPickerblock = `${e.target.name}_color`;
-                let divColorPickerBlock = document.querySelector(`input[name=${nameColorPickerblock}]`)
+                let divColorPickerBlock = document.querySelector(`input[name=${nameColorPickerblock}]`);
                 let oldColor = divColorPickerBlock.style.backgroundColor;
                 divColorPickerBlock.style.backgroundColor = (newColor !== '') ? newColor : oldColor;
             })

--- a/centreon/www/include/views/componentTemplates/formComponentTemplate.php
+++ b/centreon/www/include/views/componentTemplates/formComponentTemplate.php
@@ -160,11 +160,11 @@ $l_dsColorList = [
     ],
     'ds_color_area_warn' => [
         'label' => _('Warning Area color'),
-        'color' => '#FFFFFF'
+        'color' => '#FD9B27'
     ],
     'ds_color_area_crit' => [
         'label' => _('Critical Area color'),
-        'color' => '#FFFFFF'
+        'color' => '#FF4A4A'
     ],
 ];
 
@@ -342,8 +342,8 @@ if ($o === WATCH_COMPONENT_TEMPLATE) {
     $form->setDefaults(
         [
             'ds_color_area' => '#FFFFFF',
-            'ds_color_area_warn' => '#F8C706',
-            'ds_color_area_crit' => '#F91E05',
+            'ds_color_area_warn' => '#FD9B27',
+            'ds_color_area_crit' => '#FF4A4A',
             'ds_color_line' => '#0000FF',
             'ds_color_line_mode' => 0,
             'ds_transparency' => 80,


### PR DESCRIPTION
## Description

* At the Monitoring > Performance > Curves page, we couldn't modify a curve template because the record was blocked by two rules that checked if the template name and DNS name existed in database even if we had no change.
* Also, when we changed the color value in the inputs, we coulnd't preview the color.
* Finally, when we reset the form, a javascript bug appeared  in the console.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] develop

<h2> How this pull request can be tested ? </h2>

* Given a user accessing to “Monitoring > Performance > Curves” and creating a curve definition
When he change the color for “Line color” and “Area color”
Then the preview change.

* Given a user accessing to “Monitoring > Performance > Curves” and editing a curve definition
When he change value and click on RESET buton
Changed values must be reseted.

* Given a user accessing to “Monitoring > Performance > Curves” and creating a curve definition
The waring and critical values for “Area color” are defined.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the search field for the resource type 'host' from 'h.name' to 'host.name' to ensure accurate search results.

- **Enhancements**
  - Improved data handling by explicitly casting `compo_id` to an integer during comparison.
  - Enhanced color selection for warnings and critical areas with updated default colors and added a color picker for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->