### PR TITLE
enh(vault): manage suffix in vault path with credential key for broker input/output

### DIFF
--- a/centreon/doc/API/latest/onPremise/Configuration/Broker/Schema/AddBrokerInputOutputRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Broker/Schema/AddBrokerInputOutputRequest.yaml
@@ -1,5 +1,5 @@
 type: object
-required: ["name", "typeId", "parameters"]
+required: ["name", "type", "parameters"]
 properties:
   name:
     type: string

--- a/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
+++ b/centreon/src/Core/Broker/Application/UseCase/AddBrokerInputOutput/AddBrokerInputOutput.php
@@ -160,9 +160,8 @@ final class AddBrokerInputOutput
 
             return null;
         }
-        $vaultParts = explode('/', $vaultPath);
 
-        return end($vaultParts);
+        return $this->getUuidFromPath($vaultPath);
     }
 
     /**

--- a/centreon/src/Core/Broker/Infrastructure/API/AddBrokerInputOutput/AddBrokerInputOutputController.php
+++ b/centreon/src/Core/Broker/Infrastructure/API/AddBrokerInputOutput/AddBrokerInputOutputController.php
@@ -79,9 +79,14 @@ final class AddBrokerInputOutputController extends AbstractController
         } catch (\InvalidArgumentException $ex) {
             $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
             $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+
+            return $presenter->show();
         } catch (\Throwable $ex) {
             $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
             $presenter->setResponseStatus(new ErrorResponse(BrokerException::addBrokerInputOutput()));
+
+            return $presenter->show();
+
         }
 
         $useCase($dto, $presenter);

--- a/centreon/src/Core/Broker/Infrastructure/API/AddBrokerInputOutput/AddBrokerInputOutputController.php
+++ b/centreon/src/Core/Broker/Infrastructure/API/AddBrokerInputOutput/AddBrokerInputOutputController.php
@@ -86,7 +86,6 @@ final class AddBrokerInputOutputController extends AbstractController
             $presenter->setResponseStatus(new ErrorResponse(BrokerException::addBrokerInputOutput()));
 
             return $presenter->show();
-
         }
 
         $useCase($dto, $presenter);

--- a/centreon/src/Core/Common/Infrastructure/Repository/WriteVaultRepository.php
+++ b/centreon/src/Core/Common/Infrastructure/Repository/WriteVaultRepository.php
@@ -61,6 +61,7 @@ class WriteVaultRepository extends AbstractVaultRepository implements WriteVault
                 $payload = $responseContent['data']['data'];
             }
         }
+
         // Delete unwanted data
         foreach ($deletes as $deleteKey => $deleteValue) {
             unset($payload[$deleteKey]);

--- a/centreon/src/Core/Common/Infrastructure/Repository/WriteVaultRepository.php
+++ b/centreon/src/Core/Common/Infrastructure/Repository/WriteVaultRepository.php
@@ -61,7 +61,6 @@ class WriteVaultRepository extends AbstractVaultRepository implements WriteVault
                 $payload = $responseContent['data']['data'];
             }
         }
-
         // Delete unwanted data
         foreach ($deletes as $deleteKey => $deleteValue) {
             unset($payload[$deleteKey]);

--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -1757,7 +1757,6 @@ class CentreonConfigCentreonBroker
         $headers = [
             'Content-Type' => 'application/json',
             'X-AUTH-TOKEN' => $_COOKIE['PHPSESSID'],
-            'Cookie' => 'XDEBUG_SESSION=XDEBUG_KEY'
         ];
         $parameters = ['brokerId' => $configId];
         $basePath ? $parameters['base_uri'] = $basePath : null;

--- a/centreon/www/include/common/vault-functions.php
+++ b/centreon/www/include/common/vault-functions.php
@@ -1548,22 +1548,32 @@ function updateDatabaseYamlFile(array $vaultPaths): void
 
 // BROKER CONFIG
 
+/**
+ * Delete Broker Configuration from Vault.
+ *
+ * @param WriteVaultRepositoryInterface $writeVaultRepository
+ * @param int[] $brokerConfigIds
+ *
+ * @throws Throwable
+ */
 function deleteBrokerConfigsFromVault(
-    VaultConfiguration $vaultConfiguration,
-    Logger $logger,
+    WriteVaultRepositoryInterface $writeVaultRepository,
     array $brokerConfigIds,
 ): void {
-    $vaultPath = 'secret::' . $vaultConfiguration->getName() . '::';
-    $httpClient = new CentreonRestHttp();
-    $clientToken = authenticateToVault($vaultConfiguration, $logger, $httpClient);
-
-    $uuids = retrieveMultipleBrokerConfigUuidsFromDatabase($brokerConfigIds, $vaultPath);
+    $uuids = retrieveMultipleBrokerConfigUuidsFromDatabase($brokerConfigIds);
     foreach ($uuids as $uuid) {
-        deleteBrokerConfigFromVault($vaultConfiguration, $uuid, $clientToken, $logger, $httpClient);
+        $writeVaultRepository->delete($uuid);
     }
 }
 
-function retrieveMultipleBrokerConfigUuidsFromDatabase(array $brokerIds, string $vaultPath): array
+/**
+ * Retrieve broker config vault UUIDs from database.
+ *
+ * @param int[] $brokerIds
+ *
+ * @return string[]
+ */
+function retrieveMultipleBrokerConfigUuidsFromDatabase(array $brokerIds): array
 {
     global $pearDB;
 
@@ -1584,83 +1594,44 @@ function retrieveMultipleBrokerConfigUuidsFromDatabase(array $brokerIds, string 
     foreach ($bindParams as $token => $brokerId) {
         $statement->bindValue($token, $brokerId, PDO::PARAM_INT);
     }
-    $statement->bindValue(':vaultPath', $vaultPath . '%', PDO::PARAM_STR);
+    $statement->bindValue(':vaultPath', VaultConfiguration::VAULT_PATH_PATTERN . '%', PDO::PARAM_STR);
     $statement->execute();
     $uuids = [];
     while ($result = $statement->fetchColumn()) {
-        $vaultPathPart = explode('/', $result);
-        if (isset($vaultPathPart)) {
-            $uuids[] = end($vaultPathPart);
-        }
+        $uuids[] =
+            preg_match('/' . VaultConfiguration::UUID_EXTRACTION_REGEX . '/', $result, $matches)
+                ? $matches[2]
+                : null;
     }
 
-    return $uuids;
+    return array_filter($uuids, fn ($uuid) => $uuid !== null);
 }
 
 /**
- * @param VaultConfiguration $vaultConfiguration
- * @param string $uuid
- * @param string $clientToken
+ * Retrieve raw value of broker config parameters from vault.
+ *
+ * @param ReadVaultRepositoryInterface $readVaultRepository
  * @param Logger $logger
- * @param CentreonRestHttp $httpClient
+ * @param string $key
+ * @param string $vaultPath
  *
- * @throws Exception
+ * @throws Throwable
  *
- * @return void
+ * @return string
  */
-function deleteBrokerConfigFromVault(
-    VaultConfiguration $vaultConfiguration,
-    string $uuid,
-    string $clientToken,
-    Logger $logger,
-    CentreonRestHttp $httpClient,
-): void {
-    $url = $vaultConfiguration->getAddress() . ':' . $vaultConfiguration->getPort() . '/v1/'
-        . $vaultConfiguration->getRootPath() . '/metadata/configuration/broker/' . $uuid;
-    $url = sprintf('%s://%s', DEFAULT_SCHEME, $url);
-    $logger->info(sprintf('Deleting Broker Configuration: %s', $uuid));
-    try {
-        $httpClient->call($url, 'DELETE', null, ['X-Vault-Token: ' . $clientToken]);
-    } catch (Exception $ex) {
-        $logger->error(sprintf('Unable to delete Broker Configuration: %s', $uuid));
-
-        throw $ex;
-    }
-}
-
 function findBrokerConfigValueFromVault(
-    VaultConfiguration $vaultConfiguration,
+    ReadVaultRepositoryInterface $readVaultRepository,
     Logger $logger,
     string $key,
     string $vaultPath,
 ): string
 {
-    $httpClient = new CentreonRestHttp();
-    $clientToken = authenticateToVault($vaultConfiguration, $logger, $httpClient);
-
-    $vaultParts = explode('/', $vaultPath);
-    $uuid = end($vaultParts);
-
-    $url = $vaultConfiguration->getAddress() . ':' . $vaultConfiguration->getPort() . '/v1/'
-        . $vaultConfiguration->getRootPath() . '/data/configuration/broker/' . $uuid;
-    $url = sprintf('%s://%s', DEFAULT_SCHEME, $url);
-    $logger->info(sprintf('Search Broker Configuration: %s', $uuid));
-
     try {
-        $content = $httpClient->call($url, 'GET', null, ['X-Vault-Token: ' . $clientToken]);
-        if (
-            array_key_exists('data', $content)
-            && array_key_exists('data', $content['data'])
-            && array_key_exists($key, $content['data']['data'])
-        ) {
-            return $content['data']['data'][$key];
+        $content = $readVaultRepository->findFromPath($vaultPath);
+        if (! array_key_exists($key, $content)) {
+            return $vaultPath;
         }
-
-        return $vaultPath;
-    } catch (RestNotFoundException $ex) {
-        $logger->info('Broker Configuration not found in vault');
-
-        return $vaultPath;
+        return $content[$key];
     } catch (Exception $ex) {
         $logger->error('Unable to get secrets for Broker Configuration');
 

--- a/centreon/www/include/configuration/configCentreonBroker/DB-Func.php
+++ b/centreon/www/include/configuration/configCentreonBroker/DB-Func.php
@@ -35,6 +35,12 @@
 
 require_once _CENTREON_PATH_ . 'www/include/common/vault-functions.php';
 
+use App\Kernel;
+use Centreon\Domain\Log\Logger;
+use Core\Common\Infrastructure\FeatureFlags;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
+use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
+use Core\Security\Vault\Domain\Model\VaultConfiguration;
 /**
  *
  * Test broker file config existance
@@ -112,17 +118,22 @@ function deleteCentreonBrokerInDB($ids = array())
 
     $brokerIds = array_keys($ids);
 
-    $kernel = \App\Kernel::createForWeb();
-    /** @var \Centreon\Domain\Log\Logger $logger */
-    $logger = $kernel->getContainer()->get(\Centreon\Domain\Log\Logger::class);
+    $kernel = Kernel::createForWeb();
+    /** @var Logger $logger */
+    $logger = $kernel->getContainer()->get(Logger::class);
+    /** @var ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository */
     $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface::class
+        ReadVaultConfigurationRepositoryInterface::class
     );
-    $featureFlagManager = $kernel->getContainer()->get(Core\Common\Infrastructure\FeatureFlags::class);
+    /** @var FeatureFlags $featureFlagManager */
+    $featureFlagManager = $kernel->getContainer()->get(FeatureFlags::class);
     $vaultConfiguration = $readVaultConfigurationRepository->find();
 
+    /** @var \Core\Common\Application\Repository\WriteVaultRepositoryInterface $writeVaultRepository */
+    $writeVaultRepository = $kernel->getContainer()->get(\Core\Common\Application\Repository\WriteVaultRepositoryInterface::class);
+    $writeVaultRepository->setCustomPath(\Core\Common\Infrastructure\Repository\AbstractVaultRepository::BROKER_VAULT_PATH);
     if ($featureFlagManager->isEnabled('vault_broker') && $vaultConfiguration !== null) {
-        deleteBrokerConfigsFromVault($vaultConfiguration, $logger, $brokerIds);
+        deleteBrokerConfigsFromVault($writeVaultRepository, $brokerIds);
     }
 
     $statement = $pearDB->prepare("DELETE FROM cfg_centreonbroker WHERE config_id = :config_id");
@@ -385,39 +396,45 @@ function getCfgBrokerInfoData(int $configId): array
  */
 function retrieveOriginalPasswordValuesFromVault(array &$values): void
 {
-    $kernel = \App\Kernel::createForWeb();
-    /** @var \Centreon\Domain\Log\Logger $logger */
-    $logger = $kernel->getContainer()->get(\Centreon\Domain\Log\Logger::class);
+    $kernel = Kernel::createForWeb();
+    /** @var ReadVaultConfigurationRepositoryInterface $readVaultConfigurationRepository */
     $readVaultConfigurationRepository = $kernel->getContainer()->get(
-        Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface::class
+        ReadVaultConfigurationRepositoryInterface::class
     );
     $vaultConfiguration = $readVaultConfigurationRepository->find();
 
-    foreach (['input', 'output'] as $tag) {
-        foreach ($values[$tag] as $key => $inputOutput) {
-            foreach ($inputOutput as $name => $value) {
-                if (is_string($value) && str_starts_with($value, 'secret::')) {
-                    [$groupName, $subName] = explode('__', $name);
-                    [$subName, $subKey] = explode('_', $subName);
-                    if ($subName === 'value') {
-                        $vaultKey = implode(
-                            '_',
-                            [$inputOutput['name'], $groupName, $inputOutput["{$groupName}__name_{$subKey}"]]
-                        );
-                    } else {
-                        $vaultKey = $inputOutput['name'] . '_' . $name;
-                    }
+    if ($vaultConfiguration !== null) {
+        /** @var Logger $logger */
+        $logger = $kernel->getContainer()->get(Logger::class);
+        /** @var ReadVaultRepositoryInterface $readVaultRepository */
+        $readVaultRepository = $kernel->getContainer()->get(ReadVaultRepositoryInterface::class);
+        foreach (['input', 'output'] as $tag) {
+            foreach ($values[$tag] as $key => $inputOutput) {
+                foreach ($inputOutput as $name => $value) {
+                    if (is_string($value) && str_starts_with($value, VaultConfiguration::VAULT_PATH_PATTERN)) {
+                        [$groupName, $subName] = explode('__', $name);
+                        [$subName, $subKey] = explode('_', $subName);
+                        if ($subName === 'value') {
+                            $vaultKey = implode(
+                                '_',
+                                [$inputOutput['name'], $groupName, $inputOutput["{$groupName}__name_{$subKey}"]]
+                            );
+                        } else {
+                            $vaultKey = $inputOutput['name'] . '_' . $name;
+                        }
 
-                    $passwordValue = findBrokerConfigValueFromVault(
-                        $vaultConfiguration,
-                        $logger,
-                        $vaultKey,
-                        $value,
-                    );
-                    $values[$tag][$key][$name] = $passwordValue;
+                        $passwordValue = findBrokerConfigValueFromVault(
+                            $readVaultRepository,
+                            $logger,
+                            $vaultKey,
+                            $value,
+                        );
+                        $values[$tag][$key][$name] = $passwordValue;
+                    }
                 }
             }
         }
     }
+
 
 }

--- a/centreon/www/include/configuration/configCentreonBroker/DB-Func.php
+++ b/centreon/www/include/configuration/configCentreonBroker/DB-Func.php
@@ -38,9 +38,10 @@ require_once _CENTREON_PATH_ . 'www/include/common/vault-functions.php';
 use App\Kernel;
 use Centreon\Domain\Log\Logger;
 use Core\Common\Infrastructure\FeatureFlags;
-use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
+use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
+
 /**
  *
  * Test broker file config existance
@@ -435,6 +436,4 @@ function retrieveOriginalPasswordValuesFromVault(array &$values): void
             }
         }
     }
-
-
 }


### PR DESCRIPTION
## Description

This PR intends to manage suffix in vault path with credential key for broker input/output parameters of type passwords

**Fixes** # MON-139727

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
