### PR TITLE
fix(doc): apply suggestions from TW team

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -27,8 +27,8 @@ info:
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
   version: "24.04"
 externalDocs:
-  description: You can contact us on our community Slack
-  url: 'https://centreon.slack.com/messages/CCRGLQSE5'
+  description: You can contact us on our community platform The Watch
+  url: 'https://thewatch.centreon.com/'
 servers:
   - url: '{protocol}://{server}:{port}/centreon/api/{version}'
     variables:

--- a/centreon/doc/API/centreon-cloud-api.yaml
+++ b/centreon/doc/API/centreon-cloud-api.yaml
@@ -21,10 +21,9 @@ info:
   license:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
-  version: "24.04"
 externalDocs:
-  description: You can contact us on our community Slack
-  url: 'https://centreon.slack.com/messages/CCRGLQSE5'
+  description: You can contact us on our community platform The Watch
+  url: 'https://thewatch.centreon.com/'
 servers:
   - url: '{protocol}://{server}:{port}/centreon/api/{version}'
     variables:


### PR DESCRIPTION
🏷️ MON-143585
📝 This PR intends to apply some feedbacks from the TW Team

- Remove the version in the Cloud Web Rest API documentation
- Update links to The Watch instead of Slack (core + cloud)

ℹ️ The features section regarding Resource Access Management will be added for the dev-24.04.x branch as this feature landed for the 24.04.x cc @cg-tw 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated external documentation links to reflect the new community platform, The Watch, replacing the former Slack community link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->