### PR TITLE
fix(Resource Status): Fixed listing Real Time Service Category with a SC filter

### DIFF
--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbReadRealTimeServiceCategoryRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbReadRealTimeServiceCategoryRepository.php
@@ -116,7 +116,7 @@ class DbReadRealTimeServiceCategoryRepository extends AbstractRepositoryRDB impl
             $request .= $searchRequest;
         }
 
-        $request .= ' GROUP BY service_categories.name';
+        $request .= ' GROUP BY service_categories.id, service_categories.name';
 
         $sortRequest = $sqlTranslator?->translateSortParameterToSql();
 
@@ -226,7 +226,7 @@ class DbReadRealTimeServiceCategoryRepository extends AbstractRepositoryRDB impl
 
         $request .= " ag.acl_group_id IN ({$bindQuery})";
 
-        $request .= ' GROUP BY service_categories.name';
+        $request .= ' GROUP BY service_categories.id, service_categories.name';
 
         $sortRequest = $sqlTranslator?->translateSortParameterToSql();
 


### PR DESCRIPTION
## Description

Fixed error in listing real time service categories in Resource Status page

**Fixes** # MON-143440

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Enhanced the accuracy of service category grouping by including `service_categories.id` in the criteria. This change ensures more precise and reliable data retrieval when viewing or managing service categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->