### PR TITLE
fix (ACL): modifications to access groups are taken into account in the user's session

### DIFF
--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -316,11 +316,11 @@ class CentreonACL
 
         if ($this->hasAccessToAllHostGroups === false) {
             [$bindValues, $bindQuery] = createMultipleBindQuery(
-                list: explode(',', $this->getAccessGroupsString()),
+                list: array_keys($this->getAccessGroups()),
                 prefix: ':access_group_id_'
             );
 
-            $aclSubRequest .= ' AND arhr.acl_res_id IN (' . $bindQuery . ')';
+            $aclSubRequest .= ' AND argr.acl_group_id IN (' . $bindQuery . ')';
         }
 
         $request = <<<SQL
@@ -331,8 +331,13 @@ class CentreonACL
             FROM hostgroup hg
             INNER JOIN acl_resources_hg_relations arhr
                 ON hg.hg_id = arhr.hg_hg_id
+            INNER JOIN acl_resources res
+                ON res.acl_res_id = arhr.acl_res_id
+            INNER JOIN acl_res_group_relations argr
+                ON argr.acl_res_id = res.acl_res_id
             WHERE hg.hg_activate = '1'
             $aclSubRequest
+            GROUP BY hg.hg_id, hg.hg_name
             ORDER BY hg.hg_name ASC
         SQL;
 

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -117,7 +117,6 @@ class CentreonACL
     {
         $this->parentTemplates = null;
         $this->resourceGroups = array();
-        $this->hostGroups = array();
         $this->serviceGroups = array();
         $this->serviceCategories = array();
         $this->actions = array();
@@ -311,12 +310,20 @@ class CentreonACL
      */
     private function setHostGroups()
     {
+        $this->hostGroups = [];
+        $this->hostGroupsAlias = [];
+        $this->hostGroupsFilter = [];
         $aclSubRequest = '';
         $bindValues = [];
 
         if ($this->hasAccessToAllHostGroups === false) {
+            $accessGroups = $this->getAccessGroups();
+            if ($accessGroups === []) {
+                return;
+            }
+
             [$bindValues, $bindQuery] = createMultipleBindQuery(
-                list: array_keys($this->getAccessGroups()),
+                list: array_keys($accessGroups),
                 prefix: ':access_group_id_'
             );
 

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -2517,7 +2517,7 @@ class CentreonACL
                 . $empty_exists;
         } else {
             // Cant manage empty hostgroup with ACLs. We'll have a problem with acl for conf...
-            $groupIds = array_keys($this->accessGroups);
+            $groupIds = array_keys($this->getAccessGroups());
             $query = $request['select'] . $request['fields'] . " "
                 . "FROM hostgroup, acl_res_group_relations, acl_resources_hg_relations "
                 . "WHERE hg_activate = '1' "

--- a/centreon/www/include/common/sqlCommonFunction.php
+++ b/centreon/www/include/common/sqlCommonFunction.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,25 +21,22 @@
 
 declare(strict_types = 1);
 
-namespace Core\Common\Infrastructure\Repository;
+require_once _CENTREON_PATH_ . 'src/Core/Common/Infrastructure/Repository/SqlMultipleBindTrait.php';
 
-trait SqlMultipleBindTrait
+use \Core\Common\Infrastructure\Repository\SqlMultipleBindTrait;
+
+/**
+ * @param array<int|string, int|string> $list
+ * @param string $prefix
+ *
+ * @return array{0: array<string, mixed>, 1: string}
+ */
+function createMultipleBindQuery(array $list, string $prefix): array
 {
-    /**
-     * @param array<int|string, int|string> $list
-     * @param string $prefix
-     *
-     * @return array{0: array<string, mixed>, 1: string}
-     */
-    protected function createMultipleBindQuery(array $list, string $prefix): array
-    {
-        $bindValues = [];
-        $list = array_values($list); // Reset index to avoid SQL injection
-
-        foreach ($list as $index => $id) {
-            $bindValues[$prefix . $index] = $id;
+    return (new class {
+        use SqlMultipleBindTrait
+        {
+            SqlMultipleBindTrait::createMultipleBindQuery as public create;
         }
-
-        return [$bindValues, implode(', ', array_keys($bindValues))];
-    }
+    })->create($list, $prefix);
 }

--- a/centreon/www/include/options/accessLists/groupsACL/DB-Func.php
+++ b/centreon/www/include/options/accessLists/groupsACL/DB-Func.php
@@ -103,7 +103,13 @@ function enableGroupInDB($acl_group_id = null, $groups = array())
     }
 
     foreach ($groups as $key => $value) {
-        $dbResult = $pearDB->prepare("UPDATE acl_groups SET acl_group_activate = '1' WHERE acl_group_id = :aclGroupId");
+        $dbResult = $pearDB->prepare(<<<SQL
+            UPDATE acl_groups 
+            SET acl_group_activate = '1',
+                acl_group_changed = '1'
+            WHERE acl_group_id = :aclGroupId
+            SQL
+        );
         $dbResult->bindValue('aclGroupId', $key, PDO::PARAM_INT);
         $dbResult->execute();
 


### PR DESCRIPTION
## Description

- When activating an access group from the access group listing, the ACL calculation was not requested for this one.
- The list of access groups was stored in the user's session, making it impossible to take account of changes in their allocation unless the user reconnected.
- Users can now only list host groups (host group list page, list of host groups when editing/creating a host) linked to their ACL.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
