### PR TITLE
fix(UI): Fix resources listing when hovering status chart

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -67,6 +67,7 @@ jobs:
             has_frontend_changes:
               - '**/*.[jt]sx?'
               - '**/www/front_src/**'
+              - '**/www/widgets/src/**'
               - '**/tests/e2e/**'
               - '**/package*'
               - '**/lighthouse/**'

--- a/centreon/packages/ui/src/Graph/BarStack/ResponsiveBarStack.tsx
+++ b/centreon/packages/ui/src/Graph/BarStack/ResponsiveBarStack.tsx
@@ -33,7 +33,8 @@ const BarStack = ({
   unit = 'number',
   displayValues,
   variant = 'vertical',
-  legendDirection = 'column'
+  legendDirection = 'column',
+  tooltipProps = {}
 }: BarStackProps & { height: number; width: number }): JSX.Element => {
   const { t } = useTranslation();
   const { classes } = useBarStackStyles();
@@ -140,6 +141,7 @@ const BarStack = ({
                                 title={title}
                                 total={total}
                                 value={barStack.bars[0].bar.data[barStack.key]}
+                                {...tooltipProps}
                               />
                             )
                           }

--- a/centreon/packages/ui/src/Graph/BarStack/models.ts
+++ b/centreon/packages/ui/src/Graph/BarStack/models.ts
@@ -14,6 +14,7 @@ export type BarStackProps = {
   onSingleBarClick?: (barData) => void;
   size?: number;
   title?: string;
+  tooltipProps?: object;
   unit?: 'percentage' | 'number';
   variant?: 'vertical' | 'horizontal';
 };

--- a/centreon/packages/ui/src/Graph/PieChart/ResponsivePie.tsx
+++ b/centreon/packages/ui/src/Graph/PieChart/ResponsivePie.tsx
@@ -53,7 +53,8 @@ const ResponsivePie = ({
   onArcClick,
   displayValues,
   TooltipContent,
-  legendDirection = 'column'
+  legendDirection = 'column',
+  tooltipProps = {}
 }: PieProps & { height: number; width: number }): JSX.Element => {
   const { t } = useTranslation();
   const theme = useTheme();
@@ -157,6 +158,7 @@ const ResponsivePie = ({
                               title={title}
                               total={total}
                               value={arc.data.value}
+                              {...tooltipProps}
                             />
                           )
                         }

--- a/centreon/packages/ui/src/Graph/PieChart/models.ts
+++ b/centreon/packages/ui/src/Graph/PieChart/models.ts
@@ -14,6 +14,7 @@ export interface PieProps {
   legendDirection?: 'row' | 'column';
   onArcClick?: (ardata) => void;
   title?: string;
+  tooltipProps?: object;
   unit?: 'percentage' | 'number';
   variant?: 'pie' | 'donut';
 }

--- a/centreon/packages/ui/src/utils/useInfiniteScrollListing.ts
+++ b/centreon/packages/ui/src/utils/useInfiniteScrollListing.ts
@@ -60,7 +60,12 @@ export const useInfiniteScrollListing = <T>({
         customQueryParameters,
         parameters: { limit, page: params?.page || page, ...parameters }
       }),
-    getQueryKey: () => [queryKeyName, page],
+    getQueryKey: () => [
+      queryKeyName,
+      page,
+      JSON.stringify(parameters),
+      JSON.stringify(customQueryParameters)
+    ],
     isPaginated: true,
     queryOptions: {
       enabled,

--- a/centreon/www/widgets/src/centreon-widget-statuschart/src/Chart/Chart.tsx
+++ b/centreon/www/widgets/src/centreon-widget-statuschart/src/Chart/Chart.tsx
@@ -92,6 +92,7 @@ const Chart = ({
             displayLegend={displayLegend}
             displayValues={displayValues}
             title={title}
+            tooltipProps={{ resources }}
             unit={unit}
             variant={displayType as 'pie' | 'donut'}
             onArcClick={({ label: status }) => {
@@ -117,6 +118,7 @@ const Chart = ({
             legendDirection={isHorizontalBar ? 'row' : 'column'}
             size={80}
             title={title}
+            tooltipProps={{ resources }}
             unit={unit}
             variant={displayType as 'horizontal' | 'vertical'}
             onSingleBarClick={({ key: status }) => {

--- a/centreon/www/widgets/src/centreon-widget-statuschart/src/Tooltip/Tooltip.tsx
+++ b/centreon/www/widgets/src/centreon-widget-statuschart/src/Tooltip/Tooltip.tsx
@@ -11,6 +11,7 @@ import {
   labelStatus,
   lableNoResourceFound
 } from '../translatedLabels';
+import { Resource } from '../../../models';
 
 import { useTooltipContent } from './useTooltip';
 import { useTooltipStyles } from './Tooltip.styles';
@@ -18,6 +19,7 @@ import { useTooltipStyles } from './Tooltip.styles';
 interface Props {
   color: string;
   label: string;
+  resources: Array<Resource>;
   title: string;
   total: number;
   value: number;
@@ -28,7 +30,8 @@ const TooltipContent = ({
   color,
   value,
   total,
-  title
+  title,
+  resources: resourcesOptions
 }: Props): JSX.Element => {
   const { classes } = useTooltipStyles();
 
@@ -36,6 +39,7 @@ const TooltipContent = ({
   const { format } = useLocaleDateTimeFormat();
 
   const { elementRef, isLoading, resources } = useTooltipContent({
+    resources: resourcesOptions,
     status: label,
     type: title.slice(0, -1)
   });

--- a/centreon/www/widgets/src/centreon-widget-statuschart/src/Tooltip/useTooltip.ts
+++ b/centreon/www/widgets/src/centreon-widget-statuschart/src/Tooltip/useTooltip.ts
@@ -2,10 +2,18 @@ import { useInfiniteScrollListing } from '@centreon/ui';
 
 import { resourcesEndpoint } from '../api/endpoint';
 import { tooltipPageAtom } from '../atom';
+import { Resource } from '../../../models';
+import { getResourcesSearchQueryParameters } from '../../../utils';
 
 import { ResourceStatus } from 'src/centreon-widget-statusgrid/src/StatusGridStandard/models';
 
-interface UseHostTooltipContentState {
+interface UseTooltipContentProps {
+  resources: Array<Resource>;
+  status: string;
+  type: string;
+}
+
+interface UseTooltipContentState {
   elementRef;
   isLoading: boolean;
   resources: Array<ResourceStatus>;
@@ -14,17 +22,26 @@ interface UseHostTooltipContentState {
 
 export const useTooltipContent = ({
   type,
-  status
-}): UseHostTooltipContentState => {
+  status,
+  resources
+}: UseTooltipContentProps): UseTooltipContentState => {
+  const { resourcesSearchConditions, resourcesCustomParameters } =
+    getResourcesSearchQueryParameters(resources);
   const { elementRef, elements, isLoading, total } =
     useInfiniteScrollListing<ResourceStatus>({
       customQueryParameters: [
         { name: 'types', value: [type] },
-        { name: 'statuses', value: [status.toUpperCase()] }
+        { name: 'statuses', value: [status.toUpperCase()] },
+        ...resourcesCustomParameters
       ],
       endpoint: resourcesEndpoint,
       limit: 10,
       pageAtom: tooltipPageAtom,
+      parameters: {
+        search: {
+          conditions: resourcesSearchConditions
+        }
+      },
       queryKeyName: `statusChart_${type}_${status}`,
       suspense: false
     });

--- a/centreon/www/widgets/src/centreon-widget-statuschart/src/spec/StatusChart.cypress.spec.tsx
+++ b/centreon/www/widgets/src/centreon-widget-statuschart/src/spec/StatusChart.cypress.spec.tsx
@@ -263,7 +263,7 @@ displayTypes.forEach(({ displayType, label }) => {
       cy.makeSnapshot(`${label} : displays values with the unit "number"`);
     });
 
-    describe('Tooltip', () => {
+    describe.only('Tooltip', () => {
       ['service', 'host'].forEach((resourceType) => {
         it(`displays tooltip with correct information on hover for type ${resourceType}`, () => {
           const statuses = equals(resourceType, 'host')


### PR DESCRIPTION
## Description

This fixes the resources listing to the resources dataset upon hovering status chart.

https://github.com/user-attachments/assets/ea3c6815-1801-4670-bbfe-94e1a9a2e5a5

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
