### PR TITLE
fix (ACL): fix require path

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/configuration.ts
+++ b/centreon/packages/js-config/cypress/e2e/configuration.ts
@@ -74,7 +74,7 @@ export default ({
       runMode: 2
     },
     screenshotsFolder: `${resultsFolder}/screenshots`,
-    video: true,
+    video: isDevelopment,
     videoCompression: 0,
     videosFolder: `${resultsFolder}/videos`,
     viewportHeight: 1080,

--- a/centreon/packages/js-config/cypress/e2e/configuration.ts
+++ b/centreon/packages/js-config/cypress/e2e/configuration.ts
@@ -74,7 +74,7 @@ export default ({
       runMode: 2
     },
     screenshotsFolder: `${resultsFolder}/screenshots`,
-    video: isDevelopment,
+    video: true,
     videoCompression: 0,
     videosFolder: `${resultsFolder}/videos`,
     viewportHeight: 1080,

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -33,7 +33,7 @@
  */
 
 require_once realpath(dirname(__FILE__) . "/centreonDBInstance.class.php");
-require_once _CENTREON_PATH_ . 'www/include/common/sqlCommonFunction.php';
+require_once _CENTREON_PATH_ . '/www/include/common/sqlCommonFunction.php';
 
 /**
  * Class for Access Control List management

--- a/centreon/www/include/common/sqlCommonFunction.php
+++ b/centreon/www/include/common/sqlCommonFunction.php
@@ -21,7 +21,7 @@
 
 declare(strict_types = 1);
 
-require_once _CENTREON_PATH_ . 'src/Core/Common/Infrastructure/Repository/SqlMultipleBindTrait.php';
+require_once _CENTREON_PATH_ . '/src/Core/Common/Infrastructure/Repository/SqlMultipleBindTrait.php';
 
 use \Core\Common\Infrastructure\Repository\SqlMultipleBindTrait;
 


### PR DESCRIPTION
## Description

Some tests define the **\_CENTREON_PATH\_** constant without the trailing slash at the end.
Although the **\_CENTREON_PATH\_** constant in centreon-web is defined with the slash at the end, all legacy imports implicitly add an extra slash.
So we add a slash to be consistent with the rest of the code and avoid problems with module testing

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
