### PR TITLE
fix(open-tickets): correctly save ticket subject for GlpiRestApiProvider

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/GlpiRestApi/GlpiRestApiProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/GlpiRestApi/GlpiRestApiProvider.class.php
@@ -936,7 +936,7 @@ class GlpiRestApiProvider extends AbstractProvider
             'host_problems' => $host_problems,
             'service_problems' => $service_problems,
             'ticket_value' => $ticketId,
-            'subject' => $ticketArguments[self::ARG_TITLE],
+            'subject' => $ticketArguments[$this->internal_arg_name[self::ARG_TITLE]],
             'data_type' => self::DATA_TYPE_JSON,
             'data' => json_encode($ticketArguments)
         ));


### PR DESCRIPTION
🏷️ MON-145072
📃 This PR intends to fix an issue where the subject of the ticket was not saved when creating the ticket for the GlpiRestApiProvider

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Create a ticket using a rule configured with GlpiRestApiProvider.
Check that the subject is correctly saved.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
