### PR TITLE
fix(Authentication): OIDC auth, issue with redirect URL's protocol

### DIFF
--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -286,7 +286,7 @@ class OpenIdProvider implements OpenIdProviderInterface
             throw ConfigurationException::missingInformationEndpoint();
         }
 
-        $this->sendRequestForConnectionTokenOrFail($authorizationCode);
+        $this->sendRequestForConnectionTokenOrFail($authorizationCode, $customConfiguration->getRedirectUrl());
         $this->createAuthenticationTokens();
         if (array_key_exists('id_token', $this->connectionTokenResponseContent)) {
             $this->idTokenPayload = $this->extractTokenPayload($this->connectionTokenResponseContent['id_token']);
@@ -468,16 +468,22 @@ class OpenIdProvider implements OpenIdProviderInterface
      *
      * @throws SSOAuthenticationException
      */
-    private function sendRequestForConnectionTokenOrFail(string $authorizationCode): void
+    private function sendRequestForConnectionTokenOrFail(string $authorizationCode, ?string $redirectUrl): void
     {
         $this->info('Send request to external provider for connection token...');
 
         // Define parameters for the request
-        $redirectUri = $this->router->generate(
-            'centreon_security_authentication_login_openid',
-            [],
-            UrlGeneratorInterface::ABSOLUTE_URL
-        );
+        $redirectUri = $redirectUrl !== null
+            ? $redirectUrl . $this->router->generate(
+                'centreon_security_authentication_login_openid',
+                [],
+                UrlGeneratorInterface::ABSOLUTE_PATH
+            )
+            : $this->router->generate(
+                'centreon_security_authentication_login_openid',
+                [],
+                UrlGeneratorInterface::ABSOLUTE_URL
+            );
         $data = [
             'grant_type' => 'authorization_code',
             'code' => $authorizationCode,

--- a/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
+++ b/centreon/src/Core/Security/Authentication/Domain/Provider/OpenIdProvider.php
@@ -465,6 +465,7 @@ class OpenIdProvider implements OpenIdProviderInterface
      * Get Connection Token from OpenId Provider.
      *
      * @param string $authorizationCode
+     * @param string|null $redirectUrl
      *
      * @throws SSOAuthenticationException
      */


### PR DESCRIPTION
## Description

Fixed issue when specifying a redirect URL in OIDC configuration in https changes the protocol to http in web browser.

**Fixes** # MON-20014

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
