### PR TITLE
fix(auth): do not delete cloud acl_groups user relations on mapping

### DIFF
--- a/centreon/src/Core/Security/AccessGroup/Infrastructure/Repository/DbWriteAccessGroupRepository.php
+++ b/centreon/src/Core/Security/AccessGroup/Infrastructure/Repository/DbWriteAccessGroupRepository.php
@@ -46,9 +46,16 @@ class DbWriteAccessGroupRepository extends AbstractRepositoryDRB implements Writ
     {
         $statement = $this->db->prepare(
             $this->translateDbName(
-                'DELETE FROM acl_group_contacts_relations WHERE contact_contact_id = :userId'
+                <<<'SQL'
+                    DELETE FROM `:db`.`acl_group_contacts_relations`
+                    WHERE acl_group_contacts_relations.contact_contact_id = :userId
+                        AND acl_group_contacts_relations.acl_group_id NOT IN (
+                            SELECT acl_group_id FROM `:db`.acl_groups WHERE cloud_specific = 1
+                        )
+                    SQL
             )
         );
+
         $statement->bindValue(':userId', $user->getId(), \PDO::PARAM_INT);
         $statement->execute();
     }


### PR DESCRIPTION
🏷️ MON-146062
📃 This PR intends to patch an issue regarding user acl_groups definition when coming from openId.
The mapping defined in the authentication rule completely erases the acl_groups (specific to cloud) that gives access to the resources.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
