### PR TITLE
enh(docker): add stable docker generation for ci

### DIFF
--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -10,6 +10,8 @@ on:
     workflows: ["web"]
     types:
       - completed
+    branches:
+      - "master"
   workflow_dispatch:
 
 jobs:
@@ -21,7 +23,7 @@ jobs:
   dockerize-stable:
     needs: [get-version]
     runs-on: ubuntu-22.04
-    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.get-version.outputs.stability == 'stable' }}
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.get-version.outputs.stability == 'stable' && github.ref_name == 'master' }}
 
     env:
       project: centreon-web

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -1,0 +1,76 @@
+---
+name: docker-stable
+
+on:
+  workflow_run:
+    workflows: ["web"]
+    types:
+      - completed
+  workflow_dispatch:
+
+jobs:
+  get-version:
+    uses: ./.github/workflows/get-version.yml
+    with:
+      version_file: centreon/www/install/insertBaseConf.sql
+
+  dockerize-stable:
+    needs: [get-version]
+    runs-on: ubuntu-22.04
+
+    env:
+      project: centreon-web
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.get-version.outputs.os_and_database_matrix).operating_systems }}
+
+    name: dockerize ${{ matrix.operating_system }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Generate information according to matrix os
+        id: matrix_include
+        run: |
+          if [ "${{ matrix.operating_system }}" = "alma8" ]; then
+            DISTRIB=el8
+            PACKAGE_EXTENSION=rpm
+          elif [ "${{ matrix.operating_system }}" = "alma9" ]; then
+            DISTRIB=el9
+            PACKAGE_EXTENSION=rpm
+          elif [ "${{ matrix.operating_system }}" = "bullseye" ]; then
+            DISTRIB=bullseye
+            PACKAGE_EXTENSION=deb
+          elif [ "${{ matrix.operating_system }}" = "bookworm" ]; then
+            DISTRIB=bookworm
+            PACKAGE_EXTENSION=deb
+          elif [ "${{ matrix.operating_system }}" = "jammy" ]; then
+            DISTRIB=jammy
+            PACKAGE_EXTENSION=deb
+          else
+            echo "::error::${{ matrix.operating_system }} is not managed"
+            exit 1
+          fi
+
+          echo "distrib=$DISTRIB" >> $GITHUB_OUTPUT
+          echo "package_extension=$PACKAGE_EXTENSION" >> $GITHUB_OUTPUT
+        shell: bash
+
+      - uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3.3.0
+
+      - name: Build and push web image
+        uses: docker/build-push-action@1a162644f9a7e87d8f4b053101d1d9a712edc18c # v6.3.0
+        with:
+          file: .github/docker/${{ env.project }}/${{ matrix.operating_system }}/Dockerfile
+          context: .
+          build-args: |
+            "REGISTRY_URL=${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}"
+            "VERSION=${{ needs.get-version.outputs.major_version }}"
+            "MYDUMPER_VERSION=0.16.3-5"
+          pull: true
+          push: false
+          load: true
+          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.project }}-${{ matrix.operating_system }}:${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -1,4 +1,3 @@
----
 name: docker-stable
 
 concurrency:

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -1,6 +1,10 @@
 ---
 name: docker-stable
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 on:
   workflow_run:
     workflows: ["web"]
@@ -17,6 +21,7 @@ jobs:
   dockerize-stable:
     needs: [get-version]
     runs-on: ubuntu-22.04
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && needs.get-version.outputs.stability == 'stable' }}
 
     env:
       project: centreon-web

--- a/.github/workflows/docker-stable.yml
+++ b/.github/workflows/docker-stable.yml
@@ -79,4 +79,4 @@ jobs:
           pull: true
           push: false
           load: true
-          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.project }}-${{ matrix.operating_system }}:${{ github.head_ref || github.ref_name }}
+          tags: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ env.project }}-${{ matrix.operating_system }}:${{ github.ref_name }}


### PR DESCRIPTION
## Description

* add docker stable image generation for ci
* uses stable packages (not cache artifact) to provide base image for cloud ci

**Fixes** #MON-143664

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
