### PR TITLE
enh(Authentification): Reschedule cron to delete expired token to execute every minute (#4785) [dev-24.04.x]

### DIFF
--- a/centreon/cron/outdated-token-removal.php
+++ b/centreon/cron/outdated-token-removal.php
@@ -35,19 +35,19 @@ $centreonLog = new CentreonLog();
 $pearDB = new CentreonDB();
 
 $pearDB->beginTransaction();
- try {
+try {
     deleteExpiredProviderRefreshTokens($centreonLog, $pearDB);
     deleteExpiredProviderTokens($centreonLog, $pearDB);
+    deleteExpiredSessions($centreonLog, $pearDB);
 
     $pearDB->commit();
-} catch (\PDOException $e) {
+} catch (\Throwable) {
     $pearDB->rollBack();
     $centreonLog->insertLog(
         2,
         "TokenRemoval CRON: failed to delete old tokens"
     );
 }
-
 
 /**
  * Delete expired provider refresh tokens.
@@ -88,6 +88,29 @@ function deleteExpiredProviderTokens(CentreonLog $logger, CentreonDB $pearDB): v
                 WHERE sat.provider_token_id = st.id
                 AND (sat.provider_token_refresh_id IS NOT NULL OR sat.token_type = 'manual')
                 LIMIT 1
+            )
+            SQL
+    );
+}
+
+/**
+ * Delete expired sessions.
+ */
+function deleteExpiredSessions(CentreonLog $logger, CentreonDB $pearDB): void
+{
+    $logger->insertLog(2, 'Deleting expired sessions');
+
+    $pearDB->query(
+        <<<'SQL'
+            DELETE s FROM session s
+            WHERE s.last_reload < (
+                SELECT UNIX_TIMESTAMP(NOW() - INTERVAL (`value` * 60) SECOND)
+                FROM options
+                WHERE `key` = 'session_expire'
+            )
+            OR s.last_reload IS NULL
+            OR s.session_id NOT IN (
+                SELECT token FROM security_authentication_tokens
             )
             SQL
     );

--- a/centreon/tmpl/install/centreon.cron
+++ b/centreon/tmpl/install/centreon.cron
@@ -37,4 +37,4 @@ CRONTAB_EXEC_USER=""
 
 ##########################
 # Cron for Outdated Token removal
-0 * * * * root @INSTALL_DIR_CENTREON@/cron/outdated-token-removal.php >> @CENTREON_LOG@/centreon-tokens.log 2>&1
+* * * * * centreon @INSTALL_DIR_CENTREON@/cron/outdated-token-removal.php >> @CENTREON_LOG@/centreon-tokens.log 2>&1


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/4785 to dev-24.04.x

**Fixes** # MON-146166

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
