### PR TITLE
enh(Authentification): Reschedule cron to delete expired token to execute every minute (#4785) [dev-23.10.x]

### DIFF
--- a/centreon/cron/outdated-token-removal.php
+++ b/centreon/cron/outdated-token-removal.php
@@ -35,12 +35,12 @@ $centreonLog = new CentreonLog();
 $pearDB = new CentreonDB();
 
 $pearDB->beginTransaction();
- try {
-    deleteExpiredProviderRefreshTokens($centreonLog, $pearDB);
-    deleteExpiredProviderTokens($centreonLog, $pearDB);
-    deleteExpiredSessions($centreonLog, $pearDB);
+try {
+   deleteExpiredProviderRefreshTokens($centreonLog, $pearDB);
+   deleteExpiredProviderTokens($centreonLog, $pearDB);
+   deleteExpiredSessions($centreonLog, $pearDB);
 
-    $pearDB->commit();
+   $pearDB->commit();
 } catch (\Throwable) {
     $pearDB->rollBack();
     $centreonLog->insertLog(

--- a/centreon/tmpl/install/centreon.cron
+++ b/centreon/tmpl/install/centreon.cron
@@ -37,4 +37,4 @@ CRONTAB_EXEC_USER=""
 
 ##########################
 # Cron for Outdated Token removal
-0 * * * * root @INSTALL_DIR_CENTREON@/cron/outdated-token-removal.php >> @CENTREON_LOG@/centreon-tokens.log 2>&1
+* * * * * centreon @INSTALL_DIR_CENTREON@/cron/outdated-token-removal.php >> @CENTREON_LOG@/centreon-tokens.log 2>&1


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/4785 to dev-23.10.x

**Fixes** # MON-146165

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
