### PR TITLE
fix(host/broker): Use correct headers to connect to APIv2 through legacy

### DIFF
--- a/centreon/www/class/centreonConfigCentreonBroker.php
+++ b/centreon/www/class/centreonConfigCentreonBroker.php
@@ -1756,7 +1756,7 @@ class CentreonConfigCentreonBroker
         $client = new Symfony\Component\HttpClient\CurlHttpClient();
         $headers = [
             'Content-Type' => 'application/json',
-            'X-AUTH-TOKEN' => $_COOKIE['PHPSESSID'],
+            'Cookie' => 'PHPSESSID=' . $_COOKIE['PHPSESSID'],
         ];
         $parameters = ['brokerId' => $configId];
         $basePath ? $parameters['base_uri'] = $basePath : null;

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -2908,7 +2908,7 @@ function insertHostByApi(array $formData, bool $isCloudPlatform, string $basePat
 
     $headers = [
         'Content-Type' => 'application/json',
-        'X-AUTH-TOKEN' => $_COOKIE['PHPSESSID'],
+        'Cookie' => 'PHPSESSID=' . $_COOKIE['PHPSESSID'],
     ];
     $response = $client->request(
         'POST',


### PR DESCRIPTION
## Description

This PR intends to fix an issue where incorrect headers were used to connect to APIv2 through UI legacy forms

**Fixes** # MON-146148

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
