### PR TITLE
fix(ci): add checkout to nightly cod platform actions

### DIFF
--- a/.github/workflows/nightly-cod-platform-deploy.yml
+++ b/.github/workflows/nightly-cod-platform-deploy.yml
@@ -8,6 +8,9 @@ jobs:
   nightly-cod-platform-deploy:
     runs-on: "ubuntu-latest"
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - name: Check the status of the last nightly
         id: check-latest-nightly-status
         uses: ./.github/actions/check-latest-nightly-status

--- a/.github/workflows/nightly-cod-platform-destroy.yml
+++ b/.github/workflows/nightly-cod-platform-destroy.yml
@@ -8,6 +8,9 @@ jobs:
   nightly-cod-platform-destroy:
     runs-on: "ubuntu-latest"
     steps:
+      - name: Checkout sources
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - name: Check the status of the latest nightly build
         id: check-latest-nightly-status
         uses: ./.github/actions/check-latest-nightly-status


### PR DESCRIPTION
## Description

Add checkout action to the nightly-cod-platform-deploy/destroy workflows to prevent this error 

[nightly-cod-platform-deploy](https://github.com/centreon/centreon/actions/runs/10193863399/job/28199289115#step:2:1)

Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under '/home/runner/work/centreon/centreon/.github/actions/check-latest-nightly-status'. Did you forget to run actions/checkout before running your local action?

**Fixes** # MON-146185

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
