### PR TITLE
Fix typing issue leading to strange snackbar error message

### DIFF
--- a/centreon/src/EventSubscriber/CentreonEventSubscriber.php
+++ b/centreon/src/EventSubscriber/CentreonEventSubscriber.php
@@ -387,7 +387,7 @@ class CentreonEventSubscriber implements EventSubscriberInterface
             }
             $this->logException($event->getThrowable());
             $event->setResponse(
-                new Response($errorMessage, $httpCode)
+                new Response($errorMessage, (int) $httpCode)
             );
         }
     }


### PR DESCRIPTION
Related Jira ticket [MON-146114](https://centreon.atlassian.net/browse/MON-146114)

In some cases a Response object can be instanciated with the wrong parameters type.

⚠️ Warning 
The issue occurs on current `release-24.07-next` branch and can no longer occur on current `develop`
But the PR that fixed the issue on `develop` is a big one and I prefer not adding this part to the current release test process.

That's why I chose for process and extra-security reasons to apply this patch on both `develop` & `release-24.07-next` so it matches the standard process and can also prevent further mistakes in the future if new use cases are added to this class.

[MON-146114]: https://centreon.atlassian.net/browse/MON-146114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ