### PR TITLE
fix(Notifications): Host events are set to 1 when updating notification (#4806) [release-24.07-next]

### DIFF
--- a/centreon/src/Core/Notification/Infrastructure/Repository/DbNotifiableResourceFactory.php
+++ b/centreon/src/Core/Notification/Infrastructure/Repository/DbNotifiableResourceFactory.php
@@ -119,7 +119,9 @@ class DbNotifiableResourceFactory
             }
 
             if ($currentRecords[$index - 1] !== self::NO_HOST_EVENTS) {
-                $currentHostEvents = NotificationHostEventConverter::fromBitFlags((int) $currentRecords[$index - 1]);
+                $currentHostEvents = NotificationHostEventConverter::fromBitFlags(
+                    (int) $currentRecords[$index - 1]['host_events']
+                );
             }
 
             $notificationHosts[] = self::createNotificationHostFromRecord(


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/4806 to release-24.07-next

**Fixes** # MON-146244

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
