### PR TITLE
[dev-23.10.x] fix(saml): Accept a RequestedAuthnContext that is stronger than the default (MON-146256)

### DIFF
--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
@@ -122,7 +122,7 @@ class SAML implements ProviderAuthenticationInterface
         $errors = $this->auth->getErrors();
         if (! empty($errors)) {
             $ex = ProcessAuthenticationResponseException::create();
-            $this->loginLogger->error(Provider::SAML, $ex->getMessage(), ['context' => (string) json_encode($errors)]);
+            $this->loginLogger->error(Provider::SAML, $ex->getMessage(), ['context' => (string) json_encode($errors), 'error' => $this->auth->getLastErrorReason()]);
 
             throw $ex;
         }

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php
@@ -72,6 +72,9 @@ class OneLoginSettingsFormatter implements SettingsFormatterInterface
                 ],
                 'x509cert' => $customConfiguration->getPublicCertificate(),
             ],
+            'security' => [
+                'requestedAuthnContextComparison' => 'minimum',
+            ],
         ];
     }
 }


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/4728
**Fixes** #MON-146256

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] master