### PR TITLE
fix(gorgone): service discovery error because of a missing table

### DIFF
--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/hooks.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/hooks.pm
@@ -52,6 +52,9 @@ sub register {
     $config_core           = $options{config_core};
     $config_db_centreon    = $options{config_db_centreon};
     $config_db_centstorage = $options{config_db_centstorage};
+
+    $config->{vault_file} = defined($config->{vault_file}) ? $config->{vault_file} : '/var/lib/centreon/vault/vault.json';
+
     return (1, NAMESPACE, NAME, EVENTS);
 }
 

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/hooks.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/hooks.pm
@@ -43,14 +43,14 @@ my $config_core;
 my $config;
 my ($config_db_centreon, $config_db_centstorage);
 my $autodiscovery = {};
-my $stop = 0;
+my $stop          = 0;
 
 sub register {
     my (%options) = @_;
-    
-    $config = $options{config};
-    $config_core = $options{config_core};
-    $config_db_centreon = $options{config_db_centreon};
+
+    $config                = $options{config};
+    $config_core           = $options{config_core};
+    $config_db_centreon    = $options{config_db_centreon};
     $config_db_centstorage = $options{config_db_centstorage};
     return (1, NAMESPACE, NAME, EVENTS);
 }
@@ -71,20 +71,20 @@ sub routing {
 
     if (gorgone::class::core::waiting_ready(ready => \$autodiscovery->{ready}) == 0) {
         gorgone::standard::library::add_history({
-            dbh => $options{dbh},
-            code => GORGONE_ACTION_FINISH_KO,
-            token => $options{token},
-            data => { msg => 'gorgoneautodiscovery: still no ready' },
+            dbh         => $options{dbh},
+            code        => GORGONE_ACTION_FINISH_KO,
+            token       => $options{token},
+            data        => { msg => 'gorgoneautodiscovery: still no ready' },
             json_encode => 1
         });
         return undef;
     }
 
     $options{gorgone}->send_internal_message(
-        identity => 'gorgone-autodiscovery',
-        action => $options{action},
+        identity     => 'gorgone-autodiscovery',
+        action       => $options{action},
         raw_data_ref => $options{frame}->getRawData(),
-        token => $options{token}
+        token        => $options{token}
     );
 }
 
@@ -119,16 +119,16 @@ sub check {
     foreach my $pid (keys %{$options{dead_childs}}) {
         # Not me
         next if (!defined($autodiscovery->{pid}) || $autodiscovery->{pid} != $pid);
-        
+
         $autodiscovery = {};
         delete $options{dead_childs}->{$pid};
         if ($stop == 0) {
             create_child(logger => $options{logger});
         }
     }
-    
-    $count++  if (defined($autodiscovery->{running}) && $autodiscovery->{running} == 1);
-    
+
+    $count++ if (defined($autodiscovery->{running}) && $autodiscovery->{running} == 1);
+
     return $count;
 }
 
@@ -141,17 +141,17 @@ sub broadcast {
 # Specific functions
 sub create_child {
     my (%options) = @_;
-    
+
     $options{logger}->writeLogInfo("[autodiscovery] Create module 'autodiscovery' process");
     my $child_pid = fork();
     if ($child_pid == 0) {
-        $0 = 'gorgone-autodiscovery';
+        $0         = 'gorgone-autodiscovery';
         my $module = gorgone::modules::centreon::autodiscovery::class->new(
-            module_id => NAME,
-            logger => $options{logger},
-            config_core => $config_core,
-            config => $config,
-            config_db_centreon => $config_db_centreon,
+            module_id             => NAME,
+            logger                => $options{logger},
+            config_core           => $config_core,
+            config                => $config,
+            config_db_centreon    => $config_db_centreon,
             config_db_centstorage => $config_db_centstorage
         );
         $module->run();

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/discovery.pm
@@ -34,23 +34,23 @@ use Safe;
 
 sub new {
     my ($class, %options) = @_;
-    my $connector = $class->SUPER::new(%options);
+    my $connector         = $class->SUPER::new(%options);
     bless $connector, $class;
 
-    $connector->{internal_socket} = $options{internal_socket};
-    $connector->{class_object_centreon} = $options{class_object_centreon};
+    $connector->{internal_socket}          = $options{internal_socket};
+    $connector->{class_object_centreon}    = $options{class_object_centreon};
     $connector->{class_object_centstorage} = $options{class_object_centstorage};
-    $connector->{class_autodiscovery} = $options{class_autodiscovery};
-    $connector->{tpapi_clapi} = $options{tpapi_clapi};
-    $connector->{mail_subject} = defined($connector->{config}->{mail_subject}) ? $connector->{config}->{mail_subject} : 'Centreon Auto Discovery';
-    $connector->{mail_from} = defined($connector->{config}->{mail_from}) ? $connector->{config}->{mail_from} : 'centreon-autodisco';
+    $connector->{class_autodiscovery}      = $options{class_autodiscovery};
+    $connector->{tpapi_clapi}              = $options{tpapi_clapi};
+    $connector->{mail_subject}             = defined($connector->{config}->{mail_subject}) ? $connector->{config}->{mail_subject} : 'Centreon Auto Discovery';
+    $connector->{mail_from}                = defined($connector->{config}->{mail_from}) ? $connector->{config}->{mail_from} : 'centreon-autodisco';
 
-    $connector->{service_pollers} = {};
-    $connector->{audit_user_id} = undef;
+    $connector->{service_pollers}                   = {};
+    $connector->{audit_user_id}                     = undef;
     $connector->{service_parrallel_commands_poller} = 8;
-    $connector->{service_current_commands_poller} = {};
-    $connector->{finished} = 0;
-    $connector->{post_execution} = 0;
+    $connector->{service_current_commands_poller}   = {};
+    $connector->{finished}                          = 0;
+    $connector->{post_execution}                    = 0;
 
     $connector->{safe_display} = Safe->new();
     $connector->{safe_display}->share('$values');
@@ -82,7 +82,7 @@ sub database_init_transaction {
 
 sub database_commit_transaction {
     my ($self, %options) = @_;
-    
+
     my $status = $self->{class_object_centreon}->commit();
     if ($status == -1) {
         $self->{logger}->writeLogError("$@");
@@ -151,7 +151,13 @@ sub send_email {
             }
 
             if (scalar(@$body) > 0) {
-                $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} send email to '" . $contact_id .  "' (" . $self->{discovery}->{rules}->{$rule_id}->{contact}->{$contact_id}->{contact_email} . ")");
+                $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} send email to '" . $contact_id . "' (" . $self
+                    ->{discovery}
+                    ->{rules}
+                    ->{$rule_id}
+                    ->{contact}
+                    ->{$contact_id}
+                    ->{contact_email}          . ")");
 
                 my $smtp = Net::SMTP->new('localhost', Timeout => 15);
                 if (!defined($smtp)) {
@@ -190,8 +196,8 @@ sub restart_pollers {
         $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} generate poller config '" . $poller_id . "'");
         $self->send_internal_action({
             action => 'COMMAND',
-            token => $self->{discovery}->{token} . ':config',
-            data => {
+            token  => $self->{discovery}->{token} . ':config',
+            data   => {
                 content => [
                     {
                         command => $self->{tpapi_clapi}->get_applycfg_command(poller_id => $poller_id)
@@ -204,12 +210,12 @@ sub restart_pollers {
 
 sub audit_update {
     my ($self, %options) = @_;
-    
+
     return if ($self->{discovery}->{audit_enable} != 1);
 
-    my $query = 'INSERT INTO log_action (action_log_date, object_type, object_id, object_name, action_type, log_contact_id) VALUES (?, ?, ?, ?, ?, ?)';
+    my $query          = 'INSERT INTO log_action (action_log_date, object_type, object_id, object_name, action_type, log_contact_id) VALUES (?, ?, ?, ?, ?, ?)';
     my ($status, $sth) = $self->{class_object_centstorage}->custom_execute(
-        request => $query,
+        request     => $query,
         bind_values => [time(), $options{object_type}, $options{object_id}, $options{object_name}, $options{action_type}, $options{contact_id}]
     );
 
@@ -217,9 +223,9 @@ sub audit_update {
 
     my $action_log_id = $self->{class_object_centstorage}->{db_centreon}->last_insert_id();
     foreach (keys %{$options{fields}}) {
-        $query = 'INSERT INTO log_action_modification (action_log_id, field_name, field_value) VALUES (?, ?, ?)';
+        $query    = 'INSERT INTO log_action_modification (action_log_id, field_name, field_value) VALUES (?, ?, ?)';
         ($status) = $self->{class_object_centstorage}->custom_execute(
-            request => $query,
+            request     => $query,
             bind_values => [$action_log_id, $_, $options{fields}->{$_}]
         );
         if ($status == -1) {
@@ -246,13 +252,13 @@ sub custom_variables {
 
 sub get_description {
     my ($self, %options) = @_;
-    
+
     my $desc = $options{discovery_svc}->{service_name};
     if (defined($self->{discovery}->{rules}->{ $options{rule_id} }->{rule_scan_display_custom}) && $self->{discovery}->{rules}->{ $options{rule_id} }->{rule_scan_display_custom} ne '') {
         local $SIG{__DIE__} = 'IGNORE';
 
         our $description = $desc;
-        our $values = { attributes => $options{discovery_svc}->{attributes}, service_name => $options{discovery_svc}->{service_name} };
+        our $values      = { attributes => $options{discovery_svc}->{attributes}, service_name => $options{discovery_svc}->{service_name} };
         $self->{safe_display}->reval($self->{discovery}->{rules}->{ $options{rule_id} }->{rule_scan_display_custom}, 1);
         if ($@) {
             $self->{logger}->writeLogError("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] custom description code execution problem: " . $@);
@@ -266,27 +272,27 @@ sub get_description {
 
 sub link_service_autodisco {
     my ($self, %options) = @_;
-    
-    my $query = 'INSERT IGNORE INTO mod_auto_disco_rule_service_relation (rule_rule_id, service_service_id) VALUES (' . $options{rule_id} . ', ' . $options{service_id} . ')';
+
+    my $query          = 'INSERT IGNORE INTO mod_auto_disco_rule_service_relation (rule_rule_id, service_service_id) VALUES (' . $options{rule_id} . ', ' . $options{service_id} . ')';
     my ($status, $sth) = $self->{class_object_centreon}->custom_execute(request => $query);
     if ($status == -1) {
         return -1;
     }
-    
+
     return 0;
 }
 
 sub update_service {
     my ($self, %options) = @_;
-    my %query_update = ();
-    my @journal = ();
-    my @update_macros = ();
-    my @insert_macros = ();
-    
+    my %query_update     = ();
+    my @journal          = ();
+    my @update_macros    = ();
+    my @insert_macros    = ();
+
     if ($self->{discovery}->{is_manual} == 1) {
-        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = { 
-            type => 0,
-            macros => {},
+        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = {
+            type        => 0,
+            macros      => {},
             description => $self->get_description(%options)
         };
     }
@@ -296,25 +302,29 @@ sub update_service {
     if ($options{service}->{template_id} != $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id}) {
         $query_update{service_template_model_stm_id} = $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id};
         push @journal, {
-            host_name => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
+            host_name    => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
             service_name => $options{discovery_svc}->{service_name},
-            type => 'update',
-            msg => 'template',
-            rule_id => $options{rule_id}
-        }; 
+            type         => 'update',
+            msg          => 'template',
+            rule_id      => $options{rule_id}
+        };
 
         $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update template");
         if ($self->{discovery}->{is_manual} == 1) {
-            $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{service_template_model_stm_id} = $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id};
+            $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{service_template_model_stm_id} = $self
+                ->{discovery}
+                ->{rules}
+                ->{ $options{rule_id} }
+                ->{service_template_model_id};
         }
     }
     if ($options{service}->{activate} == '0') {
         $query_update{service_activate} = "'1'";
         push @journal, {
-            host_name => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
+            host_name    => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
             service_name => $options{discovery_svc}->{service_name},
-            type => 'enable',
-            rule_id => $options{rule_id}
+            type         => 'enable',
+            rule_id      => $options{rule_id}
         };
         $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service enable");
     }
@@ -322,30 +332,38 @@ sub update_service {
     foreach my $macro_name (keys %{$options{macros}}) {
         if (!defined($options{service}->{macros}->{'$_SERVICE' . $macro_name . '$'})) {
             push @insert_macros, {
-                name => $macro_name,
+                name  => $macro_name,
                 value => $options{macros}->{$macro_name}
             };
             if ($self->{discovery}->{is_manual} == 1) {
-                $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$macro_name} = { value => $options{macros}->{$macro_name}, type => 1 };
+                $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$macro_name} = { value =>
+                                                                                                                                                                                           $options{macros}
+                                                                                                                                                                                               ->{$macro_name},
+                                                                                                                                                                                           type  =>
+                                                                                                                                                                                           1 };
             }
-        } elsif ($options{service}->{macros}->{'$_SERVICE' . $macro_name . '$'} ne $options{macros}->{$macro_name})  {
+        } elsif ($options{service}->{macros}->{'$_SERVICE' . $macro_name . '$'} ne $options{macros}->{$macro_name}) {
             push @update_macros, {
-                name => $macro_name,
+                name  => $macro_name,
                 value => $options{macros}->{$macro_name}
             };
             if ($self->{discovery}->{is_manual} == 1) {
-                $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$macro_name} = { value => $options{macros}->{$macro_name}, type => 0 };
+                $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$macro_name} = { value =>
+                                                                                                                                                                                           $options{macros}
+                                                                                                                                                                                               ->{$macro_name},
+                                                                                                                                                                                           type  =>
+                                                                                                                                                                                           0 };
             }
         }
     }
 
     if (scalar(@insert_macros) > 0 || scalar(@update_macros) > 0) {
         push @journal, {
-            host_name => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
+            host_name    => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
             service_name => $options{discovery_svc}->{service_name},
-            type => 'update',
-            msg => 'macros',
-            rule_id => $options{rule_id}
+            type         => 'update',
+            msg          => 'macros',
+            rule_id      => $options{rule_id}
         };
         $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service update/insert macros");
     }
@@ -355,23 +373,23 @@ sub update_service {
     return -1 if ($self->database_init_transaction() == -1);
 
     if (scalar(keys %query_update) > 0) {
-        my $set = '';
+        my $set        = '';
         my $set_append = '';
         foreach (keys %query_update) {
-            $set .= $set_append . $_ . ' = ' . $query_update{$_};
+            $set        .= $set_append . $_ . ' = ' . $query_update{$_};
             $set_append = ', ';
         }
-        my $query = 'UPDATE service SET ' . $set . ' WHERE service_id = ' . $options{service}->{id};
+        my $query    = 'UPDATE service SET ' . $set . ' WHERE service_id = ' . $options{service}->{id};
         my ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
         if ($status == -1) {
             return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot update service");
         }
     }
-    
+
     foreach (@update_macros) {
-        my $query = 'UPDATE on_demand_macro_service SET svc_macro_value = ? WHERE svc_svc_id = ' . $options{service}->{id} .  ' AND svc_macro_name = ?';
+        my $query    = 'UPDATE on_demand_macro_service SET svc_macro_value = ? WHERE svc_svc_id = ' . $options{service}->{id} . ' AND svc_macro_name = ?';
         my ($status) = $self->{class_object_centreon}->custom_execute(
-            request => $query,
+            request     => $query,
             bind_values => [$_->{value}, '$_SERVICE' . $_->{name} . '$']
         );
         if ($status == -1) {
@@ -379,16 +397,16 @@ sub update_service {
         }
     }
     foreach (@insert_macros) {
-        my $query = 'INSERT on_demand_macro_service (svc_svc_id, svc_macro_name, svc_macro_value) VALUES (' . $options{service}->{id} .  ', ?, ?)';
+        my $query    = 'INSERT on_demand_macro_service (svc_svc_id, svc_macro_name, svc_macro_value) VALUES (' . $options{service}->{id} . ', ?, ?)';
         my ($status) = $self->{class_object_centreon}->custom_execute(
-            request => $query,
+            request     => $query,
             bind_values => ['$_SERVICE' . $_->{name} . '$', $_->{value}]
         );
         if ($status == -1) {
             return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot insert macro");
         }
     }
-    
+
     if ($self->link_service_autodisco(%options, service_id => $options{service}->{id}) == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot link service to autodisco");
     }
@@ -400,21 +418,21 @@ sub update_service {
 
     if (defined($query_update{service_activate})) {
         $self->audit_update(
-            object_type => 'service', 
-            action_type => 'enable', 
-            object_id => $options{service}->{id}, 
-            object_name => $options{discovery_svc}->{service_name}, 
-            contact_id => $self->{audit_user_id}
+            object_type => 'service',
+            action_type => 'enable',
+            object_id   => $options{service}->{id},
+            object_name => $options{discovery_svc}->{service_name},
+            contact_id  => $self->{audit_user_id}
         );
     }
     if (defined($query_update{service_template_model_stm_id})) {
         $self->audit_update(
-            object_type => 'service', 
-            action_type => 'c', 
-            object_id => $options{service}->{id}, 
-            object_name => $options{discovery_svc}->{service_name}, 
-            contact_id => $self->{audit_user_id},
-            fields => { service_template_model_stm_id => $query_update{service_template_model_stm_id} }
+            object_type => 'service',
+            action_type => 'c',
+            object_id   => $options{service}->{id},
+            object_name => $options{discovery_svc}->{service_name},
+            contact_id  => $self->{audit_user_id},
+            fields      => { service_template_model_stm_id => $query_update{service_template_model_stm_id} }
         );
     }
 
@@ -423,18 +441,18 @@ sub update_service {
 
 sub create_service {
     my ($self, %options) = @_;
-    
+
     if ($self->{discovery}->{is_manual} == 1) {
-        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = { 
-            type => 1, 
+        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} } = {
+            type                          => 1,
             service_template_model_stm_id => $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id},
-            macros => {},
-            description => $self->get_description(%options)
+            macros                        => {},
+            description                   => $self->get_description(%options)
         };
         foreach (keys %{$options{macros}}) {
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{discovery}->{ $options{discovery_svc}->{service_name} }->{macros}->{$_} = {
                 value => $options{macros}->{$_},
-                type => 1
+                type  => 1
             };
         }
     }
@@ -444,32 +462,32 @@ sub create_service {
 
     return -1 if ($self->database_init_transaction() == -1);
 
-    my $query = "INSERT INTO service (service_template_model_stm_id, service_description, service_register) VALUES (?, ?, '1')";
+    my $query          = "INSERT INTO service (service_template_model_stm_id, service_description, service_register) VALUES (?, ?, '1')";
     my ($status, $sth) = $self->{class_object_centreon}->custom_execute(
-        request => $query,
+        request     => $query,
         bind_values => [$self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id}, $options{discovery_svc}->{service_name}]
     );
     if ($status == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot create service");
     }
     my $service_id = $self->{class_object_centreon}->{db_centreon}->last_insert_id();
-    
-    $query = 'INSERT INTO host_service_relation (host_host_id, service_service_id) VALUES (' . $options{host_id} . ', ' . $service_id . ')';
+
+    $query    = 'INSERT INTO host_service_relation (host_host_id, service_service_id) VALUES (' . $options{host_id} . ', ' . $service_id . ')';
     ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
     if ($status == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot link service to host");
     }
-    
-    $query = 'INSERT INTO extended_service_information (service_service_id) VALUES (' . $service_id . ')';
+
+    $query    = 'INSERT INTO extended_service_information (service_service_id) VALUES (' . $service_id . ')';
     ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
     if ($status == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot service extended information");
     }
-    
+
     foreach (keys %{$options{macros}}) {
-        $query = 'INSERT INTO on_demand_macro_service (svc_svc_id, svc_macro_name, svc_macro_value) VALUES (' . $service_id . ', ?, ?)';
+        $query    = 'INSERT INTO on_demand_macro_service (svc_svc_id, svc_macro_name, svc_macro_value) VALUES (' . $service_id . ', ?, ?)';
         ($status) = $self->{class_object_centreon}->custom_execute(
-            request => $query,
+            request     => $query,
             bind_values => ['$_SERVICE' . $_ . '$', $options{macros}->{$_}]
         );
         if ($status == -1) {
@@ -480,22 +498,22 @@ sub create_service {
     if ($self->link_service_autodisco(%options, service_id => $service_id) == -1) {
         return $self->database_error_rollback(message => "$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> cannot link service to autodisco");
     }
-    
+
     return -1 if ($self->database_commit_transaction() == -1);
 
     $self->{discovery}->{pollers_reload}->{ $options{poller_id} } = 1;
 
     $self->audit_update(
-        object_type => 'service', 
-        action_type => 'a', 
-        object_id => $service_id, 
+        object_type => 'service',
+        action_type => 'a',
+        object_id   => $service_id,
         object_name => $options{discovery_svc}->{service_name},
-        contact_id => $self->{audit_user_id},
-        fields => {
-            service_template_model_id => $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id}, 
-            service_description => $options{discovery_svc}->{service_name}, 
-            service_register => '1', 
-            service_hPars => $options{host_id}
+        contact_id  => $self->{audit_user_id},
+        fields      => {
+            service_template_model_id => $self->{discovery}->{rules}->{ $options{rule_id} }->{service_template_model_id},
+            service_description       => $options{discovery_svc}->{service_name},
+            service_register          => '1',
+            service_hPars             => $options{host_id}
         }
     );
 
@@ -504,58 +522,58 @@ sub create_service {
 
 sub crud_service {
     my ($self, %options) = @_;
-    
+
     my $service_id;
     if (!defined($options{service})) {
         $service_id = $self->create_service(%options);
         $self->{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> service created");
         if ($service_id != -1) {
             push @{$self->{discovery}->{journal}}, {
-                host_name => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
+                host_name    => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
                 service_name => $options{discovery_svc}->{service_name},
-                type => 'created',
-                rule_id => $options{rule_id}
+                type         => 'created',
+                rule_id      => $options{rule_id}
             };
         }
     } else {
         $service_id = $self->update_service(%options);
     }
-    
+
     return 0;
 }
 
 sub disable_services {
     my ($self, %options) = @_;
-    
+
     return if ($self->{discovery}->{rules}->{ $options{rule_id} }->{rule_disable} != 1 || !defined($self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }));
     foreach my $service (keys %{$self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }}) {
         my $service_description = $self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }->{$service}->{service_description};
 
-        if (!defined($options{discovery_svc}->{discovered_services}->{$service_description}) && 
+        if (!defined($options{discovery_svc}->{discovered_services}->{$service_description}) &&
             $self->{discovery}->{rules}->{ $options{rule_id} }->{linked_services}->{ $options{host_id} }->{$service}->{service_activate} == 1) {
             $self->{logger}->writeLogDebug("$options{logger_pre_message} -> disable service '" . $service_description . "'");
             next if ($self->{discovery}->{dry_run} == 1);
 
-            my $query = "UPDATE service SET service_activate = '0' WHERE service_id = " . $service;
+            my $query    = "UPDATE service SET service_activate = '0' WHERE service_id = " . $service;
             my ($status) = $self->{class_object_centreon}->custom_execute(request => $query);
             if ($status == -1) {
                 $self->{logger}->writeLogError("$options{logger_pre_message} -> cannot disable service '" . $service_description . "'");
                 next;
             }
-            
+
             push @{$self->{discovery}->{journal}}, {
-                host_name => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
+                host_name    => $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name},
                 service_name => $service_description,
-                type => 'disable',
-                rule_id => $options{rule_id}
-            }; 
+                type         => 'disable',
+                rule_id      => $options{rule_id}
+            };
             $self->{discovery}->{pollers_reload}->{ $options{poller_id} } = 1;
             $self->audit_update(
-                object_type => 'service', 
-                action_type => 'disable', 
-                object_id => $service, 
+                object_type => 'service',
+                action_type => 'disable',
+                object_id   => $service,
                 object_name => $service_description,
-                contact_id => $self->{audit_user_id}
+                contact_id  => $self->{audit_user_id}
             );
         }
     }
@@ -564,9 +582,9 @@ sub disable_services {
 sub service_response_parsing {
     my ($self, %options) = @_;
 
-    my $rule_alias = $self->{discovery}->{rules}->{ $options{rule_id} }->{rule_alias};
-    my $poller_name = $self->{service_pollers}->{ $options{poller_id} }->{name};
-    my $host_name = $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name};
+    my $rule_alias         = $self->{discovery}->{rules}->{ $options{rule_id} }->{rule_alias};
+    my $poller_name        = $self->{service_pollers}->{ $options{poller_id} }->{name};
+    my $host_name          = $self->{discovery}->{hosts}->{ $options{host_id} }->{host_name};
     my $logger_pre_message = "[autodiscovery] -servicediscovery- $self->{uuid} [" . $rule_alias . "] [" . $poller_name . "] [" . $host_name . "]";
 
     my $xml;
@@ -575,7 +593,7 @@ sub service_response_parsing {
     };
     if ($@) {
         if ($self->{discovery}->{is_manual} == 1) {
-            $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{failed} = 1;
+            $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{failed}  = 1;
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{message} = 'load xml issue';
         }
         $self->{logger}->writeLogError("$logger_pre_message -> load xml issue");
@@ -586,18 +604,18 @@ sub service_response_parsing {
     my $discovery_svc = { discovered_services => {} };
     foreach my $attributes (@{$xml->{label}}) {
         $discovery_svc->{service_name} = '';
-        $discovery_svc->{attributes} = $attributes;
+        $discovery_svc->{attributes}   = $attributes;
 
         $self->custom_variables(
-            discovery_svc => $discovery_svc,
-            rule => $self->{discovery}->{rules}->{ $options{rule_id} },
+            discovery_svc      => $discovery_svc,
+            rule               => $self->{discovery}->{rules}->{ $options{rule_id} },
             logger_pre_message => $logger_pre_message
         );
 
         gorgone::modules::centreon::autodiscovery::services::resources::change_vars(
-            discovery_svc => $discovery_svc,
-            rule => $self->{discovery}->{rules}->{ $options{rule_id} },
-            logger => $self->{logger},
+            discovery_svc      => $discovery_svc,
+            rule               => $self->{discovery}->{rules}->{ $options{rule_id} },
+            logger             => $self->{logger},
             logger_pre_message => $logger_pre_message
         );
         if ($discovery_svc->{service_name} eq '') {
@@ -606,7 +624,7 @@ sub service_response_parsing {
         }
 
         if (defined($discovery_svc->{discovered_services}->{  $discovery_svc->{service_name} })) {
-            $self->{logger}->writeLogError("$logger_pre_message -> service '" .  $discovery_svc->{service_name} . "' already created");
+            $self->{logger}->writeLogError("$logger_pre_message -> service '" . $discovery_svc->{service_name} . "' already created");
             next;
         }
 
@@ -614,43 +632,43 @@ sub service_response_parsing {
 
         next if (
             gorgone::modules::centreon::autodiscovery::services::resources::check_exinc(
-                discovery_svc => $discovery_svc,
-                rule => $self->{discovery}->{rules}->{ $options{rule_id} },
-                logger => $self->{logger},
+                discovery_svc      => $discovery_svc,
+                rule               => $self->{discovery}->{rules}->{ $options{rule_id} },
+                logger             => $self->{logger},
                 logger_pre_message => $logger_pre_message
             )
         );
 
         my $macros = gorgone::modules::centreon::autodiscovery::services::resources::get_macros(
             discovery_svc => $discovery_svc,
-            rule => $self->{discovery}->{rules}->{ $options{rule_id} }
+            rule          => $self->{discovery}->{rules}->{ $options{rule_id} }
         );
-        
+
         my ($status, $service) = gorgone::modules::centreon::autodiscovery::services::resources::get_service(
             class_object_centreon => $self->{class_object_centreon},
-            host_id => $options{host_id},
-            service_name => $discovery_svc->{service_name},
-            logger => $self->{logger},
-            logger_pre_message => $logger_pre_message
+            host_id               => $options{host_id},
+            service_name          => $discovery_svc->{service_name},
+            logger                => $self->{logger},
+            logger_pre_message    => $logger_pre_message
         );
         next if ($status == -1);
 
         $self->crud_service(
-            discovery_svc => $discovery_svc,
-            rule_id => $options{rule_id},
-            host_id => $options{host_id},
-            poller_id => $options{poller_id},
-            service => $service,
-            macros => $macros,
+            discovery_svc      => $discovery_svc,
+            rule_id            => $options{rule_id},
+            host_id            => $options{host_id},
+            poller_id          => $options{poller_id},
+            service            => $service,
+            macros             => $macros,
             logger_pre_message => $logger_pre_message
         );
     }
 
     $self->disable_services(
-        discovery_svc => $discovery_svc,
-        rule_id => $options{rule_id},
-        host_id => $options{host_id},
-        poller_id => $options{poller_id},
+        discovery_svc      => $discovery_svc,
+        rule_id            => $options{rule_id},
+        host_id            => $options{host_id},
+        poller_id          => $options{poller_id},
         logger_pre_message => $logger_pre_message
     );
 }
@@ -663,8 +681,13 @@ sub discoverylistener {
     return 0 if ($data->{code} != GORGONE_MODULE_ACTION_COMMAND_RESULT && $data->{code} != GORGONE_ACTION_FINISH_KO);
 
     if ($self->{discovery}->{is_manual} == 1) {
-        $self->{discovery}->{manual}->{ $options{host_id} } = { rules => {} } if (!defined($self->{discovery}->{manual}->{ $options{host_id} }));
-        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} } = { failed => 0, discovery => {} } if (!defined($self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }));
+        $self->{discovery}->{manual}->{ $options{host_id} }                                 = { rules => {} } if (!defined($self->{discovery}->{manual}->{ $options{host_id} }));
+        $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} } = { failed => 0, discovery => {} } if (!defined($self
+            ->{discovery}
+            ->{manual}
+            ->{ $options{host_id} }
+            ->{rules}
+            ->{ $options{rule_id} }));
     }
 
     # if i have GORGONE_MODULE_ACTION_COMMAND_RESULT, i can't have GORGONE_ACTION_FINISH_KO
@@ -672,22 +695,22 @@ sub discoverylistener {
         my $exit_code = $data->{data}->{result}->{exit_code};
         if ($exit_code == 0) {
             $self->service_response_parsing(
-                rule_id => $options{rule_id},
-                host_id => $options{host_id},
+                rule_id   => $options{rule_id},
+                host_id   => $options{host_id},
                 poller_id => $self->{discovery}->{hosts}->{ $options{host_id} }->{poller_id},
-                response => $data->{data}->{result}->{stdout}
+                response  => $data->{data}->{result}->{stdout}
             );
         } else {
             $self->{discovery}->{failed_discoveries}++;
             if ($self->{discovery}->{is_manual} == 1) {
-                $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{failed} = 1;
+                $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{failed}  = 1;
                 $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{message} = $data->{data}->{message};
-                $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{data} = $data->{data};
+                $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{data}    = $data->{data};
             }
         }
     } elsif ($data->{code} == GORGONE_ACTION_FINISH_KO) {
         if ($self->{discovery}->{is_manual} == 1) {
-            $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{failed} = 1;
+            $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{failed}  = 1;
             $self->{discovery}->{manual}->{ $options{host_id} }->{rules}->{ $options{rule_id} }->{message} = $data->{data}->{message};
         }
         $self->{discovery}->{failed_discoveries}++;
@@ -700,16 +723,16 @@ sub discoverylistener {
 
     $self->{discovery}->{done_discoveries}++;
     my $progress = $self->{discovery}->{done_discoveries} * 100 / $self->{discovery}->{count_discoveries};
-    my $div = int(int($progress) / 5);
+    my $div      = int(int($progress) / 5);
     if ($div > $self->{discovery}->{progress_div}) {
         $self->{discovery}->{progress_div} = $div;
         $self->send_log(
-            code => GORGONE_MODULE_CENTREON_AUTODISCO_SVC_PROGRESS,
-            token => $self->{discovery}->{token},
+            code    => GORGONE_MODULE_CENTREON_AUTODISCO_SVC_PROGRESS,
+            token   => $self->{discovery}->{token},
             instant => 1,
-            data => {
-                message => 'current progress',
-                complete => sprintf('%.2f', $progress) 
+            data    => {
+                message  => 'current progress',
+                complete => sprintf('%.2f', $progress)
             }
         );
     }
@@ -720,14 +743,14 @@ sub discoverylistener {
         $self->{finished} = 1;
 
         $self->send_log(
-            code => GORGONE_ACTION_FINISH_OK,
+            code  => GORGONE_ACTION_FINISH_OK,
             token => $self->{discovery}->{token},
-            data => {
-                message => 'discovery finished',
+            data  => {
+                message            => 'discovery finished',
                 failed_discoveries => $self->{discovery}->{failed_discoveries},
-                count_discoveries => $self->{discovery}->{count_discoveries},
-                journal => $self->{discovery}->{journal},
-                manual => $self->{discovery}->{manual}
+                count_discoveries  => $self->{discovery}->{count_discoveries},
+                journal            => $self->{discovery}->{journal},
+                manual             => $self->{discovery}->{manual}
             }
         );
     }
@@ -744,7 +767,7 @@ sub service_discovery_post_exec {
         $self->restart_pollers();
         $self->send_email();
     }
-    
+
     return 0;
 }
 
@@ -755,7 +778,7 @@ sub service_execute_commands {
         foreach my $poller_id (keys %{$self->{discovery}->{rules}->{$rule_id}->{hosts}}) {
             next if (scalar(@{$self->{discovery}->{rules}->{$rule_id}->{hosts}->{$poller_id}}) <= 0);
             $self->{service_current_commands_poller}->{$poller_id} = 0 if (!defined($self->{service_current_commands_poller}->{$poller_id}));
-                
+
             while (1) {
                 last if ($self->{service_current_commands_poller}->{$poller_id} >= $self->{service_parrallel_commands_poller});
                 my $host_id = shift @{$self->{discovery}->{rules}->{$rule_id}->{hosts}->{$poller_id}};
@@ -766,26 +789,26 @@ sub service_execute_commands {
 
                 my $command = gorgone::modules::centreon::autodiscovery::services::resources::substitute_service_discovery_command(
                     command_line => $self->{discovery}->{rules}->{$rule_id}->{command_line},
-                    host => $host,
-                    poller => $self->{service_pollers}->{$poller_id},
-                    vault_count => $options{vault_count}
+                    host         => $host,
+                    poller       => $self->{service_pollers}->{$poller_id},
+                    vault_count  => $options{vault_count}
                 );
 
                 $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} [" .
-                    $self->{discovery}->{rules}->{$rule_id}->{rule_alias} . "] [" . 
-                    $self->{service_pollers}->{$poller_id}->{name} . "] [" .
-                    $host->{host_name} . "] -> substitute string: " . $command
+                                               $self->{discovery}->{rules}->{$rule_id}->{rule_alias} . "] [" .
+                                               $self->{service_pollers}->{$poller_id}->{name} . "] [" .
+                                               $host->{host_name} . "] -> substitute string: " . $command
                 );
 
                 $self->send_internal_action({
                     action => 'ADDLISTENER',
-                    data => [
+                    data   => [
                         {
                             identity => 'gorgoneautodiscovery',
-                            event => 'SERVICEDISCOVERYLISTENER',
-                            target => $poller_id,
-                            token => 'svc-disco-' . $self->{uuid} . '-' . $rule_id . '-' . $host_id,
-                            timeout => 120,
+                            event    => 'SERVICEDISCOVERYLISTENER',
+                            target   => $poller_id,
+                            token    => 'svc-disco-' . $self->{uuid} . '-' . $rule_id . '-' . $host_id,
+                            timeout  => 120,
                             log_pace => 15
                         }
                     ]
@@ -794,8 +817,8 @@ sub service_execute_commands {
                 $self->send_internal_action({
                     action => 'COMMAND',
                     target => $poller_id,
-                    token => 'svc-disco-' . $self->{uuid} . '-' . $rule_id . '-' . $host_id,
-                    data => {
+                    token  => 'svc-disco-' . $self->{uuid} . '-' . $rule_id . '-' . $host_id,
+                    data   => {
                         instant => 1,
                         content => [
                             {
@@ -819,9 +842,9 @@ sub launchdiscovery {
 
     $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} discovery start");
     $self->send_log(
-        code => GORGONE_ACTION_BEGIN,
+        code  => GORGONE_ACTION_BEGIN,
         token => $options{token},
-        data => { message => 'servicediscovery start' }
+        data  => { message => 'servicediscovery start' }
     );
 
     ################
@@ -856,7 +879,7 @@ sub launchdiscovery {
     }
     ($status, $message, my $user_id) = gorgone::modules::centreon::autodiscovery::services::resources::get_audit_user_id(
         class_object_centreon => $self->{class_object_centreon},
-        clapi_user => $self->{tpapi_clapi}->get_username()
+        clapi_user            => $self->{tpapi_clapi}->get_username()
     );
     if ($status < 0) {
         $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);
@@ -880,11 +903,11 @@ sub launchdiscovery {
     ################
 
     $self->{logger}->writeLogDebug("[autodiscovery] -servicediscovery- $self->{uuid} load rules configuration");
-    
+
     ($status, $message, my $rules) = gorgone::modules::centreon::autodiscovery::services::resources::get_rules(
         class_object_centreon => $self->{class_object_centreon},
-        filter_rules => $data->{content}->{filter_rules},
-        force_rule => (defined($data->{content}->{force_rule}) && $data->{content}->{force_rule} =~ /^1$/) ? 1 : 0
+        filter_rules          => $data->{content}->{filter_rules},
+        force_rule            => (defined($data->{content}->{force_rule}) && $data->{content}->{force_rule} =~ /^1$/) ? 1 : 0
     );
     if ($status < 0) {
         $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);
@@ -896,30 +919,30 @@ sub launchdiscovery {
     #################
     gorgone::modules::centreon::autodiscovery::services::resources::reset_macro_hosts();
     my $all_hosts = {};
-    my $total = 0;
+    my $total     = 0;
     foreach my $rule_id (keys %$rules) {
         ($status, $message, my $hosts, my $count) = gorgone::modules::centreon::autodiscovery::services::resources::get_hosts(
-            host_template => $rules->{$rule_id}->{host_template},
-            poller_id => $rules->{$rule_id}->{poller_id},
+            host_template         => $rules->{$rule_id}->{host_template},
+            poller_id             => $rules->{$rule_id}->{poller_id},
             class_object_centreon => $self->{class_object_centreon},
-            with_macro => 1,
-            host_lookup => $data->{content}->{filter_hosts},
-            poller_lookup => $data->{content}->{filter_pollers},
-            vault_count => $vault_count
+            with_macro            => 1,
+            host_lookup           => $data->{content}->{filter_hosts},
+            poller_lookup         => $data->{content}->{filter_pollers},
+            vault_count           => $vault_count
         );
         if ($status < 0) {
             $self->send_log_msg_error(token => $options{token}, subname => 'servicediscovery', number => $self->{uuid}, message => $message);
             return -1;
         }
-        
+
         if (!defined($hosts) || scalar(keys %$hosts) == 0) {
             $self->{logger}->writeLogInfo("[autodiscovery] -servicediscovery- $self->{uuid} no hosts found for rule '" . $options{rule}->{rule_alias} . "'");
             next;
         }
 
-        $total += $count;
+        $total                      += $count;
         $rules->{$rule_id}->{hosts} = $hosts->{pollers};
-        $all_hosts = { %$all_hosts, %{$hosts->{infos}} };
+        $all_hosts                  = { %$all_hosts, %{$hosts->{infos}} };
 
         foreach (('rule_scan_display_custom', 'rule_variable_custom')) {
             if (defined($rules->{$rule_id}->{$_}) && $rules->{$rule_id}->{$_} ne '') {
@@ -935,21 +958,21 @@ sub launchdiscovery {
     }
 
     $self->{discovery} = {
-        token => $options{token},
-        count_discoveries => $total,
+        token              => $options{token},
+        count_discoveries  => $total,
         failed_discoveries => 0,
-        done_discoveries => 0,
-        progress_div => 0,
-        rules => $rules,
-        manual => {},
-        is_manual => (defined($data->{content}->{manual}) && $data->{content}->{manual} =~ /^1$/) ? 1 : 0,
-        dry_run => (defined($data->{content}->{dry_run}) && $data->{content}->{dry_run} =~ /^1$/) ? 1 : 0,
-        audit_enable => $audit_enable,
+        done_discoveries   => 0,
+        progress_div       => 0,
+        rules              => $rules,
+        manual             => {},
+        is_manual          => (defined($data->{content}->{manual}) && $data->{content}->{manual} =~ /^1$/) ? 1 : 0,
+        dry_run            => (defined($data->{content}->{dry_run}) && $data->{content}->{dry_run} =~ /^1$/) ? 1 : 0,
+        audit_enable       => $audit_enable,
         no_generate_config => (defined($data->{content}->{no_generate_config}) && $data->{content}->{no_generate_config} =~ /^1$/) ? 1 : 0,
-        options => defined($data->{content}) ? $data->{content} : {},
-        hosts => $all_hosts,
-        journal => [],
-        pollers_reload => {}
+        options            => defined($data->{content}) ? $data->{content} : {},
+        hosts              => $all_hosts,
+        journal            => [],
+        pollers_reload     => {}
     };
 
     $self->service_execute_commands(vault_count => $vault_count);

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -99,20 +99,6 @@ sub get_audit_user_id {
     return (0, '', $user_id);
 }
 
-sub get_vault_configured {
-    my (%options) = @_;
-
-    my ($status, $datas) = $options{class_object_centreon}->custom_execute(
-        request => "SELECT count(id) FROM vault_configuration",
-        mode    => 2
-    );
-    if ($status == -1 || !defined($datas->[0])) {
-        return (-1, 'cannot get number of vault configured');
-    }
-
-    return (0, '', $datas->[0]->[0]);
-}
-
 sub get_rules {
     my (%options) = @_;
 

--- a/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
+++ b/centreon-gorgone/gorgone/modules/centreon/autodiscovery/services/resources.pm
@@ -25,11 +25,11 @@ use warnings;
 
 sub get_pollers {
     my (%options) = @_;
-    
+
     my ($status, $pollers) = $options{class_object_centreon}->custom_execute(
         request => 'SELECT id, name FROM nagios_server',
-        mode => 1,
-        keys => 'id'
+        mode    => 1,
+        keys    => 'id'
     );
     if ($status == -1) {
         return (-1, 'cannot get poller list');
@@ -41,12 +41,12 @@ sub get_pollers {
 
     foreach my $poller_id (keys %$pollers) {
         $pollers->{$poller_id}->{resources} = {};
-        ($status, my $resources) = $options{class_object_centreon}->custom_execute(
-            request =>
-                'SELECT resource_name, resource_line FROM cfg_resource_instance_relations, cfg_resource WHERE cfg_resource_instance_relations.instance_id = ?' .
-                " AND cfg_resource_instance_relations.resource_id = cfg_resource.resource_id AND resource_activate = '1'",
+        ($status, my $resources)            = $options{class_object_centreon}->custom_execute(
+            request     =>
+            'SELECT resource_name, resource_line FROM cfg_resource_instance_relations, cfg_resource WHERE cfg_resource_instance_relations.instance_id = ?' .
+            " AND cfg_resource_instance_relations.resource_id = cfg_resource.resource_id AND resource_activate = '1'",
             bind_values => [$poller_id],
-            mode => 2
+            mode        => 2
         );
         if ($status == -1) {
             return (-1, 'cannot get rules resource list');
@@ -62,12 +62,12 @@ sub get_pollers {
 
 sub get_audit {
     my (%options) = @_;
-    my $audit = 0;
+    my $audit     = 0;
 
     my ($status, $rows) = $options{class_object_centstorage}->custom_execute(
         request =>
-            'SELECT audit_log_option FROM config LIMIT 1',
-        mode => 2
+        'SELECT audit_log_option FROM config LIMIT 1',
+        mode    => 2
     );
     if ($status == -1) {
         return (-1, 'cannot get audit configuration');
@@ -81,12 +81,12 @@ sub get_audit {
 
 sub get_audit_user_id {
     my (%options) = @_;
-    my $user_id = 0;
+    my $user_id   = 0;
 
     my ($status, $contacts) = $options{class_object_centreon}->custom_execute(
-        request => 'SELECT contact_id FROM contact WHERE contact_alias = ?',
+        request     => 'SELECT contact_id FROM contact WHERE contact_alias = ?',
         bind_values => [$options{clapi_user}],
-        mode => 2
+        mode        => 2
     );
     if ($status == -1) {
         return (-1, 'cannot get audit user');
@@ -104,7 +104,7 @@ sub get_vault_configured {
 
     my ($status, $datas) = $options{class_object_centreon}->custom_execute(
         request => "SELECT count(id) FROM vault_configuration",
-        mode => 2
+        mode    => 2
     );
     if ($status == -1 || !defined($datas->[0])) {
         return (-1, 'cannot get number of vault configured');
@@ -115,7 +115,7 @@ sub get_vault_configured {
 
 sub get_rules {
     my (%options) = @_;
-    
+
     my $filter = "rule_activate = '1' AND ";
     if (defined($options{force_rule}) && $options{force_rule} == 1) {
         $filter = '';
@@ -124,7 +124,7 @@ sub get_rules {
     my @bind_values = ();
     if (defined($options{filter_rules}) && scalar(@{$options{filter_rules}}) > 0) {
         my $append = '';
-        $filter .= 'rule_alias IN (';
+        $filter    .= 'rule_alias IN (';
         foreach my $rule (@{$options{filter_rules}}) {
             $filter .= $append . '?';
             $append = ', ';
@@ -134,12 +134,12 @@ sub get_rules {
     }
 
     my ($status, $rules) = $options{class_object_centreon}->custom_execute(
-        request =>
-            "SELECT rule_id, rule_alias, service_display_name, rule_disable, rule_update, command_line, service_template_model_id, rule_scan_display_custom, rule_variable_custom
+        request     =>
+        "SELECT rule_id, rule_alias, service_display_name, rule_disable, rule_update, command_line, service_template_model_id, rule_scan_display_custom, rule_variable_custom
               FROM mod_auto_disco_rule, command WHERE " . $filter . " mod_auto_disco_rule.command_command_id = command.command_id",
         bind_values => \@bind_values,
-        mode => 1,
-        keys => 'rule_id'
+        mode        => 1,
+        keys        => 'rule_id'
     );
     if ($status == -1) {
         return (-1, 'cannot get rules list');
@@ -147,14 +147,14 @@ sub get_rules {
     if (scalar(keys %$rules) == 0) {
         return (-1, 'no rules found in configuration');
     }
-    
+
     $filter = '(' . join(',', keys %$rules) . ')';
-    
+
     ############################
     # Get mod_auto_disco_change
     ($status, my $datas) = $options{class_object_centreon}->custom_execute(
         request => 'SELECT rule_id, change_str, change_regexp, change_replace, change_modifier FROM mod_auto_disco_change WHERE rule_id IN ' . $filter . ' ORDER BY rule_id, change_order ASC',
-        mode => 2
+        mode    => 2
     );
     if ($status == -1) {
         return (-1, 'cannot get rules change list');
@@ -163,12 +163,12 @@ sub get_rules {
         $rules->{ $_->[0] }->{change} = [] if (!defined($rules->{ $_->[0] }->{change}));
         push @{$rules->{ $_->[0] }->{change}}, { change_str => $_->[1], change_regexp => $_->[2], change_replace => $_->[3], change_modifier => $_->[4] };
     }
-    
+
     #########################################
     # Get mod_auto_disco_inclusion_exclusion
     ($status, $datas) = $options{class_object_centreon}->custom_execute(
         request => 'SELECT rule_id, exinc_type, exinc_str, exinc_regexp FROM mod_auto_disco_inclusion_exclusion WHERE rule_id IN ' . $filter . ' ORDER BY rule_id, exinc_order ASC',
-        mode => 2
+        mode    => 2
     );
     if ($status == -1) {
         return (-1, 'cannot get rules exinc list');
@@ -177,26 +177,26 @@ sub get_rules {
         $rules->{ $_->[0] }->{exinc} = [] if (!defined($rules->{ $_->[0] }->{exinc}));
         push @{$rules->{ $_->[0] }->{exinc}}, { exinc_type => $_->[1], exinc_str => $_->[2], exinc_regexp => $_->[3] };
     }
-    
+
     #########################################
     # Get mod_auto_disco_macro
     ($status, $datas) = $options{class_object_centreon}->custom_execute(
         request => 'SELECT rule_id, macro_name, macro_value, is_empty FROM mod_auto_disco_macro WHERE rule_id IN ' . $filter,
-        mode => 2
+        mode    => 2
     );
     if ($status == -1) {
         return (-1, 'cannot get rules macro list');
     }
     foreach (@$datas) {
-        $rules->{ $_->[0] }->{macro} = {} if (!defined($rules->{ $_->[0] }->{macro}));
+        $rules->{ $_->[0] }->{macro}              = {} if (!defined($rules->{ $_->[0] }->{macro}));
         $rules->{ $_->[0] }->{macro}->{ $_->[1] } = { macro_value => $_->[2], is_empty => $_->[3] };
     }
-    
+
     #########################################
     # Get mod_auto_disco_inst_rule_relation
     ($status, $datas) = $options{class_object_centreon}->custom_execute(
         request => 'SELECT rule_rule_id as rule_id, instance_id FROM mod_auto_disco_inst_rule_relation WHERE rule_rule_id IN ' . $filter,
-        mode => 2
+        mode    => 2
     );
     if ($status == -1) {
         return (-1, 'cannot get rules instance list');
@@ -210,7 +210,7 @@ sub get_rules {
     # Get mod_auto_disco_ht_rule_relation
     ($status, $datas) = $options{class_object_centreon}->custom_execute(
         request => 'SELECT rule_rule_id as rule_id, host_host_id FROM mod_auto_disco_ht_rule_relation WHERE rule_rule_id IN ' . $filter,
-        mode => 2
+        mode    => 2
     );
     if ($status == -1) {
         return (-1, 'cannot get rules host template list');
@@ -219,29 +219,31 @@ sub get_rules {
         $rules->{ $_->[0] }->{host_template} = [] if (!defined($rules->{ $_->[0] }->{host_template}));
         push @{$rules->{ $_->[0] }->{host_template}}, $_->[1];
     }
-    
+
     ########################################
     # Get services added by autodisco
     ($status, $datas) = $options{class_object_centreon}->custom_execute(
-        request => 'SELECT rule_rule_id as rule_id, host_host_id as host_id, service_id, service_activate, service_description FROM mod_auto_disco_rule_service_relation, service, host_service_relation WHERE rule_rule_id IN ' . $filter . " AND mod_auto_disco_rule_service_relation.service_service_id = service.service_id AND service.service_id = host_service_relation.service_service_id",
-        mode => 2
+        request =>
+        'SELECT rule_rule_id as rule_id, host_host_id as host_id, service_id, service_activate, service_description FROM mod_auto_disco_rule_service_relation, service, host_service_relation WHERE rule_rule_id IN ' . $filter . " AND mod_auto_disco_rule_service_relation.service_service_id = service.service_id AND service.service_id = host_service_relation.service_service_id",
+        mode    =>
+        2
     );
     if ($status == -1) {
         return (-1, 'cannot get rules host template list');
     }
     foreach (@$datas) {
-        $rules->{ $_->[0] }->{linked_services} = {} if (!defined($rules->{ $_->[0] }->{linked_services}));
-        $rules->{ $_->[0] }->{linked_services}->{ $_->[1] } = {} if (!defined($rules->{ $_->[0] }->{linked_services}->{ $_->[1] }));
+        $rules->{ $_->[0] }->{linked_services}                           = {} if (!defined($rules->{ $_->[0] }->{linked_services}));
+        $rules->{ $_->[0] }->{linked_services}->{ $_->[1] }              = {} if (!defined($rules->{ $_->[0] }->{linked_services}->{ $_->[1] }));
         $rules->{ $_->[0] }->{linked_services}->{ $_->[1] }->{ $_->[2] } = {
             service_activate => $_->[3], service_description => $_->[4]
         };
     }
-    
+
     #########################################
     # Get Contact
     ($status, $datas) = $options{class_object_centreon}->custom_execute(
         request => 'SELECT rule_id, contact_id, cg_id FROM mod_auto_disco_rule_contact_relation WHERE rule_id IN ' . $filter,
-        mode => 2
+        mode    => 2
     );
     if ($status == -1) {
         return (-1, 'cannot get rules contact list');
@@ -250,14 +252,17 @@ sub get_rules {
         if (defined($_->[1])) {
             # Already add it
             next if (defined($rules->{ $_->[0] }->{contact}->{ $_->[1] }));
-            if ((my $contact = get_contact(class_object_centreon => $options{class_object_centreon}, contact_id => $_->[1]))) {
-                $rules->{ $_->[0] }->{contact} = {} if (!defined($rules->{ $_->[0] }->{contact}));
+            if ((my $contact                                               = get_contact(class_object_centreon => $options{class_object_centreon}, contact_id => $_->[1]))) {
+                $rules->{ $_->[0] }->{contact}                             = {} if (!defined($rules->{ $_->[0] }->{contact}));
                 $rules->{ $_->[0] }->{contact}->{ $contact->{contact_id} } = { contact_email => $contact->{contact_email} };
             }
         } elsif (defined($_->[2])) {
             ($status, my $datas2) = $options{class_object_centreon}->custom_execute(
-                request => "SELECT contact_contact_id as contact_id FROM contactgroup, contactgroup_contact_relation WHERE contactgroup.cg_id = '" . $_->[2] . "' AND contactgroup.cg_id = contactgroup_contact_relation.contactgroup_cg_id",
-                mode => 2
+                request =>
+                "SELECT contact_contact_id as contact_id FROM contactgroup, contactgroup_contact_relation WHERE contactgroup.cg_id = '" . $_
+                    ->[2] . "' AND contactgroup.cg_id = contactgroup_contact_relation.contactgroup_cg_id",
+                mode    =>
+                2
             );
             if ($status == -1) {
                 return (-1, 'cannot get rules contactgroup list');
@@ -265,8 +270,8 @@ sub get_rules {
             foreach my $row (@$datas2) {
                 # Already add it
                 next if (defined($rules->{ $_->[0] }->{contact}->{ $row->[0] }));
-                if ((my $contact = get_contact(class_object_centreon => $options{class_object_centreon}, contact_id => $row->[0]))) {
-                    $rules->{ $_->[0] }->{contact} = {} if (!defined($rules->{ $_->[0] }->{contact}));
+                if ((my $contact                                               = get_contact(class_object_centreon => $options{class_object_centreon}, contact_id => $row->[0]))) {
+                    $rules->{ $_->[0] }->{contact}                             = {} if (!defined($rules->{ $_->[0] }->{contact}));
                     $rules->{ $_->[0] }->{contact}->{ $contact->{contact_id} } = { contact_email => $contact->{contact_email} };
                 }
             }
@@ -283,7 +288,7 @@ sub get_rules {
                     last;
                 }
             }
-            
+
             if ($find == 0) {
                 delete $rules->{$_};
             }
@@ -298,8 +303,8 @@ sub get_contact {
 
     my ($status, $datas) = $options{class_object_centreon}->custom_execute(
         request => "SELECT contact_id, contact_email FROM contact WHERE contact_id = '" . $options{contact_id} . "' AND contact_activate = '1'",
-        mode => 1,
-        keys => 'contact_id'
+        mode    => 1,
+        keys    => 'contact_id'
     );
 
     if ($status == -1) {
@@ -322,15 +327,15 @@ sub get_hosts {
         return (0, 'cannot get host list', []);
     }
 
-    my $filter = '';
+    my $filter        = '';
     my $filter_append = '';
-    my @bind_values = ();
+    my @bind_values   = ();
 
     my $filter_host = '';
     if (defined($options{host_lookup}) && ref($options{host_lookup}) eq 'ARRAY' && scalar(@{$options{host_lookup}}) > 0) {
         my $filter_append = '';
         foreach (@{$options{host_lookup}}) {
-            $filter_host .= $filter_append . '?';
+            $filter_host   .= $filter_append . '?';
             $filter_append = ', ';
             push @bind_values, $_;
         }
@@ -338,14 +343,14 @@ sub get_hosts {
     }
 
     foreach (@{$options{host_template}}) {
-        $filter .= $filter_append . '?';
+        $filter        .= $filter_append . '?';
         $filter_append = ', ';
         push @bind_values, $_;
     }
     $filter = ' host_template_relation.host_tpl_id IN (' . $filter . ') AND ';
 
     my $filter_poller = '';
-    my $join_table = '';
+    my $join_table    = '';
     if (defined($options{poller_lookup}) && ref($options{poller_lookup}) eq 'ARRAY' && scalar(@{$options{poller_lookup}}) > 0) {
         my $filter_append = '';
         foreach (@{$options{poller_lookup}}) {
@@ -353,29 +358,29 @@ sub get_hosts {
             $filter_append = ', ';
             push @bind_values, $_;
         }
-        $filter_poller = ' nagios_server.name IN ('. $filter_poller .') AND nagios_server.id = ns_host_relation.nagios_server_id AND ';
-        $join_table = ', nagios_server ';
-    } elsif (defined($options{poller_id}) && scalar(@{$options{poller_id}}) > 0){
+        $filter_poller = ' nagios_server.name IN (' . $filter_poller . ') AND nagios_server.id = ns_host_relation.nagios_server_id AND ';
+        $join_table    = ', nagios_server ';
+    } elsif (defined($options{poller_id}) && scalar(@{$options{poller_id}}) > 0) {
         my $filter_append = '';
         foreach (@{$options{poller_id}}) {
             $filter_poller .= $filter_append . '?';
             $filter_append = ', ';
             push @bind_values, $_;
         }
-        $filter_poller =' ns_host_relation.nagios_server_id IN (' . $filter_poller . ') AND nagios_server.id = ns_host_relation.nagios_server_id AND ';
-        $join_table = ', nagios_server ';
+        $filter_poller = ' ns_host_relation.nagios_server_id IN (' . $filter_poller . ') AND nagios_server.id = ns_host_relation.nagios_server_id AND ';
+        $join_table    = ', nagios_server ';
     }
 
     my ($status, $datas) = $options{class_object_centreon}->custom_execute(
-        request => "SELECT host_id, host_address, host_name, nagios_server_id as poller_id
+        request     => "SELECT host_id, host_address, host_name, nagios_server_id as poller_id
             FROM host_template_relation, host, ns_host_relation " . $join_table . "
             WHERE " . $filter_host . $filter . " host_template_relation.host_host_id = host.host_id
             AND " . $filter_poller . " host.host_id = ns_host_relation.host_host_id
             AND `host_activate` = '1'
             ",
         bind_values => \@bind_values,
-        mode => 1,
-        keys => 'host_id'
+        mode        => 1,
+        keys        => 'host_id'
     );
     if ($status == -1) {
         return (-1, 'cannot host list');
@@ -389,14 +394,14 @@ sub get_hosts {
                 $datas->{$host_id}->{macros} = $done_macro_host->{ $host_id };
             } else {
                 ($status, my $message, my $macros) = get_macros_host(
-                    host_id => $host_id,
+                    host_id               => $host_id,
                     class_object_centreon => $options{class_object_centreon},
-                    vault_count => $options{vault_count}
+                    vault_count           => $options{vault_count}
                 );
                 if ($status == -1) {
                     return (-1, $message);
                 }
-                $datas->{$host_id}->{macros} = $macros;
+                $datas->{$host_id}->{macros}   = $macros;
                 $done_macro_host->{ $host_id } = $macros;
             }
         }
@@ -411,7 +416,7 @@ sub get_hosts {
 
 sub set_macro {
     my ($macros, $name, $value) = @_;
-    
+
     if (!defined($macros->{$name})) {
         $macros->{$name} = $value;
     }
@@ -420,10 +425,10 @@ sub set_macro {
 sub get_macros_host {
     my (%options) = @_;
     my ($status, $datas);
-    my %macros = ();
+    my %macros    = ();
     my %loop_stop = ();
-    my @stack = ($options{host_id});
-    
+    my @stack     = ($options{host_id});
+
     while ((my $lhost_id = shift(@stack))) {
         if (defined($loop_stop{$lhost_id})) {
             # Already done the host
@@ -433,7 +438,7 @@ sub get_macros_host {
 
         ($status, $datas) = $options{class_object_centreon}->custom_execute(
             request => "SELECT host_snmp_community, host_snmp_version FROM host WHERE host_id = " . $lhost_id . " LIMIT 1",
-            mode => 2
+            mode    => 2
         );
         if ($status == -1) {
             return (-1, 'get macro: cannot get snmp information');
@@ -448,13 +453,13 @@ sub get_macros_host {
 
         ($status, $datas) = $options{class_object_centreon}->custom_execute(
             request => "SELECT host_macro_name, host_macro_value, is_password FROM on_demand_macro_host WHERE host_host_id = " . $lhost_id,
-            mode => 2
+            mode    => 2
         );
         if ($status == -1) {
             return (-1, 'get macro: cannot get on_demand_macro_host');
         }
         foreach (@$datas) {
-            my $macro_name = $_->[0];
+            my $macro_name  = $_->[0];
             my $macro_value = $_->[1];
             my $is_password = $_->[2];
             # Replace macro value if a vault is used
@@ -467,7 +472,7 @@ sub get_macros_host {
 
         ($status, $datas) = $options{class_object_centreon}->custom_execute(
             request => "SELECT host_tpl_id FROM host_template_relation WHERE host_host_id = " . $lhost_id . " ORDER BY `order` DESC",
-            mode => 2
+            mode    => 2
         );
         if ($status == -1) {
             return (-1, 'get macro: cannot get host_template_relation');
@@ -482,26 +487,26 @@ sub get_macros_host {
 
 sub substitute_service_discovery_command {
     my (%options) = @_;
-    
+
     my $command = $options{command_line};
     while ($command =~ /(\$_HOST.*?\$)/) {
         my ($substitute_str, $macro) = ('', $1);
-        $substitute_str = $options{host}->{macros}->{$macro} if (defined($options{host}->{macros}->{$macro}));
+        $substitute_str              = $options{host}->{macros}->{$macro} if (defined($options{host}->{macros}->{$macro}));
         $command =~ s/\Q$macro\E/$substitute_str/g;
     }
     while ($command =~ /(\$(?:USER.*?|CENTREONPLUGINS)\$)/) {
         my ($substitute_str, $macro) = ('', $1);
-        $substitute_str = $options{poller}->{resources}->{$macro} if (defined($options{poller}->{resources}->{$macro}));
+        $substitute_str              = $options{poller}->{resources}->{$macro} if (defined($options{poller}->{resources}->{$macro}));
         $command =~ s/\Q$macro\E/$substitute_str/g;
     }
-    
+
     $command =~ s/\$HOSTADDRESS\$/$options{host}->{host_address}/g;
     $command =~ s/\$HOSTNAME\$/$options{host}->{host_name}/g;
 
     if (defined($options{vault_count}) && $options{vault_count} > 0) {
         $command .= ' --pass-manager="centreonvault"';
     }
-    
+
     return $command;
 }
 
@@ -511,7 +516,7 @@ sub change_vars {
     # First we change '$$' values
     if (defined($options{rule}->{change})) {
         foreach my $change (@{$options{rule}->{change}}) {
-            next if (!defined($change->{change_str}) || $change->{change_str} eq '' || 
+            next if (!defined($change->{change_str}) || $change->{change_str} eq '' ||
                      !defined($change->{change_regexp}) || $change->{change_regexp} eq '' ||
                      $change->{change_str} =~ /\@SERVICENAME\@/);
 
@@ -530,15 +535,15 @@ sub change_vars {
     }
 
     $options{discovery_svc}->{service_name} = substitute_vars(
-        value => $options{rule}->{service_display_name},
+        value        => $options{rule}->{service_display_name},
         service_name => $options{discovery_svc}->{service_name},
-        attributes => $options{discovery_svc}->{attributes}
+        attributes   => $options{discovery_svc}->{attributes}
     );
-    
+
     if (defined($options{rule}->{change})) {
         # Second pass for service_name now
         foreach my $change (@{$options{rule}->{change}}) {
-            next if (!defined($change->{change_str}) || $change->{change_str} eq '' || 
+            next if (!defined($change->{change_str}) || $change->{change_str} eq '' ||
                      !defined($change->{change_regexp}) || $change->{change_regexp} eq '' ||
                      $change->{change_str} !~ /\@SERVICENAME\@/);
             eval "\$options{discovery_svc}->{service_name} =~ s{$change->{change_regexp}}{$change->{change_replace}}$change->{change_modifier}";
@@ -552,7 +557,7 @@ sub substitute_vars {
     my $value = $options{value};
     while ($value =~ /\$(.+?)\$/) {
         my ($substitute_str, $macro) = ('', $1);
-        $substitute_str = $options{attributes}->{$macro} if (defined($options{attributes}->{$macro}));
+        $substitute_str              = $options{attributes}->{$macro} if (defined($options{attributes}->{$macro}));
         $value =~ s/\$\Q$macro\E\$/$substitute_str/g;
     }
     $value =~ s/\@SERVICENAME\@/$options{service_name}/g;
@@ -561,13 +566,13 @@ sub substitute_vars {
 
 sub change_bytes {
     my (%options) = @_;
-    my $divide = defined($options{network}) ? 1000 : 1024;
-    my @units = ('K', 'M', 'G', 'T');
-    my $unit = '';
-    
+    my $divide    = defined($options{network}) ? 1000 : 1024;
+    my @units     = ('K', 'M', 'G', 'T');
+    my $unit      = '';
+
     for (my $i = 0; $i < scalar(@units); $i++) {
         last if (($options{value} / $divide) < 1);
-        $unit = $units[$i];
+        $unit           = $units[$i];
         $options{value} = $options{value} / $divide;
     }
 
@@ -576,14 +581,14 @@ sub change_bytes {
 
 sub check_exinc {
     my (%options) = @_;
-    
+
     return 0 if (!defined($options{rule}->{exinc}));
     foreach my $exinc (@{$options{rule}->{exinc}}) {
         next if (!defined($exinc->{exinc_str}) || $exinc->{exinc_str} eq '');
         my $value = substitute_vars(
-            value => $exinc->{exinc_str},
+            value        => $exinc->{exinc_str},
             service_name => $options{discovery_svc}->{service_name},
-            attributes => $options{discovery_svc}->{attributes}
+            attributes   => $options{discovery_svc}->{attributes}
         );
         if ($exinc->{exinc_type} == 1 && $value =~ /$exinc->{exinc_regexp}/) {
             $options{logger}->writeLogDebug("$options{logger_pre_message} [" . $options{discovery_svc}->{service_name} . "] -> inclusion '$exinc->{exinc_regexp}'");
@@ -593,23 +598,23 @@ sub check_exinc {
             return 1;
         }
     }
-    
+
     return 0;
 }
 
 sub get_macros {
     my (%options) = @_;
-    my $macros = {};
-    
+    my $macros    = {};
+
     return $macros if (!defined($options{rule}->{macro}));
     foreach my $macro (keys %{$options{rule}->{macro}}) {
         $macros->{$macro} = substitute_vars(
-            value => $options{rule}->{macro}->{$macro}->{macro_value},
+            value        => $options{rule}->{macro}->{$macro}->{macro_value},
             service_name => $options{discovery_svc}->{service_name},
-            attributes => $options{discovery_svc}->{attributes}
+            attributes   => $options{discovery_svc}->{attributes}
         );
     }
-    
+
     return $macros;
 }
 
@@ -618,10 +623,13 @@ sub get_service {
 
     my $service;
     my ($status, $datas) = $options{class_object_centreon}->custom_execute(
-        request => 'SELECT service_id, service_template_model_stm_id, service_activate, svc_macro_name, svc_macro_value FROM host, host_service_relation, service LEFT JOIN on_demand_macro_service ON on_demand_macro_service.svc_svc_id = service.service_id WHERE host_id = ' . $options{host_id} . 
-                " AND host.host_id = host_service_relation.host_host_id AND host_service_relation.service_service_id = service.service_id AND service.service_description = ?",
-        bind_values => [$options{service_name}],
-        mode => 2
+        request     =>
+        'SELECT service_id, service_template_model_stm_id, service_activate, svc_macro_name, svc_macro_value FROM host, host_service_relation, service LEFT JOIN on_demand_macro_service ON on_demand_macro_service.svc_svc_id = service.service_id WHERE host_id = ' . $options{host_id} .
+        " AND host.host_id = host_service_relation.host_host_id AND host_service_relation.service_service_id = service.service_id AND service.service_description = ?",
+        bind_values =>
+        [$options{service_name}],
+        mode        =>
+        2
     );
     if ($status == -1) {
         $options{logger}->writeLogError("$options{logger_pre_message} [" . $options{service_name} . "] -> cannot check service in configuration");
@@ -630,10 +638,10 @@ sub get_service {
 
     foreach (@$datas) {
         $service = {
-            id => $_->[0],
-            template_id => $_->[1], 
-            activate => $_->[2],
-            macros => {}
+            id          => $_->[0],
+            template_id => $_->[1],
+            activate    => $_->[2],
+            macros      => {}
         } if (!defined($service->{id}));
         if (defined($_->[3])) {
             $service->{macros}->{ $_->[3] } = $_->[4];


### PR DESCRIPTION
REf #MON-146691

## Description

Backport [PR collect 1608](https://github.com/centreon/centreon-collect/pull/1608)

Error in service discovery:
```
2024-08-01 08:04:38 - ERROR - [autodiscovery] -servicediscovery- ea084b6a:4 cannot get number of vault configured
2024-08-01 08:25:36 - ERROR - Table 'staging_spring-moon_config.vault_configuration' doesn't exist
2024-08-01 08:25:37 - ERROR - Table 'staging_spring-moon_config.vault_configuration' doesn't exist
```

**Fixes** 
MON-146184
MON-146691

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software
- [ ] Updating documentation (missing information, typo...)

## Target serie

- [ ] 22.04.x
- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Run a service discovery and check the logs to verify that there is no more error.

## Checklist

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have made corresponding changes to the **documentation**.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).

