### PR TITLE
Fixed a broken join leading to endless sql query

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -511,8 +511,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                     ON gcgr.acl_group_id = grp.acl_group_id
                 LEFT JOIN `:db`.contactgroup_contact_relation cgcr
                     ON cgcr.contactgroup_cg_id = gcgr.cg_cg_id
-                    AND cgcr.contact_contact_id = :contact_id
-                    OR gcr.contact_contact_id = :contact_id';
+                    AND (cgcr.contact_contact_id = :contact_id OR gcr.contact_contact_id = :contact_id)';
         }
 
         // This join will only be added if a search parameter corresponding to one of the host or Service parameter


### PR DESCRIPTION
Related Jira Ticket : [MON-144594](https://centreon.atlassian.net/browse/MON-144594)

Problem: A query took too long to be executed, it was due to a bad join condition.
```
JOIN ... ON condition_a AND condition_b OR condition_c
```
is different from:
```
JOIN ... ON condition_a AND (condition_b OR condition_c)
```

Apart from the duration of the request, the result was bound to be wrong anyway.

[MON-144594]: https://centreon.atlassian.net/browse/MON-144594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ