### PR TITLE
fix(ci): use alma8 docker image to package el7 (#4596)

### DIFF
--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -41,6 +41,9 @@ inputs:
   cache_key:
     description: The package files cache key
     required: true
+  distrib:
+    description: The os distribution
+    required: true
 
 runs:
   using: composite
@@ -95,7 +98,15 @@ runs:
           cp -rp $MODULE_BASENAME/packaging/src/* ~/rpmbuild/SOURCES/
         fi
 
-        rpmbuild -ba ${{ inputs.spec_file }} -D "PACKAGE_NAME $MODULE_BASENAME" -D "PACKAGE_VERSION $VERSION" -D "PACKAGE_RELEASE $RELEASE"
+        # Define dist as an override if distrib is el7 (node16 el7 EOL on GHA runners)
+        case ${{ inputs.distrib }} in
+          el7)
+            rpmbuild --define 'dist .el7' -ba ${{ inputs.spec_file }} -D "PACKAGE_NAME $MODULE_BASENAME" -D "PACKAGE_VERSION $VERSION" -D "PACKAGE_RELEASE $RELEASE"
+            ;;
+          el8)
+            rpmbuild -ba ${{ inputs.spec_file }} -D "PACKAGE_NAME $MODULE_BASENAME" -D "PACKAGE_VERSION $VERSION" -D "PACKAGE_RELEASE $RELEASE"
+            ;;
+        esac
 
         cp -r ~/rpmbuild/RPMS/noarch/*.rpm .
 

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         include:
           - package_extension: rpm
-            image: packaging-centos7
+            image: packaging-alma8
             distrib: el7
           - package_extension: rpm
             image: packaging-alma8
@@ -82,6 +82,7 @@ jobs:
       minor_version: ${{ needs.get-version.outputs.minor_version }}
       release: ${{ needs.get-version.outputs.release }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      distrib: ${{ matrix.distrib }}
     secrets:
       registry_username: ${{ secrets.DOCKER_REGISTRY_ID }}
       registry_password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -62,7 +62,7 @@ jobs:
       matrix:
         include:
           - package_extension: rpm
-            image: packaging-centos7
+            image: packaging-alma8
             distrib: el7
           - package_extension: rpm
             image: packaging-alma8
@@ -82,6 +82,7 @@ jobs:
       minor_version: ${{ needs.get-version.outputs.minor_version }}
       release: ${{ needs.get-version.outputs.release }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      distrib: ${{ matrix.distrib }}
     secrets:
       registry_username: ${{ secrets.DOCKER_REGISTRY_ID }}
       registry_password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}

--- a/.github/workflows/gorgone.yml
+++ b/.github/workflows/gorgone.yml
@@ -64,7 +64,7 @@ jobs:
         distrib: [el7, el8, bullseye]
         include:
           - package_extension: rpm
-            image: packaging-centos7
+            image: packaging-alma8
             distrib: el7
           - package_extension: rpm
             image: packaging-alma8
@@ -84,6 +84,7 @@ jobs:
       minor_version: ${{ needs.get-version.outputs.minor_version }}
       release: ${{ needs.get-version.outputs.release }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      distrib: ${{ matrix.distrib }}
     secrets:
       registry_username: ${{ secrets.DOCKER_REGISTRY_ID }}
       registry_password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}

--- a/.github/workflows/ha.yml
+++ b/.github/workflows/ha.yml
@@ -48,7 +48,7 @@ jobs:
             image: packaging-alma8
             distrib: el8
           - package_extension: rpm
-            image: packaging-centos7
+            image: packaging-alma8
             distrib: el7
           - package_extension: deb
             image: packaging-bullseye
@@ -65,6 +65,7 @@ jobs:
       minor_version: ${{ needs.get-version.outputs.minor_version }}
       release: ${{ needs.get-version.outputs.release }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      distrib: ${{ matrix.distrib }}
     secrets:
       registry_username: ${{ secrets.DOCKER_REGISTRY_ID }}
       registry_password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -61,7 +61,7 @@ jobs:
       matrix:
         include:
           - package_extension: rpm
-            image: packaging-centos7
+            image: packaging-alma8
             distrib: el7
           - package_extension: rpm
             image: packaging-alma8
@@ -81,6 +81,7 @@ jobs:
       minor_version: ${{ needs.get-version.outputs.minor_version }}
       release: ${{ needs.get-version.outputs.release }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      distrib: ${{ matrix.distrib }}
     secrets:
       registry_username: ${{ secrets.DOCKER_REGISTRY_ID }}
       registry_password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -61,6 +61,10 @@ on:
         type: string
         description: The package files cache key
         required: true
+      distrib:
+        type: string
+        description: The os distribution
+        required: true
     secrets:
       registry_username:
         required: true
@@ -78,7 +82,8 @@ jobs:
         password: ${{ secrets.registry_password }}
 
     steps:
-      - uses: actions/checkout@v3 # el7 is not compatible with checkout v4 which uses node20
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      # node16 el7 eol on gha runners
 
       - uses: ./.github/actions/package
         with:
@@ -98,6 +103,7 @@ jobs:
           minor_version: ${{ inputs.minor_version }}
           release: ${{ inputs.release }}
           cache_key: unsigned-${{ inputs.cache_key }}
+          distrib: ${{ inputs.distrib }}
 
       - if: ${{ inputs.package_extension == 'deb' }}
         uses: actions/cache/save@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -283,7 +283,7 @@ jobs:
         distrib: [el7, el8, bullseye]
         include:
           - package_extension: rpm
-            image: packaging-centos7
+            image: packaging-alma8
             distrib: el7
           - package_extension: rpm
             image: packaging-alma8
@@ -311,6 +311,7 @@ jobs:
       minor_version: ${{ needs.get-version.outputs.minor_version }}
       release: ${{ needs.get-version.outputs.release }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      distrib: ${{ matrix.distrib }}
     secrets:
       registry_username: ${{ secrets.DOCKER_REGISTRY_ID }}
       registry_password: ${{ secrets.DOCKER_REGISTRY_PASSWD }}

--- a/.github/workflows/widget-package.yml
+++ b/.github/workflows/widget-package.yml
@@ -28,7 +28,7 @@ jobs:
         distrib: [el7, el8, bullseye]
         include:
           - package_extension: rpm
-            image: packaging-centos7
+            image: packaging-alma8
             distrib: el7
           - package_extension: rpm
             image: packaging-alma8
@@ -48,6 +48,7 @@ jobs:
       minor_version: ${{ inputs.minor_version }}
       release: ${{ inputs.release }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      distrib: ${{ matrix.distrib }}
     secrets:
       registry_username: ${{ secrets.registry_username }}
       registry_password: ${{ secrets.registry_password }}


### PR DESCRIPTION
## Description

Handle node16 deprectiation on runners + el7 depreciation

use alma8 docker container to package EL7 packages.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
