### PR TITLE
fix(ci): do not rerun dispatch to maintained branches step when rerunning nightly

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -109,7 +109,7 @@ jobs:
           features_path: centreon/tests/e2e/features
 
   dispatch-to-maintained-branches:
-    if: ${{ github.event_name == 'schedule' && github.ref_name == 'develop' }}
+    if: ${{ github.run_attempt == 1 && github.event_name == 'schedule' && github.ref_name == 'develop' }}
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Description

Adding a condition on the dispatch-to-maintained-branches flag that prevents the maintained branches' nightly to be retriggered a second time in the case of a nightly develop full rerun (since they are supposed to be treated as independent workflow runs from this point on) 

**Fixes** # MON-147064

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
