### PR TITLE
feat(dashboard): add closing ticket feature

### DIFF
--- a/centreon-open-tickets/src/CentreonOpenTickets/Resources/Infrastructure/Repository/OpenTicketExtraDataProvider.php
+++ b/centreon-open-tickets/src/CentreonOpenTickets/Resources/Infrastructure/Repository/OpenTicketExtraDataProvider.php
@@ -34,7 +34,7 @@ use PDOException;
 /**
  * @phpstan-type _TicketData array{
  *  resource_id:int,
- *  ticket_id:string,
+ *  ticket_value:string,
  *  subject:string,
  *  timestamp: int
  * }
@@ -225,7 +225,7 @@ final class OpenTicketExtraDataProvider extends AbstractRepositoryRDB implements
         $request = <<<SQL
             SELECT
                 r.resource_id,
-                tickets.ticket_id,
+                tickets.ticket_value,
                 tickets.timestamp,
                 tickets.user,
                 tickets_data.subject
@@ -263,7 +263,7 @@ final class OpenTicketExtraDataProvider extends AbstractRepositoryRDB implements
              * @var _TicketData $record
              */
             $tickets[(int) $record['resource_id']] = [
-                'id' => (int) $record['ticket_id'],
+                'id' => (int) $record['ticket_value'],
                 'subject' => $record['subject'],
                 'created_at' => (new \DateTimeImmutable())->setTimestamp((int) $record['timestamp'])
             ];
@@ -292,7 +292,7 @@ final class OpenTicketExtraDataProvider extends AbstractRepositoryRDB implements
         $request = <<<SQL
             SELECT
                 r.resource_id,
-                tickets.ticket_id,
+                tickets.ticket_value,
                 tickets.timestamp,
                 tickets.user,
                 tickets_data.subject
@@ -328,7 +328,7 @@ final class OpenTicketExtraDataProvider extends AbstractRepositoryRDB implements
              * @var _TicketData $record
              */
             $tickets[(int) $record['resource_id']] = [
-                'id' => (int) $record['ticket_id'],
+                'id' => (int) $record['ticket_value'],
                 'subject' => $record['subject'],
                 'created_at' => (new \DateTimeImmutable())->setTimestamp((int) $record['timestamp'])
             ];

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/sql/uninstall.sql
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/sql/uninstall.sql
@@ -14,3 +14,4 @@ DELETE FROM topology WHERE topology_page = '20320' AND topology_name = 'Ticket L
 DELETE FROM topology_JS WHERE id_page = '20320';
 
 DELETE FROM widget_parameters_field_type WHERE ft_typename = 'openTicketsRule';
+DELETE FROM `topology` WHERE topology_page = 60421;

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/closeTicket/action.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/closeTicket/action.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+require_once __DIR__ . '/../../../centreon-open-tickets.conf.php';
+require_once $centreon_path . 'www/modules/centreon-open-tickets/class/centreonDBManager.class.php';
+require_once $centreon_path . 'www/modules/centreon-open-tickets/class/rule.php';
+require_once $centreon_path . 'www/modules/centreon-open-tickets/providers/register.php';
+require_once $centreon_path . 'www/class/centreonXMLBGRequest.class.php';
+$centreon_open_tickets_path = $centreon_path . 'www/modules/centreon-open-tickets/';
+require_once $centreon_open_tickets_path . 'providers/Abstract/AbstractProvider.class.php';
+
+session_start();
+
+/**
+ * Function that will check the selection payload.
+ *
+ * @param string
+ * @param string $selection
+ *
+ * @return bool
+ */
+function isSelectionValid(string $selection): bool
+{
+    preg_match('/^(\d+;?\d+,?)+$/', $selection, $matches);
+
+    return ! empty($matches);
+}
+
+if (isset($_SESSION['centreon'])) {
+    /** @var Centreon $centreon */
+    $centreon = $_SESSION['centreon'];
+} else {
+    $resultat = ['code' => 1, 'msg' => 'Invalid session'];
+    header('Content-type: text/plain');
+    echo json_encode($resultat);
+
+    exit;
+}
+
+$centreon_bg = new CentreonXMLBGRequest($dependencyInjector, session_id(), 1, 1, 0, 1);
+$db = $dependencyInjector['configuration_db'];
+$rule = new Centreon_OpenTickets_Rule($db);
+
+$data = isset($_POST['data']) ? json_decode($_POST['data'], true) : null;
+
+if ($data === null) {
+    $resultat = ['code' => 1, 'msg' => 'POST data key missing'];
+    header('Content-type: text/plain');
+    echo json_encode($resultat);
+
+    exit;
+}
+
+if (
+    ! isset($data['rule_id'])
+    || ! is_int($data['rule_id'])
+) {
+    $resultat = ['code' => 1, 'msg' => 'Rule ID should be provided as an integer'];
+    header('Content-type: text/plain');
+    echo json_encode($resultat);
+
+    exit;
+}
+
+$ruleInformation = $rule->getAliasAndProviderId($data['rule_id']);
+
+if (
+    ! isset($data['selection'])
+    || ! isSelectionValid($data['selection'])
+) {
+    $resultat = ['code' => 1, 'msg' => 'Resource selection not provided or not well formatted'];
+    header('Content-type: text/plain');
+    echo json_encode($resultat);
+
+    exit;
+}
+
+// re-create payload sent from the widget directly from this file
+$get_information = [
+    'action' => 'close-ticket',
+    'rule_id' => $data['rule_id'],
+    'provider_id' => $ruleInformation['provider_id'],
+    'form' => [
+        'rule_id' => $data['rule_id'],
+        'provider_id' => $ruleInformation['provider_id'],
+        'selection' => $data['selection'],
+    ],
+];
+
+require_once __DIR__ . '/../ajax/actions/closeTicket.php';
+
+header('Content-type: text/plain');
+echo json_encode($resultat);

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/closeTicket/action.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/views/rules/closeTicket/action.php
@@ -32,7 +32,6 @@ session_start();
 /**
  * Function that will check the selection payload.
  *
- * @param string
  * @param string $selection
  *
  * @return bool

--- a/centreon/www/widgets/src/centreon-widget-resourcestable/src/Listing/Columns/OpenTicket/Modal.tsx
+++ b/centreon/www/widgets/src/centreon-widget-resourcestable/src/Listing/Columns/OpenTicket/Modal.tsx
@@ -51,8 +51,8 @@ const OpenTicketModal = ({
   }, [isOpen]);
 
   const src = resource.serviceID
-    ? `./main.get.php?p=60421&cmd=3&provider_id=${providerID}&host_id=${resource.hostID}&service_id=${resource.serviceID}`
-    : `./main.get.php?p=60421&cmd=4&provider_id=${providerID}&host_id=${resource.hostID}`;
+    ? `./main.get.php?p=60421&cmd=3&rule_id=${providerID}&host_id=${resource.hostID}&service_id=${resource.serviceID}`
+    : `./main.get.php?p=60421&cmd=4&rule_id=${providerID}&host_id=${resource.hostID}`;
 
   return (
     <Modal hasCloseButton open={isOpen} size="xlarge" onClose={close}>


### PR DESCRIPTION
🏷️ MON-147078
📃 This PR intends to add the closing ticket feature outside the open-ticket widget so that it can be used by Dashboard.
It also updates the uninstall script to remove the topology added for the submitTicket feature for dashboard.
It also fixes an issue regarding the ticket ID returned. (should be the one available in the ticket provider and not the one internal)
It also uses the correct request parameter name for the modal of ticket creation (rule_id)

Info: mechanism is different from the submitTicket feature. We do not need to display any html content as the return (in the legacy) was only a simple plain text response (so no need for ihtml or new topology)

<img width="1432" alt="image" src="https://github.com/user-attachments/assets/3c73802e-4f52-4d20-bece-92a651b14492">
