### PR TITLE
fix(ci): restore deb delivery on develop

### DIFF
--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -181,7 +181,7 @@ jobs:
 
   deliver-deb:
     needs: [get-version, package]
-    if: ${{ !needs.get-version.outputs.release_cloud && contains(fromJson('["testing", "unstable"]'), needs.get-version.outputs.stability) }}
+    if: ${{ contains(fromJson('["testing", "unstable"]'), needs.get-version.outputs.stability) }}
     runs-on: [self-hosted, common]
     environment: ${{ needs.get-version.outputs.environment }}
 

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -185,7 +185,7 @@ jobs:
 
   deliver-deb:
     needs: [get-version, package]
-    if: ${{ !needs.get-version.outputs.release_cloud && contains(fromJson('["testing", "unstable"]'), needs.get-version.outputs.stability) }}
+    if: ${{ contains(fromJson('["testing", "unstable"]'), needs.get-version.outputs.stability) }}
     runs-on: [self-hosted, common]
     environment: ${{ needs.get-version.outputs.environment }}
 

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -221,7 +221,7 @@ jobs:
 
   deliver-deb:
     needs: [get-version, package]
-    if: ${{ !needs.get-version.outputs.release_cloud && contains(fromJson('["testing", "unstable"]'), needs.get-version.outputs.stability) }}
+    if: ${{ contains(fromJson('["testing", "unstable"]'), needs.get-version.outputs.stability) }}
     runs-on: [self-hosted, common]
     environment: ${{ needs.get-version.outputs.environment }}
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -967,7 +967,7 @@ jobs:
         performances-test,
         legacy-e2e-test,
       ]
-    if: ${{ !needs.get-version.outputs.release_cloud && !cancelled() && contains(fromJson('["testing", "unstable", "pkgtest"]'), needs.get-version.outputs.stability) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+    if: ${{ !cancelled() && contains(fromJson('["testing", "unstable", "pkgtest"]'), needs.get-version.outputs.stability) && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
 
     environment: ${{ needs.get-version.outputs.environment }}
 


### PR DESCRIPTION
## Description

restore delivery to debian, when stability is testing or unstable (nightly makes use of the resulting packages)

Fixes #MON-146671

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
