### PR TITLE
fix(API): Creation of resources (hosts and services) are not visible by a non administrator

### DIFF
--- a/centreon/src/Core/Host/Application/Repository/WriteRealTimeHostRepositoryInterface.php
+++ b/centreon/src/Core/Host/Application/Repository/WriteRealTimeHostRepositoryInterface.php
@@ -26,7 +26,7 @@ namespace Core\Host\Application\Repository;
 interface WriteRealTimeHostRepositoryInterface
 {
     /**
-     * Link host to Resource ACLs
+     * Link host to Resource ACLs.
      *
      * @param int $hostId
      * @param AccessGroup[] $accessGroups

--- a/centreon/src/Core/Host/Application/Repository/WriteRealTimeHostRepositoryInterface.php
+++ b/centreon/src/Core/Host/Application/Repository/WriteRealTimeHostRepositoryInterface.php
@@ -21,6 +21,8 @@
 
 declare(strict_types=1);
 
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+
 namespace Core\Host\Application\Repository;
 
 interface WriteRealTimeHostRepositoryInterface

--- a/centreon/src/Core/Host/Application/Repository/WriteRealTimeHostRepositoryInterface.php
+++ b/centreon/src/Core/Host/Application/Repository/WriteRealTimeHostRepositoryInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Host\Application\Repository;
+
+interface WriteRealTimeHostRepositoryInterface
+{
+    /**
+     * Link host to Resource ACLs
+     *
+     * @param int $hostId
+     * @param AccessGroup[] $accessGroups
+     *
+     * @throws \Throwable
+     */
+    public function addHostToResourceAcls(int $hostId, array $accessGroups): void;
+}

--- a/centreon/src/Core/Host/Application/Repository/WriteRealTimeHostRepositoryInterface.php
+++ b/centreon/src/Core/Host/Application/Repository/WriteRealTimeHostRepositoryInterface.php
@@ -21,9 +21,9 @@
 
 declare(strict_types=1);
 
-use Core\Security\AccessGroup\Domain\Model\AccessGroup;
-
 namespace Core\Host\Application\Repository;
+
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 
 interface WriteRealTimeHostRepositoryInterface
 {

--- a/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
@@ -107,6 +107,8 @@ final class AddHost
                 return;
             }
 
+            $accessGroups = [];
+
             if (! $this->user->isAdmin()) {
                 $accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
                 $this->validation->accessGroups = $accessGroups;
@@ -120,7 +122,7 @@ final class AddHost
                 $this->linkHostGroups($request, $hostId);
                 $this->linkParentTemplates($request, $hostId);
                 $this->addMacros($request, $hostId);
-                if (isset($accessGroups) && $accessGroups !== []) {
+                if ($accessGroups !== []) {
                     $this->writeRealTimeHostRepository->addHostToResourceAcls($hostId, $accessGroups);
                 }
                 $this->writeMonitoringServerRepository->notifyConfigurationChange($request->monitoringServerId);

--- a/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
@@ -120,7 +120,6 @@ final class AddHost
                 $this->linkHostGroups($request, $hostId);
                 $this->linkParentTemplates($request, $hostId);
                 $this->addMacros($request, $hostId);
-                // Note: host is not linked to any ACLsResource
                 if (isset($accessGroups) && $accessGroups !== []) {
                     $this->writeRealTimeHostRepository->addHostToResourceAcls($hostId, $accessGroups);
                 }

--- a/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/AddHost/AddHost.php
@@ -45,6 +45,7 @@ use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\InheritanceManager;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
+use Core\Host\Application\Repository\WriteRealTimeHostRepositoryInterface;
 use Core\HostCategory\Application\Repository\ReadHostCategoryRepositoryInterface;
 use Core\HostCategory\Application\Repository\WriteHostCategoryRepositoryInterface;
 use Core\HostGroup\Application\Repository\ReadHostGroupRepositoryInterface;
@@ -82,6 +83,7 @@ final class AddHost
         private readonly AddHostValidation $validation,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly WriteRealTimeHostRepositoryInterface $writeRealTimeHostRepository,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::HOST_VAULT_PATH);
     }
@@ -119,6 +121,9 @@ final class AddHost
                 $this->linkParentTemplates($request, $hostId);
                 $this->addMacros($request, $hostId);
                 // Note: host is not linked to any ACLsResource
+                if (isset($accessGroups) && $accessGroups !== []) {
+                    $this->writeRealTimeHostRepository->addHostToResourceAcls($hostId, $accessGroups);
+                }
                 $this->writeMonitoringServerRepository->notifyConfigurationChange($request->monitoringServerId);
 
                 $this->dataStorageEngine->commitTransaction();

--- a/centreon/src/Core/Host/Infrastructure/Repository/DbWriteRealTimeHostRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbWriteRealTimeHostRepository.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Host\Infrastructure\Repository;
+
+use Centreon\Infrastructure\DatabaseConnection;
+use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Core\Host\Application\Repository\WriteRealTimeHostRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+
+class DbWriteRealTimeHostRepository extends AbstractRepositoryRDB implements WriteRealTimeHostRepositoryInterface
+{
+    /**
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addHostToResourceAcls(int $hostId, array $accessGroups): void
+    {
+        $accessGroupIds = array_map(
+            fn(AccessGroup $accessGroup) => $accessGroup->getId(),
+            $accessGroups
+        );
+
+        foreach ($accessGroupIds as $accessGroupId) {
+            $request = <<<'SQL'
+                INSERT INTO `:dbstg`.`centreon_acl`(`group_id`, `host_id`, `service_id`)
+                VALUES(:group_id, :host_id, NULL)
+                SQL;
+            $statement = $this->db->prepare($this->translateDbName($request));
+            $statement->bindValue(':group_id', $accessGroupId, \PDO::PARAM_INT);
+            $statement->bindValue(':host_id', $hostId, \PDO::PARAM_INT);
+            $statement->execute();
+        }
+    }
+}

--- a/centreon/src/Core/Service/Application/Repository/WriteRealTimeServiceRepositoryInterface.php
+++ b/centreon/src/Core/Service/Application/Repository/WriteRealTimeServiceRepositoryInterface.php
@@ -28,7 +28,7 @@ use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 interface WriteRealTimeServiceRepositoryInterface
 {
     /**
-     * Link service to Resource ACLs
+     * Link service to Resource ACLs.
      *
      * @param int $hostId
      * @param int $serviceId

--- a/centreon/src/Core/Service/Application/Repository/WriteRealTimeServiceRepositoryInterface.php
+++ b/centreon/src/Core/Service/Application/Repository/WriteRealTimeServiceRepositoryInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Service\Application\Repository;
+
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+
+interface WriteRealTimeServiceRepositoryInterface
+{
+    /**
+     * Link service to Resource ACLs
+     *
+     * @param int $hostId
+     * @param int $serviceId
+     * @param AccessGroup[] $accessGroups
+     *
+     * @throws \Throwable
+     */
+    public function addServiceToResourceAcls(int $hostId, int $serviceId, array $accessGroups): void;
+}

--- a/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
+++ b/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
@@ -69,7 +69,7 @@ final class AddService
     use LoggerTrait,VaultTrait;
 
     /** @var AccessGroup[] */
-    private array $accessGroups;
+    private array $accessGroups = [];
 
     public function __construct(
         private readonly ReadMonitoringServerRepositoryInterface $readMonitoringServerRepository,
@@ -123,8 +123,12 @@ final class AddService
             $this->assertParameters($request);
             $newServiceId = $this->createService($request);
 
-            if (isset($this->accessGroups) && $this->accessGroups !== []) {
-                $this->writeRealTimeServiceRepository->addServiceToResourceAcls($request->hostId, $newServiceId, $this->accessGroups);
+            if ($this->accessGroups !== []) {
+                $this->writeRealTimeServiceRepository->addServiceToResourceAcls(
+                    $request->hostId,
+                    $newServiceId,
+                    $this->accessGroups
+                );
             }
 
             $this->info('New service created', ['service_id' => $newServiceId]);

--- a/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
+++ b/centreon/src/Core/Service/Application/UseCase/AddService/AddService.php
@@ -51,6 +51,7 @@ use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryIn
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\Service\Application\Exception\ServiceException;
 use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
+use Core\Service\Application\Repository\WriteRealTimeServiceRepositoryInterface;
 use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
 use Core\Service\Domain\Model\NewService;
 use Core\Service\Domain\Model\Service;
@@ -90,6 +91,7 @@ final class AddService
         private readonly bool $isCloudPlatform,
         private readonly WriteVaultRepositoryInterface $writeVaultRepository,
         private readonly ReadVaultRepositoryInterface $readVaultRepository,
+        private readonly WriteRealTimeServiceRepositoryInterface $writeRealTimeServiceRepository,
     ) {
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
@@ -120,6 +122,10 @@ final class AddService
 
             $this->assertParameters($request);
             $newServiceId = $this->createService($request);
+
+            if (isset($this->accessGroups) && $this->accessGroups !== []) {
+                $this->writeRealTimeServiceRepository->addServiceToResourceAcls($request->hostId, $newServiceId, $this->accessGroups);
+            }
 
             $this->info('New service created', ['service_id' => $newServiceId]);
             $service = $this->readServiceRepository->findById($newServiceId);

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbWriteRealTimeServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbWriteRealTimeServiceRepository.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Service\Infrastructure\Repository;
+
+use Centreon\Infrastructure\DatabaseConnection;
+use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Core\Service\Application\Repository\WriteRealTimeServiceRepositoryInterface;
+
+class DbWriteRealTimeServiceRepository extends AbstractRepositoryRDB implements WriteRealTimeServiceRepositoryInterface
+{
+    /**
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addServiceToResourceAcls(int $hostId, int $serviceId, array $accessGroups): void
+    {
+        $accessGroupIds = array_map(
+            fn(AccessGroup $accessGroup) => $accessGroup->getId(),
+            $accessGroups
+        );
+
+        foreach ($accessGroupIds as $accessGroupId) {
+            $request = <<<'SQL'
+                INSERT INTO `:dbstg`.`centreon_acl`(`group_id`, `host_id`, `service_id`)
+                VALUES(:group_id, :host_id, :service_id)
+                SQL;
+
+            $statement = $this->db->prepare($this->translateDbName($request));
+            $statement->bindValue(':group_id', $accessGroupId, \PDO::PARAM_INT);
+            $statement->bindValue(':host_id', $hostId, \PDO::PARAM_INT);
+            $statement->bindValue(':service_id', $serviceId, \PDO::PARAM_INT);
+
+            $statement->execute();
+        }
+    }
+}

--- a/centreon/tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/AddHost/AddHostTest.php
@@ -43,6 +43,7 @@ use Core\Host\Application\Converter\HostEventConverter;
 use Core\Host\Application\Exception\HostException;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Host\Application\Repository\WriteHostRepositoryInterface;
+use Core\Host\Application\Repository\WriteRealTimeHostRepositoryInterface;
 use Core\Host\Application\UseCase\AddHost\AddHost;
 use Core\Host\Application\UseCase\AddHost\AddHostRequest;
 use Core\Host\Application\UseCase\AddHost\AddHostResponse;
@@ -90,6 +91,7 @@ beforeEach(function (): void {
         validation: $this->validation = $this->createMock(AddHostValidation::class),
         writeVaultRepository: $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         readVaultRepository: $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        writeRealTimeHostRepository: $this->writeRealTimeHostRepository = $this->createMock(WriteRealTimeHostRepositoryInterface::class),
     );
 
     $this->inheritanceModeOption = new Option();

--- a/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
+++ b/centreon/tests/php/Core/Service/Application/UseCase/AddService/AddServiceTest.php
@@ -44,6 +44,7 @@ use Core\MonitoringServer\Model\MonitoringServer;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
 use Core\Service\Application\Exception\ServiceException;
 use Core\Service\Application\Repository\ReadServiceRepositoryInterface;
+use Core\Service\Application\Repository\WriteRealTimeServiceRepositoryInterface;
 use Core\Service\Application\Repository\WriteServiceRepositoryInterface;
 use Core\Service\Application\UseCase\AddService\AddService;
 use Core\Service\Application\UseCase\AddService\AddServiceRequest;
@@ -85,6 +86,7 @@ beforeEach(function (): void {
         $this->isCloudPlatform = false,
         $this->writeVaultRepository = $this->createMock(WriteVaultRepositoryInterface::class),
         $this->readVaultRepository = $this->createMock(ReadVaultRepositoryInterface::class),
+        $this->writeRealTimeServiceRepository = $this->createMock(WriteRealTimeServiceRepositoryInterface::class),
     );
 
     $this->request = new AddServiceRequest();


### PR DESCRIPTION
## Description

Fixed issues on endpoints `POST /configuration/hosts` & `POST /configuration/services` where creating hosts & services by a non-admin user doesn't display them in UI until reload ACL is made.

**Fixes** # MON-147497

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
