### PR TITLE
fix(dashboard): do not take into account UNDETERMINED days in calculation

### DIFF
--- a/centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
@@ -244,7 +244,7 @@ echo _("Day") . ";"
 
 while ($row = $dbResult->fetch()) {
     $duration = $row["UPTimeScheduled"] + $row["DOWNTimeScheduled"] + $row["UNREACHABLETimeScheduled"];
-    if ($duration == 0) {
+    if ($duration === 0) {
         continue;
     }
     // Percentage by status

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
@@ -244,7 +244,9 @@ echo _("Day") . ";"
 
 while ($row = $dbResult->fetch()) {
     $duration = $row["UPTimeScheduled"] + $row["DOWNTimeScheduled"] + $row["UNREACHABLETimeScheduled"];
-
+    if ($duration == 0) {
+        continue;
+    }
     // Percentage by status
     $row["UP_MP"] = round($row["UPTimeScheduled"] * 100 / $duration, 2);
     $row["DOWN_MP"] = round($row["DOWNTimeScheduled"] * 100 / $duration, 2);

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
@@ -220,7 +220,7 @@ $dbResult->execute();
 
 while ($row = $dbResult->fetch()) {
     $duration = $row["UPTimeScheduled"] + $row["DOWNTimeScheduled"] + $row["UNREACHABLETimeScheduled"];
-    if ($duration == 0) {
+    if ($duration === 0) {
         continue;
     }
     /* Percentage by status */

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
@@ -220,6 +220,9 @@ $dbResult->execute();
 
 while ($row = $dbResult->fetch()) {
     $duration = $row["UPTimeScheduled"] + $row["DOWNTimeScheduled"] + $row["UNREACHABLETimeScheduled"];
+    if ($duration == 0) {
+        continue;
+    }
     /* Percentage by status */
     $row["UP_MP"] = round($row["UPTimeScheduled"] * 100 / $duration, 2);
     $row["DOWN_MP"] = round($row["DOWNTimeScheduled"] * 100 / $duration, 2);

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
@@ -268,7 +268,7 @@ $statesTab = ["OK", "WARNING", "CRITICAL", "UNKNOWN"];
 while ($row = $res->fetch()) {
     $duration = $row["OKTimeScheduled"] + $row["WARNINGTimeScheduled"] + $row["UNKNOWNTimeScheduled"]
         + $row["CRITICALTimeScheduled"];
-    if ($duration == 0) {
+    if ($duration === 0) {
         continue;
     }
     /* Percentage by status */

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
@@ -266,12 +266,12 @@ $res->execute();
 
 $statesTab = ["OK", "WARNING", "CRITICAL", "UNKNOWN"];
 while ($row = $res->fetch()) {
-    $duration = $row["date_end"] - $row["date_start"];
-
-    /* Percentage by status */
     $duration = $row["OKTimeScheduled"] + $row["WARNINGTimeScheduled"] + $row["UNKNOWNTimeScheduled"]
         + $row["CRITICALTimeScheduled"];
-
+    if ($duration == 0) {
+        continue;
+    }
+    /* Percentage by status */
     $row["OK_MP"] = round($row["OKTimeScheduled"] * 100 / $duration, 2);
     $row["WARNING_MP"] = round($row["WARNINGTimeScheduled"] * 100 / $duration, 2);
     $row["UNKNOWN_MP"] = round($row["UNKNOWNTimeScheduled"] * 100 / $duration, 2);

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
@@ -205,9 +205,9 @@ while ($row = $dbResult->fetch()) {
         + $row["WARNINGTimeScheduled"]
         + $row["UNKNOWNTimeScheduled"]
         + $row["CRITICALTimeScheduled"];
-    if ($duration == 0) {
+    if ($duration === 0) {
         continue;
-    }    
+    }
     /* Percentage by status */
     $row["OK_MP"] = round($row["OKTimeScheduled"] * 100 / $duration, 2);
     $row["WARNING_MP"] = round($row["WARNINGTimeScheduled"] * 100 / $duration, 2);

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
@@ -201,7 +201,13 @@ $dbResult->bindValue(':endDate', $endDate, PDO::PARAM_INT);
 $dbResult->execute();
 
 while ($row = $dbResult->fetch()) {
-    $duration = $row["date_end"] - $row["date_start"];
+    $duration = $row["OKTimeScheduled"]
+        + $row["WARNINGTimeScheduled"]
+        + $row["UNKNOWNTimeScheduled"]
+        + $row["CRITICALTimeScheduled"];
+    if ($duration == 0) {
+        continue;
+    }    
     /* Percentage by status */
     $duration = $row["OKTimeScheduled"]
         + $row["WARNINGTimeScheduled"]

--- a/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+++ b/centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
@@ -209,10 +209,6 @@ while ($row = $dbResult->fetch()) {
         continue;
     }    
     /* Percentage by status */
-    $duration = $row["OKTimeScheduled"]
-        + $row["WARNINGTimeScheduled"]
-        + $row["UNKNOWNTimeScheduled"]
-        + $row["CRITICALTimeScheduled"];
     $row["OK_MP"] = round($row["OKTimeScheduled"] * 100 / $duration, 2);
     $row["WARNING_MP"] = round($row["WARNINGTimeScheduled"] * 100 / $duration, 2);
     $row["UNKNOWN_MP"] = round($row["UNKNOWNTimeScheduled"] * 100 / $duration, 2);


### PR DESCRIPTION
## Description

To avoid this kind of error:
`[10-Sep-2024 22:58:27 Pacific/Tahiti] PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /usr/share/centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php:225
Stack trace:
#0 {main}  thrown in /usr/share/centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php on line 225`

We should exclude duration equal to 0. It means we do not list 100% UNDETERMINED days in the CSV.

**Fixes** # MON-147657

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master
