### PR TITLE
Fix([Resources status]): Refresh of the listing is triggered on hover on main left menu

### DIFF
--- a/centreon/packages/ui/src/PopoverMenu/index.tsx
+++ b/centreon/packages/ui/src/PopoverMenu/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import { type Dispatch, type SetStateAction, useEffect, useState } from 'react';
 
 import { makeStyles } from 'tss-react/mui';
 
@@ -6,9 +6,9 @@ import {
   ClickAwayListener,
   Paper,
   Popper,
-  PopperPlacementType
+  type PopperPlacementType
 } from '@mui/material';
-import { PopperProps } from '@mui/material/Popper';
+import type { PopperProps } from '@mui/material/Popper';
 
 import { IconButton } from '..';
 
@@ -80,7 +80,7 @@ const PopoverMenu = ({
   };
 
   useEffect(() => {
-    if (!canOpen) {
+    if (!canOpen && isOpen) {
       close();
     }
   }, [canOpen]);


### PR DESCRIPTION
**Description** :  close only when the poper is opened 

**video**

[screen-capture (1).webm](https://github.com/user-attachments/assets/faa23e68-7d76-49c7-ad04-f9c0ad5b3133)

