### PR TITLE
enh(UI): Graph Chart - callback to update mousePosition [x,y]

### DIFF
--- a/centreon/packages/ui-context/src/types.ts
+++ b/centreon/packages/ui-context/src/types.ts
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 
 export enum ListingVariant {
   compact = 'compact',
@@ -88,6 +88,7 @@ export interface FeatureFlags {
   adExclusionPeriods?: boolean;
   notification?: boolean;
   vault?: boolean;
+  mapVisxViewer?: boolean;
 }
 
 export interface PlatformFeatures {

--- a/centreon/packages/ui/src/Graph/Chart/Chart.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/Chart.tsx
@@ -56,6 +56,10 @@ interface Props extends LineChartProps {
   shapeLines?: GlobalAreaLines;
   thresholdUnit?: string;
   thresholds?: ThresholdsModel;
+  transformMatrix?: {
+    fx?: (pointX: number) => number;
+    fy?: (pointY: number) => number;
+  }
 }
 
 const filterLines = (lines: Array<Line>, displayThreshold): Array<Line> => {
@@ -98,7 +102,8 @@ const Chart = ({
   thresholds,
   thresholdUnit,
   limitLegend,
-  skipIntersectionObserver
+  skipIntersectionObserver,
+  transformMatrix
 }: Props): JSX.Element => {
   const { classes } = useChartStyles();
 
@@ -320,6 +325,7 @@ const Chart = ({
                       graphInterval
                     }}
                     zoomData={{ ...zoomPreview }}
+                    transformMatrix={transformMatrix}
                   />
                   {thresholds?.enabled && (
                     <Thresholds

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/useTickGraph.ts
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/useTickGraph.ts
@@ -58,10 +58,10 @@ const useTickGraph = ({
       return;
     }
     const mousePositionTimeTick = mousePosition
-      ? getTimeValue({ timeSeries, x: mousePosition[0], xScale }).timeTick
+      ? getTimeValue({ timeSeries, x: mousePosition[0], xScale })?.timeTick
       : 0;
     const timeTickValue = mousePosition
-      ? new Date(mousePositionTimeTick)
+      ? new Date(mousePositionTimeTick || 0)
       : null;
 
     setTickAxisBottom(timeTickValue);

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/index.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/index.tsx
@@ -76,13 +76,18 @@ interface Props {
   commonData: CommonData;
   timeShiftZonesData: TimeShiftZonesData;
   zoomData: ZoomPreviewModel;
+  transformMatrix?: {
+    fx?: (pointX: number) => number;
+    fy?: (pointY: number) => number;
+  }
 }
 
 const InteractionWithGraph = ({
   zoomData,
   commonData,
   annotationData,
-  timeShiftZonesData
+  timeShiftZonesData,
+  transformMatrix
 }: Props): JSX.Element => {
   const { classes } = useStyles();
 
@@ -127,7 +132,10 @@ const InteractionWithGraph = ({
     if (!mousePoint) {
       return;
     }
-    updateMousePosition([mousePoint.x, mousePoint.y]);
+    updateMousePosition([
+      transformMatrix?.fx?.(mousePoint.x) ?? mousePoint.x,
+      transformMatrix?.fy?.(mousePoint.y) ?? mousePoint.y
+    ]);
   };
 
   const mouseDown = (event): void => {

--- a/centreon/packages/ui/src/Graph/Chart/helpers/index.ts
+++ b/centreon/packages/ui/src/Graph/Chart/helpers/index.ts
@@ -2,15 +2,15 @@ import dayjs from 'dayjs';
 import durationPlugin from 'dayjs/plugin/duration';
 import { gt, gte, isEmpty, isNil, prop, propEq, reject, sortBy } from 'ramda';
 
-import { LineChartData } from '../../common/models';
+import type { LineChartData } from '../../common/models';
 import {
   getLineData,
   getTimeSeries,
   getTimeValue
 } from '../../common/timeSeries';
-import { LinesData } from '../BasicComponents/Lines/models';
+import type { LinesData } from '../BasicComponents/Lines/models';
 import { dateFormat, timeFormat } from '../common';
-import { GetDate, GraphInterval } from '../models';
+import type { GetDate, GraphInterval } from '../models';
 
 dayjs.extend(durationPlugin);
 
@@ -56,11 +56,11 @@ export const displayArea = (data: unknown): boolean =>
   !isEmpty(data) && !isNil(data);
 
 export const getDate = ({ positionX, xScale, timeSeries }: GetDate): Date => {
-  const { timeTick } = getTimeValue({
+  const timeValue = getTimeValue({
     timeSeries,
     x: positionX,
     xScale
   });
 
-  return new Date(timeTick);
+  return new Date(timeValue?.timeTick || 0);
 };

--- a/centreon/packages/ui/src/Graph/Chart/index.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/index.tsx
@@ -34,6 +34,10 @@ interface Props extends Partial<LineChartProps> {
   thresholds?: Thresholds;
   getRef?: (ref: MutableRefObject<HTMLDivElement | null>) => void;
   containerStyle?: string;
+  transformMatrix?: {
+    fx?: (pointX: number) => number;
+    fy?: (pointY: number) => number;
+  }
 }
 
 const WrapperChart = ({
@@ -65,6 +69,7 @@ const WrapperChart = ({
   thresholdUnit,
   limitLegend,
   getRef,
+  transformMatrix,
   ...rest
 }: Props): JSX.Element | null => {
   const { classes, cx } = useChartStyles();
@@ -121,6 +126,7 @@ const WrapperChart = ({
               width={width ?? responsiveWidth}
               zoomPreview={zoomPreview}
               skipIntersectionObserver={rest.skipIntersectionObserver}
+              transformMatrix={transformMatrix}
             />
           );
         }}

--- a/centreon/packages/ui/src/components/Zoom/Zoom.tsx
+++ b/centreon/packages/ui/src/components/Zoom/Zoom.tsx
@@ -3,10 +3,10 @@ import { Zoom as VisxZoom } from '@visx/zoom';
 import { ParentSize } from '../..';
 
 import ZoomContent from './ZoomContent';
-import { MinimapPosition } from './models';
+import type { MinimapPosition } from './models';
 
 export interface ZoomProps {
-  children: JSX.Element | (({ width, height }) => JSX.Element);
+  children: JSX.Element | (({ width, height, transformMatrix }) => JSX.Element);
   id?: number | string;
   minimapPosition?: MinimapPosition;
   scaleMax?: number;

--- a/centreon/packages/ui/src/components/Zoom/ZoomContent.tsx
+++ b/centreon/packages/ui/src/components/Zoom/ZoomContent.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { RectClipPath } from '@visx/clip-path';
-import { ProvidedZoom } from '@visx/zoom/lib/types';
+import type { ProvidedZoom } from '@visx/zoom/lib/types';
 
 import ZoomInIcon from '@mui/icons-material/Add';
 import ZoomOutIcon from '@mui/icons-material/Remove';
@@ -12,7 +12,7 @@ import { IconButton } from '../Button';
 import Minimap from './Minimap';
 import { useZoomStyles } from './Zoom.styles';
 import { minimapScale, radius } from './constants';
-import { ChildrenProps, MinimapPosition, ZoomState } from './models';
+import type { ChildrenProps, MinimapPosition, ZoomState } from './models';
 import { useZoom } from './useZoom';
 
 export interface Props {

--- a/centreon/packages/ui/src/components/index.ts
+++ b/centreon/packages/ui/src/components/index.ts
@@ -12,5 +12,6 @@ export * from './Avatar';
 export * from './CollapsibleItem';
 export * from './Inputs';
 export { default as Zoom } from './Zoom/Zoom';
+export type { ZoomState } from './Zoom/models';
 export * from './Tabs';
 export { default as CopyCommand } from './CopyCommand/CopyCommand';

--- a/centreon/www/front_src/src/api/decoders.ts
+++ b/centreon/www/front_src/src/api/decoders.ts
@@ -117,11 +117,13 @@ export const featuresFlagDecoder = JsonDecoder.object<FeatureFlags>(
   {
     adExclusionPeriods: JsonDecoder.optional(JsonDecoder.boolean),
     notification: JsonDecoder.optional(JsonDecoder.boolean),
-    vault: JsonDecoder.optional(JsonDecoder.boolean)
+    vault: JsonDecoder.optional(JsonDecoder.boolean),
+    mapVisxViewer: JsonDecoder.optional(JsonDecoder.boolean),
   },
   'Feature flags',
   {
-    adExclusionPeriods: 'ad_exclusion_periods'
+    adExclusionPeriods: 'ad_exclusion_periods',
+    mapVisxViewer: 'map_visx_viewer'
   }
 );
 


### PR DESCRIPTION
## Description
To support zoom and translate inside svg (currently like MAP module)
we enhanced Graph/Chart with a new prop as a callback "transformMatrix"
to update mouse position inside Graph/Chart/InteractiveComponents 

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
