### PR TITLE
fix(graph): dashboard invalid metric format fixed

### DIFF
--- a/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindPerformanceMetricsData/PerformanceMetricsDataFactory.php
@@ -57,18 +57,20 @@ use Core\Metric\Domain\Model\MetricInformation\ThresholdInformation;
  *          ds_color_line: string,
  *          ds_transparency: ?float,
  *          ds_color_area: ?string,
+ *          ds_color_area_warn?: string,
+ *          ds_color_area_crit?: string,
  *          legend: ?string,
  *          ds_filled: ?int,
  *          ds_invert: ?int,
  *          ds_stack: ?int,
- *          ds_order: ?int
+ *          ds_order: ?int,
  *     },
  *     warn: ?float,
  *     warn_low: ?float,
  *     crit: ?float,
  *     crit_low: ?float,
- *     ds_color_area_warn: string,
- *     ds_color_area_crit: string,
+ *     ds_color_area_warn?: string,
+ *     ds_color_area_crit?: string,
  *     data: array<float|null>,
  *     prints: array<array<string>>,
  *     min: ?float,
@@ -98,6 +100,8 @@ use Core\Metric\Domain\Model\MetricInformation\ThresholdInformation;
  *     ds_color_line_mode: int,
  *     ds_color_line: string,
  *     ds_transparency: ?float,
+ *     ds_color_area_warn?: string,
+ *     ds_color_area_crit?: string,
  *     ds_color_area: ?string,
  *     legend: ?string,
  *     ds_filled: ?int,
@@ -253,8 +257,8 @@ class PerformanceMetricsDataFactory
                     $metric['warn_low'] !== null ? (float) $metric['warn_low'] : null,
                     $metric['crit'] !== null ? (float) $metric['crit'] : null,
                     $metric['crit_low'] !== null ? (float) $metric['crit_low'] : null,
-                    $metric['ds_color_area_warn'],
-                    $metric['ds_color_area_crit']
+                    $metric['ds_color_area_warn'] ?? $dsData['ds_color_area_warn'] ?? '',
+                    $metric['ds_color_area_crit'] ?? $dsData['ds_color_area_crit'] ?? ''
                 );
 
                 $realTimeDataInformation = new RealTimeDataInformation(


### PR DESCRIPTION
Fixed an issue regarding metric threshold colors.
When colors were customized at curve template level it caused an error.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
