### PR TITLE
fix : backport problems fixed for CentreonDB and CentreonLog

### DIFF
--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -6878,13 +6878,13 @@
             "version": "23.04.x-dev",
             "source": {
                 "type": "git",
-                "url": "git@github.com:centreon/centreon-test-lib.git",
-                "reference": "0b72ad99bb6faaa4232e785e5e5d8b8f1b95cb1a"
+                "url": "https://github.com/centreon/centreon-test-lib.git",
+                "reference": "0c66b4be9c296fc2820c350a9deb7a16054167eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/0b72ad99bb6faaa4232e785e5e5d8b8f1b95cb1a",
-                "reference": "0b72ad99bb6faaa4232e785e5e5d8b8f1b95cb1a",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/0c66b4be9c296fc2820c350a9deb7a16054167eb",
+                "reference": "0c66b4be9c296fc2820c350a9deb7a16054167eb",
                 "shasum": ""
             },
             "require": {
@@ -6931,7 +6931,11 @@
                 "phpunit",
                 "testing"
             ],
-            "time": "2023-12-08T11:20:10+00:00"
+            "support": {
+                "issues": "https://github.com/centreon/centreon-test-lib/issues",
+                "source": "https://github.com/centreon/centreon-test-lib/tree/23.04.x"
+            },
+            "time": "2024-09-03T09:54:03+00:00"
         },
         {
             "name": "composer/pcre",
@@ -12014,5 +12018,5 @@
     "platform-overrides": {
         "php": "8.1"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/centreon/tests/php/www/class/CentreonLogTest.php
+++ b/centreon/tests/php/www/class/CentreonLogTest.php
@@ -39,6 +39,7 @@ it('test contructor arguments of CentreonLog', function () {
             CentreonLog::TYPE_LDAP => __DIR__ . '/log/ldap.log',
             CentreonLog::TYPE_UPGRADE => __DIR__ . '/log/upgrade.log',
             CentreonLog::TYPE_PLUGIN_PACK_MANAGER => __DIR__ . '/log/plugin-pack-manager.log',
+            CentreonLog::TYPE_BUSINESS_LOG => __DIR__ . '/log/centreon-web.log',
             99 => __DIR__ . '/log/custom.log',
         ]
     );
@@ -51,14 +52,16 @@ it('test changing the path of an existing log', function () {
         ->pushLogFileHandler(CentreonLog::TYPE_SQL, 'sql.log')
         ->pushLogFileHandler(CentreonLog::TYPE_LDAP, 'ldap.log')
         ->pushLogFileHandler(CentreonLog::TYPE_UPGRADE, 'upgrade.log')
-        ->pushLogFileHandler(CentreonLog::TYPE_PLUGIN_PACK_MANAGER, 'plugin.log');
+        ->pushLogFileHandler(CentreonLog::TYPE_PLUGIN_PACK_MANAGER, 'plugin.log')
+        ->pushLogFileHandler(CentreonLog::TYPE_BUSINESS_LOG, 'centreon-web.log');
     expect($loggerTest->getLogFileHandler())->toEqual(
         [
             CentreonLog::TYPE_LOGIN => '/user/test/login.log',
             CentreonLog::TYPE_SQL => '/user/test/sql.log',
             CentreonLog::TYPE_LDAP => '/user/test/ldap.log',
             CentreonLog::TYPE_UPGRADE => '/user/test/upgrade.log',
-            CentreonLog::TYPE_PLUGIN_PACK_MANAGER => '/user/test/plugin.log'
+            CentreonLog::TYPE_PLUGIN_PACK_MANAGER => '/user/test/plugin.log',
+            CentreonLog::TYPE_BUSINESS_LOG => '/user/test/centreon-web.log'
         ]
     );
 });
@@ -104,6 +107,7 @@ it('test log file handler is correct', function () {
             CentreonLog::TYPE_LDAP => __DIR__ . '/log/ldap.log',
             CentreonLog::TYPE_UPGRADE => __DIR__ . '/log/upgrade.log',
             CentreonLog::TYPE_PLUGIN_PACK_MANAGER => __DIR__ . '/log/plugin-pack-manager.log',
+            CentreonLog::TYPE_BUSINESS_LOG => __DIR__ . '/log/centreon-web.log',
             99 => __DIR__ . '/log/custom.log',
         ]
     );

--- a/centreon/www/class/centreonDB.class.php
+++ b/centreon/www/class/centreonDB.class.php
@@ -759,11 +759,14 @@ class CentreonDB extends PDO
                 $sth->execute($parameters);
             }
         } catch (\PDOException $e) {
-            // skip if we use CentreonDBStatement::execute method
             if (is_null($parameters)) {
-                $string = str_replace("`", "", $queryString);
-                $string = str_replace('*', "\*", $string);
-                $this->logSqlError($string, $e->getMessage());
+                $queryString = str_replace(["`", '*'], ["", "\*"], $queryString);
+                $this->writeDbLog(
+                    'Error while using CentreonDb::query',
+                    ['bind_params' => $parameters],
+                    query: $queryString,
+                    exception: $e
+                );
             }
 
             throw $e;
@@ -799,7 +802,11 @@ class CentreonDB extends PDO
             $rows = $result->fetchAll();
             $this->requestSuccessful++;
         } catch (\PDOException $e) {
-            $this->logSqlError($query_string, $e->getMessage());
+            $this->writeDbLog(
+                'Error while using CentreonDb::getAll',
+                query: $query_string,
+                exception: $e
+            );
             throw new \PDOException($e->getMessage(), hexdec($e->getCode()));
         }
 

--- a/centreon/www/class/centreonLog.class.php
+++ b/centreon/www/class/centreonLog.class.php
@@ -171,6 +171,7 @@ class CentreonLog
     public const TYPE_LDAP = 3;
     public const TYPE_UPGRADE = 4;
     public const TYPE_PLUGIN_PACK_MANAGER = 5;
+    public const TYPE_BUSINESS_LOG = 6;
 
     private const DEFAULT_LOG_FILES = [
         self::TYPE_LOGIN => 'login.log',
@@ -178,6 +179,7 @@ class CentreonLog
         self::TYPE_LDAP => 'ldap.log',
         self::TYPE_UPGRADE => 'upgrade.log',
         self::TYPE_PLUGIN_PACK_MANAGER => 'plugin-pack-manager.log',
+        self::TYPE_BUSINESS_LOG => 'centreon-web.log'
     ];
 
     /** @var array<int,string> */


### PR DESCRIPTION
## Description

### Fixed

* called method not exists in CentreonDB fixed
* backport for centreonLog not executed fixed

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 23.04.x

<h2> How this pull request can be tested ? </h2>

No tests

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
