### PR TITLE
Update OneLoginSettingsFormatter.php. Closes issue centreon/issues#5166

### DIFF
--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php
@@ -73,7 +73,7 @@ class OneLoginSettingsFormatter implements SettingsFormatterInterface
                 'x509cert' => $customConfiguration->getPublicCertificate(),
             ],
             'security' => [
-                'requestedAuthnContextComparison' => 'minimum',
+                'requestedAuthnContext' => false,
             ],
         ];
     }


### PR DESCRIPTION
Setting 'requestedAuthnContext' => false, fixes SAML two login errors:
1. Comparison value must be 'exact' when using PasswordProtectedTransport.
2. Users authenticated with another method than PasswordProtectedTransport, are unable to log in.
