### PR TITLE
Update OneLoginSettingsFormatter.php

### DIFF
--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php
@@ -72,6 +72,9 @@ class OneLoginSettingsFormatter implements SettingsFormatterInterface
                 ],
                 'x509cert' => $customConfiguration->getPublicCertificate(),
             ],
+            'security' => [
+                'requestedAuthnContext' => false,
+            ],
         ];
     }
 }


### PR DESCRIPTION
Users logging with SAML can be blocked due to the default config of OneLogin. 
To fix that RequestedAuthnContext must be set to false. 
This allows all users already authenticated in the identity provider to log in without error.