### PR TITLE
fix(configuration): manage the visibility of log options

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -8880,7 +8880,7 @@ msgstr "octets"
 msgid "Warning: this value can be dangerous, use -1 if you have any doubt."
 msgstr ""
 "Attention : le changement de cette valeur peut avoir des conséquences "
-"importantes. Utiliser -1 si vous avez le moindre doute"
+"importantes. Utilisez -1 si vous avez le moindre doute"
 
 #: centreon-web/www/include/configuration/configNagios/formNagios.php:905
 msgid "This option must be enabled for Centreon Dashboard module."

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -8880,7 +8880,7 @@ msgstr "octets"
 msgid "Warning: this value can be dangerous, use -1 if you have any doubt."
 msgstr ""
 "Attention : le changement de cette valeur peut avoir des conséquences "
-"importantes. Utiliser '-1' si vous avez le moindre doute"
+"importantes. Utiliser -1 si vous avez le moindre doute"
 
 #: centreon-web/www/include/configuration/configNagios/formNagios.php:905
 msgid "This option must be enabled for Centreon Dashboard module."

--- a/centreon/www/include/configuration/configNagios/formNagios.ihtml
+++ b/centreon/www/include/configuration/configNagios/formNagios.ihtml
@@ -473,9 +473,9 @@
         <td class="FormRowField"><img class="helpTooltip" name="logger_version">&nbsp;{$form.logger_version.label}</td>
         <td class="FormRowValue">{$form.logger_version.html}</td>
       </tr>
-      <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="use_syslog">&nbsp;{$form.use_syslog.label}</td><td class="FormRowValue">{$form.use_syslog.html}</td></tr>
-      <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="log_notifications">&nbsp;{$form.log_notifications.label}</td><td class="FormRowValue">{$form.log_notifications.html}</td></tr>
-            <tr class="list_one">
+      <tr class="list_one logger_v1_option"><td class="FormRowField"><img class="helpTooltip" name="use_syslog">&nbsp;{$form.use_syslog.label}</td><td class="FormRowValue">{$form.use_syslog.html}</td></tr>
+      <tr class="list_two logger_v1_option"><td class="FormRowField"><img class="helpTooltip" name="log_notifications">&nbsp;{$form.log_notifications.label}</td><td class="FormRowValue">{$form.log_notifications.html}</td></tr>
+            <tr class="list_one logger_v1_option">
                 <td class="FormRowField">
                     <div class="formRowLabel">
                         <div>
@@ -491,8 +491,8 @@
                     </div></td>
                 <td class="FormRowValue">{$form.log_service_retries.html}</td>
             </tr>
-            <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="log_host_retries">&nbsp;{$form.log_host_retries.label}</td><td class="FormRowValue">{$form.log_host_retries.html}</td></tr>
-            <tr class="list_one">
+            <tr class="list_two logger_v1_option"><td class="FormRowField"><img class="helpTooltip" name="log_host_retries">&nbsp;{$form.log_host_retries.label}</td><td class="FormRowValue">{$form.log_host_retries.html}</td></tr>
+            <tr class="list_one logger_v1_option">
                 <td class="FormRowField">
                     <div class="formRowLabel">
                         <div>
@@ -508,7 +508,7 @@
                     </td>
                 <td class="FormRowValue">{$form.log_event_handlers.html}</td>
             </tr>
-            <tr class="list_one">
+            <tr class="list_one logger_v1_option">
                 <td class="FormRowField">
                     <div class="formRowLabel">
                         <div>
@@ -524,7 +524,7 @@
                 </td>
                 <td class="FormRowValue">{$form.log_external_commands.html}</td>
             </tr>
-            <tr class="list_two">
+            <tr class="list_two logger_v1_option">
                 <td class="FormRowField">
                     <div class="formRowLabel">
                         <div>
@@ -540,7 +540,7 @@
                     </div></td>
                 <td class="FormRowValue">{$form.log_passive_checks.html}</td>
             </tr>
-            <tr class="list_one">
+            <tr class="list_one logger_v1_option">
                 <td class="FormRowField">
                     <div class="formRowLabel">
                         <div>
@@ -1048,20 +1048,31 @@ jQuery(document).ready(function() {
     });
     jQuery('input[name=event_broker_options]').trigger('change');
 
-    $('input[name="logger_version[logger_version]"]').change(function (e) {
-      var $this = $(this);
-      if (! $this.is(':checked')) {
-        return;
-      }
-      if ($this.attr('value') === 'log_legacy_enabled') {
-        $(".logger_v1_option").show();
-        $(".logger_v2_option").hide();
-      } else {
-        $(".logger_v2_option").show();
-        $(".logger_v1_option").hide();
-      }
-    });
-    $('input[name="logger_version[logger_version]"]').trigger('change');
+    var $loggerInput = $('input[name="logger_version[logger_version]"]');
+
+    var updateLoggerOptions = function() {
+        var value;
+        if ($loggerInput.is(':radio')) {
+            value = $loggerInput.filter(':checked').val();
+        } else {
+            value = $loggerInput.val();
+        }
+
+        if (value === 'log_legacy_enabled') {
+            $(".logger_v1_option").show();
+            $(".logger_v2_option").hide();
+        } else {
+            $(".logger_v2_option").show();
+            $(".logger_v1_option").hide();
+        }
+    };
+
+    // Bind the update function to change events
+    $loggerInput.on('change', updateLoggerOptions);
+
+    // Invoke the update function after all scripts have loaded
+    jQuery(window).on('load', updateLoggerOptions);
 });
+
 </script>
 {/literal}


### PR DESCRIPTION
## Description

Managing the visibility of some log options(v1/v2) in pollers engine configuration

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

see ticket [MON-147567](https://centreon.atlassian.net/browse/MON-147567)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-147567]: https://centreon.atlassian.net/browse/MON-147567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ