### PR TITLE
enh(ACC): activate topology_show flag for ACC page

### DIFF
--- a/centreon/www/install/insertTopology.sql
+++ b/centreon/www/install/insertTopology.sql
@@ -193,7 +193,7 @@ INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`,
 INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_order`, `topology_group`, `topology_feature_flag`) VALUES ( 'Resource Access Management', '/administration/resource-access/rules', '1', '1', 502, 50206, 1, 1, 'resource_access_management');
 
 -- add additional connector configuration page
-INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_order`, `topology_group`, `topology_show`) VALUES ( 'Additional connector configurations', '/configuration/additional-connector-configurations', '1', '1', 6, 618, 1, 1, '0');
+INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_order`, `topology_group`, `topology_show`) VALUES ( 'Additional Connector Configurations', '/configuration/additional-connector-configurations', '1', '1', 6, 618, 1, 1, '1');
 
 INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_order`, `topology_group`, `topology_feature_flag`) VALUES ( 'Vault', '/administration/parameters/vault', '1', '1', 501, 50112, 100, 1, 'vault');
 

--- a/centreon/www/install/php/Update-24.09.0.php
+++ b/centreon/www/install/php/Update-24.09.0.php
@@ -77,7 +77,7 @@ $insertIntoTopology = function (CentreonDB $pearDB) use (&$errorMessage): void {
     $errorMessage = 'Unable to insert data into table topology';
     $statement = $pearDB->executeQuery(
         <<<'SQL'
-            SELECT 1 FROM `topology` WHERE `topology_name` = 'Additional Connector Configuration'
+            SELECT 1 FROM `topology` WHERE `topology_name` = 'Additional Connector Configurations'
             SQL
     );
 
@@ -85,7 +85,7 @@ $insertIntoTopology = function (CentreonDB $pearDB) use (&$errorMessage): void {
         $pearDB->executeQuery(
             <<<'SQL'
                 INSERT INTO `topology` (`topology_name`, `topology_url`, `readonly`, `is_react`, `topology_parent`, `topology_page`, `topology_order`, `topology_group`, `topology_show`)
-                VALUES ( 'Additional Connector Configuration', '/configuration/additional-connector-configurations', '1', '1', 6, 618, 1, 1, '0')
+                VALUES ( 'Additional Connector Configurations', '/configuration/additional-connector-configurations', '1', '1', 6, 618, 1, 1, '0')
                 SQL
         );
     }
@@ -142,9 +142,9 @@ $addCentreonBrokerForeignKeyOnBrokerLogTable = function (CentreonDB $pearDB) use
         $pearDB->executeQuery(
             <<<'SQL'
             ALTER TABLE `cfg_centreonbroker_log`
-            ADD CONSTRAINT `cfg_centreonbroker_log_ibfk_01` 
-            FOREIGN KEY (`id_centreonbroker`) 
-            REFERENCES `cfg_centreonbroker` (`config_id`) 
+            ADD CONSTRAINT `cfg_centreonbroker_log_ibfk_01`
+            FOREIGN KEY (`id_centreonbroker`)
+            REFERENCES `cfg_centreonbroker` (`config_id`)
             ON DELETE CASCADE
             SQL
         );

--- a/centreon/www/install/php/Update-24.10.0.php
+++ b/centreon/www/install/php/Update-24.10.0.php
@@ -81,6 +81,19 @@ $addDisableServiceCheckColumn = function (CentreonDB $pearDB) use (&$errorMessag
     }
 };
 
+// ACC
+$fixNamingAndActivateAccTopology = function (CentreonDB $pearDB) use (&$errorMessage): void {
+    $errorMessage = 'Unable to update table topology';
+    $pearDB->executeQuery(
+        <<<'SQL'
+            UPDATE `topology`
+            SET `topology_show` = '1',
+                `topology_name` = 'Additional Connector Configurations'
+            WHERE `topology_url` = '/configuration/additional-connector-configurations'
+            SQL
+    );
+};
+
 try {
     $addDisableServiceCheckColumn($pearDB);
 
@@ -91,6 +104,7 @@ try {
 
     $insertVaultConfiguration($pearDB);
     $insertWebPageWidget($pearDB);
+    $fixNamingAndActivateAccTopology($pearDB);
 
     $pearDB->commit();
 } catch (\Exception $e) {


### PR DESCRIPTION
## Description

- Activate topology_show flag for ACC page for platform >=24.10
-  Fix ACC topology page naming between different SQL scripts (install and update)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master
