### PR TITLE
enh(ceip): add agent configuration to ceip stats

### DIFF
--- a/centreon/cron/centreon-send-stats.php
+++ b/centreon/cron/centreon-send-stats.php
@@ -123,6 +123,7 @@ if ($isRemote === false) {
         $authentication['api_token'] = $oStatistics->getApiTokensInfo();
         $additional = [];
         $acc = $oStatistics->getAccData();
+        $pac = $oStatistics->getAgentConfigurationData();
 
         /*
          * Only send statistics if user using a free version has enabled this option
@@ -145,7 +146,8 @@ if ($isRemote === false) {
             'timezone' => $timezone,
             'authentication' => $authentication,
             'additional' => $additional,
-            'acc' => $acc
+            'acc' => $acc,
+            'poller-agent-configuration' => $pac
         ];
 
         if ( isset($options["d"]) || isset($options["debug"]) ) {

--- a/centreon/www/class/centreonStatistics.class.php
+++ b/centreon/www/class/centreonStatistics.class.php
@@ -410,6 +410,8 @@ class CentreonStatistics
     /**
      * Get poller/agent configuration data.
      *
+     * @throws CentreonDbException
+     *
      * @return array
      */
     public function getAgentConfigurationData(): array
@@ -423,7 +425,7 @@ class CentreonStatistics
                 SQL
         );
 
-        $total = $statement->fetchColumn();
+        $total =  $this->dbConfig->fetchColumn($statement);
 
         if ($total === false) {
             return $data;
@@ -441,7 +443,8 @@ class CentreonStatistics
                 SQL
         );
 
-        foreach ($statement->fetchAll(\PDO::FETCH_ASSOC) as $row) {
+        $results = $this->dbConfig->fetchAll($statement);
+        foreach ($results as $row) {
             $data[$row['type']]['configuration'] = $row['nb_ac_per_type'];
             $data[$row['type']]['pollers'] = $row['nb_poller_per_type'];
         }


### PR DESCRIPTION
## Description
Add  poller/agent configuration stat to CEIP cron:
- total of configurations
- total of configurations per type
- total of pollers per type
```
{
    ...
    "poller-agent-configuration": {
        "total": int,
        "telegraf": { 
            "configuration": int, 
            "pollers": int
        },
       ...
    }
}
```

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master
