### PR TITLE
fix(graph): fix blank page when user adds & updates a curve on mysql

### DIFF
--- a/centreon/www/include/views/componentTemplates/formComponentTemplate.php
+++ b/centreon/www/include/views/componentTemplates/formComponentTemplate.php
@@ -74,7 +74,7 @@ $stmt->closeCursor();
  */
 $dataSources = [];
 $stmt = $pearDBO->query(
-    'SELECT 1 AS REALTIME, `metric_name`, `unit_name` FROM `metrics` GROUP BY `metric_name` ORDER BY `metric_name`'
+    'SELECT 1 AS REALTIME, `metric_name`, `unit_name` FROM `metrics` GROUP BY `metric_name`, `unit_name` ORDER BY `metric_name`'
 );
 while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
     $dataSources[$row['metric_name']] = $row['metric_name'];


### PR DESCRIPTION
## Description

Fix blank page in Graphs when user tries to update or add a curve on MySQL 8

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
