### PR TITLE
fix(ci): restore centos7 web image with skip-maxscale

### DIFF
--- a/.github/docker/Dockerfile.centreon-web-centos7
+++ b/.github/docker/Dockerfile.centreon-web-centos7
@@ -1,0 +1,109 @@
+FROM centos:7 AS web_fresh
+RUN bash -e <<'EOF'
+for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-*);do
+  if [[ "$file" == "/etc/yum.repos.d/CentOS-CR.repo" ]];then
+    echo "Enabling vault.centos.org in $file"
+    sed -i 's/baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  else
+    echo "Disabling mirrorlist.centos.org in $file"
+    sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
+    echo "Enabling vault.centos.org in $file"
+    sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  fi
+done
+EOF
+RUN bash -e <<EOF
+  yum clean all --enablerepo=*
+  yum install -y centos-release-scl
+EOF
+RUN bash -e <<'EOF'
+for file in $(grep -l mirrorlist /etc/yum.repos.d/CentOS-SCLo*);do
+  echo "Disabling mirrorlist.centos.org in $file"
+  sed -i 's/mirrorlist\=/\#mirrorlist\=/g' $file
+  if [[ "$file" == "/etc/yum.repos.d/CentOS-SCLo-scl.repo" ]];then
+    echo "Enabling vault.centos.org in scl."
+    sed -i 's/\#\ baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  elif [[ "$file" == "/etc/yum.repos.d/CentOS-SCLo-scl-rh.repo" ]];then
+    echo "Enabling vault.centos.org in scl-rh"
+    sed -i 's/\#baseurl\=http\:\/\/mirror\.centos\.org/baseurl\=http\:\/\/vault\.centos\.org/g' $file
+  else
+    echo "Not a SCL repo file"
+  fi
+done
+EOF
+RUN bash -e <<EOF
+curl -o remi-release-7.rpm https://rpms.remirepo.net/enterprise/remi-release-7.rpm
+yum install -y remi-release-7.rpm
+rm -f remi-release-7.rpm
+yum-config-manager --enable remi-php81
+curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --os-type=rhel --os-version=7 --mariadb-server-version="mariadb-10.5" --skip-maxscale
+yum install -y MariaDB-server MariaDB-client
+rpm -e --nodeps galera-4
+rm -f /var/lib/mysql/ib_logfile0
+echo "[server]
+log_output=FILE
+general_log_file=/var/lib/mysql/queries.log
+general_log=0
+slow_query_log_file=/var/lib/mysql/slow_queries.log
+slow_query_log=1
+innodb_file_per_table
+innodb_flush_method=O_DIRECT
+innodb_log_file_size=4M
+innodb_fast_shutdown=0
+" > /etc/my.cnf.d/container.cnf
+yum-config-manager --add-repo https://packages.centreon.com/rpm-standard/22.10/el7/centreon-22.10.repo
+yum-config-manager --enable 'centreon-testing*'
+yum-config-manager --enable 'centreon-unstable*'
+yum clean all --enablerepo=*
+EOF
+RUN mkdir /tmp/rpms-centreon
+COPY *.rpm /tmp/rpms-centreon/
+RUN bash -e <<EOF
+rm -f /tmp/rpms-centreon/centreon-22.10*.rpm /tmp/rpms-centreon/centreon-central-22.10*.rpm
+yum install -y /tmp/rpms-centreon/centreon-*.rpm centreon-broker-cbd centreon-broker-influxdb libfaketime jq
+echo 'date.timezone = Europe/Paris' > /etc/php.d/centreon.ini
+touch /var/log/php-fpm/centreon-error.log
+chown apache:apache /var/log/php-fpm/centreon-error.log
+yum clean all --enablerepo=*
+EOF
+COPY --chmod=+x ./.github/scripts/entrypoint/container.sh /usr/share/centreon/container.sh
+COPY ./.github/scripts/entrypoint/container.d /usr/share/centreon/container.d
+COPY ./.github/scripts/init/* /etc/init.d/
+COPY --chmod=+x ./.github/scripts/autoinstall.php /usr/share/centreon/
+COPY --chown=apache:apache ./.github/scripts/configuration /usr/share/centreon/www/install/tmp/
+RUN <<EOF
+chmod +x /usr/share/centreon/container.d/*
+chmod +x /etc/init.d/*
+service mysql start
+mysql -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY 'centreon' WITH GRANT OPTION"
+cd /usr/share/centreon/www/install/steps/process
+su apache -s /bin/bash -c "php configFileSetup.php"
+su apache -s /bin/bash -c "php installConfigurationDb.php"
+su apache -s /bin/bash -c "php installStorageDb.php"
+su apache -s /bin/bash -c "php createDbUser.php"
+su apache -s /bin/bash -c "SERVER_ADDR='127.0.0.1' php insertBaseConf.php"
+su apache -s /bin/bash -c "php partitionTables.php"
+su apache -s /bin/bash -c "php generationCache.php"
+rm -rf /usr/share/centreon/www/install
+rm -f /usr/share/centreon/.env.local.php
+echo "APP_DEBUG=true" >> /usr/share/centreon/.env
+echo "DEBUG_LEVEL=300" >> /usr/share/centreon/.env
+su - apache -s /bin/bash -c "/usr/share/centreon/bin/console cache:clear --no-warmup"
+mysql -pcentreon -e "GRANT ALL ON *.* to 'root'@'localhost' IDENTIFIED BY '' WITH GRANT OPTION"
+mysql -e "GRANT ALL ON *.* to 'root'@'%' IDENTIFIED BY 'centreon' WITH GRANT OPTION"
+centreon -d -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1
+service mysql stop
+sed -i "5s/.*/    id: 1/" /etc/centreon-gorgone/config.d/40-gorgoned.yaml
+EOF
+EXPOSE 80 3306
+ENTRYPOINT ["/usr/share/centreon/container.sh"]
+FROM web_fresh AS web_standard
+COPY ./.github/scripts/sql /tmp/sql
+RUN bash -e <<EOF
+service mysql start
+mysql centreon < /tmp/sql/standard.sql
+mysql centreon < /tmp/sql/media.sql
+mysql centreon < /tmp/sql/openldap.sql
+centreon -d -u admin -p Centreon\!2021 -a POLLERGENERATE -v 1
+service mysql stop
+EOF


### PR DESCRIPTION
## Description

* restore web centos7 image with skip-maxscale option for mariadb setup

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
