### PR TITLE
fix(ci): fix cloud context detection when onprem and cloud have the same version

### DIFF
--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -135,6 +135,16 @@ jobs:
             GITHUB_RELEASE_CLOUD=1
           fi
 
+          # Detect cloud context + handle PRs that do not directly target dev branches
+          #GIT_BRANCH_EXISTS=$(git ls-remote -h https://github.com/centreon/${{ github.repository }}.git | grep -E "refs/heads/dev-$MAJOR.x$" >/dev/null 2>&1 && echo yes || echo no)
+          # if current branch major vrsion has a matching dev-$MAJOR branch => onprem version
+          if [[ git ls-remote -q | grep -E "refs/heads/$MAJOR.x" >/dev/null 2>&1 ]]; then
+            GITHUB_RELEASE_CLOUD=0
+          # if current branch major version is greater or equal than the develop branch major version ==> cloud version
+          elif [[ "$(printf '%s\n' "${{ steps.latest_major_version.outputs.latest_major_version }}" "$MAJOR" | sort -V | head -n1)" == "${{ steps.latest_major_version.outputs.latest_major_version }}" ]]; then
+            GITHUB_RELEASE_CLOUD=1
+          fi
+
           case "$BRANCHNAME" in
             master)
               echo "release=1" >> $GITHUB_OUTPUT

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -137,7 +137,7 @@ jobs:
 
           # Detect cloud context + handle PRs that do not directly target dev branches
           #GIT_BRANCH_EXISTS=$(git ls-remote -h https://github.com/centreon/${{ github.repository }}.git | grep -E "refs/heads/dev-$MAJOR.x$" >/dev/null 2>&1 && echo yes || echo no)
-          # if current branch major vrsion has a matching dev-$MAJOR branch => onprem version
+          # if current branch major version has a matching dev-$MAJOR branch => onprem version
           if [[ git ls-remote -q | grep -E "refs/heads/$MAJOR.x" >/dev/null 2>&1 ]]; then
             GITHUB_RELEASE_CLOUD=0
           # if current branch major version is greater or equal than the develop branch major version ==> cloud version

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -131,7 +131,6 @@ jobs:
           GITHUB_RELEASE_TYPE=$(echo $BRANCHNAME |cut -d '-' -f 1)
 
           # Detect cloud context + handle PRs that do not directly target dev branches
-          #GIT_BRANCH_EXISTS=$(git ls-remote -h https://github.com/centreon/${{ github.repository }}.git | grep -E "refs/heads/dev-$MAJOR.x$" >/dev/null 2>&1 && echo yes || echo no)
           # if current branch major version has a matching dev-$MAJOR branch => onprem version
           if git ls-remote -q | grep -E "refs/heads/dev-$MAJOR.x" >/dev/null 2>&1; then
             GITHUB_RELEASE_CLOUD=0

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -138,7 +138,7 @@ jobs:
           # Detect cloud context + handle PRs that do not directly target dev branches
           #GIT_BRANCH_EXISTS=$(git ls-remote -h https://github.com/centreon/${{ github.repository }}.git | grep -E "refs/heads/dev-$MAJOR.x$" >/dev/null 2>&1 && echo yes || echo no)
           # if current branch major version has a matching dev-$MAJOR branch => onprem version
-          if [[ git ls-remote -q | grep -E "refs/heads/$MAJOR.x" >/dev/null 2>&1 ]]; then
+          if git ls-remote -q | grep -E "refs/heads/$MAJOR.x" >/dev/null 2>&1; then
             GITHUB_RELEASE_CLOUD=0
           # if current branch major version is greater or equal than the develop branch major version ==> cloud version
           elif [[ "$(printf '%s\n' "${{ steps.latest_major_version.outputs.latest_major_version }}" "$MAJOR" | sort -V | head -n1)" == "${{ steps.latest_major_version.outputs.latest_major_version }}" ]]; then

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -130,15 +130,10 @@ jobs:
           GITHUB_RELEASE_CLOUD=0
           GITHUB_RELEASE_TYPE=$(echo $BRANCHNAME |cut -d '-' -f 1)
 
-          # if current branch major version is greater or equal than the develop branch major version ==> cloud version
-          if [[ "$(printf '%s\n' "${{ steps.latest_major_version.outputs.latest_major_version }}" "$MAJOR" | sort -V | head -n1)" == "${{ steps.latest_major_version.outputs.latest_major_version }}" ]]; then
-            GITHUB_RELEASE_CLOUD=1
-          fi
-
           # Detect cloud context + handle PRs that do not directly target dev branches
           #GIT_BRANCH_EXISTS=$(git ls-remote -h https://github.com/centreon/${{ github.repository }}.git | grep -E "refs/heads/dev-$MAJOR.x$" >/dev/null 2>&1 && echo yes || echo no)
           # if current branch major version has a matching dev-$MAJOR branch => onprem version
-          if git ls-remote -q | grep -E "refs/heads/$MAJOR.x" >/dev/null 2>&1; then
+          if git ls-remote -q | grep -E "refs/heads/dev-$MAJOR.x" >/dev/null 2>&1; then
             GITHUB_RELEASE_CLOUD=0
           # if current branch major version is greater or equal than the develop branch major version ==> cloud version
           elif [[ "$(printf '%s\n' "${{ steps.latest_major_version.outputs.latest_major_version }}" "$MAJOR" | sort -V | head -n1)" == "${{ steps.latest_major_version.outputs.latest_major_version }}" ]]; then


### PR DESCRIPTION
## Description

* handle the case when a dev-xxx and develop branch have the same MAJOR version, to properly define context

**Fixes** #MON-150246

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
