### PR TITLE
Mon 150246 ci detect cloud context when onpren and cloud have the same version release2410

### DIFF
--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -130,10 +130,11 @@ jobs:
           GITHUB_RELEASE_CLOUD=0
           GITHUB_RELEASE_TYPE=$(echo $BRANCHNAME |cut -d '-' -f 1)
 
+          # if current branch major version has a matching dev-$MAJOR branch ==> onprem version
+          if git ls-remote -q | grep -E "refs/heads/dev-$MAJOR.x$" >/dev/null 2>&1; then
+            GITHUB_RELEASE_CLOUD=0
           # if current branch major version is greater or equal than the develop branch major version ==> cloud version
-          if [[ "$(printf '%s\n' "${{ steps.latest_major_version.outputs.latest_major_version }}" "$MAJOR" | sort -V | head -n1)" == "${{ steps.latest_major_version.outputs.latest_major_version }}" ]]; then
-            GITHUB_RELEASE_CLOUD=1
-          fi
+          elif [[ "$(printf '%s\n' "${{ steps.latest_major_version.outputs.latest_major_version }}" "$MAJOR" | sort -V | head -n1)" == "${{ steps.latest_major_version.outputs.latest_major_version }}" ]]; then
 
           case "$BRANCHNAME" in
             master)

--- a/.github/workflows/get-version.yml
+++ b/.github/workflows/get-version.yml
@@ -135,6 +135,8 @@ jobs:
             GITHUB_RELEASE_CLOUD=0
           # if current branch major version is greater or equal than the develop branch major version ==> cloud version
           elif [[ "$(printf '%s\n' "${{ steps.latest_major_version.outputs.latest_major_version }}" "$MAJOR" | sort -V | head -n1)" == "${{ steps.latest_major_version.outputs.latest_major_version }}" ]]; then
+            GITHUB_RELEASE_CLOUD=1
+          fi
 
           case "$BRANCHNAME" in
             master)


### PR DESCRIPTION
## Description

* temporary fix to set 24.10 as onprem version

**Fixes** #MON-150246

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
