### PR TITLE
fix(packaging): configure and migrate php timezone automatically (#5294)

### DIFF
--- a/.github/docker/centreon-web/alma8/Dockerfile
+++ b/.github/docker/centreon-web/alma8/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=bind,src=packages-centreon,dst=/tmp/packages-centreon bash -e <
 
 dnf install -y /tmp/packages-centreon/centreon-*.rpm
 
-echo 'date.timezone = Europe/Paris' > /etc/php.d/centreon.ini
+sed -i -E 's#^date\.timezone.+#date.timezone = Europe/Paris#g' /etc/php.d/20-timezone.ini
 
 touch /var/log/php-fpm/centreon-error.log
 chown apache:apache /var/log/php-fpm/centreon-error.log

--- a/.github/docker/centreon-web/alma9/Dockerfile
+++ b/.github/docker/centreon-web/alma9/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=bind,src=packages-centreon,dst=/tmp/packages-centreon bash -e <
 
 dnf install -y /tmp/packages-centreon/centreon-*.rpm
 
-echo 'date.timezone = Europe/Paris' > /etc/php.d/centreon.ini
+sed -i -E 's#^date\.timezone.+#date.timezone = Europe/Paris#g' /etc/php.d/20-timezone.ini
 
 touch /var/log/php-fpm/centreon-error.log
 chown apache:apache /var/log/php-fpm/centreon-error.log

--- a/.github/docker/centreon-web/bookworm/Dockerfile
+++ b/.github/docker/centreon-web/bookworm/Dockerfile
@@ -20,7 +20,8 @@ apt-get update
 
 apt-get install -y /tmp/packages-centreon/centreon-*.deb
 
-echo "date.timezone = Europe/Paris" >> /etc/php/8.2/mods-available/centreon.ini
+sed -i -E 's#^date\.timezone.+#date.timezone = Europe/Paris#g' /etc/php/8.2/mods-available/timezone.ini
+phpenmod -v 8.2 timezone
 
 touch /var/log/php8.2-fpm-centreon-error.log
 chown www-data:www-data /var/log/php8.2-fpm-centreon-error.log

--- a/.github/docker/centreon-web/jammy/Dockerfile
+++ b/.github/docker/centreon-web/jammy/Dockerfile
@@ -20,7 +20,8 @@ apt-get update
 
 apt-get install -y /tmp/packages-centreon/centreon-*.deb
 
-echo "date.timezone = Europe/Paris" >> /etc/php/8.2/mods-available/centreon.ini
+sed -i -E 's#^date\.timezone.+#date.timezone = Europe/Paris#g' /etc/php/8.2/mods-available/timezone.ini
+phpenmod -v 8.2 timezone
 
 touch /var/log/php8.2-fpm-centreon-error.log
 chown www-data:www-data /var/log/php8.2-fpm-centreon-error.log

--- a/centreon/packaging/scripts/centreon-web-postinstall.sh
+++ b/centreon/packaging/scripts/centreon-web-postinstall.sh
@@ -28,20 +28,60 @@ updateConfigurationFiles() {
   sed -i -e 's/mode => 1/mode => 0/g' /etc/centreon/centreontrapd.pm
 }
 
-setTimezone() {
-  PHP_TIMEZONE=$(php -r '
-    $timezoneName = timezone_name_from_abbr(trim(shell_exec("date \"+%Z\"")));
-    if (date_default_timezone_set($timezoneName) === false) {
-      $timezoneName = "UTC";
-    }
-    echo $timezoneName;
-  ' 2>/dev/null || echo "UTC")
-
-  echo "Setting php timezone to ${PHP_TIMEZONE} ..."
+setPhpTimezone() {
   if [ "$1" = "rpm" ]; then
-    sed -i "s#^date.timezone = .*#date.timezone = ${PHP_TIMEZONE}#" /etc/php.d/50-centreon.ini
+    PHP_CONFIG_DIR="/etc/php.d"
+    PHP_CONFIG_FILE="20-timezone.ini"
   else
-    sed -i "s#^date.timezone = .*#date.timezone = ${PHP_TIMEZONE}#" /etc/php/8.2/mods-available/centreon.ini
+    PHP_CONFIG_DIR="/etc/php/8.2/mods-available"
+    PHP_CONFIG_FILE="timezone.ini"
+  fi
+
+  if grep -REq "^date.timezone" $PHP_CONFIG_DIR; then
+    echo "Php timezone already set, skipping automatic configuration..."
+  else
+    PHP_TIMEZONE=$(php -r '
+      function getMachineTimezone() {
+        foreach (["cat /etc/timezone 2> /dev/null", "date \"+%Z\""] as $shellCommand) {
+          $timezoneName = trim(shell_exec($shellCommand));
+          if (!empty($timezoneName)) {
+            if (date_default_timezone_set($timezoneName) === false) {
+              $timezoneName = timezone_name_from_abbr($timezoneName);
+            }
+
+            if (!empty($timezoneName) && date_default_timezone_set($timezoneName) !== false) {
+              return $timezoneName;
+            }
+          }
+        }
+
+        return "UTC";
+      }
+
+      echo getMachineTimezone();
+    ' 2>/dev/null || echo "UTC")
+
+    echo "Setting php timezone to ${PHP_TIMEZONE} ..."
+    echo "date.timezone = ${PHP_TIMEZONE}" >> $PHP_CONFIG_DIR/$PHP_CONFIG_FILE
+    if [ "$1" = "deb" ]; then
+      phpenmod -v 8.2 timezone
+    fi
+  fi
+}
+
+migratePhpTimezone() {
+  if [ "$1" = "deb" ]; then
+    OLD_PHP_CONFIG_DIR="/etc/php/8.1/mods-available"
+    PHP_CONFIG_DIR="/etc/php/8.2/mods-available"
+    PHP_CONFIG_FILE="timezone.ini"
+
+    if ! grep -REq "^date.timezone" $PHP_CONFIG_DIR && test -d $OLD_PHP_CONFIG_DIR && PHP_TIMEZONE=$(grep -RE "^date.timezone\s*=\s*.+" $OLD_PHP_CONFIG_DIR 2>/dev/null | head -n 1 | cut -d "=" -f2 | tr -d '[:space:]'); then
+      if [ -n "${PHP_TIMEZONE}" ]; then
+        echo "Setting php timezone to ${PHP_TIMEZONE} ..."
+        echo "date.timezone = ${PHP_TIMEZONE}" >> $PHP_CONFIG_DIR/$PHP_CONFIG_FILE
+        phpenmod -v 8.2 timezone
+      fi
+    fi
   fi
 }
 
@@ -138,6 +178,7 @@ case "$action" in
     updateConfigurationFiles
     updateGorgoneConfiguration
     manageLocales $package_type
+    setPhpTimezone $package_type
     manageApacheAndPhpFpm $package_type
     fixSymfonyCacheRights $package_type
     fixCentreonCronPermissions
@@ -147,6 +188,7 @@ case "$action" in
     updateConfigurationFiles
     updateGorgoneConfiguration
     manageLocales $package_type
+    migratePhpTimezone $package_type
     manageApacheAndPhpFpm $package_type
     fixSymfonyCacheRights $package_type
     rebuildSymfonyCache $package_type

--- a/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade.feature
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade.feature
@@ -1,5 +1,5 @@
 @execTimeout(300000)
-@REQ_MON-22196 @system @ignore
+@REQ_MON-22196 @system
 Feature: Upgrade platform from major version A to major version B
 
   @TEST_MON-22198


### PR DESCRIPTION
## Description

fix(packaging): configure and migrate php timezone automatically (#5294)
reenable e2e upgrade tests

**Fixes** MON-150217

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software