### PR TITLE
enh(AC): replace class serializer by an interface serializer to handle all the ConfigurationParameters

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Serializer/ConfigurationParametersInterfaceNormalizer.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Serializer/ConfigurationParametersInterfaceNormalizer.php
@@ -23,22 +23,25 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Infrastructure\Serializer;
 
+use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\TelegrafConfigurationParameters;
+use Core\AgentConfiguration\Domain\Model\ConfigurationParametersInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**
  * @phpstan-import-type _TelegrafParameters from TelegrafConfigurationParameters
+ * @phpstan-import-type _CmaParameters from CmaConfigurationParameters
  */
-class TelegrafConfigurationParametersNormalizer implements NormalizerInterface
+class ConfigurationParametersInterfaceNormalizer implements NormalizerInterface
 {
     /**
      * {@inheritDoc}
      *
-     * @param TelegrafConfigurationParameters $object
+     * @param ConfigurationParametersInterface $object
      * @param string|null $format
      * @param array<string, mixed> $context
      *
-     * @return _TelegrafParameters|null
+     * @return _TelegrafParameters|_CmaParameters|null
      */
     public function normalize(
         mixed $object,
@@ -47,7 +50,7 @@ class TelegrafConfigurationParametersNormalizer implements NormalizerInterface
     ): float|int|bool|array|string|null {
         /** @var array{groups: string[]} $context */
         if (in_array('AgentConfiguration:Read', $context['groups'], true)) {
-            /** @var _TelegrafParameters $data */
+            /** @var _TelegrafParameters|_CmaParameters $data */
             $data = $object->getData();
         }
 
@@ -59,6 +62,6 @@ class TelegrafConfigurationParametersNormalizer implements NormalizerInterface
      */
     public function supportsNormalization(mixed $data, ?string $format = null): bool
     {
-        return $data instanceof TelegrafConfigurationParameters;
+        return $data instanceof ConfigurationParametersInterface;
     }
 }


### PR DESCRIPTION
## Description

This PR intends to replace TelegrafConfigurationParametersSerializer by a ConfigurationParametersInterfaceSerializer to easily manage existant AC Types Parameters (CMA & Telegraf) and future AC Types.

**Fixes** # MON-159509
## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
