### PR TITLE
fix(packaging): move plugins from suggests to recommends (#5318)

### DIFF
--- a/centreon/packaging/centreon-poller.yaml
+++ b/centreon/packaging/centreon-poller.yaml
@@ -90,7 +90,7 @@ overrides:
       - perl-DBD-SQLite
       - nagios-plugins-dhcp >= 2.0.0
       - nagios-plugins-icmp >= 2.0.0
-    suggests:
+    recommends:
       - centreon-plugin-Applications-Databases-Mysql
       - centreon-plugin-Applications-Monitoring-Centreon-Central
       - centreon-plugin-Applications-Monitoring-Centreon-Database
@@ -129,7 +129,7 @@ overrides:
       - libdbd-mysql-perl
       - libdbd-sqlite3-perl
       - monitoring-plugins-basic
-    suggests:
+    recommends:
       - centreon-plugin-applications-databases-mysql
       - centreon-plugin-applications-monitoring-centreon-central
       - centreon-plugin-applications-monitoring-centreon-database


### PR DESCRIPTION
## Description

fix(packaging): move plugins from suggests to recommends (#5318)
https://docs.fedoraproject.org/en-US/packaging-guidelines/WeakDependencies/

**Fixes** MON-150508

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software