### PR TITLE
enh(cma): update endpoints for type CMA

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
@@ -65,12 +65,11 @@ class CmaValidator implements TypeValidatorInterface
                     /** @var array{
                      *		address: string,
                      *		port: int,
-                     *		certificate: string,
-                     *		key: string
+                     *		poller_ca_certificate: ?string,
+                     *		poller_ca_name: ?string
                      *	} $host
                      */
-                    $this->validateFilename('configuration.hosts[].key', $host['key']);
-                    $this->validateFilename('configuration.hosts[].certificate', $host['certificate']);
+                    $this->validateFilename('configuration.hosts[].poller_ca_certificate', $host['poller_ca_certificate']);
                 }
             }
         }
@@ -88,7 +87,7 @@ class CmaValidator implements TypeValidatorInterface
             $value !== null
             && 1 === preg_match('/\.\/|\.\.\/|\.cert$|\.crt$|\.key$/', $value)
         ) {
-            throw AgentConfigurationException::invalidFilename("configuration.{$name}", (string) $value);
+            throw AgentConfigurationException::invalidFilename($name, (string) $value);
         }
     }
 }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -30,16 +30,14 @@ use Core\AgentConfiguration\Domain\Model\ConfigurationParametersInterface;
 /**
  * @phpstan-type _CmaParameters array{
  *	    is_reverse: bool,
- *		otlp_certificate: string,
- *		otlp_ca_certificate: string,
- *		otlp_private_key: string,
- *		poller_ca_certificate: ?string,
- *		poller_ca_name: ?string,
+ *		otel_public_certificate: string,
+ *		otel_private_key: string,
+ *		otel_ca_certificate: ?string,
  *		hosts: array<array{
  *			address: string,
  *			port: int,
- *			certificate: string,
- *			key: string
+ *			poller_ca_certificate: ?string,
+ *			poller_ca_name: ?string,
  *		}>
  *  }
  */
@@ -60,24 +58,13 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
         array $parameters
     ){
         /** @var _CmaParameters $parameters */
-        Assertion::notEmptyString($parameters['otlp_certificate'], 'configuration.otlp_certificate');
-        Assertion::notEmptyString($parameters['otlp_ca_certificate'], 'configuration.otlp_ca_certificate');
-        Assertion::notEmptyString($parameters['otlp_private_key'], 'configuration.otlp_private_key');
-        if ($parameters['poller_ca_certificate'] !== null) {
-            Assertion::notEmptyString($parameters['poller_ca_certificate'], 'configuration.poller_ca_certificate');
-        }
-        if ($parameters['poller_ca_name'] !== null) {
-            Assertion::notEmptyString($parameters['poller_ca_name'], 'configuration.poller_ca_name');
-        }
-
-        Assertion::maxLength($parameters['otlp_certificate'], self::MAX_LENGTH, 'configuration.otlp_certificate');
-        Assertion::maxLength($parameters['otlp_ca_certificate'], self::MAX_LENGTH, 'configuration.otlp_ca_certificate');
-        Assertion::maxLength($parameters['otlp_private_key'], self::MAX_LENGTH, 'configuration.otlp_private_key');
-        if ($parameters['poller_ca_certificate'] !== null) {
-            Assertion::maxLength($parameters['poller_ca_certificate'], self::MAX_LENGTH, 'configuration.poller_ca_certificate');
-        }
-        if ($parameters['poller_ca_name'] !== null) {
-            Assertion::maxLength($parameters['poller_ca_name'], self::MAX_LENGTH, 'configuration.poller_ca_name');
+        Assertion::notEmptyString($parameters['otel_public_certificate'], 'configuration.otel_public_certificate');
+        Assertion::maxLength($parameters['otel_public_certificate'], self::MAX_LENGTH, 'configuration.otel_public_certificate');
+        Assertion::notEmptyString($parameters['otel_private_key'], 'configuration.otel_private_key');
+        Assertion::maxLength($parameters['otel_private_key'], self::MAX_LENGTH, 'configuration.otel_private_key');
+        if ($parameters['otel_ca_certificate'] !== null) {
+            Assertion::notEmptyString($parameters['otel_ca_certificate'], 'configuration.otel_ca_certificate');
+            Assertion::maxLength($parameters['otel_ca_certificate'], self::MAX_LENGTH, 'configuration.otel_ca_certificate');
         }
 
         if ($parameters['is_reverse'] === false && $parameters['hosts'] !== []) {
@@ -87,6 +74,14 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
         foreach ($parameters['hosts'] as $host) {
             Assertion::ipOrDomain($host['address'], 'configuration.hosts[].address');
             Assertion::range($host['port'], 0, 65535, 'configuration.hosts[].port');
+            if ($host['poller_ca_certificate'] !== null) {
+                Assertion::notEmptyString($host['poller_ca_certificate'], 'configurationhosts[].poller_ca_certificate');
+                Assertion::maxLength($host['poller_ca_certificate'], self::MAX_LENGTH, 'configuration.hosts[].poller_ca_certificate');
+            }
+            if ($host['poller_ca_name'] !== null) {
+                Assertion::notEmptyString($host['poller_ca_name'], 'configuration.hosts[].poller_ca_name');
+                Assertion::maxLength($host['poller_ca_name'], self::MAX_LENGTH, 'configuration.hosts[].poller_ca_name');
+            }
         }
 
         $this->parameters = $parameters;

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/Schema/CmaConfigurationSchema.json
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/Schema/CmaConfigurationSchema.json
@@ -12,31 +12,26 @@
             "additionalProperties": false,
             "required": [
                 "is_reverse",
-                "otlp_certificate",
-                "otlp_ca_certificate",
-                "otlp_private_key",
-                "poller_ca_certificate",
-                "poller_ca_name",
+                "otel_public_certificate",
+                "otel_ca_certificate",
+                "otel_private_key",
                 "hosts"
             ],
             "properties": {
                 "is_reverse": {
                     "type": "boolean"
                 },
-                "otlp_certificate": {
+                "otel_public_certificate": {
                     "type": "string"
                 },
-                "otlp_ca_certificate": {
+                "otel_ca_certificate": {
+                    "type": [
+                        "null",
+                        "string"
+                    ]
+                },
+                "otel_private_key": {
                     "type": "string"
-                },
-                "otlp_private_key": {
-                    "type": "string"
-                },
-                "poller_ca_certificate": {
-                    "type": ["null", "string"]
-                },
-                "poller_ca_name": {
-                    "type": ["null", "string"]
                 },
                 "hosts": {
                     "type": "array",
@@ -44,8 +39,8 @@
                         "required": [
                             "address",
                             "port",
-                            "certificate",
-                            "key"
+                            "poller_ca_certificate",
+                            "poller_ca_name"
                         ],
                         "properties": {
                             "address": {
@@ -54,11 +49,17 @@
                             "port": {
                                 "type": "integer"
                             },
-                            "certificate": {
-                                "type": "string"
+                            "poller_ca_certificate": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
                             },
-                            "key": {
-                                "type": "string"
+                            "poller_ca_name": {
+                                "type": [
+                                    "null",
+                                    "string"
+                                ]
                             }
                         }
                     }

--- a/centreon/tests/e2e/features/Additional-connectors/02-ACC-listing/index.ts
+++ b/centreon/tests/e2e/features/Additional-connectors/02-ACC-listing/index.ts
@@ -68,10 +68,10 @@ Given('an already existing additional connector configuration', () => {
   cy.get('#mui-component-select-type').should('have.text', 'VMWare 6/7');
   cy.getByLabel({ label: 'Select poller(s)', tag: 'input' }).click();
   cy.contains('Central').click();
-  cy.get('#vCenternamevalue').clear().type('vCenter-001');
-  cy.get('#URLvalue').clear().type('https://10.0.0.0/sdk');
   cy.get('#Usernamevalue').type('admin');
   cy.get('#Passwordvalue').type('Abcde!2021');
+  cy.get('#vCenternamevalue').clear().type('vCenter-001');
+  cy.get('#URLvalue').clear().type('https://10.0.0.0/sdk');
   cy.get('#Portvalue').should('have.value', '5700');
   cy.getByLabel({ label: 'Create', tag: 'button' }).click();
   cy.wait('@addAdditionalConnector');
@@ -90,9 +90,9 @@ Then('a pop up is displayed with all of the additional connector informations', 
   cy.getByLabel({ label: 'Description', tag: 'textarea' }).should('be.empty');
   cy.get('#mui-component-select-type').should('have.text', 'VMWare 6/7');
   cy.get('*[class^="MuiChip-label MuiChip-labelMedium"]').should('contain', 'Central');
-  cy.get('#vCenternamevalue').should('have.value', 'vCenter-001');
-  cy.get('#URLvalue').should('have.value', 'https://10.0.0.0/sdk');
   cy.get('#Usernamevalue').should('be.empty');
   cy.get('#Passwordvalue').should('be.empty');
+  cy.get('#vCenternamevalue').should('have.value', 'vCenter-001');
+  cy.get('#URLvalue').should('have.value', 'https://10.0.0.0/sdk');
   cy.get('#Portvalue').should('have.value', '5700');
 });

--- a/centreon/tests/e2e/features/Additional-connectors/03-ACC-deletion/index.ts
+++ b/centreon/tests/e2e/features/Additional-connectors/03-ACC-deletion/index.ts
@@ -45,10 +45,10 @@ Given('an additional connector configuration is already created', () => {
   cy.get('#mui-component-select-type').should('have.text', 'VMWare 6/7');
   cy.getByLabel({ label: 'Select poller(s)', tag: 'input' }).click();
   cy.contains('Central').click();
-  cy.get('#vCenternamevalue').clear().type('vCenter-001');
-  cy.get('#URLvalue').clear().type('https://10.0.0.0/sdk');
   cy.get('#Usernamevalue').type('admin');
   cy.get('#Passwordvalue').type('Abcde!2021');
+  cy.get('#vCenternamevalue').clear().type('vCenter-001');
+  cy.get('#URLvalue').clear().type('https://10.0.0.0/sdk');
   cy.get('#Portvalue').should('have.value', '5700');
   cy.getByLabel({ label: 'Create', tag: 'button' }).click();
   cy.wait('@addAdditionalConnector');

--- a/centreon/tests/e2e/features/Additional-connectors/04-ACC-update/index.ts
+++ b/centreon/tests/e2e/features/Additional-connectors/04-ACC-update/index.ts
@@ -49,10 +49,10 @@ Given('an additional connector configuration is already created', () => {
   cy.get('#mui-component-select-type').should('have.text', 'VMWare 6/7');
   cy.getByLabel({ label: 'Select poller(s)', tag: 'input' }).click();
   cy.contains('Central').click();
-  cy.get('#vCenternamevalue').clear().type('vCenter-001');
-  cy.get('#URLvalue').clear().type('https://10.0.0.0/sdk');
   cy.get('#Usernamevalue').type('admin');
   cy.get('#Passwordvalue').type('Abcde!2021');
+  cy.get('#vCenternamevalue').clear().type('vCenter-001');
+  cy.get('#URLvalue').clear().type('https://10.0.0.0/sdk');
   cy.get('#Portvalue').should('have.value', '5700');
   cy.getByLabel({ label: 'Create', tag: 'button' }).click();
   cy.wait('@addAdditionalConnector');
@@ -74,10 +74,10 @@ Then('all of the informations of the additional connector configuration are corr
   cy.getByLabel({ label: 'Description', tag: 'textarea' }).should('be.empty');
   cy.get('#mui-component-select-type').should('have.text', 'VMWare 6/7');
   cy.get('*[class^="MuiChip-label MuiChip-labelMedium"]').should('contain', 'Central');
-  cy.get('#vCenternamevalue').should('have.value', 'vCenter-001');
-  cy.get('#URLvalue').should('have.value', 'https://10.0.0.0/sdk');
   cy.get('#Usernamevalue').should('be.empty');
   cy.get('#Passwordvalue').should('be.empty');
+  cy.get('#vCenternamevalue').should('have.value', 'vCenter-001');
+  cy.get('#URLvalue').should('have.value', 'https://10.0.0.0/sdk');
   cy.get('#Portvalue').should('have.value', '5700');
 });
 
@@ -88,10 +88,10 @@ When('the user updates some information', () => {
   cy.getByTestId({ testId: 'CancelIcon' }).click();
   cy.getByLabel({ label: 'Select poller(s)', tag: 'input' }).click().click();
   cy.contains('Poller-1').click();
-  cy.get('#vCenternamevalue').clear().type('vCenter-002');
-  cy.get('#URLvalue').clear().type('https://10.3.3.3/sdk');
   cy.get('#Usernamevalue').type('admin');
   cy.get('#Passwordvalue').type('Abcde!2022');
+  cy.get('#vCenternamevalue').clear().type('vCenter-002');
+  cy.get('#URLvalue').clear().type('https://10.3.3.3/sdk');
   cy.get('#Portvalue').clear().click().type('6900');
 });
 
@@ -112,9 +112,9 @@ Then('the informations are successfully saved', () => {
   cy.getByLabel({ label: 'Description', tag: 'textarea' }).should('be.empty');
   cy.get('#mui-component-select-type').should('have.text', 'VMWare 6/7');
   cy.get('*[class^="MuiChip-label MuiChip-labelMedium"]').should('contain', 'Poller-1');
-  cy.get('#vCenternamevalue').should('have.value', 'vCenter-002');
-  cy.get('#URLvalue').should('have.value', 'https://10.3.3.3/sdk');
   cy.get('#Usernamevalue').should('be.empty');
   cy.get('#Passwordvalue').should('be.empty');
+  cy.get('#vCenternamevalue').should('have.value', 'vCenter-002');
+  cy.get('#URLvalue').should('have.value', 'https://10.3.3.3/sdk');
   cy.get('#Portvalue').should('have.value', '6900');
 });

--- a/centreon/tests/e2e/features/Additional-connectors/05-ACC-check-permissions/index.ts
+++ b/centreon/tests/e2e/features/Additional-connectors/05-ACC-check-permissions/index.ts
@@ -62,10 +62,10 @@ When('the admin user fills in all the informations', () => {
   cy.get('#mui-component-select-type').should('have.text', 'VMWare 6/7');
   cy.getByLabel({ label: 'Select poller(s)', tag: 'input' }).click();
   cy.contains('Central').click();
-  cy.getByTestId({ testId: 'vCenter name_value' }).eq(0).clear().type('vCenter-001');
-  cy.getByTestId({ testId: 'URL_value' }).eq(0).clear().type('https://10.0.0.0/sdk');
   cy.getByTestId({ testId: 'Username_value' }).eq(0).type('admin');
   cy.getByTestId({ testId: 'Password_value' }).eq(0).type('Abcde!2021');
+  cy.getByTestId({ testId: 'vCenter name_value' }).eq(0).clear().type('vCenter-001');
+  cy.getByTestId({ testId: 'URL_value' }).eq(0).clear().type('https://10.0.0.0/sdk');
   cy.get('#Portvalue').should('have.value', '5700');
 });
 
@@ -99,10 +99,10 @@ Then('a pop up is displayed with all of the additional connector information', (
   cy.getByLabel({ label: 'Description', tag: 'textarea' }).should('have.value', "I'm the first connector created");
   cy.get('#mui-component-select-type').should('have.text', 'VMWare 6/7');
   cy.get('*[class^="MuiChip-label MuiChip-labelMedium"]').should('contain', 'Central');
-  cy.getByTestId({ testId: 'vCenter name_value' }).eq(1).should('have.value', 'vCenter-001');
-  cy.getByTestId({ testId: 'URL_value' }).eq(1).should('have.value', 'https://10.0.0.0/sdk');
   cy.getByTestId({ testId: 'Username_value' }).eq(1).should('be.empty');
   cy.getByTestId({ testId: 'Password_value' }).eq(1).should('be.empty');
+  cy.getByTestId({ testId: 'vCenter name_value' }).eq(1).should('have.value', 'vCenter-001');
+  cy.getByTestId({ testId: 'URL_value' }).eq(1).should('have.value', 'https://10.0.0.0/sdk');
   cy.get('#Portvalue').should('have.value', '5700');
 });
 
@@ -113,10 +113,10 @@ When('the user modifies the configuration', () => {
   cy.getByTestId({ testId: 'CancelIcon' }).click();
   cy.getByLabel({ label: 'Select poller(s)', tag: 'input' }).click().click();
   cy.contains('Poller-1').click();
-  cy.getByTestId({ testId: 'vCenter name_value' }).eq(0).clear().type('vCenter-002');
-  cy.getByTestId({ testId: 'URL_value' }).eq(0).clear().type('https://10.3.3.3/sdk');
   cy.getByTestId({ testId: 'Username_value' }).eq(0).type('admin');
   cy.getByTestId({ testId: 'Password_value' }).eq(0).type('Abcde!2022');
+  cy.getByTestId({ testId: 'vCenter name_value' }).eq(0).clear().type('vCenter-002');
+  cy.getByTestId({ testId: 'URL_value' }).eq(0).clear().type('https://10.3.3.3/sdk');
   cy.get('#Portvalue').clear().click().type('6900');
 });
 
@@ -177,10 +177,10 @@ Given('an Additional Connector Configuration already created linked with two pol
   cy.contains('Poller-1').click();
   cy.contains('Poller-2').click();
   cy.getByLabel({ label: 'Select poller(s)', tag: 'input' }).click();
-  cy.getByTestId({ testId: 'vCenter name_value' }).eq(0).clear().type('vCenter-001');
-  cy.getByTestId({ testId: 'URL_value' }).eq(0).clear().type('https://10.0.0.0/sdk');
   cy.getByTestId({ testId: 'Username_value' }).eq(0).type('admin');
   cy.getByTestId({ testId: 'Password_value' }).eq(0).type('Abcde!2021');
+  cy.getByTestId({ testId: 'vCenter name_value' }).eq(0).clear().type('vCenter-001');
+  cy.getByTestId({ testId: 'URL_value' }).eq(0).clear().type('https://10.0.0.0/sdk');
   cy.get('#Portvalue').should('have.value', '5700');
   cy.getByLabel({ label: 'Create', tag: 'button' }).click();
   cy.wait('@addAdditionalConnector');
@@ -246,10 +246,10 @@ When('a pop up is displayed with all of the additional connector information wit
   cy.getByLabel({ label: 'Description', tag: 'textarea' }).should('be.empty');
   cy.get('#mui-component-select-type').should('have.text', 'VMWare 6/7');
   cy.get('*[class^="MuiChip-label MuiChip-labelMedium"]').should('contain', 'Poller-1', 'Poller-2');
-  cy.getByTestId({ testId: 'vCenter name_value' }).eq(1).should('have.value', 'vCenter-001');
-  cy.getByTestId({ testId: 'URL_value' }).eq(1).should('have.value', 'https://10.0.0.0/sdk');
   cy.getByTestId({ testId: 'Username_value' }).eq(1).should('be.empty');
   cy.getByTestId({ testId: 'Password_value' }).eq(1).should('be.empty');
+  cy.getByTestId({ testId: 'vCenter name_value' }).eq(1).should('have.value', 'vCenter-001');
+  cy.getByTestId({ testId: 'URL_value' }).eq(1).should('have.value', 'https://10.0.0.0/sdk');
   cy.get('#Portvalue').should('have.value', '5700');
 });
 
@@ -286,10 +286,10 @@ When('the non-admin user fills in all the informations', () => {
   cy.get('#mui-component-select-type').should('have.text', 'VMWare 6/7');
   cy.getByLabel({ label: 'Select poller(s)', tag: 'input' }).click();
   cy.contains('Poller-1').click();
-  cy.getByTestId({ testId: 'vCenter name_value' }).eq(0).clear().type('vCenter-001');
-  cy.getByTestId({ testId: 'URL_value' }).eq(0).clear().type('https://10.1.1.1/sdk');
   cy.getByTestId({ testId: 'Username_value' }).eq(0).type('admin');
   cy.getByTestId({ testId: 'Password_value' }).eq(0).type('Abcde!2021');
+  cy.getByTestId({ testId: 'vCenter name_value' }).eq(0).clear().type('vCenter-001');
+  cy.getByTestId({ testId: 'URL_value' }).eq(0).clear().type('https://10.1.1.1/sdk');
   cy.get('#Portvalue').should('have.value', '5700');
   cy.getByLabel({ label: 'Create', tag: 'button' }).click();
 });

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\AdditionalConnectorConfiguration\Application\Validation;
+
+use Centreon\Domain\Common\Assertion\AssertionException;
+use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
+
+beforeEach(function (): void {
+    $this->parameters = [
+        'is_reverse' => true,
+        'otel_public_certificate' => 'otel_certif_filename',
+        'otel_ca_certificate' => 'ca_certif_filename',
+        'otel_private_key' => 'otel_key_filename',
+        'hosts' => [
+            [
+                'address' => '0.0.0.0',
+                'port' => 442,
+                'poller_ca_certificate' => 'poller_certif',
+                'poller_ca_name' => 'ca_name'
+            ]
+        ]
+    ];
+});
+
+foreach (
+    [
+        'port',
+    ] as $field
+) {
+    it(
+        "should throw an exception when the hosts[].{$field} is not valid",
+        function () use ($field) : void {
+            $this->parameters['hosts'][0][$field] = 9999999999;
+            new CmaConfigurationParameters($this->parameters);
+        }
+    )->throws(
+        AssertionException::range(
+            9999999999,
+            0,
+            65535,
+            "configuration.hosts[].{$field}"
+        )->getMessage()
+    );
+}
+
+foreach (
+    [
+        'otel_public_certificate',
+        'otel_ca_certificate',
+        'otel_private_key'
+    ] as $field
+) {
+    it(
+        "should throw an exception when a {$field} is too short",
+        function () use ($field) : void {
+            $this->parameters[$field] = '';
+
+            new CmaConfigurationParameters($this->parameters);
+        }
+    )->throws(
+        AssertionException::notEmptyString("configuration.{$field}")->getMessage()
+    );
+}
+
+foreach (
+    [
+        'otel_public_certificate',
+        'otel_ca_certificate',
+        'otel_private_key'
+    ] as $field
+) {
+    $tooLong = str_repeat('a', CmaConfigurationParameters::MAX_LENGTH + 1);
+    it(
+        "should throw an exception when a {$field} is too long",
+        function () use ($field, $tooLong) : void {
+            $this->parameters[$field] = $tooLong;
+
+            new CmaConfigurationParameters($this->parameters);
+        }
+    )->throws(
+        AssertionException::maxLength(
+            $tooLong,
+            CmaConfigurationParameters::MAX_LENGTH + 1,
+            CmaConfigurationParameters::MAX_LENGTH,
+            "configuration.{$field}"
+        )->getMessage()
+    );
+}

--- a/centreon/www/install/php/Update-24.11.0.php
+++ b/centreon/www/install/php/Update-24.11.0.php
@@ -25,7 +25,7 @@ require_once __DIR__ . '/../../class/centreonLog.class.php';
 $centreonLog = CentreonLog::create();
 
 // error specific content
-$versionOfTheUpgrade = 'UPGRADE - 24.10.1: ';
+$versionOfTheUpgrade = 'UPGRADE - 24.11: ';
 $errorMessage = '';
 
 // Agent Configuration
@@ -35,7 +35,7 @@ $createAgentConfiguration = function (CentreonDB $pearDB) use (&$errorMessage): 
         <<<'SQL'
             CREATE TABLE IF NOT EXISTS `agent_configuration` (
                 `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
-                `type` enum('telegraf') NOT NULL,
+                `type` enum('telegraf', 'centreon-agent') NOT NULL,
                 `name` varchar(255) NOT NULL,
                 `configuration` JSON NOT NULL,
                 PRIMARY KEY (`id`),


### PR DESCRIPTION
## Description

Update CMA support in poller/agent configuration endpoints:
- parameters `otlp_[...]` are renamed `otel_[...]`
- `otlp_certificate` is renamed `otel_public_certificate`
- `otpl_ca_certificate` is nullable
- `poller_ca_certificate` and `poller_ca_name` are moved inside the hosts section
- `certificate` and `key` in the hosts section are removed
- rename update-24.10.1.php to update-24.11.0.php

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
