### PR TITLE
fix(api): fix returned value for is_notifications_enabled on resources

### DIFF
--- a/centreon/src/Core/Resources/Application/UseCase/FindResources/FindResourcesFactory.php
+++ b/centreon/src/Core/Resources/Application/UseCase/FindResources/FindResourcesFactory.php
@@ -82,6 +82,7 @@ final class FindResourcesFactory
             $resourceDto->hasGraphData = $resource->hasGraph();
             $resourceDto->lastCheck = self::createNullableDateTimeImmutable($resource->getLastCheck());
             $resourceDto->lastStatusChange = self::createNullableDateTimeImmutable($resource->getLastStatusChange());
+            $resourceDto->areNotificationsEnabled = $resource->isNotificationEnabled();
 
             $response->resources[] = $resourceDto;
         }

--- a/centreon/src/Core/Resources/Infrastructure/API/FindResources/FindResourcesPresenter.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindResources/FindResourcesPresenter.php
@@ -178,7 +178,7 @@ class FindResourcesPresenter extends AbstractPresenter implements FindResourcesP
                     'tries' => $resource->tries,
                     'information' => $resource->information,
                     'performance_data' => null,
-                    'is_notification_enabled' => false,
+                    'is_notification_enabled' => $resource->areNotificationsEnabled,
                     'severity' => $severity,
                     'links' => $links,
                     'extra' => $resource->resourceId !== null


### PR DESCRIPTION
## Description

Value returned for is_notifications_enabled on resources is always false, even after editing it in service form

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
