### PR TITLE
fix(export): fix generation of VMWare export file

### DIFF
--- a/centreon/packaging/centreon-common.yaml
+++ b/centreon/packaging/centreon-common.yaml
@@ -71,6 +71,13 @@ contents:
       group: centreon
       mode: 2775
 
+  - dst: "/var/cache/centreon/config/vmware"
+    type: dir
+    file_info:
+      owner: centreon
+      group: centreon
+      mode: 2775
+
   - src: "../www/install/var/config.yaml"
     dst: "/etc/centreon/config.yaml"
     file_info:

--- a/centreon/packaging/scripts/centreon-common-postinstall.sh
+++ b/centreon/packaging/scripts/centreon-common-postinstall.sh
@@ -7,6 +7,7 @@ fixCacheConfigRights() {
   chmod 2775 /var/cache/centreon/config/engine
   chmod 2775 /var/cache/centreon/config/broker
   chmod 2775 /var/cache/centreon/config/export
+  chmod 2775 /var/cache/centreon/config/vmware
 
   # MON-38165
   chmod 0770 /var/cache/centreon/config/engine/*

--- a/centreon/www/class/config-generate-remote/Generate.php
+++ b/centreon/www/class/config-generate-remote/Generate.php
@@ -20,8 +20,6 @@
 
 namespace ConfigGenerateRemote;
 
-use App\Kernel;
-use Core\AdditionalConnectorConfiguration\Application\Repository\ReadAccRepositoryInterface;
 use PDO;
 use Exception;
 use Pimple\Container;
@@ -211,13 +209,6 @@ class Generate
             $this->currentPoller['id'],
             $this->currentPoller['localhost']
         );
-        $kernel = Kernel::createForWeb();
-        $readAdditionalConnectorRepository = $kernel->getContainer()->get(ReadAccRepositoryInterface::class)
-            ?? throw new \Exception('ReadAccRepositoryInterface not found');
-        (new \AdditionalConnectorVmWareV6(
-            $this->backendInstance,
-            $readAdditionalConnectorRepository
-        ))->generateFromPollerId($this->currentPoller['id']);
 
         Engine::getInstance($this->dependencyInjector)->generateFromPoller($this->currentPoller);
         Broker::getInstance($this->dependencyInjector)->generateFromPoller($this->currentPoller);

--- a/centreon/www/class/config-generate/AdditionalConnectorVmWareV6.class.php
+++ b/centreon/www/class/config-generate/AdditionalConnectorVmWareV6.class.php
@@ -20,7 +20,6 @@
  */
 
 use Assert\AssertionFailedException;
-use ConfigGenerateRemote\Backend as BackendRemote;
 use Core\AdditionalConnectorConfiguration\Application\Repository\ReadAccRepositoryInterface;
 use Core\AdditionalConnectorConfiguration\Domain\Model\Type;
 use Core\AdditionalConnectorConfiguration\Domain\Model\VmWareV6\{VmWareConfig, VSphereServer};
@@ -35,11 +34,11 @@ class AdditionalConnectorVmWareV6 extends AbstractObjectJSON
     /**
      * AdditionalConnectorVmWareV6 constructor
      *
-     * @param Backend|BackendRemote $backend
+     * @param Backend $backend
      * @param ReadAccRepositoryInterface $readAdditionalConnectorRepository
      */
     public function __construct(
-        private readonly Backend|BackendRemote $backend,
+        private readonly Backend $backend,
         private readonly ReadAccRepositoryInterface $readAdditionalConnectorRepository
     ) {
     }
@@ -86,8 +85,10 @@ class AdditionalConnectorVmWareV6 extends AbstractObjectJSON
             ];
         }
         $this->generate_filename = 'centreon_vmware.json';
+        $directory = $this->backend->generate_path . '/vmware/' . $pollerId;
+        $this->backend->createDirectories([$directory]);
         $this->generateFile($object, false);
-        $this->writeFile($this->backend->getPath());
+        $this->writeFile($directory);
     }
 
     /**

--- a/centreon/www/class/config-generate/AdditionalConnectorVmWareV6.class.php
+++ b/centreon/www/class/config-generate/AdditionalConnectorVmWareV6.class.php
@@ -20,6 +20,7 @@
  */
 
 use Assert\AssertionFailedException;
+use ConfigGenerateRemote\Backend as BackendRemote;
 use Core\AdditionalConnectorConfiguration\Application\Repository\ReadAccRepositoryInterface;
 use Core\AdditionalConnectorConfiguration\Domain\Model\Type;
 use Core\AdditionalConnectorConfiguration\Domain\Model\VmWareV6\{VmWareConfig, VSphereServer};
@@ -34,11 +35,11 @@ class AdditionalConnectorVmWareV6 extends AbstractObjectJSON
     /**
      * AdditionalConnectorVmWareV6 constructor
      *
-     * @param Backend $backend
+     * @param Backend|BackendRemote $backend
      * @param ReadAccRepositoryInterface $readAdditionalConnectorRepository
      */
     public function __construct(
-        private readonly Backend $backend,
+        private readonly Backend|BackendRemote $backend,
         private readonly ReadAccRepositoryInterface $readAdditionalConnectorRepository
     ) {
     }
@@ -85,9 +86,8 @@ class AdditionalConnectorVmWareV6 extends AbstractObjectJSON
             ];
         }
         $this->generate_filename = 'centreon_vmware.json';
-        $this->backend->createDirectories([$this->backend->generate_path . '/vmware/' . $pollerId]);
         $this->generateFile($object, false);
-        $this->writeFile($this->backend->generate_path . '/vmware/' . $pollerId);
+        $this->writeFile($this->backend->getPath());
     }
 
     /**

--- a/centreon/www/class/config-generate/generate.class.php
+++ b/centreon/www/class/config-generate/generate.class.php
@@ -325,7 +325,7 @@ class Generate
         $readAdditionalConnectorRepository = $kernel->getContainer()->get(ReadAccRepositoryInterface::class)
             ?? throw new \Exception('ReadAccRepositoryInterface not found');
         (new AdditionalConnectorVmWareV6(
-            Backend::getInstance($this->dependencyInjector),
+            $this->backend_instance,
             $readAdditionalConnectorRepository
         ))->generateFromPollerId($this->current_poller['id']);
 


### PR DESCRIPTION
## Description

This PR intends to fix the generation of VMWare export file:
- File is no longer created when creating a RS through the Wizard
- File is correctly exported to the poller when the poller is behind a Remote Server

**Fixes** # MON-150507

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
