### PR TITLE
MON-144643-acc-export-vm-ware-file-on-poller (#5116)

### DIFF
--- a/centreon/packaging/src/sudoersCentreon
+++ b/centreon/packaging/src/sudoersCentreon
@@ -49,4 +49,14 @@ CENTREON   ALL = NOPASSWD: /usr/bin/systemctl stop cbd
 CENTREON   ALL = NOPASSWD: /usr/bin/systemctl restart cbd
 CENTREON   ALL = NOPASSWD: /usr/bin/systemctl reload cbd
 
+# Centreon Vmware
+CENTREON   ALL = NOPASSWD: /usr/bin/systemctl restart centreon_vmware
+CENTREON   ALL = NOPASSWD: /usr/bin/systemctl start centreon_vmware
+CENTREON   ALL = NOPASSWD: /usr/bin/systemctl restart centreon_vmware.service
+CENTREON   ALL = NOPASSWD: /usr/bin/systemctl start centreon_vmware.service
+CENTREON   ALL = NOPASSWD: systemctl restart centreon_vmware
+CENTREON   ALL = NOPASSWD: systemctl start centreon_vmware
+CENTREON   ALL = NOPASSWD: systemctl restart centreon_vmware.service
+CENTREON   ALL = NOPASSWD: systemctl start centreon_vmware.service
+
 ## END: CENTREON SUDO


### PR DESCRIPTION
## Description
backport of MON-144643

Fixes # MON-150897

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] 24.10..x
- [ ] master

<h2> How this pull request can be tested ? </h2>
run a centreon plateform with a remote server attached, and a poller attached to the remote server. 

Add an ACC for vmware for both remote server and poller. 

Push the configuration on all nodes check the centreon_vmware.json is correctly set and readable on both server. 

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
