### PR TITLE
fix(packaging): add perl snmp dependency for centreontrapd (#5385)

### DIFF
--- a/centreon/packaging/centreon-trap.yaml
+++ b/centreon/packaging/centreon-trap.yaml
@@ -76,12 +76,14 @@ overrides:
     depends:
       - centreon-perl-libs = ${VERSION}-${RELEASE}${DIST}
       - net-snmp
+      - perl(SNMP)
     replaces:
       - centreon-trap-central
       - centreon-trap-poller
   deb:
     depends:
       - centreon-perl-libs (= ${VERSION}-${RELEASE}${DIST})
+      - libsnmp-perl
       - snmptrapd
       - snmpd
 


### PR DESCRIPTION
## Description

* add perl snmp dependency for centreontrapd

Fixes #MON-151147

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
