### PR TITLE
fix(change logs): map new fields names on legacy fields form names

### DIFF
--- a/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostActionLogRepository.php
@@ -45,6 +45,49 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
 {
     use LoggerTrait;
     public const HOST_OBJECT_TYPE = 'host';
+    public const HOST_PROPERTIES_MAP = [
+        'name' => 'host_name',
+        'alias' => 'host_alias',
+        'address' => 'host_address',
+        'monitoringServerId' => 'nagios_server_id',
+        'activeCheckEnabled' => 'host_active_checks_enabled',
+        'passiveCheckEnabled' => 'host_passive_checks_enabled',
+        'notificationEnabled' => 'host_notifications_enabled',
+        'freshnessChecked' => 'host_check_freshness',
+        'flapDetectionEnabled' => 'host_flap_detection_enabled',
+        'eventHandlerEnabled' => 'host_event_handler_enabled',
+        'isActivated' => 'host_activate',
+        'snmpVersion' => 'host_snmp_version',
+        'snmpCommunity' => 'host_snmp_community',
+        'timezoneId' => 'host_location',
+        'checkCommandId' => 'command_command_id',
+        'checkTimeperiodId' => 'timeperiod_tp_id',
+        'maxCheckAttempts' => 'host_max_check_attempts',
+        'normalCheckInterval' => 'host_check_interval',
+        'retryCheckInterval' => 'host_retry_check_interval',
+        'checkCommandArgs' => 'command_command_id_arg1',
+        'noteUrl' => 'ehi_notes_url',
+        'note' => 'ehi_notes',
+        'actionUrl' => 'ehi_action_url',
+        'iconAlternative' => 'ehi_icon_image_alt',
+        'comment' => 'host_comment',
+        'eventHandlerCommandArgs' => 'command_command_id_arg2',
+        'notificationTimeperiodId' => 'timeperiod_tp_id2',
+        'eventHandlerCommandId' => 'command_command_id2',
+        'geoCoordinates' => 'geo_coords',
+        'notificationOptions' => 'host_notifOpts',
+        'iconId' => 'ehi_icon_image',
+        'notificationInterval' => 'host_notification_interval',
+        'firstNotificationDelay' => 'host_first_notification_delay',
+        'recoveryNotificationDelay' => 'host_recovery_notification_delay',
+        'acknowledgementTimeout' => 'host_acknowledgement_timeout',
+        'freshnessThreshold' => 'host_freshness_threshold',
+        'lowFlapThreshold' => 'host_low_flap_threshold',
+        'highFlapThreshold' => 'host_high_flap_threshold',
+        'severityId' => 'severity_id',
+        'addInheritedContactGroup' => 'cg_additive_inheritance',
+        'addInheritedContact' => 'contact_additive_inheritance',
+    ];
 
     /**
      * @param WriteHostRepositoryInterface $writeHostRepository
@@ -235,6 +278,9 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
         $hostReflection = new \ReflectionClass($host);
 
         foreach ($hostReflection->getProperties() as $property) {
+            $propertyName = $property->getName();
+
+            $mappedName = self::HOST_PROPERTIES_MAP[$propertyName] ?? $propertyName;
             $value = $property->getValue($host);
             if ($value === null) {
                 $value = '';
@@ -262,7 +308,7 @@ class DbWriteHostActionLogRepository extends AbstractRepositoryRDB implements Wr
                 }
             }
 
-            $hostPropertiesArray[$property->getName()] = $value;
+            $hostPropertiesArray[$mappedName] = $value;
         }
 
         return $hostPropertiesArray;

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupActionLogRepository.php
@@ -40,6 +40,19 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
 {
     use LoggerTrait;
     public const HOSTGROUP_OBJECT_TYPE = 'hostgroup';
+    private const HOST_PROPERTIES_MAP = [
+        'name' => 'hg_name',
+        'alias' => 'hg_alias',
+        'notes' => 'hg_notes',
+        'notesUrl' => 'hg_notes_url',
+        'actionUrl' => 'hg_action_url',
+        'iconId' => 'hg_icon_image',
+        'iconMapId' => 'hg_map_icon_image',
+        'rrdRetention' => 'hg_rrd_retention',
+        'geoCoords' => 'geo_coords',
+        'comment' => 'hg_comment',
+        'isActivated' => 'hg_activate',
+    ];
 
     /**
      * @param WriteHostGroupRepositoryInterface $writeHostGroupRepository
@@ -226,6 +239,9 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
         $hostGroupReflection = new \ReflectionClass($hostGroup);
 
         foreach ($hostGroupReflection->getProperties() as $property) {
+            $propertyName = $property->getName();
+
+            $mappedName = self::HOST_PROPERTIES_MAP[$propertyName] ?? $propertyName;
             $value = $property->getValue($hostGroup);
             if ($value === null) {
                 $value = '';
@@ -235,7 +251,7 @@ class DbWriteHostGroupActionLogRepository extends AbstractRepositoryRDB implemen
                 $value = $value->__toString();
             }
 
-            $hostGroupPropertiesArray[$property->getName()] = $value;
+            $hostGroupPropertiesArray[$mappedName] = $value;
         }
 
         return $hostGroupPropertiesArray;

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -50,6 +50,7 @@ use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Infrastructure\Common\Api\Router;
 use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Host\Application\Converter\HostEventConverter;
+use Core\Host\Infrastructure\Repository\DbWriteHostActionLogRepository;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Symfony\Component\HttpClient\CurlHttpClient;
@@ -2838,14 +2839,16 @@ function insertHostInAPI(array $ret = []): int|null
             'action' => 'ADD',
             'access_grp_id' => ($formData['acl_groups'] ?? null),
         ]);
-        // Insert change logs
+
+        //Insert change logs
         $fields = CentreonLogAction::prepareChanges($formData);
+        $filteredFields = array_diff_key($fields, array_flip(DbWriteHostActionLogRepository::HOST_PROPERTIES_MAP));
         $centreon->CentreonLogAction->insertLog(
             "host",
             $hostId,
             CentreonDB::escape($formData["host_name"]),
             "a",
-            $fields
+            $filteredFields
         );
 
         return ($hostId);


### PR DESCRIPTION
## Description

Mapping new fields names for change log on legacy fields form names for hosts and hostGroups

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
