### PR TITLE
fix(cron): fix misdirected log when calling cron outdated-token

### DIFF
--- a/centreon/cron/outdated-token-removal.php
+++ b/centreon/cron/outdated-token-removal.php
@@ -43,21 +43,20 @@ try {
    $pearDB->commit();
 } catch (\Throwable) {
     $pearDB->rollBack();
-    $centreonLog->insertLog(
-        2,
+    $centreonLog->info(
+        CentreonLog::TYPE_BUSINESS_LOG,
         "TokenRemoval CRON: failed to delete old tokens"
     );
 }
-
 
 /**
  * Delete expired provider refresh tokens.
  */
 function deleteExpiredProviderRefreshTokens(CentreonLog $logger, CentreonDB $pearDB): void
 {
-    $logger->insertLog(2, 'Deleting expired refresh tokens');
+    $logger->info(CentreonLog::TYPE_BUSINESS_LOG, 'Deleting expired refresh tokens');
 
-    $pearDB->query(
+    $pearDB->executeQuery(
         <<<'SQL'
             DELETE st FROM security_token st
             WHERE st.expiration_date < UNIX_TIMESTAMP(NOW())
@@ -77,9 +76,9 @@ function deleteExpiredProviderRefreshTokens(CentreonLog $logger, CentreonDB $pea
  */
 function deleteExpiredProviderTokens(CentreonLog $logger, CentreonDB $pearDB): void
 {
-    $logger->insertLog(2, 'Deleting expired tokens which are not linked to a refresh token');
+    $logger->info(CentreonLog::TYPE_BUSINESS_LOG, 'Deleting expired tokens which are not linked to a refresh token');
 
-    $pearDB->query(
+    $pearDB->executeQuery(
         <<<'SQL'
             DELETE st FROM security_token st
             WHERE st.expiration_date < UNIX_TIMESTAMP(NOW())
@@ -100,9 +99,9 @@ function deleteExpiredProviderTokens(CentreonLog $logger, CentreonDB $pearDB): v
  */
 function deleteExpiredSessions(CentreonLog $logger, CentreonDB $pearDB): void
 {
-    $logger->insertLog(2, 'Deleting expired sessions');
+    $logger->info(CentreonLog::TYPE_BUSINESS_LOG, 'Deleting expired sessions');
 
-    $pearDB->query(
+    $pearDB->executeQuery(
         <<<'SQL'
             DELETE s FROM session s
             WHERE s.last_reload < (


### PR DESCRIPTION
## Description

Misdirected log when calling cron outdated-token-removal.php
Error : Logs are written in /var/log/centreon/sql-error.log
Fix: Fixed to write into /var/log/centreon/centreon-web.log

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
