### PR TITLE
fix(Graphs): User with ACLs download an empty csv via Performance > Graph page.

### DIFF
--- a/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
@@ -203,7 +203,7 @@ class DbReadServiceRepository extends AbstractRepositoryRDB implements ReadServi
             <<<SQL
                 SELECT 1
                 FROM `:db`.`service` s
-                INNER JOIN `:db`.`service_categories_relation` scr
+                LEFT JOIN `:db`.`service_categories_relation` scr
                     ON scr.`service_service_id` = s.`service_id`
                     {$categoryAcls}
                 JOIN `:dbstg`.`centreon_acl` acl


### PR DESCRIPTION
## Description

Fixed the issue where exporting a csv performance graph report as a non-admin user results in an empty file

**Fixes** # MON-144632

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
