### PR TITLE
fix(HA)-fix-cron-HA add centreeon core cron outdated token in gorgone cron for HA

### DIFF
--- a/centreon-ha/etc/centreon-gorgone/config.d/cron.d/10-centreon-ha.yaml
+++ b/centreon-ha/etc/centreon-gorgone/config.d/cron.d/10-centreon-ha.yaml
@@ -40,3 +40,10 @@
     - command: "/usr/bin/php /usr/share/centreon/cron/centreon-partitioning.php >> /var/log/centreon-gorgone/centreon-partitioning.log 2>&1"
       timeout: 120
   keep_token: true
+- id: outdated_token_removal
+  timespec: "*/5 * * * *"
+  action: COMMAND
+  parameters:
+    - command: "/usr/bin/php /usr/share/centreon/cron/outdated-token-removal.php >> /var/log/centreon-gorgone/outdated-token-removal.log 2>&1"
+      timeout: 120
+  keep_token: true 


### PR DESCRIPTION
## Description

Add centreon core cron outdated token in Gorgone cron for HA.
This is the cron that closes sessions when the token is outdated. The cron is in place for the Centreon-Web in the classic cron. However, it is not present for HA. This results in sessions that are not closed.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects, breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Set up an HA, connect and disconnect. Run the test over several days. You'll see that sessions are active. Even if you've closed your browser for several days.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
