### PR TITLE
fix: reset array keys in common-Func

### DIFF
--- a/centreon/www/include/common/common-Func.php
+++ b/centreon/www/include/common/common-Func.php
@@ -1787,6 +1787,7 @@ function findHostsForConfigChangeFlagFromHostGroupIds(array $hostgroupIds, bool 
     global $pearDB;
 
     $bindedParams = [];
+    $hostgroupIds = array_values($hostgroupIds);
     foreach ($hostgroupIds as $key => $hostgroupId) {
         $bindedParams[':hostgroup_id_' . $key] = $hostgroupId;
     }
@@ -1828,6 +1829,7 @@ function findHostsForConfigChangeFlagFromServiceIds(array $serviceIds, bool $sho
     global $pearDB;
 
     $bindedParams = [];
+    $serviceIds = array_values($serviceIds);
     foreach ($serviceIds as $key => $serviceId) {
         $bindedParams[':service_id_' . $key] = $serviceId;
     }
@@ -1869,6 +1871,7 @@ function findServicesForConfigChangeFlagFromServiceTemplateIds(array $serviceTem
     global $pearDB;
 
     $bindedParams = [];
+    $serviceTemplateIds = array_values($serviceTemplateIds);
     foreach ($serviceTemplateIds as $key => $serviceTemplateId) {
         $bindedParams[':servicetemplate_id_' . $key] = $serviceTemplateId;
     }
@@ -1962,6 +1965,7 @@ function findPollersForConfigChangeFlagFromHostIds(array $hostIds, bool $shouldH
     global $pearDB;
 
     $bindedParams = [];
+    $hostIds = array_values($hostIds);
     foreach ($hostIds as $key => $hostId) {
         $bindedParams[':host_id_' . $key] = $hostId;
     }
@@ -2000,6 +2004,7 @@ function definePollersToUpdated(array $pollerIds): void
     global $pearDB;
 
     $bindedParams = [];
+    $pollerIds = array_values($pollerIds);
     foreach ($pollerIds as $key => $pollerId) {
         $bindedParams[':poller_id_' . $key] = $pollerId;
     }


### PR DESCRIPTION
## Description

Reset array keys in common-Func

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
