### PR TITLE
Fix(UI): Fix crash when editing back a widget (#5456)

### DIFF
--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/Actions.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/Actions.tsx
@@ -2,7 +2,6 @@ import { useFormikContext } from 'formik';
 import { useTranslation } from 'react-i18next';
 
 import { Modal } from '@centreon/ui/components';
-
 import { useCanEditProperties } from '../hooks/useCanEditDashboard';
 import { labelCancel, labelSave } from '../translatedLabels';
 

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/utils.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/utils.ts
@@ -130,7 +130,7 @@ const getYupValidatorType = ({
               .optional()
           )
           .when('resources', ([resources], schema) => {
-            const hasMetaService = resources.some(({ resourceType }) =>
+            const hasMetaService = resources?.some(({ resourceType }) =>
               equals(resourceType, WidgetResourceType.metaService)
             );
 
@@ -213,14 +213,14 @@ export const showInput = ({
   const dependencyValue = path(when.split('.'), values) as Array<object>;
 
   if (notContains) {
-    return notContains.some(
+    return notContains?.some(
       ({ key, value }) =>
         !includes(value, pluck(key, dependencyValue).join(','))
     );
   }
 
   if (contains) {
-    return contains.some(({ key, value }) =>
+    return contains?.some(({ key, value }) =>
       includes(value, pluck(key, dependencyValue).join(','))
     );
   }

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/useWidgetModal.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/useWidgetModal.ts
@@ -153,7 +153,7 @@ const useWidgetModal = (): UseWidgetModalState => {
 
     setPanelOptions({
       data: values.data || undefined,
-      id: values.id as string,
+      id: widgetFormInitialData?.id as string,
       options: values.options
     });
     showSuccessMessage(t(labelYourWidgetHasBeenModified));

--- a/centreon/www/widgets/src/centreon-widget-groupmonitoring/src/utils.ts
+++ b/centreon/www/widgets/src/centreon-widget-groupmonitoring/src/utils.ts
@@ -16,7 +16,11 @@ import {
   labelWarning
 } from './translatedLabels';
 
-export const getResourceTypeName = (resourceType: string): string => {
+export const getResourceTypeName = (resourceType?: string | null): string => {
+  if (!resourceType) {
+    return '';
+  }
+
   const [firstPart, secondPart] = resourceType.split('-');
 
   if (!secondPart) {


### PR DESCRIPTION
## Description

This fixes a crash when editing a widget, switch to another widget type then switch back to the first widget then save the widget.

https://github.com/user-attachments/assets/224e868c-25bb-4928-8ff8-e56c09ca2d39

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
