### PR TITLE
fix(Sevice): rework service repository method 'existsByAccessGroups'

### DIFF
--- a/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidation.php
+++ b/centreon/src/Core/Service/Application/UseCase/PartialUpdateService/PartialUpdateServiceValidation.php
@@ -206,10 +206,16 @@ class PartialUpdateServiceValidation
      */
     public function assertIsValidSeverity(?int $severityId): void
     {
-        if ($severityId !== null && ! $this->serviceSeverityRepository->exists($severityId)) {
-            $this->error('Service severity does not exist', ['severity_id' => $severityId]);
+        if ($severityId !== null) {
+            $exists = ($this->accessGroups === [])
+                ? $this->serviceSeverityRepository->exists($severityId)
+                : $this->serviceSeverityRepository->existsByAccessGroups($severityId, $this->accessGroups);
 
-            throw ServiceException::idDoesNotExist('severity_id', $severityId);
+            if (! $exists) {
+                $this->error('Service severity does not exist', ['severity_id' => $severityId]);
+
+                throw ServiceException::idDoesNotExist('severity_id', $severityId);
+            }
         }
     }
 

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
@@ -175,7 +175,7 @@ class DbReadServiceRepository extends AbstractRepositoryRDB implements ReadServi
      */
     public function existsByAccessGroups(int $serviceId, array $accessGroups): bool
     {
-        if (empty($accessGroups)) {
+        if ($accessGroups === []) {
             $this->debug('Access groups array empty');
 
             return false;

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
@@ -175,7 +175,7 @@ class DbReadServiceRepository extends AbstractRepositoryRDB implements ReadServi
      */
     public function existsByAccessGroups(int $serviceId, array $accessGroups): bool
     {
-        if ($accessGroups === []) {
+        if (empty($accessGroups)) {
             $this->debug('Access groups array empty');
 
             return false;
@@ -186,21 +186,37 @@ class DbReadServiceRepository extends AbstractRepositoryRDB implements ReadServi
             $accessGroups
         );
 
-        $concatenator = $this->findServicesRequest($accessGroupIds);
-        $concatenator->defineSelect('SELECT 1');
-        $concatenator->appendJoins(
-            <<<'SQL'
-                JOIN `:dbstg`.centreon_acl acl
-                    ON service.service_id = acl.service_id
-                SQL
-        );
-        $concatenator->appendWhere('acl.group_id IN (:access_group_ids)');
-        $concatenator->appendWhere('service.service_id = :service_id');
-        $concatenator->storeBindValue(':service_id', $serviceId, \PDO::PARAM_INT);
-        $concatenator->storeBindValueMultiple(':access_group_ids', $accessGroupIds, \PDO::PARAM_INT);
+        $bindValuesArray = [];
+        foreach ($accessGroupIds as $index => $id) {
+            $bindValuesArray[':access_group_id_' . $index] = $id;
+        }
+        $bindParamsAsString = implode(',', array_keys($bindValuesArray));
 
-        $statement = $this->db->prepare($this->translateDbName($concatenator->__toString()));
-        $concatenator->bindValuesToStatement($statement);
+        $subRequest = $this->generateServiceCategoryAclSubRequest($accessGroupIds);
+        $categoryAcls = empty($subRequest)
+            ? ''
+            : <<<SQL
+                AND scr.sc_id IN ({$subRequest})
+                SQL;
+
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<SQL
+                SELECT 1
+                FROM `:db`.`service` s
+                LEFT JOIN `:db`.`service_categories_relation` scr
+                    ON scr.`service_service_id` = s.`service_id`
+                JOIN `:dbstg`.`centreon_acl` acl
+                WHERE acl.`group_id` IN ({$bindParamsAsString})
+                    AND s.`service_id` = :service_id
+                    AND s.`service_register` = '1'
+                    {$categoryAcls}
+                SQL
+        ));
+        $statement->bindValue(':service_id', $serviceId, \PDO::PARAM_INT);
+        foreach ($bindValuesArray as $bindParam => $bindValue) {
+            $statement->bindValue($bindParam, $bindValue, \PDO::PARAM_INT);
+        }
+
         $statement->execute();
 
         return (bool) $statement->fetchColumn();

--- a/centreon/tests/rest_api/collections/configuration/Service.postman_collection.json
+++ b/centreon/tests/rest_api/collections/configuration/Service.postman_collection.json
@@ -9058,7 +9058,7 @@
 											"pm.test(\"The service was not updated because the user does not have sufficient rights for the severity which is not recognized.\", function () {\r",
 											"    pm.response.to.have.status(409);\r",
 											"\r",
-											"    pm.expect(responseJson.message).to.eql(\"The severity_id with value'\" + pm.collectionVariables.get(\"ServiceSeverity1Id\") + \"' does not exist\");\r",
+											"    pm.expect(responseJson.message).to.eql(\"The severity_id with value '\" + pm.collectionVariables.get(\"ServiceSeverity1Id\") + \"' does not exist\");\r",
 											"\r",
 											"});"
 										],

--- a/centreon/tests/rest_api/collections/configuration/Service.postman_collection.json
+++ b/centreon/tests/rest_api/collections/configuration/Service.postman_collection.json
@@ -9056,9 +9056,9 @@
 											"const responseJson = pm.response.json();\r",
 											"console.log(responseJson);\r",
 											"pm.test(\"The service was not updated because the user does not have sufficient rights for the severity which is not recognized.\", function () {\r",
-											"    pm.response.to.have.status(404);\r",
+											"    pm.response.to.have.status(409);\r",
 											"\r",
-											"    pm.expect(responseJson.message).to.eql('Service not found');\r",
+											"    pm.expect(responseJson.message).to.eql(\"The severity_id with value'\" + pm.collectionVariables.get(\"ServiceSeverity1Id\") + \"' does not exist\");\r",
 											"\r",
 											"});"
 										],
@@ -9085,14 +9085,14 @@
 									}
 								},
 								"url": {
-									"raw": "{{baseUrl}}/configuration/services/{{Service3Id}}",
+									"raw": "{{baseUrl}}/configuration/services/{{Service1Id}}",
 									"host": [
 										"{{baseUrl}}"
 									],
 									"path": [
 										"configuration",
 										"services",
-										"{{Service3Id}}"
+										"{{Service1Id}}"
 									]
 								}
 							},


### PR DESCRIPTION
## Description

- Reworked Service repository method `existsByAccessGroups`
- Fixed PartialUpdateService return code & ACL checks
- Adapted API tests

**Fixes** # MON-151521

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
