### PR TITLE
MON-106121-pull-wss-add-gorgone-parameter-to-get-vault-credentials

### DIFF
--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -115,7 +115,7 @@ runs:
         key: ${{ inputs.cache_key }}
 
     # Update if condition to true to get packages as artifacts
-    - if: ${{ true }}
+    - if: ${{ false }}
       name: Upload package artifacts
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -115,7 +115,7 @@ runs:
         key: ${{ inputs.cache_key }}
 
     # Update if condition to true to get packages as artifacts
-    - if: ${{ false }}
+    - if: ${{ true }}
       name: Upload package artifacts
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -114,8 +114,8 @@ runs:
         path: ./*.${{ inputs.package_extension }}
         key: ${{ inputs.cache_key }}
 
-    # Update if condition to true to get packages as artifacts
-    - if: ${{ false }}
+    # Add to your PR the label upload-artifacts to get packages as artifacts
+    - if: ${{ contains(github.event.pull_request.labels.*.name, 'upload-artifacts') }}
       name: Upload package artifacts
       uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:

--- a/.github/workflows/perl-unit-tests.yml
+++ b/.github/workflows/perl-unit-tests.yml
@@ -1,0 +1,72 @@
+name: perl-unit-tests
+# this simple workflow is used to run the unit tests on the perl code in this repo.
+# We can't add this before the packaging, as the packaging is generic for all Centreon package.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/perl-unit-tests.yml'
+      - 'centreon/lib/perl/**'
+      - 'centreon/packaging/centreon-perl*.yaml'
+  push:
+    branches:
+      - develop
+      - master
+    paths:
+      - '.github/workflows/perl-unit-tests.yml'
+      - 'centreon/lib/perl/**'
+      - 'centreon/packaging/centreon-perl*.yaml'
+
+
+jobs:
+  unit-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        image: [unit-tests-alma8, unit-tests-alma9, unit-tests-bullseye, unit-tests-bullseye-arm64, unit-tests-bookworm, unit-tests-jammy]
+        include:
+          - runner_name: ubuntu-22.04
+          - package_extension: rpm
+            image: unit-tests-alma8
+            distrib: el8
+          - package_extension: rpm
+            image: unit-tests-alma9
+            distrib: el9
+          - package_extension: deb
+            image: unit-tests-bullseye
+            distrib: bullseye
+          - package_extension: deb
+            image: unit-tests-bullseye-arm64
+            distrib: bullseye-arm64
+            runner_name: ["self-hosted", "collect-arm64"]
+          - package_extension: deb
+            image: unit-tests-bookworm
+            distrib: bookworm
+          - package_extension: deb
+            image: unit-tests-jammy
+            distrib: jammy
+    runs-on: ${{ matrix.runner_name }}
+    container:
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/${{ matrix.image }}
+      credentials:
+        username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
+        password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Run unit tests
+        run: yath -L test ./centreon/lib/perl/
+
+      - name: Upload logs as artifacts if tests failed
+        if: failure()
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: plugin-installation-${{ matrix.distrib }}
+          path: ./lastlog.jsonl
+          retention-days: 1

--- a/centreon/lib/perl/README.md
+++ b/centreon/lib/perl/README.md
@@ -1,0 +1,33 @@
+# centreon-perl-libs / centreon-perl-libs-common
+
+This directory contains the common Perl libraries used by Centreon.
+
+## centreon-perl-libs-common
+
+This package contain libraries located in centreon::common namespace.
+they are generic library used by multiples centreon modules.
+
+### tests
+
+to execute the test, see t/ directory in the package.
+First install the dependency : 
+```bash
+# distro package to install :  
+openssl-dev
+# cpan package to install :
+Test2::V0 Test2::Plugin::NoWarnings Crypt::OpenSSL::AES
+```
+
+run the following command passing the path to t/ folder as argument :
+```bash
+prove -r t/
+```
+
+
+## centreon-perl-libs
+
+This package contain libraries associated to specific binary, they are located in centreon::[area] namespace.
+
+for exemple the package centreon-trap contain a binary calling centreon::trap namespace which contain all the logic.
+
+

--- a/centreon/lib/perl/centreon/common/centreonvault.pm
+++ b/centreon/lib/perl/centreon/common/centreonvault.pm
@@ -1,0 +1,428 @@
+#
+# Copyright 2024 Centreon (http://www.centreon.com/)
+#
+# Centreon is a full-fledged industry-strength solution that meets
+# the needs in IT infrastructure and application monitoring for
+# service performance.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+package centreon::common::centreonvault;
+
+use strict;
+use warnings;
+
+use MIME::Base64;
+use Crypt::OpenSSL::AES;
+use Net::Curl::Easy qw(:constants);
+use JSON::XS;
+
+my $VAULT_PATH_REGEX = qr/^secret::hashicorp_vault::([^:]+)::(.+)$/;
+
+sub new {
+    my ($class, %options) = @_;
+    my $self  = bless \%options, $class;
+    # mandatory options:
+    # - logger: logger object
+    # - config_file: either path of a JSON vault config file or the configuration as a perl hash.
+
+    $self->{enabled} = 1;
+    $self->{crypted_credentials} = 1;
+
+    if ( !$self->init() ) {
+        $self->{enabled} = 0;
+        $self->{logger}->writeLogWarning("Something happened during init() method that makes Centreonvault not usable. Ignore this if you don't use Centreonvault");
+    }
+    return $self;
+}
+
+
+sub init {
+    my ($self, %options) = @_;
+
+    $self->check_options() or return undef;
+
+    # for unit test purpose, if the config is given as an hash, we don't try to read the config file.
+    if (ref $self->{config_file} eq ref {}) {
+        $self->{vault_config} = $self->{config_file};
+    } else {
+        # check if the following information is available
+        $self->{logger}->writeLogDebug("Reading Vault configuration from file " . $self->{config_file} . ".");
+        $self->{vault_config} = parse_json_file('json_file' => $self->{config_file});
+        if (defined($self->{vault_config}->{error_message})) {
+            $self->{logger}->writeLogInfo("Error while parsing " . $self->{config_file} . ": "
+                . $self->{vault_config}->{error_message});
+            return undef;
+        }
+    }
+    $self->check_configuration() or return undef;
+
+    $self->{logger}->writeLogDebug("Vault configuration read. Name: " . $self->{vault_config}->{name}
+        . ". Url: " . $self->{vault_config}->{url} . ".");
+
+    # Create the Curl object, it will be used several times
+    $self->{curl_easy} = Net::Curl::Easy->new();
+    $self->{curl_easy}->setopt( CURLOPT_USERAGENT, "Centreon VMware daemon's centreonvault.pm");
+
+    return 1;
+}
+
+sub check_options {
+    my ($self, %options) = @_;
+
+    if ( !defined($self->{logger}) ) {
+        die "FATAL: No logger given to the constructor. Centreonvault cannot be used.";
+    }
+    if ( !defined($self->{config_file})) {
+        $self->{logger}->writeLogNotice("No config file given to the constructor. Centreonvault cannot be used.");
+        return undef;
+    }
+    if ( ! -f $self->{config_file} and ref $self->{config_file} ne ref {}) {
+        $self->{logger}->writeLogNotice("The given configuration file " . $self->{config_file}
+            . " does not exist. Passwords won't be retrieved from Centreonvault. Ignore this if you don't use Centreonvault.");
+        return undef;
+    }
+
+    return 1;
+}
+
+sub check_configuration {
+    my ($self, %options) = @_;
+
+    if ( !defined($self->{vault_config}->{url}) || $self->{vault_config}->{url} eq '') {
+        $self->{logger}->writeLogDebug("Vault url is missing from configuration.");
+        $self->{vault_config}->{url} = '127.0.0.1';
+    }
+    if ( !defined($self->{vault_config}->{port}) || $self->{vault_config}->{port} eq '') {
+        $self->{logger}->writeLogDebug("Vault port is missing from configuration.");
+        $self->{vault_config}->{port} = '443';
+    }
+
+    # Normally, the role_id and secret_id data are encrypted using AES wit the following information:
+    # firstKey = APP_SECRET (environment variable)
+    # secondKey = 'salt' (hashing) key given by vault.json configuration file
+    # both are base64 encoded
+    if ( !defined($self->{vault_config}->{salt}) || $self->{vault_config}->{salt} eq '') {
+        $self->{logger}->writeLogNotice("Vault environment does not seem complete: 'salt' attribute missing from "
+            . $self->{config_file}
+            . ". 'role_id' and 'secret_id' won't be decrypted, so they'll be used as they're stored in the vault config file.");
+        $self->{crypted_credentials} = 0;
+        $self->{hash_key} = '';
+    } else {
+        $self->{hash_key} = $self->{vault_config}->{salt}; # key for sha3-512 hmac
+    }
+    $self->{encryption_key} = get_app_secret();
+    if ( !defined($self->{encryption_key}) or $self->{encryption_key} eq '' ) {
+        $self->{logger}->writeLogInfo("Vault environment does not seem complete. 'APP_SECRET' environment variable missing."
+            . " 'role_id' and 'secret_id' won't be decrypted, so they'll be used as they're stored in the vault config file.");
+        $self->{crypted_credentials} = 0;
+        $self->{encryption_key} = '';
+    }
+
+    return 1;
+}
+
+sub get_app_secret {
+    if (defined($ENV{'APP_SECRET'}) && $ENV{'APP_SECRET'} ne '' ) {
+        return $ENV{'APP_SECRET'};
+    }
+    if (-r '/usr/share/centreon/.env'){
+        open(my $fh, '<', '/usr/share/centreon/.env') or return '';
+        while (my $line = <$fh>) {
+            chomp $line;
+            if ($line =~ /^APP_SECRET=(.+)$/) {
+                return $1;
+            }
+        }
+    }
+    return ''; # if no app_secret found return empty string so caller don't try to use it.
+}
+
+sub extract_and_decrypt {
+    my ($self, %options) = @_;
+
+    my $input = decode_base64($options{data});
+    $self->{logger}->writeLogDebug("data to extract and decrypt: '" . $options{data} . "'");
+
+    # with AES-256, the IV length must 16 bytes
+    my $iv_length = 16;
+    # extract the IV, the hashed data, the encrypted data
+    my $iv             = substr($input, 0, $iv_length);     # initialization vector
+    my $hashed_data    = substr($input, $iv_length, 64);    # hmac of the original data, for integrity control
+    my $encrypted_data = substr($input, $iv_length + 64);   # data to decrypt
+
+    # create the AES object
+    $self->{logger}->writeLogDebug(
+            "Creating the AES decryption object for initialization vector (IV) of length "
+            . length($iv) . "B, key of length " . length($self->{encryption_key}) . "B."
+    );
+    my $cipher;
+    eval {
+        $cipher = Crypt::OpenSSL::AES->new(
+            decode_base64( $self->{encryption_key} ),
+            {
+                'cipher'  => 'AES-256-CBC',
+                'iv'      => $iv,
+                'padding' => 1
+            }
+        );
+    };
+    if ($@) {
+        $self->{logger}->writeLogNotice("There was an error while creating the AES object: " . $@);
+        return undef;
+    }
+
+    # decrypt
+    $self->{logger}->writeLogDebug("Decrypting the data of length " . length($encrypted_data) . "B.");
+    my $decrypted_data;
+    eval {$decrypted_data = $cipher->decrypt($encrypted_data);};
+    if ($@) {
+        $self->{logger}->writeLogNotice("There was an error while decrypting one of the AES-encrypted data: " . $@);
+        return undef;
+    }
+
+    return $decrypted_data;
+}
+
+sub authenticate {
+    my ($self) = @_;
+
+    # initial value: assuming the role and secret id might not be encrypted
+    my $role_id   = $self->{vault_config}->{role_id};
+    my $secret_id = $self->{vault_config}->{secret_id};
+
+
+    if ($self->{crypted_credentials}) {
+        # Then decrypt using https://github.com/perl-openssl/perl-Crypt-OpenSSL-AES
+        # keep the decrypted data in local variables so that they stay in memory for as little time as possible
+        $self->{logger}->writeLogDebug("Decrypting the credentials needed to authenticate to the vault.");
+        $role_id   = $self->extract_and_decrypt( ('data' => $role_id ));
+        $secret_id = $self->extract_and_decrypt( ('data' => $secret_id ));
+        $self->{logger}->writeLogDebug("role_id and secret_id have been decrypted.");
+    } else {
+        $self->{logger}->writeLogDebug("role_id and secret_id are not crypted");
+    }
+
+
+    # Authenticate to get the token
+    my $url = "https://" . $self->{vault_config}->{url} . ":" . $self->{vault_config}->{port} . "/v1/auth/approle/login";
+    $self->{logger}->writeLogDebug("Authenticating to the vault server at URL: $url");
+    $self->{curl_easy}->setopt( CURLOPT_URL, $url );
+
+    my $post_data = "role_id=$role_id&secret_id=$secret_id";
+    my $auth_result_json;
+    # to get more details (in STDERR)
+    #$self->{curl_easy}->setopt(CURLOPT_VERBOSE, 1);
+    $self->{curl_easy}->setopt(CURLOPT_POST, 1);
+    $self->{curl_easy}->setopt(CURLOPT_POSTFIELDS, $post_data);
+    $self->{curl_easy}->setopt(CURLOPT_POSTFIELDSIZE, length($post_data));
+    $self->{curl_easy}->setopt(CURLOPT_WRITEDATA(), \$auth_result_json);
+
+    eval {
+        $self->{curl_easy}->perform();
+    };
+    if ($@) {
+        $self->{logger}->writeLogError("Error while authenticating to the vault: " . $@);
+        return undef;
+    }
+
+    $self->{logger}->writeLogInfo("Authentication to the vault passed." );
+
+    my $auth_result_obj = transform_json_to_object($auth_result_json);
+    if (defined($auth_result_obj->{error_message})) {
+        $self->{logger}->writeLogError("Error while decoding JSON '$auth_result_json'. Message: "
+                . $auth_result_obj->{error_message});
+        return undef;
+    }
+
+    # store the token (.auth.client_token) and its expiration date (current date + .lease_duration)
+    my $expiration_epoch = -1;
+    my $lease_duration = $auth_result_obj->{auth}->{lease_duration};
+    if ( defined($lease_duration)
+            && $lease_duration =~ /\d+/
+            && $lease_duration > 0 ) {
+        $expiration_epoch = time() + $lease_duration;
+    }
+    $self->{auth} = {
+        'token'            => $auth_result_obj->{auth}->{client_token},
+        'expiration_epoch' => $expiration_epoch
+    };
+    $self->{logger}->writeLogInfo("Authenticating worked. Token valid until "
+        . localtime($self->{auth}->{expiration_epoch}));
+
+    return 1;
+}
+
+sub is_token_still_valid {
+    my ($self) = @_;
+    if (
+            !defined($self->{auth})
+            || !defined($self->{auth}->{token})
+            || $self->{auth}->{token} eq ''
+            || $self->{auth}->{expiration_epoch} <= time()
+    ) {
+        $self->{logger}->writeLogInfo("The token has expired or is invalid.");
+        return undef;
+    }
+    $self->{logger}->writeLogDebug("The token is still valid.");
+    return 1;
+}
+
+sub get_secret {
+    my ($self, $secret) = @_;
+
+    # if vault not enabled, return the secret unchanged
+    return $secret if ( ! $self->{enabled});
+
+    my ($secret_path, $secret_name) = $secret =~ $VAULT_PATH_REGEX;
+    if (!defined($secret_path) || !defined($secret_name)) {
+        return $secret;
+    }
+    $self->{logger}->writeLogDebug("Secret path: $secret_path - Secret name: $secret_name");
+
+    if (!defined($self->{auth}) || !$self->is_token_still_valid() ) {
+        $self->authenticate() or return $secret;
+    }
+
+    # prepare the GET statement
+    my $get_result_json;
+    my $url = "https://" . $self->{vault_config}->{url} . ":" . $self->{vault_config}->{port} . "/v1/" . $secret_path;
+    $self->{logger}->writeLogDebug("Requesting URL: $url");
+
+    #$self->{curl_easy}->setopt( CURLOPT_VERBOSE, 1 );
+    $self->{curl_easy}->setopt( CURLOPT_URL, $url );
+    $self->{curl_easy}->setopt( CURLOPT_POST, 0 );
+    $self->{curl_easy}->setopt( CURLOPT_WRITEDATA(), \$get_result_json );
+    $self->{curl_easy}->setopt( CURLOPT_HTTPHEADER(), ["X-Vault-Token: " . $self->{auth}->{token}]);
+
+    eval {
+        $self->{curl_easy}->perform();
+    };
+    if ($@) {
+        $self->{logger}->writeLogError("Error while getting a secret from the vault: " . $@);
+        return $secret;
+    }
+
+    $self->{logger}->writeLogDebug("Request passed.");
+    # request_id
+
+    # the result is a json string, convert it into an object
+    my $get_result_obj = transform_json_to_object($get_result_json);
+    if (defined($get_result_obj->{error_message})) {
+        $self->{logger}->writeLogError("Error while decoding JSON '$get_result_json'. Message: "
+                . $get_result_obj->{error_message});
+        return $secret;
+    }
+    $self->{logger}->writeLogDebug("Request id is " . $get_result_obj->{request_id});
+
+    # .data.data will contain the stored macros
+    if ( !defined($get_result_obj->{data})
+            || !defined($get_result_obj->{data}->{data})
+            || !defined($get_result_obj->{data}->{data}->{$secret_name}) ) {
+        $self->{logger}->writeLogError("Could not get secret '$secret_name' from path '$secret_path' from the vault. Enable debug for more details.");
+        $self->{logger}->writeLogDebug("Response: " . $get_result_json);
+        return $secret;
+    }
+    $self->{logger}->writeLogInfo("Secret '$secret_name' from path '$secret_path' retrieved from the vault.");
+    return $get_result_obj->{data}->{data}->{$secret_name};
+}
+
+sub transform_json_to_object {
+    my ($json_data) = @_;
+
+    my $json_as_object;
+    eval {
+        $json_as_object = decode_json($json_data);
+    };
+    if ($@) {
+        return ({'error_message' => "Could not decode JSON from '$json_data'. Reason: " . $@});
+    };
+    return($json_as_object);
+}
+
+sub parse_json_file {
+    my (%options) = @_;
+
+    my $fh;
+    my $json_data = '';
+
+    my $json_file = $options{json_file};
+
+    open($fh, '<', $json_file) or return ('error_message' => "parse_json_file: Cannot open " . $json_file);
+    for my $line (<$fh>) {
+        chomp $line;
+        $json_data .= $line;
+    }
+    close($fh);
+    return transform_json_to_object($json_data);
+}
+
+1;
+
+__END__
+
+=head1 NAME
+
+Centreon Vault password manager
+
+=head1 SYNOPSIS
+
+Allows to retrieve secrets (usually username and password) from a Hashicorp vault compatible api given a config file as constructor.
+
+    use centreon::common::logger;
+    use centreon::script::centreonvault;
+    my $vault = centreon::script::centreonvault->new(
+        (
+            'logger'      => centreon::common::logger->new(),
+            'config_file' =>  '/var/lib/centreon/vault/vault.json'
+        )
+    );
+    my $password = $vault->get_secret('secret::hashicorp_vault::mypath/to/mysecrets::password');
+
+=head1 METHODS
+
+=head2 new(\%options)
+
+Constructor of the vault object.
+
+%options must provide:
+
+- logger: an object of the centreon::common::logger class.
+
+- config_file: full path and file name of the Centreon Vault JSON config file.
+
+The default config_file path should be '/var/lib/centreon/vault/vault.json'.
+The expected file format for Centreon Vault is:
+
+    {
+      "name": "hashicorp_vault",
+      "url": "vault-server.mydomain.com",
+      "salt": "<base64 encoded(<32 bytes long key used to hash the crypted data)>",
+      "port": 443,
+      "root_path": "vmware_daemon",
+      "role_id": "<base64 encoded(<iv><hmac_hash><encrypted_role_id>)",
+      "secret_id": "<base64 encoded(<iv><hmac_hash><encrypted_secret_id>)"
+    }
+
+This sub will not emit Error logs (only Notice and inferior) as it can be called on environment where the Vault is not used.
+get_secret() can emit Error logs if vault is considered enabled.
+
+=head2 get_secret($secret)
+
+Returns the secret stored in the Centreon Vault at the given path.
+If the format of the secret does not match the regular expression
+C</^secret::hashicorp_vault::([^:]+)::(.+)$/>
+or in case of any failure in the process, the method will return the secret unchanged.
+
+=cut

--- a/centreon/lib/perl/centreon/common/logger.pm
+++ b/centreon/lib/perl/centreon/common/logger.pm
@@ -126,10 +126,10 @@ sub is_file_mode {
 sub is_debug {
     my $self = shift;
 
-    if ($self->{severity} < 6) {
-        return 0;
+    if ($self->{severity} == 7) {
+        return 1;
     }
-    return 1;
+    return 0;
 }
 
 sub syslog_mode($$$) {
@@ -150,7 +150,7 @@ sub redirect_output {
         open STDERR, '>&', $lfh;
     }
 }
-# Bypass the write cache set up by the kernel/file system and always write the log
+# Bypass the buffers set up by the kernel/file system and always write the log
 # as soon as it is sent.
 sub flush_output {
     my ($self, %options) = @_;

--- a/centreon/lib/perl/centreon/common/logger.pm
+++ b/centreon/lib/perl/centreon/common/logger.pm
@@ -192,8 +192,6 @@ sub severity {
             $self->{severity} = 6;
         } elsif ($input_severity eq "debug") {
             $self->{severity} = 7;
-            # if we debug we probably nearly always want the pid of the process.
-            $self->withpid(1);
         } else {
             $self->writeLogError("Wrong severity value set.");
             return -1;

--- a/centreon/lib/perl/t/common/centreonvault.t
+++ b/centreon/lib/perl/t/common/centreonvault.t
@@ -1,0 +1,289 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test2::V0;
+use Test2::Plugin::NoWarnings echo => 1;
+use Test2::Tools::Compare qw{is like match};
+use Net::Curl::Easy qw(:constants);
+use Data::Dumper qw(Dumper);
+use Storable qw(dclone);
+use FindBin;
+use lib "$FindBin::RealBin/../../";
+
+use centreon::common::centreonvault;
+use centreon::common::logger;
+use JSON::XS;
+
+
+# this sub make an hash with all generic data used in the tests, and send back a hashref.
+sub create_data_set {
+    my $set = {};
+    $set->{vault} = undef;
+    $set->{logger} = centreon::common::logger->new();
+    $set->{logger}->file_mode("/dev/null");
+
+    # this is an exemple of configuration for vault.
+    # I encrypted the string "String-to-encrypt" from the C++ implementation, and set it to secret_id and role_id
+    # the key to decrypt should be set as an environment variable.
+    # the salt can be used to encrypt again the data, so the script can be sure the decryption worked correctly, but this function is not implemented yet.
+    $set->{default_app_secret} = 'SGVsbG8gd29ybGQsIGRvZywgY2F0LCBwdXBwaWVzLgo=';
+    $set->{decryted_string} = 'String-to-encrypt';
+    $set->{vault_config_hash} = {
+        "name"      => "default",
+        "url"       => "localhost",
+        "port"      => 443,
+        "root_path" => "path",
+        "role_id"   => "4vOkzIaIJ7yxGWmysGVYY9sYHDyDM1nEv1++jSx9eAHpj83J6aIjE5SPvvpF6kBu3JeFga7o6DDS2yC7jVPAwXsWiur+KUOQncPq0JtjiFojr9YkrO8x1w1dmQFq/RqYV/S/kUare8z6r6+RnAxwsA==",
+        "secret_id" => "4vOkzIaIJ7yxGWmysGVYY9sYHDyDM1nEv1++jSx9eAHpj83J6aIjE5SPvvpF6kBu3JeFga7o6DDS2yC7jVPAwXsWiur+KUOQncPq0JtjiFojr9YkrO8x1w1dmQFq/RqYV/S/kUare8z6r6+RnAxwsA==",
+        "salt"      => "U2FsdA==" }; # for now the salt is not used, it will be used to check if the data where correctly decrypted.
+
+    $set->{wrong_vault_config_hash} = {
+        "name"      => "default",
+        "url"       => "localhost",
+        "port"      => 443,
+        "root_path" => "path",
+        "role_id"   => "WrongCryptedDataThatAESWontBeAbleToDecrypt==",
+        "secret_id" => "WrongCryptedDataThatAESWontBeAbleToDecrypt==",
+        "salt"      => "U2FsdA==" };
+
+    # We will make multiples tests about authentication.
+    # this is all the fields that should be set everytime.
+    $set->{http}->{generic_auth_fields} = {
+        CURLOPT_POST()          => { result => 1, detail => 'the http request should be POST' },
+        CURLOPT_POSTFIELDS()    => { result => 'role_id=String-to-encrypt&secret_id=String-to-encrypt', detail => 'postfields are correct' },
+        CURLOPT_POSTFIELDSIZE() => { result => 53, detail => 'post field size is set' },
+        CURLOPT_URL()           => { result => 'https://localhost:443/v1/auth/approle/login', detail => 'target url was set' }, };
+    # this is the token given by the API when the authentication work.
+    $set->{http}->{"Vault_Token"} = "RandomAuthTokenGivenByVault";
+    $set->{http}->{"vault_token_expiration"} = 13455;
+
+    $set->{http}->{working_auth} = {
+        (CURLOPT_WRITEDATA() => {
+            result => '{"auth":{"lease_duration": "' . $set->{http}->{"vault_token_expiration"} . '",
+            "client_token": "' . $set->{http}->{"Vault_Token"} . '"}}' }),
+        %{$set->{http}->{generic_auth_fields}} };
+
+    $set->{http}->{wrong_auth} = { (CURLOPT_WRITEDATA() => { result => '{' }), %{$set->{http}->{generic_auth_fields}} };
+
+    return $set;
+
+}
+
+sub test_new {
+    my $set = shift;
+    my $vault = '';
+    my @test_data = (
+        { 'logger' => undef, 'config_file' => undef, 'test' => '$error_message =~ /FATAL: No logger given to the constructor/' },
+        { 'logger' => $set->{logger}, 'config_file' => undef, 'test' => '$vault->{enabled} == 0' },
+        { 'logger' => $set->{logger}, 'config_file' => 'does_not_exist.json', 'test' => '$vault->{enabled} == 0' }
+    );
+
+    for my $i (0 .. $#test_data) {
+        my $logger = $test_data[$i]->{logger};
+        my $config_file = $test_data[$i]->{config_file};
+        my $test = $test_data[$i]->{test};
+
+        eval {
+            $vault = centreon::common::centreonvault->new(
+                (
+                    'logger'      => $logger,
+                    'config_file' => $config_file
+                )
+            );
+        };
+        my $error_message = defined($@) ? $@ : '';
+        ok(eval($test), "'$test' should be true");
+    }
+}
+
+sub test_decrypt {
+    my $set = shift;
+    my $vault = centreon::common::centreonvault->new(
+        (
+            'logger'      => $set->{logger},
+            'config_file' => $set->{vault_config_hash}
+        )
+    );
+
+    is($vault->extract_and_decrypt(('data' => $set->{vault_config_hash}->{secret_id})), 'String-to-encrypt', 'extract_and_decrypt() worked');
+
+}
+
+sub test_transform_json_to_object {
+    my $tests_cases = [
+        {
+            json   => '{"int": 12, "string": "A String with space", "array" : ["array-key", "string"]}',
+            result => { "int" => 12, "string" => "A String with space", "array" => [ "array-key", "string" ] },
+            detail => "simple json can be decoded as a perl object"
+        },
+        {
+            json   => '"int": 12, "string": "A String with space", "array" : ["array-key", "string"]}',
+            result => { "error_message" => match(qr/^Could not decode JSON from/) },
+            detail => "invalid json should generate an error"
+        },
+        {
+            json   => '',
+            result => { "error_message" => match(qr/^Could not decode JSON from.*'. Reason:/) },
+            detail => "empty json"
+        },
+        {
+            json   => 'abcdef',
+            result => { "error_message" => match(qr/^Could not decode JSON from/) },
+            detail => "simple string json"
+        },
+        {
+            json   => '{}',
+            result => {},
+            detail => "empty json brace should make an empty object"
+        },
+    ];
+
+    for my $test (@$tests_cases) {
+        is(centreon::common::centreonvault::transform_json_to_object($test->{json}), $test->{result}, $test->{detail});
+    }
+
+}
+sub test_get_app_secret {
+    `mkdir -p /usr/share/centreon/`;
+    `mv /usr/share/centreon/.env /usr/share/centreon/.env.back`;
+    my $old_app_secret = $ENV{'APP_SECRET'};
+    my $res = "SECRET";
+    $ENV{'APP_SECRET'} = $res;
+    is(centreon::common::centreonvault->get_app_secret(), $res, "get_app_secret() should return the correct value");
+    $ENV{'APP_SECRET'} = undef;
+    is(centreon::common::centreonvault->get_app_secret(), "", "get_app_secret() should return an empty string");
+    open(my $fh, '>', '/usr/share/centreon/.env');
+    print $fh "NotAPP_SECRET=toto\n";
+    print $fh "APP_SECRT=tata\n";
+    is(centreon::common::centreonvault->get_app_secret(), "", "get_app_secret() should return empty string if file don't ha.");
+
+    print $fh "APP_SECRET=$res\n";
+    close($fh);
+    is(centreon::common::centreonvault->get_app_secret(), $res, "get_app_secret() should get value from file.");
+    `rm /usr/share/centreon/.env`;
+    `mv /usr/share/centreon/.env.back /usr/share/centreon/.env`;
+    $ENV{'APP_SECRET'} = $old_app_secret;
+}
+
+sub test_authenticate {
+    my $set = shift;
+    my $vault = centreon::common::centreonvault->new(
+        (
+            'logger'      => $set->{logger},
+            'config_file' => $set->{vault_config_hash}
+        )
+    );
+
+    my $mock_http_authenticate = mock_http($set->{http}->{working_auth});
+    $vault->authenticate();
+    is($vault->{auth}->{token}, $set->{http}->{"Vault_Token"}, "the token was correctly retrieved by authenticate()");
+    is($vault->{auth}->{expiration_epoch}, time() + $set->{http}->{"vault_token_expiration"}, 'the expiration date is correct');
+}
+
+sub test_get_secret {
+    my $set = shift;
+
+    print("    When vault don't work we should send back the input token\n");
+    my $vault = centreon::common::centreonvault->new(
+        (
+            'logger'      => $set->{logger},
+            'config_file' => $set->{wrong_vault_config_hash}
+        )
+    );
+    is($vault->get_secret("token"), "token", "role_id and secret_id can't be decrypted");
+
+    $vault = centreon::common::centreonvault->new(
+        (
+            'logger'      => $set->{logger},
+            'config_file' => $set->{vault_config_hash}
+        )
+    );
+    my $clear_password = $vault->get_secret("token");
+    is($vault->get_secret("token"), "token", "no authentication done because secret don't look like an hashicorp path");
+
+    my $http_wrong_authentication = { (CURLOPT_WRITEDATA() => { result => '{' }), %{$set->{http}->{generic_auth_fields}} };
+    my $mock_http_authenticate = mock_http($http_wrong_authentication);
+    $clear_password = $vault->get_secret("secret::hashicorp_vault::SecretPathArg::secretNameFromApiResponse");
+    is($vault->get_secret("token"), "token", "authentication didn't work because api send back an invalid authentication response");
+
+    print("    When vault work we should send back the token retrieved by the API\n");
+    my $http_get_secret_work = {
+        CURLOPT_WRITEDATA()  => { result => '{"request_id": "ARandomString", "data": {"data" : {"secretNameFromApiResponse": "tokenGotFromApi"}}}' },
+        CURLOPT_POST()       => { result => '0', detail => 'the http request should not be POST.' },
+        CURLOPT_HTTPHEADER() => { result => [ "X-Vault-Token: " . $set->{http}->{"Vault_Token"} ], detail => 'the authentication header should be set.' },
+        CURLOPT_URL()        => { result => 'https://localhost:443/v1/SecretPathArg', detail => 'target url was set' }
+    };
+    $mock_http_authenticate = mock_http( $set->{http}->{working_auth}, $http_get_secret_work);
+    $clear_password = $vault->get_secret("secret::hashicorp_vault::SecretPathArg::secretNameFromApiResponse");
+    is($clear_password, "tokenGotFromApi", "authentication worked, the token was correctly retrieved by get_secret() from the API");
+
+}
+
+sub main {
+    my $set = create_data_set();
+
+    test_get_app_secret();
+    my $old_app_secret = $ENV{'APP_SECRET'};
+    $ENV{'APP_SECRET'} = $set->{default_app_secret};
+    print "    Validate function not reaching external ressources\n";
+    test_new($set);
+    test_decrypt($set);
+
+    test_transform_json_to_object($set);
+    print "    Validate authentication and secret retrieving\n";
+    test_authenticate($set);
+    test_get_secret($set);
+    $ENV{'APP_SECRET'} = $old_app_secret;
+
+    done_testing();
+}
+
+# this sub is used to mock the Net::Curl::Easy object, to simulate the http request.
+# the returned object should be stored in a local variable for the time of your test,
+# as the mock will be enabled until the variable is deleted.
+sub mock_http {
+    # without dclone, the hash is modified by the test, and the second test using it will fail.
+    my @mock_list = @{dclone(\@_)};
+    my $required_option = shift(@mock_list);
+
+    my $mock = mock 'Net::Curl::Easy'; # is from Test2::Tools::Mock, included by Test2::V0
+    $mock->override('perform' => sub($) {
+        # Normally this sub perform the actual http request and set the result to the variable given to setopt().
+        # For test purpose, we set the mocked data in the setopt(), and only use perform() to check every parameter have correctly been set.
+        # once we are sure all parameter where correctly set, we prepare the next request if there is any.
+        # this is not what is done in reality, but it's easier for mocking purpose.
+        if (keys %{$required_option}) {
+            fail "[mock-curl] Some curl parameter where not correctly set : " . join(', ', keys(%{$required_option})) . "\n";
+        }
+        $required_option = shift(@mock_list);
+    },
+        # this sub is called for each parameter set to curl, we will check if the parameter is correctly set.
+        'setopt'              => sub($$$) {
+            my $self = shift; # we don't need this one
+            my $opt_name = shift; # the option name, see Net::Curl::Easy (:constant) for the list of possible value.
+            my $opt_value = shift;
+            # the real workhorse of the lib, we must have an hashref $required_option = {} already declared.
+            # this sub check in the hash if the option is correctly set, and delete it from the hash if it's correct.
+            # when doing perform, all options should have been set. So if there is still element in the hash,
+            # it is an error, as some parameter where not correctly set.
+            # writedata is processed differently to send back the data to the caller.
+            if ($opt_name == CURLOPT_WRITEDATA) {
+                $$opt_value = $required_option->{$opt_name}->{result};
+                delete($required_option->{$opt_name});
+                return;
+            }
+            if ($required_option->{$opt_name}) {
+                is($opt_value, $required_option->{$opt_name}->{result}, "[mock-curl] " . $required_option->{$opt_name}->{detail});
+                delete($required_option->{$opt_name});
+            } else {
+                print(Dumper($required_option));
+                fail("$opt_name is not present in the required_option hash.");
+
+            }
+        }
+    );
+    # we need to return the mocked object and to keep it, or the mock will be deleted and reverted.
+    return $mock;
+
+}
+&main;

--- a/centreon/lib/perl/t/common/logger.t
+++ b/centreon/lib/perl/t/common/logger.t
@@ -1,0 +1,115 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+
+use Test2::V0;
+use FindBin;
+use lib "$FindBin::Bin/../../";
+use centreon::common::logger;
+
+# Each function test a different aspect of the library (roughtly one public function each).
+# To be sure there is no side effect each test create it's own test object
+sub test_severity {
+    my $logger = centreon::common::logger->new();
+    is($logger->severity(), "WARNING", "default severity should be warning.");
+
+    for my $sev ('FATAL', 'fatal', 'ERROR', 'Error', 'WARNING', 'NOTICE', 'INFO', 'DEBUG') {
+
+        is($logger->severity($sev), uc($sev), "severity $sev was correctly set.");
+        is($logger->severity(), uc($sev), "getter was correct.");
+    }
+    $logger->severity("FATAL");
+    is($logger->severity("toto"), -1, "if severity is unknown we don't change anything.");
+}
+
+# By default the logger should write to stdout, so we capture stdout to a variable and check what the object did write.
+sub test_writeLogInfo_Stdout {
+    my %options = @_;
+
+    my $logger = centreon::common::logger->new();
+    $logger->flush_output(enabled => 1);
+    $logger->severity($options{severity});
+    $logger->withpid($options{pid});
+    my $out;
+    my $logExemple = "this is an info log.";
+    do {
+        local *STDOUT;
+        open STDOUT, ">", \$out;
+        $logger->writeLogInfo($logExemple);
+    };
+    my $log = check_log_format(log => $out, severity => "INFO", pid => $options{pid});
+
+    is($log, $logExemple, "log is the same as what we sent.");
+
+    print "    written to original STDOUT : $out";
+}
+
+sub test_writeLogInfo_Stdout_is_empty {
+    my %options = @_;
+
+    my $logger = centreon::common::logger->new();
+    $logger->flush_output(enabled => 1);
+    $logger->severity($options{severity});
+    $logger->withpid($options{pid});
+    my $out;
+    my $logExemple = "this is an info log.";
+    do {
+        local *STDOUT;
+        open STDOUT, ">", \$out;
+        $logger->writeLogInfo($logExemple);
+    };
+    is($out, undef, "log is not written if severity is not high enough : $options{severity}");
+}
+
+sub test_writeLogFunc {
+    my %options = @_;
+    my $logger = centreon::common::logger->new();
+    $logger->flush_output(enabled => 1);
+    $logger->severity("debug");
+    $logger->withpid($options{pid});
+    my $out;
+    my $logExemple = "this is an info log.";
+    do {
+        local *STDOUT;
+        open STDOUT, ">", \$out;
+        # for now we just check the function exist, we should check the log is written correctly in the future.
+        $logger->writeLogDebug($logExemple);
+        $logger->writeLogInfo($logExemple);
+        $logger->writeLogNotice($logExemple);
+        $logger->writeLogWarning($logExemple);
+        $logger->writeLogError($logExemple);
+        eval {$logger->writeLogFatal($logExemple); }; # for now we just ignore the die()
+    };
+}
+
+sub main {
+    test_severity();
+    test_writeLogInfo_Stdout(pid => 1, severity => "info");
+    test_writeLogInfo_Stdout(pid => 0, severity => "info");
+    test_writeLogInfo_Stdout(pid => 1, severity => "debug");
+    test_writeLogInfo_Stdout(pid => 0, severity => "debug");
+    # let's check the log is not written when the severity is not high enough
+    test_writeLogInfo_Stdout_is_empty(pid => 1, severity => "error");
+    test_writeLogInfo_Stdout_is_empty(pid => 0, severity => "notice");
+    test_writeLogFunc(pid => 1);
+
+    done_testing;
+}
+# Helper function
+sub check_log_format {
+    # the best way to check the date would be to mock the time() function, and to run get_date().
+    # as it is a builtin function, it is possible but hard to setup and can have various hard to debug side effect.
+    my %options = @_;
+
+    my $regex = '^\[\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2}\] \[' . $options{severity} . '\] ';
+    # if there is pid we ignore it in the regex
+    $options{pid} and $regex .= '\[\d+\] ';
+    $regex .= '(.*)$';
+    like($options{log}, qr/$regex/, "log format is respected.");
+    $options{log} =~ /$regex/; # like() don't seem to return the matched string
+
+    ok(defined($1), "the log is not empty");
+    return $1;
+}
+
+&main;

--- a/centreon/lib/perl/t/common/logger.t
+++ b/centreon/lib/perl/t/common/logger.t
@@ -7,8 +7,7 @@ use FindBin;
 use lib "$FindBin::Bin/../../";
 use centreon::common::logger;
 
-# Each function test a different aspect of the library (roughtly one public function each).
-# To be sure there is no side effect each test create it's own test object
+
 sub test_severity {
     my $logger = centreon::common::logger->new();
     is($logger->severity(), "WARNING", "default severity should be warning.");
@@ -22,79 +21,66 @@ sub test_severity {
     is($logger->severity("toto"), -1, "if severity is unknown we don't change anything.");
 }
 
-# By default the logger should write to stdout, so we capture stdout to a variable and check what the object did write.
-sub test_writeLogInfo_Stdout {
+sub test_logging_levels {
     my %options = @_;
-
     my $logger = centreon::common::logger->new();
     $logger->flush_output(enabled => 1);
-    $logger->severity($options{severity});
     $logger->withpid($options{pid});
-    my $out;
-    my $logExemple = "this is an info log.";
-    do {
-        local *STDOUT;
-        open STDOUT, ">", \$out;
-        $logger->writeLogInfo($logExemple);
-    };
-    my $log = check_log_format(log => $out, severity => "INFO", pid => $options{pid});
+    $logger->withdate($options{with_date});
 
-    is($log, $logExemple, "log is the same as what we sent.");
+    my @levels = (
+        { method => 'writeLogDebug',   severity => 'DEBUG',   message => 'Debug message' },
+        { method => 'writeLogInfo',    severity => 'INFO',    message => 'Info message' },
+        { method => 'writeLogNotice',  severity => 'NOTICE',  message => 'Notice message' },
+        { method => 'writeLogWarning', severity => 'WARNING', message => 'Warning message' },
+        { method => 'writeLogError',   severity => 'ERROR',   message => 'Error message' },
+    );
 
-    print "    written to original STDOUT : $out";
+    foreach my $level (@levels) {
+        my $out;
+        $logger->severity($level->{severity});
+        do {
+            local *STDOUT;
+            open STDOUT, ">", \$out;
+            my $met = $logger->can($level->{method});
+            $met->($logger, $level->{message});
+        };
+        my $log = check_log_format(log => $out, severity => $level->{severity}, pid => $options{pid}, date => $options{with_date});
+        is($log, $level->{message}, $level->{message} . " is correctly logged with pid set to " . $options{pid});
+    }
 }
 
-sub test_writeLogInfo_Stdout_is_empty {
-    my %options = @_;
-
-    my $logger = centreon::common::logger->new();
-    $logger->flush_output(enabled => 1);
-    $logger->severity($options{severity});
-    $logger->withpid($options{pid});
-    my $out;
-    my $logExemple = "this is an info log.";
-    do {
-        local *STDOUT;
-        open STDOUT, ">", \$out;
-        $logger->writeLogInfo($logExemple);
-    };
-    is($out, undef, "log is not written if severity is not high enough : $options{severity}");
-}
-
-sub test_writeLogFunc {
+sub test_writeLogFatal {
     my %options = @_;
     my $logger = centreon::common::logger->new();
     $logger->flush_output(enabled => 1);
-    $logger->severity("debug");
     $logger->withpid($options{pid});
+    $logger->withdate($options{with_date});
+    $logger->severity('FATAL');
+
+    my $message = 'Fatal error occurred';
     my $out;
-    my $logExemple = "this is an info log.";
-    do {
-        local *STDOUT;
-        open STDOUT, ">", \$out;
-        # for now we just check the function exist, we should check the log is written correctly in the future.
-        $logger->writeLogDebug($logExemple);
-        $logger->writeLogInfo($logExemple);
-        $logger->writeLogNotice($logExemple);
-        $logger->writeLogWarning($logExemple);
-        $logger->writeLogError($logExemple);
-        eval {$logger->writeLogFatal($logExemple); }; # for now we just ignore the die()
-    };
+    like(dies {
+        do {
+            local *STDOUT;
+            open STDOUT, ">", \$out;
+            $logger->writeLogFatal($message); };  },
+        qr/Fatal error occurred/,
+        "writeLogFatal dies as expected"
+    );
 }
 
 sub main {
-    test_severity();
-    test_writeLogInfo_Stdout(pid => 1, severity => "info");
-    test_writeLogInfo_Stdout(pid => 0, severity => "info");
-    test_writeLogInfo_Stdout(pid => 1, severity => "debug");
-    test_writeLogInfo_Stdout(pid => 0, severity => "debug");
-    # let's check the log is not written when the severity is not high enough
-    test_writeLogInfo_Stdout_is_empty(pid => 1, severity => "error");
-    test_writeLogInfo_Stdout_is_empty(pid => 0, severity => "notice");
-    test_writeLogFunc(pid => 1);
 
-    done_testing;
+    test_severity();
+    test_logging_levels(pid => 1, with_date => 1);
+    test_logging_levels(pid => 0, with_date => 1);
+    test_writeLogFatal(pid => 1, with_date => 1);
+    test_writeLogFatal(pid => 0, with_date => 1);
+
+    done_testing();
 }
+
 # Helper function
 sub check_log_format {
     # the best way to check the date would be to mock the time() function, and to run get_date().
@@ -103,7 +89,7 @@ sub check_log_format {
 
     my $regex = '^\[\d{4}\-\d{2}\-\d{2} \d{2}:\d{2}:\d{2}\] \[' . $options{severity} . '\] ';
     # if there is pid we ignore it in the regex
-    $options{pid} and $regex .= '\[\d+\] ';
+    $options{pid} == 1 and $regex .= '\[\d+\] ';
     $regex .= '(.*)$';
     like($options{log}, qr/$regex/, "log format is respected.");
     $options{log} =~ /$regex/; # like() don't seem to return the matched string
@@ -112,4 +98,4 @@ sub check_log_format {
     return $1;
 }
 
-&main;
+main();

--- a/centreon/packaging/centreon-perl-libs-common.yaml
+++ b/centreon/packaging/centreon-perl-libs-common.yaml
@@ -25,6 +25,8 @@ overrides:
   rpm:
     depends:
       - perl-interpreter
+      - perl(Crypt::OpenSSL::AES)
+      - perl(JSON::XS)
       - perl(DBI)
       - perl(FindBin)
       - perl(IO::Handle)
@@ -42,6 +44,9 @@ overrides:
   deb:
     depends:
       - libconfig-inifiles-perl
+      - libcrypt-openssl-aes-perl
+      - libjson-xs-perl
+      - libnet-curl-perl
       - libcrypt-des-perl
       - librrds-perl
       - libdigest-hmac-perl

--- a/centreon/packaging/centreon-perl-libs-common.yaml
+++ b/centreon/packaging/centreon-perl-libs-common.yaml
@@ -1,0 +1,56 @@
+name: "centreon-perl-libs-common"
+arch: "all"
+platform: "linux"
+version_schema: "none"
+version: "${VERSION}"
+release: "${RELEASE}${DIST}"
+section: "default"
+priority: "optional"
+maintainer: "Centreon <contact@centreon.com>"
+description: |
+  This package contains Centreon Perl library for logging and vault integration.
+  Commit: @COMMIT_HASH@
+vendor: "Centreon"
+homepage: "https://www.centreon.com"
+license: "Apache-2.0"
+
+contents:
+  - src: "../lib/perl/centreon/common"
+    dst: "${PERL_VENDORLIB}/centreon/common"
+    expand: true
+    file_info:
+      mode: 0755
+
+overrides:
+  rpm:
+    depends:
+      - perl-interpreter
+      - perl(DBI)
+      - perl(FindBin)
+      - perl(IO::Handle)
+      - perl(POSIX)
+      - perl(Pod::Usage)
+      - perl(Sys::Syslog)
+    provides:
+      - perl-centreon-base
+      - perl(centreon::common::db)
+      - perl(centreon::common::lock)
+      - perl(centreon::common::lock::file)
+      - perl(centreon::common::lock::sql)
+      - perl(centreon::common::logger)
+      - perl(centreon::common::misc)
+  deb:
+    depends:
+      - libconfig-inifiles-perl
+      - libcrypt-des-perl
+      - librrds-perl
+      - libdigest-hmac-perl
+      - libdigest-sha-perl
+      - libgd-perl
+
+rpm:
+  summary: Centreon Perl libraries Common
+  compression: zstd
+  signature:
+    key_file: ${RPM_SIGNING_KEY_FILE}
+    key_id: ${RPM_SIGNING_KEY_ID}

--- a/centreon/packaging/centreon-perl-libs.yaml
+++ b/centreon/packaging/centreon-perl-libs.yaml
@@ -8,22 +8,44 @@ section: "default"
 priority: "optional"
 maintainer: "Centreon <contact@centreon.com>"
 description: |
-  This package contains Centreon Perl libraries.
+  This package contains Centreon Perl libraries for various script.
   Commit: @COMMIT_HASH@
 vendor: "Centreon"
 homepage: "https://www.centreon.com"
 license: "Apache-2.0"
 
 contents:
-  - src: "../lib/perl/centreon"
-    dst: "${PERL_VENDORLIB}/centreon"
+  - src: "../lib/perl/centreon/health"
+    dst: "${PERL_VENDORLIB}/centreon/health"
+    expand: true
+    file_info:
+      mode: 0755
+  - src: "../lib/perl/centreon/reporting"
+    dst: "${PERL_VENDORLIB}/centreon/reporting"
+    expand: true
+    file_info:
+      mode: 0755
+  - src: "../lib/perl/centreon/script"
+    dst: "${PERL_VENDORLIB}/centreon/script"
+    expand: true
+    file_info:
+      mode: 0755
+  - src: "../lib/perl/centreon/trapd"
+    dst: "${PERL_VENDORLIB}/centreon/trapd"
+    expand: true
+    file_info:
+      mode: 0755
+  - src: "../lib/perl/centreon/script.pm"
+    dst: "${PERL_VENDORLIB}/centreon/script.pm"
     expand: true
     file_info:
       mode: 0755
 
+
 overrides:
   rpm:
     depends:
+      - centreon-perl-libs-common
       - centreon-common = ${VERSION}-${RELEASE}${DIST}
       - perl-interpreter
       - perl(DBI)
@@ -35,12 +57,6 @@ overrides:
       - perl(Sys::Syslog)
     provides:
       - perl-centreon-base
-      - perl(centreon::common::db)
-      - perl(centreon::common::lock)
-      - perl(centreon::common::lock::file)
-      - perl(centreon::common::lock::sql)
-      - perl(centreon::common::logger)
-      - perl(centreon::common::misc)
       - perl(centreon::script)
       - perl(centreon::script::centreontrapd)
       - perl(centreon::script::centreontrapdforward)
@@ -57,6 +73,7 @@ overrides:
       - perl-centreon-base
   deb:
     depends:
+      - centreon-perl-libs-common
       - centreon-common (= ${VERSION}-${RELEASE}${DIST})
       - libconfig-inifiles-perl
       - libcrypt-des-perl


### PR DESCRIPTION
## Description
move the centreonvault.pm file made in centreon-plugin to the generic library stored here.
splitted the package in 2, centreon-perl-libs-common will be installed by everyone, centreon-perl-libs will only be installed by webapp (it contain mainly logic for script about dashboard, trap management and reporting)

**Fixes** # mon-106121

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] master

<h2> How this pull request can be tested ? </h2>
install both package, they should not have any error.
The library inside should all be callable by using a command of the form 
```
perl -e 'use strict ; use centreon::common::logger; print "ok\n" '
```

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
