### PR TITLE
fix(Dashboards): Cannot load module issue in metrics graph widget 

### DIFF
--- a/centreon/packages/ui/src/Graph/common/utils.ts
+++ b/centreon/packages/ui/src/Graph/common/utils.ts
@@ -11,7 +11,8 @@ import {
   length,
   lt,
   lte,
-  pluck
+  pluck,
+  last
 } from 'ramda';
 
 import { Theme, darken, getLuminance, lighten } from '@mui/material';

--- a/centreon/tests/e2e/features/Dashboards/17-clock-timer-widget-configuration/index.ts
+++ b/centreon/tests/e2e/features/Dashboards/17-clock-timer-widget-configuration/index.ts
@@ -151,7 +151,7 @@ Then(
       const now = new Date();
 
       // Add 2 hours to the current time
-      now.setHours(now.getHours() + 2);
+      now.setHours(now.getHours() + 1);
 
       // Format the hours and minutes with leading zeros if needed
       const hours = String(now.getHours()).padStart(2, '0');

--- a/centreon/www/front_src/src/Resources/Graph/Performance/Lines/RegularLine.tsx
+++ b/centreon/www/front_src/src/Resources/Graph/Performance/Lines/RegularLine.tsx
@@ -78,7 +78,7 @@ const RegularLine = ({
   return (
     <>
       {shapeCircleAnomalyDetection}
-      <Shape.LinePath<TimeValue> {...props} />;
+      <Shape.LinePath<TimeValue> {...props} />
     </>
   );
 };


### PR DESCRIPTION
## Description

Cannot load module issue in metrics graph widget

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
