### PR TITLE
fix(Discovery): Hosts discovery can't export/reload centengine via automatic analysis

### DIFF
--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
@@ -62,23 +62,24 @@ class GenerateAllConfigurations
     public function execute(): void
     {
         try {
-            if (
-                ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
-                && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
-            ) {
-                throw new AccessDeniedException(
-                    'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
-                );
-            }
+            if ($this->contact->isAdmin()) {
+                $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParameters();
+            } else {
+                if (
+                    ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
+                    && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
+                ) {
+                    throw new AccessDeniedException(
+                        'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or '
+                            . 'ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
+                    );
+                }
 
-            if (! $this->contact->isAdmin()) {
                 $accessGroups = $this->readAccessGroupRepositoryInterface->findByContact($this->contact);
 
                 $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParametersAndAccessGroups(
                     $accessGroups
                 );
-            } else {
-                $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParameters();
             }
         } catch(AccessDeniedException $ex) {
             throw new AccessDeniedException($ex->getMessage());

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateConfiguration.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateConfiguration.php
@@ -64,7 +64,8 @@ class GenerateConfiguration
     {
         try {
             if (
-                ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
+                $this->contact->isAllowedToReachWeb()
+                && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
                 && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
             ) {
                 throw new AccessDeniedException(

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateConfiguration.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateConfiguration.php
@@ -63,25 +63,25 @@ class GenerateConfiguration
     public function execute(int $monitoringServerId): void
     {
         try {
-            if (
-                $this->contact->isAllowedToReachWeb()
-                && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
-                && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
-            ) {
-                throw new AccessDeniedException(
-                    'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
-                );
-            }
+            if ($this->contact->isAdmin()) {
+                $monitoringServer = $this->monitoringServerRepository->findServer($monitoringServerId);
+            } else {
+                if (
+                    ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
+                    && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
+                ) {
+                    throw new AccessDeniedException(
+                        'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or '
+                            . 'ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
+                    );
+                }
 
-            if (! $this->contact->isAdmin()) {
                 $accessGroups = $this->readAccessGroupRepositoryInterface->findByContact($this->contact);
 
                 $monitoringServer = $this->monitoringServerRepository->findByIdAndAccessGroups(
                     $monitoringServerId,
                     $accessGroups
                 );
-            } else {
-                $monitoringServer = $this->monitoringServerRepository->findServer($monitoringServerId);
             }
 
             if ($monitoringServer === null) {

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/ReloadAllConfigurations.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/ReloadAllConfigurations.php
@@ -62,23 +62,24 @@ class ReloadAllConfigurations
     public function execute(): void
     {
         try {
-            if (
-                ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
-                && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
-            ) {
-                throw new AccessDeniedException(
-                    'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
-                );
-            }
+            if ($this->contact->isAdmin()) {
+                $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParameters();
+            } else {
+                if (
+                    ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
+                    && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
+                ) {
+                    throw new AccessDeniedException(
+                        'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or '
+                            . 'ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
+                    );
+                }
 
-            if (! $this->contact->isAdmin()) {
                 $accessGroups = $this->readAccessGroupRepositoryInterface->findByContact($this->contact);
 
                 $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParametersAndAccessGroups(
                     $accessGroups
                 );
-            } else {
-                $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParameters();
             }
         } catch(AccessDeniedException $ex) {
             throw new AccessDeniedException($ex->getMessage());

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/ReloadConfiguration.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/ReloadConfiguration.php
@@ -64,25 +64,25 @@ class ReloadConfiguration
     public function execute(int $monitoringServerId): void
     {
         try {
-            if (
-                $this->contact->isAllowedToReachWeb()
-                && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
-                && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
-            ) {
-                throw new AccessDeniedException(
-                    'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
-                );
-            }
+            if ($this->contact->isAdmin()) {
+                $monitoringServer = $this->monitoringServerRepository->findServer($monitoringServerId);
+            } else {
+                if (
+                    ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
+                    && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
+                ) {
+                    throw new AccessDeniedException(
+                        'Insufficient rights (required: ROLE_CONFIGURATION_MONITORING_SERVER_READ or '
+                            . 'ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)'
+                    );
+                }
 
-            if (! $this->contact->isAdmin()) {
                 $accessGroups = $this->readAccessGroupRepositoryInterface->findByContact($this->contact);
 
                 $monitoringServer = $this->monitoringServerRepository->findByIdAndAccessGroups(
                     $monitoringServerId,
                     $accessGroups
                 );
-            } else {
-                $monitoringServer = $this->monitoringServerRepository->findServer($monitoringServerId);
             }
 
             if ($monitoringServer === null) {

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/ReloadConfiguration.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/ReloadConfiguration.php
@@ -65,7 +65,8 @@ class ReloadConfiguration
     {
         try {
             if (
-                ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
+                $this->contact->isAllowedToReachWeb()
+                && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
                 && ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ_WRITE)
             ) {
                 throw new AccessDeniedException(


### PR DESCRIPTION
## Description

Fixed issue where hosts discovery can't export/reload centengine via automatic analysis.

**Fixes** # MON-150932

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
