### PR TITLE
Backport([UX]): Logo Centreon "Lost in space" isn't align with text

### DIFF
--- a/centreon/packages/ui/src/FallbackPage/FallbackPage.tsx
+++ b/centreon/packages/ui/src/FallbackPage/FallbackPage.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles()((theme) => ({
   logo: {
     alignSelf: 'flex-end',
     height: theme.spacing(11),
-    width: '22rem'
+    width: '239px'
   },
   message: {
     color: theme.palette.text.primary


### PR DESCRIPTION
**Description**: backport

**video**

[screen-capture (21).webm](https://github.com/user-attachments/assets/04ba1957-4f41-449d-ae9f-7dae6eaa829f)
