### PR TITLE
fix: update smarty version in composer.json to match composer.lock

### DIFF
--- a/centreon/composer.json
+++ b/centreon/composer.json
@@ -31,7 +31,7 @@
     "phpdocumentor/reflection-docblock": "^5.2",
     "pimple/pimple": "^3.2",
     "sensio/framework-extra-bundle": "^6.2",
-    "smarty/smarty": "^v4.3",
+    "smarty/smarty": "^v4.5",
     "smarty-gettext/smarty-gettext": "^1.6",
     "symfony/config": "6.4.*",
     "symfony/console": "6.4.*",


### PR DESCRIPTION
## Description

This PR simply aligns the `composer.json` file with the existing locked version of smarty/smarty to ensure consistency.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
