### PR TITLE
fix select2 for sg

### DIFF
--- a/centreon/www/class/centreonServicegroups.class.php
+++ b/centreon/www/class/centreonServicegroups.class.php
@@ -247,9 +247,9 @@ class CentreonServicegroups
                     $queryValues[':sg_' . $serviceGroupId] = (int) $serviceGroupId;
                 }
             }
-
-            $whereCondition = ' WHERE sg_id IN (' . implode(',', array_keys($queryValues)) . ')';
         }
+
+        $whereCondition = ' WHERE sg_id IN (' . (count($queryValues) ? implode(',', array_keys($queryValues)) : "''") . ')';
 
         $request = <<<SQL
             SELECT


### PR DESCRIPTION
## Description

when you open a form containing a "select2"  for service groups such as parameters form from a widget like service monitoring or the recurrent downtime for (in the relation tab) you will have all service groups from your platform selected.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- have multiple SG on your platform
- create a recurrent downtime (put random information, we don't care if it works or not)
- save it
- edit it again and see that in the relation tab, all your SG are now selected

you can do the same with widgets

- have a widget such a service monitoring (we don't care if it works)
- save your widget preferences
- edit your widgetpreferences again and you'll see that all the SG are selected

with this patch, they shouldn't be selected



## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
