### PR TITLE
fix(router): Correctly set host and scheme for router call in legacy

### DIFF
--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -83,6 +83,15 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
             $parameters['base_uri'] .= '/';
         }
 
+        // Manage URL Generation for HTTPS and Legacy nested route generation calls
+        $context = $this->router->getContext();
+        if ($_SERVER['REQUEST_SCHEME'] === "https") {
+                $context->setScheme($_SERVER['REQUEST_SCHEME']);
+        }
+        if ($_SERVER['SERVER_NAME'] !== "localhost") {
+            $context->setHost($_SERVER['SERVER_NAME']);
+        }
+
         $generatedRoute = $this->router->generate($name, $parameters, $referenceType);
 
         // remove double slashes

--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -85,10 +85,10 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
         // Manage URL Generation for HTTPS and Legacy nested route generation calls
         $context = $this->router->getContext();
-        if ($_SERVER['REQUEST_SCHEME'] === "https") {
+        if ($_SERVER['REQUEST_SCHEME'] === 'https') {
                 $context->setScheme($_SERVER['REQUEST_SCHEME']);
         }
-        if ($_SERVER['SERVER_NAME'] !== "localhost") {
+        if ($_SERVER['SERVER_NAME'] !== 'localhost') {
             $context->setHost($_SERVER['SERVER_NAME']);
         }
 


### PR DESCRIPTION
## Description

This PR intends to fix Url generation when calling the Router into the legacy.

Scheme and Server Name was not set and by default http & localhost were used.

**Fixes** # MON-152217

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Setup a platform in HTTPS and try to create an host or update a broker input/output

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
