### PR TITLE
fix(nightly/cod): fix nightly platform destroy payload

### DIFF
--- a/.github/workflows/nightly-cod-platform-destroy.yml
+++ b/.github/workflows/nightly-cod-platform-destroy.yml
@@ -28,7 +28,7 @@ jobs:
                  https://api.github.com/repos/centreon/centreon-on-demand/dispatches \
                  -d '{"event_type": "destroy-nightly-platform",
                     "client_payload": {
-                        "workspace_to_destroy_id": 0,
+                        "workspace_to_destroy_id": "0",
                         "confirm": true
                       }
                     }'


### PR DESCRIPTION
## Description

the payload uses a string instead of a number on the on-demand side, and i think it is wrongly interpreted because of the use of an unquoted number in the cod destroy action

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
