### PR TITLE
fix(ci): fix get environment's nightly input

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -121,7 +121,7 @@ jobs:
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon/www/install/insertBaseConf.sql
-      nightly_manual_trigger: ${{ inputs.nightly_manual_trigger }}
+      nightly_manual_trigger: ${{ inputs.nightly_manual_trigger || false }}
 
   gherkin-lint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Description

took me an embarrassing amount of time to realize that ${{ inputs.nightly_manual_trigger }} was invalid if the pipeline is triggered in any other way than a workflow dispatch 

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ]New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
