### PR TITLE
enh(ui): forwardRef in EllipsisTypography

### DIFF
--- a/centreon/packages/ui/src/Typography/EllipsisTypography.tsx
+++ b/centreon/packages/ui/src/Typography/EllipsisTypography.tsx
@@ -1,21 +1,25 @@
-import { Box, Typography, TypographyProps } from '@mui/material';
+import { forwardRef, type ForwardedRef } from 'react';
 
-const EllipsisTypography = ({
-  containerClassname,
-  ...props
-}: TypographyProps & { containerClassname?: string }): JSX.Element => {
-  return (
-    <Box className={containerClassname} sx={{ width: '100%' }}>
-      <Typography
-        sx={{
-          overflow: 'hidden',
-          textOverflow: 'ellipsis',
-          whiteSpace: 'nowrap'
-        }}
-        {...props}
-      />
-    </Box>
-  );
-};
+import { Box, Typography, type TypographyProps } from '@mui/material';
+
+const EllipsisTypography = forwardRef(
+  (
+    { containerClassname, ...props }: TypographyProps & { containerClassname?: string },
+    ref?: ForwardedRef<HTMLSpanElement>) => {
+    return (
+      <Box className={containerClassname} sx={{ width: '100%' }}>
+        <Typography
+          ref={ref}
+          sx={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap'
+          }}
+          {...props}
+        />
+      </Box>
+    );
+  }
+);
 
 export default EllipsisTypography;


### PR DESCRIPTION
## Description

update EllipsisTypography component, so it can forward ref prop

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
