### PR TITLE
fix(cloud): remove host-group requirement in mass changes

### DIFF
--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -800,7 +800,7 @@ $form->addElement('textarea', 'host_comment', _('Comments'), $attrsTextarea);
 
 $form->addElement('select2', 'host_hgs', _('Host Groups'), [], $attributes['host_groups']);
 
-if ($isCloudPlatform) {
+if ($isCloudPlatform && $o !== HOST_MASSIVE_CHANGE) {
     $form->addRule('host_hgs', _('Mandatory field for ACL purpose.'), 'required');
 }
 


### PR DESCRIPTION
## Description

[Cloud] Mass change on Hosts make "Host-Groups" mandatory for Incremental changes

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
