### PR TITLE
enh(ci): trigger scheduled builds on maintenance branches weekly

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -110,6 +110,7 @@ jobs:
       - name: Check current day of the week
         id: day_check
         run: echo "day_of_week=$(date +%u)" >> $GITHUB_OUTPUT
+        shell: bash
 
       - if: ${{ steps.day_check.outputs.day_of_week == '1' }}
         run: |

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -107,8 +107,13 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
 
-      - run: |
-          NIGHTLY_TARGETS=("dev-23.04.x" "dev-23.10.x" "dev-24.04.x" "dev-24.10.x")
+      - name: Check current day of the week
+        id: day_check
+        run: echo "day_of_week=$(date +%u)" >> $GITHUB_OUTPUT
+
+      - if: ${{ steps.day_check.outputs.day_of_week == '1' }}
+        run: |
+          NIGHTLY_TARGETS=("dev-22.10.x" "dev-23.04.x" "dev-23.10.x" "dev-24.04.x" "dev-24.10.x")
           for target in "${NIGHTLY_TARGETS[@]}"; do
             echo "[INFO] - Dispatching nightly run to $target branch."
             gh workflow run web.yml -r "$target" -f nightly_manual_trigger=true


### PR DESCRIPTION
## Description

trigger scheduled builds on maintenance branches only weekly (on monday)
github does not store the day of the week in the context so we have to add a step that checks the day of the week (via a `$(date +%u)` first) 

**Fixes** # MON-152331

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
