### PR TITLE
fix(Cloud): Mass change on Services make "Host" mandatory

### DIFF
--- a/centreon/www/include/configuration/configObject/service/formService.php
+++ b/centreon/www/include/configuration/configObject/service/formService.php
@@ -807,7 +807,9 @@ if ($form_service_type === 'BYHOST') {
             [],
             array_merge($attributes['hosts_cloud_specific'], ['defaultDataset' => $defaultDataset])
         );
-        $form->addRule('service_hPars', _("Host / Service Required"), 'required');
+        if ($o !== SERVICE_MASSIVE_CHANGE) {
+            $form->addRule('service_hPars', _("Host / Service Required"), 'required');
+        }
     } else {
         if (isset($service['service_hPars']) && count($service['service_hPars']) > 1) {
             $sgReadOnly = true;


### PR DESCRIPTION
fix the Mass change on Services that makes "Host" mandatory

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Check [Ticket](https://centreon.atlassian.net/browse/MON-143748)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
