### PR TITLE
fix(clapi): rename method to avoid conflict with php extension

### DIFF
--- a/centreon/www/api/class/centreon_clapi.class.php
+++ b/centreon/www/api/class/centreon_clapi.class.php
@@ -184,7 +184,7 @@ class CentreonClapi extends CentreonWebService implements CentreonWebServiceDiIn
             }
 
             $lastRecord = end($result);
-            if ($lastRecord && str_starts_with($lastRecord[0], 'Return code end :')) {
+            if ($lastRecord && str_starts_with($lastRecord[0] ?? '', 'Return code end :')) {
                 array_pop($result);
             }
         } else {

--- a/centreon/www/include/common/csvFunctions.php
+++ b/centreon/www/include/common/csvFunctions.php
@@ -23,7 +23,7 @@
  *
  * @return Generator
  */
-function readLine(string &$text): Generator
+function readCsvLine(string &$text): Generator
 {
     $len = strlen($text);
     $cursor = 0;
@@ -54,7 +54,7 @@ function csvToArray(&$text, bool $useCsvHeaderAsKey, string $delimiter = ';'): a
     $delimiterNumber = 0;
     $data = [];
     $headers = [];
-    foreach (readLine($text) as $line) {
+    foreach (readCsvLine($text) as $line) {
         if ($lineNumber++ === 0) {
             $headers = explode($delimiter, $line);
             $delimiterNumber = count($headers);


### PR DESCRIPTION
## Description

- Renamed the function `readLine` to `readCsvLine` to prevent conflict with a method brought by a php extension with same name.
- Fix warning in centroen_clapi.class.php

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master
