### PR TITLE
fix(vmware): Correctly copy centreon_vmware conf file on Central when export

### DIFF
--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -229,6 +229,7 @@ try {
     chdir(_CENTREON_PATH_ . "www");
     $nagiosCFGPath = _CENTREON_CACHEDIR_ . "/config/engine/";
     $centreonBrokerPath = _CENTREON_CACHEDIR_ . "/config/broker/";
+    $vmWareConfigPath = _CENTREON_CACHEDIR_ . "/config/vmware/";
 
     /*  Set new error handler */
     set_error_handler($log_error);
@@ -248,6 +249,7 @@ try {
     foreach ($tab_server as $host) {
         if (isset($pollers) && ($pollers == 0 || in_array($host['id'], $pollers))) {
             $listBrokerFile = glob($centreonBrokerPath . $host['id'] . "/*.{xml,json,cfg,sql}", GLOB_BRACE);
+            $listVmWareFile = glob($vmWareConfigPath . $host['id'] . "/*.json", GLOB_BRACE);
             if (isset($host['localhost']) && $host['localhost'] == 1) {
                 /*
                  * Check if monitoring engine's configuration directory existss
@@ -331,6 +333,24 @@ try {
                             } elseif (posix_getuid() === fileowner($targetFilePath)) {
                                 @chmod($targetFilePath, 0664);
                             }
+                        }
+                    }
+                }
+                /**
+                 * VMWare configuration
+                 */
+                if (count($listVmWareFile) > 0) {
+                    foreach ($listVmWareFile as $fileCfg) {
+                        $succeded = copy($fileCfg, _CENTREON_ETC_ . '/' . 'centreon_vmware.json');
+                        if (! $succeded) {
+                            throw new Exception(sprintf(
+                                "Could not write to VMWare's configuration file '%s' for monitoring server '%s'."
+                                    . "Please add writing permissions for the webserver's user",
+                                basename($fileCfg),
+                                $host['name']
+                            ));
+                        } elseif (posix_getuid() === fileowner($targetFilePath)) {
+                            @chmod($targetFilePath, 0664);
                         }
                     }
                 }

--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -346,7 +346,7 @@ try {
                                 <<<'MSG'
                                     Could not write to VMWare's configuration file '%s' for monitoring server '%s'.
                                     Please add writing permissions for the webserver's user.
-                                    MSG;,
+                                    MSG,
                                 basename($fileCfg),
                                 $host['name']
                             ));

--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -339,21 +339,26 @@ try {
                 /**
                  * VMWare configuration
                  */
-                if (count($listVmWareFile) > 0) {
-                    foreach ($listVmWareFile as $fileCfg) {
-                        if (! copy($fileCfg, _CENTREON_ETC_ . '/' . 'centreon_vmware.json')) {
-                            throw new Exception(sprintf(
-                                <<<'MSG'
-                                    Could not write to VMWare's configuration file '%s' for monitoring server '%s'.
-                                    Please add writing permissions for the webserver's user.
-                                    MSG,
-                                basename($fileCfg),
-                                $host['name']
-                            ));
-                        } elseif (posix_getuid() === fileowner(_CENTREON_ETC_ . '/' . 'centreon_vmware.json')) {
-                            @chmod(_CENTREON_ETC_ . '/' . 'centreon_vmware.json', 0664);
-                        }
-                    }
+                if (count($listVmWareFile) > 1) {
+                    throw new Exception(
+                        sprintf(
+                            <<<'MSG'
+                            There are more than one VMWare configuration file for monitoring engine '%s'.
+                            Please check it's path or create it
+                            MSG,
+                            $host['name']
+                        )
+                    );
+                }
+                if (! copy($listVmWareFile[0], _CENTREON_ETC_ . '/' . 'centreon_vmware.json')) {
+                    throw new Exception(sprintf(
+                        <<<'MSG'
+                            Could not write to VMWare's configuration file '%s' for monitoring server '%s'.
+                            Please add writing permissions for the webserver's user.
+                            MSG,
+                        basename($fileCfg),
+                        $host['name']
+                    ));
                 }
             } else {
                 passthru(

--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -350,8 +350,8 @@ try {
                                 basename($fileCfg),
                                 $host['name']
                             ));
-                        } elseif (posix_getuid() === fileowner($targetFilePath)) {
-                            @chmod($targetFilePath, 0664);
+                        } elseif (posix_getuid() === fileowner(_CENTREON_ETC_ . '/' . 'centreon_vmware.json')) {
+                            @chmod(_CENTREON_ETC_ . '/' . 'centreon_vmware.json', 0664);
                         }
                     }
                 }

--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -341,11 +341,12 @@ try {
                  */
                 if (count($listVmWareFile) > 0) {
                     foreach ($listVmWareFile as $fileCfg) {
-                        $succeded = copy($fileCfg, _CENTREON_ETC_ . '/' . 'centreon_vmware.json');
-                        if (! $succeded) {
+                        if (! copy($fileCfg, _CENTREON_ETC_ . '/' . 'centreon_vmware.json')) {
                             throw new Exception(sprintf(
-                                "Could not write to VMWare's configuration file '%s' for monitoring server '%s'."
-                                    . "Please add writing permissions for the webserver's user",
+                                <<<'MSG'
+                                    Could not write to VMWare's configuration file '%s' for monitoring server '%s'.
+                                    Please add writing permissions for the webserver's user.
+                                    MSG;,
                                 basename($fileCfg),
                                 $host['name']
                             ));


### PR DESCRIPTION

## Description

This PR intends to correctly copy centreon_vmware conf file on Central when export.
Before when exporting files of a Central, the centreon_vmware.json was correctly filled in /var/cache/centreon/vmware/<centralId>, but the file was never copied to /etc/centreon.

**Fixes** # MON-152426

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Create ACC VMWare linked to Central.
Export Configuration.
centreon_vmware.json should have been copied to /etc/centreon

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
