### PR TITLE
fix : problems with closeQuery in fetchColumn of CentreonDB fixed

### DIFF
--- a/centreon/www/class/centreonDB.class.php
+++ b/centreon/www/class/centreonDB.class.php
@@ -437,6 +437,7 @@ class CentreonDB extends PDO
         try {
             return $pdoStatement->fetchColumn($column);
         } catch (PDOException $e) {
+            $this->closeQuery($pdoStatement);
             $message = "Error while fetching all the rows by column: {$e->getMessage()}";
             $this->writeDbLog($message, ['column' => $column], query: $pdoStatement->queryString, exception: $e);
             throw new CentreonDbException(
@@ -448,8 +449,6 @@ class CentreonDB extends PDO
                 ],
                 $e
             );
-        } finally {
-            $this->closeQuery($pdoStatement);
         }
     }
 


### PR DESCRIPTION
## Description

### FIXED

* problems with closeQuery in fetchColumn of CentreonDB fixed

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] develop

<h2> How this pull request can be tested ? </h2>

No test.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
