### PR TITLE
fix(conf) do no accept duplicate service name for a same host

### DIFF
--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -266,6 +266,7 @@ function testServiceExistence($name = null, $hPars = [], $hgPars = [], $returnId
             $id = $arr["service_id"];
         }
         $hPars = $arr["service_hPars"] ?? [];
+        $hPars = is_array($hPars) ? $hPars : [$hPars];
         $hgPars = $arr["service_hgPars"] ?? [];
     }
 


### PR DESCRIPTION
## Description

Duplicates in service name for a same host was not detected on cloud platform.
<img width="373" alt="image" src="https://github.com/user-attachments/assets/9e69106b-b91d-4bec-b401-68d55f286da2">

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
