### PR TITLE
fix(Downtimes/Widgets): fix wrong service groups field value

### DIFF
--- a/centreon/www/class/centreonServicegroups.class.php
+++ b/centreon/www/class/centreonServicegroups.class.php
@@ -221,10 +221,14 @@ class CentreonServicegroups
      */
     public function getObjectForSelect2($values = [], $options = [])
     {
-        global $centreon;
         $items = [];
-        $sgAcl = [];
 
+        if (empty($values)) {
+            return $items;
+        }
+
+        global $centreon;
+        $sgAcl = [];
         # get list of authorized servicegroups
         if (
             ! $centreon->user->access->admin


### PR DESCRIPTION
## Description

Fixed issue in CentreonServicegroups::getObjectForSelect2() where the method was returning all service groups when called with empty values. This caused:
- All service groups being displayed in recurrent downtime forms when none were selected
- Service groups persisting in the form even after being removed
- Same behavior affecting Widget forms using service group selection

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- Modify a reccurent downtime 
- Remove the list of service groups 
- Save the form
- Go back to the reccurent downtime configuration
- Only service groups that are linked to the reccurent downtime should be present, or empty field if no service group is linked

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
