### PR TITLE
fix (clapi): suppress the status response line when the CLAPI command is called from the APIv1

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -806,13 +806,13 @@ class CentreonAPI
             }
         } elseif (method_exists($this, $action)) {
             $this->return_code = $this->$action();
-            print "Return code end : " . $this->return_code . "\n";
         } else {
             print "Method not implemented into Centreon API.\n";
             $this->return_code = 1;
         }
 
         if ($exit) {
+            print "Return code end : " . $this->return_code . "\n";
             exit($this->return_code);
         } else {
             return $this->return_code;


### PR DESCRIPTION
## Description

The **POLLERLIST** command called from APIv1 causes error 500.

- Suppress the status response line when the CLAPI command is called from the APIv1
- Improve CSV parsing to take into account double-quote between CSV fields

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
