### PR TITLE
fix(action logs): correctly set the field name column while displaying log details

### DIFF
--- a/centreon/www/class/centreonLogAction.class.php
+++ b/centreon/www/class/centreonLogAction.class.php
@@ -424,9 +424,13 @@ class CentreonLogAction
                     }
                 } elseif (isset($ref[$field["field_name"]]) && $ref[$field["field_name"]] != $field["field_value"]) {
                     $list_modifications[$i]["action_log_id"] = $field["action_log_id"];
-                    $list_modifications[$i]["field_name"] = HtmlSanitizer::createFromString($ref[$field["field_name"]])->sanitize()->getString();
-                    $list_modifications[$i]["field_value_before"] = $ref[$field["field_name"]];
-                    $list_modifications[$i]["field_value_after"] = HtmlSanitizer::createFromString($field["field_value"])->sanitize()->getString();
+                    $list_modifications[$i]["field_name"] = $field["field_name"];
+                    $list_modifications[$i]["field_value_before"] = HtmlSanitizer::createFromString(
+                        $ref[$field["field_name"]]
+                    )->sanitize()->getString();
+                    $list_modifications[$i]["field_value_after"] = HtmlSanitizer::createFromString(
+                        $field["field_value"]
+                    )->sanitize()->getString();
                     foreach ($macroPasswordRef as $macroPasswordId) {
                         // handle the display modification for the fields macroOldValue_n for "Before" and "After" value
                         if (str_contains($field["field_name"], 'macroOldValue_' . $macroPasswordId)) {


### PR DESCRIPTION
## Description

This PR intends to fix display of field name column to display the field name and not the "before" value

**Fixes** # MON-153788

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
