### PR TITLE
fix(cloud): save ARGn in service configuration for cloud

### DIFF
--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -1061,7 +1061,11 @@ function updateServiceForCloud($serviceId = null, $massiveChange = false, $param
     isset($ret["geo_coords"]) && $ret["geo_coords"] != null
         ? $rq .= "'" . CentreonDB::escape($ret["geo_coords"]) . "', "
         : $rq .= "NULL, ";
-    $rq .= "command_command_id_arg = null, ";
+    $ret["command_command_id_arg"] = getCommandArgs($_POST, $ret);
+    $rq .= "command_command_id_arg = ";
+    isset($ret["command_command_id_arg"]) && $ret["command_command_id_arg"] != null
+        ? $rq .= "'" . CentreonDB::escape($ret["command_command_id_arg"]) . "', "
+        : $rq .= "NULL, ";
     $rq .= "command_command_id_arg2 = null, service_register = ";
     isset($ret["service_register"]) && $ret["service_register"] != null
         ? $rq .= "'" . $ret["service_register"] . "', "
@@ -1167,6 +1171,12 @@ function updateService_MCForCloud($serviceId = null, $parameters = [])
         $ret["sg_name"] = $centreon->checkIllegalChar($ret["sg_name"]);
     }
 
+    if (isset($ret["command_command_id_arg"]) && $ret["command_command_id_arg"] != null) {
+        $ret["command_command_id_arg"] = str_replace("\n", "//BR//", $ret["command_command_id_arg"]);
+        $ret["command_command_id_arg"] = str_replace("\t", "//T//", $ret["command_command_id_arg"]);
+        $ret["command_command_id_arg"] = str_replace("\r", "//R//", $ret["command_command_id_arg"]);
+    }
+
     $rq = "UPDATE service SET ";
     if (isset($ret["service_template_model_stm_id"]) && $ret["service_template_model_stm_id"] != null) {
         $rq .= "service_template_model_stm_id = '" . $ret["service_template_model_stm_id"] . "', ";
@@ -1206,7 +1216,12 @@ function updateService_MCForCloud($serviceId = null, $parameters = [])
     $rq .= 'service_stalking_options = null, service_comment = null, ';
 
 
-    $rq .= 'command_command_id_arg = null, command_command_id_arg2 = null, ';
+    $ret["command_command_id_arg"] = getCommandArgs($_POST, $ret);
+    $rq .= "command_command_id_arg = ";
+    isset($ret["command_command_id_arg"]) && $ret["command_command_id_arg"] != null
+        ? $rq .= "'" . CentreonDB::escape($ret["command_command_id_arg"]) . "', "
+        : $rq .= "NULL, ";
+    $rq .= "command_command_id_arg2 = null, ";
     if (isset($ret["service_register"]) && $ret["service_register"] != null) {
         $rq .= "service_register = '" . $ret["service_register"] . "', ";
     }
@@ -1829,7 +1844,10 @@ function insertServiceForCloud($submittedValues = [], $onDemandMacro = null)
     isset($submittedValues["geo_coords"]) && $submittedValues["geo_coords"] != null
         ? $request .= "'" . CentreonDB::escape($submittedValues["geo_coords"]) . "', "
         : $request .= "NULL, ";
-    $request .= "null, "; // command_command_id_arg = null
+    $submittedValues['command_command_id_arg'] = getCommandArgs($_POST, $submittedValues);
+    isset($submittedValues["command_command_id_arg"]) && $submittedValues["command_command_id_arg"] != null
+        ? $request .= "'" . CentreonDB::escape($submittedValues["command_command_id_arg"]) . "', "
+        : $request .= "NULL, ";
     $request .= 'null, '; // command_command_id_arg2 = null
     isset($submittedValues["service_register"]) && $submittedValues["service_register"] != null
         ? $request .= "'" . $submittedValues["service_register"] . "', "


### PR DESCRIPTION
## Description

fixed issue : $ARGn$ in service configuration are not saved while on cloud.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
