### PR TITLE
fix(PAC): json export file now has empty string value instead of null for ca_certificate property (#5723)

### DIFF
--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -83,7 +83,7 @@ class AgentConfiguration extends AbstractObjectJSON
             'private_key' => '/etc/pki/' . $data['otel_private_key'] . '.key',
             'ca_certificate' => $data['otel_ca_certificate'] !== null
                 ? '/etc/pki/' . $data['otel_ca_certificate'] . '.crt'
-                : null,
+                : '',
         ];
     }
 
@@ -111,7 +111,7 @@ class AgentConfiguration extends AbstractObjectJSON
                     'encryption' => true,
                     'ca_certificate' => $host['poller_ca_certificate'] !== null
                         ? '/etc/pki/' . $host['poller_ca_certificate'] . '.crt'
-                        : null,
+                        : '',
                     'ca_name' => $host['poller_ca_name'],
                 ],
                 $data['hosts']


### PR DESCRIPTION
## Description

BACKPORT of #5723 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] master
