### PR TITLE
fix(acc): handle scheme separatly from the rest of URL

### DIFF
--- a/centreon/src/Core/AdditionalConnectorConfiguration/Domain/Model/VmWareV6/VmWareV6Parameters.php
+++ b/centreon/src/Core/AdditionalConnectorConfiguration/Domain/Model/VmWareV6/VmWareV6Parameters.php
@@ -34,6 +34,10 @@ use Security\Interfaces\EncryptionInterface;
  *      port:int,
  *      vcenters:array<array{name:string,url:string,username:string,password:string}>
  *  }
+ * @phpstan-type _VmWareV6ParametersRequest array{
+ *      port:int,
+ *      vcenters:array<array{name:string,url:string,scheme:string|null,username:string,password:string}>
+ *  }
  *  @phpstan-type _VmWareV6ParametersWithoutCredentials array{
  *      port:int,
  *      vcenters:array<array{name:string,url:string,username:null,password:null}>
@@ -59,7 +63,7 @@ class VmWareV6Parameters implements AccParametersInterface
         array $parameters,
         private readonly bool $isEncrypted = false
     ){
-        /** @var _VmWareV6Parameters $parameters */
+        /** @var _VmWareV6ParametersRequest $parameters */
         Assertion::range($parameters['port'], 0, 65535, 'parameters.port');
         foreach ($parameters['vcenters'] as $index => $vcenter) {
             // Validate min length
@@ -74,8 +78,14 @@ class VmWareV6Parameters implements AccParametersInterface
             Assertion::maxLength($vcenter['password'], self::MAX_LENGTH, "parameters.vcenters[{$index}].password");
             Assertion::maxLength($vcenter['url'], self::MAX_LENGTH, "parameters.vcenters[{$index}].url");
 
+            // This is a temporary fix to handle the case where the scheme should be not be a part of the URL.
+            // The scheme is removed after being reunified with the url to ensure this is not stored.
+            $parameters['vcenters'][$index]['url'] = $vcenter['scheme'] !== null
+                ? $vcenter['scheme'] . '://' . $vcenter['url']
+                : $vcenter['url'];
+            unset($parameters['vcenters'][$index]['scheme']);
             // Validate specific format
-            Assertion::urlOrIpOrDomain($vcenter['url'], "parameters.vcenters[{$index}].url");
+            Assertion::urlOrIpOrDomain($parameters['vcenters'][$index]['url'], "parameters.vcenters[{$index}].url");
         }
         $this->parameters = $parameters;
 

--- a/centreon/src/Core/AdditionalConnectorConfiguration/Infrastructure/API/Schema/VmWareV6Schema.json
+++ b/centreon/src/Core/AdditionalConnectorConfiguration/Infrastructure/API/Schema/VmWareV6Schema.json
@@ -22,6 +22,7 @@
                     "type": "array",
                     "required": [
                         "name",
+                        "scheme",
                         "url",
                         "username",
                         "password"
@@ -31,6 +32,10 @@
                         "properties": {
                             "name": {
                                 "type": "string"
+                            },
+                            "scheme": {
+                                "type": ["string", "null"],
+                                "enum": ["http", "https", null]
                             },
                             "url": {
                                 "type": "string"

--- a/centreon/tests/php/Core/AdditionalConnectorConfiguration/Domain/Model/VmWareV6ParametersTest.php
+++ b/centreon/tests/php/Core/AdditionalConnectorConfiguration/Domain/Model/VmWareV6ParametersTest.php
@@ -34,6 +34,7 @@ beforeEach(function (): void {
         'vcenters' => [
             [
                 'name' => 'my-vcenter',
+                'scheme' => null,
                 'url' => 'http://10.10.10.10/sdk',
                 'username' => 'admin',
                 'password' => 'pwd',


### PR DESCRIPTION
## Description

This PR intends to handle URL Scheme separatly of the the rest of the URL Content.

**Fixes** # MON-154290

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Create an ACC or Update an ACC with following payload

```json
{
    "name": "ACC1Name",
    "description": "ACC1Description",
    "pollers": [1],
    "type": "vmware_v6",
    "parameters": {
        "port": 5780,
        "vcenters": [{
            "name": "my-vcenter",
            "scheme": "http",
            "url": "10.10.10.10/sdk",
            "username": "admin",
            "password": "my-pwd"
        }]
    }
}
```

In database the result should keep unchanged, no "scheme" in JSON, and the scheme has been concatenated to the rest of the url

```json
{"port":5780,"vcenters":[{"name":"my-vcenter","url":"http:\/\/10.10.10.10\/sdk","username":"Ct0PBA5S8BQ6cngvNv7RRgPIy6SWJPu9rY66Ezf8u\/XY+fortSlfqZgB+N0rYjJpLAymvCphApgXMrA\/lPPprVhz1+CuLpiSxSZknaQ1zhEUYKH0156liu\/woQDJE3aF","password":"cYTKrIsKm+Q7x\/+ijc5CGJVVS2GXy\/Twhv76phzXOR1ub9DPFhrUWvHovtYUa4wWqEhTDA4BVOU2Fglpj+ys1rrsmkeyxT5eyYeiHHyU3DpqQZ5j6QCJkaKAKmxLTGJt"}]}
```
## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
