### PR TITLE
fix(Dashboards): Passive host are not taken into account on status chart/grid (#5912) [dev-24.04.x]

### DIFF
--- a/centreon/src/Core/Host/Infrastructure/Repository/DbReadRealTimeHostRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbReadRealTimeHostRepository.php
@@ -200,9 +200,9 @@ class DbReadRealTimeHostRepository extends AbstractRepositoryRDB implements Read
                     hosts.id AS `id`,
                     hosts.name AS `name`,
                     hosts.status AS `status`
-                FROM `:dbstg`.resources AS services
-                INNER JOIN `:dbstg`.resources AS hosts
-                    ON hosts.id = services.parent_id
+                FROM `:dbstg`.resources AS hosts
+                LEFT JOIN `:dbstg`.resources AS services
+                    ON services.parent_id = hosts.id
                 LEFT JOIN `:dbstg`.resources_tags AS rtags_host_groups
                     ON hosts.resource_id = rtags_host_groups.resource_id
                 LEFT JOIN `:dbstg`.tags host_groups


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/5912 to dev-24.04.x

**Fixes** # MON-154572

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] 24.10.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
