### PR TITLE
fix(administration): add rules for len_storage_downtimes

### DIFF
--- a/centreon/www/include/Administration/parameters/centstorage/form.php
+++ b/centreon/www/include/Administration/parameters/centstorage/form.php
@@ -134,6 +134,9 @@ $form->addElement('text', 'reporting_retention', _("Retention duration for repor
 $form->addElement('checkbox', 'audit_log_option', _("Enable/Disable audit logs"));
 $form->addElement('text', 'audit_log_retention', _("Retention duration for audit logs"), $attrsText2);
 
+$form->addRule('len_storage_downtimes', _("Mandatory field"), 'required');
+$form->addRule('len_storage_downtimes', _("Must be a number"), 'numeric');
+
 // Parameters for Partitioning
 $form->addElement('text', 'partitioning_retention', _("Retention duration for partitioning"), $attrsText2);
 $form->addElement('text', 'partitioning_retention_forward', _("Forward provisioning"), $attrsText2);


### PR DESCRIPTION
## Description

In case the len_storage_downtimes field is left empty, the form would allow submission, but a blank page appears => as a fix two rules were added for this field (required and numeric).

**Fixes** # MON-138500

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- Login the Centreon Platform
- Go to Administration  >  Parameters  >  Options
- remove the value for Retention duration for downtimes
- Save

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
