### PR TITLE
enh(Dashboards): added health calculation in Status grid widget for Impact BAs

### DIFF
--- a/centreon/cypress/fixtures/Widgets/StatusGrid/criticalImpactBA.json
+++ b/centreon/cypress/fixtures/Widgets/StatusGrid/criticalImpactBA.json
@@ -14,6 +14,7 @@
        "critical_threshold":70,
        "is_percentage":true
     },
+    "current_level":70,
     "indicators":[
        {
           "id":10,

--- a/centreon/cypress/fixtures/Widgets/StatusGrid/criticalRatioBA.json
+++ b/centreon/cypress/fixtures/Widgets/StatusGrid/criticalRatioBA.json
@@ -14,6 +14,7 @@
        "critical_threshold":80,
        "is_percentage":true
     },
+    "current_level":null,
     "indicators":[
        {
           "id":6,

--- a/centreon/cypress/fixtures/Widgets/StatusGrid/impactBA.json
+++ b/centreon/cypress/fixtures/Widgets/StatusGrid/impactBA.json
@@ -14,6 +14,7 @@
        "critical_threshold":70,
        "is_percentage":true
     },
+    "current_level":100,
     "indicators":[
        {
           "id":10,

--- a/centreon/cypress/fixtures/Widgets/StatusGrid/ratioBA.json
+++ b/centreon/cypress/fixtures/Widgets/StatusGrid/ratioBA.json
@@ -14,6 +14,7 @@
        "critical_threshold":80,
        "is_percentage":true
     },
+    "current_level":null,
     "indicators":[
        {
           "id":6,

--- a/centreon/cypress/fixtures/Widgets/StatusGrid/worstStatusBA.json
+++ b/centreon/cypress/fixtures/Widgets/StatusGrid/worstStatusBA.json
@@ -14,6 +14,7 @@
        "critical_threshold":null,
        "is_percentage":false
     },
+    "current_level":null,
     "indicators":[
        {
           "id":1,

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
@@ -133,7 +133,7 @@ const getHealthSeverityCode = (): SeverityCode => {
                   <Typography
                     sx={{
                       color: getColor({
-                        severityCode: calculateSeverityCode(),
+                        severityCode: isImpact ? getHealthSeverityCode(): 1,
                         theme
                       })
                     }}

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
@@ -32,6 +32,7 @@ import {
 import { getColor } from '../utils';
 
 import useBATooltipContent from './useBATooltipContent';
+import { useMemo } from 'react';
 
 interface Props {
   data: ResourceData;
@@ -76,17 +77,22 @@ const BATooltipContent = ({ data }: Props): JSX.Element | null => {
       : `${threshold}%`;
   };
 
-const getHealthSeverityCode = (): SeverityCode => {
-  if (isNil(criticalLevel) || isNil(warningLevel) || health <= criticalLevel) {
-    return SeverityCode.High;
-  }
+  const getHealthSeverityCode = (): SeverityCode => {
+    if (isNil(criticalLevel) || isNil(warningLevel) || health <= criticalLevel) {
+      return SeverityCode.High;
+    }
 
-  if (health <= warningLevel) {
-    return SeverityCode.Medium;
-  }
+    if (health <= warningLevel) {
+      return SeverityCode.Medium;
+    }
 
-  return SeverityCode.OK;
-};
+    return SeverityCode.OK;
+  };
+
+  const healthSeverityCode = useMemo(
+    getHealthSeverityCode,
+    [criticalLevel, warningLevel, health]
+  );
 
   return (
     <Box className={classes.container}>
@@ -133,7 +139,7 @@ const getHealthSeverityCode = (): SeverityCode => {
                   <Typography
                     sx={{
                       color: getColor({
-                        severityCode: isImpact ? getHealthSeverityCode(): 1,
+                        severityCode: isImpact ? healthSeverityCode : 1,
                         theme
                       })
                     }}

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
@@ -76,20 +76,17 @@ const BATooltipContent = ({ data }: Props): JSX.Element | null => {
       : `${threshold}%`;
   };
 
-  const calculateSeverityCode = (): SeverityCode => {
-    if (isImpact && isNotNil(criticalLevel) && isNotNil(warningLevel)) {
-      if (health <= criticalLevel) {
-        return SeverityCode.High;
-      }
-      if (health <= warningLevel) {
-        return SeverityCode.Medium;
-      }
-
-      return SeverityCode.OK;
-    }
-
+const getHealthSeverityCode = (): SeverityCode => {
+  if (isNil(criticalLevel) || isNil(warningLevel) || health <= criticalLevel) {
     return SeverityCode.High;
-  };
+  }
+
+  if (health <= warningLevel) {
+    return SeverityCode.Medium;
+  }
+
+  return SeverityCode.OK;
+};
 
   return (
     <Box className={classes.container}>

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
@@ -76,6 +76,21 @@ const BATooltipContent = ({ data }: Props): JSX.Element | null => {
       : `${threshold}%`;
   };
 
+  const calculateSeverityCode = (): SeverityCode => {
+    if (isImpact && isNotNil(criticalLevel) && isNotNil(warningLevel)) {
+      if (health <= criticalLevel) {
+        return SeverityCode.High;
+      }
+      if (health <= warningLevel) {
+        return SeverityCode.Medium;
+      }
+
+      return SeverityCode.OK;
+    }
+
+    return SeverityCode.High;
+  };
+
   return (
     <Box className={classes.container}>
       <Box className={classes.header}>
@@ -121,7 +136,7 @@ const BATooltipContent = ({ data }: Props): JSX.Element | null => {
                   <Typography
                     sx={{
                       color: getColor({
-                        severityCode: isImpact ? 5 : 1,
+                        severityCode: calculateSeverityCode(),
                         theme
                       })
                     }}

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
@@ -77,20 +77,16 @@ const BATooltipContent = ({ data }: Props): JSX.Element | null => {
       : `${threshold}%`;
   };
 
-  const getHealthSeverityCode = (): SeverityCode => {
-    if (isNil(criticalLevel) || isNil(warningLevel) || health <= criticalLevel) {
-      return SeverityCode.High;
-    }
-
-    if (health <= warningLevel) {
-      return SeverityCode.Medium;
-    }
-
-    return SeverityCode.OK;
-  };
-
   const healthSeverityCode = useMemo(
-    getHealthSeverityCode,
+    (): SeverityCode => {
+        if (isNil(criticalLevel) || isNil(warningLevel) || health <= criticalLevel) {
+        return SeverityCode.High;
+      }
+      if (health <= warningLevel) {
+        return SeverityCode.Medium;
+      }
+      return SeverityCode.OK;
+    },
     [criticalLevel, warningLevel, health]
   );
 

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/BATooltipContent.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import { equals, isEmpty, isNotNil } from 'ramda';
+import { equals, isEmpty, isNil, isNotNil } from 'ramda';
 import { useTranslation } from 'react-i18next';
 
 import {

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/useBATooltipContent.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/useBATooltipContent.ts
@@ -8,12 +8,7 @@ import {
 
 import { getBAEndpoint } from '../../api/endpoints';
 import { businessActivityDecoder } from '../api/decoders';
-import {
-  BusinessActivity,
-  CalculationMethodType,
-  Indicator,
-  ResourceData
-} from '../models';
+import { BusinessActivity, Indicator, ResourceData } from '../models';
 
 interface UseServiceTooltipContentState {
   calculationMethod?: string;

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/useBATooltipContent.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/useBATooltipContent.ts
@@ -8,7 +8,12 @@ import {
 
 import { getBAEndpoint } from '../../api/endpoints';
 import { businessActivityDecoder } from '../api/decoders';
-import { BusinessActivity, Indicator, ResourceData } from '../models';
+import {
+  BusinessActivity,
+  CalculationMethodType,
+  Indicator,
+  ResourceData
+} from '../models';
 
 interface UseServiceTooltipContentState {
   calculationMethod?: string;
@@ -58,7 +63,9 @@ const useBATooltipContent = (
 
   const ProblematicKPIsCount = indicatorsWithProblems?.length || 0;
 
-  const health = Math.floor(((total - ProblematicKPIsCount) * 100) / total);
+  const health = equals(calculationMethod, CalculationMethodType.Impact) 
+    ? businessActivity?.currentLevel || 0
+    : Math.floor(((total - ProblematicKPIsCount) * 100) / total);
 
   const criticalKPIsCount =
     businessActivity?.indicators?.filter(({ status }) =>

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/useBATooltipContent.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/Tooltip/useBATooltipContent.ts
@@ -61,11 +61,7 @@ const useBATooltipContent = (
   const isPercentage = businessActivity?.calculationMethod.isPercentage;
   const total = businessActivity?.indicators?.length || 0;
 
-  const ProblematicKPIsCount = indicatorsWithProblems?.length || 0;
-
-  const health = equals(calculationMethod, CalculationMethodType.Impact) 
-    ? businessActivity?.currentLevel || 0
-    : Math.floor(((total - ProblematicKPIsCount) * 100) / total);
+  const health = businessActivity?.currentLevel || 0;
 
   const criticalKPIsCount =
     businessActivity?.indicators?.filter(({ status }) =>

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/api/decoders.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/api/decoders.ts
@@ -98,6 +98,7 @@ const calculationMethodDecoder = JsonDecoder.object<CalculationMethod>(
 export const businessActivityDecoder = JsonDecoder.object<BusinessActivity>(
   {
     calculationMethod: calculationMethodDecoder,
+    currentLevel: JsonDecoder.nullable(JsonDecoder.number),
     id: JsonDecoder.number,
     indicators: JsonDecoder.array(indicatorDecoder, 'indicators'),
     infrastructureView: JsonDecoder.nullable(JsonDecoder.string),
@@ -107,6 +108,7 @@ export const businessActivityDecoder = JsonDecoder.object<BusinessActivity>(
   'BusinessActivity',
   {
     calculationMethod: 'calculation_method',
+    currentLevel: 'current_level',
     infrastructureView: 'infrastructure_view'
   }
 );

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/models.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/models.ts
@@ -160,6 +160,7 @@ export interface CalculationMethod {
 
 export interface BusinessActivity {
   calculationMethod: CalculationMethod;
+  currentLevel: number | null;
   id: number;
   indicators: Array<Indicator>;
   infrastructureView: string | null;

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/spec/StatusGridWithBam.cypress.spec.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/spec/StatusGridWithBam.cypress.spec.tsx
@@ -137,7 +137,7 @@ const baTestCases = [
 
       cy.contains('State information').should('be.visible');
       cy.contains('Health').should('be.visible');
-      cy.contains('100%').should('be.visible');
+      cy.contains('70%').should('be.visible');
       cy.contains('Warning threshold').should('be.visible');
       cy.contains('80%').should('be.visible');
       cy.contains('Critical threshold').should('be.visible');


### PR DESCRIPTION
## Description

Enhanced health calculation in Status grid widget for impact BAs to display the current level of a BA and color it depending on the current level.

![image](https://github.com/user-attachments/assets/5b00b223-ef1d-48f5-a68d-eb8945f7daa4)

**Fixes** # MON-152749

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
