### PR TITLE
feat(backend/dashboard): add favorite management

### DIFF
--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -55,6 +55,7 @@ services:
             - '../../src/Core/HostCategory'
             - '../../src/Core/ServiceSeverity/*'
             - '../../src/Core/HostSeverity/*'
+            - '../../src/Core/UserProfile/*'
         bind:
             $isCloudPlatform: '%env(bool:IS_CLOUD_PLATFORM)%'
 

--- a/centreon/config/symfony_serializer/Dashboard/Dashboard.yaml
+++ b/centreon/config/symfony_serializer/Dashboard/Dashboard.yaml
@@ -1,0 +1,24 @@
+Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response\DashboardResponseDto:
+  attributes:
+    id:
+      groups: ['FavoriteDashboards:Read']
+    name:
+      groups: ['FavoriteDashboards:Read']
+    description:
+      groups: ['FavoriteDashboards:Read']
+    createdBy:
+      groups: ['FavoriteDashboards:Read']
+    updatedBy:
+      groups: ['FavoriteDashboards:Read']
+    createdAt:
+      groups: ['FavoriteDashboards:Read']
+    updatedAt:
+      groups: ['FavoriteDashboards:Read']
+    ownRole:
+      groups: ['FavoriteDashboards:Read']
+    shares:
+      groups: ['FavoriteDashboards:Read']
+    thumbnail:
+      groups: ['FavoriteDashboards:Read']
+    isFavorite:
+      groups: ['FavoriteDashboards:Read']

--- a/centreon/config/symfony_serializer/Dashboard/Thumbnail.yaml
+++ b/centreon/config/symfony_serializer/Dashboard/Thumbnail.yaml
@@ -1,0 +1,8 @@
+Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response\ThumbnailResponseDto:
+  attributes:
+    id:
+      groups: ['FavoriteDashboards:Read']
+    name:
+      groups: ['FavoriteDashboards:Read']
+    directory:
+      groups: ['FavoriteDashboards:Read']

--- a/centreon/config/symfony_serializer/Dashboard/User.yaml
+++ b/centreon/config/symfony_serializer/Dashboard/User.yaml
@@ -1,0 +1,6 @@
+Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response\UserResponseDto:
+  attributes:
+    id:
+      groups: ['FavoriteDashboards:Read']
+    name:
+      groups: ['FavoriteDashboards:Read']

--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -1531,6 +1531,10 @@ paths:
     $ref: './latest/onPremise/Configuration/Dashboard/Dashboards.yaml'
   /configuration/dashboards/{dashboard_id}:
     $ref: './latest/onPremise/Configuration/Dashboard/Dashboard.yaml'
+  /configuration/dashboards/{dashboard_id}/favorites:
+    $ref: './latest/onPremise/Configuration/Dashboard/DeleteDashboardFromFavorites.yaml'
+  /configuration/dashboards/favorites:
+    $ref: './latest/onPremise/Configuration/Dashboard/FavoriteDashboards.yaml'
   /configuration/dashboards/{dashboard_id}/shares:
     $ref: './latest/onPremise/Configuration/Dashboard/ShareDashboard.yaml'
   /configuration/dashboards/{dashboard_id}/access_rights/contacts/{contact_id}:

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/DeleteDashboardFromFavorites.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/DeleteDashboardFromFavorites.yaml
@@ -1,0 +1,21 @@
+delete:
+  tags:
+    - Dashboard
+  summary: "Unset dashboard from current user favorites"
+  description: |
+    Unset dashboard from current user favorites
+
+    `Since Centreon Web 24.10`
+  parameters:
+    - $ref: 'QueryParameter/DashboardId.yaml'
+  responses:
+    '204':
+      $ref: '../../../Common/Response/NoContent.yaml'
+    '400':
+      $ref: '../../../Common/Response/BadRequest.yaml'
+    '403':
+      $ref: '../../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../../Common/Response/InternalServerError.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/FavoriteDashboards.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/FavoriteDashboards.yaml
@@ -1,0 +1,65 @@
+get:
+  tags:
+    - Dashboard
+  summary: "List all dashboards set as favorite for the current user"
+  description: |
+    Return all dashboard configurations that were marked as favorite for the current user.
+
+    The available parameters to **search** / **sort_by** are:
+
+    * id
+    * name
+    * created_by
+    * created_at
+    * updated_at
+
+    `Since Centreon web 23.10`
+  parameters:
+    - $ref: '../../Common/QueryParameter/Limit.yaml'
+    - $ref: '../../Common/QueryParameter/Page.yaml'
+    - $ref: '../../Common/QueryParameter/Search.yaml'
+    - $ref: '../../Common/QueryParameter/SortBy.yaml'
+  responses:
+    "200":
+      description: "OK"
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              result:
+                type: array
+                items: { $ref: 'Schema/Dashboard.Listing.yaml' }
+              meta:
+                $ref: '../../Common/Schema/Meta.yaml'
+    '403': { $ref: '../../Common/Response/Forbidden.yaml' }
+    '404': { $ref: '../../Common/Response/NotFound.yaml' }
+    '500': { $ref: '../../Common/Response/InternalServerError.yaml' }
+
+post:
+  tags:
+    - Dashboard
+  summary: "Set dashboard as favorite for the current user"
+  description: |
+    Set dashboard as favorite for the current user
+
+    `Since Centreon Web 24.10`
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: 'Schema/Dashboard.AddAsFavorite.yaml'
+  responses:
+    '204':
+      $ref: '../../../Common/Response/NoContent.yaml'
+    '400':
+      $ref: '../../../Common/Response/BadRequest.yaml'
+    '403':
+      $ref: '../../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../../Common/Response/NotFound.yaml'
+    '409':
+      $ref: '../../../Common/Response/Conflict.yaml'
+    '500':
+      $ref: '../../../Common/Response/InternalServerError.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.AddAsFavorite.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.AddAsFavorite.yaml
@@ -1,0 +1,7 @@
+type: object
+required:
+  - dashboard_id
+properties:
+  dashboard_id:
+    type: integer
+    example: 1

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.One.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.One.yaml
@@ -62,3 +62,8 @@ properties:
         type: integer
         nullable: true
         example: 10
+
+  is_favorite:
+    type: boolean
+    description: "Indicates if the dashboard is marked as favorite for current user"
+    example: true

--- a/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Dashboard/Schema/Dashboard.Listing.yaml
@@ -82,3 +82,8 @@ properties:
       directory:
         type: string
         example: 'dashboard'
+
+  is_favorite:
+    type: boolean
+    description: "Indicates if the dashboard is marked as favorite for current user"
+    example: true

--- a/centreon/phpstan.core.neon
+++ b/centreon/phpstan.core.neon
@@ -75,6 +75,7 @@ parameters:
                 - src/Core/Dashboard/Application/UseCase/AddDashboardThumbnail/AddDashboardThumbnail.php
                 - src/Core/Command/Infrastructure/Command/MigrateAllCommands/MigrateAllCommandsCommand.php
                 - src/Core/Command/Application/UseCase/MigrateAllCommands/MigrateAllCommands.php
+                - src/Core/UserProfile/Infrastructure/Repository/DbWriteUserProfileRepository.php
 
         - # [CENTREON-RULE]: The class is extended or mocked. MUST be used only as a baseline.
             reportUnmatched: false

--- a/centreon/src/Core/Application/Common/UseCase/ListingResponseInterface.php
+++ b/centreon/src/Core/Application/Common/UseCase/ListingResponseInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,19 +19,11 @@
  *
  */
 
-declare(strict_types=1);
+declare(strict_types = 1);
 
-namespace Core\Dashboard\Application\UseCase\FindDashboards;
+namespace Core\Application\Common\UseCase;
 
-use Core\Dashboard\Application\UseCase\FindDashboards\Response\DashboardResponseDto;
-
-final class FindDashboardsResponse
+interface ListingResponseInterface extends StandardResponseInterface
 {
-    /**
-     * @param DashboardResponseDto[] $dashboards
-     */
-    public function __construct(
-        public array $dashboards = []
-    ) {
-    }
+    public function getData(): mixed;
 }

--- a/centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+++ b/centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
@@ -27,6 +27,7 @@ class DashboardException extends \Exception
 {
     public const CODE_NOT_FOUND = 1;
     public const CODE_FORBIDDEN = 2;
+    public const CODE_CONFLICT = 3;
 
     /**
      * @return self
@@ -34,6 +35,14 @@ class DashboardException extends \Exception
     public static function errorWhileSearching(): self
     {
         return new self(_('Error while searching for dashboards'));
+    }
+
+    /**
+     * @return self
+     */
+    public static function errorWhileSearchingFavorites(): self
+    {
+        return new self(_('Error while searching for user favorite dashboards'));
     }
 
     /**
@@ -147,6 +156,16 @@ class DashboardException extends \Exception
     public static function theDashboardDoesNotExist(int $dashboardId): self
     {
         return new self(sprintf(_('The dashboard [%d] does not exist'), $dashboardId), self::CODE_NOT_FOUND);
+    }
+
+    /**
+     * @param int $dashboardId
+     *
+     * @return self
+     */
+    public static function dashboardAlreadySetAsFavorite(int $dashboardId): self
+    {
+        return new self(sprintf(_('The dashboard [%d] is already set as favorite'), $dashboardId), self::CODE_CONFLICT);
     }
 
     /**

--- a/centreon/src/Core/Dashboard/Application/UseCase/AddDashboardToFavorites/AddDashboardToFavorites.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/AddDashboardToFavorites/AddDashboardToFavorites.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Application\UseCase\AddDashboardToFavorites;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ConflictResponse;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Dashboard\Application\Exception\DashboardException;
+use Core\Dashboard\Application\Repository\ReadDashboardRepositoryInterface;
+use Core\UserProfile\Application\Repository\ReadUserProfileRepositoryInterface;
+use Core\UserProfile\Application\Repository\WriteUserProfileRepositoryInterface;
+
+final class AddDashboardToFavorites
+{
+    use LoggerTrait;
+
+    /**
+     * @param ReadUserProfileRepositoryInterface $userProfileReader
+     * @param WriteUserProfileRepositoryInterface $userProfileWriter
+     * @param ReadDashboardRepositoryInterface $dashboardReader
+     * @param ContactInterface $user
+     */
+    public function __construct(
+        private readonly ReadUserProfileRepositoryInterface $userProfileReader,
+        private readonly WriteUserProfileRepositoryInterface $userProfileWriter,
+        private readonly ReadDashboardRepositoryInterface $dashboardReader,
+        private readonly ContactInterface $user,
+    ) {
+    }
+
+    /**
+     * @param AddDashboardToFavoritesRequest $request
+     * @return ResponseStatusInterface
+     */
+    public function __invoke(AddDashboardToFavoritesRequest $request): ResponseStatusInterface
+    {
+        try {
+            $this->assertDashboardId($request);
+
+            $favorites = [];
+            $profile = $this->userProfileReader->findByContact($this->user);
+            $profileId = $profile === null ? $this->addDefaultUserProfileForUser() : $profile->getId();
+            $favorites = $profile === null ? [] : $profile->getFavoriteDashboards();
+
+            if (in_array($request->dashboardId, $favorites, true)) {
+                $this->error(
+                    'Dashboard already set as favorite for user',
+                    [
+                        'dashboard_id' => $request->dashboardId,
+                        'user_id' => $this->user->getId(),
+                    ]
+                );
+
+                return new ConflictResponse(DashboardException::dashboardAlreadySetAsFavorite($request->dashboardId));
+            }
+
+            $this->userProfileWriter->addDashboardAsFavorites(
+                profileId: $profileId,
+                dashboardId: $request->dashboardId,
+            );
+
+            return new NoContentResponse();
+        } catch (\InvalidArgumentException $exception) {
+            $this->error($exception->getMessage());
+
+            return new InvalidArgumentResponse($exception);
+        } catch (\Throwable $exception) {
+            $this->error(
+                'Error while adding dashboard as favorite for user',
+                [
+                    'user_id' => $this->user->getId(),
+                    'dashboard_id' => $request->dashboardId,
+                    'message' => $exception->getMessage(),
+                    'trace' => $exception->getTraceAsString(),
+                ]
+            );
+
+            return new ErrorResponse($exception);
+        }
+    }
+
+    /**
+     * @throws \Throwable
+     * @return int
+     */
+    private function addDefaultUserProfileForUser(): int
+    {
+        return $this->userProfileWriter->addDefaultProfileForUser(contact: $this->user);
+    }
+
+    /**
+     * @param AddDashboardToFavoritesRequest $request
+     *
+     * @throws \Throwable
+     * @throws DashboardException
+     */
+    private function assertDashboardId(AddDashboardToFavoritesRequest $request): void
+    {
+        if (! $this->dashboardReader->existsOne($request->dashboardId)) {
+            throw DashboardException::theDashboardDoesNotExist($request->dashboardId);
+        }
+    }
+}

--- a/centreon/src/Core/Dashboard/Application/UseCase/AddDashboardToFavorites/AddDashboardToFavoritesRequest.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/AddDashboardToFavorites/AddDashboardToFavoritesRequest.php
@@ -21,17 +21,14 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Application\UseCase\FindDashboards;
+namespace Core\Dashboard\Application\UseCase\AddDashboardToFavorites;
 
-use Core\Dashboard\Application\UseCase\FindDashboards\Response\DashboardResponseDto;
-
-final class FindDashboardsResponse
+readonly final class AddDashboardToFavoritesRequest
 {
     /**
-     * @param DashboardResponseDto[] $dashboards
+     * @param int $dashboardId
      */
-    public function __construct(
-        public array $dashboards = []
-    ) {
+    public function __construct(public int $dashboardId)
+    {
     }
 }

--- a/centreon/src/Core/Dashboard/Application/UseCase/DeleteDashboardFromFavorites/DeleteDashboardFromFavorites.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/DeleteDashboardFromFavorites/DeleteDashboardFromFavorites.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Application\UseCase\DeleteDashboardFromFavorites;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Dashboard\Application\Exception\DashboardException;
+use Core\Dashboard\Application\Repository\ReadDashboardRepositoryInterface;
+use Core\UserProfile\Application\Repository\ReadUserProfileRepositoryInterface;
+use Core\UserProfile\Application\Repository\WriteUserProfileRepositoryInterface;
+use Throwable;
+
+final class DeleteDashboardFromFavorites
+{
+    use LoggerTrait;
+
+    /**
+     * @param WriteUserProfileRepositoryInterface $userProfileWriter
+     * @param ReadUserProfileRepositoryInterface $userProfileReader
+     * @param ReadDashboardRepositoryInterface $dashboardReader
+     * @param ContactInterface $user
+     */
+    public function __construct(
+        private readonly WriteUserProfileRepositoryInterface $userProfileWriter,
+        private readonly ReadUserProfileRepositoryInterface $userProfileReader,
+        private readonly ReadDashboardRepositoryInterface $dashboardReader,
+        private readonly ContactInterface $user
+    )
+    {
+    }
+
+    /**
+     * @param int $dashboardId
+     * @return ResponseStatusInterface
+     */
+    public function __invoke(int $dashboardId): ResponseStatusInterface
+    {
+        try {
+            $this->assertDashboardId($dashboardId);
+
+            $profile = $this->userProfileReader->findByContact($this->user);
+
+            if ($profile === null) {
+                $this->error('Profile not found for user', ['user_id' => $this->user->getId()]);
+
+                return new NotFoundResponse('User profile');
+            }
+
+            if (! in_array($dashboardId, $profile->getFavoriteDashboards(), true)) {
+                $this->error(
+                    'Dashboard is not set as favorite for user',
+                    [
+                        'dashboard_id' => $dashboardId,
+                        'user_id' => $this->user->getId(),
+                    ]
+                );
+
+                return new NotFoundResponse('Dashboard');
+            }
+
+            $this->userProfileWriter->removeDashboardFromFavorites($profile->getId(), $dashboardId);
+
+            return new NoContentResponse();
+        } catch (DashboardException $exception) {
+            $response = match ($exception->getCode()) {
+                DashboardException::CODE_NOT_FOUND => new NotFoundResponse('Dashboard'),
+                default => new ErrorResponse($exception)
+            };
+
+            $this->error(
+                $exception->getMessage(),
+                [
+                    'user_id' => $this->user->getId(),
+                    'dashboard_id' => $dashboardId,
+                    'trace' => $exception->getTraceAsString(),
+                ],
+            );
+
+            return $response;
+        } catch (Throwable $exception) {
+            $this->error(
+                'Error while removing dashboard from user favorite dashboards',
+                [
+                    'user_id' => $this->user->getId(),
+                    'dashboard_id' => $dashboardId,
+                    'message' => $exception->getMessage(),
+                    'trace' => $exception->getTraceAsString(),
+                ]
+            );
+
+            return new ErrorResponse($exception);
+        }
+    }
+
+    /**
+     * @param int $dashboardId
+     *
+     * @throws Throwable
+     * @throws DashboardException
+     */
+    private function assertDashboardId(int $dashboardId): void
+    {
+        if (! $this->dashboardReader->existsOne($dashboardId)) {
+            throw DashboardException::theDashboardDoesNotExist($dashboardId);
+        }
+    }
+}

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboardResponse.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindDashboard/FindDashboardResponse.php
@@ -68,6 +68,8 @@ final class FindDashboardResponse
      */
     public array $shares = ['contacts' => [], 'contact_groups' => []];
 
+    public bool $isFavorite = false;
+
     public function __construct() {
         $this->createdAt = new \DateTimeImmutable();
         $this->updatedAt = new \DateTimeImmutable();

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindDashboards/FindDashboardsFactory.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindDashboards/FindDashboardsFactory.php
@@ -43,6 +43,7 @@ final class FindDashboardsFactory
      * @param array<int, array<DashboardContactGroupShare>> $contactGroupShares
      * @param DashboardSharingRole $defaultRole
      * @param array<int, Media> $thumbnails
+     * @param int[] $favoriteDashboards
      *
      * @return FindDashboardsResponse
      */
@@ -53,7 +54,8 @@ final class FindDashboardsFactory
         array $contactShares,
         array $contactGroupShares,
         DashboardSharingRole $defaultRole,
-        array $thumbnails
+        array $thumbnails,
+        array $favoriteDashboards
     ): FindDashboardsResponse {
         $response = new FindDashboardsResponse();
 
@@ -110,6 +112,10 @@ final class FindDashboardsFactory
                     $thumbnail->getFilename(),
                     $thumbnail->getDirectory()
                 );
+            }
+
+            if (in_array($dto->id, $favoriteDashboards, true)) {
+                $dto->isFavorite = true;
             }
 
             $response->dashboards[] = $dto;

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindFavoriteDashboards/FindFavoriteDashboards.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindFavoriteDashboards/FindFavoriteDashboards.php
@@ -1,0 +1,304 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Application\UseCase\FindFavoriteDashboards;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Contact\Application\Repository\ReadContactRepositoryInterface;
+use Core\Dashboard\Application\Exception\DashboardException;
+use Core\Dashboard\Application\Repository\ReadDashboardRepositoryInterface;
+use Core\Dashboard\Application\Repository\ReadDashboardShareRepositoryInterface;
+use Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response\DashboardResponseDto;
+use Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response\ThumbnailResponseDto;
+use Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response\UserResponseDto;
+use Core\Dashboard\Domain\Model\Dashboard;
+use Core\Dashboard\Domain\Model\DashboardRights;
+use Core\Dashboard\Domain\Model\Role\DashboardSharingRole;
+use Core\Dashboard\Domain\Model\Share\DashboardContactGroupShare;
+use Core\Dashboard\Domain\Model\Share\DashboardContactShare;
+use Core\Dashboard\Domain\Model\Share\DashboardSharingRoles;
+use Core\Media\Domain\Model\Media;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Core\UserProfile\Application\Repository\ReadUserProfileRepositoryInterface;
+
+final class FindFavoriteDashboards
+{
+    use LoggerTrait;
+    public const AUTHORIZED_ACL_GROUPS = ['customer_admin_acl'];
+
+    /** @var int[] */
+    private array $usersFavoriteDashboards;
+
+    /**
+     * @param RequestParametersInterface $requestParameters
+     * @param ReadDashboardRepositoryInterface $dashboardReader
+     * @param ReadUserProfileRepositoryInterface $userProfileReader
+     * @param ContactInterface $contact
+     * @param DashboardRights $rights
+     * @param ReadAccessGroupRepositoryInterface $readAccessGroupRepository
+     * @param ReadContactRepositoryInterface $readContactRepository
+     * @param ReadDashboardShareRepositoryInterface $readDashboardShareRepository
+     * @param bool $isCloudPlatform
+     */
+    public function __construct(
+        private readonly RequestParametersInterface $requestParameters,
+        private readonly ReadDashboardRepositoryInterface $dashboardReader,
+        private readonly ReadUserProfileRepositoryInterface $userProfileReader,
+        private readonly ContactInterface $contact,
+        private readonly DashboardRights $rights,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
+        private readonly ReadContactRepositoryInterface $readContactRepository,
+        private readonly ReadDashboardShareRepositoryInterface $readDashboardShareRepository,
+        private readonly bool $isCloudPlatform,
+    ) {
+    }
+
+    /**
+     * @return FindFavoriteDashboardsResponse|ResponseStatusInterface
+     */
+    public function __invoke(): FindFavoriteDashboardsResponse|ResponseStatusInterface
+    {
+        try {
+            $profile = $this->userProfileReader->findByContact($this->contact);
+            $this->usersFavoriteDashboards = $profile !== null ? $profile->getFavoriteDashboards(): [];
+
+            if ($this->usersFavoriteDashboards === []) {
+                return new FindFavoriteDashboardsResponse([]);
+            }
+
+            // Hack to benifit from existing code.
+            $search = $this->requestParameters->getSearch();
+            $search = ['id' => ['$in' => $this->usersFavoriteDashboards], ...$search];
+            $this->requestParameters->setSearch(json_encode($search) ?: '');
+
+            return $this->isUserAdmin() ? $this->findDashboardAsAdmin() : $this->findDashboardAsViewer();
+        } catch (\Throwable $ex) {
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+
+            return new ErrorResponse(DashboardException::errorWhileSearching());
+        }
+    }
+
+    /**
+     * @throws \Throwable
+     *
+     * @return FindFavoriteDashboardsResponse
+     */
+    private function findDashboardAsAdmin(): FindFavoriteDashboardsResponse
+    {
+        $dashboards = $this->dashboardReader->findByRequestParameter($this->requestParameters);
+
+        $dashboardIds = array_map(
+            static fn (Dashboard $dashboard): int => $dashboard->getId(),
+            $dashboards
+        );
+
+        $thumbnails = $this->dashboardReader->findThumbnailsByDashboardIds($dashboardIds);
+        $contactIds = $this->extractAllContactIdsFromDashboards($dashboards);
+
+        return $this->createResponse(
+            dashboards: $dashboards,
+            contactNames: $this->readContactRepository->findNamesByIds(...$contactIds),
+            sharingRolesList: $this->readDashboardShareRepository->getMultipleSharingRoles($this->contact, ...$dashboards),
+            contactShares: $this->readDashboardShareRepository->findDashboardsContactShares(...$dashboards),
+            contactGroupShares: $this->readDashboardShareRepository->findDashboardsContactGroupShares(...$dashboards),
+            defaultRole: DashboardSharingRole::Editor,
+            thumbnails: $thumbnails
+        );
+    }
+
+    /**
+     * @throws \Throwable
+     *
+     * @return FindFavoriteDashboardsResponse
+     */
+    private function findDashboardAsViewer(): FindFavoriteDashboardsResponse
+    {
+        $dashboards = $this->dashboardReader->findByRequestParameterAndContact(
+            $this->requestParameters,
+            $this->contact,
+        );
+
+        $dashboardIds = array_map(
+            static fn (Dashboard $dashboard): int => $dashboard->getId(),
+            $dashboards
+        );
+
+        $thumbnails = $this->dashboardReader->findThumbnailsByDashboardIds($dashboardIds);
+
+        $editorIds = $this->extractAllContactIdsFromDashboards($dashboards);
+
+        $userAccessGroups = $this->readAccessGroupRepository->findByContact($this->contact);
+        $accessGroupsIds = array_map(
+            static fn (AccessGroup $accessGroup): int => $accessGroup->getId(),
+            $userAccessGroups
+        );
+
+        $userInCurrentUserAccessGroups = $this->readContactRepository->findContactIdsByAccessGroups($accessGroupsIds);
+
+        return $this->createResponse(
+            dashboards: $dashboards,
+            contactNames: $this->readContactRepository->findNamesByIds(...$editorIds),
+            sharingRolesList: $this->readDashboardShareRepository->getMultipleSharingRoles($this->contact, ...$dashboards),
+            contactShares: $this->readDashboardShareRepository->findDashboardsContactSharesByContactIds(
+                $userInCurrentUserAccessGroups,
+                ...$dashboards
+            ),
+            contactGroupShares: $this->readDashboardShareRepository->findDashboardsContactGroupSharesByContact($this->contact, ...$dashboards),
+            defaultRole: DashboardSharingRole::Viewer,
+            thumbnails: $thumbnails
+        );
+    }
+
+    /**
+     * @param list<Dashboard> $dashboards
+     *
+     * @return int[]
+     */
+    private function extractAllContactIdsFromDashboards(array $dashboards): array
+    {
+        $contactIds = [];
+        foreach ($dashboards as $dashboard) {
+            if ($id = $dashboard->getCreatedBy()) {
+                $contactIds[] = $id;
+            }
+            if ($id = $dashboard->getUpdatedBy()) {
+                $contactIds[] = $id;
+            }
+        }
+
+        return $contactIds;
+    }
+
+    /**
+     * @throws \Throwable
+     *
+     * @return bool
+     */
+    private function isUserAdmin(): bool
+    {
+        if ($this->rights->hasAdminRole()) {
+            return true;
+        }
+
+        $userAccessGroupNames = array_map(
+            static fn (AccessGroup $accessGroup): string => $accessGroup->getName(),
+            $this->readAccessGroupRepository->findByContact($this->contact)
+        );
+
+        return ! (empty(array_intersect($userAccessGroupNames, self::AUTHORIZED_ACL_GROUPS)))
+            && $this->isCloudPlatform;
+    }
+
+    /**
+     * @param list<Dashboard> $dashboards
+     * @param array<int, array{id: int, name: string}> $contactNames
+     * @param array<int, DashboardSharingRoles> $sharingRolesList
+     * @param array<int, array<DashboardContactShare>> $contactShares
+     * @param array<int, array<DashboardContactGroupShare>> $contactGroupShares
+     * @param DashboardSharingRole $defaultRole
+     * @param array<int, Media> $thumbnails
+     *
+     * @return FindFavoriteDashboardsResponse
+     */
+    private function createResponse(
+        array $dashboards,
+        array $contactNames,
+        array $sharingRolesList,
+        array $contactShares,
+        array $contactGroupShares,
+        DashboardSharingRole $defaultRole,
+        array $thumbnails
+    ): FindFavoriteDashboardsResponse {
+
+        $dashboardsResponse = [];
+        foreach ($dashboards as $dashboard) {
+            $sharingRoles = $sharingRolesList[$dashboard->getId()] ?? null;
+            $ownRole = $defaultRole->getTheMostPermissiveOfBoth($sharingRoles?->getTheMostPermissiveRole());
+
+            $thumbnail = $thumbnails[$dashboard->getId()] ?? null;
+
+            $dto = new DashboardResponseDto();
+
+            $dto->id = $dashboard->getId();
+            $dto->name = $dashboard->getName();
+            $dto->description = $dashboard->getDescription();
+            $dto->createdAt = $dashboard->getCreatedAt();
+            $dto->updatedAt = $dashboard->getUpdatedAt();
+            $dto->ownRole = $ownRole;
+
+            if (null !== ($contactId = $dashboard->getCreatedBy())) {
+                $dto->createdBy = new UserResponseDto();
+                $dto->createdBy->id = $contactId;
+                $dto->createdBy->name = $contactNames[$contactId]['name'] ?? '';
+            }
+            if (null !== ($contactId = $dashboard->getCreatedBy())) {
+                $dto->updatedBy = new UserResponseDto();
+                $dto->updatedBy->id = $contactId;
+                $dto->updatedBy->name = $contactNames[$contactId]['name'] ?? '';
+            }
+
+            // Add shares only if the user if editor, as the viewers should not be able to see shares.
+            if ($ownRole === DashboardSharingRole::Editor && array_key_exists($dashboard->getId(), $contactShares)) {
+                $dto->shares['contacts'] = array_map(static fn (DashboardContactShare $contactShare): array => [
+                    'id' => $contactShare->getContactId(),
+                    'name' => $contactShare->getContactName(),
+                    'email' => $contactShare->getContactEmail(),
+                    'role' => $contactShare->getRole(),
+                ]
+                , $contactShares[$dashboard->getId()]);
+            }
+
+            if ($ownRole === DashboardSharingRole::Editor && array_key_exists($dashboard->getId(), $contactGroupShares)) {
+                $dto->shares['contact_groups'] = array_map(
+                    static fn (DashboardContactGroupShare $contactGroupShare): array => [
+                        'id' => $contactGroupShare->getContactGroupId(),
+                        'name' => $contactGroupShare->getContactGroupName(),
+                        'role' => $contactGroupShare->getRole(),
+                    ],
+                    $contactGroupShares[$dashboard->getId()]);
+            }
+
+            if ($thumbnail !== null) {
+                $dto->thumbnail = new ThumbnailResponseDto(
+                    $thumbnail->getId(),
+                    $thumbnail->getFilename(),
+                    $thumbnail->getDirectory()
+                );
+            }
+
+            if (in_array($dto->id, $this->usersFavoriteDashboards, true)) {
+                $dto->isFavorite = true;
+            }
+
+            $dashboardsResponse[] = $dto;
+        }
+
+        return new FindFavoriteDashboardsResponse(dashboards: $dashboardsResponse);
+    }
+}

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindFavoriteDashboards/FindFavoriteDashboardsResponse.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindFavoriteDashboards/FindFavoriteDashboardsResponse.php
@@ -21,17 +21,25 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Application\UseCase\FindDashboards;
+namespace Core\Dashboard\Application\UseCase\FindFavoriteDashboards;
 
-use Core\Dashboard\Application\UseCase\FindDashboards\Response\DashboardResponseDto;
+use Core\Application\Common\UseCase\ListingResponseInterface;
+use Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response\DashboardResponseDto;
 
-final class FindDashboardsResponse
+final class FindFavoriteDashboardsResponse implements ListingResponseInterface
 {
     /**
      * @param DashboardResponseDto[] $dashboards
      */
     public function __construct(
-        public array $dashboards = []
+        public array $dashboards
     ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getData(): mixed {
+        return $this->dashboards;
     }
 }

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindFavoriteDashboards/Response/DashboardResponseDto.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindFavoriteDashboards/Response/DashboardResponseDto.php
@@ -21,7 +21,7 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Application\UseCase\FindDashboards\Response;
+namespace Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response;
 
 use Core\Dashboard\Domain\Model\Role\DashboardSharingRole;
 use DateTimeImmutable;

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindFavoriteDashboards/Response/ThumbnailResponseDto.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindFavoriteDashboards/Response/ThumbnailResponseDto.php
@@ -21,17 +21,15 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Application\UseCase\FindDashboards;
+namespace Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response;
 
-use Core\Dashboard\Application\UseCase\FindDashboards\Response\DashboardResponseDto;
-
-final class FindDashboardsResponse
+final class ThumbnailResponseDto
 {
-    /**
-     * @param DashboardResponseDto[] $dashboards
-     */
     public function __construct(
-        public array $dashboards = []
+        public int $id = 0,
+        public string $name = '',
+        public string $directory = '',
     ) {
     }
 }
+

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindFavoriteDashboards/Response/UserResponseDto.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindFavoriteDashboards/Response/UserResponseDto.php
@@ -21,17 +21,13 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Application\UseCase\FindDashboards;
+namespace Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response;
 
-use Core\Dashboard\Application\UseCase\FindDashboards\Response\DashboardResponseDto;
-
-final class FindDashboardsResponse
+final class UserResponseDto
 {
-    /**
-     * @param DashboardResponseDto[] $dashboards
-     */
     public function __construct(
-        public array $dashboards = []
+        public int $id = 0,
+        public string $name = '',
     ) {
     }
 }

--- a/centreon/src/Core/Dashboard/Infrastructure/API/AddDashboardToFavorites/AddDashboardToFavoritesController.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/AddDashboardToFavorites/AddDashboardToFavoritesController.php
@@ -21,39 +21,34 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Infrastructure\API\FindDashboard;
+namespace Core\Dashboard\Infrastructure\API\AddDashboardToFavorites;
 
 use Centreon\Application\Controller\AbstractController;
-use Core\Dashboard\Application\UseCase\FindDashboard\FindDashboard;
+use Core\Dashboard\Application\UseCase\AddDashboardToFavorites\AddDashboardToFavorites;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\HttpKernel\Attribute\MapRequestPayload;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[IsGranted(
     'dashboard_access',
     null,
-    'You do not have sufficient rights to access the dashboard'
+    'You do not have sufficient rights to add the dashboard as favorite'
 )]
-final class FindDashboardController extends AbstractController
+final class AddDashboardToFavoritesController extends AbstractController
 {
     /**
-     * @param int $dashboardId
-     * @param FindDashboard $useCase
-     * @param FindDashboardPresenter $presenter
-     *
-     * @throws AccessDeniedException
-     *
+     * @param AddDashboardToFavorites $useCase
+     * @param AddDashboardToFavoritesInput $input
      * @return Response
      */
     public function __invoke(
-        int $dashboardId,
-        FindDashboard $useCase,
-        FindDashboardPresenter $presenter,
+        AddDashboardToFavorites $useCase,
+        #[MapRequestPayload] AddDashboardToFavoritesInput $input
     ): Response {
-        $this->denyAccessUnlessGrantedForApiConfiguration();
-
-        $useCase($dashboardId, $presenter);
-
-        return $presenter->show();
+        return $this->createResponse(
+            $useCase(
+                AddDashboardToFavoritesRequestTransformer::transform($input),
+            )
+        );
     }
 }

--- a/centreon/src/Core/Dashboard/Infrastructure/API/AddDashboardToFavorites/AddDashboardToFavoritesInput.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/AddDashboardToFavorites/AddDashboardToFavoritesInput.php
@@ -21,17 +21,19 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Application\UseCase\FindDashboards;
+namespace Core\Dashboard\Infrastructure\API\AddDashboardToFavorites;
 
-use Core\Dashboard\Application\UseCase\FindDashboards\Response\DashboardResponseDto;
+use Symfony\Component\Validator\Constraints as Assert;
 
-final class FindDashboardsResponse
+final class AddDashboardToFavoritesInput
 {
     /**
-     * @param DashboardResponseDto[] $dashboards
+     * @param int $dashboardId
      */
     public function __construct(
-        public array $dashboards = []
+        #[Assert\NotNull]
+        #[Assert\Type('integer')]
+        public readonly mixed $dashboardId
     ) {
     }
 }

--- a/centreon/src/Core/Dashboard/Infrastructure/API/AddDashboardToFavorites/AddDashboardToFavoritesRequestTransformer.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/AddDashboardToFavorites/AddDashboardToFavoritesRequestTransformer.php
@@ -21,17 +21,18 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Application\UseCase\FindDashboards;
+namespace Core\Dashboard\Infrastructure\API\AddDashboardToFavorites;
 
-use Core\Dashboard\Application\UseCase\FindDashboards\Response\DashboardResponseDto;
+use Core\Dashboard\Application\UseCase\AddDashboardToFavorites\AddDashboardToFavoritesRequest;
 
-final class FindDashboardsResponse
+abstract readonly class AddDashboardToFavoritesRequestTransformer
 {
     /**
-     * @param DashboardResponseDto[] $dashboards
+     * @param AddDashboardToFavoritesInput $input
+     * @return AddDashboardToFavoritesRequest
      */
-    public function __construct(
-        public array $dashboards = []
-    ) {
+    public static function transform(AddDashboardToFavoritesInput $input): AddDashboardToFavoritesRequest
+    {
+        return new AddDashboardToFavoritesRequest(dashboardId: (int) $input->dashboardId);
     }
 }

--- a/centreon/src/Core/Dashboard/Infrastructure/API/AddDashboardToFavorites/AddDashboardToFavoritesRoute.yaml
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/AddDashboardToFavorites/AddDashboardToFavoritesRoute.yaml
@@ -1,0 +1,5 @@
+AddFavoriteDashboard:
+  methods: POST
+  path: /configuration/dashboards/favorites
+  controller: 'Core\Dashboard\Infrastructure\API\AddDashboardToFavorites\AddDashboardToFavoritesController'
+  condition: "request.attributes.get('version') >= 24.10"

--- a/centreon/src/Core/Dashboard/Infrastructure/API/DeleteDashboardFromFavorites/DeleteDashboardFromFavoritesController.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/DeleteDashboardFromFavorites/DeleteDashboardFromFavoritesController.php
@@ -21,39 +21,29 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Infrastructure\API\FindDashboard;
+namespace Core\Dashboard\Infrastructure\API\DeleteDashboardFromFavorites;
 
 use Centreon\Application\Controller\AbstractController;
-use Core\Dashboard\Application\UseCase\FindDashboard\FindDashboard;
+use Core\Dashboard\Application\UseCase\DeleteDashboardFromFavorites\DeleteDashboardFromFavorites;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[IsGranted(
     'dashboard_access',
     null,
-    'You do not have sufficient rights to access the dashboard'
+    'You do not have sufficient rights to remove the dashboard from favorites'
 )]
-final class FindDashboardController extends AbstractController
+final class DeleteDashboardFromFavoritesController extends AbstractController
 {
     /**
      * @param int $dashboardId
-     * @param FindDashboard $useCase
-     * @param FindDashboardPresenter $presenter
-     *
-     * @throws AccessDeniedException
-     *
+     * @param DeleteDashboardFromFavorites $useCase
      * @return Response
      */
     public function __invoke(
         int $dashboardId,
-        FindDashboard $useCase,
-        FindDashboardPresenter $presenter,
+        DeleteDashboardFromFavorites $useCase
     ): Response {
-        $this->denyAccessUnlessGrantedForApiConfiguration();
-
-        $useCase($dashboardId, $presenter);
-
-        return $presenter->show();
+        return $this->createResponse($useCase($dashboardId));
     }
 }

--- a/centreon/src/Core/Dashboard/Infrastructure/API/DeleteDashboardFromFavorites/DeleteDashboardFromFavoritesRoute.yaml
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/DeleteDashboardFromFavorites/DeleteDashboardFromFavoritesRoute.yaml
@@ -1,0 +1,7 @@
+DeleteDashboardFromFavorites:
+  methods: DELETE
+  path: /configuration/dashboards/{dashboardId}/favorites
+  controller: 'Core\Dashboard\Infrastructure\API\DeleteDashboardFromFavorites\DeleteDashboardFromFavoritesController'
+  requirements:
+    hostId: '\d+'
+  condition: "request.attributes.get('version') >= 24.04"

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindDashboard/FindDashboardPresenter.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindDashboard/FindDashboardPresenter.php
@@ -56,6 +56,7 @@ final class FindDashboardPresenter extends DefaultPresenter implements FindDashb
                 'refresh' => $this->globalRefreshToArray($data->refresh),
                 'shares' => $this->formatShares($data->shares),
                 'thumbnail' => $this->thumbnailToOptionalArray($data->thumbnail),
+                'is_favorite' => $data->isFavorite,
             ]);
         } else {
             $this->setResponseStatus($data);

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindDashboards/FindDashboardsController.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindDashboards/FindDashboardsController.php
@@ -27,7 +27,13 @@ use Centreon\Application\Controller\AbstractController;
 use Core\Dashboard\Application\UseCase\FindDashboards\FindDashboards;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
 
+#[IsGranted(
+    'dashboard_access',
+    null,
+    'You are not allowed to set dashboard as favorites'
+)]
 final class FindDashboardsController extends AbstractController
 {
     /**

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindDashboards/FindDashboardsPresenter.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindDashboards/FindDashboardsPresenter.php
@@ -62,6 +62,7 @@ final class FindDashboardsPresenter extends DefaultPresenter implements FindDash
                     'own_role' => DashboardSharingRoleConverter::toString($dashboard->ownRole),
                     'shares' => $this->formatShares($dashboard->shares),
                     'thumbnail' => $this->formatThumbnail($dashboard->thumbnail),
+                    'is_favorite' => $dashboard->isFavorite,
                 ];
             }
 

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindFavoriteDashboards/FindFavoriteDashboardsController.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindFavoriteDashboards/FindFavoriteDashboardsController.php
@@ -21,39 +21,36 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Infrastructure\API\FindDashboard;
+namespace Core\Dashboard\Infrastructure\API\FindFavoriteDashboards;
 
 use Centreon\Application\Controller\AbstractController;
-use Core\Dashboard\Application\UseCase\FindDashboard\FindDashboard;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Dashboard\Application\UseCase\FindFavoriteDashboards\FindFavoriteDashboards;
+use Core\Infrastructure\Common\Api\StandardPresenter;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 #[IsGranted(
     'dashboard_access',
     null,
-    'You do not have sufficient rights to access the dashboard'
+    'You do not have sufficient rights to list the dashboards'
 )]
-final class FindDashboardController extends AbstractController
+final class FindFavoriteDashboardsController extends AbstractController
 {
-    /**
-     * @param int $dashboardId
-     * @param FindDashboard $useCase
-     * @param FindDashboardPresenter $presenter
-     *
-     * @throws AccessDeniedException
-     *
-     * @return Response
-     */
     public function __invoke(
-        int $dashboardId,
-        FindDashboard $useCase,
-        FindDashboardPresenter $presenter,
+        FindFavoriteDashboards $useCase,
+        StandardPresenter $presenter
     ): Response {
-        $this->denyAccessUnlessGrantedForApiConfiguration();
+        $response = $useCase();
 
-        $useCase($dashboardId, $presenter);
+        if ($response instanceof ResponseStatusInterface) {
+            return $this->createResponse($response);
+        }
 
-        return $presenter->show();
+        return JsonResponse::fromJsonString(
+            $presenter->present($response, ['groups' => ['FavoriteDashboards:Read']])
+        );
+ 
     }
 }

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindFavoriteDashboards/FindFavoriteDashboardsRoute.yaml
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindFavoriteDashboards/FindFavoriteDashboardsRoute.yaml
@@ -1,0 +1,5 @@
+FindFavoriteDashboards:
+  methods: GET
+  path: /configuration/dashboards/favorites
+  controller: 'Core\Dashboard\Infrastructure\API\FindFavoriteDashboards\FindFavoriteDashboardsController'
+  condition: "request.attributes.get('version') >= 24.10"

--- a/centreon/src/Core/Dashboard/Infrastructure/Serializer/DashboardResponseDtoNormalizer.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Serializer/DashboardResponseDtoNormalizer.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Infrastructure\Serializer;
+
+use Core\Dashboard\Application\UseCase\FindFavoriteDashboards\Response\DashboardResponseDto;
+use Core\Dashboard\Infrastructure\Model\DashboardSharingRoleConverter;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+final class DashboardResponseDtoNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        private readonly ObjectNormalizer $normalizer,
+    ) {
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null)
+    {
+        return $data instanceof DashboardResponseDto;
+    }
+
+    /**
+     * @param DashboardResponseDto $object
+     * @param string|null $format
+     * @param array<string, mixed> $context
+     *
+     * @throws \Throwable
+     *
+     * @return array<string, mixed>|bool|float|int|string|null
+     */
+    public function normalize(mixed $object, ?string $format = null, array $context = [])
+    {
+        /** @var array<string, bool|float|int|string> $data */
+        $data = $this->normalizer->normalize($object, $format, $context);
+        $data['own_role'] = DashboardSharingRoleConverter::toString($object->ownRole);
+
+        /** array{
+         *     contacts: array<array{
+         *      id: int,
+         *      name: string,
+         *      email: string,
+         *      role: DashboardSharingRole
+         *     }>,
+         *     contact_groups: array<array{
+         *      id: int,
+         *      name: string,
+         *      role: DashboardSharingRole
+         *     }>
+         * } $shares
+         */
+        $shares = $object->shares;
+
+        foreach ($shares['contacts'] as $key => $contact) {
+            $data['shares']['contacts'][$key]['role'] = DashboardSharingRoleConverter::toString($contact['role']);
+        }
+
+        foreach ($shares['contact_groups'] as $key => $contactGroup) {
+            $data['shares']['contact_groups'][$key]['role'] = DashboardSharingRoleConverter::toString($contactGroup['role']);
+        }
+
+        return $data;
+    }
+}

--- a/centreon/src/Core/Dashboard/Infrastructure/Voters/DashboardVoter.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Voters/DashboardVoter.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Infrastructure\Voters;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+/**
+ * @extends Voter<string, mixed>
+ */
+final class DashboardVoter extends Voter
+{
+    public const DASHBOARD_ACCESS = 'dashboard_access';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        if ($attribute === self::DASHBOARD_ACCESS) {
+            return $subject === null;
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+
+        if (! $user instanceof ContactInterface) {
+            return false;
+        }
+
+        return match ($attribute) {
+            self::DASHBOARD_ACCESS => $this->checkUsersRights($user),
+            default => throw new \LogicException('Action on dashboard not handled')
+        };
+    }
+
+    /**
+     * @param ContactInterface $user
+     * @return bool
+     */
+    private function checkUsersRights(ContactInterface $user): bool
+    {
+        return (bool) (
+            $user->hasTopologyRole(Contact::ROLE_HOME_DASHBOARD_ADMIN)
+            || $user->hasTopologyRole(Contact::ROLE_HOME_DASHBOARD_CREATOR)
+            || $user->hasTopologyRole(Contact::ROLE_HOME_DASHBOARD_VIEWER)
+        );
+    }
+}

--- a/centreon/src/Core/Infrastructure/Common/Api/StandardPresenter.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/StandardPresenter.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Core\Infrastructure\Common\Api;
 
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+use Core\Application\Common\UseCase\ListingResponseInterface;
 use Core\Application\Common\UseCase\StandardPresenterInterface;
 use Core\Application\Common\UseCase\StandardResponseInterface;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -34,9 +36,12 @@ class StandardPresenter implements StandardPresenterInterface
 {
     /**
      * @param Serializer $serializer
+     * @param RequestParametersInterface $requestParameters
      */
-    public function __construct(readonly private SerializerInterface $serializer)
-    {
+    public function __construct(
+        private readonly SerializerInterface $serializer,
+        private readonly RequestParametersInterface $requestParameters,
+    ) {
     }
 
     /**
@@ -53,6 +58,17 @@ class StandardPresenter implements StandardPresenterInterface
         array $context = [],
         string $format = JsonEncoder::FORMAT,
     ): string {
+        if ($data instanceof ListingResponseInterface) {
+            return $this->serializer->serialize(
+                [
+                    'result' => $data->getData(),
+                    'meta' => $this->requestParameters->toArray(),
+                ],
+                $format,
+                $context,
+            );
+        }
+
         return $this->serializer->serialize($data->getData(), $format, $context);
     }
 }

--- a/centreon/src/Core/UserProfile/Application/Repository/ReadUserProfileRepositoryInterface.php
+++ b/centreon/src/Core/UserProfile/Application/Repository/ReadUserProfileRepositoryInterface.php
@@ -21,17 +21,16 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Application\UseCase\FindDashboards;
+namespace Core\UserProfile\Application\Repository;
 
-use Core\Dashboard\Application\UseCase\FindDashboards\Response\DashboardResponseDto;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\UserProfile\Domain\Model\UserProfile;
 
-final class FindDashboardsResponse
+interface ReadUserProfileRepositoryInterface
 {
     /**
-     * @param DashboardResponseDto[] $dashboards
+     * @param ContactInterface $contact
+     * @return null|UserProfile
      */
-    public function __construct(
-        public array $dashboards = []
-    ) {
-    }
+    public function findByContact(ContactInterface $contact): ?UserProfile;
 }

--- a/centreon/src/Core/UserProfile/Application/Repository/WriteUserProfileRepositoryInterface.php
+++ b/centreon/src/Core/UserProfile/Application/Repository/WriteUserProfileRepositoryInterface.php
@@ -21,17 +21,30 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Application\UseCase\FindDashboards;
+namespace Core\UserProfile\Application\Repository;
 
-use Core\Dashboard\Application\UseCase\FindDashboards\Response\DashboardResponseDto;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
 
-final class FindDashboardsResponse
+interface WriteUserProfileRepositoryInterface
 {
     /**
-     * @param DashboardResponseDto[] $dashboards
+     * @param int $profileId
+     * @param int $dashboardId
+     * @throws \Throwable
      */
-    public function __construct(
-        public array $dashboards = []
-    ) {
-    }
+    public function addDashboardAsFavorites(int $profileId, int $dashboardId): void;
+
+    /**
+     * @param int $profileId
+     * @param int $dashboardId
+     */
+    public function removeDashboardFromFavorites(int $profileId, int $dashboardId): void;
+
+    /**
+     * @param ContactInterface $contact
+     *
+     * @throws \Throwable
+     * @return int
+     */
+    public function addDefaultProfileForUser(ContactInterface $contact): int;
 }

--- a/centreon/src/Core/UserProfile/Domain/Model/UserProfile.php
+++ b/centreon/src/Core/UserProfile/Domain/Model/UserProfile.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\UserProfile\Domain\Model;
+
+final class UserProfile
+{
+    /** @var int[] */
+    private array $favoriteDashboards = [];
+
+    /**
+     * @param int $id
+     * @param int $userId
+     */
+    public function __construct(
+        private readonly int $id,
+        private readonly int $userId
+    ) {
+    }
+
+    /**
+     * @param int $dashboardId
+     */
+    public function addFavoriteDashboard(int $dashboardId): void
+    {
+        $this->favoriteDashboards[] = $dashboardId;
+    }
+
+    /**
+     * @param int[] $dashboardIds
+     * @return self
+     */
+    public function setFavoriteDashboards(array $dashboardIds): self
+    {
+        foreach ($dashboardIds as $dashboardId) {
+            $this->addFavoriteDashboard($dashboardId);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getFavoriteDashboards(): array
+    {
+        return $this->favoriteDashboards;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getUserId(): int
+    {
+        return $this->userId;
+    }
+}

--- a/centreon/src/Core/UserProfile/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/UserProfile/Infrastructure/Configuration/symfony.yaml
@@ -1,0 +1,8 @@
+services:
+    _defaults:
+        public: false
+        autowire: true      # Automatically injects dependencies in your services.
+        autoconfigure: true # Automatically registers your services as commands, event subscribers, controller...
+
+    Core\UserProfile\:
+        resource: '../../../../Core/UserProfile/*'

--- a/centreon/src/Core/UserProfile/Infrastructure/Repository/DbReadUserProfileRepository.php
+++ b/centreon/src/Core/UserProfile/Infrastructure/Repository/DbReadUserProfileRepository.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\UserProfile\Infrastructure\Repository;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Infrastructure\DatabaseConnection;
+use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Core\Common\Infrastructure\Repository\SqlMultipleBindTrait;
+use Core\UserProfile\Application\Repository\ReadUserProfileRepositoryInterface;
+use Core\UserProfile\Domain\Model\UserProfile;
+
+/**
+ * @phpstan-type _UserProfileRecord array{
+ *    id:int,
+ *    contact_id:int,
+ *    favorite_dashboards:string|null
+ * }
+ */
+final class DbReadUserProfileRepository extends AbstractRepositoryRDB implements ReadUserProfileRepositoryInterface
+{
+    use SqlMultipleBindTrait;
+
+    /**
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function findByContact(ContactInterface $contact): ?UserProfile
+    {
+        $request = <<<'SQL'
+                SELECT
+                    `id`,
+                    `contact_id`,
+                    GROUP_CONCAT(DISTINCT user_profile_favorite_dashboards.dashboard_id) AS `favorite_dashboards`
+                FROM `:db`.user_profile
+                LEFT JOIN `:db`.user_profile_favorite_dashboards
+                    ON user_profile_favorite_dashboards.profile_id = user_profile.id
+                WHERE contact_id = :contactId
+                GROUP BY contact_id
+            SQL;
+
+        $statement = $this->db->prepare($this->translateDbName($request));
+        $statement->bindValue(':contactId', $contact->getId(), \PDO::PARAM_INT);
+        $statement->execute();
+
+        if (false !== ($record = $statement->fetch(\PDO::FETCH_ASSOC))) {
+            /** @var _UserProfileRecord $record */
+            return $this->createUserProfileFromRecord($record);
+        }
+
+        return null;
+    }
+
+    /**
+     * @param _UserProfileRecord $record
+     * @return UserProfile
+     */
+    private function createUserProfileFromRecord(array $record): UserProfile
+    {
+        $profile = new UserProfile(
+            id: (int) $record['id'],
+            userId: (int) $record['contact_id'],
+        );
+
+        if ($record['favorite_dashboards'] !== null) {
+            $favoriteDashboardIds = array_map(
+                static fn (string $dashboardId) => (int) $dashboardId,
+                explode(',', $record['favorite_dashboards'])
+            );
+            $profile->setFavoriteDashboards($favoriteDashboardIds);
+        }
+
+        return $profile;
+    }
+}

--- a/centreon/src/Core/UserProfile/Infrastructure/Repository/DbWriteUserProfileRepository.php
+++ b/centreon/src/Core/UserProfile/Infrastructure/Repository/DbWriteUserProfileRepository.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\UserProfile\Infrastructure\Repository;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Infrastructure\DatabaseConnection;
+use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
+use Core\Common\Infrastructure\Repository\SqlMultipleBindTrait;
+use Core\UserProfile\Application\Repository\WriteUserProfileRepositoryInterface;
+
+final class DbWriteUserProfileRepository extends AbstractRepositoryRDB implements WriteUserProfileRepositoryInterface
+{
+    use SqlMultipleBindTrait;
+
+    /**
+     * @param DatabaseConnection $db
+     */
+    public function __construct(DatabaseConnection $db)
+    {
+        $this->db = $db;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addDefaultProfileForUser(ContactInterface $contact): int
+    {
+        $alreadyInTransaction = $this->db->inTransaction();
+
+        if (! $alreadyInTransaction) {
+            $this->db->beginTransaction();
+        }
+
+        try {
+            $statement = $this->db->prepare(
+                $this->translateDbName(
+                    <<<'SQL'
+                        INSERT INTO `:db`.user_profile (contact_id) VALUES (:contactId)
+                        SQL
+                )
+            );
+
+            $statement->bindValue(':contactId', $contact->getId(), \PDO::PARAM_INT);
+            $statement->execute();
+
+            $profileId = (int) $this->db->lastInsertId();
+
+            if (! $alreadyInTransaction) {
+                $this->db->commit();
+            }
+
+            return $profileId;
+        } catch (\Throwable $exception) {
+            if (! $alreadyInTransaction) {
+                $this->db->rollBack();
+            }
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addDashboardAsFavorites(int $profileId, int $dashboardId): void
+    {
+        $alreadyInTransaction = $this->db->inTransaction();
+
+        if (! $alreadyInTransaction) {
+            $this->db->beginTransaction();
+        }
+
+        try {
+            $request = <<<'SQL'
+                INSERT INTO `:db`.user_profile_favorite_dashboards (profile_id, dashboard_id) VALUES (:profileId, :dashboardId)
+                SQL;
+
+            $statement = $this->db->prepare($this->translateDbName($request));
+            $statement->bindValue(':profileId', $profileId, \PDO::PARAM_INT);
+            $statement->bindValue(':dashboardId', $dashboardId, \PDO::PARAM_INT);
+
+            $statement->execute();
+
+            if (! $alreadyInTransaction) {
+                $this->db->commit();
+            }
+        } catch (\Throwable $exception) {
+            if (! $alreadyInTransaction) {
+                $this->db->rollBack();
+            }
+
+            throw $exception;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function removeDashboardFromFavorites(int $profileId, int $dashboardId): void
+    {
+        $request = <<<'SQL'
+            DELETE FROM `:db`.user_profile_favorite_dashboards
+            WHERE profile_id = :profileId
+                AND dashboard_id = :dashboardId
+            SQL;
+
+        $statement = $this->db->prepare($this->translateDbName($request));
+        $statement->bindValue(':profileId', $profileId, \PDO::PARAM_INT);
+        $statement->bindValue(':dashboardId', $dashboardId, \PDO::PARAM_INT);
+
+        $statement->execute();
+    }
+}

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -2699,6 +2699,27 @@ CREATE TABLE IF NOT EXISTS `ac_poller_relation` (
     REFERENCES `nagios_server` (`id`) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS `user_profile` (
+  `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  `contact_id` INT(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `unique_user_profile` (`id`, `contact_id`),
+  CONSTRAINT `fk_user_profile_contact_id`
+    FOREIGN KEY (`contact_id`)
+    REFERENCES `contact` (`contact_id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS `user_profile_favorite_dashboards` (
+  `profile_id` INT UNSIGNED NOT NULL,
+  `dashboard_id` INT UNSIGNED NOT NULL,
+  CONSTRAINT `fk_user_profile_favorite_dashboards_profile_id`
+    FOREIGN KEY (`profile_id`)
+    REFERENCES `user_profile` (`id`) ON DELETE CASCADE,
+  CONSTRAINT `fk_user_profile_favorite_dashboards_dashboard_id`
+    FOREIGN KEY (`dashboard_id`)
+    REFERENCES `dashboard` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
 /*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;


### PR DESCRIPTION
🏷️ MON-141593 backend part to implement MON-113483.
---
ℹ️ What as been done

- Add the concept of user profile in the database.
- Add the concept of favorite dashboards (_linked to a user profile_)
- Add a new dashboard endpoint that will allow to mark a dashboard as favorite for the current user (_client of the API_)
- Add a new dashboard endpoint that will allow to unmark a dashboard from favorites for the current user (_client of the API_)
- Add new key to the dashboard listing indicating if the dashboard is marked as favorite for the current user (_client of the API_)
- Add new key to the dashboard detail indicating if the dashboard is marked as favorite for the current user (_client of the API_)

⚠️ Upgrade script was not added yet as we need the Release Management to push the bump version on develop ⚠️ 