### PR TITLE
fix(resources status) : slow sql query with tags fixed

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -329,8 +329,8 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
                             SELECT resources.resource_id
                             FROM `:dbstg`.`resources` resources
                             LEFT JOIN `:dbstg`.`resources` parent_resource
-                                ON parent_resource.id = resources.parent_id
-                            LEFT JOIN `:dbstg`.resources_tags AS rtags
+                                ON parent_resource.id = resources.parent_id AND parent_resource.type = 1
+                            INNER JOIN `:dbstg`.resources_tags AS rtags
                               ON rtags.resource_id = resources.resource_id
                               OR rtags.resource_id = parent_resource.resource_id
                             INNER JOIN `:dbstg`.tags
@@ -344,8 +344,12 @@ class DbReadResourceRepository extends AbstractRepositoryDRB implements ReadReso
                             FROM `:dbstg`.resources_tags AS rtags
                             INNER JOIN `:dbstg`.tags
                                 ON tags.tag_id = rtags.tag_id
-                            WHERE tags.name IN ({$literalTagKeys})
-                            AND tags.type = {$type}
+                            WHERE resources.name NOT LIKE '\_Module\_%'
+                                AND resources.parent_name NOT LIKE '\_Module\_BAM%'
+                                AND resources.enabled = 1
+                                AND resources.type != 3
+                                AND tags.name IN ({$literalTagKeys})
+                                AND tags.type = {$type}
                         SQL;
                 }
             }


### PR DESCRIPTION
## Description

* slow sql query with tags fixed

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Given to resources status page, my resoources display.
When I search my resources with filters, I have the good resources.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
