### PR TITLE
fix (media): SVG clean-up after downloading

### DIFF
--- a/centreon/www/include/options/media/images/formImg.php
+++ b/centreon/www/include/options/media/images/formImg.php
@@ -137,6 +137,8 @@ if ($o == IMAGE_ADD) {
     );
     $form->setDefaults($img);
     $form->addRule('img_name', _("Compulsory image name"), 'required');
+    $form->registerRule('isCorrectMIMEType', 'callback', 'isCorrectMIMEType');
+    $form->addRule('filename', _('Invalid Image Format.'), 'isCorrectMIMEType');
 } elseif ($o == IMAGE_WATCH) {
     $form->addElement('header', 'title', _("View Image"));
     $form->addElement('text', 'img_name', _("Image Name"), $attrsText);

--- a/centreon/www/include/options/media/images/images.php
+++ b/centreon/www/include/options/media/images/images.php
@@ -40,14 +40,13 @@
 if (!isset($oreon)) {
     exit();
 }
-
-define('IMAGE_ADD', 'a');
-define('IMAGE_WATCH', 'w');
-define('IMAGE_MODIFY', 'ci');
-define('IMAGE_MODIFY_DIRECTORY', 'cd');
-define('IMAGE_MOVE', 'm');
-define('IMAGE_DELETE', 'd');
-define('IMAGE_SYNC_DIR', 'sd');
+const IMAGE_ADD = 'a';
+const IMAGE_WATCH = 'w';
+const IMAGE_MODIFY = 'ci';
+const IMAGE_MODIFY_DIRECTORY = 'cd';
+const IMAGE_MOVE = 'm';
+const IMAGE_DELETE = 'd';
+const IMAGE_SYNC_DIR = 'sd';
 
 $imageId = filter_var(
     $_GET["img_id"] ?? $_POST["img_id"] ?? null,
@@ -71,6 +70,7 @@ require_once $path . "DB-Func.php";
 require_once "./include/common/common-Func.php";
 
 switch ($o) {
+    case IMAGE_MODIFY:
     case IMAGE_ADD:
         require_once($path . "formImg.php");
         break;
@@ -79,13 +79,8 @@ switch ($o) {
             require_once($path . "formImg.php");
         }
         break;
-    case IMAGE_MODIFY:
-        require_once($path . "formImg.php");
-        break;
-    case IMAGE_MODIFY_DIRECTORY:
-        require_once($path . "formDirectory.php");
-        break;
     case IMAGE_MOVE:
+    case IMAGE_MODIFY_DIRECTORY:
         require_once($path . "formDirectory.php");
         break;
     case IMAGE_DELETE:


### PR DESCRIPTION
## Description

SVG clean-up after downloading following modification of existing media.

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
