### PR TITLE
fix(widgets) Fix query on hostgroup-monitoring widget - Issue with orderby

### DIFF
--- a/centreon/www/widgets/hostgroup-monitoring/src/index.php
+++ b/centreon/www/widgets/hostgroup-monitoring/src/index.php
@@ -134,7 +134,7 @@ try {
 
     $statement = $dbb->prepareQuery($query);
 
-    $bindParams = ['orderby' => [$orderby, PDO::PARAM_STR]];
+    $bindParams['orderby'] = [$orderby, PDO::PARAM_STR];
     $bindParams['offset'] = [$page * $preferences['entries'], PDO::PARAM_INT];
     $bindParams['entries'] = [$preferences['entries'], PDO::PARAM_INT];
 


### PR DESCRIPTION
## Description

There was a mistake/typo in the orderby bind param.

**Fixes** # MON-154804

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
