### PR TITLE
enh(ci): move veracode analysis out of base workflows (#5888)

### DIFF
--- a/.github/workflows/awie-analysis.yml
+++ b/.github/workflows/awie-analysis.yml
@@ -1,0 +1,84 @@
+name: awie-analysis
+run-name: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.nightly_manual_trigger == 'true')) && format('awie-analysis nightly {0}', github.ref_name) || '' }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      nightly_manual_trigger:
+        description: 'Set to true for nightly run'
+        required: true
+        default: false
+        type: boolean
+  schedule:
+    - cron: "0 3 * * 1-5"
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - "centreon-awie/**"
+      - "!centreon-awie/features/**"
+      - "!centreon-awie/behat.yml"
+      - "!centreon-awie/veracode.json"
+      - "!centreon-awie/.veracode-exclusions"
+  push:
+    branches:
+      - develop
+      - dev-[2-9][0-9].[0-9][0-9].x
+      - master
+      - "[2-9][0-9].[0-9][0-9].x"
+    paths:
+      - "centreon-awie/**"
+
+env:
+  module: awie
+
+jobs:
+  dispatch-to-maintained-branches:
+    if: |
+      github.run_attempt == 1 &&
+      github.event_name == 'schedule' &&
+      github.ref_name == 'develop'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - run: |
+          NIGHTLY_TARGETS=("dev-23.04.x" "dev-23.10.x" "dev-24.04.x" "dev-24.10.x")
+          for target in "${NIGHTLY_TARGETS[@]}"; do
+            echo "[INFO] - Dispatching nightly run to $target branch."
+            gh workflow run awie-analysis.yml -r "$target" -f nightly_manual_trigger=true
+          done
+        shell: bash
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  get-environment:
+    uses: ./.github/workflows/get-environment.yml
+    with:
+      version_file: centreon-awie/www/modules/centreon-awie/conf.php
+
+  veracode-analysis:
+    needs: [get-environment]
+    if: ${{ needs.get-environment.outputs.is_targeting_feature_branch != 'true' && github.event.pull_request.draft != 'true' }}
+    uses: ./.github/workflows/veracode-analysis.yml
+    with:
+      module_directory: centreon-awie
+      module_name: centreon-awie
+      major_version: ${{ needs.get-environment.outputs.major_version }}
+      minor_version: ${{ needs.get-environment.outputs.minor_version }}
+      stability: ${{ needs.get-environment.outputs.stability }}
+    secrets:
+      veracode_api_id: ${{ secrets.VERACODE_API_ID }}
+      veracode_api_key: ${{ secrets.VERACODE_API_KEY }}
+      veracode_srcclr_token: ${{ secrets.VERACODE_SRCCLR_TOKEN }}
+      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -67,30 +67,6 @@ jobs:
           has_backend_changes: ${{ steps.filter.outputs.has_backend_changes }}
           has_test_changes: ${{ steps.filter.outputs.has_test_changes }}
 
-  backend-lint:
-    runs-on: ubuntu-24.04
-    needs: [changes, get-environment]
-    if: ${{ needs.get-environment.outputs.skip_workflow == 'false' && needs.changes.outputs.has_backend_changes == 'true' }}
-    steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
-        with:
-          php-version: 8.2
-          coverage: none
-        env:
-          runner: ubuntu-24.04
-
-      - name: Install Dependencies
-        run: composer install --optimize-autoloader
-        working-directory: centreon-awie
-        shell: bash
-
-      - name: Run of phpstan on /www at level 6
-        run: vendor/bin/phpstan analyse --no-progress --level=6 --configuration=phpstan.neon
-        working-directory: centreon-awie
-
   package:
     needs: [get-environment]
 

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -16,8 +16,6 @@ on:
       - "centreon-awie/**"
       - "!centreon-awie/features/**"
       - "!centreon-awie/behat.yml"
-      - "!centreon-awie/veracode.json"
-      - "!centreon-awie/.veracode-exclusions"
   push:
     branches:
       - develop
@@ -28,8 +26,6 @@ on:
       - "centreon-awie/**"
       - "!centreon-awie/features/**"
       - "!centreon-awie/behat.yml"
-      - "!centreon-awie/veracode.json"
-      - "!centreon-awie/.veracode-exclusions"
 
 env:
   module: awie
@@ -71,23 +67,29 @@ jobs:
           has_backend_changes: ${{ steps.filter.outputs.has_backend_changes }}
           has_test_changes: ${{ steps.filter.outputs.has_test_changes }}
 
-  veracode-analysis:
-    needs: [get-environment]
-    if: ${{ needs.get-environment.outputs.is_targeting_feature_branch != 'true' && github.event.pull_request.draft != 'true' }}
-    uses: ./.github/workflows/veracode-analysis.yml
-    with:
-      module_directory: centreon-awie
-      module_name: centreon-awie
-      major_version: ${{ needs.get-environment.outputs.major_version }}
-      minor_version: ${{ needs.get-environment.outputs.minor_version }}
-      stability: ${{ needs.get-environment.outputs.stability }}
-    secrets:
-      veracode_api_id: ${{ secrets.VERACODE_API_ID }}
-      veracode_api_key: ${{ secrets.VERACODE_API_KEY }}
-      veracode_srcclr_token: ${{ secrets.VERACODE_SRCCLR_TOKEN }}
-      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
+  backend-lint:
+    runs-on: ubuntu-24.04
+    needs: [changes, get-environment]
+    if: ${{ needs.get-environment.outputs.skip_workflow == 'false' && needs.changes.outputs.has_backend_changes == 'true' }}
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
+        with:
+          php-version: 8.2
+          coverage: none
+        env:
+          runner: ubuntu-24.04
+
+      - name: Install Dependencies
+        run: composer install --optimize-autoloader
+        working-directory: centreon-awie
+        shell: bash
+
+      - name: Run of phpstan on /www at level 6
+        run: vendor/bin/phpstan analyse --no-progress --level=6 --configuration=phpstan.neon
+        working-directory: centreon-awie
 
   package:
     needs: [get-environment]

--- a/.github/workflows/dsm-analysis.yml
+++ b/.github/workflows/dsm-analysis.yml
@@ -1,0 +1,82 @@
+name: dsm-analysis
+run-name: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.nightly_manual_trigger == 'true')) && format('dsm-analysis nightly {0}', github.ref_name) || '' }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      nightly_manual_trigger:
+        description: 'Set to true for nightly run'
+        required: true
+        default: false
+        type: boolean
+  schedule:
+    - cron: "0 3 * * 1-5"
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - "centreon-dsm/**"
+      - "!centreon-dsm/veracode.json"
+      - "!centreon-dsm/.veracode-exclusions"
+  push:
+    branches:
+      - develop
+      - dev-[2-9][0-9].[0-9][0-9].x
+      - master
+      - "[2-9][0-9].[0-9][0-9].x"
+    paths:
+      - "centreon-dsm/**"
+
+env:
+  module: dsm
+
+jobs:
+  dispatch-to-maintained-branches:
+    if: |
+      github.run_attempt == 1 &&
+      github.event_name == 'schedule' &&
+      github.ref_name == 'develop'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - run: |
+          NIGHTLY_TARGETS=("dev-23.04.x" "dev-23.10.x" "dev-24.04.x" "dev-24.10.x")
+          for target in "${NIGHTLY_TARGETS[@]}"; do
+            echo "[INFO] - Dispatching nightly run to $target branch."
+            gh workflow run dsm-analysis.yml -r "$target" -f nightly_manual_trigger=true
+          done
+        shell: bash
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  get-environment:
+    uses: ./.github/workflows/get-environment.yml
+    with:
+      version_file: centreon-dsm/www/modules/centreon-dsm/conf.php
+
+  veracode-analysis:
+    needs: [get-environment]
+    if: ${{ needs.get-environment.outputs.is_targeting_feature_branch != 'true' && github.event.pull_request.draft != 'true' }}
+    uses: ./.github/workflows/veracode-analysis.yml
+    with:
+      module_directory: centreon-dsm
+      module_name: centreon-dsm
+      major_version: ${{ needs.get-environment.outputs.major_version }}
+      minor_version: ${{ needs.get-environment.outputs.minor_version }}
+      stability: ${{ needs.get-environment.outputs.stability }}
+    secrets:
+      veracode_api_id: ${{ secrets.VERACODE_API_ID }}
+      veracode_api_key: ${{ secrets.VERACODE_API_KEY }}
+      veracode_srcclr_token: ${{ secrets.VERACODE_SRCCLR_TOKEN }}
+      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -36,24 +36,6 @@ jobs:
     with:
       version_file: centreon-dsm/www/modules/centreon-dsm/conf.php
 
-  veracode-analysis:
-    needs: [get-environment]
-    if: ${{ needs.get-environment.outputs.is_targeting_feature_branch != 'true' && github.event.pull_request.draft != 'true' }}
-    uses: ./.github/workflows/veracode-analysis.yml
-    with:
-      module_directory: centreon-dsm
-      module_name: centreon-dsm
-      major_version: ${{ needs.get-environment.outputs.major_version }}
-      minor_version: ${{ needs.get-environment.outputs.minor_version }}
-      stability: ${{ needs.get-environment.outputs.stability }}
-    secrets:
-      veracode_api_id: ${{ secrets.VERACODE_API_ID }}
-      veracode_api_key: ${{ secrets.VERACODE_API_KEY }}
-      veracode_srcclr_token: ${{ secrets.VERACODE_SRCCLR_TOKEN }}
-      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
-
   package:
     needs: [get-environment]
 

--- a/.github/workflows/open-tickets-analysis.yml
+++ b/.github/workflows/open-tickets-analysis.yml
@@ -1,0 +1,82 @@
+name: open-tickets-analysis
+run-name: ${{ (github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.nightly_manual_trigger == 'true')) && format('open-tickets-analysis nightly {0}', github.ref_name) || '' }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  workflow_dispatch:
+    inputs:
+      nightly_manual_trigger:
+        description: 'Set to true for nightly run'
+        required: true
+        default: false
+        type: boolean
+  schedule:
+    - cron: "0 3 * * 1-5"
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+    paths:
+      - "centreon-open-tickets/**"
+      - "!centreon-open-tickets/veracode.json"
+      - "!centreon-open-tickets/.veracode-exclusions"
+  push:
+    branches:
+      - develop
+      - dev-[2-9][0-9].[0-9][0-9].x
+      - master
+      - "[2-9][0-9].[0-9][0-9].x"
+    paths:
+      - "centreon-open-tickets/**"
+
+env:
+  module: open-tickets
+
+jobs:
+  dispatch-to-maintained-branches:
+    if: |
+      github.run_attempt == 1 &&
+      github.event_name == 'schedule' &&
+      github.ref_name == 'develop'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - run: |
+          NIGHTLY_TARGETS=("dev-23.04.x" "dev-23.10.x" "dev-24.04.x" "dev-24.10.x")
+          for target in "${NIGHTLY_TARGETS[@]}"; do
+            echo "[INFO] - Dispatching nightly run to $target branch."
+            gh workflow run open-tickets-analysis.yml -r "$target" -f nightly_manual_trigger=true
+          done
+        shell: bash
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  get-environment:
+    uses: ./.github/workflows/get-environment.yml
+    with:
+      version_file: centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
+
+  veracode-analysis:
+    needs: [get-environment]
+    if: ${{ needs.get-environment.outputs.is_targeting_feature_branch != 'true' && github.event.pull_request.draft != 'true' }}
+    uses: ./.github/workflows/veracode-analysis.yml
+    with:
+      module_directory: centreon-open-tickets
+      module_name: centreon-open-tickets
+      major_version: ${{ needs.get-environment.outputs.major_version }}
+      minor_version: ${{ needs.get-environment.outputs.minor_version }}
+      stability: ${{ needs.get-environment.outputs.stability }}
+    secrets:
+      veracode_api_id: ${{ secrets.VERACODE_API_ID }}
+      veracode_api_key: ${{ secrets.VERACODE_API_KEY }}
+      veracode_srcclr_token: ${{ secrets.VERACODE_SRCCLR_TOKEN }}
+      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
+      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
+      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -36,24 +36,6 @@ jobs:
     with:
       version_file: centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
 
-  veracode-analysis:
-    needs: [get-environment]
-    if: ${{ needs.get-environment.outputs.is_targeting_feature_branch != 'true' && github.event.pull_request.draft != 'true' }}
-    uses: ./.github/workflows/veracode-analysis.yml
-    with:
-      module_directory: centreon-open-tickets
-      module_name: centreon-open-tickets
-      major_version: ${{ needs.get-environment.outputs.major_version }}
-      minor_version: ${{ needs.get-environment.outputs.minor_version }}
-      stability: ${{ needs.get-environment.outputs.stability }}
-    secrets:
-      veracode_api_id: ${{ secrets.VERACODE_API_ID }}
-      veracode_api_key: ${{ secrets.VERACODE_API_KEY }}
-      veracode_srcclr_token: ${{ secrets.VERACODE_SRCCLR_TOKEN }}
-      jira_base_url: ${{ secrets.JIRA_BASE_URL }}
-      jira_user_email: ${{ secrets.XRAY_JIRA_USER_EMAIL }}
-      jira_api_token: ${{ secrets.XRAY_JIRA_TOKEN }}
-
   package:
     needs: [get-environment]
     if: ${{ contains(fromJson('["testing", "unstable"]'), needs.get-environment.outputs.stability) }}

--- a/centreon-awie/veracode.json
+++ b/centreon-awie/veracode.json
@@ -1,3 +1,0 @@
-{
-  "ignorethirdparty": "false"
-}

--- a/centreon-dsm/veracode.json
+++ b/centreon-dsm/veracode.json
@@ -1,3 +1,0 @@
-{
-  "ignorethirdparty": "false"
-}

--- a/centreon-ha/veracode.json
+++ b/centreon-ha/veracode.json
@@ -1,3 +1,0 @@
-{
-  "ignorethirdparty": "false"
-}

--- a/centreon-open-tickets/veracode.json
+++ b/centreon-open-tickets/veracode.json
@@ -1,3 +1,0 @@
-{
-  "ignorethirdparty": "false"
-}


### PR DESCRIPTION
## Description

* move veracode analysis out of base workflows
* nothing for ha since there is no analysis involved

Fixes #MON-154048

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
