### PR TITLE
enh (legacy): Retrieving Symfony environment variables for legacy code

### DIFF
--- a/centreon/bootstrap.php
+++ b/centreon/bootstrap.php
@@ -59,4 +59,7 @@ $loader = require __DIR__ . '/vendor/autoload.php';
 
 Doctrine\Common\Annotations\AnnotationRegistry::registerLoader([$loader, 'loadClass']);
 
+// Retrieving Symfony environment variables for legacy code (APIv1,...)
+(new Symfony\Component\Dotenv\Dotenv())->bootEnv(__DIR__ . '/.env');
+
 require_once __DIR__ . "/container.php";


### PR DESCRIPTION
## Description

The goal is to share Symfony environment variables with legacy code (APIv1, ...).

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
