### PR TITLE
fix(dashboard): do not condition the rights validation on contact_ore…

### DIFF
--- a/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardShareRepository.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/Repository/DbReadDashboardShareRepository.php
@@ -564,7 +564,6 @@ class DbReadDashboardShareRepository extends AbstractRepositoryDRB implements Re
                     WHERE parent.topology_name = 'Dashboards'
                         AND topology.topology_name IN ('Viewer','Administrator','Creator')
                         AND acltr.access_right IS NOT NULL
-                        AND c.contact_oreon = '1'
                         AND c.contact_id IN ({$bindTokenAsString})
                         GROUP BY c.contact_id
             SQL;


### PR DESCRIPTION
…on field

ℹ️ [https://centreon.atlassian.net/browse/MON-147254](Issue)
↪️ Fixed when issue preventing user from sharing a dashboard when he has the "Reach Centreon Web Front End" set to no.

Expected result after applying the patch:
With this option set to no, the user should be able to share a dashboard to other contacts.