### PR TITLE
enh(ui): I can use initial matrix with Zoom

### DIFF
--- a/centreon/packages/ui/src/components/Zoom/Zoom.tsx
+++ b/centreon/packages/ui/src/components/Zoom/Zoom.tsx
@@ -1,5 +1,7 @@
 import { Zoom as VisxZoom } from '@visx/zoom';
 
+import type { TransformMatrix } from '@visx/zoom/lib/types';
+
 import { ParentSize } from '../..';
 
 import ZoomContent from './ZoomContent';
@@ -12,6 +14,7 @@ export interface ZoomProps {
   scaleMax?: number;
   scaleMin?: number;
   showMinimap?: boolean;
+  initialTransformMatrix?: TransformMatrix
 }
 
 const initialTransform = {
@@ -29,14 +32,15 @@ const Zoom = ({
   scaleMax = 4,
   showMinimap = false,
   minimapPosition = 'top-left',
-  id = 0
+  id = 0,
+  initialTransformMatrix = initialTransform
 }: ZoomProps): JSX.Element => {
   return (
     <ParentSize>
       {({ width, height }) => (
         <VisxZoom<SVGSVGElement>
           height={height}
-          initialTransformMatrix={initialTransform}
+          initialTransformMatrix={initialTransformMatrix}
           scaleXMax={scaleMax}
           scaleXMin={scaleMin}
           scaleYMax={scaleMax}

--- a/centreon/packages/ui/src/components/Zoom/ZoomContent.tsx
+++ b/centreon/packages/ui/src/components/Zoom/ZoomContent.tsx
@@ -105,7 +105,6 @@ const ZoomContent = ({
             contentClientRect,
             height,
             transformMatrix: zoom.transformMatrix,
-            setTransformMatrix: zoom.setTransformMatrix,
             width
           })}
         </g>
@@ -135,7 +134,6 @@ const ZoomContent = ({
                   contentClientRect,
                   height,
                   transformMatrix: zoom.transformMatrix,
-                  setTransformMatrix: zoom.setTransformMatrix,
                   width
                 })}
               </g>

--- a/centreon/packages/ui/src/components/Zoom/models.ts
+++ b/centreon/packages/ui/src/components/Zoom/models.ts
@@ -9,7 +9,6 @@ export interface ZoomState {
     translateX: number;
     translateY: number;
   };
-  setTransformMatrix?: ProvidedZoom<SVGSVGElement>['setTransformMatrix'];
 }
 
 export type MinimapPosition =


### PR DESCRIPTION
## Description

Zoom can accept initialTransformMatrix as props

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

In map modules, use Zoom component with custom initials values

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
