### PR TITLE
fea (user): new API endpoint to list user permissions

### DIFF
--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -9174,16 +9174,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.7",
+            "version": "1.12.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0"
+                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
-                "reference": "dc2b9976bd8b0f84ec9b0e50cc35378551de7af0",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e73868f809e68fff33be961ad4946e2e43ec9e38",
+                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38",
                 "shasum": ""
             },
             "require": {
@@ -9228,7 +9228,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-18T11:12:07+00:00"
+            "time": "2024-12-31T07:26:13+00:00"
         },
         {
             "name": "phpstan/phpstan-beberlei-assert",
@@ -13000,5 +13000,5 @@
     "platform-overrides": {
         "php": "8.2"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -9174,16 +9174,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.14",
+            "version": "1.12.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38"
+                "reference": "c91d4e8bc056f46cf653656e6f71004b254574d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e73868f809e68fff33be961ad4946e2e43ec9e38",
-                "reference": "e73868f809e68fff33be961ad4946e2e43ec9e38",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c91d4e8bc056f46cf653656e6f71004b254574d1",
+                "reference": "c91d4e8bc056f46cf653656e6f71004b254574d1",
                 "shasum": ""
             },
             "require": {
@@ -9228,7 +9228,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-31T07:26:13+00:00"
+            "time": "2025-01-05T16:40:22+00:00"
         },
         {
             "name": "phpstan/phpstan-beberlei-assert",

--- a/centreon/config/symfony_serializer/Common/NotEmptyString.yaml
+++ b/centreon/config/symfony_serializer/Common/NotEmptyString.yaml
@@ -1,0 +1,4 @@
+Core\Common\Domain\NotEmptyString:
+  attributes:
+    value:
+      groups: ['NotEmptyString:Read']

--- a/centreon/config/symfony_serializer/User/FindUserPermissionsResponse.yaml
+++ b/centreon/config/symfony_serializer/User/FindUserPermissionsResponse.yaml
@@ -1,0 +1,4 @@
+Core\User\Application\UseCase\FindUserPermissions\FindUserPermissionsResponse:
+  attributes:
+    permissions:
+      groups: ['FindUserPermissions:Read']

--- a/centreon/config/symfony_serializer/User/Permission.yaml
+++ b/centreon/config/symfony_serializer/User/Permission.yaml
@@ -1,0 +1,6 @@
+Core\User\Domain\Model\Permission:
+  attributes:
+    name:
+      groups: ['FindUserPermissions:Read']
+    isActive:
+      groups: ['FindUserPermissions:Read']

--- a/centreon/phpstan.core.neon
+++ b/centreon/phpstan.core.neon
@@ -10,7 +10,6 @@ rules:
     - Centreon\PHPStan\CustomRules\MiscRules\VariableLengthCustomRule
     - Centreon\PHPStan\CustomRules\MiscRules\StringBackquotesCustomRule
     - Centreon\PHPStan\CustomRules\LoggerRules\LogMethodInCatchCustomRule
-    - Centreon\PHPStan\CustomRules\LoggerRules\LoggerUseCaseCustomRule
     - Centreon\PHPStan\CustomRules\RepositoryRules\RepositoryImplementsInterfaceCustomRule
     - Centreon\PHPStan\CustomRules\ArchitectureRules\DomainCallNamespacesCustomRule
     - Centreon\PHPStan\CustomRules\ArchitectureRules\FinalClassCustomRule

--- a/centreon/src/Centreon/Domain/Contact/Contact.php
+++ b/centreon/src/Centreon/Domain/Contact/Contact.php
@@ -54,6 +54,8 @@ class Contact implements UserInterface, ContactInterface
     public const ROLE_MANAGE_TOKENS = 'ROLE_MANAGE_TOKENS';
     public const ROLE_CREATE_EDIT_POLLER_CFG = 'CREATE_EDIT_POLLER_CFG';
     public const ROLE_DELETE_POLLER_CFG = 'DELETE_POLLER_CFG';
+    public const ROLE_DISPLAY_TOP_COUNTER = 'DISPLAY_TOP_COUNTER';
+    public const ROLE_DISPLAY_TOP_COUNTER_POLLERS_STATISTICS = 'DISPLAY_TOP_COUNTER_POLLERS_STATISTICS';
 
     // user pages access
     public const ROLE_HOME_DASHBOARD_VIEWER = 'ROLE_HOME_DASHBOARDS_VIEWER_RW';

--- a/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Contact/ContactRepositoryRDB.php
@@ -555,6 +555,12 @@ final class ContactRepositoryRDB implements ContactRepositoryInterface
             case 'delete_poller_cfg':
                 $contact->addRole(Contact::ROLE_DELETE_POLLER_CFG);
                 break;
+            case 'top_counter':
+                $contact->addRole(Contact::ROLE_DISPLAY_TOP_COUNTER);
+                break;
+            case 'poller_stats':
+                $contact->addRole(Contact::ROLE_DISPLAY_TOP_COUNTER_POLLERS_STATISTICS);
+                break;
         }
     }
 

--- a/centreon/src/Core/Common/Infrastructure/Normalizer/NotEmptyStringNormalizer.php
+++ b/centreon/src/Core/Common/Infrastructure/Normalizer/NotEmptyStringNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\Common\Infrastructure\Normalizer;
+
+use Core\Common\Domain\NotEmptyString;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+final readonly class NotEmptyStringNormalizer implements NormalizerInterface
+{
+    public function __construct(private ObjectNormalizer $normalizer)
+    {
+    }
+
+    /**
+     * @param mixed $object
+     * @param string|null $format
+     * @param array<string, mixed> $context
+     *
+     * @throws ExceptionInterface
+     * @return string
+     */
+    public function normalize(
+        mixed $object,
+        ?string $format = null,
+        array $context = []
+    ): string
+    {
+        /** @var array{value: string} $data */
+        $data = $this->normalizer->normalize($object, $format, $context);
+
+        return $data['value'];
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    {
+        return $data instanceof NotEmptyString;
+    }
+}

--- a/centreon/src/Core/User/Application/UseCase/FindUserPermissions/FindUserPermissions.php
+++ b/centreon/src/Core/User/Application/UseCase/FindUserPermissions/FindUserPermissions.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\User\Application\UseCase\FindUserPermissions;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Common\Domain\NotEmptyString;
+use Core\User\Domain\Model\Permission;
+
+final class FindUserPermissions
+{
+    /** @var array<string, string> */
+    private array $permissions = [
+        'top_counter' => Contact::ROLE_DISPLAY_TOP_COUNTER,
+        'poller_statistics' => Contact::ROLE_DISPLAY_TOP_COUNTER_POLLERS_STATISTICS,
+    ];
+
+    public function __invoke(ContactInterface $user): FindUserPermissionsResponse|ResponseStatusInterface
+    {
+        return new FindUserPermissionsResponse($this->createPermissionsToReturn($user));
+    }
+
+    /**
+     * @param ContactInterface $user
+     *
+     * @return Permission[]
+     */
+    private function createPermissionsToReturn(ContactInterface $user): array
+    {
+        $permissions = [];
+        foreach ($this->permissions as $permissionName => $role) {
+            if ($user->isAdmin() || $user->hasRole($role)) {
+                $permissions[] = new Permission(new NotEmptyString($permissionName), true);
+            }
+
+        }
+
+        return $permissions;
+    }
+}

--- a/centreon/src/Core/User/Application/UseCase/FindUserPermissions/FindUserPermissionsResponse.php
+++ b/centreon/src/Core/User/Application/UseCase/FindUserPermissions/FindUserPermissionsResponse.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\User\Application\UseCase\FindUserPermissions;
+
+use Core\Application\Common\UseCase\StandardResponseInterface;
+use Core\User\Domain\Model\Permission;
+
+final readonly class FindUserPermissionsResponse implements StandardResponseInterface
+{
+    /**
+     * @param Permission[] $permissions
+     */
+    public function __construct(public readonly array $permissions)
+    {
+    }
+
+    public function getData(): mixed
+    {
+        return $this;
+    }
+}

--- a/centreon/src/Core/User/Domain/Model/Permission.php
+++ b/centreon/src/Core/User/Domain/Model/Permission.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\User\Domain\Model;
+
+use Core\Common\Domain\NotEmptyString;
+
+readonly class Permission
+{
+    public function __construct(private NotEmptyString $name, private bool $isActive)
+    {
+    }
+
+    public function getName(): NotEmptyString
+    {
+        return $this->name;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->isActive;
+    }
+}

--- a/centreon/src/Core/User/Infrastructure/API/FindUserPermissions/FindUserPermissionsController.php
+++ b/centreon/src/Core/User/Infrastructure/API/FindUserPermissions/FindUserPermissionsController.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\User\Infrastructure\API\FindUserPermissions;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Infrastructure\Common\Api\StandardPresenter;
+use Core\User\Application\UseCase\FindUserPermissions\FindUserPermissions;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+
+final class FindUserPermissionsController extends AbstractController
+{
+    /**
+     * @param StandardPresenter $presenter
+     * @param FindUserPermissions $useCase
+     * @param ContactInterface $user
+     *
+     * @throws ExceptionInterface
+     * @return Response
+     */
+    public function __invoke(
+        StandardPresenter $presenter,
+        FindUserPermissions $useCase,
+        ContactInterface $user
+    ): Response
+    {
+        $response = $useCase($user);
+
+        if ($response instanceof ResponseStatusInterface) {
+            return $this->createResponse($response);
+        }
+
+        return JsonResponse::fromJsonString(
+            $presenter->present($response, ['groups' => ['FindUserPermissions:Read', 'NotEmptyString:Read']])
+        );
+    }
+}

--- a/centreon/src/Core/User/Infrastructure/API/FindUserPermissions/FindUserPermissionsResponseNormalizer.php
+++ b/centreon/src/Core/User/Infrastructure/API/FindUserPermissions/FindUserPermissionsResponseNormalizer.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\User\Infrastructure\API\FindUserPermissions;
+
+use Core\User\Application\UseCase\FindUserPermissions\FindUserPermissionsResponse;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+final readonly class FindUserPermissionsResponseNormalizer implements NormalizerInterface
+{
+    public function __construct(private ObjectNormalizer $normalizer)
+    {
+    }
+
+    /**
+     * @param mixed $object
+     * @param string|null $format
+     * @param array<string, mixed> $context
+     *
+     * @throws ExceptionInterface
+     * @return array<string, bool>|null
+     */
+    public function normalize(
+        mixed $object,
+        ?string $format = null,
+        array $context = []
+    ): array|null
+    {
+        $data = $this->normalizer->normalize($object, $format, $context);
+        $normalizedData = [];
+        if (! isset($data['permissions'])) {
+            throw new \InvalidArgumentException('Normalized data missing, required fields: permissions');
+        }
+
+        if (! is_iterable($data['permissions'])) {
+            return null;
+        }
+        foreach ($data['permissions'] as $permission) {
+            $name = key($permission);
+            $normalizedData[$name] = $permission[$name];
+        }
+
+        return $normalizedData;
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null)
+    {
+        return $data instanceof FindUserPermissionsResponse;
+    }
+}

--- a/centreon/src/Core/User/Infrastructure/API/FindUserPermissions/FindUserPermissionsRoute.yaml
+++ b/centreon/src/Core/User/Infrastructure/API/FindUserPermissions/FindUserPermissionsRoute.yaml
@@ -1,0 +1,5 @@
+FindUsersPermissions:
+  methods: GET
+  path: /users/acl/permissions
+  controller: 'Core\User\Infrastructure\API\FindUserPermissions\FindUserPermissionsController'
+  condition: "request.attributes.get('version') >= 24.10"

--- a/centreon/src/Core/User/Infrastructure/API/FindUserPermissions/PermissionNormalizer.php
+++ b/centreon/src/Core/User/Infrastructure/API/FindUserPermissions/PermissionNormalizer.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types = 1);
+
+namespace Core\User\Infrastructure\API\FindUserPermissions;
+
+use Core\User\Domain\Model\Permission;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+final readonly class PermissionNormalizer implements NormalizerInterface
+{
+    public function __construct(private ObjectNormalizer $normalizer)
+    {
+    }
+
+    /**
+     * @param mixed $object
+     * @param string|null $format
+     * @param array<string, mixed> $context
+     *
+     * @throws ExceptionInterface
+     * @return array<string, bool>
+     */
+    public function normalize(
+        mixed $object,
+        ?string $format = null,
+        array $context = []
+    ): array
+    {
+        $data = $this->normalizer->normalize($object, $format, $context);
+        if (! isset($data['name'], $data['is_active'])) {
+            throw new \InvalidArgumentException('Normalized data missing, required fields: name, is_active');
+        }
+
+        return [$data['name'] => $data['is_active']];
+    }
+
+    public function supportsNormalization(mixed $data, ?string $format = null): bool
+    {
+        return $data instanceof Permission;
+    }
+}


### PR DESCRIPTION
## Description

Create a new API endpoint to list user permissions
```
GET /api/latest/users/acl/permissions

{
    'top_counter': true|false,
    'poller_statistics': true|false,
    ...
}
```

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
