### PR TITLE
fix(HA): Update 10-centreon-ha.yaml to integrate token removal

### DIFF
--- a/centreon-ha/etc/centreon-gorgone/config.d/cron.d/10-centreon-ha.yaml
+++ b/centreon-ha/etc/centreon-gorgone/config.d/cron.d/10-centreon-ha.yaml
@@ -44,6 +44,6 @@
   timespec: "* * * * *"
   action: COMMAND
   parameters:
-    - command: "/usr/bin/php /usr/share/centreon/cron/outdated-token-removal.php >> /var/log/centreon/centreon-tokens.log 2>&1"
+    - command: "/usr/bin/php /usr/share/centreon/cron/outdated-token-removal.php >> /var/log/centreon-gorgone/centreon-tokens.log 2>&1"
       timeout: 60
   keep_token: true


### PR DESCRIPTION
## Description

Outdated token removal isn't present in centreon HA crons.

**Fixes** # MON-155698

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master
