### PR TITLE
fix(purge): edit REGEXP for MySQL 8 compatibility

### DIFF
--- a/centreon/www/class/centreonPurgeEngine.class.php
+++ b/centreon/www/class/centreonPurgeEngine.class.php
@@ -125,7 +125,7 @@ class CentreonPurgeEngine
             $row = $DBRESULT->fetchRow();
             $matches = [];
             // dont care of MAXVALUE
-            if (preg_match_all('/PARTITION `(.*?)` VALUES LESS THAN \((.*?)\)/', $row['Create Table'], $matches)) {
+            if (preg_match_all('/PARTITION `?(.*?)`? VALUES LESS THAN \((.*?)\)/', $row['Create Table'], $matches)) {
                 $this->tablesToPurge[$name]['is_partitioned'] = true;
                 $this->tablesToPurge[$name]['partitions'] = [];
                 for ($i = 0; isset($matches[1][$i]); $i++) {


### PR DESCRIPTION
## Description

purge cron is not working properly when you are using mysql 8 (it deletes data in partitioned tables instead of droping the partition)

below are the screenshots showing the result of the fixed regular expression

![image](https://github.com/user-attachments/assets/ae6c24a5-6d32-40eb-b509-32f9d0e3820f)
![image](https://github.com/user-attachments/assets/93cc30a8-95e6-4005-b58f-d985beebe949)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- have a look at all your available table partitions (the data_bin one for exemple) from the menu Administration  >  Platform Status  >  Databases 
- have centreon with mysql 8 installed
- in administration -> parameters -> option, lower the retention for the data_bin table (for example)
- manually run the cron `/usr/bin/php /usr/share/centreon/cron/centstorage_purge.php`

without the patch,  in the Administration  >  Platform Status  >  Databases menu, you'll see that all the partitions are still there
with the patch  in the Administration  >  Platform Status  >  Databases menu, you'll see that partitions have been properly droped according to your configuration.


## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
