### PR TITLE
fix(packaging): retrieve centreon-perl-libs dependency without version

### DIFF
--- a/centreon/packaging/centreon-trap.yaml
+++ b/centreon/packaging/centreon-trap.yaml
@@ -82,7 +82,7 @@ overrides:
       - centreon-trap-poller
   deb:
     depends:
-      - centreon-perl-libs (= ${VERSION}-${RELEASE}${DIST})
+      - centreon-perl-libs
       - libsnmp-perl
       - snmptrapd
       - snmpd


### PR DESCRIPTION
## Description

fix(packaging): retrieve centreon-perl-libs dependency without version requirement

**Fixes** MON-156600