### PR TITLE
fix(exportCfg): GenerateAllConfiguration and ReloadAllConfiguration now handle more than 10 pollers (#6068)

### DIFF
--- a/centreon/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/Interfaces/MonitoringServerRepositoryInterface.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace Centreon\Domain\MonitoringServer\Interfaces;
 
-use Centreon\Domain\MonitoringServer\MonitoringServer;
 use Centreon\Domain\MonitoringServer\Exception\MonitoringServerException;
+use Centreon\Domain\MonitoringServer\MonitoringServer;
 use Centreon\Domain\MonitoringServer\MonitoringServerResource;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 
@@ -40,6 +40,15 @@ interface MonitoringServerRepositoryInterface
      * @throws \Exception
      */
     public function findServersWithRequestParameters(): array;
+
+    /**
+     * @param AccessGroup[] $accessGroups
+     *
+     * @throws \Throwable
+     *
+     * @return MonitoringServer[]
+     */
+  public function findAllServersWithAccessGroups(array $accessGroups): array;
 
     /**
      * @param AccessGroup[] $accessGroups

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurations.php
@@ -63,7 +63,7 @@ class GenerateAllConfigurations
     {
         try {
             if ($this->contact->isAdmin()) {
-                $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParameters();
+                $monitoringServers = $this->monitoringServerRepository->findServersWithoutRequestParameters();
             } else {
                 if (
                     ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
@@ -77,7 +77,7 @@ class GenerateAllConfigurations
 
                 $accessGroups = $this->readAccessGroupRepositoryInterface->findByContact($this->contact);
 
-                $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParametersAndAccessGroups(
+                $monitoringServers = $this->monitoringServerRepository->findAllServersWithAccessGroups(
                     $accessGroups
                 );
             }

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/ReloadAllConfigurations.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/ReloadAllConfigurations.php
@@ -27,8 +27,8 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Exception\TimeoutException;
 use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\MonitoringServer\Exception\ConfigurationMonitoringServerException;
-use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerConfigurationRepositoryInterface;
+use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
@@ -63,7 +63,7 @@ class ReloadAllConfigurations
     {
         try {
             if ($this->contact->isAdmin()) {
-                $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParameters();
+                $monitoringServers = $this->monitoringServerRepository->findServersWithoutRequestParameters();
             } else {
                 if (
                     ! $this->contact->hasTopologyRole(Contact::ROLE_CONFIGURATION_MONITORING_SERVER_READ)
@@ -77,7 +77,7 @@ class ReloadAllConfigurations
 
                 $accessGroups = $this->readAccessGroupRepositoryInterface->findByContact($this->contact);
 
-                $monitoringServers = $this->monitoringServerRepository->findServersWithRequestParametersAndAccessGroups(
+                $monitoringServers = $this->monitoringServerRepository->findAllServersWithAccessGroups(
                     $accessGroups
                 );
             }

--- a/centreon/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/MonitoringServer/MonitoringServerRepositoryRDB.php
@@ -146,6 +146,14 @@ class MonitoringServerRepositoryRDB extends AbstractRepositoryDRB implements Mon
     /**
      * @inheritDoc
      */
+    public function findAllServersWithAccessGroups(array $accessGroups): array
+    {
+        return $this->findServers(searchRequest: null, sortRequest: null, paginationRequest: null, accessGroups: $accessGroups);
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function findServersWithoutRequestParameters(): array
     {
         return $this->findServers(null, null, null);

--- a/centreon/tests/php/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurationsTest.php
+++ b/centreon/tests/php/Centreon/Domain/MonitoringServer/UseCase/GenerateAllConfigurationsTest.php
@@ -23,15 +23,15 @@ declare(strict_types=1);
 namespace Tests\Centreon\Domain\MonitoringServer\UseCase;
 
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
-use Centreon\Domain\MonitoringServer\MonitoringServer;
-use Centreon\Domain\MonitoringServer\UseCase\GenerateAllConfigurations;
-use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
 use Centreon\Domain\MonitoringServer\Exception\ConfigurationMonitoringServerException;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerConfigurationRepositoryInterface;
+use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
+use Centreon\Domain\MonitoringServer\MonitoringServer;
+use Centreon\Domain\MonitoringServer\UseCase\GenerateAllConfigurations;
 use Centreon\Domain\Repository\RepositoryException;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class GenerateAllConfigurationsTest extends TestCase
@@ -72,7 +72,7 @@ class GenerateAllConfigurationsTest extends TestCase
         $exception = new \Exception();
         $this->monitoringServerRepository
             ->expects($this->once())
-            ->method('findServersWithRequestParameters')
+            ->method('findServersWithoutRequestParameters')
             ->willThrowException($exception);
 
         $this->expectException(ConfigurationMonitoringServerException::class);
@@ -132,7 +132,7 @@ class GenerateAllConfigurationsTest extends TestCase
 
         $this->monitoringServerRepository
             ->expects($this->once())
-            ->method('findServersWithRequestParameters')
+            ->method('findServersWithoutRequestParameters')
             ->willReturn($monitoringServers);
 
         $this->monitoringServerConfigurationRepository
@@ -171,7 +171,7 @@ class GenerateAllConfigurationsTest extends TestCase
         $monitoringServers = [$monitoringServer];
         $this->monitoringServerRepository
             ->expects($this->once())
-            ->method('findServersWithRequestParameters')
+            ->method('findServersWithoutRequestParameters')
             ->willReturn($monitoringServers);
 
         $this->monitoringServerConfigurationRepository
@@ -210,7 +210,7 @@ class GenerateAllConfigurationsTest extends TestCase
         $monitoringServers = [$monitoringServer];
         $this->monitoringServerRepository
             ->expects($this->once())
-            ->method('findServersWithRequestParametersAndAccessGroups')
+            ->method('findAllServersWithAccessGroups')
             ->willReturn($monitoringServers);
 
         $this->monitoringServerConfigurationRepository

--- a/centreon/tests/php/Centreon/Domain/MonitoringServer/UseCase/ReloadAllConfigurationsTest.php
+++ b/centreon/tests/php/Centreon/Domain/MonitoringServer/UseCase/ReloadAllConfigurationsTest.php
@@ -23,15 +23,15 @@ declare(strict_types=1);
 namespace Tests\Centreon\Domain\MonitoringServer\UseCase;
 
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
-use PHPUnit\Framework\TestCase;
-use PHPUnit\Framework\MockObject\MockObject;
-use Centreon\Domain\MonitoringServer\MonitoringServer;
-use Centreon\Domain\MonitoringServer\UseCase\ReloadAllConfigurations;
-use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
 use Centreon\Domain\MonitoringServer\Exception\ConfigurationMonitoringServerException;
 use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerConfigurationRepositoryInterface;
+use Centreon\Domain\MonitoringServer\Interfaces\MonitoringServerRepositoryInterface;
+use Centreon\Domain\MonitoringServer\MonitoringServer;
+use Centreon\Domain\MonitoringServer\UseCase\ReloadAllConfigurations;
 use Centreon\Domain\Repository\RepositoryException;
 use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 
 class ReloadAllConfigurationsTest extends TestCase
@@ -72,7 +72,7 @@ class ReloadAllConfigurationsTest extends TestCase
         $exception = new \Exception();
         $this->monitoringServerRepository
             ->expects($this->once())
-            ->method('findServersWithRequestParameters')
+            ->method('findServersWithoutRequestParameters')
             ->willThrowException($exception);
 
         $this->expectException(ConfigurationMonitoringServerException::class);
@@ -135,7 +135,7 @@ class ReloadAllConfigurationsTest extends TestCase
 
         $this->monitoringServerRepository
             ->expects($this->once())
-            ->method('findServersWithRequestParameters')
+            ->method('findServersWithoutRequestParameters')
             ->willReturn($monitoringServers);
 
         $this->monitoringServerConfigurationRepository
@@ -175,7 +175,7 @@ class ReloadAllConfigurationsTest extends TestCase
         $monitoringServers = [$monitoringServer];
         $this->monitoringServerRepository
             ->expects($this->once())
-            ->method('findServersWithRequestParameters')
+            ->method('findServersWithoutRequestParameters')
             ->willReturn($monitoringServers);
 
         $this->monitoringServerConfigurationRepository
@@ -208,7 +208,7 @@ class ReloadAllConfigurationsTest extends TestCase
         $monitoringServers = [$monitoringServer];
         $this->monitoringServerRepository
             ->expects($this->once())
-            ->method('findServersWithRequestParametersAndAccessGroups')
+            ->method('findAllServersWithAccessGroups')
             ->willReturn($monitoringServers);
 
         $this->monitoringServerConfigurationRepository


### PR DESCRIPTION
## Description

BACKPORT of #6068 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] master
