### PR TITLE
fix(dashboard): incompatibility with MySQL8 fixed

### DIFF
--- a/centreon/src/Core/UserProfile/Infrastructure/Repository/DbReadUserProfileRepository.php
+++ b/centreon/src/Core/UserProfile/Infrastructure/Repository/DbReadUserProfileRepository.php
@@ -72,7 +72,7 @@ final class DbReadUserProfileRepository extends AbstractRepositoryRDB implements
                 LEFT JOIN `:db`.user_profile_favorite_dashboards
                     ON user_profile_favorite_dashboards.profile_id = user_profile.id
                 WHERE contact_id = :contactId
-                GROUP BY contact_id
+                GROUP BY id, contact_id
                 SQL;
 
             $statement = $this->db->prepare($this->translateDbName($query));


### PR DESCRIPTION
📃 This PR fixes an issue to specific MySQL8 env for the dashboard favorite management feature
ℹ️ [Ticket](https://centreon.atlassian.net/browse/MON-156700)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

See ticket

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
