### PR TITLE
enh(services): Use APIv2 while deleting service/template through the UI

### DIFF
--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -3847,23 +3847,7 @@ function callApi(string $url, string $httpMethod, array $payload): array
     );
 
     $status = $response->getStatusCode();
-    $responseAsArray = ['status_code' => $status, 'content' => null];
-    if ($httpMethod === 'POST') {
-        if ($status !== 201) {
-            $content = json_decode($response->getContent(false), true);
-            $responseAsArray['content'] = $content;
-        }
+    $content = json_decode($response->getContent(false), true);
 
-        $data = $response->toArray();
-
-        /** @var array{id:int} $data */
-        return $data['id'];
-    }
-
-    if ($status !== 204 && $status !== 200) {
-        $content = json_decode($response->getContent(false), true);
-        $responseAsArray['content'] = $content;
-    }
-
-    return $responseAsArray;
+    return ['status_code' => $status, 'content' => $content];
 }

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -3753,6 +3753,7 @@ function deleteServiceByApi(array $services = []): void
     $kernel = Kernel::createForWeb();
     $router = $kernel->getContainer()->get(Router::class)
         ?? throw new LogicException('Router not found in container');
+    $servicesWithError = [];
     foreach ($serviceIds as $serviceId) {
         $url = $router->generate(
             'DeleteService',
@@ -3760,7 +3761,6 @@ function deleteServiceByApi(array $services = []): void
             UrlGeneratorInterface::ABSOLUTE_URL
         );
         $response = callApi($url, 'DELETE', []);
-        $servicesWithError = [];
         if ($response['status_code'] !== 204) {
             $servicesWithError[] = [
                 'service_id' => $serviceId,
@@ -3797,6 +3797,7 @@ function deleteServiceTemplateByApi(array $serviceTemplates = []): void
     $kernel = Kernel::createForWeb();
     $router = $kernel->getContainer()->get(Router::class)
         ?? throw new LogicException('Router not found in container');
+    $serviceTemplatesWithError = [];
     foreach ($serviceTemplateIds as $serviceTemplateId) {
         $url = $router->generate(
             'DeleteServiceTemplate',
@@ -3804,7 +3805,6 @@ function deleteServiceTemplateByApi(array $serviceTemplates = []): void
             UrlGeneratorInterface::ABSOLUTE_URL
         );
         $response = callApi($url, 'DELETE', []);
-        $serviceTemplatesWithError = [];
         if ($response['status_code'] !== 204) {
             $serviceTemplatesWithError[] = [
                 'service_template_id' => $serviceTemplateId,

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -429,10 +429,8 @@ function removeRelationLastServiceDependency(int $serviceId): void
  * Keep this method as service deletion by hostgroup is not supported in APIv2 for the moment.
  *
  * @param array<int, int> $services The list of service IDs to delete (Ids are the keys)
- *
- * @return void
  */
-function deleteServiceInDB(array $services = [])
+function deleteServiceInDB(array $services = []): void
 {
     global $pearDB, $centreon;
 
@@ -3797,7 +3795,7 @@ function deleteServiceTemplateByApi(array $serviceTemplates = []): void
  * @param string $httpMethod
  * @param array<string, mixed> $payload
  *
- * @return int|null
+ * @return int|null Return the newly created ID for POST request, null otherwiseÙ
  */
 function callApi(string $url, string $httpMethod, array $payload): ?int
 {

--- a/centreon/www/include/configuration/configObject/service/serviceByHost.php
+++ b/centreon/www/include/configuration/configObject/service/serviceByHost.php
@@ -173,7 +173,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            deleteServiceInDB($select ?? []);
+            deleteServiceByApi($select ?? []);
         } else {
             unvalidFormMessage();
         }

--- a/centreon/www/include/configuration/configObject/service_template_model/serviceTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/service_template_model/serviceTemplateModel.php
@@ -152,7 +152,7 @@ switch ($o) {
         purgeOutdatedCSRFTokens();
         if (isCSRFTokenValid()) {
             purgeCSRFToken();
-            deleteServiceInDB($select ?? []);
+            deleteServiceTemplateByApi($select ?? []);
         } else {
             unvalidFormMessage();
         }


### PR DESCRIPTION
## Description

This PR intends to Use APIv2 while deleting service/template through the UI

**Fixes** # MON-155958

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
