### PR TITLE
fix(Configuration): ACL aren't affected to a hostgroup when it's created by a non-admin user

### DIFF
--- a/centreon/www/include/configuration/configObject/hostgroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/DB-Func.php
@@ -683,6 +683,7 @@ function updateHostGroupAcl(int $hostGroupId, bool $isCloudPlatform, $submittedV
                         $statement->execute();
                     }
                     unset($userResourceAccesses);
+                    $pearDB->commit();
                 } catch (\Throwable $exception) {
                     $pearDB->rollBack();
                     throw $exception;

--- a/centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
@@ -276,6 +276,8 @@ if ($form->validate()) {
         $hgObj->setValue(
             insertHostGroupInDB(isCloudPlatform: $isCloudPlatform)
         );
+        $hgs = $acl->getHostGroupAclConf(null, 'broker');
+        $hostGroupIds = array_keys($hgs);
     } elseif ($form->getSubmitValue('submitC')) {
         updateHostGroupInDB(
             hostGroupId: $hgObj->getValue(),

--- a/centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
@@ -206,9 +206,22 @@ for ($i = 0; $hg = $dbResult->fetch(); $i++) {
         $isHGSvgFile = true;
         $hgIcone = returnSvg("www/img/icons/host_group.svg", "var(--icons-fill-color)", 16, 16);
     }
-    $elemArr[$i] = ["MenuClass" => "list_" . $style, "RowMenu_select" => $selectedElements->toHtml(), "RowMenu_name" => CentreonUtils::escapeSecure($hg["hg_name"]), "RowMenu_link" => "main.php?p=" . $p . "&o=c&hg_id=" . $hg['hg_id'], "RowMenu_desc" => ($hg["hg_alias"] == ''
-        ? '-'
-        : CentreonUtils::escapeSecure(html_entity_decode($hg["hg_alias"]), CentreonUtils::ESCAPE_ALL)), "RowMenu_status" => $hg["hg_activate"] ? _("Enabled") : _("Disabled"), "RowMenu_badge" => $hg["hg_activate"] ? "service_ok" : "service_critical", "RowMenu_hostAct" => $nbrhostAct, "RowMenu_icone" => $hgIcone, "RowMenu_hostDeact" => $nbrhostDeact, "RowMenu_options" => $moptions, "isHgSvgFile" => $isHGSvgFile];
+    $elemArr[$i] = [
+        "MenuClass" => "list_" . $style,
+        "RowMenu_select" => $selectedElements->toHtml(),
+        "RowMenu_name" => CentreonUtils::escapeSecure($hg["hg_name"]),
+        "RowMenu_link" => "main.php?p=" . $p . "&o=c&hg_id=" . $hg['hg_id'],
+        "RowMenu_desc" => $hg["hg_alias"] == ''
+            ? '-'
+            : CentreonUtils::escapeSecure(html_entity_decode($hg["hg_alias"]), CentreonUtils::ESCAPE_ALL),
+        "RowMenu_status" => $hg["hg_activate"] ? _("Enabled") : _("Disabled"),
+        "RowMenu_badge" => $hg["hg_activate"] ? "service_ok" : "service_critical",
+        "RowMenu_hostAct" => $nbrhostAct,
+        "RowMenu_icone" => $hgIcone,
+        "RowMenu_hostDeact" => $nbrhostDeact,
+        "RowMenu_options" => $moptions,
+        "isHgSvgFile" => $isHGSvgFile
+    ];
 
     // Switch color line
     $style = $style != "two" ? "two" : "one";


### PR DESCRIPTION
## Description

- Fixed the issue where hostgroups are not displayed after creating for an ACL user without "include all hostgroups" option.
- Fixed the issue where hostgroup listing is not refreshed after adding a new hostgroup for an ACL user without "include all hostgroups" option.

**Fixes** # MON-154563

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
