### PR TITLE
fix(packaging): use nfpm 2.41.1 to avoid rpm signature regression

### DIFF
--- a/.github/docker/Dockerfile.packaging-alma8
+++ b/.github/docker/Dockerfile.packaging-alma8
@@ -12,7 +12,7 @@ baseurl=https://repo.goreleaser.com/yum/
 enabled=1
 gpgcheck=0' | tee /etc/yum.repos.d/goreleaser.repo
 
-dnf install -y make rpm-build rpm-sign zstd perl-devel nfpm selinux-policy-devel
+dnf install -y make rpm-build rpm-sign zstd perl-devel nfpm-2.41.1 selinux-policy-devel
 
 dnf clean all
 

--- a/.github/docker/Dockerfile.packaging-alma9
+++ b/.github/docker/Dockerfile.packaging-alma9
@@ -8,7 +8,7 @@ baseurl=https://repo.goreleaser.com/yum/
 enabled=1
 gpgcheck=0' | tee /etc/yum.repos.d/goreleaser.repo
 
-dnf install -y make rpm-build rpm-sign zstd perl perl-devel nfpm selinux-policy-devel
+dnf install -y make rpm-build rpm-sign zstd perl perl-devel nfpm-2.41.1 selinux-policy-devel
 
 dnf clean all
 

--- a/.github/docker/Dockerfile.packaging-bookworm
+++ b/.github/docker/Dockerfile.packaging-bookworm
@@ -12,7 +12,7 @@ echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sourc
 
 apt-get update
 
-apt-get install -y nfpm
+apt-get install -y nfpm=2.41.1
 
 apt-get clean
 

--- a/.github/docker/Dockerfile.packaging-bullseye
+++ b/.github/docker/Dockerfile.packaging-bullseye
@@ -12,7 +12,7 @@ echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sourc
 
 apt-get update
 
-apt-get install -y nfpm
+apt-get install -y nfpm=2.41.1
 
 apt-get clean
 

--- a/.github/docker/Dockerfile.packaging-nfpm-alma8
+++ b/.github/docker/Dockerfile.packaging-nfpm-alma8
@@ -8,7 +8,7 @@ baseurl=https://repo.goreleaser.com/yum/
 enabled=1
 gpgcheck=0' | tee /etc/yum.repos.d/goreleaser.repo
 
-dnf install -y zstd nfpm-2.35.3 selinux-policy-devel
+dnf install -y zstd nfpm-2.41.1 selinux-policy-devel
 
 rm -f /etc/yum.repos.d/goreleaser.repo
 

--- a/.github/docker/Dockerfile.packaging-nfpm-alma9
+++ b/.github/docker/Dockerfile.packaging-nfpm-alma9
@@ -8,7 +8,7 @@ baseurl=https://repo.goreleaser.com/yum/
 enabled=1
 gpgcheck=0' | tee /etc/yum.repos.d/goreleaser.repo
 
-dnf install -y zstd nfpm-2.35.3 selinux-policy-devel
+dnf install -y zstd nfpm-2.41.1 selinux-policy-devel
 
 rm -f /etc/yum.repos.d/goreleaser.repo
 

--- a/.github/docker/Dockerfile.packaging-nfpm-bookworm
+++ b/.github/docker/Dockerfile.packaging-nfpm-bookworm
@@ -12,7 +12,7 @@ echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sourc
 
 apt-get update
 
-apt-get install -y zstd nfpm
+apt-get install -y zstd nfpm=2.41.1
 
 apt-get remove -y ca-certificates
 

--- a/.github/docker/Dockerfile.packaging-nfpm-bullseye
+++ b/.github/docker/Dockerfile.packaging-nfpm-bullseye
@@ -12,7 +12,7 @@ echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sourc
 
 apt-get update
 
-apt-get install -y zstd nfpm=2.35.3
+apt-get install -y zstd nfpm=2.41.1
 
 apt-get remove -y ca-certificates
 

--- a/.github/docker/Dockerfile.packaging-nfpm-jammy
+++ b/.github/docker/Dockerfile.packaging-nfpm-jammy
@@ -12,7 +12,7 @@ echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sourc
 
 apt-get update
 
-apt-get install -y zstd nfpm
+apt-get install -y zstd nfpm=2.41.1
 
 apt-get remove -y ca-certificates
 


### PR DESCRIPTION
## Description

fix(packaging): use nfpm 2.41.1 to avoid rpm signature regression
https://github.com/goreleaser/nfpm/releases/tag/v2.41.2
https://github.com/ProtonMail/go-crypto/issues/263

**Fixes** MON-157151