### PR TITLE
fix(packaging): use nfpm 2.41.1 to avoid rpm signature regression

### DIFF
--- a/.github/docker/Dockerfile.packaging-alma8
+++ b/.github/docker/Dockerfile.packaging-alma8
@@ -12,7 +12,7 @@ baseurl=https://repo.goreleaser.com/yum/
 enabled=1
 gpgcheck=0' | tee /etc/yum.repos.d/goreleaser.repo
 
-dnf install -y make rpm-build rpm-sign zstd perl-devel nfpm selinux-policy-devel
+dnf install -y make rpm-build rpm-sign zstd perl-devel nfpm-2.41.1 selinux-policy-devel
 
 dnf clean all
 

--- a/.github/docker/Dockerfile.packaging-alma9
+++ b/.github/docker/Dockerfile.packaging-alma9
@@ -8,7 +8,7 @@ baseurl=https://repo.goreleaser.com/yum/
 enabled=1
 gpgcheck=0' | tee /etc/yum.repos.d/goreleaser.repo
 
-dnf install -y make rpm-build rpm-sign zstd perl perl-devel nfpm selinux-policy-devel
+dnf install -y make rpm-build rpm-sign zstd perl perl-devel nfpm-2.41.1 selinux-policy-devel
 
 dnf clean all
 

--- a/.github/docker/Dockerfile.packaging-bullseye
+++ b/.github/docker/Dockerfile.packaging-bullseye
@@ -12,7 +12,7 @@ echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sourc
 
 apt-get update
 
-apt-get install -y nfpm
+apt-get install -y nfpm=2.41.1
 
 apt-get clean
 


### PR DESCRIPTION
## Description

fix(packaging): use nfpm 2.41.1 to avoid rpm signature regression (#6362)