### PR TITLE
fix(ci): add centreon ha missing ci packaging references

### DIFF
--- a/.github/workflows/ha.yml
+++ b/.github/workflows/ha.yml
@@ -73,6 +73,8 @@ jobs:
     secrets:
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}
+      registry_private_username: ${{ secrets.HARBOR_CENTREON_PRIVATE_USERNAME }}
+      registry_private_token: ${{ secrets.HARBOR_CENTREON_PRIVATE_TOKEN }}
 
   deliver-sources:
     runs-on: [self-hosted, common]

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -132,7 +132,7 @@ jobs:
     needs: [package]
     runs-on: ubuntu-24.04
     container:
-      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/rpm-signing:ubuntu
+      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/rpm-signing:latest
       options: -t
       credentials:
         username: ${{ secrets.registry_username }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -83,6 +83,10 @@ on:
         required: true
       registry_password:
         required: true
+      registry_private_username:
+        required: true
+      registry_private_token:
+        required: true
 
 jobs:
   package:
@@ -132,11 +136,11 @@ jobs:
     needs: [package]
     runs-on: ubuntu-24.04
     container:
-      image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/rpm-signing:latest
+      image: docker.centreon.com/centreon-private/rpm-signing:latest
       options: -t
       credentials:
-        username: ${{ secrets.registry_username }}
-        password: ${{ secrets.registry_password }}
+        username: ${{ secrets.registry_private_username }}
+        password: ${{ secrets.registry_private_token }}
 
     steps:
       - run: |


### PR DESCRIPTION
## Description

* fix missing packaging references for ha

**Fixes** #

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
