### PR TITLE
fix(contact): fix contact group deletion for contact on remote server

### DIFF
--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -558,7 +558,7 @@ function multipleContactInDB($contacts = [], $nbrDup = [])
  * @param null $contact_id
  * @param bool $from_MC
  */
-function updateContactInDB($contact_id = null, $from_MC = false)
+function updateContactInDB($contact_id = null, $from_MC = false, bool $isRemote = false)
 {
     global $form;
 
@@ -599,12 +599,14 @@ function updateContactInDB($contact_id = null, $from_MC = false)
     # 1 - MC with deletion of existing cg
     # 2 - MC with addition of new cg
     # 3 - Normal update
-    if (isset($ret["mc_mod_cg"]["mc_mod_cg"]) && $ret["mc_mod_cg"]["mc_mod_cg"]) {
-        updateContactContactGroup($contact_id);
-    } elseif (isset($ret["mc_mod_cg"]["mc_mod_cg"]) && !$ret["mc_mod_cg"]["mc_mod_cg"]) {
-        updateContactContactGroup_MC($contact_id);
-    } else {
-        updateContactContactGroup($contact_id);
+    if (! $isRemote) {
+        if (isset($ret["mc_mod_cg"]["mc_mod_cg"]) && $ret["mc_mod_cg"]["mc_mod_cg"]) {
+            updateContactContactGroup($contact_id);
+        } elseif (isset($ret["mc_mod_cg"]["mc_mod_cg"]) && !$ret["mc_mod_cg"]["mc_mod_cg"]) {
+            updateContactContactGroup_MC($contact_id);
+        } else {
+            updateContactContactGroup($contact_id);
+        }
     }
 
     /**

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -1151,7 +1151,10 @@ if ($form->validate() && $from_list_menu == false) {
             ]
         );
     } elseif ($form->getSubmitValue("submitC")) {
-        updateContactInDB($cctObj->getValue());
+        updateContactInDB(
+            contact_id:$cctObj->getValue(),
+            isRemote: $isRemote
+        );
 
         $eventDispatcher->notify(
             'contact.form',
@@ -1165,7 +1168,7 @@ if ($form->validate() && $from_list_menu == false) {
         $select = explode(",", $select);
         foreach ($select as $key => $selectedContactId) {
             if ($selectedContactId) {
-                updateContactInDB($selectedContactId, true);
+                updateContactInDB($selectedContactId, true, $isRemote);
 
                 $eventDispatcher->notify(
                     'contact.form',


### PR DESCRIPTION
## Description

this PR intends to avoid contact deletion from a contact group while editing a contact on a Remote Server:
Behaviour before bugfix:
- Create a Contact Group
- Add a contact to it
- Edit this contact
- The contact has been deleted from the contact group

Behaviour after bugfix:
- Create a Contact Group
- Add a contact to it
- Edit this contact
- The contact is still in the contactgroup

**Fixes** # MON-14725

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
