### PR TITLE
[E2E] Remove unecessary test combinaison on cloud notifications-dev-24.04.x 

### DIFF
--- a/centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature
+++ b/centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature
@@ -24,7 +24,6 @@ Feature: Creating a Notification Rule
     Then an email is sent to the configured '<contact_settings>' with the configured format
     Examples:
       | contact_settings | resource_type                           |
-      | one contact      | host group                              |
       | two contacts     | host group and services for these hosts |
 
   @TEST_MON-33204
@@ -43,5 +42,4 @@ Feature: Creating a Notification Rule
     Then an email is sent to the configured '<contact_settings>' with the configured format
     Examples:
       | contact_settings |
-      | one contact      |
       | two contacts     |

--- a/centreon/tests/e2e/features/Cloud-notifications/01-notification-create/index.ts
+++ b/centreon/tests/e2e/features/Cloud-notifications/01-notification-create/index.ts
@@ -61,28 +61,19 @@ Given(
     globalResourceType = resourceType;
     globalContactSettings = contactSettings;
 
-    switch (contactSettings) {
-      case 'one contact':
-        cy.addContact({
-          email: data.contacts.contact1.email,
-          name: data.contacts.contact1.name,
-          password: data.contacts.contact1.password
-        });
-        break;
-      case 'two contacts':
-        cy.addContact({
-          email: data.contacts.contact1.email,
-          name: data.contacts.contact1.name,
-          password: data.contacts.contact1.password
-        });
-        cy.addContact({
-          email: data.contacts.contact2.email,
-          name: data.contacts.contact2.name,
-          password: data.contacts.contact2.password
-        });
-        break;
-      default:
-        throw new Error(`${contactSettings} not managed`);
+    if (contactSettings === "two contacts") {
+      cy.addContact({
+        email: data.contacts.contact1.email,
+        name: data.contacts.contact1.name,
+        password: data.contacts.contact1.password,
+      });
+      cy.addContact({
+        email: data.contacts.contact2.email,
+        name: data.contacts.contact2.name,
+        password: data.contacts.contact2.password,
+      });
+    } else {
+      throw new Error(`${contactSettings} not managed`);
     }
 
     cy.addHostGroup({
@@ -152,44 +143,29 @@ When('the user defines a name for the rule', () => {
 When(
   'the user selects a {string} with associated events on which to notify',
   (resourceType: string) => {
-    switch (resourceType) {
-      case 'host group':
-        cy.get('#Searchhostgroups').click();
-        cy.contains(data.hostGroups.hostGroup1.name).click();
-        cy.get('#Recovery').click();
-        cy.get('#Down').click();
-        cy.get('#Unreachable').click();
-        break;
-      case 'host group and services for these hosts':
-        cy.get('#Searchhostgroups').click();
+     if (resourceType === "host group and services for these hosts"){
+       cy.get('#Searchhostgroups').click();
         cy.contains(data.hostGroups.hostGroup1.name).click();
         cy.get('#Searchhostgroups').blur();
         cy.contains('Include services for these hosts').click();
         cy.get('[data-testid="Extra events services"] >').each(($el) => {
           cy.wrap($el).click();
-        });
-        break;
-      default:
-        throw new Error(`${resourceType} not managed`);
+             });
+     } else {
+      throw new Error(`${resourceType} not managed`);
     }
+
   }
 );
 
 When('the user selects the {string}', (contactSettings: string) => {
-  switch (contactSettings) {
-    case 'one contact':
-      cy.get('#Searchcontacts').click();
-      cy.wait('@getUsers');
-      cy.contains(data.contacts.contact1.name).click();
-      break;
-    case 'two contacts':
-      cy.get('#Searchcontacts').click();
-      cy.wait('@getUsers');
-      cy.contains(data.contacts.contact1.name).click();
-      cy.contains(data.contacts.contact2.name).click();
-      break;
-    default:
-      throw new Error(`${contactSettings} not managed`);
+  if (contactSettings === "two contacts") {
+    cy.get("#Searchcontacts").click();
+    cy.wait("@getUsers");
+    cy.contains(data.contacts.contact1.name).click();
+    cy.contains(data.contacts.contact2.name).click();
+  } else {
+    throw new Error(`${contactSettings} not managed`);
   }
 });
 
@@ -231,73 +207,46 @@ Then(
 When(
   'changes occur in the configured statuses for the selected {string}',
   (resourceType) => {
-    switch (resourceType) {
-      case 'host group':
-        cy.submitResults([
-          {
-            host: data.hosts.host2.name,
-            output: 'submit_status_1',
-            status: 'down'
-          }
-        ]);
+    if (resourceType === "host group and services for these hosts") {
+      cy.submitResults([
+        {
+          host: data.hosts.host1.name,
+          output: "submit_status_2",
+          service: data.services.service1.name,
+          status: "critical",
+        },
+      ]);
 
-        checkHostsAreMonitored([
-          {
-            name: data.hosts.host2.name,
-            status: 'down'
-          }
-        ]);
-        break;
-      case 'host group and services for these hosts':
-        cy.submitResults([
-          {
-            host: data.hosts.host1.name,
-            output: 'submit_status_2',
-            service: data.services.service1.name,
-            status: 'critical'
-          }
-        ]);
-
-        checkServicesAreMonitored([
-          {
-            name: data.services.service1.name,
-            status: 'critical'
-          }
-        ]);
-        break;
-      default:
-        throw new Error(`${resourceType} not managed`);
+      checkServicesAreMonitored([
+        {
+          name: data.services.service1.name,
+          status: "critical",
+        },
+      ]);
+    } else {
+      throw new Error(`${resourceType} not managed`);
     }
+
   }
 );
 
 When('the hard state has been reached', () => {
-  switch (globalResourceType) {
-    case 'host group':
-      checkHostsAreMonitored([
-        {
-          name: data.hosts.host2.name,
-          status: 'down',
-          statusType: 'hard'
-        }
-      ]);
-      break;
-    case 'host group and services for these hosts':
-      checkServicesAreMonitored([
-        {
-          name: data.services.service1.name,
-          status: 'critical',
-          statusType: 'hard'
-        }
-      ]);
-      break;
-    default:
-      const servicesToBeChecked = Array.from({ length: 1000 }, (_, i) => ({
+  if (globalResourceType === "host group and services for these hosts") {
+    checkServicesAreMonitored([
+      {
+        name: data.services.service1.name,
+        status: "critical",
+        statusType: "hard",
+      },
+    ]);
+  } else {
+    checkServicesAreMonitored(
+      Array.from({ length: 1000 }, (_, i) => ({
         name: `service_${i + 1}`,
-        status: 'ok',
-        statusType: 'hard'
-      }));
-      checkServicesAreMonitored(servicesToBeChecked);
+        status: "ok",
+        statusType: "hard",
+      })),
+    );
   }
 });
 
@@ -308,39 +257,19 @@ When('the notification refresh_delay has been reached', () => {
 Then(
   'an email is sent to the configured {string} with the configured format',
   (contactSettings) => {
-    switch (contactSettings) {
-      case 'one contact':
-        if (globalResourceType) {
-          notificationSentCheck({ logs: `<<${data.hosts.host2.name}>>` });
-        } else {
-          const logsToCheck = Array.from(
-            { length: 1000 },
-            (_, i) => `<<${data.hosts.host1.name}/service_${i + 1}`
-          );
-          notificationSentCheck({ logs: logsToCheck });
-        }
+    if (contactSettings === "two contacts") {
+      if (globalResourceType) {
         notificationSentCheck({
-          logs: `[{"email_address":"${data.contacts.contact1.email}","full_name":"${data.contacts.contact1.name}"}]`
+          logs: `<<${data.hosts.host1.name}/${data.services.service1.name}`,
         });
-        break;
-      case 'two contacts':
-        if (globalResourceType) {
-          notificationSentCheck({
-            logs: `<<${data.hosts.host1.name}/${data.services.service1.name}`
-          });
-        } else {
-          const logsToCheck = Array.from(
-            { length: 1000 },
-            (_, i) => `<<${data.hosts.host1.name}/service_${i + 1}`
-          );
-          notificationSentCheck({ logs: logsToCheck });
-        }
-        notificationSentCheck({
-          logs: `[{"email_address":"${data.contacts.contact1.email}","full_name":"${data.contacts.contact1.name}"},{"email_address":"${data.contacts.contact2.email}","full_name":"${data.contacts.contact2.name}"}]`
-        });
-        break;
-      default:
-        throw new Error(`${contactSettings} not managed`);
+      } else {
+        notificationSentCount(1000);
+      }
+      notificationSentCheck({
+        logs: `[{"email_address":"${data.contacts.contact1.email}","full_name":"${data.contacts.contact1.name}"},{"email_address":"${data.contacts.contact2.email}","full_name":"${data.contacts.contact2.name}"}]`,
+      });
+    } else {
+      throw new Error(`${contactSettings} not managed`);
     }
   }
 );
@@ -348,28 +277,19 @@ Then(
 Given(
   'a minimum of 1000 services linked to a host group and {string}',
   (contactSettings) => {
-    switch (contactSettings) {
-      case 'one contact':
-        cy.addContact({
-          email: data.contacts.contact1.email,
-          name: data.contacts.contact1.name,
-          password: data.contacts.contact1.password
-        });
-        break;
-      case 'two contacts':
-        cy.addContact({
-          email: data.contacts.contact1.email,
-          name: data.contacts.contact1.name,
-          password: data.contacts.contact1.password
-        });
-        cy.addContact({
-          email: data.contacts.contact2.email,
-          name: data.contacts.contact2.name,
-          password: data.contacts.contact2.password
-        });
-        break;
-      default:
-        throw new Error(`${contactSettings} not managed`);
+    if (contactSettings === "two contacts") {
+      cy.addContact({
+        email: data.contacts.contact1.email,
+        name: data.contacts.contact1.name,
+        password: data.contacts.contact1.password,
+      });
+      cy.addContact({
+        email: data.contacts.contact2.email,
+        name: data.contacts.contact2.name,
+        password: data.contacts.contact2.password,
+      });
+    } else {
+      throw new Error(`${contactSettings} not managed`);
     }
 
     cy.addHostGroup({


### PR DESCRIPTION
…4.04.x

## Description

It’s not necessary to keep and test the 1 user case since 2 users scenario contains the single user implicitly. This will save CI time. ( backport PR )

**Fixes** # MON-158229

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
