### PR TITLE
fix(clapi): fix getmacro php warning

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonObject.class.php
+++ b/centreon/www/class/centreon-clapi/centreonObject.class.php
@@ -667,7 +667,7 @@ abstract class CentreonObject
      */
     protected function csvEscape($text)
     {
-        if ($text[0] === '"' || str_contains($text, $this->delim) || str_contains($text, "\n")) {
+        if ($text !== '' && ($text[0] === '"' || str_contains($text, $this->delim) || str_contains($text, "\n"))) {
             $text = '"' . str_replace('"', '""', $text) . '"';
         }
         return $text;


### PR DESCRIPTION
## Description

Using getmacro (host or service object) will return the warning:

Fix: https://github.com/centreon/centreon/issues/6166

```
# centreon -u admin -p password -o HOST -a getmacro -v "central"
macro name;macro value;is_password;description;source
PHP Warning:  Uninitialized string offset 0 in /usr/share/centreon/www/class/centreon-clapi/centreonObject.class.php on line 668
MYMACRO;VALUE;;:;direct
```

The fix here enhanced the condition to test if the description is empty or not.


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] 24.10.x
- [X] master
