### PR TITLE
Remove the shell command SENDCBCFG

### DIFF
--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -371,15 +371,6 @@ try {
                 if (!isset($msg_restart[$host["id"]])) {
                     $msg_restart[$host["id"]] = "";
                 }
-                if (count($listBrokerFile) > 0) {
-                    passthru(
-                        escapeshellcmd("echo 'SENDCBCFG:{$host['id']}") . ' >> ' . escapeshellcmd($centcore_pipe),
-                        $return
-                    );
-                    if ($return) {
-                        throw new Exception(_("Could not write into centcore.cmd. Please check file permissions."));
-                    }
-                }
                 $msg_restart[$host["id"]] .= _("<br><b>Centreon : </b>All configuration will be send to " .
                     $host['name'] . " by centcore in several minutes.");
             }


### PR DESCRIPTION
## Description

SENDCBCFG isn't used anymore.

**Fixes** # MON-157139

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master
