### PR TITLE
fix(Resouces status): Host & Services columns don't contain the rights infos in the view by host

### DIFF
--- a/centreon/www/front_src/src/Resources/Listing/columns/Parent.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/columns/Parent.tsx
@@ -2,8 +2,7 @@ import type { ComponentColumnProps } from '@centreon/ui';
 
 import StatusChip from './ServiceSubItemColumn/StatusChip';
 import { getStatus } from './ServiceSubItemColumn/SubItem';
-
-import { useColumnStyles } from '.';
+import useColumnStyles from './colomuns.style';
 
 const ParentResourceColumn = ({
   row,

--- a/centreon/www/front_src/src/Resources/Listing/columns/Resource.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/columns/Resource.tsx
@@ -1,5 +1,5 @@
 import { useAtomValue } from 'jotai';
-import { equals } from 'ramda';
+import { equals, isNil } from 'ramda';
 
 import type { ComponentColumnProps } from '@centreon/ui';
 
@@ -9,8 +9,7 @@ import { Visualization } from '../../models';
 
 import StatusChip from './ServiceSubItemColumn/StatusChip';
 import { getStatus } from './ServiceSubItemColumn/SubItem';
-
-import { useColumnStyles } from '.';
+import useColumnStyles from './colomuns.style';
 
 const ResourceColumn = ({
   row,
@@ -24,35 +23,30 @@ const ResourceColumn = ({
   const isViewByHostMode = equals(visualization, Visualization.Host);
   const isViewByServiceMode = equals(visualization, Visualization.Service);
   const status = row?.status.name;
+  const isNestedRow = isNil(row?.children) && isViewByHostMode;
 
   const resourceName = renderEllipsisTypography?.({
     className: classes.resourceNameText,
-    formattedString: row.name
+    formattedString: row.name || row.resource_name
   });
 
-  if (isViewByServiceMode) {
-    return <div>{resourceName}</div>;
+  if (isNestedRow) {
+    return <div />;
   }
 
   if (isViewByHostMode) {
     return (
       <div>
-        {equals(row?.type, 'host') && (
-          <>
-            <StatusChip
-              content={getStatus(status?.toLowerCase())?.label}
-              severityCode={getStatus(status?.toLowerCase())?.severity}
-            />
-            {row?.icon && (
-              <img
-                alt={row.icon.name}
-                height={16}
-                src={row.icon.url}
-                width={16}
-              />
-            )}
-          </>
+        <div className={classes.statusChip}>
+          <StatusChip
+            content={getStatus(status?.toLowerCase())?.label}
+            severityCode={getStatus(status?.toLowerCase())?.severity}
+          />
+        </div>
+        {row?.icon && (
+          <img alt={row.icon.name} height={16} src={row.icon.url} width={16} />
         )}
+
         {resourceName}
       </div>
     );
@@ -61,10 +55,11 @@ const ResourceColumn = ({
   return (
     <>
       <div className={classes.resourceDetailsCell}>
-        {row.icon ? (
-          <img alt={row.icon.name} height={16} src={row.icon.url} width={16} />
-        ) : (
+        {!isViewByServiceMode && !row.icon && (
           <ShortTypeChip label={row.short_type} />
+        )}
+        {row.icon && (
+          <img alt={row.icon.name} height={16} src={row.icon.url} width={16} />
         )}
       </div>
       {resourceName}

--- a/centreon/www/front_src/src/Resources/Listing/columns/ServiceSubItemColumn/SubItem.styles.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/columns/ServiceSubItemColumn/SubItem.styles.tsx
@@ -19,6 +19,12 @@ const useStyles = makeStyles<StylesProps>()((theme, { severityCode }) => ({
     gap: theme.spacing(0.5),
     marginRight: theme.spacing(1)
   },
+  nestedStatus: {
+    alignItems: 'center',
+    display: 'flex',
+    gap: theme.spacing(0.5),
+    marginLeft: theme.spacing(3)
+  },
   statusCount: {
     alignItems: 'center',
     display: 'flex'

--- a/centreon/www/front_src/src/Resources/Listing/columns/ServiceSubItemColumn/SubItem.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/columns/ServiceSubItemColumn/SubItem.tsx
@@ -1,4 +1,4 @@
-import { cond, equals, keys } from 'ramda';
+import { cond, equals, isNil, keys } from 'ramda';
 
 import { Box } from '@mui/material';
 
@@ -17,13 +17,15 @@ export const getStatus = cond([
 ]);
 
 const SubItem = ({ row }: ComponentColumnProps): JSX.Element => {
-  const statusCount = row?.childrenCount;
   const { classes } = useStyles({});
+
+  const statusCount = row?.childrenCount;
+  const isNestedRow = isNil(row?.children);
 
   return (
     <Box className={classes.statusCount}>
-      {row?.resource_name && (
-        <Box className={classes.status}>
+      {row?.resource_name && isNestedRow && (
+        <Box className={classes.nestedStatus}>
           <StatusChip
             content={getStatus(row?.status.name.toLowerCase())?.label}
             severityCode={getStatus(row?.status.name.toLowerCase())?.severity}
@@ -31,6 +33,7 @@ const SubItem = ({ row }: ComponentColumnProps): JSX.Element => {
           <p>{row?.resource_name}</p>
         </Box>
       )}
+
       {keys(statusCount)?.map((item) => {
         if (statusCount?.[item]) {
           return (

--- a/centreon/www/front_src/src/Resources/Listing/columns/colomuns.style.ts
+++ b/centreon/www/front_src/src/Resources/Listing/columns/colomuns.style.ts
@@ -1,0 +1,33 @@
+import { makeStyles } from 'tss-react/mui';
+
+interface StyleProps {
+  isHovered: boolean;
+}
+
+const useColumnStyles = makeStyles<StyleProps>()((theme, { isHovered }) => ({
+  extraSmallChip: {
+    height: theme.spacing(1.25),
+    lineHeight: theme.spacing(1.25),
+    minWidth: theme.spacing(1.25)
+  },
+  resourceDetailsCell: {
+    alignItems: 'center',
+    display: 'flex',
+    flexWrap: 'nowrap'
+  },
+  resourceNameItem: {
+    lineHeight: 1,
+    whiteSpace: 'nowrap'
+  },
+  resourceNameText: {
+    color: isHovered
+      ? theme.palette.text.primary
+      : theme.palette.text.secondary,
+    paddingLeft: theme.spacing(0.5)
+  },
+  statusChip: {
+    marginRight: theme.spacing(0.5)
+  }
+}));
+
+export default useColumnStyles;


### PR DESCRIPTION
## Description

When chosing to show resources by host view, in the listing the Host column contains the status info and the Services column contains the name of host.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
