### PR TITLE
fix(cron): run outdated tokens removal cron with apache user

### DIFF
--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -117,7 +117,7 @@ runs:
         key: ${{ inputs.cache_key }}
 
     # Update if condition to true to get packages as artifacts
-    - if: ${{ true }}
+    - if: ${{ false }}
       name: Upload package artifacts
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -117,7 +117,7 @@ runs:
         key: ${{ inputs.cache_key }}
 
     # Update if condition to true to get packages as artifacts
-    - if: ${{ false }}
+    - if: ${{ true }}
       name: Upload package artifacts
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:

--- a/centreon/packaging/scripts/centreon-web-postinstall.sh
+++ b/centreon/packaging/scripts/centreon-web-postinstall.sh
@@ -153,11 +153,18 @@ fixSymfonyCacheRights() {
 fixCentreonCronPermissions() {
   # MON-146883
   # Override permissions for cron scripts
-  chmod 0755 \
-    /usr/share/centreon/cron/outdated-token-removal.php
+  chmod 0755 /usr/share/centreon/cron/outdated-token-removal.php
+  chown -R centreon:centreon /usr/share/centreon/cron/outdated-token-removal.php
 
-  chown -R centreon:centreon \
-    /usr/share/centreon/cron/outdated-token-removal.php
+  # Update log file permissions which has been potentially created by centreon user
+  APP_LOG_FILE="/var/log/centreon/centreon-web.log"
+  if [ -f "$APP_LOG_FILE" ]; then
+    if [ "$1" = "rpm" ]; then
+      chown apache:apache "$APP_LOG_FILE"
+    else
+      chown www-data:www-data "$APP_LOG_FILE"
+    fi
+  fi
 }
 
 package_type="rpm"
@@ -194,7 +201,7 @@ case "$action" in
     manageApacheAndPhpFpm $package_type
     fixSymfonyCacheRights $package_type
     rebuildSymfonyCache $package_type
-    fixCentreonCronPermissions
+    fixCentreonCronPermissions $package_type
     ;;
   *)
     # $1 == version being installed

--- a/centreon/tmpl/install/centreon.cron
+++ b/centreon/tmpl/install/centreon.cron
@@ -37,4 +37,4 @@ CRONTAB_EXEC_USER=""
 
 ##########################
 # Cron for Outdated Token removal
-* * * * * centreon @INSTALL_DIR_CENTREON@/cron/outdated-token-removal.php >> @CENTREON_LOG@/centreon-tokens.log 2>&1
+* * * * * @WEB_USER@ @INSTALL_DIR_CENTREON@/cron/outdated-token-removal.php >> @CENTREON_LOG@/centreon-tokens.log 2>&1


### PR DESCRIPTION
## Description

fix(cron): run outdated tokens removal cron with apache user

**Fixes** MON-156023

before upgrade:

```shell
[root@a6ece9d39f4e /]# ls -l /var/log/centreon/centreon-web.log
-rw-r--r-- 1 centreon centreon 984 Jan 31 08:23 centreon-web.log
```

after upgrade: 
```shell
[root@a6ece9d39f4e ~]# ls -l /var/log/centreon/centreon-web.log 
-rw-r--r-- 1 apache apache 984 Jan 31 08:23 /var/log/centreon/centreon-web.log
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software