### PR TITLE
enh(ceip): add LACCESS in metadata

### DIFF
--- a/centreon/www/api/class/centreon_ceip.class.php
+++ b/centreon/www/api/class/centreon_ceip.class.php
@@ -268,7 +268,6 @@ class CentreonCeip extends CentreonWebService
             foreach ($centreonModules as $module) {
                 $licenseObject->setProduct($module);
                 $isLicenseValid = $licenseObject->validate();
-
                 if ($isLicenseValid && ! empty($licenseObject->getData())) {
                     /**
                      * @var array<

--- a/centreon/www/api/class/centreon_ceip.class.php
+++ b/centreon/www/api/class/centreon_ceip.class.php
@@ -209,6 +209,9 @@ class CentreonCeip extends CentreonWebService
         // Get Instance information
         $instanceInformation = $this->getServerType();
 
+        // Get LACCESS
+        $laccess = $this->getLaccess();
+
         $accountInformation =  [
             'id' => $this->uuid,
             'name' => $licenseInfo['companyName'],
@@ -230,6 +233,10 @@ class CentreonCeip extends CentreonWebService
 
         if (isset($licenseInfo['fingerprint'])) {
             $accountInformation['fingerprint'] = $licenseInfo['fingerprint'];
+        }
+
+        if (!empty($laccess) && isset($licenseInfo['mode']) && $licenseInfo['mode'] !== 'offline') {
+            $accountInformation['LACCESS'] = $laccess;
         }
 
         return $accountInformation;
@@ -272,6 +279,7 @@ class CentreonCeip extends CentreonWebService
                     /** @var string $licenseClientName */
                     $licenseClientName = $licenseInformation[$module]['client']['name'];
                     $hostsLimitation = $licenseInformation[$module]['licensing']['hosts'];
+                    $licenseMode = $licenseInformation[$module]['platform']['mode'] ?? null;
                     $licenseStart = DateTime::createFromFormat(
                         'Y-m-d',
                         $licenseInformation[$module]['licensing']['start']
@@ -321,6 +329,10 @@ class CentreonCeip extends CentreonWebService
             $licenseInformation['fingerprint'] = $fingerprint;
         }
 
+        if (isset($licenseMode)) {
+            $licenseInformation['mode'] = $licenseMode;
+        }
+
         return $licenseInformation;
     }
 
@@ -328,7 +340,7 @@ class CentreonCeip extends CentreonWebService
      * Get the major and minor versions of Centreon web.
      *
      * @return array{major: string, minor: string} with major and minor versions
-     *@throws PDOException
+     * @throws PDOException
      *
      */
     private function getCentreonVersion(): array
@@ -344,7 +356,7 @@ class CentreonCeip extends CentreonWebService
      * Get CEIP status.
      *
      * @return bool the status of CEIP
-     *@throws PDOException
+     * @throws PDOException
      *
      */
     private function isCeipActive(): bool
@@ -419,6 +431,21 @@ class CentreonCeip extends CentreonWebService
         }
 
         return $agents;
+    }
+
+    /**
+     * Get LACCESS to complete the connection between Pendo and Salesforce.
+     *
+     * @return string LACCESS value from options table.
+     *
+     * @throws PDOException
+     *
+     */
+    private function getLaccess(): string
+    {
+        $sql = "SELECT `value` FROM `options` WHERE `key` = 'LACCESS' LIMIT 1";
+
+        return (string) $this->sqlFetchValue($sql);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR intends to add LACCESS from centreon.options database into account metadata. If platform is offline or without LACCESS available, we won't set it.

**Fixes** # ([MON-158538](https://centreon.atlassian.net/browse/MON-158538))

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

1- Enable the CEIP program: on menu Administration  >  Parameters  >  Centreon UI click on “Send anonymous statistics”
2- Click on Save button
3- Open develop console of the browser.
4- If LACCESSis set in options, it should be visible under "account"

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-158538]: https://centreon.atlassian.net/browse/MON-158538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ