### PR TITLE
Remove unexisting column

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1571,7 +1571,6 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 INNER JOIN `:dbstg`.hosts h
                     ON h.host_id = ssg.host_id
                     AND h.enabled = \'1\'
-                    AND h.host_register = \'1\'
                 INNER JOIN `:dbstg`.resources
                     ON resources.id = h.host_id';
 
@@ -1580,8 +1579,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
                 ' LEFT JOIN `:dbstg`.`services` srv
                     ON srv.service_id = ssg.service_id
                     AND srv.host_id = h.host_id
-                    AND srv.enabled = \'1\'
-                    AND srv.service_register = \'1\'';
+                    AND srv.enabled = \'1\'';
             }
 
             if ($shouldJoinHostGroup) {


### PR DESCRIPTION
## Description

hosts.host_register and services.service_register doesn't exist.
hosts.enabled and services.enabled are enough on centreon_storage

**Fixes** # MON-159570

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master
