### PR TITLE
enh(ui): [MAP] 23.04 when too many elements are selected in a Geoview the list is out of visibility

### DIFF
--- a/centreon/packages/ui/src/InputField/Select/Autocomplete/Multi/index.tsx
+++ b/centreon/packages/ui/src/InputField/Select/Autocomplete/Multi/index.tsx
@@ -30,35 +30,31 @@ export interface Props
       'multiple'
     > {
   disableSortedOptions?: boolean;
-  TagsProps?: {
-    tagsClassName?: string;
-  };
+  customRenderTags?: Function;
 }
 
 const MultiAutocompleteField = ({
   value,
   options,
   disableSortedOptions = false,
-  TagsProps,
+  customRenderTags,
   ...props
 }: Props): JSX.Element => {
   const { classes } = useStyles();
 
-  const renderTags = (renderedValue, getTagProps): JSX.Element =>
-    <div className={TagsProps?.tagsClassName}>
-      {renderedValue.map((option, index) => (
-        <Chip
-          classes={{
-            deleteIcon: classes.deleteIcon,
-            root: classes.tag
-          }}
-          key={option.id}
-          label={option.name}
-          size="medium"
-          {...getTagProps({ index })}
-        />
-      ))}
-    </div>;
+  const renderTags = (renderedValue, getTagProps): Array<JSX.Element> =>
+    renderedValue.map((option, index) => (
+      <Chip
+        classes={{
+          deleteIcon: classes.deleteIcon,
+          root: classes.tag
+        }}
+        key={option.id}
+        label={option.name}
+        size="medium"
+        {...getTagProps({ index })}
+      />
+    ));
 
   const getLimitTagsText = (more): JSX.Element => <Option>{`+${more}`}</Option>;
 
@@ -89,7 +85,10 @@ const MultiAutocompleteField = ({
           <Option checkboxSelected={selected}>{option.name}</Option>
         </li>
       )}
-      renderTags={renderTags}
+      renderTags={(renderedValue, getTagProps) => customRenderTags
+        ? customRenderTags(renderTags(renderedValue, getTagProps))
+        : renderTags(renderedValue, getTagProps)
+      }
       value={value}
       {...props}
     />

--- a/centreon/packages/ui/src/InputField/Select/Autocomplete/Multi/index.tsx
+++ b/centreon/packages/ui/src/InputField/Select/Autocomplete/Multi/index.tsx
@@ -9,10 +9,6 @@ import { SelectEntry } from '../..';
 import Option from '../../Option';
 
 const useStyles = makeStyles()((theme) => ({
-  checkbox: {
-    marginRight: theme.spacing(1),
-    padding: 0
-  },
   deleteIcon: {
     height: theme.spacing(1.5),
     width: theme.spacing(1.5)
@@ -34,29 +30,35 @@ export interface Props
       'multiple'
     > {
   disableSortedOptions?: boolean;
+  TagsProps?: {
+    tagsClassName?: string;
+  };
 }
 
 const MultiAutocompleteField = ({
   value,
   options,
   disableSortedOptions = false,
+  TagsProps,
   ...props
 }: Props): JSX.Element => {
   const { classes } = useStyles();
 
-  const renderTags = (renderedValue, getTagProps): Array<JSX.Element> =>
-    renderedValue.map((option, index) => (
-      <Chip
-        classes={{
-          deleteIcon: classes.deleteIcon,
-          root: classes.tag
-        }}
-        key={option.id}
-        label={option.name}
-        size="medium"
-        {...getTagProps({ index })}
-      />
-    ));
+  const renderTags = (renderedValue, getTagProps): JSX.Element =>
+    <div className={TagsProps?.tagsClassName}>
+      {renderedValue.map((option, index) => (
+        <Chip
+          classes={{
+            deleteIcon: classes.deleteIcon,
+            root: classes.tag
+          }}
+          key={option.id}
+          label={option.name}
+          size="medium"
+          {...getTagProps({ index })}
+        />
+      ))}
+    </div>;
 
   const getLimitTagsText = (more): JSX.Element => <Option>{`+${more}`}</Option>;
 

--- a/centreon/packages/ui/src/InputField/Select/Autocomplete/Multi/index.tsx
+++ b/centreon/packages/ui/src/InputField/Select/Autocomplete/Multi/index.tsx
@@ -29,8 +29,8 @@ export interface Props
       UseAutocompleteProps<SelectEntry, Multiple, DisableClearable, FreeSolo>,
       'multiple'
     > {
+  customRenderTags?: (tags: React.ReactNode) => React.ReactNode;
   disableSortedOptions?: boolean;
-  customRenderTags?: Function;
 }
 
 const MultiAutocompleteField = ({
@@ -42,7 +42,7 @@ const MultiAutocompleteField = ({
 }: Props): JSX.Element => {
   const { classes } = useStyles();
 
-  const renderTags = (renderedValue, getTagProps): Array<JSX.Element> =>
+  const renderTags = (renderedValue, getTagProps): React.ReactNode =>
     renderedValue.map((option, index) => (
       <Chip
         classes={{
@@ -85,9 +85,10 @@ const MultiAutocompleteField = ({
           <Option checkboxSelected={selected}>{option.name}</Option>
         </li>
       )}
-      renderTags={(renderedValue, getTagProps) => customRenderTags
-        ? customRenderTags(renderTags(renderedValue, getTagProps))
-        : renderTags(renderedValue, getTagProps)
+      renderTags={(renderedValue, getTagProps): React.ReactNode =>
+        customRenderTags
+          ? customRenderTags(renderTags(renderedValue, getTagProps))
+          : renderTags(renderedValue, getTagProps)
       }
       value={value}
       {...props}


### PR DESCRIPTION
## Description

[MON-149678](https://centreon.atlassian.net/browse/MON-149678)


## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [x] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-149678]: https://centreon.atlassian.net/browse/MON-149678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ