### PR TITLE
enh(composer) : realign composer on release-22.10-next

### DIFF
--- a/centreon-awie/composer.lock
+++ b/centreon-awie/composer.lock
@@ -349,12 +349,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "3b6a8ac8a0c1bc9d2a40bd9761f514e0456028f6"
+                "reference": "1ed402fa5bf72b511fd9d520f6ff3aade97ac80f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/3b6a8ac8a0c1bc9d2a40bd9761f514e0456028f6",
-                "reference": "3b6a8ac8a0c1bc9d2a40bd9761f514e0456028f6",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/1ed402fa5bf72b511fd9d520f6ff3aade97ac80f",
+                "reference": "1ed402fa5bf72b511fd9d520f6ff3aade97ac80f",
                 "shasum": ""
             },
             "require": {
@@ -403,7 +403,7 @@
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
                 "source": "https://github.com/centreon/centreon-test-lib/tree/22.10.x"
             },
-            "time": "2024-09-03T09:56:30+00:00"
+            "time": "2025-01-28T10:49:04+00:00"
         },
         {
             "name": "composer/pcre",


### PR DESCRIPTION
## Description

### Changed

* realign composer to the release-22.10-next branch of centreon web

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] release-22.10-next

<h2> How this pull request can be tested ? </h2>

By CI Tests

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
