### PR TITLE
enh(deps): increase dependabot allowed pull request openings for github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: '/'
     schedule:
       interval: monthly
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 50
     labels:
       - 'dependencies'
       - 'gha'
@@ -20,6 +20,8 @@ updates:
     allow:
       - dependency-type: "direct"
       - dependency-type: "production"
+    ignore:
+      - dependency-name: '*'
 
   - package-ecosystem: composer
     directory: '/'
@@ -32,3 +34,5 @@ updates:
     allow:
       - dependency-type: "direct"
       - dependency-type: "production"
+    ignore:
+      - dependency-name: '*'


### PR DESCRIPTION
## Description

increase the amount of gha pull requests opened by dependabot in each monthly scan + trying to prevent pull requests from other dependency sectors from being opened

**Fixes** # MON-147318

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
