### PR TITLE
enh(ci): upload logs of e2e upgrade tests + clear cypress network cache

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/commands.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands.ts
@@ -511,103 +511,111 @@ Cypress.Commands.add(
   }
 );
 
+Cypress.Commands.add(
+  'getLogDirectory',
+  (): Cypress.Chainable => {
+    const logDirectory = `results/logs/${Cypress.spec.name.replace(
+        artifactIllegalCharactersMatcher,
+        '_'
+      )}/${Cypress.currentTest.title.replace(
+        artifactIllegalCharactersMatcher,
+        '_'
+      )}`;
+
+    return cy
+      .createDirectory(logDirectory)
+      .exec(`chmod -R 755 "${logDirectory}"`)
+      .wrap(logDirectory);
+  }
+);
+
+interface CopyWebContainerLogsProps {
+  name: string;
+}
+
+Cypress.Commands.add(
+  'copyWebContainerLogs',
+  ({ name }: CopyWebContainerLogsProps): Cypress.Chainable => {
+    cy.log(`Getting logs from container ${name} ...`);
+
+    return cy.getLogDirectory().then((logDirectory) => {
+      let sourcePhpLogs = '/var/log/php8.1-fpm-centreon-error.log';
+      let targetPhpLogs = `${logDirectory}/php8.1-fpm-centreon-error.log`;
+      let sourceApacheLogs = '/var/log/apache2';
+      let targetApacheLogs = `${logDirectory}/apache2`;
+      if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {
+        sourcePhpLogs = '/var/log/php-fpm';
+        targetPhpLogs = `${logDirectory}/php`;
+        sourceApacheLogs = '/var/log/httpd';
+        targetApacheLogs = `${logDirectory}/httpd`;
+      }
+
+      return cy
+        .copyFromContainer({
+          destination: `${logDirectory}/broker`,
+          name,
+          source: '/var/log/centreon-broker'
+        })
+        .copyFromContainer({
+          destination: `${logDirectory}/engine`,
+          name,
+          source: '/var/log/centreon-engine'
+        })
+        .copyFromContainer({
+          destination: `${logDirectory}/centreon`,
+          name,
+          source: '/var/log/centreon'
+        })
+        .copyFromContainer({
+          destination: `${logDirectory}/centreon-gorgone`,
+          name,
+          source: '/var/log/centreon-gorgone'
+        })
+        .copyFromContainer({
+          destination: targetPhpLogs,
+          name,
+          source: sourcePhpLogs,
+        })
+        .copyFromContainer({
+          destination: targetApacheLogs,
+          name,
+          source: sourceApacheLogs,
+        })
+        .exec(`chmod -R 755 "${logDirectory}"`);
+      });
+});
+
 Cypress.Commands.add('stopContainers', (): Cypress.Chainable => {
   cy.log('Stopping containers ...');
-
-  const logDirectory = `results/logs/${Cypress.spec.name.replace(
-    artifactIllegalCharactersMatcher,
-    '_'
-  )}/${Cypress.currentTest.title.replace(
-    artifactIllegalCharactersMatcher,
-    '_'
-  )}`;
 
   const name = 'web';
 
   return cy
     .visitEmptyPage()
-    .createDirectory(logDirectory)
-    .getContainersLogs()
-    .then((containersLogs: Array<Array<string>>) => {
-      if (!containersLogs) {
-        return;
-      }
+    .getLogDirectory()
+    .then((logDirectory) => {
+      return cy
+        .getContainersLogs()
+        .then((containersLogs: Array<Array<string>>) => {
+          if (!containersLogs) {
+            return;
+          }
 
-      Object.entries(containersLogs).forEach(([containerName, logs]) => {
-        cy.writeFile(
-          `results/logs/${Cypress.spec.name.replace(
-            artifactIllegalCharactersMatcher,
-            '_'
-          )}/${Cypress.currentTest.title.replace(
-            artifactIllegalCharactersMatcher,
-            '_'
-          )}/container-${containerName}.log`,
-          logs
+          Object.entries(containersLogs).forEach(([containerName, logs]) => {
+            cy.writeFile(
+              `${logDirectory}/container-${containerName}.log`,
+              logs
+            );
+          });
+        })
+        .copyWebContainerLogs({ name })
+        .exec(`chmod -R 755 "${logDirectory}"`)
+        .task(
+          'stopContainers',
+          {},
+          { timeout: 600000 } // 10 minutes because docker pull can be very slow
         );
-      });
-    })
-    .copyFromContainer({
-      destination: `${logDirectory}/broker`,
-      name,
-      source: '/var/log/centreon-broker'
-    })
-    .copyFromContainer({
-      destination: `${logDirectory}/engine`,
-      name,
-      source: '/var/log/centreon-engine'
-    })
-    .copyFromContainer({
-      destination: `${logDirectory}/centreon`,
-      name,
-      source: '/var/log/centreon'
-    })
-    .copyFromContainer({
-      destination: `${logDirectory}/centreon-gorgone`,
-      name,
-      source: '/var/log/centreon-gorgone'
-    })
-    .then(() => {
-      if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {
-        return cy.copyFromContainer({
-          destination: `${logDirectory}/php`,
-          name,
-          source: '/var/log/php-fpm'
-        });
-      }
-
-      return cy.copyFromContainer(
-        {
-          destination: `${logDirectory}/php8.1-fpm-centreon-error.log`,
-          name,
-          source: '/var/log/php8.1-fpm-centreon-error.log'
-        },
-        { failOnNonZeroExit: false }
-      );
-    })
-    .then(() => {
-      if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {
-        return cy.copyFromContainer({
-          destination: `${logDirectory}/httpd`,
-          name,
-          source: '/var/log/httpd'
-        });
-      }
-
-      return cy.copyFromContainer(
-        {
-          destination: `${logDirectory}/apache2`,
-          name,
-          source: '/var/log/apache2'
-        },
-        { failOnNonZeroExit: false }
-      );
-    })
-    .exec(`chmod -R 755 "${logDirectory}"`)
-    .task(
-      'stopContainers',
-      {},
-      { timeout: 600000 } // 10 minutes because docker pull can be very slow
-    );
+    });
 });
 
 Cypress.Commands.add(
@@ -880,6 +888,7 @@ declare global {
         props: CopyToContainerProps,
         options?: Partial<Cypress.ExecOptions>
       ) => Cypress.Chainable;
+      copyWebContainerLogs: (props: CopyWebContainerLogsProps) => Cypress.Chainable;
       createDirectory: (directoryPath: string) => Cypress.Chainable;
       execInContainer: (
         props: ExecInContainerProps,
@@ -899,6 +908,7 @@ declare global {
       getContainerIpAddress: (containerName: string) => Cypress.Chainable;
       getContainersLogs: () => Cypress.Chainable;
       getIframeBody: () => Cypress.Chainable;
+      getLogDirectory: () => Cypress.Chainable;
       getTimeFromHeader: () => Cypress.Chainable;
       getWebVersion: () => Cypress.Chainable;
       hoverRootMenuItem: (rootItemNumber: number) => Cypress.Chainable;

--- a/centreon/packages/js-config/cypress/e2e/configuration.ts
+++ b/centreon/packages/js-config/cypress/e2e/configuration.ts
@@ -50,14 +50,21 @@ export default ({
       },
       setupNodeEvents: async (cypressOn, config) => {
         const on = require('cypress-on-fix')(cypressOn)
-        installLogsPrinter(on);
+        installLogsPrinter(
+          on,
+          {
+            commandTrimLength: 5000,
+            defaultTrimLength: 5000,
+          }
+      );
         await esbuildPreprocessor(on, config);
         tasks(on);
 
         return plugins(on, config);
       },
       specPattern,
-      supportFile: 'support/e2e.{js,jsx,ts,tsx}'
+      supportFile: 'support/e2e.{js,jsx,ts,tsx}',
+      testIsolation: true,
     },
     env: {
       ...env,

--- a/centreon/packages/js-config/cypress/e2e/tasks.ts
+++ b/centreon/packages/js-config/cypress/e2e/tasks.ts
@@ -55,19 +55,17 @@ export default (on: Cypress.PluginEvents): void => {
   on('task', {
     copyFromContainer: async ({ destination, serviceName, source }) => {
       try {
-        if (dockerEnvironment !== null) {
-          const container = dockerEnvironment.getContainer(`${serviceName}-1`);
+        const container = getContainer(serviceName);
 
-          await container
-            .copyArchiveFromContainer(source)
-            .then((archiveStream) => {
-              return new Promise<void>((resolve) => {
-                const dest = tar.extract(destination);
-                archiveStream.pipe(dest);
-                dest.on('finish', resolve);
-              });
+        await container
+          .copyArchiveFromContainer(source)
+          .then((archiveStream) => {
+            return new Promise<void>((resolve) => {
+              const dest = tar.extract(destination);
+              archiveStream.pipe(dest);
+              dest.on('finish', resolve);
             });
-        }
+          });
       } catch (error) {
         console.error(error);
       }

--- a/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
@@ -7,6 +7,11 @@ import {
 } from '../common';
 
 beforeEach(() => {
+  // clear network cache to avoid chunk loading issues
+  cy.wrap(Cypress.automation('remote:debugger:protocol', {
+    command: 'Network.clearBrowserCache',
+  }));
+
   cy.getWebVersion().then(({ major_version }) => {
     cy.intercept({
       method: 'GET',
@@ -158,5 +163,8 @@ Given(
 );
 
 afterEach(() => {
-  cy.visitEmptyPage().stopContainer({ name: 'web' });
+  cy
+    .visitEmptyPage()
+    .copyWebContainerLogs({ name: 'web' })
+    .stopContainer({ name: 'web' });
 });

--- a/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade/index.ts
@@ -27,6 +27,11 @@ before(() => {
 });
 
 beforeEach(() => {
+  // clear network cache to avoid chunk loading issues
+  cy.wrap(Cypress.automation('remote:debugger:protocol', {
+    command: 'Network.clearBrowserCache',
+  }));
+
   cy.intercept({
     method: 'GET',
     url: '/centreon/api/internal.php?object=centreon_topology&action=navigationList'
@@ -224,5 +229,8 @@ EOF`,
 );
 
 afterEach(() => {
-  cy.visitEmptyPage().stopContainer({ name: 'web' });
+  cy
+    .visitEmptyPage()
+    .copyWebContainerLogs({ name: 'web' })
+    .stopContainer({ name: 'web' });
 });

--- a/centreon/www/install/php/Update-24.10.5.php
+++ b/centreon/www/install/php/Update-24.10.5.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2024 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

enh(ci): upload logs of e2e upgrade tests + clear cypress network cache (#6700)

**Fixes** MON-160273

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software