### PR TITLE
fix(API): Added handling of 401 Unauthorized Response

### DIFF
--- a/centreon/src/Centreon/Application/Controller/AbstractController.php
+++ b/centreon/src/Centreon/Application/Controller/AbstractController.php
@@ -33,6 +33,7 @@ use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Application\Common\UseCase\NotModifiedResponse;
 use Core\Application\Common\UseCase\PaymentRequiredResponse;
 use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Application\Common\UseCase\UnauthorizedResponse;
 use FOS\RestBundle\Controller\AbstractFOSRestController;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
@@ -64,6 +65,7 @@ abstract class AbstractController extends AbstractFOSRestController
             $response instanceof NotFoundResponse => Response::HTTP_NOT_FOUND,
             $response instanceof NotModifiedResponse => Response::HTTP_NOT_MODIFIED,
             $response instanceof PaymentRequiredResponse => Response::HTTP_PAYMENT_REQUIRED,
+            $response instanceof UnauthorizedResponse => Response::HTTP_UNAUTHORIZED,
             default => Response::HTTP_INTERNAL_SERVER_ERROR
         };
 


### PR DESCRIPTION
## Description

Added handling of 401 Unauthorized Response code in `AbstractController::createResponse` method

**Fixes** # MON-159656

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
