### PR TITLE
fix(downtime): listing broken when BAM module was installed

### DIFF
--- a/centreon/www/include/monitoring/downtime/listDowntime.php
+++ b/centreon/www/include/monitoring/downtime/listDowntime.php
@@ -147,7 +147,7 @@ $result = $pearDB->executeQuery("SELECT id FROM modules_informations WHERE name 
 if ($result->rowCount()) {
     $result = $pearDB->executeQuery("SELECT CONCAT('ba_', ba_id) AS id, ba_id, name FROM mod_bam");
 
-    while ($elem = $result->fetchRow()) {
+    while ($elem = $result->fetch()) {
         $tab_service_bam[$elem['id']] = ['name' => $elem['name'], 'id' => $elem['ba_id']];
     }
 }


### PR DESCRIPTION
Refs: MON-160983
This PR intends to fix the listing of the downtimes (downtime configuration page) when BAM is installed.