### PR TITLE
fix(UI): Retrieve the correct iframe on legacy page

### DIFF
--- a/centreon/www/front_src/src/route-components/legacyRoute/index.tsx
+++ b/centreon/www/front_src/src/route-components/legacyRoute/index.tsx
@@ -21,46 +21,55 @@ const LegacyRoute = (): JSX.Element => {
   const load = (): void => {
     setLoading(false);
 
-    window.frames[0].document.querySelectorAll('a').forEach((element) => {
-      element.addEventListener(
-        'click',
-        (e) => {
-          const href = (e.target as HTMLLinkElement).getAttribute('href');
-          const target = (e.target as HTMLLinkElement).getAttribute('target');
+    document
+      .getElementById('main-content')
+      ?.contentWindow?.document.querySelectorAll('a')
+      .forEach((element) => {
+        element.addEventListener(
+          'click',
+          (e) => {
+            const href = (e.target as HTMLLinkElement).getAttribute('href');
+            const target = (e.target as HTMLLinkElement).getAttribute('target');
 
-          if (equals(target, '_blank')) {
-            return;
-          }
+            if (equals(target, '_blank')) {
+              return;
+            }
 
-          e.preventDefault();
+            e.preventDefault();
 
-          if (isNil(href)) {
-            return;
-          }
+            if (isNil(href)) {
+              return;
+            }
 
-          const formattedHref = replace('./', '', href);
+            const formattedHref = replace('./', '', href);
 
-          if (equals(formattedHref, '#') || !formattedHref.match(/^main.php/)) {
-            return;
-          }
+            if (
+              equals(formattedHref, '#') ||
+              !formattedHref.match(/^main.php/)
+            ) {
+              return;
+            }
 
-          navigate(`/${formattedHref}`, { replace: true });
-        },
-        { once: true }
-      );
-    });
+            navigate(`/${formattedHref}`, { replace: true });
+          },
+          { once: true }
+        );
+      });
   };
 
   const toggle = (event: KeyboardEvent): void => {
     if (
-      includes(window.frames[0].document.activeElement?.tagName, [
-        'INPUT',
-        'TEXTAREA'
-      ]) ||
+      includes(
+        document.getElementById('main-content')?.contentWindow?.document
+          .activeElement?.tagName,
+        ['INPUT', 'TEXTAREA']
+      ) ||
       equals(
-        window.frames[0].document.activeElement?.getAttribute(
-          'contenteditable'
-        ),
+        document
+          .getElementById('main-content')
+          ?.contentWindow?.document.activeElement?.getAttribute(
+            'contenteditable'
+          ),
         'true'
       ) ||
       !equals(event.code, 'KeyF')
@@ -73,11 +82,15 @@ const LegacyRoute = (): JSX.Element => {
 
   useEffect(() => {
     window.addEventListener('react.href.update', handleHref, false);
-    window.frames[0].addEventListener('keypress', toggle, false);
+    document
+      .getElementById('main-content')
+      ?.contentWindow?.addEventListener('keypress', toggle, false);
 
     return () => {
       window.removeEventListener('react.href.update', handleHref);
-      window.frames[0]?.removeEventListener('keypress', toggle);
+      document
+        .getElementById('main-content')
+        ?.contentWindow?.removeEventListener('keypress', toggle);
     };
   }, []);
 


### PR DESCRIPTION
## Description

This retrieves the correct iframe to apply actions on instead of potentially retrieve iframes auto-generated by password managers

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
