### PR TITLE
fix(Host Groups): remove sunset fields from bulk duplicate endpoint

### DIFF
--- a/centreon/doc/API/latest/onPremise/Configuration/HostGroup/DuplicateHostGroups.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/HostGroup/DuplicateHostGroups.yaml
@@ -46,6 +46,7 @@ post:
                   type: string
                   nullable: true
                   description: "Error message for non 204 status"
+                  example: null
     '404':
       description: "Host Group not found"
       content:
@@ -67,6 +68,7 @@ post:
                   type: string
                   nullable: true
                   description: "Host Group not found"
+                  example: "Host Group not found"
     '401':
       $ref: '../../Common/Response/Unauthorized.yaml'
     '403':

--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbWriteHostGroupRepository.php
@@ -217,12 +217,6 @@ class DbWriteHostGroupRepository extends AbstractRepositoryDRB implements WriteH
             (
                 hg_name,
                 hg_alias,
-                hg_notes,
-                hg_notes_url,
-                hg_action_url,
-                hg_icon_image,
-                hg_map_icon_image,
-                hg_rrd_retention,
                 geo_coords,
                 hg_comment,
                 hg_activate
@@ -230,12 +224,6 @@ class DbWriteHostGroupRepository extends AbstractRepositoryDRB implements WriteH
             SELECT
                 CONCAT(hg_name, '_', :duplicateIndex),
                 hg_alias,
-                hg_notes,
-                hg_notes_url,
-                hg_action_url,
-                hg_icon_image,
-                hg_map_icon_image,
-                hg_rrd_retention,
                 geo_coords,
                 hg_comment,
                 hg_activate


### PR DESCRIPTION
## Description

In this PR we remove the following sunset fields from the bulk duplicate endpoint : 
```
- notes, 
- notes_url, 
- action_url,
- icon
- icon_map
- rrd
```

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
