### PR TITLE
fix(configuration): fix notification period field in add/update service

### DIFF
--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -1569,7 +1569,11 @@ function updateServiceInDBForOnPrem($serviceId = null, $massiveChange = false, $
 {
     global $form;
 
-    if (!$serviceId) {
+    if (! count($parameters)) {
+        $parameters = $form->getSubmitValues();
+    }
+
+    if (! $serviceId) {
         return;
     }
 
@@ -1656,16 +1660,15 @@ function updateServiceInDBForOnPrem($serviceId = null, $massiveChange = false, $
         isset($ret["mc_mod_notifopt_timeperiod"]["mc_mod_notifopt_timeperiod"])
         && $ret["mc_mod_notifopt_timeperiod"]["mc_mod_notifopt_timeperiod"]
     ) {
-        updateServiceNotifOptionTimeperiod($serviceId);
+        updateServiceNotifOptionTimeperiod($serviceId, $parameters);
     } elseif (
         isset($ret["mc_mod_notifopt_timeperiod"]["mc_mod_notifopt_timeperiod"])
         && !$ret["mc_mod_notifopt_timeperiod"]["mc_mod_notifopt_timeperiod"]
     ) {
         updateServiceNotifOptionTimeperiod_MC($serviceId);
     } else {
-        updateServiceNotifOptionTimeperiod($serviceId);
+        updateServiceNotifOptionTimeperiod($serviceId, $parameters);
     }
-
 
     // Function for updating host/hg parent
     // 1 - MC with deletion of existing host/hg parent
@@ -2209,7 +2212,11 @@ function insertServiceInDBForCloud($submittedValues = [], $onDemandMacro = null)
 
 function insertServiceInDBForOnPremise($submittedValues = [], $onDemandMacro = null)
 {
-    global $centreon;
+    global $form, $centreon;
+
+    if (! count($submittedValues)) {
+        $submittedValues = $form->getSubmitValues();
+    }
 
     $tmp_fields = insertServiceForOnPremise($submittedValues, $onDemandMacro);
     if (! isset($tmp_fields['service_id'])) {
@@ -2591,6 +2598,7 @@ function insertServiceForOnPremise($submittedValues = [], $onDemandMacro = null)
         ? $rq .= "'" . $submittedValues["service_acknowledgement_timeout"] . "'"
         : $rq .= "NULL";
     $rq .= ")";
+
     $dbResult = $pearDB->query($rq);
     $dbResult = $pearDB->query("SELECT MAX(service_id) FROM service");
     $service_id = $dbResult->fetch();
@@ -3433,7 +3441,7 @@ function updateServiceNotifOptionTimeperiod(int $serviceId, $ret = array())
         $stmt = $pearDB->prepareQuery($request);
         $queryParams['service_id'] = $serviceId;
 
-        $queryParams['timeperiod_tp_id2'] = $ret['timeperiod_tp_id2'] ?? null;
+        $queryParams['timeperiod_tp_id2'] = !empty($ret['timeperiod_tp_id2']) ? $ret['timeperiod_tp_id2'] : null;
 
         $pearDB->executePreparedQuery($stmt, $queryParams);
     } catch (CentreonDbException $exception) {
@@ -3753,6 +3761,7 @@ function updateServiceHost($service_id = null, $ret = [], $from_MC = false)
     } else {
         $ret2 = CentreonUtils::mergeWithInitialValues($form, 'service_hgPars');
     }
+
 
     /*
      * Get actual config


### PR DESCRIPTION
## Description

This PR intends to fix the following bug : 
While creating/updating a service by host or a service by host group, the field “notification period” is not saved.

**Fixes** # ([MON-158257](https://centreon.atlassian.net/browse/MON-158257))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

By adding a new service by host or service by group or updating an existing one from the form, the field notifiraction period should be saved.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-158257]: https://centreon.atlassian.net/browse/MON-158257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ