### PR TITLE
enh(rule): do not block Rule retrieval if not contact and contact groups

### DIFF
--- a/centreon/src/Core/ResourceAccess/Domain/Model/NewRule.php
+++ b/centreon/src/Core/ResourceAccess/Domain/Model/NewRule.php
@@ -69,8 +69,6 @@ class NewRule
         }
 
         Assertion::notEmpty($this->datasetFilters, "{$shortName}::datasetFilters");
-
-        $this->assertContactAndOrContactGroup();
     }
 
     /**
@@ -145,21 +143,6 @@ class NewRule
     public function doesApplyToAllContactGroups(): bool
     {
         return $this->applyToAllContactGroups;
-    }
-
-    /**
-     * @throws \InvalidArgumentException
-     */
-    private function assertContactAndOrContactGroup(): void
-    {
-        if (
-            $this->linkedContactIds === []
-            && $this->linkedContactGroupIds === []
-            && $this->applyToAllContacts === false
-            && $this->applyToAllContactGroups === false
-        ) {
-            throw new \InvalidArgumentException('At least one contact or contactgroup should be linked to the rule');
-        }
     }
 }
 

--- a/centreon/tests/php/Core/ResourceAccess/Domain/Model/RuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Domain/Model/RuleTest.php
@@ -157,21 +157,6 @@ it('should throw an exception when rules name is an string exceeding max size', 
     )->getMessage(),
 );
 
-it('should throw an exception when linked contact groups and contacts are empty arrays', function (): void {
-    new Rule(
-        id: 1,
-        name: 'FULL',
-        description: 'Full access',
-        linkedContacts: [],
-        linkedContactGroups: [],
-        datasets: $this->datasets,
-        isEnabled: true
-    );
-})->throws(
-    \InvalidArgumentException::class,
-    'At least one contact or contactgroup should be linked to the rule'
-);
-
 it('should throw an exception when linked contacts is not an array of int', function (): void {
     new Rule(
         id: 1,


### PR DESCRIPTION
> [!TIP]
> Ticket - https://centreon.atlassian.net/browse/MON-161109
> This PR intends to remove the validation of the presence of contact + contactgroups on the Rule definition. This will allow to retrieve a rule through the FindRule endpoint without errors if contactgroups and contacts are empty (due to a contactgroup deletion for instance)

> [!IMPORTANT]
> This will not allow to create a rule / update a rule without providing the necessary contacts and contactgroups as those validations are done in the related use cases (AddRule + UpdateRule)  