### PR TITLE
enh(database): add comments for hosts related tables

### DIFF
--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -1695,7 +1695,7 @@ CREATE TABLE `on_demand_macro_host` (
   PRIMARY KEY (`host_macro_id`),
   KEY `host_host_id` (`host_host_id`),
   CONSTRAINT `on_demand_macro_host_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores the on-demand macros for hosts.';
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores the on-demand macros for hosts/host templates.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -755,13 +755,13 @@ CREATE TABLE `contact` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `contact_host_relation` (
-  `host_host_id` int(11) DEFAULT NULL,
-  `contact_id` int(11) DEFAULT NULL,
+  `host_host_id` int(11) DEFAULT NULL COMMENT 'Host ID',
+  `contact_id` int(11) DEFAULT NULL COMMENT 'Contact ID',
   KEY `host_index` (`host_host_id`),
   KEY `contact_id` (`contact_id`),
   CONSTRAINT `contact_host_relation_ibfk_2` FOREIGN KEY (`contact_id`) REFERENCES `contact` (`contact_id`) ON DELETE CASCADE,
   CONSTRAINT `contact_host_relation_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between contact and host';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -838,24 +838,24 @@ CREATE TABLE `contactgroup_contact_relation` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `contactgroup_host_relation` (
-  `host_host_id` int(11) DEFAULT NULL,
-  `contactgroup_cg_id` int(11) DEFAULT NULL,
+  `host_host_id` int(11) DEFAULT NULL COMMENT 'Host ID',
+  `contactgroup_cg_id` int(11) DEFAULT NULL COMMENT 'Contactgroup ID',
   KEY `host_index` (`host_host_id`),
   KEY `contactgroup_index` (`contactgroup_cg_id`),
   CONSTRAINT `contactgroup_host_relation_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `contactgroup_host_relation_ibfk_2` FOREIGN KEY (`contactgroup_cg_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between contactgroup and host';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `contactgroup_hostgroup_relation` (
-  `contactgroup_cg_id` int(11) DEFAULT NULL,
-  `hostgroup_hg_id` int(11) DEFAULT NULL,
+  `contactgroup_cg_id` int(11) DEFAULT NULL COMMENT 'Contactgroup ID',
+  `hostgroup_hg_id` int(11) DEFAULT NULL COMMENT 'Hostgroup ID',
   KEY `contactgroup_index` (`contactgroup_cg_id`),
   KEY `hostgroup_index` (`hostgroup_hg_id`),
   CONSTRAINT `contactgroup_hostgroup_relation_ibfk_1` FOREIGN KEY (`contactgroup_cg_id`) REFERENCES `contactgroup` (`cg_id`) ON DELETE CASCADE,
   CONSTRAINT `contactgroup_hostgroup_relation_ibfk_2` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between contactgroup and hostgroup';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -961,50 +961,50 @@ CREATE TABLE `dependency` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `dependency_hostChild_relation` (
-  `dependency_dep_id` int(11) DEFAULT NULL,
-  `host_host_id` int(11) DEFAULT NULL,
+  `dependency_dep_id` int(11) DEFAULT NULL COMMENT 'Dependency ID',
+  `host_host_id` int(11) DEFAULT NULL COMMENT 'Child host ID',
   KEY `dependency_index` (`dependency_dep_id`),
   KEY `host_index` (`host_host_id`),
   UNIQUE (`dependency_dep_id`, `host_host_id`),
   CONSTRAINT `dependency_hostChild_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_hostChild_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between dependency and host as child';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `dependency_hostParent_relation` (
-  `dependency_dep_id` int(11) DEFAULT NULL,
-  `host_host_id` int(11) DEFAULT NULL,
+  `dependency_dep_id` int(11) DEFAULT NULL COMMENT 'Dependency ID',
+  `host_host_id` int(11) DEFAULT NULL COMMENT 'Parent host ID',
   KEY `dependency_index` (`dependency_dep_id`),
   KEY `host_index` (`host_host_id`),
   UNIQUE (`dependency_dep_id`, `host_host_id`),
   CONSTRAINT `dependency_hostParent_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_hostParent_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between dependency and host as parent';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `dependency_hostgroupChild_relation` (
-  `dependency_dep_id` int(11) DEFAULT NULL,
-  `hostgroup_hg_id` int(11) DEFAULT NULL,
+  `dependency_dep_id` int(11) DEFAULT NULL COMMENT 'Dependency ID',
+  `hostgroup_hg_id` int(11) DEFAULT NULL COMMENT 'Child hostgroup ID',
   KEY `dependency_index` (`dependency_dep_id`),
   KEY `hostgroup_index` (`hostgroup_hg_id`),
   UNIQUE (`dependency_dep_id`, `hostgroup_hg_id`),
   CONSTRAINT `dependency_hostgroupChild_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_hostgroupChild_relation_ibfk_2` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between dependency and hostgroup as child';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `dependency_hostgroupParent_relation` (
-  `dependency_dep_id` int(11) DEFAULT NULL,
-  `hostgroup_hg_id` int(11) DEFAULT NULL,
+  `dependency_dep_id` int(11) DEFAULT NULL COMMENT 'Dependency ID',
+  `hostgroup_hg_id` int(11) DEFAULT NULL COMMENT 'Parent hostgroup ID',
   KEY `dependency_index` (`dependency_dep_id`),
   KEY `hostgroup_index` (`hostgroup_hg_id`),
   UNIQUE (`dependency_dep_id`, `hostgroup_hg_id`),
   CONSTRAINT `dependency_hostgroupParent_relation_ibfk_1` FOREIGN KEY (`dependency_dep_id`) REFERENCES `dependency` (`dep_id`) ON DELETE CASCADE,
   CONSTRAINT `dependency_hostgroupParent_relation_ibfk_2` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between dependency and hostgroup as parent';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1099,24 +1099,24 @@ CREATE TABLE `downtime` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `downtime_host_relation` (
-  `dt_id` int(11) NOT NULL,
-  `host_host_id` int(11) NOT NULL,
+  `dt_id` int(11) NOT NULL COMMENT 'Downtime ID',
+  `host_host_id` int(11) NOT NULL COMMENT 'Host ID',
   PRIMARY KEY (`dt_id`,`host_host_id`),
   KEY `downtime_host_relation_ibfk_1` (`host_host_id`),
   CONSTRAINT `downtime_host_relation_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `downtime_host_relation_ibfk_2` FOREIGN KEY (`dt_id`) REFERENCES `downtime` (`dt_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between downtime and host';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `downtime_hostgroup_relation` (
-  `dt_id` int(11) NOT NULL,
-  `hg_hg_id` int(11) NOT NULL,
+  `dt_id` int(11) NOT NULL COMMENT 'Downtime ID',
+  `hg_hg_id` int(11) NOT NULL COMMENT 'Hostgroup ID',
   PRIMARY KEY (`dt_id`,`hg_hg_id`),
   KEY `downtime_hostgroup_relation_ibfk_1` (`hg_hg_id`),
   CONSTRAINT `downtime_hostgroup_relation_ibfk_1` FOREIGN KEY (`hg_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE,
   CONSTRAINT `downtime_hostgroup_relation_ibfk_2` FOREIGN KEY (`dt_id`) REFERENCES `downtime` (`dt_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between downtime and hostgroup';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1194,24 +1194,24 @@ CREATE TABLE `escalation_contactgroup_relation` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `escalation_host_relation` (
-  `escalation_esc_id` int(11) DEFAULT NULL,
-  `host_host_id` int(11) DEFAULT NULL,
+  `escalation_esc_id` int(11) DEFAULT NULL COMMENT 'Escalation ID',
+  `host_host_id` int(11) DEFAULT NULL COMMENT 'Host ID',
   KEY `escalation_index` (`escalation_esc_id`),
   KEY `host_index` (`host_host_id`),
   CONSTRAINT `escalation_host_relation_ibfk_1` FOREIGN KEY (`escalation_esc_id`) REFERENCES `escalation` (`esc_id`) ON DELETE CASCADE,
   CONSTRAINT `escalation_host_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between escalation and host';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `escalation_hostgroup_relation` (
-  `escalation_esc_id` int(11) DEFAULT NULL,
-  `hostgroup_hg_id` int(11) DEFAULT NULL,
+  `escalation_esc_id` int(11) DEFAULT NULL COMMENT 'Escalation ID',
+  `hostgroup_hg_id` int(11) DEFAULT NULL COMMENT 'Hostgroup ID',
   KEY `escalation_index` (`escalation_esc_id`),
   KEY `hg_index` (`hostgroup_hg_id`),
   CONSTRAINT `escalation_hostgroup_relation_ibfk_1` FOREIGN KEY (`escalation_esc_id`) REFERENCES `escalation` (`esc_id`) ON DELETE CASCADE,
   CONSTRAINT `escalation_hostgroup_relation_ibfk_2` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='Relation table between escalation and hostgroup';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1252,17 +1252,17 @@ CREATE TABLE `escalation_servicegroup_relation` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `extended_host_information` (
-  `ehi_id` int(11) NOT NULL AUTO_INCREMENT,
-  `host_host_id` int(11) DEFAULT NULL,
-  `ehi_notes` TEXT DEFAULT NULL,
-  `ehi_notes_url` TEXT DEFAULT NULL,
-  `ehi_action_url` TEXT DEFAULT NULL,
-  `ehi_icon_image` int(11) DEFAULT NULL,
-  `ehi_icon_image_alt` varchar(200) DEFAULT NULL,
+  `ehi_id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Unique identifier for the extended host information entry.',
+  `host_host_id` int(11) DEFAULT NULL COMMENT 'The host this extended information belongs to.',
+  `ehi_notes` TEXT DEFAULT NULL COMMENT 'Notes about the host.',
+  `ehi_notes_url` TEXT DEFAULT NULL COMMENT 'URL to additional notes about the host.',
+  `ehi_action_url` TEXT DEFAULT NULL COMMENT 'URL to an action to be performed on the host.',
+  `ehi_icon_image` int(11) DEFAULT NULL COMMENT 'The icon image for the host.',
+  `ehi_icon_image_alt` varchar(200) DEFAULT NULL COMMENT 'The alt text for the icon image.',
   `ehi_vrml_image` int(11) DEFAULT NULL,
-  `ehi_statusmap_image` int(11) DEFAULT NULL,
-  `ehi_2d_coords` varchar(200) DEFAULT NULL,
-  `ehi_3d_coords` varchar(200) DEFAULT NULL,
+  `ehi_statusmap_image` int(11) DEFAULT NULL COMMENT 'The statusmap image for the host.',
+  `ehi_2d_coords` varchar(200) DEFAULT NULL COMMENT 'The 2D coordinates for the host.',
+  `ehi_3d_coords` varchar(200) DEFAULT NULL COMMENT 'The 3D coordinates for the host.',
   PRIMARY KEY (`ehi_id`),
   UNIQUE KEY `host_host_id` (`host_host_id`),
   KEY `host_index` (`host_host_id`),
@@ -1271,7 +1271,7 @@ CREATE TABLE `extended_host_information` (
   CONSTRAINT `extended_host_information_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `extended_host_information_ibfk_2` FOREIGN KEY (`ehi_icon_image`) REFERENCES `view_img` (`img_id`) ON DELETE SET NULL,
   CONSTRAINT `extended_host_information_ibfk_4` FOREIGN KEY (`ehi_statusmap_image`) REFERENCES `view_img` (`img_id`) ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores additional details about hosts.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1349,53 +1349,53 @@ CREATE TABLE `giv_graphs_template` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `host` (
-  `host_id` int(11) NOT NULL AUTO_INCREMENT,
-  `host_template_model_htm_id` int(11) DEFAULT NULL,
-  `command_command_id` int(11) DEFAULT NULL,
-  `command_command_id_arg1` text,
-  `timeperiod_tp_id` int(11) DEFAULT NULL,
-  `timeperiod_tp_id2` int(11) DEFAULT NULL,
-  `command_command_id2` int(11) DEFAULT NULL,
-  `command_command_id_arg2` text,
-  `host_name` varchar(200) DEFAULT NULL,
-  `host_alias` varchar(200) DEFAULT NULL,
-  `host_address` varchar(255) DEFAULT NULL,
-  `display_name` varchar(255) DEFAULT NULL,
-  `host_max_check_attempts` int(11) DEFAULT NULL,
-  `host_check_interval` int(11) DEFAULT NULL,
-  `host_retry_check_interval` int(11) DEFAULT NULL,
-  `host_active_checks_enabled` enum('0','1','2') DEFAULT NULL,
-  `host_passive_checks_enabled` enum('0','1','2') DEFAULT NULL,
-  `host_checks_enabled` enum('0','1','2') DEFAULT NULL,
-  `initial_state` enum('o','d','u') DEFAULT NULL,
-  `host_obsess_over_host` enum('0','1','2') DEFAULT NULL,
-  `host_check_freshness` enum('0','1','2') DEFAULT NULL,
-  `host_freshness_threshold` int(11) DEFAULT NULL,
-  `host_event_handler_enabled` enum('0','1','2') DEFAULT NULL,
-  `host_low_flap_threshold` int(11) DEFAULT NULL,
-  `host_high_flap_threshold` int(11) DEFAULT NULL,
-  `host_flap_detection_enabled` enum('0','1','2') DEFAULT NULL,
-  `flap_detection_options` varchar(255) DEFAULT NULL,
-  `host_process_perf_data` enum('0','1','2') DEFAULT NULL,
-  `host_retain_status_information` enum('0','1','2') DEFAULT NULL,
-  `host_retain_nonstatus_information` enum('0','1','2') DEFAULT NULL,
-  `host_notification_interval` int(11) DEFAULT NULL,
-  `host_recovery_notification_delay` int(11) DEFAULT NULL,
-  `host_notification_options` varchar(200) DEFAULT NULL,
-  `host_notifications_enabled` enum('0','1','2') DEFAULT NULL,
-  `contact_additive_inheritance` boolean DEFAULT 0,
-  `cg_additive_inheritance` boolean DEFAULT 0,
-  `host_first_notification_delay` int(11) DEFAULT NULL,
-  `host_acknowledgement_timeout` int(11) DEFAULT NULL,
-  `host_stalking_options` varchar(200) DEFAULT NULL,
-  `host_snmp_community` varchar(255) DEFAULT NULL,
-  `host_snmp_version` varchar(255) DEFAULT NULL,
-  `host_location` int(11) DEFAULT '0',
-  `host_comment` text,
-  `geo_coords` varchar(32) DEFAULT NULL,
-  `host_locked` BOOLEAN DEFAULT 0,
-  `host_register` enum('0','1','2','3') DEFAULT NULL,
-  `host_activate` enum('0','1','2') DEFAULT '1',
+  `host_id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Unique identifier for the host',
+  `host_template_model_htm_id` int(11) DEFAULT NULL COMMENT 'Identifier for the host template model',
+  `command_command_id` int(11) DEFAULT NULL COMMENT 'Identifier for the command used for host checks',
+  `command_command_id_arg1` text COMMENT 'Arguments for the command used for host checks',
+  `timeperiod_tp_id` int(11) DEFAULT NULL COMMENT 'Identifier for the time period during which host checks are performed',
+  `timeperiod_tp_id2` int(11) DEFAULT NULL COMMENT 'Identifier for the time period during which host notifications are sent',
+  `command_command_id2` int(11) DEFAULT NULL COMMENT 'Identifier for the command used for host notifications',
+  `command_command_id_arg2` text COMMENT 'Arguments for the command used for host notifications',
+  `host_name` varchar(200) DEFAULT NULL COMMENT 'Name of the host',
+  `host_alias` varchar(200) DEFAULT NULL COMMENT 'Alias of the host',
+  `host_address` varchar(255) DEFAULT NULL COMMENT 'Address of the host',
+  `display_name` varchar(255) DEFAULT NULL COMMENT 'Display name of the host',
+  `host_max_check_attempts` int(11) DEFAULT NULL COMMENT 'Maximum number of check attempts for the host',
+  `host_check_interval` int(11) DEFAULT NULL COMMENT 'Interval between checks for the host',
+  `host_retry_check_interval` int(11) DEFAULT NULL COMMENT 'Interval between retry checks for the host',
+  `host_active_checks_enabled` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether active checks are enabled for the host',
+  `host_passive_checks_enabled` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether passive checks are enabled for the host',
+  `host_checks_enabled` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether checks are enabled for the host',
+  `initial_state` enum('o','d','u') DEFAULT NULL COMMENT 'Initial state of the host',
+  `host_obsess_over_host` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether to obsess over the host',
+  `host_check_freshness` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether to check the freshness of the host',
+  `host_freshness_threshold` int(11) DEFAULT NULL COMMENT 'Freshness threshold for the host',
+  `host_event_handler_enabled` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether the event handler is enabled for the host',
+  `host_low_flap_threshold` int(11) DEFAULT NULL COMMENT 'Low flapping threshold for the host',
+  `host_high_flap_threshold` int(11) DEFAULT NULL COMMENT 'High flapping threshold for the host',
+  `host_flap_detection_enabled` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether flapping detection is enabled for the host',
+  `flap_detection_options` varchar(255) DEFAULT NULL COMMENT 'Options for detecting frequent state changes (flapping)',
+  `host_process_perf_data` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether to process performance data for the host',
+  `host_retain_status_information` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether to retain status information for the host',
+  `host_retain_nonstatus_information` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether to retain non-status information for the host',
+  `host_notification_interval` int(11) DEFAULT NULL COMMENT 'Interval between notifications for the host',
+  `host_recovery_notification_delay` int(11) DEFAULT NULL COMMENT 'Delay before sending recovery notifications for the host',
+  `host_notification_options` varchar(200) DEFAULT NULL COMMENT 'Options for host notifications',
+  `host_notifications_enabled` enum('0','1','2') DEFAULT NULL COMMENT 'Indicates whether notifications are enabled for the host',
+  `contact_additive_inheritance` boolean DEFAULT 0 COMMENT 'Indicates whether contact inheritance is additive',
+  `cg_additive_inheritance` boolean DEFAULT 0 COMMENT 'Indicates whether contact group inheritance is additive',
+  `host_first_notification_delay` int(11) DEFAULT NULL COMMENT 'Delay before sending the first notification for the host',
+  `host_acknowledgement_timeout` int(11) DEFAULT NULL COMMENT 'Timeout for host acknowledgements',
+  `host_stalking_options` varchar(200) DEFAULT NULL COMMENT 'Options for host stalking',
+  `host_snmp_community` varchar(255) DEFAULT NULL COMMENT 'SNMP community string used for SNMP communication with the host',
+  `host_snmp_version` varchar(255) DEFAULT NULL COMMENT 'SNMP version for the host',
+  `host_location` int(11) DEFAULT '0' COMMENT 'Location identifier for the host',
+  `host_comment` text COMMENT 'Comment about the host',
+  `geo_coords` varchar(32) DEFAULT NULL COMMENT 'Geographical coordinates of the host',
+  `host_locked` BOOLEAN DEFAULT 0 COMMENT 'Indicates whether the host is locked',
+  `host_register` enum('0','1','2','3') DEFAULT NULL COMMENT 'Indicates whether is is a host template 0, a host 1 or a meta host 2',
+  `host_activate` enum('0','1','2') DEFAULT '1' COMMENT 'Indicates whether the host is active, 0 for active, 1 for inactive',
   PRIMARY KEY (`host_id`),
   KEY `htm_index` (`host_template_model_htm_id`),
   KEY `cmd1_index` (`command_command_id`),
@@ -1410,27 +1410,27 @@ CREATE TABLE `host` (
   CONSTRAINT `host_ibfk_2` FOREIGN KEY (`command_command_id2`) REFERENCES `command` (`command_id`) ON DELETE SET NULL,
   CONSTRAINT `host_ibfk_3` FOREIGN KEY (`timeperiod_tp_id`) REFERENCES `timeperiod` (`tp_id`) ON DELETE SET NULL,
   CONSTRAINT `host_ibfk_4` FOREIGN KEY (`timeperiod_tp_id2`) REFERENCES `timeperiod` (`tp_id`) ON DELETE SET NULL
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores configuration information about hosts and host templates.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `host_hostparent_relation` (
-  `host_parent_hp_id` int(11) DEFAULT NULL,
-  `host_host_id` int(11) DEFAULT NULL,
+  `host_parent_hp_id` int(11) DEFAULT NULL COMMENT 'Identifier for the parent host',
+  `host_host_id` int(11) DEFAULT NULL COMMENT 'Identifier for the child host',
   KEY `host1_index` (`host_parent_hp_id`),
   KEY `host2_index` (`host_host_id`),
   CONSTRAINT `host_hostparent_relation_ibfk_1` FOREIGN KEY (`host_parent_hp_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `host_hostparent_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores the parent-child relationship between hosts.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `host_service_relation` (
-  `hsr_id` int(11) NOT NULL AUTO_INCREMENT,
-  `hostgroup_hg_id` int(11) DEFAULT NULL,
-  `host_host_id` int(11) DEFAULT NULL,
-  `servicegroup_sg_id` int(11) DEFAULT NULL,
-  `service_service_id` int(11) DEFAULT NULL,
+  `hsr_id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Unique identifier for the host-service relation',
+  `hostgroup_hg_id` int(11) DEFAULT NULL COMMENT 'Identifier for the host group',
+  `host_host_id` int(11) DEFAULT NULL COMMENT 'Identifier for the host',
+  `servicegroup_sg_id` int(11) DEFAULT NULL COMMENT 'Identifier for the service group',
+  `service_service_id` int(11) DEFAULT NULL COMMENT 'Identifier for the service',
   PRIMARY KEY (`hsr_id`),
   KEY `hostgroup_index` (`hostgroup_hg_id`),
   KEY `host_index` (`host_host_id`),
@@ -1441,90 +1441,90 @@ CREATE TABLE `host_service_relation` (
   CONSTRAINT `host_service_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `host_service_relation_ibfk_3` FOREIGN KEY (`servicegroup_sg_id`) REFERENCES `servicegroup` (`sg_id`) ON DELETE CASCADE,
   CONSTRAINT `host_service_relation_ibfk_4` FOREIGN KEY (`service_service_id`) REFERENCES `service` (`service_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores the relationship between hosts and services.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `host_template_relation` (
-  `host_host_id` int(11) NOT NULL DEFAULT '0',
-  `host_tpl_id` int(11) NOT NULL DEFAULT '0',
-  `order` int(11) DEFAULT NULL,
+  `host_host_id` int(11) NOT NULL DEFAULT '0' COMMENT 'Identifier for the host',
+  `host_tpl_id` int(11) NOT NULL DEFAULT '0' COMMENT 'Identifier for the host template',
+  `order` int(11) DEFAULT NULL COMMENT 'Order of inheritance',
   PRIMARY KEY (`host_host_id`,`host_tpl_id`),
   KEY `host_tpl_id` (`host_tpl_id`),
   CONSTRAINT `host_template_relation_ibfk_2` FOREIGN KEY (`host_tpl_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `host_template_relation_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores the relationship between hosts and host templates.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `hostcategories` (
-  `hc_id` int(11) NOT NULL AUTO_INCREMENT,
-  `hc_name` varchar(200) DEFAULT NULL,
-  `hc_alias` varchar(200) DEFAULT NULL,
-  `level` TINYINT(5) DEFAULT NULL,
-  `icon_id` INT(11) DEFAULT NULL,
-  `hc_comment` text,
-  `hc_activate` enum('0','1') NOT NULL DEFAULT '1',
+  `hc_id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Unique identifier for the host category',
+  `hc_name` varchar(200) DEFAULT NULL COMMENT 'Name of the host category',
+  `hc_alias` varchar(200) DEFAULT NULL COMMENT 'Alias of the host category',
+  `level` TINYINT(5) DEFAULT NULL COMMENT 'Hierarchy level of the host category',
+  `icon_id` INT(11) DEFAULT NULL COMMENT 'Identifier for the icon image',
+  `hc_comment` text COMMENT 'Comment about the host category',
+  `hc_activate` enum('0','1') NOT NULL DEFAULT '1' COMMENT 'Indicates whether the category is active 1 or disabled 0',
   PRIMARY KEY (`hc_id`),
   KEY `name_index` (`hc_name`),
   KEY `alias_index` (`hc_alias`),
   KEY `level_index` (`level`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores the host categories.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `hostcategories_relation` (
-  `hostcategories_hc_id` int(11) DEFAULT NULL,
-  `host_host_id` int(11) DEFAULT NULL,
+  `hostcategories_hc_id` int(11) DEFAULT NULL COMMENT 'Identifier for the host category',
+  `host_host_id` int(11) DEFAULT NULL COMMENT 'Identifier for the host',
   KEY `hostcategories_index` (`hostcategories_hc_id`),
   KEY `host_index` (`host_host_id`),
   CONSTRAINT `hostcategories_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE,
   CONSTRAINT `hostcategories_relation_ibfk_1` FOREIGN KEY (`hostcategories_hc_id`) REFERENCES `hostcategories` (`hc_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores the relationship between hosts and host categories.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `hostgroup` (
-  `hg_id` int(11) NOT NULL AUTO_INCREMENT,
-  `hg_name` varchar(200) DEFAULT NULL,
-  `hg_alias` varchar(200) DEFAULT NULL,
-  `hg_notes` varchar(255) DEFAULT NULL,
-  `hg_notes_url` varchar(255) DEFAULT NULL,
-  `hg_action_url` varchar(255) DEFAULT NULL,
-  `hg_icon_image` int(11) DEFAULT NULL,
-  `hg_map_icon_image` int(11) DEFAULT NULL,
-  `hg_rrd_retention` int(11) DEFAULT NULL,
-  `geo_coords` varchar(32) DEFAULT NULL,
-  `hg_comment` text,
-  `hg_activate` enum('0','1') NOT NULL DEFAULT '1',
+  `hg_id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Unique identifier for the host group',
+  `hg_name` varchar(200) DEFAULT NULL COMMENT 'Name of the host group',
+  `hg_alias` varchar(200) DEFAULT NULL COMMENT 'Alias of the host group',
+  `hg_notes` varchar(255) DEFAULT NULL COMMENT 'Notes about the host group',
+  `hg_notes_url` varchar(255) DEFAULT NULL COMMENT 'URL for notes about the host group',
+  `hg_action_url` varchar(255) DEFAULT NULL COMMENT 'URL for actions about the host group',
+  `hg_icon_image` int(11) DEFAULT NULL COMMENT 'Identifier for the icon image',
+  `hg_map_icon_image` int(11) DEFAULT NULL COMMENT 'Identifier for the map icon image',
+  `hg_rrd_retention` int(11) DEFAULT NULL COMMENT 'RRD retention for the host group',
+  `geo_coords` varchar(32) DEFAULT NULL COMMENT 'Geographical coordinates of the host group',
+  `hg_comment` text COMMENT 'Comment about the host group',
+  `hg_activate` enum('0','1') NOT NULL DEFAULT '1' COMMENT 'Indicates whether the host group is active 1 or disabled 0',
   PRIMARY KEY (`hg_id`),
   KEY `name_index` (`hg_name`),
   KEY `alias_index` (`hg_alias`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores configuration information about host groups.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `hostgroup_hg_relation` (
-  `hg_parent_id` int(11) DEFAULT NULL,
-  `hg_child_id` int(11) DEFAULT NULL,
+  `hg_parent_id` int(11) DEFAULT NULL COMMENT 'Identifier for the parent host group',
+  `hg_child_id` int(11) DEFAULT NULL COMMENT 'Identifier for the child host group',
   KEY `hg_parent_id` (`hg_parent_id`),
   KEY `hg_child_id` (`hg_child_id`),
   CONSTRAINT `hostgroup_hg_relation_ibfk_2` FOREIGN KEY (`hg_child_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE,
   CONSTRAINT `hostgroup_hg_relation_ibfk_1` FOREIGN KEY (`hg_parent_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores the parent-child relationship between host groups.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `hostgroup_relation` (
-  `hgr_id` int(11) NOT NULL AUTO_INCREMENT,
-  `hostgroup_hg_id` int(11) DEFAULT NULL,
-  `host_host_id` int(11) DEFAULT NULL,
+  `hgr_id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Unique identifier for the host group relation',
+  `hostgroup_hg_id` int(11) DEFAULT NULL COMMENT 'Identifier for the host group',
+  `host_host_id` int(11) DEFAULT NULL COMMENT 'Identifier for the host',
   PRIMARY KEY (`hgr_id`),
   KEY `hostgroup_index` (`hostgroup_hg_id`),
   KEY `host_index` (`host_host_id`),
   CONSTRAINT `hostgroup_relation_ibfk_1` FOREIGN KEY (`hostgroup_hg_id`) REFERENCES `hostgroup` (`hg_id`) ON DELETE CASCADE,
   CONSTRAINT `hostgroup_relation_ibfk_2` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores the relationship between host groups and hosts.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
@@ -1659,8 +1659,8 @@ CREATE TABLE `nagios_server` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `ns_host_relation` (
-  `nagios_server_id` int(11) NOT NULL DEFAULT '0',
-  `host_host_id` int(11) NOT NULL DEFAULT '0',
+  `nagios_server_id` int(11) NOT NULL DEFAULT '0' COMMENT 'Identifier for the centreon server',
+  `host_host_id` int(11) NOT NULL DEFAULT '0' COMMENT 'Identifier for the host',
   PRIMARY KEY (`nagios_server_id`,`host_host_id`),
   KEY `host_host_id` (`host_host_id`),
   KEY `nagios_server_id` (`nagios_server_id`),
@@ -1685,17 +1685,17 @@ CREATE TABLE `ods_view_details` (
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;
 CREATE TABLE `on_demand_macro_host` (
-  `host_macro_id` int(11) NOT NULL AUTO_INCREMENT,
-  `host_macro_name` varchar(255) NOT NULL,
-  `host_macro_value` varchar(4096) NOT NULL,
-  `is_password` tinyint(2) DEFAULT 0,
-  `description` text DEFAULT NULL,
-  `host_host_id` int(11) NOT NULL,
-  `macro_order` int(11) NULL DEFAULT 0,
+  `host_macro_id` int(11) NOT NULL AUTO_INCREMENT COMMENT 'Unique identifier for the on-demand macro',
+  `host_macro_name` varchar(255) NOT NULL COMMENT 'Name of the on-demand macro',
+  `host_macro_value` varchar(4096) NOT NULL COMMENT 'Value of the on-demand macro',
+  `is_password` tinyint(2) DEFAULT 0 COMMENT 'Indicates whether the macro is a password',
+  `description` text DEFAULT NULL COMMENT 'Description of the on-demand macro',
+  `host_host_id` int(11) NOT NULL COMMENT 'Identifier for the host',
+  `macro_order` int(11) NULL DEFAULT 0 COMMENT 'Order of the macro',
   PRIMARY KEY (`host_macro_id`),
   KEY `host_host_id` (`host_host_id`),
   CONSTRAINT `on_demand_macro_host_ibfk_1` FOREIGN KEY (`host_host_id`) REFERENCES `host` (`host_id`) ON DELETE CASCADE
-) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COMMENT='This table stores the on-demand macros for hosts.';
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;


### PR DESCRIPTION
## Description

The goal from this PR is to add comments on Host related tables to help understanding the use of the columns / tables.

Commented tables (and associated columns) :

```
host
host_hostparent_relation
host_service_relation
host_template_relation
hostcategories
hostcategories_relation
hostgroup
hostgroup_hg_relation
hostgroup_relation
on_demand_macro_host
extended_host_information
contact_host_relation
contactgroup_host_relation
contactgroup_hostgroup_relation
dependency_hostChild_relation
dependency_hostParent_relation
dependency_hostgroupChild_relation
dependency_hostgroupParent_relation
downtime_host_relation
downtime_hostgroup_relation
escalation_host_relation
escalation_hostgroup_relation
ns_host_relation
```

**Fixes** # ([MON-155277](https://centreon.atlassian.net/browse/MON-155277))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-155277]: https://centreon.atlassian.net/browse/MON-155277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ