### PR TITLE
fix(host): only update severity when severity is set

### DIFF
--- a/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostRepository.php
+++ b/centreon/src/Core/Host/Infrastructure/Repository/DbWriteHostRepository.php
@@ -182,7 +182,9 @@ class DbWriteHostRepository extends AbstractRepositoryRDB implements WriteHostRe
     private function updateSeverity(Host $host): void
     {
         $this->deleteLinkToSeverity($host->getId());
-        $this->addSeverity($host->getId(), $host);
+        if ($host->getSeverityId() !== null) {
+            $this->addSeverity($host->getId(), $host);
+        }
     }
 
     /**


### PR DESCRIPTION
This PR itends to fix an issue where Severity was trying to be updated without even has been setted before.

**Fixes** # MON-158875

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] 24.10.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
