### PR TITLE
fix(cloud): fix poller not visible in list after creation

### DIFF
--- a/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
+++ b/centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
@@ -371,6 +371,7 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
      */
     public function postLinkCentreonRemoteServer(): array
     {
+        global $pearDB;
         // retrieve post values to be used in other classes
         $_POST = json_decode(file_get_contents('php://input'), true);
 
@@ -541,6 +542,15 @@ class CentreonConfigurationRemote extends CentreonWebServiceAbstract
                 'address' => $serverIP,
             ]);
         }
+
+        // Update session to reload ACL
+        $sid = session_id();
+        $statement = $pearDB->prepareQuery(
+            <<<'SQL'
+                UPDATE session SET update_acl = '1' WHERE session_id = :sessionId
+                SQL
+        );
+        $pearDB->executePreparedQuery($statement, ['sessionId' => $sid]);
 
         return ['success' => true, 'task_id' => $taskId];
     }

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -165,6 +165,17 @@ class CentreonACL
     }
 
     /**
+     * Function that will update poller ACL
+     *
+     * @return void
+     */
+    public function updatePollerACL(): void
+    {
+        $this->pollers = [];
+        $this->setPollers();
+    }
+
+    /**
      * Function that will check whether or not the user needs to rebuild his ACL
      *
      * @return void

--- a/centreon/www/include/configuration/configServers/DB-Func.php
+++ b/centreon/www/include/configuration/configServers/DB-Func.php
@@ -721,6 +721,11 @@ function insertServer(array $data): int
         $fields
     );
 
+    /**
+     * Update poller ACL.
+     */
+    $centreon->user->access->updatePollerACL();
+
     return (int)$poller["last_id"];
 }
 

--- a/centreon/www/include/configuration/configServers/servers.php
+++ b/centreon/www/include/configuration/configServers/servers.php
@@ -64,6 +64,14 @@ if (isset($ret) && is_array($ret) && $ret['topology_page'] != "" && $p != $ret['
     $p = $ret['topology_page'];
 }
 
+/* 
+ * Call poller update function to manage poller auto injection by script 
+ */
+$centreon->user->access->updatePollerACL();
+
+/* 
+ * Build poller listing for ACL
+ */
 $serverResult =
     $centreon->user->access->getPollerAclConf(
         [

--- a/centreon/www/include/configuration/configServers/servers.php
+++ b/centreon/www/include/configuration/configServers/servers.php
@@ -64,12 +64,7 @@ if (isset($ret) && is_array($ret) && $ret['topology_page'] != "" && $p != $ret['
     $p = $ret['topology_page'];
 }
 
-/* 
- * Call poller update function to manage poller auto injection by script 
- */
-$centreon->user->access->updatePollerACL();
-
-/* 
+/*
  * Build poller listing for ACL
  */
 $serverResult =


### PR DESCRIPTION
## Description

This PR solves an issue in cloud platform where non-admin users couldn't see newly created pollers and remote servers without manually reloading ACLs or loging out / in.

**Fixes** # ([MON-157190](https://centreon.atlassian.net/browse/MON-157190))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- Create a new poller / remote server from the wizard or the advanced form
- The poller should apprear in the list without needing to reload ACLs

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-157190]: https://centreon.atlassian.net/browse/MON-157190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ