### PR TITLE
fix(ci): centreon-broker-cbmod does not exist anymore

### DIFF
--- a/.github/docker/centreon-web/alma8/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma8/Dockerfile.dependencies
@@ -139,7 +139,6 @@ dnf install -y \
   centreon-common \
   centreon-gorgone \
   centreon-engine \
-  centreon-broker-cbmod \
   centreon-broker-cbd \
   centreon-connector
 

--- a/.github/docker/centreon-web/alma9/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma9/Dockerfile.dependencies
@@ -135,7 +135,6 @@ dnf install -y \
   centreon-common \
   centreon-gorgone \
   centreon-engine \
-  centreon-broker-cbmod \
   centreon-broker-cbd \
   centreon-connector
 

--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -144,7 +144,6 @@ apt-get install -y \
   centreon-common \
   centreon-gorgone \
   centreon-engine \
-  centreon-broker-cbmod \
   centreon-broker-cbd \
   centreon-connector
 

--- a/.github/docker/centreon-web/jammy/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/jammy/Dockerfile.dependencies
@@ -134,7 +134,6 @@ apt-get install -y \
   centreon-common \
   centreon-gorgone \
   centreon-engine \
-  centreon-broker-cbmod \
   centreon-broker-cbd \
   centreon-connector
 

--- a/centreon/packaging/centreon-poller.yaml
+++ b/centreon/packaging/centreon-poller.yaml
@@ -86,8 +86,6 @@ overrides:
       - centreon-trap = ${VERSION}-${RELEASE}${DIST}
       - centreon-engine >= ${MAJOR_VERSION}
       - centreon-engine < ${NEXT_MAJOR_VERSION}
-      - centreon-broker-cbmod >= ${MAJOR_VERSION}
-      - centreon-broker-cbmod < ${NEXT_MAJOR_VERSION}
       - centreon-connector >= ${MAJOR_VERSION}
       - centreon-connector < ${NEXT_MAJOR_VERSION}
       - centreon-gorgone-centreon-config >= ${MAJOR_VERSION}
@@ -120,6 +118,7 @@ overrides:
       - centreon-poller-centreon-engine
     conflicts:
       - centreon-poller-nagios
+      - centreon-broker-cbmod
   deb:
     depends:
       - "centreon-common (>= ${MAJOR_VERSION}~)"
@@ -127,8 +126,6 @@ overrides:
       - centreon-trap (= ${VERSION}-${RELEASE}${DIST})
       - "centreon-engine (>= ${MAJOR_VERSION}~)"
       - "centreon-engine (<< ${NEXT_MAJOR_VERSION}~)"
-      - "centreon-broker-cbmod (>= ${MAJOR_VERSION}~)"
-      - "centreon-broker-cbmod (<< ${NEXT_MAJOR_VERSION}~)"
       - "centreon-connector (>= ${MAJOR_VERSION}~)"
       - "centreon-connector (<< ${NEXT_MAJOR_VERSION}~)"
       - "centreon-gorgone-centreon-config (>= ${MAJOR_VERSION}~)"
@@ -158,6 +155,7 @@ overrides:
       - centreon-poller-centreon-engine
     conflicts:
       - centreon-poller-centreon-engine
+      - centreon-broker-cbmod
 
 rpm:
   summary: Rights and file for pollers (including central)

--- a/centreon/packaging/centreon-poller.yaml
+++ b/centreon/packaging/centreon-poller.yaml
@@ -118,7 +118,6 @@ overrides:
       - centreon-poller-centreon-engine
     conflicts:
       - centreon-poller-nagios
-      - centreon-broker-cbmod
   deb:
     depends:
       - "centreon-common (>= ${MAJOR_VERSION}~)"
@@ -155,7 +154,6 @@ overrides:
       - centreon-poller-centreon-engine
     conflicts:
       - centreon-poller-centreon-engine
-      - centreon-broker-cbmod
 
 rpm:
   summary: Rights and file for pollers (including central)

--- a/centreon/packaging/src/install.conf.php
+++ b/centreon/packaging/src/install.conf.php
@@ -23,4 +23,5 @@ $conf_centreon['monitoring_varlog'] = "/var/log/centreon-engine";
 $conf_centreon['plugin_dir'] = "/usr/lib64/nagios/plugins";
 $conf_centreon['centreon_engine_connectors'] = "/usr/lib64/centreon-connector";
 $conf_centreon['centreon_engine_lib'] = "/usr/lib64/centreon-engine";
+$conf_centreon['centreonbroker_cbmod'] = "/usr/lib64/nagios/cbmod.so";
 $conf_centreon['centreon_plugins'] = "/usr/lib/centreon/plugins";

--- a/centreon/packaging/src/install.conf.php
+++ b/centreon/packaging/src/install.conf.php
@@ -23,5 +23,4 @@ $conf_centreon['monitoring_varlog'] = "/var/log/centreon-engine";
 $conf_centreon['plugin_dir'] = "/usr/lib64/nagios/plugins";
 $conf_centreon['centreon_engine_connectors'] = "/usr/lib64/centreon-connector";
 $conf_centreon['centreon_engine_lib'] = "/usr/lib64/centreon-engine";
-$conf_centreon['centreonbroker_cbmod'] = "/usr/lib64/nagios/cbmod.so";
 $conf_centreon['centreon_plugins'] = "/usr/lib/centreon/plugins";


### PR DESCRIPTION
## Description

centreon-broker-cbmod is no more available. This fixes this point on centreon-poller side.

REFS: MON-162194

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [X] master
