### PR TITLE
fix(purge): make regexp compatible with mysql and mariadb

### DIFF
--- a/centreon/www/class/centreonPurgeEngine.class.php
+++ b/centreon/www/class/centreonPurgeEngine.class.php
@@ -125,7 +125,7 @@ class CentreonPurgeEngine
             $row = $DBRESULT->fetchRow();
             $matches = [];
             // dont care of MAXVALUE
-            if (preg_match_all('/PARTITION `(.*?)` VALUES LESS THAN \((.*?)\)/', $row['Create Table'], $matches)) {
+            if (preg_match_all('/PARTITION `{0,1}(.*?)`{0,1} VALUES LESS THAN \((.*?)\)/', $row['Create Table'], $matches)) {
                 $this->tablesToPurge[$name]['is_partitioned'] = true;
                 $this->tablesToPurge[$name]['partitions'] = [];
                 for ($i = 0; isset($matches[1][$i]); $i++) {


### PR DESCRIPTION
This PR intends to fix the regex to detect if a table is partitioned or not.

The issue comes form the format of partition as there is backticks around partition name in MariaDB but not in MySQL

MySQL:
```
PARTITION p20250318 VALUES LESS THAN (1742252400) ENGINE = InnoDB,
```

MariaDB:
```
PARTITION `p20250318` VALUES LESS THAN (1742252400) ENGINE = InnoDB,
```

**Fixes** # MON-159107

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
