### PR TITLE
fix(host template): fix edit host/ht in cloud

### DIFF
--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
@@ -70,6 +70,19 @@ properties:
 
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
+  event_handler_enabled:
+    type: integer
+    description: |
+      Indicates whether the event handler is enabled or not
+
+      * `0` - STATUS_DISABLED
+      * `1` - STATUS_ENABLED
+      * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
+  event_handler_command_id:
+    type: integer
+    description: "Event handler command ID"
+    example: 1
+    nullable: true
   note_url:
     type: string
     nullable: true

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
@@ -107,6 +107,19 @@ properties:
 
       Once the host has been retried max_check_attempts times without a change in its status,
       it will revert to being scheduled at its "normal" check interval rate.
+  event_handler_enabled:
+    type: integer
+    description: |
+      Indicates whether the event handler is enabled or not
+
+      * `0` - STATUS_DISABLED
+      * `1` - STATUS_ENABLED
+      * `2` - STATUS_DEFAULT (inheritance of its parent's value. If there is no parent, the values used will be that of Centreon Engine)
+  event_handler_command_id:
+    type: integer
+    description: "Event handler command ID"
+    example: 1
+    nullable: true
   note_url:
     type: string
     nullable: true

--- a/centreon/src/Core/Host/Infrastructure/API/PartialUpdateHost/PartialUpdateHostSaasSchema.json
+++ b/centreon/src/Core/Host/Infrastructure/API/PartialUpdateHost/PartialUpdateHostSaasSchema.json
@@ -49,6 +49,24 @@
                 "integer"
             ]
         },
+        "event_handler_enabled": {
+            "type": [
+                "null",
+                "integer"
+            ],
+            "enum": [
+                null,
+                0,
+                1,
+                2
+            ]
+        },
+        "event_handler_command_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
         "note_url": {
             "type": [
                 "null",

--- a/centreon/src/Core/HostTemplate/Infrastructure/API/PartialUpdateHostTemplate/PartialUpdateHostTemplateSaasSchema.json
+++ b/centreon/src/Core/HostTemplate/Infrastructure/API/PartialUpdateHostTemplate/PartialUpdateHostTemplateSaasSchema.json
@@ -108,6 +108,24 @@
                 "integer"
             ]
         },
+        "event_handler_enabled": {
+            "type": [
+                "null",
+                "integer"
+            ],
+            "enum": [
+                null,
+                0,
+                1,
+                2
+            ]
+        },
+        "event_handler_command_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
         "note_url": {
             "type": [
                 "null",


### PR DESCRIPTION
## Description

This PR intends to fix edit Host and Host template in cloud platform,
Added the fields event_handler_enabled and event_handler_command_id to endpoints PartialUpdateHost and PartialUpdateHostTemplate as they exist in the cloud forms.

**Fixes** # ([MON-16130](https://centreon.atlassian.net/browse/MON-161307))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

In a cloud platform, edit a configured Host and a Host template
Expected result => Host/Host template should be saved without errors

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-16130]: https://centreon.atlassian.net/browse/MON-16130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ