### PR TITLE
fix(downtimes): fix downtimes listing for users under ACLs

### DIFF
--- a/centreon/www/include/monitoring/downtime/listDowntime.php
+++ b/centreon/www/include/monitoring/downtime/listDowntime.php
@@ -167,8 +167,11 @@ $hostAclSubRequest = '';
 
 if (! $is_admin) {
     if ($centreon->user->access->getAccessGroups() !== []) {
-        [$aclBindValues, $aclQuery] = createMultipleBindQuery($centreon->user->access->getAccessGroups(), 'group_id');
-        $bindValues = array_merge($bindValues, $aclBindValues);
+        [$aclBindValues, $aclQuery] = createMultipleBindQuery(array_keys($centreon->user->access->getAccessGroups()), ':group_id');
+
+        foreach ($aclBindValues as $key => $value) {
+            $bindValues[$key] = [$value, PDO::PARAM_INT];
+        }
     } else {
         $aclQuery = '-1';
     }


### PR DESCRIPTION
## Description

This PR intends to fix the listing of downtimes for non admin users, the list does not appear and there is a 500.

**Fixes** # ([MON-163550](https://centreon.atlassian.net/browse/MON-163550))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

The downtimes list for non admin users should appear without any errors.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-163550]: https://centreon.atlassian.net/browse/MON-163550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ