### PR TITLE
enh(agent configuration): update endpoint to allow connection without TLS

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Application/Factory/AgentConfigurationFactory.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Factory/AgentConfigurationFactory.php
@@ -27,6 +27,7 @@ use Assert\AssertionFailedException;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\TelegrafConfigurationParameters;
+use Core\AgentConfiguration\Domain\Model\ConnectionMode;
 use Core\AgentConfiguration\Domain\Model\NewAgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\Type;
 
@@ -35,6 +36,7 @@ class AgentConfigurationFactory
     /**
      * @param string $name
      * @param Type $type
+     * @param ?ConnectionMode $connectionMode
      * @param array<string,mixed> $parameters
      *
      * @throws AssertionFailedException
@@ -44,9 +46,12 @@ class AgentConfigurationFactory
     public static function createNewAgentConfiguration(
         string $name,
         Type $type,
+        ?ConnectionMode $connectionMode,
         array $parameters,
     ): NewAgentConfiguration
     {
+        $parameters['connection_mode'] = $connectionMode->value ?? null;
+
         return new NewAgentConfiguration(
             name: $name,
             type: $type,
@@ -62,6 +67,7 @@ class AgentConfigurationFactory
      * @param string $name
      * @param Type $type
      * @param array<string,mixed> $parameters
+     * @param ?ConnectionMode $connectionMode
      *
      * @throws AssertionFailedException
      *
@@ -72,8 +78,11 @@ class AgentConfigurationFactory
         string $name,
         Type $type,
         array $parameters,
+        ?ConnectionMode $connectionMode = null,
     ): AgentConfiguration
     {
+        $parameters['connection_mode'] = $connectionMode->value ?? null;
+
         return new AgentConfiguration(
             id: $id,
             name: $name,

--- a/centreon/src/Core/AgentConfiguration/Application/Factory/AgentConfigurationFactory.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Factory/AgentConfigurationFactory.php
@@ -27,7 +27,7 @@ use Assert\AssertionFailedException;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\TelegrafConfigurationParameters;
-use Core\AgentConfiguration\Domain\Model\ConnectionMode;
+use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 use Core\AgentConfiguration\Domain\Model\NewAgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\Type;
 
@@ -36,7 +36,7 @@ class AgentConfigurationFactory
     /**
      * @param string $name
      * @param Type $type
-     * @param ?ConnectionMode $connectionMode
+     * @param ConnectionModeEnum $connectionMode
      * @param array<string,mixed> $parameters
      *
      * @throws AssertionFailedException
@@ -46,11 +46,11 @@ class AgentConfigurationFactory
     public static function createNewAgentConfiguration(
         string $name,
         Type $type,
-        ?ConnectionMode $connectionMode,
+        ConnectionModeEnum $connectionMode,
         array $parameters,
     ): NewAgentConfiguration
     {
-        $parameters['connection_mode'] = $connectionMode->value ?? null;
+        $parameters['connection_mode'] = $connectionMode;
 
         return new NewAgentConfiguration(
             name: $name,
@@ -67,7 +67,7 @@ class AgentConfigurationFactory
      * @param string $name
      * @param Type $type
      * @param array<string,mixed> $parameters
-     * @param ?ConnectionMode $connectionMode
+     * @param ConnectionModeEnum $connectionMode
      *
      * @throws AssertionFailedException
      *
@@ -78,10 +78,10 @@ class AgentConfigurationFactory
         string $name,
         Type $type,
         array $parameters,
-        ?ConnectionMode $connectionMode = null,
+        ConnectionModeEnum $connectionMode,
     ): AgentConfiguration
     {
-        $parameters['connection_mode'] = $connectionMode->value ?? null;
+        $parameters['connection_mode'] = $connectionMode;
 
         return new AgentConfiguration(
             id: $id,

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/AddAgentConfiguration.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/AddAgentConfiguration.php
@@ -33,6 +33,7 @@ use Core\AgentConfiguration\Application\Factory\AgentConfigurationFactory;
 use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Application\Repository\WriteAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
+use Core\AgentConfiguration\Domain\Model\ConnectionMode;
 use Core\AgentConfiguration\Domain\Model\NewAgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\Poller;
 use Core\AgentConfiguration\Domain\Model\Type;
@@ -72,12 +73,16 @@ final class AddAgentConfiguration
 
             $request->pollerIds = array_unique($request->pollerIds);
             $type = Type::from($request->type);
+            $connectionMode = $request->connectionMode
+                ? ConnectionMode::from($request->connectionMode)
+                : ConnectionMode::SECURE;
 
             $this->validator->validateRequestOrFail($request);
 
             $newAc = AgentConfigurationFactory::createNewAgentConfiguration(
                 name: $request->name,
                 type: $type,
+                connectionMode: $connectionMode,
                 parameters: $request->configuration,
             );
 

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/AddAgentConfiguration.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/AddAgentConfiguration.php
@@ -33,7 +33,6 @@ use Core\AgentConfiguration\Application\Factory\AgentConfigurationFactory;
 use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Application\Repository\WriteAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
-use Core\AgentConfiguration\Domain\Model\ConnectionMode;
 use Core\AgentConfiguration\Domain\Model\NewAgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\Poller;
 use Core\AgentConfiguration\Domain\Model\Type;
@@ -73,16 +72,13 @@ final class AddAgentConfiguration
 
             $request->pollerIds = array_unique($request->pollerIds);
             $type = Type::from($request->type);
-            $connectionMode = $request->connectionMode
-                ? ConnectionMode::from($request->connectionMode)
-                : ConnectionMode::SECURE;
 
             $this->validator->validateRequestOrFail($request);
 
             $newAc = AgentConfigurationFactory::createNewAgentConfiguration(
                 name: $request->name,
                 type: $type,
-                connectionMode: $connectionMode,
+                connectionMode: $request->connectionMode,
                 parameters: $request->configuration,
             );
 

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/AddAgentConfigurationRequest.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/AddAgentConfigurationRequest.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration;
 
-use Core\AgentConfiguration\Domain\Model\ConnectionMode;
+use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 
 final class AddAgentConfigurationRequest
 {
@@ -31,7 +31,7 @@ final class AddAgentConfigurationRequest
 
     public string $type = '';
 
-    public ConnectionMode $connectionMode = ConnectionMode::SECURE;
+    public ConnectionModeEnum $connectionMode = ConnectionModeEnum::SECURE;
 
 	/** @var int[] */
 	public array $pollerIds = [];

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/AddAgentConfigurationRequest.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/AddAgentConfigurationRequest.php
@@ -23,13 +23,15 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration;
 
+use Core\AgentConfiguration\Domain\Model\ConnectionMode;
+
 final class AddAgentConfigurationRequest
 {
     public string $name = '';
 
     public string $type = '';
 
-    public ?string $connectionMode = '';
+    public ConnectionMode $connectionMode = ConnectionMode::SECURE;
 
 	/** @var int[] */
 	public array $pollerIds = [];

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/Validator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/Validator.php
@@ -72,7 +72,6 @@ class Validator
         $this->validatePollersOrFail($request);
         $this->validateTypeOrFail($request);
         $this->validateParametersOrFail($request);
-        $this->validateConnectionModeOrFail($request);
     }
 
     /**
@@ -149,22 +148,6 @@ class Validator
     public function validateTypeOrFail(AddAgentConfigurationRequest $request): void
     {
         Type::from($request->type);
-    }
-
-    /**
-     * Validate connection mode.
-     *
-     * @param AddAgentConfigurationRequest $request
-     *
-     * @throws ValueError
-     */
-    public function validateConnectionModeOrFail(AddAgentConfigurationRequest $request): void
-    {
-        if (null === $request->connectionMode) {
-            return;
-        }
-
-        ConnectionMode::from($request->connectionMode);
     }
 
     /**

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/Validator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/Validator.php
@@ -29,7 +29,6 @@ use Centreon\Domain\Log\LoggerTrait;
 use Core\AgentConfiguration\Application\Exception\AgentConfigurationException;
 use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Application\Validation\TypeValidatorInterface;
-use Core\AgentConfiguration\Domain\Model\ConnectionMode;
 use Core\AgentConfiguration\Domain\Model\Poller;
 use Core\AgentConfiguration\Domain\Model\Type;
 use Core\Common\Domain\TrimmedString;

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/Validator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/Validator.php
@@ -29,6 +29,7 @@ use Centreon\Domain\Log\LoggerTrait;
 use Core\AgentConfiguration\Application\Exception\AgentConfigurationException;
 use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Application\Validation\TypeValidatorInterface;
+use Core\AgentConfiguration\Domain\Model\ConnectionMode;
 use Core\AgentConfiguration\Domain\Model\Poller;
 use Core\AgentConfiguration\Domain\Model\Type;
 use Core\Common\Domain\TrimmedString;
@@ -71,6 +72,7 @@ class Validator
         $this->validatePollersOrFail($request);
         $this->validateTypeOrFail($request);
         $this->validateParametersOrFail($request);
+        $this->validateConnectionModeOrFail($request);
     }
 
     /**
@@ -146,7 +148,23 @@ class Validator
      */
     public function validateTypeOrFail(AddAgentConfigurationRequest $request): void
     {
-        $type = Type::from($request->type);
+        Type::from($request->type);
+    }
+
+    /**
+     * Validate connection mode.
+     *
+     * @param AddAgentConfigurationRequest $request
+     *
+     * @throws ValueError
+     */
+    public function validateConnectionModeOrFail(AddAgentConfigurationRequest $request): void
+    {
+        if (null === $request->connectionMode) {
+            return;
+        }
+
+        ConnectionMode::from($request->connectionMode);
     }
 
     /**

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/UpdateAgentConfiguration.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/UpdateAgentConfiguration.php
@@ -33,7 +33,6 @@ use Core\AgentConfiguration\Application\Factory\AgentConfigurationFactory;
 use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Application\Repository\WriteAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
-use Core\AgentConfiguration\Domain\Model\ConnectionMode;
 use Core\AgentConfiguration\Domain\Model\Poller;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
@@ -85,9 +84,6 @@ final class UpdateAgentConfiguration
             }
 
             $request->pollerIds = array_unique($request->pollerIds);
-            $connectionMode = $request->connectionMode
-                ? ConnectionMode::from($request->connectionMode)
-                : ConnectionMode::SECURE;
 
             $this->validator->validateRequestOrFail($request, $agentConfiguration);
 
@@ -96,7 +92,7 @@ final class UpdateAgentConfiguration
                 name: $request->name,
                 type: $agentConfiguration->getType(),
                 parameters: $request->configuration,
-                connectionMode: $connectionMode,
+                connectionMode: $request->connectionMode,
             );
 
             $this->save($updatedAgentConfiguration, $request->pollerIds);

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/UpdateAgentConfiguration.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/UpdateAgentConfiguration.php
@@ -33,6 +33,7 @@ use Core\AgentConfiguration\Application\Factory\AgentConfigurationFactory;
 use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Application\Repository\WriteAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
+use Core\AgentConfiguration\Domain\Model\ConnectionMode;
 use Core\AgentConfiguration\Domain\Model\Poller;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ForbiddenResponse;
@@ -84,6 +85,9 @@ final class UpdateAgentConfiguration
             }
 
             $request->pollerIds = array_unique($request->pollerIds);
+            $connectionMode = $request->connectionMode
+                ? ConnectionMode::from($request->connectionMode)
+                : ConnectionMode::SECURE;
 
             $this->validator->validateRequestOrFail($request, $agentConfiguration);
 
@@ -91,7 +95,8 @@ final class UpdateAgentConfiguration
                 id: $agentConfiguration->getId(),
                 name: $request->name,
                 type: $agentConfiguration->getType(),
-                parameters: $request->configuration
+                parameters: $request->configuration,
+                connectionMode: $connectionMode,
             );
 
             $this->save($updatedAgentConfiguration, $request->pollerIds);

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/UpdateAgentConfigurationRequest.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/UpdateAgentConfigurationRequest.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Application\UseCase\UpdateAgentConfiguration;
 
+use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
+
 final class UpdateAgentConfigurationRequest
 {
     public int $id = 0;
@@ -31,7 +33,7 @@ final class UpdateAgentConfigurationRequest
 
     public string $type = '';
 
-    public ?string $connectionMode = '';
+    public ConnectionModeEnum $connectionMode = ConnectionModeEnum::SECURE;
 
 	/** @var int[] */
 	public array $pollerIds = [];

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/UpdateAgentConfigurationRequest.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/UpdateAgentConfigurationRequest.php
@@ -31,6 +31,8 @@ final class UpdateAgentConfigurationRequest
 
     public string $type = '';
 
+    public ?string $connectionMode = '';
+
 	/** @var int[] */
 	public array $pollerIds = [];
 

--- a/centreon/src/Core/AgentConfiguration/Application/Validation/TelegrafValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/TelegrafValidator.php
@@ -55,9 +55,10 @@ class TelegrafValidator implements TypeValidatorInterface
                     str_ends_with($key, '_certificate')
                     || str_ends_with($key, '_key')
                 )
-                && 1 === preg_match('/\.\/|\.\.\/|\.cert$|\.crt$|\.key$/', (string) $value)
+                && is_string($value)
+                && 1 === preg_match('/\.\/|\.\.\/|\.cert$|\.crt$|\.key$/', $value)
             ) {
-                throw AgentConfigurationException::invalidFilename("configuration.{$key}", (string) $value);
+                throw AgentConfigurationException::invalidFilename("configuration.{$key}", $value);
             }
         }
     }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -31,6 +31,7 @@ use Core\AgentConfiguration\Domain\Model\ConnectionMode;
 /**
  * @phpstan-type _CmaParameters array{
  *	    is_reverse: bool,
+ *		connection_mode?: ?string,
  *		otel_public_certificate: string,
  *		otel_private_key: string,
  *		otel_ca_certificate: ?string,
@@ -87,6 +88,8 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
             $this->validateHostCertificate($host['poller_ca_certificate'], $connectionMode, 'configuration.hosts[].poller_ca_certificate');
             $this->validateOptionalCertificate($host['poller_ca_name'], 'configuration.hosts[].poller_ca_name');
         }
+
+        unset($parameters['connection_mode']);
 
         $this->parameters = $parameters;
     }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -60,6 +60,7 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
      */
     public function __construct(array $parameters)
     {
+        /** @var _CmaParameters $parameters */
         if (isset($parameters['connection_mode'])) {
             $connectionMode = $parameters['connection_mode'];
         } else {
@@ -68,7 +69,6 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
                 : ConnectionModeEnum::SECURE;
         }
 
-        /** @var _CmaParameters $parameters */
         if ($connectionMode === ConnectionModeEnum::SECURE) {
             $this->validateCertificate($parameters['otel_public_certificate'], 'configuration.otel_public_certificate');
             $this->validateCertificate($parameters['otel_private_key'], 'configuration.otel_private_key');

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
@@ -55,6 +55,7 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
     public function __construct(
         array $parameters
     ){
+        /** @var _TelegrafParameters $parameters */
         if (isset($parameters['connection_mode'])) {
             $connectionMode = $parameters['connection_mode'];
         } else {
@@ -66,7 +67,6 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
                     : ConnectionModeEnum::SECURE;
         }
 
-        /** @var _TelegrafParameters $parameters */
         Assertion::range($parameters['conf_server_port'], 0, 65535, 'configuration.conf_server_port');
 
         if ($connectionMode === ConnectionModeEnum::SECURE) {

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
@@ -30,6 +30,7 @@ use Core\AgentConfiguration\Domain\Model\ConnectionMode;
 
 /**
  * @phpstan-type _TelegrafParameters array{
+ *      connection_mode?: ?string,
  *	    otel_public_certificate: string,
  *	    otel_ca_certificate: string|null,
  *	    otel_private_key: string,
@@ -80,6 +81,8 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
             $this->validateOptionalCertificate($parameters['conf_private_key'], 'configuration.conf_private_key');
             $this->validateOptionalCertificate($parameters['otel_ca_certificate'], 'configuration.otel_ca_certificate');
         }
+
+        unset($parameters['connection_mode']);
 
         $this->parameters = $parameters;
     }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParametersInterface.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParametersInterface.php
@@ -30,5 +30,10 @@ interface ConfigurationParametersInterface
      */
     public function getData(): array;
 
+    /**
+     * Retrieves the broker directive.
+     *
+     * @return ?string
+     */
     public function getBrokerDirective(): ?string;
 }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConnectionMode.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConnectionMode.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
- * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConnectionMode.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConnectionMode.php
@@ -21,19 +21,9 @@
 
 declare(strict_types=1);
 
-namespace Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration;
+namespace Core\AgentConfiguration\Domain\Model;
 
-final class AddAgentConfigurationRequest
-{
-    public string $name = '';
-
-    public string $type = '';
-
-    public ?string $connectionMode = '';
-
-	/** @var int[] */
-	public array $pollerIds = [];
-
-    /** @var array<string,mixed> */
-    public array $configuration = [];
+enum ConnectionMode: string {
+    case SECURE = 'secure';
+    case NO_TLS = 'no-tls';
 }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConnectionModeEnum.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConnectionModeEnum.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Domain\Model;
 
-enum ConnectionMode: string {
-    case SECURE = 'secure';
-    case NO_TLS = 'no-tls';
+enum ConnectionModeEnum {
+    case SECURE;
+    case NO_TLS;
 }

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationController.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationController.php
@@ -27,7 +27,7 @@ use Centreon\Application\Controller\AbstractController;
 use Centreon\Domain\Log\LoggerTrait;
 use Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration\AddAgentConfiguration;
 use Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration\AddAgentConfigurationRequest;
-use Core\AgentConfiguration\Domain\Model\ConnectionMode;
+use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -89,9 +89,9 @@ final class AddAgentConfigurationController extends AbstractController
         $addRequest = new AddAgentConfigurationRequest();
         $addRequest->type = $data['type'];
         $addRequest->name = $data['name'];
-        $addRequest->connectionMode = $data['connection_mode'] === "no-tls"
-            ? ConnectionMode::NO_TLS
-            : ConnectionMode::SECURE;
+        $addRequest->connectionMode = $data['connection_mode'] === 'no-tls'
+            ? ConnectionModeEnum::NO_TLS
+            : ConnectionModeEnum::SECURE;
         $addRequest->pollerIds = $data['poller_ids'];
         $addRequest->configuration = $data['configuration'];
 

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationController.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationController.php
@@ -70,6 +70,7 @@ final class AddAgentConfigurationController extends AbstractController
          * @var array{
          *     name:string,
          *     type:string,
+         *     connection_mode:string|null,
          *     poller_ids:int[],
          *     configuration:array<string,mixed>
          * } $data
@@ -87,6 +88,7 @@ final class AddAgentConfigurationController extends AbstractController
         $addRequest = new AddAgentConfigurationRequest();
         $addRequest->type = $data['type'];
         $addRequest->name = $data['name'];
+        $addRequest->connectionMode = $data['connection_mode'];
         $addRequest->pollerIds = $data['poller_ids'];
         $addRequest->configuration = $data['configuration'];
 

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationController.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationController.php
@@ -27,6 +27,7 @@ use Centreon\Application\Controller\AbstractController;
 use Centreon\Domain\Log\LoggerTrait;
 use Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration\AddAgentConfiguration;
 use Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration\AddAgentConfigurationRequest;
+use Core\AgentConfiguration\Domain\Model\ConnectionMode;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -88,7 +89,9 @@ final class AddAgentConfigurationController extends AbstractController
         $addRequest = new AddAgentConfigurationRequest();
         $addRequest->type = $data['type'];
         $addRequest->name = $data['name'];
-        $addRequest->connectionMode = $data['connection_mode'];
+        $addRequest->connectionMode = $data['connection_mode'] === "no-tls"
+            ? ConnectionMode::NO_TLS
+            : ConnectionMode::SECURE;
         $addRequest->pollerIds = $data['poller_ids'];
         $addRequest->configuration = $data['configuration'];
 

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationSchema.json
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationSchema.json
@@ -20,6 +20,14 @@
         "name": {
             "type": "string"
         },
+        "connection_mode": {
+            "type": "string",
+            "enum": [
+                "secure",
+                "no-tls"
+            ],
+            "default": "secure"
+        },
         "poller_ids": {
             "type": "array",
             "items": {

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/Schema/CmaConfigurationSchema.json
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/Schema/CmaConfigurationSchema.json
@@ -22,7 +22,10 @@
                     "type": "boolean"
                 },
                 "otel_public_certificate": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "otel_ca_certificate": {
                     "type": [
@@ -31,7 +34,10 @@
                     ]
                 },
                 "otel_private_key": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "hosts": {
                     "type": "array",

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/Schema/TelegrafConfigurationSchema.json
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/Schema/TelegrafConfigurationSchema.json
@@ -20,7 +20,10 @@
             ],
             "properties": {
                 "otel_public_certificate": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "otel_ca_certificate": {
                     "type": [
@@ -29,16 +32,25 @@
                     ]
                 },
                 "otel_private_key": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "conf_server_port": {
                     "type": "integer"
                 },
                 "conf_certificate": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 },
                 "conf_private_key": {
-                    "type": "string"
+                    "type": [
+                        "null",
+                        "string"
+                    ]
                 }
             }
         }

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/UpdateAgentConfiguration/UpdateAgentConfigurationController.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/UpdateAgentConfiguration/UpdateAgentConfigurationController.php
@@ -27,6 +27,7 @@ use Centreon\Application\Controller\AbstractController;
 use Centreon\Domain\Log\LoggerTrait;
 use Core\AgentConfiguration\Application\UseCase\UpdateAgentConfiguration\UpdateAgentConfiguration;
 use Core\AgentConfiguration\Application\UseCase\UpdateAgentConfiguration\UpdateAgentConfigurationRequest;
+use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\InvalidArgumentResponse;
 use Core\Infrastructure\Common\Api\DefaultPresenter;
@@ -92,7 +93,9 @@ final class UpdateAgentConfigurationController extends AbstractController
         $updateRequest->id = $id;
         $updateRequest->type = $data['type'];
         $updateRequest->name = $data['name'];
-        $updateRequest->connectionMode = $data['connection_mode'];
+        $updateRequest->connectionMode = $data['connection_mode'] === 'no-tls'
+            ? ConnectionModeEnum::NO_TLS
+            : ConnectionModeEnum::SECURE;
         $updateRequest->pollerIds = $data['poller_ids'];
         $updateRequest->configuration = $data['configuration'];
 

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/UpdateAgentConfiguration/UpdateAgentConfigurationController.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/UpdateAgentConfiguration/UpdateAgentConfigurationController.php
@@ -73,6 +73,7 @@ final class UpdateAgentConfigurationController extends AbstractController
          * @var array{
          *     name:string,
          *     type:string,
+         *     connection_mode:string|null,
          *     poller_ids:int[],
          *     configuration:array<string,mixed>
          * } $data
@@ -91,6 +92,7 @@ final class UpdateAgentConfigurationController extends AbstractController
         $updateRequest->id = $id;
         $updateRequest->type = $data['type'];
         $updateRequest->name = $data['name'];
+        $updateRequest->connectionMode = $data['connection_mode'];
         $updateRequest->pollerIds = $data['poller_ids'];
         $updateRequest->configuration = $data['configuration'];
 

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/UpdateAgentConfiguration/UpdateAgentConfigurationSchema.json
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/UpdateAgentConfiguration/UpdateAgentConfigurationSchema.json
@@ -20,6 +20,14 @@
         "name": {
             "type": "string"
         },
+        "connection_mode": {
+            "type": "string",
+            "enum": [
+                "secure",
+                "no-tls"
+            ],
+            "default": "secure"
+        },
         "poller_ids": {
             "type": "array",
             "items": {

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
@@ -25,10 +25,11 @@ namespace Core\AdditionalConnectorConfiguration\Application\Validation;
 
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
+use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 
 beforeEach(function (): void {
     $this->parameters = [
-        'connection_mode' => 'secure',
+        'connection_mode' => ConnectionModeEnum::SECURE,
         'is_reverse' => true,
         'otel_public_certificate' => 'otel_certif_filename',
         'otel_ca_certificate' => 'ca_certif_filename',

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
@@ -28,6 +28,7 @@ use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfiguratio
 
 beforeEach(function (): void {
     $this->parameters = [
+        'connection_mode' => 'secure',
         'is_reverse' => true,
         'otel_public_certificate' => 'otel_certif_filename',
         'otel_ca_certificate' => 'ca_certif_filename',

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/TelegrafConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/TelegrafConfigurationParametersTest.php
@@ -25,10 +25,11 @@ namespace Core\AdditionalConnectorConfiguration\Application\Validation;
 
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\TelegrafConfigurationParameters;
+use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 
 beforeEach(function (): void {
     $this->parameters = [
-        'connection_mode' => 'secure',
+        'connection_mode' => ConnectionModeEnum::SECURE,
         'otel_public_certificate' => 'otel_certif_filename',
         'otel_ca_certificate' => 'ca_certif_filename',
         'otel_private_key' => 'otel_key_filename',

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/TelegrafConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/TelegrafConfigurationParametersTest.php
@@ -28,6 +28,7 @@ use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\TelegrafConfigu
 
 beforeEach(function (): void {
     $this->parameters = [
+        'connection_mode' => 'secure',
         'otel_public_certificate' => 'otel_certif_filename',
         'otel_ca_certificate' => 'ca_certif_filename',
         'otel_private_key' => 'otel_key_filename',

--- a/centreon/tests/rest_api/collections/configuration/Agent_Configuration.postman_collection.json
+++ b/centreon/tests/rest_api/collections/configuration/Agent_Configuration.postman_collection.json
@@ -464,7 +464,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC1Name}}\",\r\n    \"poller_ids\": [{{Central_Id}}, {{poller1_Id}}],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC1Name}}\",\r\n    \"poller_ids\": [{{Central_Id}}, {{poller1_Id}}],\r\n    \"type\": \"telegraf\",\r\n    \"connection_mode\": \"secure\",\r\n   \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -750,7 +750,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC2Name}}\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2\",\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC2Name}}\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n  \"connection_mode\": \"secure\",\r\n   \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2\",\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -947,7 +947,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -1003,7 +1003,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -1059,7 +1059,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -1115,7 +1115,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -1171,7 +1171,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"vmware_v6\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"vmware_v6\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -1227,7 +1227,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"vmware_v6\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"vmware_v6\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -1339,7 +1339,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": 1,\r\n    \"poller_ids\": [true],\r\n    \"type\": false,\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": 3,\r\n        \"otel_ca_certificate\": 0,\r\n        \"otel_private_key\": false,\r\n        \"conf_server_port\": \"1443\",\r\n        \"conf_certificate\": true,\r\n        \"conf_private_key\": 123\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": 1,\r\n    \"poller_ids\": [true],\r\n    \"type\": false,\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": 3,\r\n        \"otel_ca_certificate\": 0,\r\n        \"otel_private_key\": false,\r\n        \"conf_server_port\": \"1443\",\r\n        \"conf_certificate\": true,\r\n        \"conf_private_key\": 123\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -1395,7 +1395,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"bac-ac\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": 3,\r\n        \"otel_ca_certificate\": 0,\r\n        \"otel_private_key\": false,\r\n        \"conf_server_port\": \"1443\",\r\n        \"conf_certificate\": true,\r\n        \"conf_private_key\": 123\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"bac-ac\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": 3,\r\n        \"otel_ca_certificate\": 0,\r\n        \"otel_private_key\": false,\r\n        \"conf_server_port\": \"1443\",\r\n        \"conf_certificate\": true,\r\n        \"conf_private_key\": 123\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -1451,7 +1451,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2\",\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2\",\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -1541,7 +1541,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC3Name}}\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otél-certificate-name-ac2!\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otél_private-key-name-ac2\",\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"poller_ca_certificate\": \"ca-filé\",\r\n            \"poller_ca_name\": null\r\n        },\r\n        {\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC3Name}}\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otél-certificate-name-ac2!\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otél_private-key-name-ac2\",\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"poller_ca_certificate\": \"ca-filé\",\r\n            \"poller_ca_name\": null\r\n        },\r\n        {\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -1596,7 +1596,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC2Name}}\",\r\n    \"poller_ids\": [{{poller3_Id}}],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-123\",\r\n        \"otel_ca_certificate\": \"ca-file-123\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-123\",\r\n        \"conf_server_port\": 1444,\r\n        \"conf_certificate\": \"my-certificate-name-123\",\r\n        \"conf_private_key\": \"my-private-key-name-123\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC2Name}}\",\r\n    \"poller_ids\": [{{poller3_Id}}],\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-123\",\r\n        \"otel_ca_certificate\": \"ca-file-123\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-123\",\r\n        \"conf_server_port\": 1444,\r\n        \"conf_certificate\": \"my-certificate-name-123\",\r\n        \"conf_private_key\": \"my-private-key-name-123\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations/{{AC2Id}}",
@@ -1745,7 +1745,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC1Name}}\",\r\n    \"poller_ids\": [{{poller3_Id}}],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-123\",\r\n        \"otel_ca_certificate\": \"ca-file-123\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-123\",\r\n        \"conf_server_port\": 1444,\r\n        \"conf_certificate\": \"my-certificate-name-123\",\r\n        \"conf_private_key\": \"my-private-key-name-123\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC1Name}}\",\r\n    \"poller_ids\": [{{poller3_Id}}],\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-123\",\r\n        \"otel_ca_certificate\": \"ca-file-123\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-123\",\r\n        \"conf_server_port\": 1444,\r\n        \"conf_certificate\": \"my-certificate-name-123\",\r\n        \"conf_private_key\": \"my-private-key-name-123\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations/{{AC1Id}}",
@@ -2668,7 +2668,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC1Name}}\",\r\n    \"poller_ids\": [{{Central_Id}}, {{poller1_Id}}],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC1Name}}\",\r\n    \"poller_ids\": [{{Central_Id}}, {{poller1_Id}}],\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -2782,7 +2782,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC1Name}}\",\r\n    \"poller_ids\": [{{poller3_Id}}],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-123\",\r\n        \"otel_ca_certificate\": \"ca-file-123\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-123\",\r\n        \"conf_server_port\": 1444,\r\n        \"conf_certificate\": \"my-certificate-name-123\",\r\n        \"conf_private_key\": \"my-private-key-name-123\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC1Name}}\",\r\n    \"poller_ids\": [{{poller3_Id}}],\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-123\",\r\n        \"otel_ca_certificate\": \"ca-file-123\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-123\",\r\n        \"conf_server_port\": 1444,\r\n        \"conf_certificate\": \"my-certificate-name-123\",\r\n        \"conf_private_key\": \"my-private-key-name-123\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations/{{AC1Id}}",
@@ -3234,7 +3234,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4\",\r\n        \"otel_ca_certificate\": \"hello\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4\",\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"poller_ca_certificate\": \"hi\",\r\n            \"poller_ca_name\": \"halo\"\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4\",\r\n        \"otel_ca_certificate\": \"hello\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4\",\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"poller_ca_certificate\": \"hi\",\r\n            \"poller_ca_name\": \"halo\"\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -3537,7 +3537,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4\",\r\n        \"otel_ca_certificate\": \"hello\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4\",\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"poller_ca_certificate\": \"hi\",\r\n            \"poller_ca_name\": \"halo\"\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4\",\r\n        \"otel_ca_certificate\": \"hello\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4\",\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"poller_ca_certificate\": \"hi\",\r\n            \"poller_ca_name\": \"halo\"\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations/{{AC4Id}}",
@@ -4103,7 +4103,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC5Name}}\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-sss\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-sss\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name-sss\",\r\n        \"conf_private_key\": \"my-private-key-name-sss\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC5Name}}\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-sss\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-sss\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name-sss\",\r\n        \"conf_private_key\": \"my-private-key-name-sss\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -4181,7 +4181,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC5Name}}\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-sss\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-sss\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name-sss\",\r\n        \"conf_private_key\": \"my-private-key-name-sss\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC5Name}}\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-sss\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-sss\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name-sss\",\r\n        \"conf_private_key\": \"my-private-key-name-sss\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -4308,7 +4308,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"nop\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2\",\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"nop\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2\",\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations/{{AC4Id}}",
@@ -4361,7 +4361,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC5Name}}\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"telegraf\",\r\n    \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC5Name}}\",\r\n    \"poller_ids\": [{{poller2_Id}}],\r\n    \"type\": \"telegraf\",\r\n  \"connection_mode\": \"secure\",\r\n  \"configuration\": {\r\n        \"otel_public_certificate\": \"my-otel-certificate-name\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name\",\r\n        \"conf_server_port\": 1443,\r\n        \"conf_certificate\": \"my-certificate-name\",\r\n        \"conf_private_key\": \"my-private-key-name\"\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations/{{AC5Id}}",

--- a/centreon/tests/rest_api/collections/configuration/Agent_Configuration.postman_collection.json
+++ b/centreon/tests/rest_api/collections/configuration/Agent_Configuration.postman_collection.json
@@ -1375,7 +1375,7 @@
 									"pm.test(\"The AC has not been created, because the configuration values are not correct.\", function () {\r",
 									"    pm.response.to.have.status(400);\r",
 									"\r",
-									"    pm.expect(responseJson.message).to.eql(\"[configuration.otel_public_certificate] Integer value found, but a string is required\\n[configuration.otel_ca_certificate] Integer value found, but a string or a null is required\\n[configuration.otel_private_key] Boolean value found, but a string is required\\n[configuration.conf_server_port] String value found, but an integer is required\\n[configuration.conf_certificate] Boolean value found, but a string is required\\n[configuration.conf_private_key] Integer value found, but a string is required\\n\");\r",
+									"    pm.expect(responseJson.message).to.eql(\"[configuration.otel_public_certificate] Integer value found, but a null or a string is required\\n[configuration.otel_ca_certificate] Integer value found, but a string or a null is required\\n[configuration.otel_private_key] Boolean value found, but a null or a string is required\\n[configuration.conf_server_port] String value found, but an integer is required\\n[configuration.conf_certificate] Boolean value found, but a null or a string is required\\n[configuration.conf_private_key] Integer value found, but a null or a string is required\\n\");\r",
 									"\r",
 									"});"
 								],


### PR DESCRIPTION
## Description

This PR intends to add a new parameter [secure / no-tls] to endpoints ADD and UPDATE agent configuration in order to allow empty certificates for unsecure mode,

example of payload :

```json
{
  "name": "cma",
  "type": "centreon-agent",
  "poller_ids": [1],
  "connection_mode": "no-tls",  // Possible values: "secure" and "no-tls". Field is optional (defaults to "secure")
  "configuration": {
  "is_reverse": true,
  "otel_ca_certificate": null,
  "otel_public_certificate": null,
  "otel_private_key": "good-key",
  "hosts": [
      {
        "address": "127.0.0.0",
        "port": 4317,
        "poller_ca_name": "test",
        "poller_ca_certificate": "certificate1"
       }
    ]
  }
}
```

**Fixes** # ([MON-163293](https://centreon.atlassian.net/browse/MON-163293))

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-163293]: https://centreon.atlassian.net/browse/MON-163293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ