### PR TITLE
fix(hostgroup): Use DISTINCT instead of UNIQUE in SQL Query

### DIFF
--- a/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
+++ b/centreon/src/Core/HostGroup/Infrastructure/Repository/DbReadHostGroupRepository.php
@@ -562,8 +562,7 @@ class DbReadHostGroupRepository extends AbstractRepositoryDRB implements ReadHos
 
         $statement = $this->db->prepare($this->translateDbName(
             <<<SQL
-                SELECT
-                    UNIQUE(hrel.hostgroup_hg_id),
+                SELECT DISTINCT hrel.hostgroup_hg_id,
                     h.host_id,
                     IF (h.host_activate = '0', false, true) as is_activated
                 FROM `:db`.host h


### PR DESCRIPTION
## Description

This PR intends to fix an issue with a SQL Query compatible with MariaDB but not with MySQL

**Fixes** # MON-163720

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
