### PR TITLE
enh(agent configuration): update export file to allow no tls

### DIFF
--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration as ModelAgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
+use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\TelegrafConfigurationParameters;
 use Core\AgentConfiguration\Domain\Model\Type;
 
 /**
@@ -78,10 +79,14 @@ class AgentConfiguration extends AbstractObjectJSON
         return [
             'host' => ModelAgentConfiguration::DEFAULT_HOST,
             'port' => ModelAgentConfiguration::DEFAULT_PORT,
-            'encryption' => true,
-            'public_cert' => '/etc/pki/' . $data['otel_public_certificate'] . '.crt',
-            'private_key' => '/etc/pki/' . $data['otel_private_key'] . '.key',
-            'ca_certificate' => $data['otel_ca_certificate'] !== null
+            'encryption' => ! empty($data['otel_public_certificate']) && ! empty($data['otel_private_key']),
+            'public_cert' => ! empty($data['otel_public_certificate'])
+                ? '/etc/pki/' . $data['otel_public_certificate'] . '.crt'
+                : '',
+            'private_key' => ! empty($data['otel_private_key'])
+                ? '/etc/pki/' . $data['otel_private_key'] . '.key'
+                : '',
+            'ca_certificate' => ! empty($data['otel_ca_certificate'])
                 ? '/etc/pki/' . $data['otel_ca_certificate'] . '.crt'
                 : '',
         ];
@@ -103,12 +108,13 @@ class AgentConfiguration extends AbstractObjectJSON
                 'export_period' => CmaConfigurationParameters::DEFAULT_EXPORT_PERIOD,
             ]
         ];
+
         if ($data['is_reverse']) {
             $configuration['centreon_agent']['reverse_connections'] = array_map(
                 static fn(array $host): array => [
                     'host' => $host['address'],
                     'port' => $host['port'],
-                    'encryption' => true,
+                    'encryption' => $configuration['otel_server']['encryption'],
                     'ca_certificate' => $host['poller_ca_certificate'] !== null
                         ? '/etc/pki/' . $host['poller_ca_certificate'] . '.crt'
                         : '',
@@ -132,14 +138,20 @@ class AgentConfiguration extends AbstractObjectJSON
      */
     private function formatTelegraphConfiguration(array $data): array
     {
+        $otelConfiguration = $this->formatOtelConfiguration($data);
+
         return [
-            'otel_server' => $this->formatOtelConfiguration($data),
+            'otel_server' => $otelConfiguration,
             'telegraf_conf_server' => [
                 'http_server' => [
                     'port' => $data['conf_server_port'],
-                    'encryption' => true,
-                    'public_cert' => '/etc/pki/' . $data['conf_certificate'] .'.crt',
-                    'private_key' => '/etc/pki/' . $data['conf_private_key'] .'.key',
+                    'encryption' => $otelConfiguration['encryption'],
+                    'public_cert' => $data['conf_certificate'] !== null
+                        ? '/etc/pki/' . $data['conf_certificate'] .'.crt'
+                        : '',
+                    'private_key' => $data['conf_private_key'] !== null
+                        ? '/etc/pki/' . $data['conf_private_key'] .'.key'
+                        : '',
                 ]
             ]
         ];


### PR DESCRIPTION
## Description

This Pr intends to edit the export conf in order to allow empty certificates and set encryption to false in case of empty certificates (no-tls mode).

**Fixes** # ([MON-163294](https://centreon.atlassian.net/browse/MON-163294))

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

After creating an agent configuration and exporting the configuration, verify the generated export file to ensure:

- When connection mode is secure:
   - Encryption should be set to true
   - All certificates should be properly configured
- When connection mode is no_tls:
   - Encryption should be set to false
   - Certificates may be null

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-163294]: https://centreon.atlassian.net/browse/MON-163294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ