### PR TITLE
enh(SAML): Added requested authentication context property in SAML configuration endplints

### DIFF
--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/Settings/Formatter/OneLoginSettingsFormatter.php
@@ -73,7 +73,7 @@ class OneLoginSettingsFormatter implements SettingsFormatterInterface
                 'x509cert' => $customConfiguration->getPublicCertificate(),
             ],
             'security' => [
-                'requestedAuthnContextComparison' => 'minimum',
+                'requestedAuthnContextComparison' => $customConfiguration->getRequestedAuthnContext()->toString(),
             ],
         ];
     }

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfiguration.php
@@ -75,6 +75,7 @@ final class FindSAMLConfiguration
         $response->remoteLoginUrl = $customConfiguration->getRemoteLoginUrl();
         $response->publicCertificate = $customConfiguration->getPublicCertificate();
         $response->userIdAttribute = $customConfiguration->getUserIdAttribute();
+        $response->requestedAuthnContext = $customConfiguration->getRequestedAuthnContext()->toString();
         $response->logoutFrom = $customConfiguration->getLogoutFrom();
         $response->logoutFromUrl = $customConfiguration->getLogoutFromUrl();
         $response->isAutoImportEnabled = $customConfiguration->isAutoImportEnabled();

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationResponse.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationResponse.php
@@ -77,6 +77,9 @@ final class FindSAMLConfigurationResponse
     /** @var string */
     public string $userIdAttribute = '';
 
+    /** @var string */
+    public string $requestedAuthnContext = 'Minimum';
+
     /** @var bool */
     public bool $logoutFrom = true;
 

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationResponse.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationResponse.php
@@ -78,7 +78,7 @@ final class FindSAMLConfigurationResponse
     public string $userIdAttribute = '';
 
     /** @var string */
-    public string $requestedAuthnContext = 'Minimum';
+    public string $requestedAuthnContext = 'minimum';
 
     /** @var bool */
     public bool $logoutFrom = true;

--- a/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfigurationRequest.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfigurationRequest.php
@@ -51,6 +51,9 @@ final class UpdateSAMLConfigurationRequest
     /** @var string */
     public string $userIdAttribute = '';
 
+    /** @var string */
+    public string $requestedAuthnContext = 'minimum';
+
     /** @var bool */
     public bool $logoutFrom = true;
 
@@ -119,6 +122,7 @@ final class UpdateSAMLConfigurationRequest
             'entity_id_url' => $this->entityIdUrl,
             'remote_login_url' => $this->remoteLoginUrl,
             'user_id_attribute' => $this->userIdAttribute,
+            'requested_authn_context' => $this->requestedAuthnContext,
             'certificate' => $this->publicCertificate,
             'logout_from' => $this->logoutFrom,
             'logout_from_url' => $this->logoutFromUrl,

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/SAML/Model/CustomConfiguration.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/SAML/Model/CustomConfiguration.php
@@ -78,6 +78,9 @@ final class CustomConfiguration implements CustomConfigurationInterface, SAMLCus
     /** @var string */
     private string $userIdAttribute = '';
 
+    /** @var RequestedAuthnContextEnum */
+    private RequestedAuthnContextEnum $requestedAuthnContext;
+
     /** @var bool */
     private bool $logoutFrom = true;
 
@@ -156,6 +159,22 @@ final class CustomConfiguration implements CustomConfigurationInterface, SAMLCus
     public function setUserIdAttribute(string $value): void
     {
         $this->userIdAttribute = $value;
+    }
+
+    /**
+     * @return RequestedAuthnContextEnum
+     */
+    public function getRequestedAuthnContext(): RequestedAuthnContextEnum
+    {
+        return $this->requestedAuthnContext;
+    }
+
+    /**
+     * @param RequestedAuthnContextEnum $value
+     */
+    public function setRequestedAuthnContext(RequestedAuthnContextEnum $value): void
+    {
+        $this->requestedAuthnContext = $value;
     }
 
     /**
@@ -387,6 +406,7 @@ final class CustomConfiguration implements CustomConfigurationInterface, SAMLCus
 
         $this->setLogoutFromUrl($json['logout_from_url']);
         $this->setUserIdAttribute($json['user_id_attribute']);
+        $this->setRequestedAuthnContext(RequestedAuthnContextEnum::fromString($json['requested_authn_context']));
         $this->setAutoImportEnabled($json['auto_import']);
         $this->setUserNameBindAttribute($json['fullname_bind_attribute']);
         $this->setEmailBindAttribute($json['email_bind_attribute']);
@@ -421,6 +441,7 @@ final class CustomConfiguration implements CustomConfigurationInterface, SAMLCus
             'remote_login_url',
             'certificate',
             'user_id_attribute',
+            'requested_authn_context',
             'logout_from',
         ];
 

--- a/centreon/src/Core/Security/ProviderConfiguration/Domain/SAML/Model/RequestedAuthnContextEnum.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Domain/SAML/Model/RequestedAuthnContextEnum.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Security\ProviderConfiguration\Domain\SAML\Model;
+
+enum RequestedAuthnContextEnum 
+{
+    case MINIMUM;
+    case EXACT;
+    case BETTER;
+    case MAXIMUM;
+
+    /**
+     * @return string
+     */
+    public function toString(): string
+    {
+        return match ($this) {
+            self::MINIMUM => 'minimum',
+            self::EXACT => 'exact',
+            self::BETTER => 'better',
+            self::MAXIMUM => 'maximum',
+        };
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return self
+     */
+    public static function fromString(string $value): self
+    {
+        return match ($value) {
+            'minimum' => self::MINIMUM,
+            'exact' => self::EXACT,
+            'better' => self::BETTER,
+            'maximum' => self::MAXIMUM,
+            default => self::MINIMUM,
+        };
+    }
+}

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Api/FindSAMLConfiguration/FindSAMLConfigurationPresenter.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Api/FindSAMLConfiguration/FindSAMLConfigurationPresenter.php
@@ -45,6 +45,7 @@ class FindSAMLConfigurationPresenter extends AbstractPresenter implements FindSA
             'remote_login_url' => $data->remoteLoginUrl,
             'certificate' => $data->publicCertificate,
             'user_id_attribute' => $data->userIdAttribute,
+            'requested_authn_context' => $data->requestedAuthnContext,
             'logout_from' => $data->logoutFrom,
             'logout_from_url' => $data->logoutFromUrl,
             'auto_import' => $data->isAutoImportEnabled,

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Api/UpdateSAMLConfiguration/UpdateSAMLConfigurationController.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Api/UpdateSAMLConfiguration/UpdateSAMLConfigurationController.php
@@ -78,6 +78,7 @@ final class UpdateSAMLConfigurationController extends AbstractController
         $updateRequest->remoteLoginUrl = $requestData['remote_login_url'];
         $updateRequest->publicCertificate = $requestData['certificate'];
         $updateRequest->userIdAttribute = $requestData['user_id_attribute'];
+        $updateRequest->requestedAuthnContext = $requestData['requested_authn_context'];
         $updateRequest->logoutFrom = $requestData['logout_from'];
         $updateRequest->logoutFromUrl = $requestData['logout_from_url'];
         $updateRequest->isAutoImportEnabled = $requestData['auto_import'];

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Api/UpdateSAMLConfiguration/UpdateSAMLConfigurationSchema.json
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Api/UpdateSAMLConfiguration/UpdateSAMLConfigurationSchema.json
@@ -38,6 +38,9 @@
     "user_id_attribute": {
       "type": "string"
     },
+    "requested_authn_context": {
+      "type": "string"
+    },
     "logout_from": {
       "type": "boolean"
     },

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Repository/CustomConfigurationSchema.json
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Repository/CustomConfigurationSchema.json
@@ -42,6 +42,9 @@
     "user_id_attribute": {
       "type": "string"
     },
+    "requested_authn_context": {
+      "type": "string"
+    },
     "logout_from": {
       "type": "boolean"
     },

--- a/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Repository/DbWriteSAMLConfigurationRepository.php
+++ b/centreon/src/Core/Security/ProviderConfiguration/Infrastructure/SAML/Repository/DbWriteSAMLConfigurationRepository.php
@@ -159,6 +159,7 @@ class DbWriteSAMLConfigurationRepository extends AbstractRepositoryDRB implement
             'entity_id_url' => $customConfiguration->getEntityIDUrl(),
             'certificate' => $customConfiguration->getPublicCertificate(),
             'user_id_attribute' => $customConfiguration->getUserIdAttribute(),
+            'requested_authn_context' => $customConfiguration->getRequestedAuthnContext()->toString(),
             'logout_from' => $customConfiguration->getLogoutFrom(),
             'logout_from_url' => $customConfiguration->getLogoutFromUrl(),
             'auto_import' => $customConfiguration->isAutoImportEnabled(),

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationPresenterStub.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationPresenterStub.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\ProviderConfiguration\Application\SAML\UseCase\FindSAMLConfiguration;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Security\ProviderConfiguration\Application\SAML\UseCase\FindSAMLConfiguration\FindSAMLConfigurationPresenterInterface;
+use Core\Security\ProviderConfiguration\Application\SAML\UseCase\FindSAMLConfiguration\FindSAMLConfigurationResponse;
+
+class FindSAMLConfigurationPresenterStub extends AbstractPresenter implements FindSAMLConfigurationPresenterInterface
+{
+    /** @var ResponseStatusInterface|FindSAMLConfigurationResponse */
+    public $response;
+
+    /**
+     * @param ResponseStatusInterface|FindSAMLConfigurationResponse $response
+     */
+    public function present(mixed $response): void
+    {
+        $this->response = $response;
+    }
+}

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/FindSAMLConfiguration/FindSAMLConfigurationTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\ProviderConfiguration\Application\SAML\UseCase\FindSAMLConfiguration;
+
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
+use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
+use Core\Security\ProviderConfiguration\Application\SAML\UseCase\FindSAMLConfiguration\FindSAMLConfiguration;
+use Core\Security\ProviderConfiguration\Application\SAML\UseCase\FindSAMLConfiguration\FindSAMLConfigurationResponse;
+use Core\Security\ProviderConfiguration\Domain\Model\ACLConditions;
+use Core\Security\ProviderConfiguration\Domain\Model\AuthenticationConditions;
+use Core\Security\ProviderConfiguration\Domain\Model\Endpoint;
+use Core\Security\ProviderConfiguration\Domain\Model\GroupsMapping;
+use Core\Security\ProviderConfiguration\Domain\Model\Provider;
+use Core\Security\ProviderConfiguration\Domain\SAML\Model\Configuration;
+use Core\Security\ProviderConfiguration\Domain\SAML\Model\CustomConfiguration;
+use Security\Domain\Authentication\Exceptions\ProviderException;
+
+beforeEach(function (): void {
+    $this->providerFactory = $this->createMock(ProviderAuthenticationFactoryInterface::class);
+    $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
+    $this->provider = $this->createMock(ProviderAuthenticationInterface::class);
+});
+
+it('should present a SAML provider configuration', function (): void {
+    $configuration = new Configuration(1, 'saml', 'saml', '{}', true, true);
+    $customConfiguration = new CustomConfiguration([
+        'is_active' => true,
+        'is_forced' => false,
+        'entity_id_url' => 'http://127.0.0.1:4000/realms/my-realm',
+        'remote_login_url' => 'http://127.0.0.1:4000/realms/my-realm/protocol/saml/clients/my-client',
+        'certificate' => 'my-certificate',
+        'logout_from' => true,
+        'logout_from_url' => 'http://127.0.0.1:4000/realms/my-realm/protocol/saml',
+        'user_id_attribute' => 'email',
+        'requested_authn_context' => 'exact',
+        'auto_import' => false,
+        'contact_template' => null,
+        'fullname_bind_attribute' => null,
+        'email_bind_attribute' => null,
+        'authentication_conditions' => new AuthenticationConditions(false, '', new Endpoint(), []),
+        'roles_mapping' => new ACLConditions(false, false, '', new Endpoint(Endpoint::INTROSPECTION, ''), []),
+        'groups_mapping' => new GroupsMapping(false, '', new Endpoint(), []),
+    ]);
+    $configuration->setCustomConfiguration($customConfiguration);
+
+    $this->provider
+        ->expects($this->any())
+        ->method('getConfiguration')
+        ->willReturn($configuration);
+
+    $this->providerFactory
+        ->expects($this->once())
+        ->method('create')
+        ->with(Provider::SAML)
+        ->willReturn($this->provider);
+
+    $useCase = new FindSAMLConfiguration($this->providerFactory);
+    $presenter = new FindSAMLConfigurationPresenterStub($this->presenterFormatter);
+
+    $useCase($presenter);
+
+    expect($presenter->response)->toBeInstanceOf(FindSAMLConfigurationResponse::class);
+    expect($presenter->response->isActive)->toBeTrue();
+    expect($presenter->response->isForced)->toBeTrue();
+    expect($presenter->response->entityIdUrl)->toBe($customConfiguration->getEntityIDUrl());
+    expect($presenter->response->remoteLoginUrl)->toBe($customConfiguration->getRemoteLoginUrl());
+    expect($presenter->response->logoutFrom)->toBe($customConfiguration->getLogoutFrom());
+    expect($presenter->response->logoutFromUrl)->toBe($customConfiguration->getLogoutFromUrl());
+    expect($presenter->response->userIdAttribute)->toBe($customConfiguration->getUserIdAttribute());
+    expect($presenter->response->requestedAuthnContext)
+        ->toBe($customConfiguration->getRequestedAuthnContext()->toString());
+});
+
+it('should present an ErrorResponse when an error occurs during the process', function (): void {
+    $this->providerFactory
+        ->expects($this->once())
+        ->method('create')
+        ->with(Provider::SAML)
+        ->willThrowException(ProviderException::providerConfigurationNotFound(Provider::SAML));
+
+    $useCase = new FindSAMLConfiguration($this->providerFactory);
+    $presenter = new FindSAMLConfigurationPresenterStub($this->presenterFormatter);
+
+    $useCase($presenter);
+
+    expect($presenter->getResponseStatus())->toBeInstanceOf(ErrorResponse::class);
+    expect($presenter->getResponseStatus()?->getMessage())->toBe('Provider configuration (saml) not found');
+});

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfigurationPresenterStub.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfigurationPresenterStub.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\ProviderConfiguration\Application\SAML\UseCase\UpdateSAMLConfiguration;
+
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+use Core\Security\ProviderConfiguration\Application\SAML\UseCase\UpdateSAMLConfiguration\UpdateSAMLConfigurationPresenterInterface;
+
+class UpdateSAMLConfigurationPresenterStub extends AbstractPresenter implements UpdateSAMLConfigurationPresenterInterface
+{
+    /** @var ResponseStatusInterface|null $responseStatus */
+    public ?ResponseStatusInterface $responseStatus = null;
+
+    /**
+     * @param ResponseStatusInterface $response
+     */
+    public function presentResponse(ResponseStatusInterface $response): void
+    {
+        $this->responseStatus = $response;
+    }
+}

--- a/centreon/tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfigurationTest.php
+++ b/centreon/tests/php/Core/Security/ProviderConfiguration/Application/SAML/UseCase/UpdateSAMLConfiguration/UpdateSAMLConfigurationTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Security\ProviderConfiguration\Application\SAML\UseCase\UpdateSAMLConfiguration;
+
+use Centreon\Domain\Repository\Interfaces\DataStorageEngineInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Contact\Application\Repository\ReadContactGroupRepositoryInterface;
+use Core\Contact\Application\Repository\ReadContactTemplateRepositoryInterface;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Security\Authentication\Application\Provider\ProviderAuthenticationFactoryInterface;
+use Core\Security\Authentication\Application\Provider\ProviderAuthenticationInterface;
+use Core\Security\ProviderConfiguration\Application\SAML\Repository\WriteSAMLConfigurationRepositoryInterface;
+use Core\Security\ProviderConfiguration\Application\SAML\UseCase\UpdateSAMLConfiguration\UpdateSAMLConfiguration;
+use Core\Security\ProviderConfiguration\Application\SAML\UseCase\UpdateSAMLConfiguration\UpdateSAMLConfigurationRequest;
+use Core\Security\ProviderConfiguration\Domain\Model\ACLConditions;
+use Core\Security\ProviderConfiguration\Domain\Model\AuthenticationConditions;
+use Core\Security\ProviderConfiguration\Domain\Model\Endpoint;
+use Core\Security\ProviderConfiguration\Domain\Model\GroupsMapping;
+use Core\Security\ProviderConfiguration\Domain\Model\Provider;
+use Core\Security\ProviderConfiguration\Domain\SAML\Model\Configuration;
+use Core\Security\ProviderConfiguration\Domain\SAML\Model\CustomConfiguration;
+
+beforeEach(function (): void {
+    $this->repository = $this->createMock(WriteSAMLConfigurationRepositoryInterface::class);
+    $this->contactTemplateRepository = $this->createMock(ReadContactTemplateRepositoryInterface::class);
+    $this->contactGroupRepository = $this->createMock(ReadContactGroupRepositoryInterface::class);
+    $this->accessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
+    $this->dataStorageEngine = $this->createMock(DataStorageEngineInterface::class);
+    $this->providerFactory = $this->createMock(ProviderAuthenticationFactoryInterface::class);
+    $this->provider = $this->createMock(ProviderAuthenticationInterface::class);
+    $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
+});
+
+it('should present a No Content Response when the use case is executed correctly', function (): void {
+    $request = new UpdateSAMLConfigurationRequest();
+    $request->isActive = true;
+    $request->isForced = true;
+    $request->remoteLoginUrl = 'http://127.0.0.1:4000/realms/my-realm/protocol/saml/clients/my-client';
+    $request->entityIdUrl = 'http://127.0.0.1:4000/realms/my-realm';
+    $request->publicCertificate = 'my-certificate';
+    $request->logoutFrom = true;
+    $request->logoutFromUrl = 'http://127.0.0.1:4000/realms/my-realm/protocol/saml';
+    $request->userIdAttribute = 'email';
+    $request->requestedAuthnContext = 'exact';
+    $request->isAutoImportEnabled = false;
+    $request->contactTemplate = null;
+    $request->emailBindAttribute = null;
+    $request->userNameBindAttribute = null;
+    $request->authenticationConditions = [
+        'is_enabled' => false,
+        'attribute_path' => '',
+        'authorized_values' => [],
+        'trusted_client_addresses' => [],
+        'blacklist_client_addresses' => [],
+    ];
+    $request->rolesMapping = [
+        'is_enabled' => false,
+        'apply_only_first_role' => false,
+        'attribute_path' => '',
+        'relations' => [],
+    ];
+    $request->groupsMapping = [
+        'is_enabled' => false,
+        'attribute_path' => '',
+        'relations' => [],
+    ];
+
+    $this->providerFactory
+        ->expects($this->once())
+        ->method('create')
+        ->willReturn($this->provider);
+
+    $configuration = new Configuration(1, 'saml', 'saml', '{}', true, false);
+    $customConfiguration = new CustomConfiguration([
+        'is_active' => true,
+        'is_forced' => false,
+        'entity_id_url' => 'http://127.0.0.1:4000/realms/my-realm',
+        'remote_login_url' => 'http://127.0.0.1:4000/realms/my-realm/protocol/saml/clients/my-client',
+        'certificate' => 'my-old-certificate',
+        'logout_from' => true,
+        'logout_from_url' => 'http://127.0.0.1:4000/realms/my-realm/protocol/saml',
+        'user_id_attribute' => 'email',
+        'requested_authn_context' => 'exact',
+        'auto_import' => false,
+        'contact_template' => null,
+        'fullname_bind_attribute' => null,
+        'email_bind_attribute' => null,
+        'authentication_conditions' => new AuthenticationConditions(false, '', new Endpoint(), []),
+        'roles_mapping' => new ACLConditions(false, false, '', new Endpoint(Endpoint::INTROSPECTION, ''), []),
+        'groups_mapping' => new GroupsMapping(false, '', new Endpoint(), []),
+    ]);
+
+    $configuration->setCustomConfiguration($customConfiguration);
+
+    $this->provider
+        ->expects($this->once())
+        ->method('getConfiguration')
+        ->willReturn($configuration);
+
+    $this->repository
+        ->expects($this->once())
+        ->method('updateConfiguration');
+
+    $useCase = new UpdateSAMLConfiguration(
+        $this->repository,
+        $this->contactTemplateRepository,
+        $this->contactGroupRepository,
+        $this->accessGroupRepository,
+        $this->dataStorageEngine,
+        $this->providerFactory
+    );
+    $presenter = new UpdateSAMLConfigurationPresenterStub($this->presenterFormatter);
+
+    $useCase($presenter, $request);
+
+    expect($presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should presenet an Error Response when an error occurs during the process', function (): void {
+    $request = new UpdateSAMLConfigurationRequest();
+    $request->isActive = true;
+    $request->isForced = true;
+    $request->remoteLoginUrl = 'http://127.0.0.1:4000/realms/my-realm/protocol/saml/clients/my-client';
+    $request->entityIdUrl = 'http://127.0.0.1:4000/realms/my-realm';
+    $request->publicCertificate = 'my-certificate';
+    $request->logoutFrom = true;
+    $request->logoutFromUrl = 'http://127.0.0.1:4000/realms/my-realm/protocol/saml';
+    $request->userIdAttribute = 'email';
+    $request->requestedAuthnContext = 'exact';
+    $request->isAutoImportEnabled = false;
+    $request->contactTemplate = null;
+    $request->emailBindAttribute = null;
+    $request->userNameBindAttribute = null;
+    $request->authenticationConditions = [
+        'is_enabled' => false,
+        'attribute_path' => '',
+        'authorized_values' => [],
+        'trusted_client_addresses' => [],
+        'blacklist_client_addresses' => [],
+    ];
+    $request->rolesMapping = [
+        'is_enabled' => false,
+        'apply_only_first_role' => false,
+        'attribute_path' => '',
+        'relations' => [],
+    ];
+    $request->groupsMapping = [
+        'is_enabled' => false,
+        'attribute_path' => '',
+        'relations' => [],
+    ];
+    $this->providerFactory
+        ->expects($this->once())
+        ->method('create')
+        ->with(Provider::SAML)
+        ->willThrowException(new \Exception('An error occured'));
+
+    $useCase = new UpdateSAMLConfiguration(
+        $this->repository,
+        $this->contactTemplateRepository,
+        $this->contactGroupRepository,
+        $this->accessGroupRepository,
+        $this->dataStorageEngine,
+        $this->providerFactory
+    );
+
+    $presenter = new UpdateSAMLConfigurationPresenterStub($this->presenterFormatter);
+
+    $useCase($presenter, $request);
+
+    expect($presenter->getResponseStatus())->toBeInstanceOf(ErrorResponse::class);
+});

--- a/centreon/www/install/insertBaseConf.sql
+++ b/centreon/www/install/insertBaseConf.sql
@@ -1490,7 +1490,7 @@ INSERT INTO `password_expiration_excluded_users` (provider_configuration_id, use
 VALUES (1, 4);
 
 INSERT INTO provider_configuration (`type`, `name`, `custom_configuration`, `is_active`, `is_forced`)
-VALUES ('saml', 'SAML', '{"remote_login_url":"","entity_id_url":"","certificate":"","user_id_attribute":"","logout_from":false,"logout_from_url":null,"auto_import":false,"contact_template_id":null,"email_bind_attribute":null,"fullname_bind_attribute":null,"authentication_conditions":{"is_enabled":false,"attribute_path":"","authorized_values":[]},"roles_mapping":{"is_enabled":false,"apply_only_first_role":false,"attribute_path":""},"groups_mapping":{"is_enabled":false,"attribute_path":""}}', 0, 0);
+VALUES ('saml', 'SAML', '{"remote_login_url":"","entity_id_url":"","certificate":"","user_id_attribute":"","requested_authn_context":"minimum","logout_from":false,"logout_from_url":null,"auto_import":false,"contact_template_id":null,"email_bind_attribute":null,"fullname_bind_attribute":null,"authentication_conditions":{"is_enabled":false,"attribute_path":"","authorized_values":[]},"roles_mapping":{"is_enabled":false,"apply_only_first_role":false,"attribute_path":""},"groups_mapping":{"is_enabled":false,"attribute_path":""}}', 0, 0);
 
 INSERT INTO dashboard_widgets (`name`)
 VALUES ('centreon-widget-generictext');

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -1,4 +1,7 @@
 <?php
+
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
 /*
  * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
  *
@@ -68,7 +71,40 @@ $updateTopologyForHostGroup = function (CentreonDB $pearDB) use (&$errorMessage)
     );
 };
 
+$updateSamlProviderConfiguration = function (CentreonDB $pearDB) use (&$errorMessage): void {
+    $errorMessage = 'Unable to retrieve SAML provider configuration';
+    $samlConfiguration = $pearDB->fetchAssociative(
+        <<<'SQL'
+            SELECT * FROM `provider_configuration`
+            WHERE `type` = 'saml'
+            SQL
+    );
 
+    if (!isset($samlConfiguration['custom_configuration'])) {
+        throw new \Exception('SAML custom configuration is missing');
+    }
+
+    $customConfiguration = json_decode($samlConfiguration['custom_configuration'], true, JSON_THROW_ON_ERROR);
+
+    if (!isset($customConfiguration['requested_authn_context'])) {
+        $customConfiguration['requested_authn_context'] = 'minimum';
+        $query = <<<'SQL'
+                UPDATE `provider_configuration`
+                SET `custom_configuration` = :custom_configuration
+                WHERE `type` = 'saml'
+            SQL;
+        $queryParameters = QueryParameters::create(
+            [
+                QueryParameter::string(
+                    'custom_configuration',
+                    json_encode($customConfiguration, JSON_THROW_ON_ERROR)
+                )
+            ]
+        );
+
+        $pearDB->update($query, $queryParameters);
+    }
+};
 
 try {
     // TODO add your function calls to update the real time database structure here
@@ -81,6 +117,7 @@ try {
     }
 
     $updateTopologyForHostGroup($pearDB);
+    $updateSamlProviderConfiguration($pearDB);
 
     $pearDB->commit();
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -80,8 +80,8 @@ $updateSamlProviderConfiguration = function (CentreonDB $pearDB) use (&$errorMes
             SQL
     );
 
-    if (!isset($samlConfiguration['custom_configuration'])) {
-        throw new \Exception('SAML custom configuration is missing');
+    if (! $samlConfiguration || ! isset($samlConfiguration['custom_configuration'])) {
+        throw new \Exception('SAML configuration is missing');
     }
 
     $customConfiguration = json_decode($samlConfiguration['custom_configuration'], true, JSON_THROW_ON_ERROR);


### PR DESCRIPTION
## Description

Added `requested_authn_context` property in 
- `GET: /administration/authentication/providers/saml` 
- `PUT: /administration/authentication/providers/saml`

**Fixes** # MON-164373

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
