### PR TITLE
fix(composer): update composer reference for centreon-test-lib

### DIFF
--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3603c6759448a8cdb123474d5e8caada",
+    "content-hash": "6ab66bdc3338441d1c42e95f1607e11c",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -6880,12 +6880,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "c524733598a236d74c25da5a3afce1d0af4aaddc"
+                "reference": "316fda1c6edbb4513e65b7917a7564d24495ac51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/c524733598a236d74c25da5a3afce1d0af4aaddc",
-                "reference": "c524733598a236d74c25da5a3afce1d0af4aaddc",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/316fda1c6edbb4513e65b7917a7564d24495ac51",
+                "reference": "316fda1c6edbb4513e65b7917a7564d24495ac51",
                 "shasum": ""
             },
             "require": {
@@ -6936,7 +6936,7 @@
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
                 "source": "https://github.com/centreon/centreon-test-lib/tree/23.04.x"
             },
-            "time": "2024-10-11T08:01:22+00:00"
+            "time": "2025-03-25T14:51:25+00:00"
         },
         {
             "name": "composer/pcre",

--- a/centreon/features/bootstrap/DowntimeDSTContext.php
+++ b/centreon/features/bootstrap/DowntimeDSTContext.php
@@ -108,14 +108,14 @@ class DowntimeDSTContext extends CentreonContext
     {
         // on Europe/Paris at 2AM, we jump to 3AM
         $this->downtimeProperties = array(
-            'start_day' => '03/30/2025',
+            'start_day' => '03/25/2029',
             'start_time' => '02:30',
-            'end_day' => '03/30/2025',
+            'end_day' => '03/25/2029',
             'end_time' => '03:30',
-            'expected_start' => '2025-03-30 03:00',
-            'expected_end' => '2025-03-30 03:30',
+            'expected_start' => '2029-03-25 03:00',
+            'expected_end' => '2029-03-25 03:30',
             'expected_duration' => '1800', // 30m
-            'faketime' => '2025-03-30 01:56:00'
+            'faketime' => '2029-03-25 01:56:00'
         );
     }
 
@@ -126,14 +126,14 @@ class DowntimeDSTContext extends CentreonContext
     {
         // on Europe/Paris at 2AM, we jump to 3AM
         $this->downtimeProperties = array(
-            'start_day' => '03/30/2025',
+            'start_day' => '03/25/2029',
             'start_time' => '01:30',
-            'end_day' => '03/30/2025',
+            'end_day' => '03/25/2029',
             'end_time' => '02:30',
-            'expected_start' => '2025-03-30 01:30',
-            'expected_end' => '2025-03-30 03:00',
+            'expected_start' => '2029-03-25 01:30',
+            'expected_end' => '2029-03-25 03:00',
             'expected_duration' => '1800', // 30m
-            'faketime' => '2025-03-30 01:26:00'
+            'faketime' => '2029-03-25 01:26:00'
         );
     }
 
@@ -144,14 +144,14 @@ class DowntimeDSTContext extends CentreonContext
     {
         // on Europe/Paris at 2AM, we jump to 3AM
         $this->downtimeProperties = array(
-            'start_day' => '03/30/2025',
+            'start_day' => '03/25/2029',
             'start_time' => '02:03',
-            'end_day' => '03/30/2025',
+            'end_day' => '03/25/2029',
             'end_time' => '02:33',
             'expected_start' => '',
             'expected_end' => '',
             'expected_duration' => '0',
-            'faketime' => '2025-03-30 01:58:00'
+            'faketime' => '2029-03-25 01:58:00'
         );
     }
 
@@ -162,14 +162,14 @@ class DowntimeDSTContext extends CentreonContext
     {
         // on Europe/Paris at 2AM, we jump to 3AM
         $this->downtimeProperties = array(
-            'start_day' => '03/30/2025',
+            'start_day' => '03/25/2029',
             'start_time' => '00:00',
-            'end_day' => '03/30/2025',
+            'end_day' => '03/25/2029',
             'end_time' => '24:00',
-            'expected_start' => '2025-03-30 00:00',
-            'expected_end' => '2025-03-31 00:00',
-            'expected_duration' => '82800', // 23h
-            'faketime' => '2025-03-29 23:56:00'
+            'expected_start' => '2029-03-25 00:00',
+            'expected_end' => '2029-03-26 00:00',
+            'expected_duration' => '82800', //23h
+            'faketime' => '2029-03-24 23:56:00'
         );
     }
 
@@ -189,14 +189,14 @@ class DowntimeDSTContext extends CentreonContext
     public function aDowntimeOfNextDayOfSummerChangingDate()
     {
         $this->downtimeProperties = array(
-            'start_day' => '03/31/2025',
+            'start_day' => '03/26/2029',
             'start_time' => '00:00',
-            'end_day' => '03/31/2025',
+            'end_day' => '03/26/2029',
             'end_time' => '24:00',
-            'expected_start' => '2025-03-31 00:00',
-            'expected_end' => '2025-04-01 00:00',
+            'expected_start' => '2029-03-26 00:00',
+            'expected_end' => '2029-03-27 00:00',
             'expected_duration' => '86400', // 24h
-            'faketime' => '2025-03-30 23:58:00'
+            'faketime' => '2029-03-25 23:58:00'
         );
     }
 
@@ -344,7 +344,9 @@ class DowntimeDSTContext extends CentreonContext
                     if ($dateStart->format('Y-m-d H:i') != $context->downtimeProperties['expected_start'] ||
                         $dateEnd->format('Y-m-d H:i') != $context->downtimeProperties['expected_end'] ||
                         ($endTimestamp - $startTimestamp) != (int)$context->downtimeProperties['expected_duration']) {
-                        throw new \Exception('Downtime external command parameters are wrong (start, end or duration)');
+                            throw new \Exception(
+                                'Downtime external command parameters are wrong (start, end or duration)'
+                            );
                     }
                     $storageDb = $context->getStorageDatabase();
                     $res = $storageDb->query(


### PR DESCRIPTION
## Description

- due to recent changes in runner configuration, docker daemon only listens on unix socket and not tcp
- added a condition specific to unix socket docker_host
- this should fix the issue where some behat tests resolved docker_host as "unix" instead of "127.0.0.1"
- added backport of DST downtime tests issue

Fixes #MON-164097 #MON-164505

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
