### PR TITLE
fix(ceip): fix bad value in LACCESS in metadata

### DIFF
--- a/centreon/www/api/class/centreon_ceip.class.php
+++ b/centreon/www/api/class/centreon_ceip.class.php
@@ -442,9 +442,20 @@ class CentreonCeip extends CentreonWebService
      */
     private function getLaccess(): string
     {
-        $sql = "SELECT `value` FROM `options` WHERE `key` = 'LACCESS' LIMIT 1";
+        $sql = "SELECT `value` FROM `options` WHERE `key` = 'impCompanyToken' LIMIT 1";
+        $impCompanyToken = (string) $this->sqlFetchValue($sql);
 
-        return (string) $this->sqlFetchValue($sql);
+        $decodedToken = json_decode($impCompanyToken, true);
+        if (is_array($decodedToken) && isset($decodedToken['token'])) {
+            return $decodedToken['token'];
+        }
+
+        $this->logger->error(
+            "Invalid JSON format in options table for key 'impCompanyToken'",
+            ['context' => $impCompanyToken]
+        );
+
+        return '';
     }
 
     /**


### PR DESCRIPTION
## Description

This PR intends to fix LACCESS valus in ceip metadata;
used this sql query to retrieve laccess value :
``` SELECT `value` FROM `options` WHERE `key` = 'impCompanyToken' LIMIT 1; ```
as it is stored into impCompanyToken :
```json
{"apiVersion":"v2","token":"LACCESS.e764ab8ad9f9-42a3-b348-c265ad1b14cd"}
``` 
laccess value should be : 
`LACCESS.e764ab8ad9f9-42a3-b348-c265ad1b14cd`

**Fixes** # ([MON-164131](https://centreon.atlassian.net/browse/MON-164131))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-164131]: https://centreon.atlassian.net/browse/MON-164131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ