### PR TITLE
chore(composer): update composer reference for centreon-test-lib

### DIFF
--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -6565,12 +6565,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "1ed402fa5bf72b511fd9d520f6ff3aade97ac80f"
+                "reference": "a688fb07bc646389d57cb3d0cf67fbf27ad84077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/1ed402fa5bf72b511fd9d520f6ff3aade97ac80f",
-                "reference": "1ed402fa5bf72b511fd9d520f6ff3aade97ac80f",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/a688fb07bc646389d57cb3d0cf67fbf27ad84077",
+                "reference": "a688fb07bc646389d57cb3d0cf67fbf27ad84077",
                 "shasum": ""
             },
             "require": {
@@ -6619,7 +6619,7 @@
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
                 "source": "https://github.com/centreon/centreon-test-lib/tree/22.10.x"
             },
-            "time": "2025-01-28T10:49:04+00:00"
+            "time": "2025-03-25T14:52:06+00:00"
         },
         {
             "name": "composer/pcre",


### PR DESCRIPTION
## Description

- due to recent changes in runner configuration, docker daemon only listens on unix socket and not tcp
- added a condition specific to unix socket docker_host
- this should fix the issue where some behat tests resolved docker_host as "unix" instead of "127.0.0.1"

Fixes #MON-164099

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
