### PR TITLE
chore(composer): update composer reference for centreon-test-lib

### DIFF
--- a/centreon/composer.lock
+++ b/centreon/composer.lock
@@ -6947,12 +6947,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/centreon/centreon-test-lib.git",
-                "reference": "132e0a1c7288079d057d18dcc1460893e53e9257"
+                "reference": "c0547ab9cc2b98ebd1bfada9bc896ef95321e507"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/132e0a1c7288079d057d18dcc1460893e53e9257",
-                "reference": "132e0a1c7288079d057d18dcc1460893e53e9257",
+                "url": "https://api.github.com/repos/centreon/centreon-test-lib/zipball/c0547ab9cc2b98ebd1bfada9bc896ef95321e507",
+                "reference": "c0547ab9cc2b98ebd1bfada9bc896ef95321e507",
                 "shasum": ""
             },
             "require": {
@@ -7006,9 +7006,9 @@
             ],
             "support": {
                 "issues": "https://github.com/centreon/centreon-test-lib/issues",
-                "source": "https://github.com/centreon/centreon-test-lib/tree/master"
+                "source": "https://github.com/centreon/centreon-test-lib/tree/24.10.x"
             },
-            "time": "2024-10-04T08:35:10+00:00"
+            "time": "2025-04-03T07:20:39+00:00"
         },
         {
             "name": "clue/ndjson-react",


### PR DESCRIPTION
## Description

- due to recent changes in runner configuration, docker daemon only listens on unix socket and not tcp
- added a condition specific to unix socket docker_host
- this should fix the issue where some behat tests resolved docker_host as "unix" instead of "127.0.0.1"

Fixes #MON-164106

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
