### PR TITLE
fix(ci): fix 409 conflict errors on behat-testing artifact uploads (#7066)

### DIFF
--- a/.github/workflows/behat-test.yml
+++ b/.github/workflows/behat-test.yml
@@ -116,6 +116,15 @@ jobs:
           cd ${{ inputs.module_name }}
           ./vendor/bin/behat --config="${{ inputs.config_file }}" --format=pretty --out=std --format=junit --out="$BASE_DIRECTORY/xunit-reports" "${{ inputs.features_path }}/${{ matrix.feature }}"
 
+      - name: Replace / with - in the feature path
+        id: feature-path
+        if: always()
+        run: |
+          feature_name="${{ matrix.feature }}"
+          feature_name_with_dash="${feature_name//\//-}"
+          echo "Modified Feature Name: $feature_name_with_dash"
+          echo "feature_name_with_dash=$feature_name_with_dash" >> $GITHUB_OUTPUT
+
       - name: Clean empty reports
         if: ${{ !cancelled() }}
         run: find ./xunit-reports/* -type f | xargs grep -l -E "<testsuites.+></testsuites>" | xargs -r rm
@@ -129,7 +138,7 @@ jobs:
         if: failure()
         name: Upload acceptance test logs
         with:
-          name: ${{ inputs.name }}-test-logs
+          name: ${{ inputs.name }}-alma8-test-logs-${{ steps.feature-path.outputs.feature_name_with_dash }}
           path: acceptance-logs
           retention-days: 1
 
@@ -137,7 +146,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
         with:
-          name: ${{ inputs.name }}-test-reports
+          name: ${{ inputs.name }}-alma8-test-reports-${{ steps.feature-path.outputs.feature_name_with_dash }}
           path: xunit-reports
           retention-days: 1
 
@@ -152,8 +161,9 @@ jobs:
       - name: Download Artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
-          name: ${{ inputs.name }}-test-reports
+          pattern: ${{ inputs.name }}-alma8-test-reports-*
           path: ${{ inputs.name }}-xunit-reports
+          merge-multiple: true
 
       - uses: ./.github/actions/publish-report
         with:


### PR DESCRIPTION
## Description

fixes errors related to 409: conflict failures that appear on Upload test reports on behat testing (especially in nightly contexts)
however, it does not fix the failures related to the behat tests themselves (the step Behat acceptance testing)
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
partially fixes # MON-164617

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
