### PR TITLE
fix(WIDGET): back to deprecated method initSmartyTplForPopup for 22.10

### DIFF
--- a/widgets/centreon-widget-servicegroup-monitoring/servicegroup-monitoring/src/index.php
+++ b/widgets/centreon-widget-servicegroup-monitoring/servicegroup-monitoring/src/index.php
@@ -57,7 +57,9 @@ if (CentreonSession::checkSession(session_id(), $db) == 0) {
 
 // Smarty template initialization
 $path = $centreon_path . "www/widgets/servicegroup-monitoring/src/";
-$template = SmartyBC::createSmartyTemplate($path, './');
+
+$template = new Smarty();
+$template = initSmartyTplForPopup($path, $template, "./", $centreon_path);
 
 $centreon = $_SESSION['centreon'];
 

--- a/widgets/centreon-widget-servicegroup-monitoring/servicegroup-monitoring/src/index.php
+++ b/widgets/centreon-widget-servicegroup-monitoring/servicegroup-monitoring/src/index.php
@@ -44,6 +44,7 @@ require_once $centreon_path . 'www/class/centreonUtils.class.php';
 require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonLog.class.php';
 require_once $centreon_path . 'www/widgets/servicegroup-monitoring/src/class/ServicegroupMonitoring.class.php';
+require_once $centreon_path . 'www/include/common/sqlCommonFunction.php';
 
 CentreonSession::start(1);
 
@@ -118,7 +119,7 @@ if (isset($preferences['sg_name_search']) && trim($preferences['sg_name_search']
 
 if (!$centreon->user->admin) {
     [$bindValues, $bindQuery] = createMultipleBindQuery($aclObj->getServiceGroups(), ':servicegroup_name_', PDO::PARAM_STR);
-    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, "name IN ($bindQuery)");
+    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, "name IN (" . ($bindQuery ?: "''") . ")");
     $bindParams = array_merge($bindParams, $bindValues);
 }
 


### PR DESCRIPTION
## Description

remove the new static method which doesn't exist on 22.10 (SmartyBC::createSmartyTemplate)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Check [Ticket](https://centreon.atlassian.net/browse/MON-161209)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
