### PR TITLE
Fix([Resource Status]):Calculation type tile is displayed twice

### DIFF
--- a/centreon/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
+++ b/centreon/www/front_src/src/Resources/Details/tabs/Details/DetailsCard/cards.tsx
@@ -25,6 +25,7 @@ import {
   labelLatency,
   labelMonitoringServer,
   labelNextCheck,
+  labelParentAlias,
   labelPerformanceData,
   labelSeverity,
   labelStatusChangePercentage,
@@ -201,8 +202,8 @@ const getDetailCardLines = ({
     },
     {
       line: <DetailsLine line={details.parent?.uuid} />,
-      shouldBeDisplayed: !isNil(details.calculation_type),
-      title: labelCalculationType
+      shouldBeDisplayed: !isNil(details.parent?.uuid),
+      title: labelParentAlias
     },
     {
       isCustomCard: true,


### PR DESCRIPTION
**Description**:  fix the duplication of displayed information calculation_type [link](https://centreon.atlassian.net/browse/MON-153333)
**Video**

[screen-capture (9).webm](https://github.com/user-attachments/assets/f13f78ad-40b0-4e93-a6aa-1165bea13152)
