### PR TITLE
Fix([Resources Status]): Graph - Filling and invert options are the inverse of the curve template

### DIFF
--- a/centreon/packages/ui/src/Graph/Chart/useChartData.ts
+++ b/centreon/packages/ui/src/Graph/Chart/useChartData.ts
@@ -30,6 +30,8 @@ interface Props {
   start?: string;
 }
 
+const getBoolean = (value) => Boolean(Number(value));
+
 const useGraphData = ({ data, end, start }: Props): GraphDataResult => {
   const adjustedDataRef = useRef<Data>();
 
@@ -48,7 +50,16 @@ const useGraphData = ({ data, end, start }: Props): GraphDataResult => {
 
     const newMetrics = Object.entries(metricsGroupedByColor).map(
       ([color, value]) => {
-        return value?.map((metric, index) =>
+        const adjustedValue = value?.map((item) => ({
+          ...item,
+          ds_data: {
+            ...item?.ds_data,
+            ds_invert: getBoolean(item?.ds_data?.ds_invert),
+            ds_filled: getBoolean(item?.ds_data?.ds_filled)
+          }
+        }));
+
+        return adjustedValue?.map((metric, index) =>
           set(
             lensPath(['ds_data', 'ds_color_line']),
             emphasizeCurveColor({ color, index }),
@@ -76,6 +87,7 @@ const useGraphData = ({ data, end, start }: Props): GraphDataResult => {
     const { title } = dataWithAdjustedMetricsColor.global;
 
     const newLineData = adjustGraphData(dataWithAdjustedMetricsColor).lines;
+
     const sortedLines = sortBy(compose(toLower, prop('name')), newLineData);
 
     adjustedDataRef.current = {


### PR DESCRIPTION
**Description**: parse invert and filled values ..

**Video** 

[screen-capture.webm](https://github.com/user-attachments/assets/a5354f29-a6e6-4123-a0ed-0262f283c231)
