### PR TITLE
Add notification TP import for PP manager

### DIFF
--- a/centreon/www/class/centreonHost.class.php
+++ b/centreon/www/class/centreonHost.class.php
@@ -2396,6 +2396,9 @@ class CentreonHost
         $rq .= (isset($ret['contact_additive_inheritance']) ? 1 : 0) . ', ';
         $rq .= "cg_additive_inheritance = ";
         $rq .= (isset($ret['cg_additive_inheritance']) ? 1 : 0) . ', ';
+        $rq .= "timeperiod_tp_id2 = ";
+        isset($ret["timeperiod_tp_id2"]) && $ret["timeperiod_tp_id2"] != null ?
+        $rq .= "'" . $ret["timeperiod_tp_id2"] . "', " : $rq .= "NULL, ";
         $rq .= "host_stalking_options = ";
         isset($ret["host_stalOpts"]) && $ret["host_stalOpts"] != null ?
             $rq .= "'" . implode(",", array_keys($ret["host_stalOpts"])) . "', " : $rq .= "NULL, ";


### PR DESCRIPTION


## Description

This pull request (alongside this one https://github.com/centreon/centreon-modules/pull/5381) allows the PP manager to import the host notification period defined in the connectors host template. 
This is needed for cloud platforms as users cannot define host notification period and will have warnings such as
`Warning Notifier 'host-XXXXX' has no check time period defined!`

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [X] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

* Add the changes in this pull request https://github.com/centreon/centreon-modules/pull/5381
* Login to Centreon
* Install or update the Base Pack (latest vertion) in the **Configuration  >  Monitoring Connector Manager** page
* Go to the **Configuration  >  Hosts  >  Templates** page and check any generic templates added by the Base Pack (for example **generic-active-host**)
* Check the notification tab, 24x7 should appear in the **Notification Period** field

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
