### PR TITLE
enh(nightly): assign nightly incident ticket to squad according to sprint number

### DIFF
--- a/.github/actions/create-jira-ticket/action.yml
+++ b/.github/actions/create-jira-ticket/action.yml
@@ -98,6 +98,8 @@ runs:
             ;;
         esac
 
+        echo "Ticket will be assigned to the $squad_name team."
+
         current_sprint=$(curl --request GET \
           --url ${{ inputs.jira_base_url }}/rest/agile/1.0/board/$ticket_board_id/sprint?state=active \
           --user "${{ inputs.jira_user_email }}:${{ inputs.jira_api_token }}" \

--- a/.github/actions/create-jira-ticket/action.yml
+++ b/.github/actions/create-jira-ticket/action.yml
@@ -68,38 +68,41 @@ runs:
           "DevSecOps")
             ticket_squad_id=10524
             ticket_board_id=184
-            assign_to_current_sprint=true
+            squad_name="DEVSECOPS"
             ;;
           "Collect")
             ticket_squad_id=10255
             ticket_board_id=118
-            assign_to_current_sprint=true
+            squad_name="COLLECT"
             ;;
           "MAP")
             ticket_squad_id=10258
             ticket_board_id=149
-            assign_to_current_sprint=true
+            squad_name="MAP"
             ;;
           "Product Backlog")
-            ticket_squad_id=10623
-            ticket_board_id=211
-            assign_to_current_sprint=false
+            # Every two weeks, these tickets get assigned to either Metropolis or Gotham
+            if [[ $(( $(date -d '+1 week' '+%-V') % 4 )) -ge 2 ]]; then
+              ticket_squad_id=10625
+              ticket_board_id=213
+              squad_name="METROPOLIS"
+            else
+              ticket_squad_id=10882
+              ticket_board_id=225
+              squad_name="GOTHAM"
+            fi
             ;;
           *)
             echo "::error::Cannot find a valid squad for value ${{ inputs.ticket_squad }}."
             exit 1
             ;;
         esac
-        echo "Ticket will be assigned to the ${{ inputs.ticket_squad }} team."
 
-        if [[ $assign_to_current_sprint == true ]]; then
-          current_sprint=$(curl --request GET \
-            --url ${{ inputs.jira_base_url }}/rest/agile/1.0/board/$ticket_board_id/sprint?state=active \
-            --user "${{ inputs.jira_user_email }}:${{ inputs.jira_api_token }}" \
-            --header "Accept: application/json" | jq .values[0].id)
-        else
-          current_sprint="null"
-        fi
+        current_sprint=$(curl --request GET \
+          --url ${{ inputs.jira_base_url }}/rest/agile/1.0/board/$ticket_board_id/sprint?state=active \
+          --user "${{ inputs.jira_user_email }}:${{ inputs.jira_api_token }}" \
+          --header "Accept: application/json" | jq --arg squad_name "$squad_name" '.values[] | select(.name | test($squad_name)) | .id')
+
         echo "[DEBUG] current_sprint: $current_sprint"
 
         # General updates on all template files

--- a/.github/actions/create-jira-ticket/action.yml
+++ b/.github/actions/create-jira-ticket/action.yml
@@ -101,7 +101,7 @@ runs:
         current_sprint=$(curl --request GET \
           --url ${{ inputs.jira_base_url }}/rest/agile/1.0/board/$ticket_board_id/sprint?state=active \
           --user "${{ inputs.jira_user_email }}:${{ inputs.jira_api_token }}" \
-          --header "Accept: application/json" | jq --arg squad_name "$squad_name" '.values[] | select(.name | test($squad_name)) | .id')
+          --header "Accept: application/json" | jq --arg squad_name "$squad_name" '.values[] | select(.name | test($squad_name; "i")) | .id')
 
         echo "[DEBUG] current_sprint: $current_sprint"
 

--- a/.github/actions/create-jira-ticket/action.yml
+++ b/.github/actions/create-jira-ticket/action.yml
@@ -83,13 +83,13 @@ runs:
           "Product Backlog")
             # Every two weeks, these tickets get assigned to either Metropolis or Gotham
             if [[ $(( $(date -d '+1 week' '+%-V') % 4 )) -ge 2 ]]; then
-              ticket_squad_id=10882
-              ticket_board_id=225
-              squad_name="GOTHAM"
-            else
               ticket_squad_id=10625
               ticket_board_id=213
               squad_name="METROPOLIS"
+            else
+              ticket_squad_id=10882
+              ticket_board_id=225
+              squad_name="GOTHAM"
             fi
             ;;
           *)

--- a/.github/actions/create-jira-ticket/action.yml
+++ b/.github/actions/create-jira-ticket/action.yml
@@ -83,13 +83,13 @@ runs:
           "Product Backlog")
             # Every two weeks, these tickets get assigned to either Metropolis or Gotham
             if [[ $(( $(date -d '+1 week' '+%-V') % 4 )) -ge 2 ]]; then
-              ticket_squad_id=10625
-              ticket_board_id=213
-              squad_name="METROPOLIS"
-            else
               ticket_squad_id=10882
               ticket_board_id=225
               squad_name="GOTHAM"
+            else
+              ticket_squad_id=10625
+              ticket_board_id=213
+              squad_name="METROPOLIS"
             fi
             ;;
           *)

--- a/.github/workflows/cypress-component-parallelization.yml
+++ b/.github/workflows/cypress-component-parallelization.yml
@@ -45,8 +45,6 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - run: exit 1
-
       - name: List of specs
         id: list-specs
         run: |
@@ -294,6 +292,7 @@ jobs:
     if: |
       inputs.is_nightly == 'true' && github.run_attempt == 1 &&
       (failure() || cancelled()) &&
+      startsWith(github.ref_name, 'dev') &&
       github.repository == 'centreon/centreon'
     steps:
       - name: Checkout sources

--- a/.github/workflows/cypress-component-parallelization.yml
+++ b/.github/workflows/cypress-component-parallelization.yml
@@ -294,7 +294,6 @@ jobs:
     if: |
       inputs.is_nightly == 'true' && github.run_attempt == 1 &&
       (failure() || cancelled()) &&
-      startsWith(github.ref_name, 'dev') &&
       github.repository == 'centreon/centreon'
     steps:
       - name: Checkout sources

--- a/.github/workflows/cypress-component-parallelization.yml
+++ b/.github/workflows/cypress-component-parallelization.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - run: exit 1
+
       - name: List of specs
         id: list-specs
         run: |

--- a/.github/workflows/cypress-component-parallelization.yml
+++ b/.github/workflows/cypress-component-parallelization.yml
@@ -45,6 +45,8 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - run: exit 1
+
       - name: List of specs
         id: list-specs
         run: |
@@ -292,7 +294,6 @@ jobs:
     if: |
       inputs.is_nightly == 'true' && github.run_attempt == 1 &&
       (failure() || cancelled()) &&
-      startsWith(github.ref_name, 'dev') &&
       github.repository == 'centreon/centreon'
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Description

examples where the additions of the script worked properly (the tickets were deleted to not create interference and false alarms with the dev squad) for both gotham and metropolis
https://github.com/centreon/centreon/actions/runs/14383721054/job/40333851941
https://github.com/centreon/centreon/actions/runs/14383550310/job/40333246437

**Fixes** # MON-164492

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
