### PR TITLE
update RAM listing rules

### DIFF
--- a/centreon/src/Core/ResourceAccess/Application/Repository/ReadResourceAccessRepositoryInterface.php
+++ b/centreon/src/Core/ResourceAccess/Application/Repository/ReadResourceAccessRepositoryInterface.php
@@ -32,11 +32,23 @@ use Core\ResourceAccess\Domain\Model\TinyRule;
 interface ReadResourceAccessRepositoryInterface
 {
     /**
+     * List all rules.
+     *
      * @param RequestParametersInterface $requestParameters
      *
      * @return TinyRule[]
      */
     public function findAllByRequestParameters(RequestParametersInterface $requestParameters): array;
+
+    /**
+     * List all rules the user is linked to.
+     *
+     * @param RequestParametersInterface $requestParameters
+     * @param int $userId
+     *
+     * @return TinyRule[]
+     */
+    public function findAllByRequestParametersAndUserId(RequestParametersInterface $requestParameters, int $userId): array;
 
     /**
      * Checks if the rule name provided as been already used for a rule.

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRules/FindRules.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRules/FindRules.php
@@ -29,7 +29,6 @@ use Centreon\Domain\Log\LoggerTrait;
 use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
 use Centreon\Infrastructure\RequestParameters\RequestParametersTranslatorException;
 use Core\Application\Common\UseCase\ErrorResponse;
-use Core\Application\Common\UseCase\ForbiddenResponse;
 use Core\ResourceAccess\Application\Exception\RuleException;
 use Core\ResourceAccess\Application\Repository\ReadResourceAccessRepositoryInterface;
 use Core\ResourceAccess\Domain\Model\TinyRule;


### PR DESCRIPTION
## Description

Update FindRules endpoint `/administration/resource-access/rules`

Previously:
- user must be super-admin or cloud-admin to be allowed rules listing

Now:
- any user list the rules
- non-admin user can only see rules they are linked to (directly or via contactgroups)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
