### PR TITLE
force server short name in ocf scripts

### DIFF
--- a/centreon-ha/ocf-scripts/mariadb-centreon
+++ b/centreon-ha/ocf-scripts/mariadb-centreon
@@ -561,7 +561,7 @@ check_slave() {
             ocf_log warn "MariaDB Slave IO threads currently not running."
 
             # Sanity check, are we at least on the right master
-            new_master=$($CRM_ATTR_REPL_INFO --query  -q)
+            new_master=$($CRM_ATTR_REPL_INFO --query  -q | awk -F\. '{ print $1 }')
 
             if [ "$master_host" != "$new_master" ]; then
                # Not pointing to the right master, not good, removing the VIPs
@@ -600,7 +600,7 @@ check_slave() {
 }
 
 set_master() {
-    local new_master=$($CRM_ATTR_REPL_INFO --query  -q)
+    local new_master=$($CRM_ATTR_REPL_INFO --query  -q | awk -F\. '{ print $1 }')
 
     # Informs the MariaDB server of the master to replicate
     # from. Accepts one mandatory argument which must contain the host
@@ -714,7 +714,7 @@ get_local_ip() {
    local IP
    IP=$($CRM_ATTR -l forever -n ${INSTANCE_ATTR_NAME}_mysql_master_IP -q -G 2>/dev/null)
    if [ ! $? -eq 0 ]; then
-      uname -n
+      uname -n | awk -F\. '{ print $1 }'
    else
       echo $IP
    fi

--- a/centreon-ha/ocf-scripts/mariadb-centreon-common.sh
+++ b/centreon-ha/ocf-scripts/mariadb-centreon-common.sh
@@ -107,7 +107,7 @@ MYSQL_OPTIONS_TEST="$MYSQL_OPTIONS_LOCAL --user=$OCF_RESKEY_test_user --password
 MYSQL_TOO_MANY_CONN_ERR=1040
 
 CRM_MASTER="${HA_SBIN_DIR}/crm_master -l reboot "
-NODENAME=$(ocf_local_nodename)
+NODENAME=$(ocf_local_nodename) # will perform the crm_node -n command for pacemaker version > 1.1.8
 CRM_ATTR="${HA_SBIN_DIR}/crm_attribute -N $NODENAME "
 INSTANCE_ATTR_NAME=`echo ${OCF_RESOURCE_INSTANCE}| awk -F : '{print $1}'`
 CRM_ATTR_REPL_INFO="${HA_SBIN_DIR}/crm_attribute --type crm_config --name ${INSTANCE_ATTR_NAME}_REPL_INFO -s mysql_replication"


### PR DESCRIPTION
## Description

when your /etc/hostname has the following kind of server name:  `server-ha-1.localdomain` you may have a bug in your mysql replication. This is caused by an inconsistency from pacemaker and the resource agents  that will sometime get you the the short name a.k.a `server-ha-1` and sometimes the full name. 
This is quite important because the cluster is going to compare both values to know if a server must be set as a slave or master. 
When the bug is triggered you'll end up with a master that is also slave of himself and slave that is properly set up as a slave of the master. While this work as is, you will break everything when trying to promote the slave as a master and demote the master.

this bug is because we compare the following values:

- the NODENAME value that comes from the command `crm_node -n`  that must give you the name of the server used when you've created the cluster with the `pcs auth` command 
- the command `crm_attribute --type crm_config --name ms_mysql_REPL_INFO -s mysql_replication --query -q`

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

this is quite hard to test. 

- first you must have the /etc/hostname configured to have the dns name of your server such as server-ha-1.localdomain on all your cluster servers (looks like you can easily have the bug on debian 12 but not on el9 servers)
- then you must create the cluster as usual
- then try the `crm_node -n` and  `crm_attribute --type crm_config --name ms_mysql_REPL_INFO -s mysql_replication --query -q` commands. If they show the same value, then you don't have the bug. If you have the different results then you'll have the bug that is fixed by the patch
- without the patch, if you do a `show slave status\G` and `show master status` on both db servers you will probably end up with a master server that is slave of himself and a slave server that is slave of the master server. If not, keep an eye on the name of the Master_Host value that is displayed on the show slave status command. It should be the short name
- if everything looked before, move your ms_mysql resource and now should see the full server name instead of its short name

```sql
*************************** 1. row ***************************
                Slave_IO_State: Waiting for master to send event
                   Master_Host: debian-ha-2.localdomain
                   Master_User: centreon_repl
                   Master_Port: 3306
                 Connect_Retry: 60
               Master_Log_File: mysql-bin.000001
```

this result can lead to many problems. 

With the patch, you shouldn't face this kind of issue.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
