### PR TITLE
ci(secu): replace gitleaks secret and remove PRT

### DIFF
--- a/.github/workflows/check-status.yml
+++ b/.github/workflows/check-status.yml
@@ -106,7 +106,7 @@ jobs:
 
   get-environment:
     if: |
-      contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) &&
+      contains(fromJSON('["pull_request"]') , github.event_name) &&
       (startsWith(github.base_ref, 'release-') || startsWith(github.base_ref, 'hotfix-'))
     uses: ./.github/workflows/get-environment.yml
     with:
@@ -116,7 +116,7 @@ jobs:
     needs: [get-environment, check-status]
     runs-on: ubuntu-24.04
     if: |
-      contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) &&
+      contains(fromJSON('["pull_request"]') , github.event_name) &&
       needs.get-environment.outputs.target_stability == 'testing' &&
       ! contains(needs.get-environment.outputs.labels, 'skip-cherry-pick')
 

--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -83,7 +83,7 @@ jobs:
             let hasSkipLabel = false;
             let labels = [];
 
-            if (${{ contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }} === true) {
+            if (${{ contains(fromJSON('["pull_request"]') , github.event_name) }} === true) {
               try {
                 const fetchedLabels = await github.rest.issues.listLabelsOnIssue({
                   owner: context.repo.owner,
@@ -221,7 +221,7 @@ jobs:
           echo "latest_major_version=$MAJOR" >> $GITHUB_OUTPUT
         shell: bash
 
-      - if: ${{ contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }}
+      - if: ${{ contains(fromJSON('["pull_request"]') , github.event_name) }}
         name: Get nested pull request path
         id: pr_path
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -270,7 +270,7 @@ jobs:
             core.setOutput('stability', getStability('${{ github.head_ref || github.ref_name }}'));
 
             let isTargetingFeatureBranch = false;
-            if (${{ contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }} === true) {
+            if (${{ contains(fromJSON('["pull_request"]') , github.event_name) }} === true) {
               let targetStability = 'canary';
               const prPath = ${{ steps.pr_path.outputs.result || '[]' }};
               prPath.shift(); // remove current branch
@@ -361,7 +361,7 @@ jobs:
               return true;
             }
 
-            if (${{ contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }} === true) {
+            if (${{ contains(fromJSON('["pull_request"]') , github.event_name) }} === true) {
               const prPath = ${{ steps.pr_path.outputs.result || '[]' }};
               const finalTargetBranch = prPath.pop();
               if (['develop', 'master'].includes(finalTargetBranch)) {
@@ -493,7 +493,7 @@ jobs:
               .addHeading(`${context.workflow} environment outputs`)
               .addTable(outputTable);
 
-            if (${{ contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }} === true) {
+            if (${{ contains(fromJSON('["pull_request"]') , github.event_name) }} === true) {
               const prPath = ${{ steps.pr_path.outputs.result || '[]' }};
               const mainBranchName = prPath.pop();
               let codeBlock = `

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: gitleaks/gitleaks-action@83373cf2f8c4db6e24b41c1a9b086bb9619e9cd3 # v2.3.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE}}
+          GITLEAKS_LICENSE: "Centreon"
           GITLEAKS_ENABLE_COMMENTS: false
           GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
           GITLEAKS_ENABLE_SUMMARY: false

--- a/.github/workflows/set-pull-request-external-label.yml
+++ b/.github/workflows/set-pull-request-external-label.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   set-pull-request-external-label:

--- a/.github/workflows/set-pull-request-skip-label.yml
+++ b/.github/workflows/set-pull-request-skip-label.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   set-pull-request-skip-label:
-    if: ${{ success() && contains(fromJSON('["pull_request", "pull_request_target"]') , github.event_name) }}
+    if: ${{ success() && contains(fromJSON('["pull_request"]') , github.event_name) }}
     runs-on: ubuntu-24.04
 
     steps:


### PR DESCRIPTION
## Description

Remove secret in order to allow dependabot and external PR to be able to run the gitleaks mandatory workflow