### PR TITLE
fix(timeperiods): maxlength should match the database columns size

### DIFF
--- a/centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+++ b/centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
@@ -75,7 +75,7 @@ $dbResult->closeCursor();
  * Var information to format the element
  */
 $attrsText = ["size" => "35"];
-$attrsTextLong = ["size" => "55", "maxlength" => "200"];
+$attrsTextLong = ["size" => "55", "maxlength" => "2048"];
 $attrsAdvSelect = ["style" => "width: 300px; height: 130px;"];
 $eTemplate = '<table><tr><td><div class="ams">{label_2}</div>{unselected}</td><td align="center">{add}<br /><br />'
     . '<br />{remove}</td><td><div class="ams">{label_3}</div>{selected}</td></tr></table>';


### PR DESCRIPTION
## Description

The timeperiod table contains columns that allow 2048 characters but the form only accepted 200.
![image](https://github.com/user-attachments/assets/cd8f6a19-73e2-457c-ab07-db22c1baaf3f)

With this PR, we have the same value (2048) on both side.

**Fixes** #MON-166146

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
