### PR TITLE
fix(services): Check that inherited templates has a check command

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -19869,3 +19869,6 @@ msgstr "Vous avez sélectionné Aucun TLS comme niveau de chiffrement. Ce param�
 
 msgid "'{{total}} element(s) found"
 msgstr "'{{total}} élément(s) trouvé(s)"
+
+msgid "The selected inherited service template does not contain any check command. You must select one here."
+msgstr "Le modèle de service hérité sélectionné ne comporte pas de commande de vérification. Vous devez en sélectionner une ici."

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -4237,8 +4237,8 @@ function checkServiceTemplateHasCommand(array $fields): array|bool
             QueryParameters::create([QueryParameter::int('stm_id', $serviceTemplateId)])
         );
         if ($serviceTemplateCommand === null) {
-            $errors['command_command_id'] = _("The inherited service template has also no check command. "
-                . "Please select a command."
+            $errors['command_command_id'] = _("The selected inherited service template does not contain any "
+                . "check command. You must select one here."
             );
         }
     }

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -4220,7 +4220,7 @@ function findHostsOfService(int $serviceId): array
 }
 
 /**
- * Will check is the service template inherited by the service has a command.
+ * Will check if the service template inherited by the service has a command.
  *
  * @param array<string, mixed> $fields The fields of the service
  *

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -4219,7 +4219,14 @@ function findHostsOfService(int $serviceId): array
     return $hostIds;
 }
 
-function checkServiceTemplateHasCommand(array $fields)
+/**
+ * Will check is the service template inherited by the service has a command.
+ *
+ * @param array<string, mixed> $fields The fields of the service
+ *
+ * @return array<string, string>|bool
+ */
+function checkServiceTemplateHasCommand(array $fields): array|bool
 {
     global $pearDB;
     $errors = [];

--- a/centreon/www/include/configuration/configObject/service/formService.php
+++ b/centreon/www/include/configuration/configObject/service/formService.php
@@ -1038,6 +1038,10 @@ if ($o !== SERVICE_MASSIVE_CHANGE) {
         if (! $form->getSubmitValue('service_hgPars') && $serviceHParsFieldIsAdded) {
             $form->addRule('service_hPars', _('HostGroup or Host Required'), 'required');
         }
+    } else {
+        if (! $isCloudPlatform) {
+            $form->addFormRule('checkServiceTemplateHasCommand');
+        }
     }
     if (! $form->getSubmitValue('service_hPars') && $serviceHgParsFieldIsAdded) {
         $form->addRule('service_hgPars', _('HostGroup or Host Required'), 'required');


### PR DESCRIPTION
## Description

This PR intends to fix an issue where it was possible to create a service inherited of a service template, without a command, even if the templates has no commands too.
Then the conf export was broken when trying to export this service

**Fixes** # MON-157042

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
