### PR TITLE
Backport(web): % unit is not correctly formatted on axis

### DIFF
--- a/centreon/packages/ui/src/Graph/common/Axes/useAxisY.ts
+++ b/centreon/packages/ui/src/Graph/common/Axes/useAxisY.ts
@@ -5,7 +5,7 @@ import { isNil } from 'ramda';
 
 import { useTheme } from '@mui/material';
 
-import { formatMetricValue, getUnits } from '../timeSeries';
+import { formatMetricValueWithUnit, getUnits } from '../timeSeries';
 import { commonTickLabelProps } from '../utils';
 
 import { Data, LabelProps } from './models';
@@ -69,7 +69,7 @@ const useAxisY = ({
         return '';
       }
 
-      return formatMetricValue({ base: data.baseAxis, unit, value }) as string;
+      return formatMetricValueWithUnit({ base: data.baseAxis, unit, value }) as string;
     };
 
   const labelProps = ({


### PR DESCRIPTION
**Description**: Backport

**Video**

[screen-capture (6).webm](https://github.com/user-attachments/assets/4a656a1d-976a-445a-be51-50303238b471)

