### PR TITLE
enh(Agent Configuration): add insecure connection mode to api

### DIFF
--- a/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/AddAcRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/AddAcRequest.yaml
@@ -20,6 +20,16 @@ properties:
       type: integer
     description: Poller ID(s) associated with the configuration
     example: [1, 12]
+  connection_mode:
+    type: string
+    description: |
+      Connection mode for the configuration
+
+      Supported modes:
+        * secure
+        * no-tls
+        * insecure
+    example: secure
   configuration:
     type: object
     description: |

--- a/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/AddAcResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/AddAcResponse.yaml
@@ -9,8 +9,21 @@ properties:
     example: "my-cfg-name"
   type:
     type: string
-    description: Type of configuration
+    description: |
+      Type of configuration
+        Supported types:
+          * telegraf
+          * centreon-agent
     example: telegraf
+  connection_mode:
+    type: string
+    description: |
+      Connection mode for the configuration
+      Supported modes:
+        * secure
+        * no-tls
+        * insecure
+    example: no-tls
   pollers:
     type: array
     items:

--- a/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/FindAcsResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/FindAcsResponse.yaml
@@ -14,6 +14,7 @@ properties:
 
       Supported types:
         * telegraf
+        * centreon-agent
     example: telegraf
   pollers:
     type: array

--- a/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/GetAcResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/GetAcResponse.yaml
@@ -14,7 +14,18 @@ properties:
 
       Supported types:
         * telegraf
+        * centreon-agent
     example: telegraf
+  connection_mode:
+    type: string
+    description: |
+      Connection mode for the configuration
+
+      Supported modes:
+        * secure
+        * no-tls
+        * insecure
+    example: no-tls
   pollers:
     type: array
     description: "List of pollers that are attached to this object"

--- a/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/UpdateAcRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/AgentConfiguration/Schema/UpdateAcRequest.yaml
@@ -14,6 +14,16 @@ properties:
         * telegraf
         * centreon-agent
     example: telegraf
+  connection_mode:
+    type: string
+    description: |
+      Connection mode for the configuration
+
+      Supported modes:
+        * secure
+        * no-tls
+        * insecure
+    example: no-tls
   poller_ids:
     type: array
     items:

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/Validator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/Validator.php
@@ -71,7 +71,7 @@ class Validator
         $this->validateNameOrFail($request);
         $this->validatePollersOrFail($request);
         $this->validateTypeOrFail($request);
-        if ($request->connectionMode === ConnectionModeEnum::SECURE) {
+        if ($request->connectionMode !== ConnectionModeEnum::NO_TLS) {
             $this->validateParametersOrFail($request);
         }
     }

--- a/centreon/src/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/Validator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/UseCase/UpdateAgentConfiguration/Validator.php
@@ -76,7 +76,7 @@ class Validator
         $this->validateNameOrFail($request, $agentConfiguration);
         $this->validatePollersOrFail($request, $agentConfiguration);
         $this->validateTypeOrFail($request, $agentConfiguration);
-        if ($request->connectionMode === ConnectionModeEnum::SECURE) {
+        if ($request->connectionMode !== ConnectionModeEnum::NO_TLS) {
             $this->validateParametersOrFail($request);
         }
     }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -68,6 +68,7 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
             $this->validateCertificate($parameters['otel_public_certificate'], 'configuration.otel_public_certificate');
             $this->validateCertificate($parameters['otel_private_key'], 'configuration.otel_private_key');
             $this->validateOptionalCertificate($parameters['otel_ca_certificate'], 'configuration.otel_ca_certificate');
+        // For NO-TLS and INSECURE modes
         } else {
             $this->validateOptionalCertificate(
                 $parameters['otel_public_certificate'],

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -64,11 +64,12 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
     public function __construct(array $parameters, ConnectionModeEnum $connectionMode){
         $parameters = $this->normalizeCertificatePaths($parameters);
 
-        if ($connectionMode === ConnectionModeEnum::SECURE) {
+        // For secure and insecure modes
+        if ($connectionMode !== ConnectionModeEnum::NO_TLS) {
             $this->validateCertificate($parameters['otel_public_certificate'], 'configuration.otel_public_certificate');
             $this->validateCertificate($parameters['otel_private_key'], 'configuration.otel_private_key');
             $this->validateOptionalCertificate($parameters['otel_ca_certificate'], 'configuration.otel_ca_certificate');
-        // For NO-TLS and INSECURE modes
+        // For NO-TLS mode
         } else {
             $this->validateOptionalCertificate(
                 $parameters['otel_public_certificate'],

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
@@ -60,13 +60,14 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
 
         Assertion::range($parameters['conf_server_port'], 0, 65535, 'configuration.conf_server_port');
 
-        if ($connectionMode === ConnectionModeEnum::SECURE) {
+        // For secure and insecure modes
+        if ($connectionMode !== ConnectionModeEnum::NO_TLS) {
             $this->validateCertificate($parameters['otel_public_certificate'], 'configuration.otel_public_certificate');
             $this->validateCertificate($parameters['otel_private_key'], 'configuration.otel_private_key');
             $this->validateCertificate($parameters['conf_certificate'], 'configuration.conf_certificate');
             $this->validateCertificate($parameters['conf_private_key'], 'configuration.conf_private_key');
             $this->validateOptionalCertificate($parameters['otel_ca_certificate'], 'configuration.otel_ca_certificate');
-        // For NO-TLS and INSECURE modes
+        // For NO-TLS mode
         } else {
             $this->validateOptionalCertificate(
                 $parameters['otel_public_certificate'],

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
@@ -66,6 +66,7 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
             $this->validateCertificate($parameters['conf_certificate'], 'configuration.conf_certificate');
             $this->validateCertificate($parameters['conf_private_key'], 'configuration.conf_private_key');
             $this->validateOptionalCertificate($parameters['otel_ca_certificate'], 'configuration.otel_ca_certificate');
+        // For NO-TLS and INSECURE modes
         } else {
             $this->validateOptionalCertificate(
                 $parameters['otel_public_certificate'],

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConnectionModeEnum.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConnectionModeEnum.php
@@ -26,4 +26,5 @@ namespace Core\AgentConfiguration\Domain\Model;
 enum ConnectionModeEnum {
     case SECURE;
     case NO_TLS;
+    case INSECURE;
 }

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationController.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationController.php
@@ -92,6 +92,7 @@ final class AddAgentConfigurationController extends AbstractController
         $addRequest->connectionMode = match ($data['connection_mode']) {
             'no-tls' => ConnectionModeEnum::NO_TLS,
             'insecure' => ConnectionModeEnum::INSECURE,
+            'secure' => ConnectionModeEnum::SECURE,
             default => ConnectionModeEnum::SECURE,
         };
         $addRequest->pollerIds = $data['poller_ids'];

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationController.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationController.php
@@ -89,9 +89,11 @@ final class AddAgentConfigurationController extends AbstractController
         $addRequest = new AddAgentConfigurationRequest();
         $addRequest->type = $data['type'];
         $addRequest->name = $data['name'];
-        $addRequest->connectionMode = $data['connection_mode'] === 'no-tls'
-            ? ConnectionModeEnum::NO_TLS
-            : ConnectionModeEnum::SECURE;
+        $addRequest->connectionMode = match ($data['connection_mode']) {
+            'no-tls' => ConnectionModeEnum::NO_TLS,
+            'insecure' => ConnectionModeEnum::INSECURE,
+            default => ConnectionModeEnum::SECURE,
+        };
         $addRequest->pollerIds = $data['poller_ids'];
         $addRequest->configuration = $data['configuration'];
 

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationPresenter.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationPresenter.php
@@ -65,6 +65,7 @@ class AddAgentConfigurationPresenter extends AbstractPresenter implements AddAge
         return match ($connectionMode) {
             ConnectionModeEnum::SECURE => 'secure',
             ConnectionModeEnum::NO_TLS => 'no-tls',
+            ConnectionModeEnum::INSECURE => 'insecure',
         };
     }
 }

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationSchema.json
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/AddAgentConfiguration/AddAgentConfigurationSchema.json
@@ -24,7 +24,8 @@
             "type": "string",
             "enum": [
                 "secure",
-                "no-tls"
+                "no-tls",
+                "insecure"
             ],
             "default": "secure"
         },

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/UpdateAgentConfiguration/UpdateAgentConfigurationController.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/UpdateAgentConfiguration/UpdateAgentConfigurationController.php
@@ -93,9 +93,12 @@ final class UpdateAgentConfigurationController extends AbstractController
         $updateRequest->id = $id;
         $updateRequest->type = $data['type'];
         $updateRequest->name = $data['name'];
-        $updateRequest->connectionMode = $data['connection_mode'] === 'no-tls'
-            ? ConnectionModeEnum::NO_TLS
-            : ConnectionModeEnum::SECURE;
+        $updateRequest->connectionMode = match ($data['connection_mode']) {
+            'no-tls' => ConnectionModeEnum::NO_TLS,
+            'insecure' => ConnectionModeEnum::INSECURE,
+            'secure' => ConnectionModeEnum::SECURE,
+            default => ConnectionModeEnum::SECURE,
+        };
         $updateRequest->pollerIds = $data['poller_ids'];
         $updateRequest->configuration = $data['configuration'];
 

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/UpdateAgentConfiguration/UpdateAgentConfigurationSchema.json
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/UpdateAgentConfiguration/UpdateAgentConfigurationSchema.json
@@ -24,7 +24,8 @@
             "type": "string",
             "enum": [
                 "secure",
-                "no-tls"
+                "no-tls",
+                "insecure"
             ],
             "default": "secure"
         },

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbReadAgentConfigurationRepository.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbReadAgentConfigurationRepository.php
@@ -401,6 +401,7 @@ class DbReadAgentConfigurationRepository extends AbstractRepositoryRDB implement
         $connectionMode = match ($row['connection_mode']) {
             'secure' => ConnectionModeEnum::SECURE,
             'no-tls' => ConnectionModeEnum::NO_TLS,
+            'insecure' => ConnectionModeEnum::INSECURE,
             default => throw new \InvalidArgumentException('Invalid connection mode'),
         };
 

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbWriteAgentConfigurationRepository.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbWriteAgentConfigurationRepository.php
@@ -69,6 +69,7 @@ class DbWriteAgentConfigurationRepository extends DatabaseRepository implements 
                         match ($agentConfiguration->getConnectionMode()) {
                             ConnectionModeEnum::NO_TLS => 'no-tls',
                             ConnectionModeEnum::SECURE => 'secure',
+                            ConnectionModeEnum::INSECURE => 'insecure',
                         }
                     ),
                     QueryParameter::string(
@@ -111,6 +112,7 @@ class DbWriteAgentConfigurationRepository extends DatabaseRepository implements 
                         match ($agentConfiguration->getConnectionMode()) {
                             ConnectionModeEnum::NO_TLS => 'no-tls',
                             ConnectionModeEnum::SECURE => 'secure',
+                            ConnectionModeEnum::INSECURE => 'insecure',
                         }
                     ),
                     QueryParameter::string(

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Serializer/AgentConfigurationNormalizer.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Serializer/AgentConfigurationNormalizer.php
@@ -54,6 +54,7 @@ class AgentConfigurationNormalizer implements NormalizerInterface
         $data['connection_mode'] = match ($object->getConnectionMode()) {
             ConnectionModeEnum::SECURE => 'secure',
             ConnectionModeEnum::NO_TLS => 'no-tls',
+            ConnectionModeEnum::INSECURE => 'insecure',
         };
 
         return $data;

--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -82,7 +82,7 @@ class AgentConfiguration extends AbstractObjectJSON
         return [
             'host' => ModelAgentConfiguration::DEFAULT_HOST,
             'port' => ModelAgentConfiguration::DEFAULT_PORT,
-            'encryption' => ConnectionModeEnum::NO_TLS !== $connectionMode,
+            'encryption' => ConnectionModeEnum::SECURE === $connectionMode,
             'public_cert' => ! empty($data['otel_public_certificate'])
                 ? $data['otel_public_certificate']
                 : '',

--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -82,7 +82,12 @@ class AgentConfiguration extends AbstractObjectJSON
         return [
             'host' => ModelAgentConfiguration::DEFAULT_HOST,
             'port' => ModelAgentConfiguration::DEFAULT_PORT,
-            'encryption' => ConnectionModeEnum::SECURE === $connectionMode,
+            'encryption' => match ($connectionMode) {
+                ConnectionModeEnum::SECURE => 'full',
+                ConnectionModeEnum::INSECURE => 'insecure',
+                ConnectionModeEnum::NO_TLS => 'no',
+                default => 'full',
+            },
             'public_cert' => ! empty($data['otel_public_certificate'])
                 ? $data['otel_public_certificate']
                 : '',

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -189,7 +189,7 @@ $updateAgentConfiguration = function (CentreonDB $pearDB) use (&$errorMessage): 
 
 /**
   * Add Column connection_mode to agent_configuration table.
-  * This Column is used to define the connection mode of the agent between ("no-tls","tls","secure","insecure").
+  * This Column is used to define the connection mode of the agent between ("no-tls","secure","insecure").
   *
   * @param CentreonDB $pearDB
   *


### PR DESCRIPTION
## Description

Add insecure connection mode to CMA and Telegraf in agent configuration

**Fixes** # ([MON-167130](https://centreon.atlassian.net/browse/MON-167130))

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- Check that endpoints ADD/UPDATE accept “Insecure” in connection mode, and empty certificates are accepted
- Check that the GET endpoint and otl_server.json include this information

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-167130]: https://centreon.atlassian.net/browse/MON-167130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ