### PR TITLE
fix(database) : heredoc and nowdoc accepted with connection interface

### DIFF
--- a/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
+++ b/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
@@ -136,9 +136,11 @@ trait ConnectionTrait
     public function insert(string $query, ?QueryParameters $queryParameters = null): int
     {
         try {
-            if (! str_starts_with($query, 'INSERT INTO ')
-                && ! str_starts_with($query, 'insert into ')
-            ) {
+            // Clean up the query string
+            $query = ltrim($query);
+
+            // Check if the query starts with a valid SQL command
+            if (preg_match('/^(INSERT INTO|WITH)\b/i', $query) !== 1) {
                 throw ConnectionException::insertQueryBadFormat($query);
             }
 
@@ -268,9 +270,11 @@ trait ConnectionTrait
     public function update(string $query, ?QueryParameters $queryParameters = null): int
     {
         try {
-            if (! str_starts_with($query, 'UPDATE ')
-                && ! str_starts_with($query, 'update ')
-            ) {
+            // Clean up the query string
+            $query = ltrim($query);
+
+            // Check if the query starts with a valid SQL command
+            if (preg_match('/^(UPDATE|WITH)\b/i', $query) !== 1) {
                 throw ConnectionException::updateQueryBadFormat($query);
             }
 
@@ -298,9 +302,11 @@ trait ConnectionTrait
     public function delete(string $query, ?QueryParameters $queryParameters = null): int
     {
         try {
-            if (! str_starts_with($query, 'DELETE ')
-                && ! str_starts_with($query, 'delete ')
-            ) {
+            // Clean up the query string
+            $query = ltrim($query);
+
+            // Check if the query starts with a valid SQL command
+            if (preg_match('/^(DELETE|WITH)\b/i', $query) !== 1) {
                 throw ConnectionException::deleteQueryBadFormat($query);
             }
 
@@ -522,7 +528,12 @@ trait ConnectionTrait
         if (empty($query)) {
             throw ConnectionException::notEmptyQuery();
         }
-        if (! str_starts_with($query, 'SELECT') && ! str_starts_with($query, 'select')) {
+
+        // Clean up the query string
+        $query = ltrim($query);
+
+        // Check if the query starts with a valid SQL command
+        if (preg_match('/^(SELECT|EXPLAIN|SHOW|DESCRIBE|WITH)\b/i', $query) !== 1) {
             throw ConnectionException::selectQueryBadFormat($query);
         }
     }

--- a/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
+++ b/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
@@ -1415,7 +1415,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -------------------------------------- QUERY FORMAT ---------------------------------------
 
     it(
-        'fetchAssociative with string format with indent before the query ',
+        'execute a query with string format with indent before',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $query = '    SELECT * FROM contact WHERE contact_id = :id';
@@ -1429,7 +1429,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with NowDoc format with no indent before the query',
+        'execute a query with NowDoc format with no indent before',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $query =
@@ -1446,7 +1446,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with NowDoc format with indent before the query',
+        'execute a query with NowDoc format with indent before',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $query =
@@ -1463,7 +1463,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with HereDoc format with no indent before the query',
+        'execute a query with HereDoc format with no indent before',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $query =
@@ -1480,7 +1480,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with HereDoc format with indent before the query',
+        'execute a query with HereDoc format with indent before',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $query =

--- a/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
+++ b/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
@@ -88,7 +88,7 @@ function hasConnectionDb(ConnectionConfig $connectionConfig): bool
 
 if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     it(
-        'test DbalConnectionAdapter : DbalConnectionAdapter::createFromConfig factory with a good connection',
+        'DbalConnectionAdapter::createFromConfig factory with a good connection',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $pdo = $db->getNativeConnection();
@@ -102,7 +102,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'test DbalConnectionAdapter : DbalConnectionAdapter::createFromConfig factory with a bad connection',
+        'DbalConnectionAdapter::createFromConfig factory with a bad connection',
         function () use ($dbHost, $dbUser, $dbPassword): void {
             $dbConfigCentreon = new ConnectionConfig(
                 host: $dbHost,
@@ -117,7 +117,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : create query builder with success',
+        'create query builder with success',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $queryBuilder = $db->createQueryBuilder();
@@ -128,7 +128,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'test DbalConnectionAdapter : create expression builder with success',
+        'create expression builder with success',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $expressionBuilder = $db->createExpressionBuilder();
@@ -139,7 +139,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'test DbalConnectionAdapter : get connection config',
+        'get connection config',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $connectionConfig = $db->getConnectionConfig();
@@ -153,7 +153,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'test DbalConnectionAdapter : get the database name of the current connection',
+        'get the database name of the current connection',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $dbName = $db->getDatabaseName();
@@ -161,13 +161,13 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     );
 
-    it('test DbalConnectionAdapter : get native connection', function () use ($dbConfigCentreon): void {
+    it('get native connection', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $pdo = $db->getNativeConnection();
         expect($pdo)->toBeInstanceOf(\PDO::class);
     });
 
-    it('test DbalConnectionAdapter : get last insert id', function () use ($dbConfigCentreon): void {
+    it('get last insert id', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $pdo = $db->getNativeConnection();
         $insert = $pdo->exec(
@@ -181,12 +181,12 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         expect($delete)->toBeInt()->toBe(1);
     });
 
-    it('test DbalConnectionAdapter : is connected', function () use ($dbConfigCentreon): void {
+    it('is connected', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         expect($db->isConnected())->toBeTrue();
     });
 
-    it('test DbalConnectionAdapter : quote string', function () use ($dbConfigCentreon): void {
+    it('quote string', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $pdo = $db->getNativeConnection();
         $quotedString = $pdo->quote("foo");
@@ -198,7 +198,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- executeStatement()
 
     it(
-        'test DbalConnectionAdapter : execute statement with a correct query without query parameters',
+        'execute statement with a correct query without query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $pdo = $db->getNativeConnection();
@@ -213,7 +213,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'test DbalConnectionAdapter : execute statement with a correct query with query parameters',
+        'execute statement with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $pdo = $db->getNativeConnection();
@@ -236,7 +236,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'test DbalConnectionAdapter : execute statement with a correct query with query parameters with ":" before keys',
+        'execute statement with a correct query with query parameters with ":" before keys',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $pdo = $db->getNativeConnection();
@@ -258,18 +258,18 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     );
 
-    it('test DbalConnectionAdapter : execute statement with a SELECT query', function () use ($dbConfigCentreon): void {
+    it('execute statement with a SELECT query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->executeStatement("SELECT * FROM contact");
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : execute statement with an empty query', function () use ($dbConfigCentreon): void {
+    it('execute statement with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->executeStatement("");
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : execute statement with an incorrect query',
+        'execute statement with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->executeStatement("foo");
@@ -277,7 +277,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : execute statement with an incorrect query parameters',
+        'execute statement with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $queryParameters = QueryParameters::create(
@@ -296,7 +296,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- insert()
 
     it(
-        'test DbalConnectionAdapter : insert with a correct query with query parameters',
+        'insert with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $pdo = $db->getNativeConnection();
@@ -318,7 +318,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     );
 
-    it('test DbalConnectionAdapter : insert with a SELECT query', function () use ($dbConfigCentreon): void {
+    it('insert with a SELECT query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->insert(
             "SELECT * FROM contact WHERE contact_id = :id",
@@ -326,18 +326,18 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         );
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : insert with an empty query', function () use ($dbConfigCentreon): void {
+    it('insert with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->insert("", QueryParameters::create([QueryParameter::int('contact_id', 110)]));
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : insert with an incorrect query', function () use ($dbConfigCentreon): void {
+    it('insert with an incorrect query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->insert("foo", QueryParameters::create([QueryParameter::int('contact_id', 110)]));
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : insert with an incorrect query parameters',
+        'insert with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $queryParameters = QueryParameters::create(
@@ -356,7 +356,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- batchInsert()
 
     it(
-        'test DbalConnectionAdapter : batch insert with a correct query with batch query parameters',
+        'batch insert with a correct query with batch query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $pdo = $db->getNativeConnection();
@@ -390,7 +390,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'test DbalConnectionAdapter : batch insert with a correct query with empty batch query parameters',
+        'batch insert with a correct query with empty batch query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->batchInsert(
@@ -402,7 +402,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : batch insert with an incorrect batch query parameters',
+        'batch insert with an incorrect batch query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $batchQueryParameters = BatchInsertParameters::create([
@@ -430,7 +430,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- update()
 
     it(
-        'test DbalConnectionAdapter : update with a correct query with query parameters',
+        'update with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $pdo = $db->getNativeConnection();
@@ -456,7 +456,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     );
 
-    it('test DbalConnectionAdapter : update with a SELECT query', function () use ($dbConfigCentreon): void {
+    it('update with a SELECT query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->update(
             "SELECT * FROM contact WHERE contact_id = :id",
@@ -464,18 +464,18 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         );
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : update with an empty query', function () use ($dbConfigCentreon): void {
+    it('update with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->update("", QueryParameters::create([QueryParameter::int('contact_id', 110)]));
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : update with an incorrect query', function () use ($dbConfigCentreon): void {
+    it('update with an incorrect query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->update("foo", QueryParameters::create([QueryParameter::int('contact_id', 110)]));
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : update with an incorrect query parameters',
+        'update with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $queryParameters = QueryParameters::create(
@@ -494,7 +494,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- delete()
 
     it(
-        'test DbalConnectionAdapter : delete with a correct query with query parameters',
+        'delete with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $inserted = $db->executeStatement(
@@ -507,7 +507,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     );
 
-    it('test DbalConnectionAdapter : delete with a SELECT query', function () use ($dbConfigCentreon): void {
+    it('delete with a SELECT query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->delete(
             "SELECT * FROM contact WHERE contact_id = :id",
@@ -515,18 +515,18 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         );
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : delete with an empty query', function () use ($dbConfigCentreon): void {
+    it('delete with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->delete("", QueryParameters::create([QueryParameter::int('contact_id', 110)]));
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : delete with an incorrect query', function () use ($dbConfigCentreon): void {
+    it('delete with an incorrect query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->delete("foo", QueryParameters::create([QueryParameter::int('contact_id', 110)]));
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : delete with an incorrect query parameters',
+        'delete with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $queryParameters = QueryParameters::create(
@@ -547,7 +547,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- fetchNumeric()
 
     it(
-        'test DbalConnectionAdapter : fetchNumeric with a correct query with query parameters',
+        'fetchNumeric with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contact = $db->fetchNumeric(
@@ -569,7 +569,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
             ->and($contact[0])->toBe(1);
     });
 
-    it('test DbalConnectionAdapter : fetchNumeric with a CUD query', function () use ($dbConfigCentreon): void {
+    it('fetchNumeric with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchNumeric(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -577,18 +577,18 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         );
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : fetchNumeric with an empty query', function () use ($dbConfigCentreon): void {
+    it('fetchNumeric with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchNumeric("", QueryParameters::create([QueryParameter::int('id', 1)]));
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : fetchNumeric with an incorrect query', function () use ($dbConfigCentreon): void {
+    it('fetchNumeric with an incorrect query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchNumeric("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchNumeric with an incorrect query parameters',
+        'fetchNumeric with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchNumeric(
@@ -601,7 +601,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- fetchAssociative()
 
     it(
-        'test DbalConnectionAdapter : fetchAssociative with a correct query with query parameters',
+        'fetchAssociative with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contact = $db->fetchAssociative(
@@ -623,7 +623,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
             ->and($contact['contact_id'])->toBe(1);
     });
 
-    it('test DbalConnectionAdapter : fetchAssociative with a CUD query', function () use ($dbConfigCentreon): void {
+    it('fetchAssociative with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchAssociative(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -631,13 +631,13 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         );
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : fetchAssociative with an empty query', function () use ($dbConfigCentreon): void {
+    it('fetchAssociative with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchAssociative("", QueryParameters::create([QueryParameter::int('id', 1)]));
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAssociative with an incorrect query',
+        'fetchAssociative with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAssociative("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -645,7 +645,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAssociative with an incorrect query parameters',
+        'fetchAssociative with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAssociative(
@@ -658,7 +658,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- fetchOne()
 
     it(
-        'test DbalConnectionAdapter : fetchOne with a correct query with query parameters',
+        'fetchOne with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $alias = $db->fetchOne(
@@ -678,7 +678,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         expect($alias)->toBeString()->toBe('admin');
     });
 
-    it('test DbalConnectionAdapter : fetchOne with a CUD query', function () use ($dbConfigCentreon): void {
+    it('fetchOne with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchOne(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -686,18 +686,18 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         );
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : fetchOne with an empty query', function () use ($dbConfigCentreon): void {
+    it('fetchOne with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchOne("", QueryParameters::create([QueryParameter::int('id', 1)]));
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : fetchOne with an incorrect query', function () use ($dbConfigCentreon): void {
+    it('fetchOne with an incorrect query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchOne("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchOne with an incorrect query parameters',
+        'fetchOne with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchOne(
@@ -710,7 +710,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- fetchFirstColumn()
 
     it(
-        'test DbalConnectionAdapter : fetchFirstColumn with a correct query with query parameters',
+        'fetchFirstColumn with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contact = $db->fetchFirstColumn(
@@ -733,7 +733,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     });
 
     it(
-        'test DbalConnectionAdapter : fetchFirstColumn with a correct query with query parameters and another column',
+        'fetchFirstColumn with a correct query with query parameters and another column',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contact = $db->fetchFirstColumn("SELECT contact_alias FROM contact ORDER BY contact_id");
@@ -742,7 +742,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     );
 
-    it('test DbalConnectionAdapter : fetchFirstColumn with a CUD query', function () use ($dbConfigCentreon): void {
+    it('fetchFirstColumn with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchFirstColumn(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -750,13 +750,13 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         );
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : fetchFirstColumn with an empty query', function () use ($dbConfigCentreon): void {
+    it('fetchFirstColumn with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchFirstColumn("", QueryParameters::create([QueryParameter::int('id', 1)]));
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchFirstColumn with an incorrect query',
+        'fetchFirstColumn with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchFirstColumn("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -764,7 +764,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchFirstColumn with an incorrect query parameters',
+        'fetchFirstColumn with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchFirstColumn(
@@ -777,7 +777,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- fetchAllNumeric()
 
     it(
-        'test DbalConnectionAdapter : fetchAllNumeric with a correct query with query parameters',
+        'fetchAllNumeric with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contact = $db->fetchAllNumeric(
@@ -799,7 +799,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
             ->and($contact[0][0])->toBe(1);
     });
 
-    it('test DbalConnectionAdapter : fetchAllNumeric with a CUD query', function () use ($dbConfigCentreon): void {
+    it('fetchAllNumeric with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchAllNumeric(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -807,13 +807,13 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         );
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : fetchAllNumeric with an empty query', function () use ($dbConfigCentreon): void {
+    it('fetchAllNumeric with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchAllNumeric("", QueryParameters::create([QueryParameter::int('id', 1)]));
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAllNumeric with an incorrect query',
+        'fetchAllNumeric with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllNumeric("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -821,7 +821,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAllNumeric with an incorrect query parameters',
+        'fetchAllNumeric with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllNumeric(
@@ -834,7 +834,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- fetchAllAssociative()
 
     it(
-        'test DbalConnectionAdapter : fetchAllAssociative with a correct query with query parameters',
+        'fetchAllAssociative with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contact = $db->fetchAllAssociative(
@@ -856,7 +856,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
             ->and($contact[0]['contact_id'])->toBe(1);
     });
 
-    it('test DbalConnectionAdapter : fetchAllAssociative with a CUD query', function () use ($dbConfigCentreon): void {
+    it('fetchAllAssociative with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchAllAssociative(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -865,7 +865,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAllAssociative with an empty query',
+        'fetchAllAssociative with an empty query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllAssociative("", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -873,7 +873,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAllAssociative with an incorrect query',
+        'fetchAllAssociative with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllAssociative("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -881,7 +881,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAllAssociative with an incorrect query parameters',
+        'fetchAllAssociative with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllAssociative(
@@ -894,7 +894,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- fetchAllKeyValue()
 
     it(
-        'test DbalConnectionAdapter : fetchAllKeyValue with a correct query with query parameters',
+        'fetchAllKeyValue with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contact = $db->fetchAllKeyValue(
@@ -916,7 +916,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
             ->and($contact)->toBeArray()->toBe(['1' => 'admin']);
     });
 
-    it('test DbalConnectionAdapter : fetchAllKeyValue with a CUD query', function () use ($dbConfigCentreon): void {
+    it('fetchAllKeyValue with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchAllKeyValue(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -924,13 +924,13 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         );
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : fetchAllKeyValue with an empty query', function () use ($dbConfigCentreon): void {
+    it('fetchAllKeyValue with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->fetchAllKeyValue("", QueryParameters::create([QueryParameter::int('id', 1)]));
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAllKeyValue with an incorrect query',
+        'fetchAllKeyValue with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllKeyValue("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -938,7 +938,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAllKeyValue with an incorrect query parameters',
+        'fetchAllKeyValue with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllKeyValue(
@@ -951,7 +951,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- fetchAllAssociativeIndexed()
 
     it(
-        'test DbalConnectionAdapter : fetchAllAssociativeIndexed with a correct query with query parameters',
+        'fetchAllAssociativeIndexed with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contact = $db->fetchAllAssociativeIndexed(
@@ -974,7 +974,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     });
 
     it(
-        'test DbalConnectionAdapter : fetchAllAssociativeIndexed with a CUD query',
+        'fetchAllAssociativeIndexed with a CUD query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllAssociativeIndexed(
@@ -985,7 +985,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAllAssociativeIndexed with an empty query',
+        'fetchAllAssociativeIndexed with an empty query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllAssociativeIndexed("", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -993,7 +993,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAllAssociativeIndexed with an incorrect query',
+        'fetchAllAssociativeIndexed with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllAssociativeIndexed("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -1001,7 +1001,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : fetchAllAssociativeIndexed with an incorrect query parameters',
+        'fetchAllAssociativeIndexed with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->fetchAllAssociativeIndexed(
@@ -1016,7 +1016,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- iterateNumeric()
 
     it(
-        'test DbalConnectionAdapter : iterateNumeric with a correct query with query parameters',
+        'iterateNumeric with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateNumeric(
@@ -1040,7 +1040,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     });
 
-    it('test DbalConnectionAdapter : iterateNumeric with a CUD query', function () use ($dbConfigCentreon): void {
+    it('iterateNumeric with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $contacts = $db->iterateNumeric(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -1052,7 +1052,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : iterateNumeric with an empty query', function () use ($dbConfigCentreon): void {
+    it('iterateNumeric with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $contacts = $db->iterateNumeric("", QueryParameters::create([QueryParameter::int('id', 1)]));
         foreach ($contacts as $contact) {
@@ -1062,7 +1062,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateNumeric with an incorrect query',
+        'iterateNumeric with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateNumeric("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -1074,7 +1074,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateNumeric with an incorrect query parameters',
+        'iterateNumeric with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateNumeric(
@@ -1091,7 +1091,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- iterateAssociative()
 
     it(
-        'test DbalConnectionAdapter : iterateAssociative with a correct query with query parameters',
+        'iterateAssociative with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateAssociative(
@@ -1115,7 +1115,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     });
 
-    it('test DbalConnectionAdapter : iterateAssociative with a CUD query', function () use ($dbConfigCentreon): void {
+    it('iterateAssociative with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $contacts = $db->iterateAssociative(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -1128,7 +1128,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateAssociative with an empty query',
+        'iterateAssociative with an empty query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateAssociative("", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -1140,7 +1140,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateAssociative with an incorrect query',
+        'iterateAssociative with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateAssociative("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -1152,7 +1152,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateAssociative with an incorrect query parameters',
+        'iterateAssociative with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateAssociative(
@@ -1169,7 +1169,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- iterateColumn()
 
     it(
-        'test DbalConnectionAdapter : iterateColumn with a correct query with query parameters',
+        'iterateColumn with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateColumn(
@@ -1194,7 +1194,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     });
 
     it(
-        'test DbalConnectionAdapter : iterateColumn with a correct query with query parameters and another column',
+        'iterateColumn with a correct query with query parameters and another column',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateColumn(
@@ -1207,7 +1207,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     );
 
-    it('test DbalConnectionAdapter : iterateColumn with a CUD query', function () use ($dbConfigCentreon): void {
+    it('iterateColumn with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $contacts = $db->iterateColumn(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -1219,7 +1219,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : iterateColumn with an empty query', function () use ($dbConfigCentreon): void {
+    it('iterateColumn with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $contacts = $db->iterateColumn("", QueryParameters::create([QueryParameter::int('id', 1)]));
         foreach ($contacts as $contact) {
@@ -1228,7 +1228,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : iterateColumn with an incorrect query', function () use ($dbConfigCentreon): void {
+    it('iterateColumn with an incorrect query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $contacts = $db->iterateColumn("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
         foreach ($contacts as $contact) {
@@ -1238,7 +1238,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateColumn with an incorrect query parameters',
+        'iterateColumn with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateColumn(
@@ -1255,7 +1255,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- iterateKeyValue()
 
     it(
-        'test DbalConnectionAdapter : iterateKeyValue with a correct query with query parameters',
+        'iterateKeyValue with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateKeyValue(
@@ -1281,7 +1281,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     });
 
-    it('test DbalConnectionAdapter : iterateKeyValue with a CUD query', function () use ($dbConfigCentreon): void {
+    it('iterateKeyValue with a CUD query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $contacts = $db->iterateKeyValue(
             "DELETE FROM contact WHERE contact_id = :id",
@@ -1293,7 +1293,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     })->throws(ConnectionException::class);
 
-    it('test DbalConnectionAdapter : iterateKeyValue with an empty query', function () use ($dbConfigCentreon): void {
+    it('iterateKeyValue with an empty query', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $contacts = $db->iterateKeyValue("", QueryParameters::create([QueryParameter::int('id', 1)]));
         foreach ($contacts as $contact) {
@@ -1303,7 +1303,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     })->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateKeyValue with an incorrect query',
+        'iterateKeyValue with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateKeyValue("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -1315,7 +1315,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateKeyValue with an incorrect query parameters',
+        'iterateKeyValue with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateKeyValue(
@@ -1332,7 +1332,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -- iterateAssociativeIndexed()
 
     it(
-        'test DbalConnectionAdapter : iterateAssociativeIndexed with a correct query with query parameters',
+        'iterateAssociativeIndexed with a correct query with query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateAssociativeIndexed(
@@ -1359,7 +1359,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     });
 
     it(
-        'test DbalConnectionAdapter : iterateAssociativeIndexed with a CUD query',
+        'iterateAssociativeIndexed with a CUD query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateAssociativeIndexed(
@@ -1374,7 +1374,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateAssociativeIndexed with an empty query',
+        'iterateAssociativeIndexed with an empty query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateAssociativeIndexed("", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -1386,7 +1386,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateAssociativeIndexed with an incorrect query',
+        'iterateAssociativeIndexed with an incorrect query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateAssociativeIndexed("foo", QueryParameters::create([QueryParameter::int('id', 1)]));
@@ -1398,7 +1398,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     )->throws(ConnectionException::class);
 
     it(
-        'test DbalConnectionAdapter : iterateAssociativeIndexed with an incorrect query parameters',
+        'iterateAssociativeIndexed with an incorrect query parameters',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $contacts = $db->iterateAssociativeIndexed(
@@ -1412,26 +1412,110 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     )->throws(ConnectionException::class);
 
+    // -------------------------------------- QUERY FORMAT ---------------------------------------
+
+    it(
+        'fetchAssociative with string format with indent before the query ',
+        function () use ($dbConfigCentreon): void {
+            $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
+            $query = '    SELECT * FROM contact WHERE contact_id = :id';
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with NowDoc format with no indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
+            $query =
+                <<<'SQL'
+                SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with NowDoc format with indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
+            $query =
+                <<<'SQL'
+                    SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with HereDoc format with no indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
+            $query =
+                <<<SQL
+                SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with HereDoc format with indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
+            $query =
+                <<<SQL
+                    SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
     // ----------------------------------------- TRANSACTIONS -----------------------------------------
 
-    it('test DbalConnectionAdapter : is auto commit', function () use ($dbConfigCentreon): void {
+    it('is auto commit', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         expect($db->isAutoCommit())->toBeTrue();
     });
 
-    it('test DbalConnectionAdapter : set auto commit', function () use ($dbConfigCentreon): void {
+    it('set auto commit', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->setAutoCommit(false);
         expect($db->isAutoCommit())->toBeFalse();
     });
 
-    it('test DbalConnectionAdapter : execute startTransaction with success', function () use ($dbConfigCentreon): void {
+    it('execute startTransaction with success', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->startTransaction();
         expect($db->isTransactionActive())->toBeTrue();
     });
 
-    it('test DbalConnectionAdapter : execute commit with success', function () use ($dbConfigCentreon): void {
+    it('execute commit with success', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->startTransaction();
         $response = $db->commitTransaction();
@@ -1439,7 +1523,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
             ->and($db->isTransactionActive())->toBeFalse();
     });
 
-    it('test DbalConnectionAdapter : execute rollback with success', function () use ($dbConfigCentreon): void {
+    it('execute rollback with success', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $db->startTransaction();
         $response = $db->rollBackTransaction();
@@ -1449,13 +1533,13 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
 
     // ------------------------------------- UNBUFFERED QUERIES -----------------------------------------
 
-    it('test DbalConnectionAdapter : allow unbuffered query with success', function () use ($dbConfigCentreon): void {
+    it('allow unbuffered query with success', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         expect($db->allowUnbufferedQuery())->toBeTrue();
     });
 
     it(
-        'test DbalConnectionAdapter : execute unbufferedQuery with correct query',
+        'execute unbufferedQuery with correct query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             /** @var \PDO $pdo */
@@ -1476,7 +1560,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'test DbalConnectionAdapter : stop unbuffered query without start unbuffered query',
+        'stop unbuffered query without start unbuffered query',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             $db->stopUnbufferedQuery();
@@ -1486,7 +1570,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // ----------------------------------- QUERY ON SEVERAL DATABASES -------------------------------------
 
     it(
-        'test DbalConnectionAdapter : execute query on several databases with success',
+        'execute query on several databases with success',
         function () use ($dbConfigCentreon): void {
             $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
             // get log actions done by admin

--- a/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
+++ b/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
@@ -1412,7 +1412,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -------------------------------------- QUERY FORMAT ---------------------------------------
 
     it(
-        'fetchAssociative with string format with indent before the query ',
+        'execute a query with string format with indent before',
         function () use ($dbConfigCentreon): void {
             $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
             $query = '    SELECT * FROM contact WHERE contact_id = :id';
@@ -1426,7 +1426,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with NowDoc format with no indent before the query',
+        'execute a query with NowDoc format with no indent before',
         function () use ($dbConfigCentreon): void {
             $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
             $query =
@@ -1443,7 +1443,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with NowDoc format with indent before the query',
+        'execute a query with NowDoc format with indent before',
         function () use ($dbConfigCentreon): void {
             $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
             $query =
@@ -1460,7 +1460,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with HereDoc format with no indent before the query',
+        'execute a query with HereDoc format with no indent before',
         function () use ($dbConfigCentreon): void {
             $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
             $query =
@@ -1477,7 +1477,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with HereDoc format with indent before the query',
+        'execute a query with HereDoc format with indent before',
         function () use ($dbConfigCentreon): void {
             $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
             $query =

--- a/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
+++ b/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
@@ -1409,6 +1409,90 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     );
 
+    // -------------------------------------- QUERY FORMAT ---------------------------------------
+
+    it(
+        'fetchAssociative with string format with indent before the query ',
+        function () use ($dbConfigCentreon): void {
+            $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
+            $query = '    SELECT * FROM contact WHERE contact_id = :id';
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with NowDoc format with no indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
+            $query =
+                <<<'SQL'
+                SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with NowDoc format with indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
+            $query =
+                <<<'SQL'
+                    SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with HereDoc format with no indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
+            $query =
+                <<<SQL
+                SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with HereDoc format with indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
+            $query =
+                <<<SQL
+                    SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
     // ----------------------------------------- TRANSACTIONS -----------------------------------------
 
     it('execute startTransaction with success', function () use ($dbConfigCentreon): void {

--- a/centreon/tests/php/www/class/CentreonDBTest.php
+++ b/centreon/tests/php/www/class/CentreonDBTest.php
@@ -1512,6 +1512,90 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     );
 
+    // -------------------------------------- QUERY FORMAT ---------------------------------------
+
+    it(
+        'fetchAssociative with string format with indent before the query ',
+        function () use ($dbConfigCentreon): void {
+            $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
+            $query = '    SELECT * FROM contact WHERE contact_id = :id';
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with NowDoc format with no indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
+            $query =
+                <<<'SQL'
+                SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with NowDoc format with indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
+            $query =
+                <<<'SQL'
+                    SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with HereDoc format with no indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
+            $query =
+                <<<SQL
+                SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
+    it(
+        'fetchAssociative with HereDoc format with indent before the query',
+        function () use ($dbConfigCentreon): void {
+            $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
+            $query =
+                <<<SQL
+                    SELECT * FROM contact WHERE contact_id = :id
+                SQL;
+            $contact = $db->fetchAssociative(
+                $query,
+                QueryParameters::create([QueryParameter::int('id', 1)])
+            );
+            expect($contact)->toBeArray()
+                ->and($contact['contact_id'])->toBe(1);
+        }
+    );
+
     // ----------------------------------------- TRANSACTIONS -----------------------------------------
 
     it('execute startTransaction with success', function () use ($dbConfigCentreon): void {

--- a/centreon/tests/php/www/class/CentreonDBTest.php
+++ b/centreon/tests/php/www/class/CentreonDBTest.php
@@ -1515,7 +1515,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     // -------------------------------------- QUERY FORMAT ---------------------------------------
 
     it(
-        'fetchAssociative with string format with indent before the query ',
+        'execute a query  with string format with indent before',
         function () use ($dbConfigCentreon): void {
             $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
             $query = '    SELECT * FROM contact WHERE contact_id = :id';
@@ -1529,7 +1529,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with NowDoc format with no indent before the query',
+        'execute a query  with NowDoc format with no indent before',
         function () use ($dbConfigCentreon): void {
             $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
             $query =
@@ -1546,7 +1546,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with NowDoc format with indent before the query',
+        'execute a query with NowDoc format with indent before',
         function () use ($dbConfigCentreon): void {
             $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
             $query =
@@ -1563,7 +1563,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with HereDoc format with no indent before the query',
+        'execute a query with HereDoc format with no indent before',
         function () use ($dbConfigCentreon): void {
             $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
             $query =
@@ -1580,7 +1580,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     );
 
     it(
-        'fetchAssociative with HereDoc format with indent before the query',
+        'execute a query with HereDoc format with indent before',
         function () use ($dbConfigCentreon): void {
             $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
             $query =


### PR DESCRIPTION
## Description

### Added

* Unit tests added to test heredoc and nowdoc with several formats
* Allowed SQL keywords added

### Fixed

* heredoc and nowdoc accepted with connection interface

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] develop

<h2> How this pull request can be tested ? </h2>

Run the following unit tests:
````
tests/php/www/class/CentreonDBTest.php
tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
tests/php/Adaptation/Database
````

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
