### PR TITLE
enh(PAC) handle cma tokens in Agent configration for reverse connection

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
@@ -88,7 +88,8 @@ class CmaValidator implements TypeValidatorInterface
                      *		address: string,
                      *		port: int,
                      *		poller_ca_certificate: ?string,
-                     *		poller_ca_name: ?string
+                     *		poller_ca_name: ?string,
+                     *      token: ?array{name:string,creator_id:int}
                      *	} $host
                      */
                     if ($host['poller_ca_certificate'] !== null) {

--- a/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
@@ -89,7 +89,7 @@ class CmaValidator implements TypeValidatorInterface
                      *		port: int,
                      *		poller_ca_certificate: ?string,
                      *		poller_ca_name: ?string,
-                     *      token: ?array{name:string,creator_id:int}
+                     *		token: ?array{name:string,creator_id:int}
                      *	} $host
                      */
                     if ($host['poller_ca_certificate'] !== null) {

--- a/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
@@ -81,7 +81,7 @@ class CmaValidator implements TypeValidatorInterface
                 $this->validateTokens($value);
             }
 
-            if ($key === 'hosts') {
+            if ($key === 'hosts' && $configuration['is_reverse'] === true) {
                 foreach ($value as $host) {
                     /** @var array{
                      *		id: int,
@@ -97,15 +97,27 @@ class CmaValidator implements TypeValidatorInterface
                     if (! $this->readHostRepository->exists(hostId: $host['id'])) {
                         throw AgentConfigurationException::invalidHostId($host['id']);
                     }
+
+                    if (
+                        $request->connectionMode !== ConnectionModeEnum::NO_TLS
+                        && $host['token'] === null
+                    ) {
+                        throw AgentConfigurationException::tokensAreMandatory();
+                    }
+
+                    if ($host['token'] !== null) {
+                        $this->validateTokens([$host['token']]);
+                    }
                 }
             }
         }
 
         if (
             $request->connectionMode !== ConnectionModeEnum::NO_TLS
-            && $value === []
+            && $configuration['is_reverse'] === false
+            && $configuration['tokens'] === []
         ) {
-            AgentConfigurationException::tokensAreMandatory();
+            throw AgentConfigurationException::tokensAreMandatory();
         }
     }
 

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -41,7 +41,7 @@ use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
  *			port: int,
  *			poller_ca_certificate: ?string,
  *			poller_ca_name: ?string,
- *          token: null|array{name:string,creator_id:int}
+ *			token: null|array{name:string,creator_id:int}
  *		}>
  *  }
  */

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -41,6 +41,7 @@ use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
  *			port: int,
  *			poller_ca_certificate: ?string,
  *			poller_ca_name: ?string,
+ *          token: null|array{name:string,creator_id:int}
  *		}>
  *  }
  */
@@ -110,6 +111,16 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
         }
 
         foreach ($parameters['hosts'] as $host) {
+            if (
+                $connectionMode !== ConnectionModeEnum::NO_TLS
+                && $parameters['is_reverse'] === true
+            ) {
+                Assertion::notNull($host['token'], 'configuration.hosts[].token');
+                Assertion::notEmptyString($host['token']['name'] ?? '');
+                Assertion::positiveInt($host['token']['creator_id'] ?? 0);
+            } else {
+                $host['token'] = null;
+            }
             Assertion::ipOrDomain($host['address'], 'configuration.hosts[].address');
             Assertion::range($host['port'], 0, 65535, 'configuration.hosts[].port');
             $this->validateOptionalCertificate(

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/Schema/CmaConfigurationSchema.json
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/Schema/CmaConfigurationSchema.json
@@ -15,7 +15,8 @@
                 "otel_public_certificate",
                 "otel_ca_certificate",
                 "otel_private_key",
-                "hosts"
+                "hosts",
+                "tokens"
             ],
             "properties": {
                 "is_reverse": {
@@ -64,7 +65,8 @@
                             "id",
                             "port",
                             "poller_ca_certificate",
-                            "poller_ca_name"
+                            "poller_ca_name",
+                            "token"
                         ],
                         "properties": {
                             "id": {
@@ -87,6 +89,20 @@
                                     "null",
                                     "string"
                                 ]
+                            },
+                            "token": {
+                                "type": [
+                                    "null",
+                                    "object"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string"
+                                    },
+                                    "creator_id": {
+                                        "type": "integer"
+                                    }
+                                }
                             }
                         }
                     }

--- a/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
@@ -30,8 +30,10 @@ use Core\AgentConfiguration\Application\Validation\CmaValidator;
 use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 use Core\AgentConfiguration\Domain\Model\Poller;
 use Core\AgentConfiguration\Domain\Model\Type;
+use Core\Common\Domain\TrimmedString;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
 use Core\Security\Token\Application\Repository\ReadTokenRepositoryInterface;
+use Core\Security\Token\Domain\Model\JwtToken;
 
 beforeEach(function (): void {
     $this->cmaValidator = new CmaValidator(
@@ -40,6 +42,13 @@ beforeEach(function (): void {
         $this->user = $this->createMock(ContactInterface::class),
     );
 
+    $this->token = new JwtToken(
+        name: new TrimmedString('tokenName'),
+        creatorId: 1,
+        creatorName: new TrimmedString('tokenCreator'),
+        creationDate: new \DateTimeImmutable(),
+        expirationDate: null,
+    );
     $this->request = new AddAgentConfigurationRequest();
     $this->request->name = 'cmatest';
     $this->request->type = 'centeron-agent';
@@ -51,7 +60,19 @@ beforeEach(function (): void {
         'otel_private_key' => '/etc/pki/test.key',
         'otel_ca_certificate' => '/etc/pki/test.cer',
         'tokens' => [],
-        'hosts' => [],
+        'hosts' => [
+            [
+                'id' => 1,
+                'address' => '',
+                'port' => 0,
+                'poller_ca_certificate' => '/etc/pki/test.cer',
+                'poller_ca_name' => 'poller-name',
+                'token' => [
+                    'name' => $this->token->getName(),
+                    'creator_id' => $this->token->getCreatorId(),
+                ],
+            ],
+        ],
     ];
 
     $this->poller = new Poller(1, 'poller-name');
@@ -93,10 +114,13 @@ foreach (
     ] as $filename
 ) {
     it("should not throw an exception when the filename for certificate {$filename} is valid", function () use ($filename): void {
-        $this->request->configuration['hosts'][] = [
+        $this->request->configuration['hosts'][0] = [
             'poller_ca_certificate' => $filename,
             'id' => 9999,
         ] ;
+        $this->user
+            ->method('isAdmin')
+            ->willReturn(true);
         $this->readHostRepository
             ->expects($this->once())
             ->method('exists')
@@ -129,6 +153,12 @@ foreach (
 ) {
     it("should not throw an exception when the filename for key {$filename} is valid", function () use ($filename): void {
         $this->request->configuration['otel_private_key'] = $filename;
+        $this->user
+            ->method('isAdmin')
+            ->willReturn(true);
+        $this->readTokenRepository
+            ->method('findByNameAndUserId')
+            ->willReturn($this->token);
         $this->cmaValidator->validateParametersOrFail($this->request);
     })->expectNotToPerformAssertions();
 }
@@ -155,11 +185,9 @@ it("should throw an exception when a token is provided but invalid and connectio
 });
 
 it('should throw an exception when the host id is invalid', function (): void {
-    $this->request->configuration['hosts'] = [
-        [
-            'id' => 9999,
-            'poller_ca_certificate' => null,
-        ]
+    $this->request->configuration['hosts'][0] = [
+        'id' => 9999,
+        'poller_ca_certificate' => null,
     ];
     $this->readHostRepository
         ->expects($this->once())
@@ -168,3 +196,22 @@ it('should throw an exception when the host id is invalid', function (): void {
 
     $this->cmaValidator->validateParametersOrFail($this->request);
 })->throws((AgentConfigurationException::invalidHostId(9999)->getMessage()));
+
+it("should throw an exception when a token is not provided for an host and connection is reverse and not no_tls", function (): void { ;
+    $this->request->configuration['hosts'][0]['token'] = null;
+    $this->expectException(AgentConfigurationException::class);
+    $this->cmaValidator->validateParametersOrFail($this->request);
+});
+
+it("should throw an exception when a token is provided for an host but invalid and connection is reverse and not no_tls", function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readTokenRepository
+        ->expects($this->once())
+        ->method('findByNameAndUserId')
+        ->willReturn(null);
+    $this->expectException(AgentConfigurationException::class);
+    $this->cmaValidator->validateParametersOrFail($this->request);
+});

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
@@ -25,7 +25,7 @@ namespace Core\AdditionalConnectorConfiguration\Application\Validation;
 
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
-use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;s
+use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 
 beforeEach(function (): void {
     $this->parameters = [

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
@@ -25,7 +25,7 @@ namespace Core\AdditionalConnectorConfiguration\Application\Validation;
 
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
-use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
+use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;s
 
 beforeEach(function (): void {
     $this->parameters = [
@@ -39,7 +39,11 @@ beforeEach(function (): void {
                 'address' => '0.0.0.0',
                 'port' => 442,
                 'poller_ca_certificate' => 'poller_certif',
-                'poller_ca_name' => 'ca_name'
+                'poller_ca_name' => 'ca_name',
+                'token' => [
+                    'name' => 'tokenName',
+                    'creator_id' => 1,
+                ],
             ]
         ]
     ];

--- a/centreon/tests/rest_api/collections/configuration/Agent_Configuration.postman_collection.json
+++ b/centreon/tests/rest_api/collections/configuration/Agent_Configuration.postman_collection.json
@@ -1121,7 +1121,8 @@
 									"                    \"id\": pm.collectionVariables.get(\"Host1Id\"),\r",
 									"                    \"poller_ca_certificate\": null,\r",
 									"                    \"poller_ca_name\": null,\r",
-									"                    \"name\": pm.collectionVariables.get(\"Host1Name\")\r",
+									"                    \"name\": pm.collectionVariables.get(\"Host1Name\"),\r",
+									"                    \"token\": {\"name\": pm.collectionVariables.get(\"Token-1-name\"), \"creator_id\": pm.collectionVariables.get(\"Token-1-creator-id\")},\r",
 									"                }\r",
 									"            ]\r",
 									"        },\r",
@@ -1166,7 +1167,8 @@
 									"                                \"id\": { \"type\": \"integer\" },\r",
 									"                                \"poller_ca_certificate\": { \"type\": [\"string\", \"null\"] },\r",
 									"                                \"poller_ca_name\": { \"type\": [\"string\", \"null\"] },\r",
-									"                                \"name\": { \"type\": \"string\" }\r",
+									"                                \"name\": { \"type\": \"string\" },\r",
+									"                                \"token\": { \"type\": [\"object\", \"null\"] }\r",
 									"                            },\r",
 									"                            \"required\": [\"address\", \"port\", \"id\", \"poller_ca_certificate\", \"poller_ca_name\", \"name\"]\r",
 									"                        },\r",
@@ -1209,7 +1211,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC2Name}}\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC2Name}}\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\": \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -2092,7 +2094,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": null\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -2149,7 +2151,8 @@
 									"                    \"id\": pm.collectionVariables.get(\"Host1Id\"),\r",
 									"                    \"poller_ca_certificate\": \"/etc/pki/ca-filé.crt\",\r",
 									"                    \"poller_ca_name\": null,\r",
-									"                    \"name\": pm.collectionVariables.get(\"Host1Name\")\r",
+									"                    \"name\": pm.collectionVariables.get(\"Host1Name\"),\r",
+									"                    \"token\": {\"name\": pm.collectionVariables.get(\"Token-1-name\"), \"creator_id\": pm.collectionVariables.get(\"Token-1-creator-id\")},\r",
 									"                },\r",
 									"                {\r",
 									"                    \"address\": \"127.0.0.1\",\r",
@@ -2157,7 +2160,8 @@
 									"                    \"id\": pm.collectionVariables.get(\"Host1Id\"),\r",
 									"                    \"poller_ca_certificate\": null,\r",
 									"                    \"poller_ca_name\": null,\r",
-									"                    \"name\": pm.collectionVariables.get(\"Host1Name\")\r",
+									"                    \"name\": pm.collectionVariables.get(\"Host1Name\"),\r",
+									"                    \"token\": {\"name\": pm.collectionVariables.get(\"Token-1-name\"), \"creator_id\": pm.collectionVariables.get(\"Token-1-creator-id\")},\r",
 									"                }\r",
 									"            ]\r",
 									"        },\r",
@@ -2204,7 +2208,8 @@
 									"                                \"id\": { \"type\": \"integer\" },\r",
 									"                                \"poller_ca_certificate\": { \"type\": [\"string\", \"null\"] },\r",
 									"                                \"poller_ca_name\": { \"type\": [\"string\", \"null\"] },\r",
-									"                                \"name\": { \"type\": \"string\" }\r",
+									"                                \"name\": { \"type\": \"string\" },\r",
+									"                                \"token\": { \"type\": [\"object\", \"null\"] }\r",
 									"                            },\r",
 									"                            \"required\": [\"address\", \"port\", \"id\", \"poller_ca_certificate\", \"poller_ca_name\", \"name\"]\r",
 									"                        },\r",
@@ -2246,7 +2251,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC3Name}}\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otél-certificate-name-ac2!.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otél_private-key-name-ac2.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"ca-filé.crt\",\r\n            \"poller_ca_name\": null\r\n        },\r\n        {\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC3Name}}\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otél-certificate-name-ac2!.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otél_private-key-name-ac2.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"ca-filé.crt\",\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\":  \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }\r\n        },\r\n        {\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\":  \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -3990,6 +3995,57 @@
 					"response": []
 				},
 				{
+					"name": "Grant token right",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						},
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"The Authentication tokens rights has been successfully added.\", function () {\r",
+									"  pm.response.to.have.status(200);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "centreon-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"action\": \"grantrw\",\r\n  \"object\": \"ACLMENU\",\r\n  \"values\": \"RW;1;Administration;Authentication Tokens\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUriCentreonCLAPI}}",
+							"host": [
+								"{{baseUriCentreonCLAPI}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Logout from admin user",
 					"event": [
 						{
@@ -4117,6 +4173,60 @@
 					"response": []
 				},
 				{
+					"name": "Create a CMA token",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"The token has been successfully created.\", function () {\r",
+									"  pm.response.to.have.status(201);\r",
+									"});\r",
+									"\r",
+									"const responseJson = pm.response.json();\r",
+									"pm.collectionVariables.set(\"Token-2-name\", responseJson.name);\r",
+									"pm.collectionVariables.set(\"Token-2-creator-id\", responseJson.creator.id);"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"disableCookies": true
+					},
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "centreon-auth-token",
+								"value": "{{token}}",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"name\" : \"CMA-token-name-2\",\r\n    \"type\": \"cma\",\r\n    \"expiration_date\": \"9999-12-02T00:00:00+01:00\",\r\n    \"user_id\": {{currentUserID}} \r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/administration/tokens",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"administration",
+								"tokens"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Add a centreon-agent configuration",
 					"event": [
 						{
@@ -4157,7 +4267,8 @@
 									"                \"id\": pm.collectionVariables.get(\"Host1Id\"),\r",
 									"                \"poller_ca_certificate\": \"/etc/pki/hi.crt\",\r",
 									"                \"poller_ca_name\": \"halo\",\r",
-									"                \"name\": pm.collectionVariables.get(\"Host1Name\")\r",
+									"                \"name\": pm.collectionVariables.get(\"Host1Name\"),\r",
+									"                \"token\": {\"name\": pm.collectionVariables.get(\"Token-2-name\"), \"creator_id\": pm.collectionVariables.get(\"Token-2-creator-id\")}\r",
 									"            }]\r",
 									"        },\r",
 									"        \"connection_mode\": \"secure\",\r",
@@ -4206,7 +4317,8 @@
 									"                                \"id\": { \"type\": \"integer\" },\r",
 									"                                \"poller_ca_certificate\": { \"type\": [\"string\", \"null\"] },\r",
 									"                                \"poller_ca_name\": { \"type\": [\"string\", \"null\"] },\r",
-									"                                \"name\": { \"type\": \"string\" }\r",
+									"                                \"name\": { \"type\": \"string\" },\r",
+									"                                \"token\": { \"type\": [\"object\", \"null\"] }\r",
 									"                            },\r",
 									"                            \"required\": [\"address\", \"port\", \"id\", \"poller_ca_certificate\", \"poller_ca_name\", \"name\"]\r",
 									"                        },\r",
@@ -4249,7 +4361,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4.crt\",\r\n        \"otel_ca_certificate\": \"hello.crt\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"hi.crt\",\r\n            \"poller_ca_name\": \"halo\"\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4.crt\",\r\n        \"otel_ca_certificate\": \"hello.crt\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"hi.crt\",\r\n            \"poller_ca_name\": \"halo\",\r\n            \"token\": {\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -4653,7 +4765,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4.crt\",\r\n        \"otel_ca_certificate\": \"hello.crt\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"hi.crt\",\r\n            \"poller_ca_name\": \"halo\"\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4.crt\",\r\n        \"otel_ca_certificate\": \"hello.crt\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"hi.crt\",\r\n            \"poller_ca_name\": \"halo\",\r\n            \"token\": {\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations/{{AC4Id}}",
@@ -5580,7 +5692,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"nop\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"nop\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"is_reverse\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n"
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations/{{AC4Id}}",


### PR DESCRIPTION
## Description

Handle token in agent configuration for reverse connection (one token is attached to each defined hosts in the configuration)

```
{
  "configuration": [
    "hosts": [
      {
        "token": null|array{name:string, creator_id:int}
      },
      ...
    ]
  ]
}
```

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

