### PR TITLE
fix(ci): update mariadb repo setup on el7 web container (#7364)

### DIFF
--- a/.github/docker/Dockerfile.centreon-web-centos7
+++ b/.github/docker/Dockerfile.centreon-web-centos7
@@ -41,7 +41,31 @@ yum install -y remi-release-7.rpm
 rm -f remi-release-7.rpm
 yum-config-manager --enable remi-php81
 
-curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup | bash -s -- --os-type=rhel --os-version=7 --mariadb-server-version="mariadb-10.5" --skip-maxscale
+echo "Using custom mariadb repofile for rhel 7 as repo_setup script does not support it anymore."
+echo "[mariadb-main]
+name = MariaDB Server
+baseurl = https://mirror.mariadb.org/yum/10.5/rhel/7/x86_64
+gpgkey = file:///etc/pki/rpm-gpg/MariaDB-Server-GPG-KEY
+gpgcheck = 1
+enabled = 1
+
+[mariadb-tools]
+name = MariaDB Tools
+baseurl = https://downloads.mariadb.com/Tools/rhel/7/x86_64
+gpgkey = file:///etc/pki/rpm-gpg/MariaDB-Enterprise-GPG-KEY
+gpgcheck = 1
+enabled = 1
+" > /etc/yum.repos.d/mariadb.repo
+
+echo "Adding trusted mariadb package signing keys..."
+if rpm --import "https://supplychain.mariadb.com/MariaDB-Server-GPG-KEY"
+then
+  curl -o /etc/pki/rpm-gpg/MariaDB-Server-GPG-KEY https://supplychain.mariadb.com/MariaDB-Server-GPG-KEY
+  echo "Successfully added trusted package signing keys"
+else
+  echo "Failed to add trusted package signing keys"
+fi
+
 yum install -y MariaDB-server MariaDB-client
 rpm -e --nodeps galera-4
 rm -f /var/lib/mysql/ib_logfile0


### PR DESCRIPTION
## Description

* use a custom mariadb repo file instead of repo_setup script as it does not work with EL7 + mariadb 10.5 combination

Fixes #MON-164286

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
