### PR TITLE
fix(Resource Status): Multiple errors with Meta Services resources + MySQL 8 (#7265) [dev-24.04.x]

### DIFF
--- a/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+++ b/centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
@@ -1019,7 +1019,7 @@ final class MonitoringRepositoryRDB extends AbstractRepositoryDRB implements Mon
             . ' WHERE srv.enabled = \'1\'
               AND h.enabled = \'1\'
               AND srv.description = :service_description
-            GROUP BY srv.service_id';
+            GROUP BY srv.service_id, h.host_id';
 
         $request = $this->translateDbName($request);
 


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/7265 to dev-24.04.x

**Fixes** # MON-168872

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [ ] 24.10.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
