### PR TITLE
fix(docker): add jammy/noble non-nfpm packaging docker image for ha

### DIFF
--- a/.github/docker/Dockerfile.packaging-bookworm
+++ b/.github/docker/Dockerfile.packaging-bookworm
@@ -1,6 +1,6 @@
 FROM debian:bookworm
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN bash -e <<EOF
 

--- a/.github/docker/Dockerfile.packaging-bullseye
+++ b/.github/docker/Dockerfile.packaging-bullseye
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN bash -e <<EOF
 

--- a/.github/docker/Dockerfile.packaging-jammy
+++ b/.github/docker/Dockerfile.packaging-jammy
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN bash -e <<EOF
 

--- a/.github/docker/Dockerfile.packaging-jammy
+++ b/.github/docker/Dockerfile.packaging-jammy
@@ -1,0 +1,21 @@
+FROM ubuntu:jammy
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN bash -e <<EOF
+
+apt-get update
+
+apt-get install -y debmake pbuilder dh-exec aptitude zstd ca-certificates
+
+echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
+
+apt-get update
+
+apt-get install -y nfpm=2.41.1
+
+apt-get clean
+
+EOF
+
+WORKDIR /src

--- a/.github/docker/Dockerfile.packaging-nfpm-bookworm
+++ b/.github/docker/Dockerfile.packaging-nfpm-bookworm
@@ -1,6 +1,6 @@
 FROM debian:bookworm
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN bash -e <<EOF
 

--- a/.github/docker/Dockerfile.packaging-nfpm-bullseye
+++ b/.github/docker/Dockerfile.packaging-nfpm-bullseye
@@ -1,6 +1,6 @@
 FROM debian:bullseye
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN bash -e <<EOF
 

--- a/.github/docker/Dockerfile.packaging-nfpm-jammy
+++ b/.github/docker/Dockerfile.packaging-nfpm-jammy
@@ -1,6 +1,6 @@
 FROM ubuntu:jammy
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN bash -e <<EOF
 

--- a/.github/docker/Dockerfile.packaging-nfpm-noble
+++ b/.github/docker/Dockerfile.packaging-nfpm-noble
@@ -1,6 +1,6 @@
 FROM ubuntu:noble
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN bash -e <<EOF
 

--- a/.github/docker/Dockerfile.packaging-noble
+++ b/.github/docker/Dockerfile.packaging-noble
@@ -1,0 +1,21 @@
+FROM ubuntu:noble
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN bash -e <<EOF
+
+apt-get update
+
+apt-get install -y debmake pbuilder dh-exec aptitude zstd ca-certificates
+
+echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | tee /etc/apt/sources.list.d/goreleaser.list
+
+apt-get update
+
+apt-get install -y nfpm=2.41.1
+
+apt-get clean
+
+EOF
+
+WORKDIR /src

--- a/.github/docker/Dockerfile.packaging-noble
+++ b/.github/docker/Dockerfile.packaging-noble
@@ -1,6 +1,6 @@
 FROM ubuntu:noble
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN bash -e <<EOF
 

--- a/.github/workflows/docker-packaging.yml
+++ b/.github/workflows/docker-packaging.yml
@@ -56,8 +56,14 @@ jobs:
             dockerfile: packaging-nfpm-bookworm
             image: packaging-nfpm-bookworm
           - runner: ubuntu-24.04
+            dockerfile: packaging-jammy
+            image: packaging-jammy
+          - runner: ubuntu-24.04
             dockerfile: packaging-nfpm-jammy
             image: packaging-nfpm-jammy
+          - runner: ubuntu-24.04
+            dockerfile: packaging-noble
+            image: packaging-noble
           - runner: ubuntu-24.04
             dockerfile: packaging-nfpm-noble
             image: packaging-nfpm-noble


### PR DESCRIPTION
## Description

ha is not on nfpm so we have to use older packaging images that we therefore have to build 
**Fixes** # MON-169071

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
