### PR TITLE
fix(behat): stabilize test DisableFieldsOnBlockedObjectsContext

### DIFF
--- a/centreon/features/bootstrap/DisableFieldsOnBlockedObjectsContext.php
+++ b/centreon/features/bootstrap/DisableFieldsOnBlockedObjectsContext.php
@@ -27,12 +27,20 @@ class DisableFieldsOnBlockedObjectsContext extends CentreonContext
 
         $hostTemplate = new HostTemplateConfigurationListingPage($this);
         $hostTemplate->setLockedElementsFilter(true);
-        $hostTemplate = $hostTemplate->getEntries();
-        $hostTemplate = $hostTemplate['myHostTemplate'];
 
-        if (!$hostTemplate['locked']) {
-            throw new \Exception('the host template myHostTemplate is not locked');
-        };
+        $this->spin(
+            function ($context) use ($hostTemplate) {
+                $entries = $hostTemplate->getEntries();
+
+                if (!isset($entries['myHostTemplate']) && !$entries['myHostTemplate']['locked']) {
+                    throw new \Exception('the host template myHostTemplate is not locked');
+                };
+
+                return true;
+            },
+            'timeout : the host template myHostTemplate is not locked',
+            120
+        );
     }
 
     /**
@@ -53,9 +61,18 @@ class DisableFieldsOnBlockedObjectsContext extends CentreonContext
     public function theFieldsAreFrozen()
     {
         $this->iOpenTheForm();
-        $macro = $this->getSession()->getPage()->find('css', '#macro li.clone_template span input[type="text"]');
-        if (!$macro->getAttribute('disabled')) {
-            throw new \Exception('the macros are not disabled');
-        }
+
+        $this->spin(
+            function ($context) {
+                $macro = $context->getSession()->getPage()->find('css', '#macro li.clone_template span input[type="text"]');
+                if (!$macro->getAttribute('disabled')) {
+                    throw new \Exception('the macros are not disabled');
+                }
+
+                return true;
+            },
+            'timeout : the macros are not disabled',
+            120
+        );
     }
 }


### PR DESCRIPTION
## Description

This PR intends to stabilize flacky test DisableFieldsOnBlockedObjectsContext

**Fixes** # ([MON-166474](https://centreon.atlassian.net/browse/MON-166474))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-166474]: https://centreon.atlassian.net/browse/MON-166474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ