### PR TITLE
do not use bookworm in get environment matrix

### DIFF
--- a/.github/workflows/get-environment.yml
+++ b/.github/workflows/get-environment.yml
@@ -429,11 +429,6 @@ jobs:
               "database": "mariadb:10.11",
               "test_tags": "not @ignore and @system"
             };
-            const bookworm_mysql = {
-              "operating_system": "bookworm",
-              "database": "mysql:8.3",
-              "test_tags": "not @ignore"
-            };
 
             let matrix = {
               "main": [alma9_mariadb],
@@ -444,16 +439,16 @@ jobs:
             if (${{ contains(github.event.pull_request.labels.*.name, 'database') && 'true' || 'false' }}) {
               matrix = {
                 ...matrix,
-                "operating_systems": [alma9_mariadb, bookworm_mysql],
-                "databases": [alma9_mariadb, bookworm_mysql],
+                "operating_systems": [alma9_mariadb],
+                "databases": [alma9_mariadb],
               };
             }
 
             if (${{ steps.get_nightly_status.outputs.is_nightly }} == 'true' || ${{ contains(github.event.pull_request.labels.*.name, 'system') && 'true' || 'false' }}) {
               matrix = {
                 ...matrix,
-                "operating_systems": [alma9_mariadb, alma8_mariadb, bookworm_mysql],
-                "databases": [alma9_mariadb, bookworm_mysql],
+                "operating_systems": [alma9_mariadb, alma8_mariadb],
+                "databases": [alma9_mariadb],
               };
             }
 


### PR DESCRIPTION
## Description

* do not use bookworm in get environment matrix, as bookworm support only comes with 24.04 and later

**Fixes** #MON-169493

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
