### PR TITLE
Fix wrong csv escaping in CLAPI

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonObject.class.php
+++ b/centreon/www/class/centreon-clapi/centreonObject.class.php
@@ -667,7 +667,7 @@ abstract class CentreonObject
      */
     protected function csvEscape($text)
     {
-        if ($text[0] === '"' || str_contains($text, $this->delim) || str_contains($text, "\n")) {
+        if (str_contains($text, '"') || str_contains($text, $this->delim) || str_contains($text, "\n")) {
             $text = '"' . str_replace('"', '""', $text) . '"';
         }
         return $text;


### PR DESCRIPTION
Fix [MON-158675](https://centreon.atlassian.net/browse/MON-158675) / #6166

Replaces #6536

CLAPI method to escape strings raised a warning when an empty string was provided.

This PR fixes it and the double quotes are now escaped if macro contains some (and not only the first char).

[MON-158675]: https://centreon.atlassian.net/browse/MON-158675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ