### PR TITLE
fix(contacts): Add missing field

### DIFF
--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1705,7 +1705,7 @@ function filterNonAdminFields(array $ret): array
         'contact_lang', 'default_page', 'contact_location', 'contact_autologin_key', 'contact_auth_type',
         'contact_acl_groups', 'contact_address1', 'contact_address2', 'contact_address3', 'contact_address4',
         'contact_address5', 'contact_address6', 'contact_comment', 'contact_register', 'contact_activate',
-        'contact_id', 'initialValues', 'centreon_token', 'contact_template_id', 'contact_type_msg'
+        'contact_id', 'initialValues', 'centreon_token', 'contact_template_id', 'contact_type_msg','contact_ldap_dn'
     ];
 
     foreach ($ret as $field => $value) {


### PR DESCRIPTION
## Description

It missed the contact_ldap_dn field in the non-admin filter.
Due to this miss, Centreon didn't link the user to template and groups if he was added by another non-admin user.

**Fixes** # MON-166728

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
