### PR TITLE
fix(centreon): Avoid warning when using centreon CLI without -u

### DIFF
--- a/centreon/bin/centreon
+++ b/centreon/bin/centreon
@@ -119,7 +119,7 @@ $db_storage = $dependencyInjector['realtime_db'];
 /**
  * Create Centreon API object
  */
-CentreonClapi\CentreonUtils::setUserName($options['u']);
+CentreonClapi\CentreonUtils::setUserName($options['u'] ?? "");
 $api = CentreonClapi\CentreonAPI::getInstance(
     ($options["u"] ?? ""),
     ($options["p"] ?? ""),


### PR DESCRIPTION
## Description

Just run `/usr/share/centreon/bin/centreon --help` and look for 
```PHP Warning:  Undefined array key "u" in /usr/share/centreon/bin/centreon on line 122```

**Fixes** #[MON-173704](https://centreon.atlassian.net/browse/MON-173704)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master


[MON-173704]: https://centreon.atlassian.net/browse/MON-173704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ