### PR TITLE
fix(ci): only run dispatch from specific repositories

### DIFF
--- a/.github/workflows/awie-analysis.yml
+++ b/.github/workflows/awie-analysis.yml
@@ -32,6 +32,7 @@ env:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon-awie/www/modules/centreon-awie/conf.php
@@ -42,8 +43,7 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.repository == 'centreon/centreon'
+      needs.get-environment.outputs.skip_workflow == 'false'
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/awie-analysis.yml
+++ b/.github/workflows/awie-analysis.yml
@@ -42,7 +42,8 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false'
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      github.repository == 'centreon/centreon'
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/checkmarx-analysis.yml
+++ b/.github/workflows/checkmarx-analysis.yml
@@ -23,8 +23,7 @@ on:
 jobs:
   build:
     name: Checks before analysis
-    if: |
-      github.repository == 'centreon/centreon'
+    if: github.repository == 'centreon/centreon'
 
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/checkmarx-analysis.yml
+++ b/.github/workflows/checkmarx-analysis.yml
@@ -23,6 +23,9 @@ on:
 jobs:
   build:
     name: Checks before analysis
+    if: |
+      github.repository == 'centreon/centreon'
+
     runs-on: ubuntu-24.04
     outputs:
       enable_analysis: ${{ steps.routing.outputs.enable_analysis }}

--- a/.github/workflows/docker-vault.yml
+++ b/.github/workflows/docker-vault.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon/www/install/insertBaseConf.sql

--- a/.github/workflows/docker-web-dependencies.yml
+++ b/.github/workflows/docker-web-dependencies.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   dispatch-to-maintained-branches:
-    if: ${{ github.run_attempt == 1 && github.event_name == 'schedule' && github.ref_name == 'develop' }}
+    if: ${{ github.run_attempt == 1 && github.event_name == 'schedule' && github.ref_name == 'develop' && github.repository == 'centreon/centreon' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources

--- a/.github/workflows/dsm-analysis.yml
+++ b/.github/workflows/dsm-analysis.yml
@@ -32,6 +32,7 @@ env:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon-dsm/www/modules/centreon-dsm/conf.php
@@ -42,8 +43,7 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.repository == 'centreon/centreon'
+      needs.get-environment.outputs.skip_workflow == 'false'
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/dsm-analysis.yml
+++ b/.github/workflows/dsm-analysis.yml
@@ -42,7 +42,8 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false'
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      github.repository == 'centreon/centreon'
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ha-analysis.yml
+++ b/.github/workflows/ha-analysis.yml
@@ -42,7 +42,8 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false'
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      github.repository == 'centreon/centreon'
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ha-analysis.yml
+++ b/.github/workflows/ha-analysis.yml
@@ -32,6 +32,7 @@ env:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon-ha/.env
@@ -42,8 +43,7 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.repository == 'centreon/centreon'
+      needs.get-environment.outputs.skip_workflow == 'false'
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/open-tickets-analysis.yml
+++ b/.github/workflows/open-tickets-analysis.yml
@@ -43,7 +43,7 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false' 
+      needs.get-environment.outputs.skip_workflow == 'false'
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/open-tickets-analysis.yml
+++ b/.github/workflows/open-tickets-analysis.yml
@@ -42,7 +42,8 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false'
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      github.repository == 'centreon/centreon'
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/open-tickets-analysis.yml
+++ b/.github/workflows/open-tickets-analysis.yml
@@ -32,6 +32,7 @@ env:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
@@ -42,8 +43,7 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.repository == 'centreon/centreon'
+      needs.get-environment.outputs.skip_workflow == 'false' 
 
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   release:
-    if: ${{ github.event.pull_request.merged == true }}
+    if: ${{ github.event.pull_request.merged == true && github.repository == 'centreon/centreon' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Check base_ref

--- a/.github/workflows/ui-beta.yml
+++ b/.github/workflows/ui-beta.yml
@@ -19,7 +19,6 @@ env:
 
 jobs:
   lint:
-    if: github.repository == 'centreon/centreon'
     runs-on: ubuntu-22.04
 
     steps:
@@ -34,7 +33,6 @@ jobs:
           lint_path: ./src/
 
   cypress-component-testing:
-    if: github.repository == 'centreon/centreon'
     uses: ./.github/workflows/cypress-component-parallelization.yml
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.LIGHTHOUSE_ID }}

--- a/.github/workflows/ui-beta.yml
+++ b/.github/workflows/ui-beta.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   lint:
+    if: github.repository == 'centreon/centreon'
     runs-on: ubuntu-22.04
 
     steps:
@@ -33,6 +34,7 @@ jobs:
           lint_path: ./src/
 
   cypress-component-testing:
+    if: github.repository == 'centreon/centreon'
     uses: ./.github/workflows/cypress-component-parallelization.yml
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.LIGHTHOUSE_ID }}

--- a/.github/workflows/web-analysis.yml
+++ b/.github/workflows/web-analysis.yml
@@ -29,6 +29,7 @@ on:
 
 jobs:
   get-environment:
+    if: github.repository == 'centreon/centreon'
     uses: ./.github/workflows/get-environment.yml
     with:
       version_file: centreon/www/install/insertBaseConf.sql
@@ -39,8 +40,7 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      github.repository == 'centreon/centreon'
+      needs.get-environment.outputs.skip_workflow == 'false'
 
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/web-analysis.yml
+++ b/.github/workflows/web-analysis.yml
@@ -39,7 +39,8 @@ jobs:
       github.run_attempt == 1 &&
       github.event_name == 'schedule' &&
       github.ref_name == 'develop' &&
-      needs.get-environment.outputs.skip_workflow == 'false'
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      github.repository == 'centreon/centreon'
 
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -109,7 +109,7 @@ jobs:
           has_test_changes: ${{ steps.filter.outputs.has_test_changes || 'true' }}
 
   dispatch-to-maintained-branches:
-    if: ${{ github.run_attempt == 1 && github.event_name == 'schedule' && github.ref_name == 'develop' && github.repository == 'centreon/centreon'}}
+    if: ${{ github.run_attempt == 1 && github.event_name == 'schedule' && github.ref_name == 'develop' && github.repository == 'centreon/centreon' }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout sources


### PR DESCRIPTION
## Description

In order to reduce the amount of GHA runtime
* run dispatch jobs only on specific repositories
* run analysis jobs on relevant repositories only

**Fixes** #MON-170068

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
