### PR TITLE
MON-150244-remove-whitelist-from-40-gorgoned-yaml-file-for-now-plateform

### DIFF
--- a/centreon/www/include/configuration/configServers/popup/central.yaml
+++ b/centreon/www/include/configuration/configServers/popup/central.yaml
@@ -18,23 +18,6 @@ gorgone:
         enabled: true
         subnets:
           - 127.0.0.1/32
-    - name: action
-      package: "gorgone::modules::core::action::hooks"
-      enable: true
-      command_timeout: 30
-      whitelist_cmds: true
-      allowed_cmds:
-        - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
-        - ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
-        - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine\.cfg\s*$
-        - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats\.json\s*$
-        - ^/usr/lib/centreon/plugins/.*$
-        - ^/bin/perl /usr/share/centreon/bin/anomaly_detection --seasonality >> /var/log/centreon/anomaly_detection\.log 2>&1\s*$
-        - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
-        - ^centreon
-        - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
-        - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
     - name: cron
       package: "gorgone::modules::core::cron::hooks"
       enable: true

--- a/centreon/www/include/configuration/configServers/popup/poller.yaml
+++ b/centreon/www/include/configuration/configServers/popup/poller.yaml
@@ -9,23 +9,6 @@ gorgone:
     privkey: "/var/lib/centreon-gorgone/.keys/rsakey.priv.pem"
     pubkey: "/var/lib/centreon-gorgone/.keys/rsakey.pub.pem"
   modules:
-    - name: action
-      package: gorgone::modules::core::action::hooks
-      enable: true
-      whitelist_cmds: true
-      allowed_cmds:
-        - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
-        - ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
-        - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine\.cfg\s*$
-        - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats\.json\s*$
-        - ^/usr/lib/centreon/plugins/.*$
-        - ^/bin/perl /usr/share/centreon/bin/anomaly_detection --seasonality >> /var/log/centreon/anomaly_detection\.log 2>&1\s*$
-        - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
-        - ^centreon
-        - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
-        - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
-
     - name: engine
       package: gorgone::modules::centreon::engine::hooks
       enable: true

--- a/centreon/www/include/configuration/configServers/popup/remote.yaml
+++ b/centreon/www/include/configuration/configServers/popup/remote.yaml
@@ -9,24 +9,6 @@ gorgone:
     privkey: "/var/lib/centreon-gorgone/.keys/rsakey.priv.pem"
     pubkey: "/var/lib/centreon-gorgone/.keys/rsakey.pub.pem"
   modules:
-    - name: action
-      package: gorgone::modules::core::action::hooks
-      enable: true
-      command_timeout: 30
-      whitelist_cmds: true
-      allowed_cmds:
-        - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
-        - ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
-        - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine\.cfg\s*$
-        - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats\.json\s*$
-        - ^/usr/lib/centreon/plugins/.*$
-        - ^/bin/perl /usr/share/centreon/bin/anomaly_detection --seasonality >> /var/log/centreon/anomaly_detection\.log 2>&1\s*$
-        - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
-        - ^centreon
-        - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
-        - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
-
     - name: cron
       package: "gorgone::modules::core::cron::hooks"
       enable: true

--- a/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
+++ b/centreon/www/install/var/gorgone/gorgoneCentralTemplate.yaml
@@ -18,24 +18,6 @@ gorgone:
         subnets:
           - 127.0.0.1/32
 
-    - name: action
-      package: "gorgone::modules::core::action::hooks"
-      enable: true
-      command_timeout: 30
-      whitelist_cmds: true
-      allowed_cmds:
-        - ^sudo\s+(/bin/)?systemctl\s+(reload|restart)\s+(centengine|centreontrapd|cbd)\s*$
-        - ^(sudo\s+)?(/usr/bin/)?service\s+(centengine|centreontrapd|cbd|cbd-sql)\s+(reload|restart)\s*$
-        - ^/usr/sbin/centenginestats\s+-c\s+/etc/centreon-engine/centengine\.cfg\s*$
-        - ^cat\s+/var/lib/centreon-engine/[a-zA-Z0-9\-]+-stats\.json\s*$
-        - ^/usr/lib/centreon/plugins/.*$
-        - ^/bin/perl /usr/share/centreon/bin/anomaly_detection --seasonality >> /var/log/centreon/anomaly_detection\.log 2>&1\s*$
-        - ^/usr/bin/php -q /usr/share/centreon/cron/centreon-helios\.php >> /var/log/centreon-helios\.log 2>&1\s*$
-        - ^centreon
-        - ^mkdir
-        - ^/usr/share/centreon/www/modules/centreon-autodiscovery-server/script/run_save_discovered_host
-        - ^/usr/share/centreon/bin/centreon -u \"centreon-gorgone\" -p \S+ -w -o CentreonWorker -a processQueue$
-
     - name: cron
       package: "gorgone::modules::core::cron::hooks"
       enable: true


### PR DESCRIPTION
Refs:MON-150244

## Description

remove gorgone unused configuration

gorgone action module now have it's own dedicated file, so it should not be present in the main 40-gorgoned.yaml file.
This pr aim to remove the module for new instance.


## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>

install a new plateform from this branch, check in the file /etc/centreon-gorgone/config.d/40-gorgoned.yaml that action module is not present anymore.
install a new poller, check the same file, action module should not be present.
Check a file 39-action.yaml exist.
Check autodiscovery and pushing a conf to the poller work.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [X] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [X] I have commented my code, especially **hard-to-understand areas** of the PR.
- [X] I have **rebased** my development branch on the base branch (master, maintenance).
