### PR TITLE
fix(web): Remove references to cbmod.so

### DIFF
--- a/.github/docker/centreon-web/alma8/configuration/broker.json
+++ b/.github/docker/centreon-web/alma8/configuration/broker.json
@@ -1,6 +1,5 @@
 {
   "centreonbroker_etc": "\/etc\/centreon-broker",
-  "centreonbroker_cbmod": "\/usr\/lib64\/nagios\/cbmod.so",
   "centreonbroker_log": "\/var\/log\/centreon-broker",
   "centreonbroker_varlib": "\/var\/lib\/centreon-broker",
   "centreonbroker_lib": "\/usr\/share\/centreon\/lib\/centreon-broker"

--- a/.github/docker/centreon-web/alma8/configuration/configuration.json
+++ b/.github/docker/centreon-web/alma8/configuration/configuration.json
@@ -25,6 +25,5 @@
   "plugin_dir": "\/usr\/lib64\/nagios\/plugins",
   "centreon_engine_connectors": "\/usr\/lib64\/centreon-connector",
   "centreon_engine_lib": "\/usr\/lib64\/centreon-engine",
-  "centreonbroker_cbmod": "\/usr\/lib64\/nagios\/cbmod.so",
   "centreon_plugins": "\/usr\/lib\/centreon\/plugins"
 }

--- a/.github/docker/centreon-web/alma9/configuration/broker.json
+++ b/.github/docker/centreon-web/alma9/configuration/broker.json
@@ -1,6 +1,5 @@
 {
   "centreonbroker_etc": "\/etc\/centreon-broker",
-  "centreonbroker_cbmod": "\/usr\/lib64\/nagios\/cbmod.so",
   "centreonbroker_log": "\/var\/log\/centreon-broker",
   "centreonbroker_varlib": "\/var\/lib\/centreon-broker",
   "centreonbroker_lib": "\/usr\/share\/centreon\/lib\/centreon-broker"

--- a/.github/docker/centreon-web/alma9/configuration/configuration.json
+++ b/.github/docker/centreon-web/alma9/configuration/configuration.json
@@ -25,6 +25,5 @@
   "plugin_dir": "\/usr\/lib64\/nagios\/plugins",
   "centreon_engine_connectors": "\/usr\/lib64\/centreon-connector",
   "centreon_engine_lib": "\/usr\/lib64\/centreon-engine",
-  "centreonbroker_cbmod": "\/usr\/lib64\/nagios\/cbmod.so",
   "centreon_plugins": "\/usr\/lib\/centreon\/plugins"
 }

--- a/.github/docker/centreon-web/bookworm/configuration/broker.json
+++ b/.github/docker/centreon-web/bookworm/configuration/broker.json
@@ -1,6 +1,5 @@
 {
   "centreonbroker_etc": "\/etc\/centreon-broker",
-  "centreonbroker_cbmod": "\/usr\/lib64\/nagios\/cbmod.so",
   "centreonbroker_log": "\/var\/log\/centreon-broker",
   "centreonbroker_varlib": "\/var\/lib\/centreon-broker",
   "centreonbroker_lib": "\/usr\/share\/centreon\/lib\/centreon-broker"

--- a/.github/docker/centreon-web/bookworm/configuration/configuration.json
+++ b/.github/docker/centreon-web/bookworm/configuration/configuration.json
@@ -25,6 +25,5 @@
   "plugin_dir": "\/usr\/lib\/nagios\/plugins",
   "centreon_engine_connectors": "\/usr\/lib64\/centreon-connector",
   "centreon_engine_lib": "\/usr\/lib64\/centreon-engine",
-  "centreonbroker_cbmod": "\/usr\/lib64\/nagios\/cbmod.so",
   "centreon_plugins": "\/usr\/lib\/centreon\/plugins"
 }

--- a/.github/docker/centreon-web/jammy/configuration/broker.json
+++ b/.github/docker/centreon-web/jammy/configuration/broker.json
@@ -1,6 +1,5 @@
 {
   "centreonbroker_etc": "\/etc\/centreon-broker",
-  "centreonbroker_cbmod": "\/usr\/lib64\/nagios\/cbmod.so",
   "centreonbroker_log": "\/var\/log\/centreon-broker",
   "centreonbroker_varlib": "\/var\/lib\/centreon-broker",
   "centreonbroker_lib": "\/usr\/share\/centreon\/lib\/centreon-broker"

--- a/.github/docker/centreon-web/jammy/configuration/configuration.json
+++ b/.github/docker/centreon-web/jammy/configuration/configuration.json
@@ -25,6 +25,5 @@
   "plugin_dir": "\/usr\/lib\/nagios\/plugins",
   "centreon_engine_connectors": "\/usr\/lib64\/centreon-connector",
   "centreon_engine_lib": "\/usr\/lib64\/centreon-engine",
-  "centreonbroker_cbmod": "\/usr\/lib64\/nagios\/cbmod.so",
   "centreon_plugins": "\/usr\/lib\/centreon\/plugins"
 }

--- a/centreon/packaging/src/install.conf.php
+++ b/centreon/packaging/src/install.conf.php
@@ -23,5 +23,4 @@ $conf_centreon['monitoring_varlog'] = "/var/log/centreon-engine";
 $conf_centreon['plugin_dir'] = "/usr/lib64/nagios/plugins";
 $conf_centreon['centreon_engine_connectors'] = "/usr/lib64/centreon-connector";
 $conf_centreon['centreon_engine_lib'] = "/usr/lib64/centreon-engine";
-$conf_centreon['centreonbroker_cbmod'] = "/usr/lib64/nagios/cbmod.so";
 $conf_centreon['centreon_plugins'] = "/usr/lib/centreon/plugins";

--- a/centreon/src/Centreon/Infrastructure/Service/CentcoreConfigService.php
+++ b/centreon/src/Centreon/Infrastructure/Service/CentcoreConfigService.php
@@ -90,7 +90,6 @@ class CentcoreConfigService
             'centreonbroker_lib' => '/usr/share/centreon/lib/centreon-broker',
             'centreonbroker_varlib' => '/var/lib/centreon-broker',
             'centreonbroker_log' => '/var/log/centreon-broker',
-            'centreonbroker_cbmod' => '/usr/lib64/nagios/cbmod.so',
             'centreonbroker_etc' => '/etc/centreon-broker',
             'centreonplugins' => '/usr/lib/centreon/plugins',
             'centreon_plugins' => '/usr/lib/centreon/plugins',
@@ -106,7 +105,6 @@ class CentcoreConfigService
          * centreonbroker_lib -> nagios_server.centreonbroker_module_path
          * centreonbroker_varlib -> cfg_centreonbroker.cache_directory
          * centreonbroker_log
-         * centreonbroker_cbmod
          * centreonbroker_etc
          * centreonplugins -> cfg_resource.resource_line (resource_name: $CENTREONPLUGINS$)
          * centreon_plugins

--- a/centreon/src/CentreonRemote/Domain/Resources/DefaultConfig/CfgNagiosBrokerModule.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/DefaultConfig/CfgNagiosBrokerModule.php
@@ -42,7 +42,7 @@ class CfgNagiosBrokerModule
             ],
             [
                 'cfg_nagios_id' => 1,
-                'broker_module' => '@centreonbroker_cbmod@ @centreonbroker_etc@/central-module.json',
+                'broker_module' => '@centreonbroker_etc@/central-module.json',
             ],
         ];
     }

--- a/centreon/unattended.sh
+++ b/centreon/unattended.sh
@@ -937,7 +937,14 @@ function play_install_wizard() {
 	sessionID=$(curl -s -v "http://${central_ip}/centreon/install/install.php" 2>&1 | grep Set-Cookie | awk '{print $3}')
 	curl -s "http://${central_ip}/centreon/install/steps/step.php?action=stepContent" -H "Cookie: ${sessionID}" >/dev/null
 	install_wizard_post ${sessionID} "process_step3.php" 'centreon_engine_stats_binary=%2Fusr%2Fsbin%2Fcentenginestats&monitoring_var_lib=%2Fvar%2Flib%2Fcentreon-engine&centreon_engine_connectors=%2Fusr%2Flib64%2Fcentreon-connector&centreon_engine_lib=%2Fusr%2Flib64%2Fcentreon-engine&centreonplugins=%2Fusr%2Flib%2Fcentreon%2Fplugins%2F'
-	install_wizard_post ${sessionID} "process_step4.php" 'centreonbroker_etc=%2Fetc%2Fcentreon-broker&centreonbroker_cbmod=%2Fusr%2Flib64%2Fnagios%2Fcbmod.so&centreonbroker_log=%2Fvar%2Flog%2Fcentreon-broker&centreonbroker_varlib=%2Fvar%2Flib%2Fcentreon-broker&centreonbroker_lib=%2Fusr%2Fshare%2Fcentreon%2Flib%2Fcentreon-broker'
+    case $version in
+    "2"[234]"."*)
+        install_wizard_post ${sessionID} "process_step4.php" 'centreonbroker_etc=%2Fetc%2Fcentreon-broker&centreonbroker_cbmod=%2Fusr%2Flib64%2Fnagios%2Fcbmod.so&centreonbroker_log=%2Fvar%2Flog%2Fcentreon-broker&centreonbroker_varlib=%2Fvar%2Flib%2Fcentreon-broker&centreonbroker_lib=%2Fusr%2Fshare%2Fcentreon%2Flib%2Fcentreon-broker'
+    ;;
+    *)
+        install_wizard_post ${sessionID} "process_step4.php" 'centreonbroker_etc=%2Fetc%2Fcentreon-broker&centreonbroker_log=%2Fvar%2Flog%2Fcentreon-broker&centreonbroker_varlib=%2Fvar%2Flib%2Fcentreon-broker&centreonbroker_lib=%2Fusr%2Fshare%2Fcentreon%2Flib%2Fcentreon-broker'
+    ;;
+    esac
 	install_wizard_post ${sessionID} "process_step5.php" "admin_password=${centreon_admin_password}&confirm_password=${centreon_admin_password}&firstname=${centreon_admin_firstname}&lastname=${centreon_admin_lastname}&email=${centreon_admin_email}"
 	install_wizard_post ${sessionID} "process_step6.php" "address=&port=3306&root_user=root&root_password=${db_root_password}&db_configuration=centreon&db_storage=centreon_storage&db_user=centreon&db_password=${db_centreon_password}&db_password_confirm=${db_centreon_password}"
 	if [[ -v use_vault ]]; then

--- a/centreon/www/install/install.conf.dist.php
+++ b/centreon/www/install/install.conf.dist.php
@@ -23,5 +23,4 @@ $conf_centreon['monitoring_varlog'] = "/var/log/centreon-engine";
 $conf_centreon['plugin_dir'] = "/usr/lib/nagios/plugins";
 $conf_centreon['centreon_engine_connectors'] = "/usr/lib64/centreon-connector";
 $conf_centreon['centreon_engine_lib'] = "/usr/lib64/centreon-engine";
-$conf_centreon['centreonbroker_cbmod'] = "/usr/lib64/nagios/cbmod.so";
 $conf_centreon['centreon_plugins'] = "/usr/lib/centreon/plugins";

--- a/centreon/www/install/steps/functions.php
+++ b/centreon/www/install/steps/functions.php
@@ -283,7 +283,6 @@ function setSessionVariables($conf_centreon)
     $_SESSION['MONITORING_VAR_LOG'] = $conf_centreon['monitoring_varlog'];
     $_SESSION['CENTREON_ENGINE_CONNECTORS'] = $conf_centreon['centreon_engine_connectors'];
     $_SESSION['CENTREON_ENGINE_LIB'] = $conf_centreon['centreon_engine_lib'];
-    $_SESSION['CENTREONBROKER_CBMOD'] = $conf_centreon['centreonbroker_cbmod'];
     $_SESSION['CENTREONPLUGINS'] = $conf_centreon['centreon_plugins'];
 }
 

--- a/centreon/www/install/var/baseconf/centreon-broker.sql
+++ b/centreon/www/install/var/baseconf/centreon-broker.sql
@@ -170,4 +170,4 @@ INSERT INTO `cfg_centreonbroker_log` (`id_centreonbroker`, `id_log`, `id_level`)
 UPDATE `nagios_server` SET `centreonbroker_cfg_path` = '@broker_etc@' WHERE `id` = 1;
 UPDATE `nagios_server` SET `centreonbroker_module_path` = '@centreonbroker_lib@' WHERE `id` = 1;
 
-INSERT INTO cfg_nagios_broker_module (`cfg_nagios_id`, `broker_module`) VALUES (1, '@centreonbroker_cbmod@ @centreonbroker_etc@/central-module.json');
+INSERT INTO cfg_nagios_broker_module (`cfg_nagios_id`, `broker_module`) VALUES (1, '@centreonbroker_etc@/central-module.json');

--- a/centreon/www/install/var/brokers/centreon-broker
+++ b/centreon/www/install/var/brokers/centreon-broker
@@ -4,7 +4,6 @@
 # column 4 => 0:directory, 1: file
 # column 5 => default value
 CENTREONBROKER_ETC;Centreon Broker etc directory;1;0;/etc/centreon-broker
-CENTREONBROKER_CBMOD;Centreon Broker module (cbmod.so);0;1;/usr/lib64/nagios/cbmod.so
 CENTREONBROKER_LOG;Centreon Broker log directory;1;0;/var/log/centreon-broker
 CENTREONBROKER_VARLIB;Retention file directory;1;0;/var/lib/centreon-broker
 CENTREONBROKER_LIB;Centreon Broker lib (*.so) directory;1;0;/usr/share/centreon/lib/centreon-broker


### PR DESCRIPTION
## Description
This is gone in develop, and the code requires it, so because of its non-existence, the install fails.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master