### PR TITLE
fix(Host templates): fix error on mass change

### DIFF
--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -1465,20 +1465,23 @@ function updateHost_MC($hostId = null)
         );
     }
 
-    $request = "UPDATE host SET ";
-    foreach (array_keys($bindParams) as $token) {
-        $request .= ltrim($token, ':') . " = " . $token . ", ";
-    }
-    $request = rtrim($request, ', ');
-    $request .= " WHERE host_id = :hostId";
-    $statement = $pearDB->prepare($request);
-    foreach ($bindParams as $token => $bindValues) {
-        foreach ($bindValues as $paramType => $value) {
-            $statement->bindValue($token, $value, $paramType);
+    if (! empty($bindParams)) {
+        $request = "UPDATE host SET ";
+        foreach (array_keys($bindParams) as $token) {
+            $request .= ltrim($token, ':') . " = " . $token . ", ";
         }
+        $request = rtrim($request, ', ');
+        $request .= " WHERE host_id = :hostId";
+
+        $statement = $pearDB->prepare($request);
+        foreach ($bindParams as $token => $bindValues) {
+            foreach ($bindValues as $paramType => $value) {
+                $statement->bindValue($token, $value, $paramType);
+            }
+        }
+        $statement->bindValue(':hostId', $hostId, \PDO::PARAM_INT);
+        $statement->execute();
     }
-    $statement->bindValue(':hostId', $hostId, \PDO::PARAM_INT);
-    $statement->execute();
 
     /*
      *  update multiple templates


### PR DESCRIPTION
## Description

Fixed error on Mass change of host templates, while modifing linked services or categories arror accures due to sql error.

**Fixes** # ([MON-166248](https://centreon.atlassian.net/browse/MON-166248))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

on host templates, add linked services and/or categories to a bunch of templates, services should be added without any errors

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-166248]: https://centreon.atlassian.net/browse/MON-166248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ