### PR TITLE
fix(dsm): startup query for alarms in the mod_dsm_cache table

### DIFF
--- a/centreon-dsm/bin/dsmd.pl
+++ b/centreon-dsm/bin/dsmd.pl
@@ -229,10 +229,11 @@ sub get_alarms {
     # if hosts is disabled: it's an host on the wrong instance or instance is not running. otherwise we care about enabled only.
     my ($status, $sth) = $self->{db_centstorage}->query(
         "SELECT mdc.`cache_id`, mdc.`host_id`, mdc.`ctime`, mdc.`status`, mdc.`pool_prefix`, mdc.`id`, mdc.`macros`, mdc.`output`
-         FROM mod_dsm_cache mdc, hosts
-         WHERE mdc.host_id = hosts.host_id AND
-               hosts.enabled = '1'
-         "
+        FROM mod_dsm_cache mdc, hosts
+        WHERE mdc.host_id = hosts.host_id AND
+            hosts.enabled = '1'
+        GROUP BY CONCAT(mdc.host_id, '_', mdc.pool_prefix)
+        "
     );
     if ($status == -1) {
         $self->{logger}->writeLogError('cannot get alarms');

--- a/centreon-dsm/bin/dsmd.pl
+++ b/centreon-dsm/bin/dsmd.pl
@@ -232,7 +232,7 @@ sub get_alarms {
         FROM mod_dsm_cache mdc, hosts
         WHERE mdc.host_id = hosts.host_id AND
             hosts.enabled = '1'
-        GROUP BY CONCAT(mdc.host_id, '_', mdc.pool_prefix)
+        GROUP BY mdc.host_id, mdc.pool_prefix
         "
     );
     if ($status == -1) {


### PR DESCRIPTION
## Description

dsm is not able to work after having started (can even crash the database) if there are too many entries in the mod_dsm_cache table.

that's because it will concatenate thousands of OR conditions in one of its sql queries (number of OR conditions is equal to number of rows in the centreon_storage.mod_dsm_cache table)

this leads to something like 

```sql
SELECT hosts.`name`, hosts.`instance_id`, resources.`parent_id`, resources.`id`, resources.`name`, resources.`last_check`, resources.`status`, cv.`value` FROM resources LEFT JOIN customvariables cv ON cv.host_id = resources.parent_id AND cv.service_id = resources.id AND cv.name = 'ALARM_ID', hosts 
WHERE ((resources.parent_id = 19 AND resources.name LIKE 'tanguy-%')
OR(resources.parent_id = 19 AND resources.name LIKE 'tanguy-%')
OR(resources.parent_id = 19 AND resources.name LIKE 'tanguy-%')
OR(resources.parent_id = 19 AND resources.name LIKE 'tanguy-%')
OR(resources.parent_id = 19 AND resources.name LIKE 'tanguy-%')
```



**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 22.10.x
- [x] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- install your dsm module
- have some slots for a host
- run the below command:  (replace host_id and mysql connection information according to your platform and configuration, you need to root account of your database)

the below one-liner do the following things: 
- stop dsmd
- generates 100 alarms using the dsm client binary (therefore it creates 100 entries in the centreon_storage.mod_dsm_cache table)
- activates the general log of the database
- start dsmd
- wait 2 seconds
- disables the general log of the database

```bash
systemctl stop dsmd; count=0; while [ $count -lt 100 ]; do /usr/share/centreon/bin/dsmclient.pl -i "test-$count" -s 1 -t $(date +%s) -o "test $count" --host-id=19; count=$(($count+1)); done; mysql -pcentreon -e "SET GLOBAL general_log = 'ON'"; systemctl start dsmd; sleep 2; mysql -pcentreon -e "SET GLOBAL general_log = 'OFF'"
```

you should have a log in /var/lib/mysql with all the queries that have been executed.

Search for the "ALARM_ID" keyword in the logfile to find the query

without the patch you'll find the bugged query as shown at the beginning.
with the patch you now have a the proper query



## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
