### PR TITLE
enh(cfg) bbdo version to 3.1 in engine cfg

### DIFF
--- a/centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+++ b/centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
@@ -184,9 +184,9 @@ $stats_activate[] = $form->createElement('radio', 'stats_activate', null, _("No"
 $form->addGroup($stats_activate, 'stats_activate', _("Statistics"), '&nbsp;');
 
 $bbdo_versions = [
-    '2.0.0' => 'v.2.0.0 (old protocol)',
     '3.0.0' => 'v.3.0.0 (with protobuf)',
-    '3.0.1' => 'v.3.0.1 (full protobuf)'
+    '3.0.1' => 'v.3.0.1 (full protobuf)',
+    '3.1.0' => 'v.3.1.0',
 ];
 
 $form->addElement('select', 'bbdo_version', _("BBDO version"), $bbdo_versions);
@@ -203,7 +203,7 @@ foreach ($tags as $tagId => $tag) {
  */
 if (isset($_GET["o"]) && $_GET["o"] == ADD_BROKER_CONFIGURATION) {
     $result = array_merge(
-        ["name" => '', "cache_directory" => '/var/lib/centreon-broker/', "log_directory" => '/var/log/centreon-broker/', "write_timestamp" => '1', "write_thread_id" => '1', "stats_activate" => '1', "activate" => '1', "activate_watchdog" => '1', "bbdo_version" => '3.0.1'],
+        ["name" => '', "cache_directory" => '/var/lib/centreon-broker/', "log_directory" => '/var/log/centreon-broker/', "write_timestamp" => '1', "write_thread_id" => '1', "stats_activate" => '1', "activate" => '1', "activate_watchdog" => '1', "bbdo_version" => '3.1.0'],
         $defaultLog
     );
     $form->setDefaults($result);

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -463,7 +463,7 @@ CREATE TABLE `cfg_centreonbroker` (
   `stats_activate` enum('0','1') DEFAULT '1',
   `daemon` TINYINT(1),
   `pool_size` int(11) DEFAULT NULL,
-  `bbdo_version` varchar(50) DEFAULT '3.0.1',
+  `bbdo_version` varchar(50) DEFAULT '3.1.0',
   PRIMARY KEY (`config_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -93,14 +93,22 @@ $updateCfgParameters = function () use ($pearDB, &$errorMessage) {
     );
 };
 
+/** -------------------------------------------- BBDO cfg update -------------------------------------------- */
+$bbdoDefaultUpdate= function () use ($pearDB, &$errorMessage) {
+    if ($pearDB->isColumnExist('cfg_centreonbroker', 'bbdo_version') !== 1) {
+        $errorMessage = "Unable to update 'bbdo_version' column to 'cfg_centreonbroker' table";
+        $pearDB->query('ALTER TABLE `cfg_centreonbroker` MODIFY `bbdo_version` VARCHAR(50) DEFAULT "3.1.0"');
+    }
+};
+
+$bbdoCfgUpdate = function () use ($pearDB, &$errorMessage) {
+    $errorMessage = "Unable to update 'bbdo_version' version in 'cfg_centreonbroker' table";
+    $pearDB->query('UPDATE `cfg_centreonbroker` SET `bbdo_version` = "3.1.0"');
+};
 
 try {
-    // DDL statements for real time database
-    // TODO add your function calls to update the real time database structure here
-    
 
-    // DDL statements for configuration database
-    // TODO add your function calls to update the configuration database structure here
+    $bbdoDefaultUpdate();
     $addDeprecateCustomViewsToContact();
 
     // Transactional queries for configuration database
@@ -111,6 +119,7 @@ try {
     $updateDashboardAndCustomViewsTopology();
     $updateContactsShowDeprecatedCustomViews();
     $updateCfgParameters();
+    $bbdoCfgUpdate();
 
     $pearDB->commit();
 


### PR DESCRIPTION
## Description
Remove Bbdo_version 2.0
Add Bbdo_version 3.1 option in engine configuration form
Force current config to 3.1 
Default new config are 3.1

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
