### PR TITLE
feat(routing): Implement route loader to manage modules routing

### DIFF
--- a/centreon/src/Core/Common/Infrastructure/Routing/ModuleRouteLoader.php
+++ b/centreon/src/Core/Common/Infrastructure/Routing/ModuleRouteLoader.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Core\Common\Infrastructure\Routing;
+
+use Core\Module\Infrastructure\ModuleVersionChecker;
+use Symfony\Bundle\FrameworkBundle\Routing\RouteLoaderInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Routing\Loader\AttributeFileLoader;
+use Symfony\Component\Routing\RouteCollection;
+
+abstract readonly class ModuleRouteLoader implements RouteLoaderInterface
+{
+    public function __construct(
+        #[Autowire(service: 'routing.loader.attribute.file')] private AttributeFileLoader $loader,
+        #[Autowire(param: 'kernel.project_dir')] private string $projectDir,
+        private ModuleVersionChecker $versionChecker
+    ) {
+    }
+
+    abstract protected function getModuleName(): string;
+
+    abstract protected function getModuleDirectory(): string;
+
+    final public function __invoke(): RouteCollection
+    {
+        if($this->versionChecker->hasANewVersionAvailable($this->getModuleName())) {
+            return new RouteCollection();
+        }
+
+        $moduleDir = $this->projectDir . '/src/' . $this->getModuleDirectory() . '/**/*Controller.php';
+        $routes = new RouteCollection();
+        foreach ($this->loader->import($moduleDir, 'attribute') as $routeCollection) {
+            $routes->addCollection($routeCollection);
+        }
+        $routes->addPrefix('/{base_uri}api/{version}');
+        $routes->addDefaults(['base_uri' => 'centreon/']);
+        $routes->addRequirements(['base_uri' => '(.+/)|.{0}']);
+
+        return $routes;
+    }
+}

--- a/centreon/src/Core/Module/Application/Repository/ModuleInformationRepositoryInterface.php
+++ b/centreon/src/Core/Module/Application/Repository/ModuleInformationRepositoryInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * Centreon
+ *
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Unauthorized reproduction, copy and distribution
+ * are not allowed.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Module\Application\Repository;
+
+use Core\Module\Domain\ModuleInformation;
+
+interface ModuleInformationRepositoryInterface
+{
+	public function findByName(string $name): ?ModuleInformation;
+}

--- a/centreon/src/Core/Module/Domain/ModuleInformation.php
+++ b/centreon/src/Core/Module/Domain/ModuleInformation.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Centreon
+ *
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Unauthorized reproduction, copy and distribution
+ * are not allowed.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Module\Domain;
+
+final readonly class ModuleInformation
+{
+	public function __construct(
+		private string $packageName,
+		private string $displayName,
+		private string $version,
+	) {
+	}
+
+	public function getPackageName(): string
+	{
+		return $this->packageName;
+	}
+
+	public function getDisplayName(): string
+	{
+		return $this->displayName;
+	}
+
+	public function getVersion(): string
+	{
+		return $this->version;
+	}
+}

--- a/centreon/src/Core/Module/Infrastructure/ModuleVersionChecker.php
+++ b/centreon/src/Core/Module/Infrastructure/ModuleVersionChecker.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Core\Module\Infrastructure;
+
+use Core\Module\Application\Repository\ModuleInformationRepositoryInterface;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+
+final readonly class ModuleVersionChecker
+{
+    public function __construct(
+        #[Autowire(param: 'kernel.project_dir')] private string $projectDir,
+        private ModuleInformationRepositoryInterface $repository
+    ) {
+    }
+
+    public function hasANewVersionAvailable(string $moduleName): bool
+    {
+        $moduleInformation = $this->repository->findByName($moduleName);
+        if (! $moduleInformation) {
+            throw new \RuntimeException($moduleName . " is not installed");
+        }
+        $getConfigFileVersion = function() use ($moduleName): string {
+            require $this->projectDir . "/www/modules/$moduleName/conf.php";
+
+            return $module_conf[$moduleName]["mod_release"];
+        };
+
+        return version_compare($getConfigFileVersion(), $moduleInformation->getVersion(), ">");
+    }
+}

--- a/centreon/src/Core/Module/Infrastructure/Repository/DbReadModuleInformationRepository.php
+++ b/centreon/src/Core/Module/Infrastructure/Repository/DbReadModuleInformationRepository.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Centreon
+ *
+ * Copyright 2005 - 2023 Centreon (https://www.centreon.com/)
+ *
+ * Unauthorized reproduction, copy and distribution
+ * are not allowed.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Module\Infrastructure\Repository;
+
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Common\Infrastructure\Repository\DatabaseRepository;
+use Core\Module\Application\Repository\ModuleInformationRepositoryInterface;
+use Core\Module\Domain\ModuleInformation;
+
+class DbReadModuleinformationRepository extends DatabaseRepository implements ModuleInformationRepositoryInterface
+{
+    public function findByName(string $name): ?ModuleInformation
+    {
+        $query = $this->queryBuilder
+            ->select('name', 'rname', 'mod_release')
+            ->from('modules_informations')
+            ->where($this->queryBuilder->expr()->equal('name', ':name'))
+            ->getQuery();
+
+        $queryParameters = QueryParameters::create([QueryParameter::string('name', $name)]);
+        $result = $this->connection->fetchAssociative($query, $queryParameters);
+
+        if ($result !== []) {
+            return new ModuleInformation(
+                packageName: $result['name'],
+                displayName: $result['rname'],
+                version: $result['mod_release']
+            );
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Description

This PR Intends to add a Route Loader mechanism to handle route management on modules.
This is a first step of multiple ones:
- Implement Route Loader on Web (this PR)
- Implement Route Loader on Modules
- Migrate .yaml modules route definition to PHP Attributes
- Remove the manual install/update of modules from centreon UI, to automate it in .postinstall script during RPM installation (TBD)

**Fixes** # MON-171783

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
