### PR TITLE
enh(agent configuration): set certificate fields to optional

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Application/Factory/AgentConfigurationFactory.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Factory/AgentConfigurationFactory.php
@@ -54,7 +54,7 @@ class AgentConfigurationFactory
             type: $type,
             connectionMode: $connectionMode,
             configuration: match ($type) {
-                Type::TELEGRAF => new TelegrafConfigurationParameters($parameters, $connectionMode),
+                Type::TELEGRAF => new TelegrafConfigurationParameters($parameters),
                 Type::CMA => new CmaConfigurationParameters($parameters, $connectionMode)
             }
         );
@@ -84,7 +84,7 @@ class AgentConfigurationFactory
             type: $type,
             connectionMode: $connectionMode,
             configuration: match ($type) {
-                Type::TELEGRAF => new TelegrafConfigurationParameters($parameters, $connectionMode),
+                Type::TELEGRAF => new TelegrafConfigurationParameters($parameters),
                 Type::CMA => new CmaConfigurationParameters($parameters, $connectionMode)
             }
         );

--- a/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
@@ -122,7 +122,7 @@ class CmaValidator implements TypeValidatorInterface
             ? '/\.\/|\.\.\/|\/\/|^(?!.*\.(cer|crt)$).+$/'
             : '/\.\/|\.\.\/|\/\/|^(?!.*\.key$).+$/';
 
-        if ($value === null || preg_match($pattern, $value)) {
+        if ($value !== null && preg_match($pattern, $value)) {
             throw AgentConfigurationException::invalidFilename($name, (string) $value);
         }
     }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -66,35 +66,20 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
         /** @var _CmaParameters $parameters */
         $parameters = $this->normalizeCertificatePaths($parameters);
 
-        // For secure and insecure modes
-        if ($connectionMode !== ConnectionModeEnum::NO_TLS) {
-            $this->validateCertificate(
-                $parameters['otel_public_certificate'],
-                'configuration.otel_public_certificate'
-            );
-            $this->validateCertificate(
-                $parameters['otel_private_key'],
-                'configuration.otel_private_key'
-            );
-            $this->validateOptionalCertificate(
-                $parameters['otel_ca_certificate'],
-                'configuration.otel_ca_certificate'
-            );
-        // For NO-TLS mode
-        } else {
-            $this->validateOptionalCertificate(
-                $parameters['otel_public_certificate'],
-                'configuration.otel_public_certificate'
-            );
-            $this->validateOptionalCertificate(
-                $parameters['otel_private_key'],
-                'configuration.otel_private_key'
-            );
-            $this->validateOptionalCertificate(
-                $parameters['otel_ca_certificate'],
-                'configuration.otel_ca_certificate'
-            );
-        }
+        $this->validateOptionalCertificate(
+            $parameters['otel_public_certificate'],
+            'configuration.otel_public_certificate'
+        );
+
+        $this->validateOptionalCertificate(
+            $parameters['otel_private_key'],
+            'configuration.otel_private_key'
+        );
+
+        $this->validateOptionalCertificate(
+            $parameters['otel_ca_certificate'],
+            'configuration.otel_ca_certificate'
+        );
 
         if (! $parameters['is_reverse'] && ! empty($parameters['hosts'])) {
             $parameters['hosts'] = [];
@@ -194,20 +179,6 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
         return str_starts_with($path, self::CERTIFICATE_BASE_PATH)
             ? $path
             : self::CERTIFICATE_BASE_PATH . ltrim($path, '/');
-    }
-
-    /**
-     * Validates a certificate.
-     *
-     * @param ?string $certificate
-     * @param string $field Used for error reporting
-     *
-     * @throws AssertionFailedException
-     */
-    private function validateCertificate(?string $certificate, string $field): void
-    {
-        Assertion::notEmptyString($certificate, $field);
-        Assertion::maxLength($certificate ?? '', self::MAX_LENGTH, $field);
     }
 
     /**

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbReadAgentConfigurationRepository.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbReadAgentConfigurationRepository.php
@@ -416,7 +416,7 @@ class DbReadAgentConfigurationRepository extends AbstractRepositoryRDB implement
             type: $type,
             connectionMode: $connectionMode,
             configuration: match ($type->value) {
-                Type::TELEGRAF->value => new TelegrafConfigurationParameters($configuration, $connectionMode),
+                Type::TELEGRAF->value => new TelegrafConfigurationParameters($configuration),
                 Type::CMA->value => new CmaConfigurationParameters($configuration, $connectionMode),
             }
         );

--- a/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/FindAgentConfiguration/FindAgentConfigurationTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/FindAgentConfiguration/FindAgentConfigurationTest.php
@@ -82,8 +82,7 @@ it('should present a FindConfigurationResponse when everything is ok', function 
             'conf_server_port' => 454,
             'conf_certificate' => 'conf-certif.crt',
             'conf_private_key' => 'conf-key.key'
-        ],
-        ConnectionModeEnum::SECURE
+        ]
     );
 
     $pollers = [

--- a/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/FindAgentConfigurations/FindAgentConfigurationsTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/FindAgentConfigurations/FindAgentConfigurationsTest.php
@@ -141,8 +141,7 @@ it('should present a FindAgentConfigurationsResponse when no errors occurred', f
                 'conf_server_port' => 454,
                 'conf_certificate' => 'conf-certif',
                 'conf_private_key' => 'conf-key'
-            ],
-            ConnectionModeEnum::SECURE
+            ]
         )
     );
 
@@ -161,8 +160,7 @@ it('should present a FindAgentConfigurationsResponse when no errors occurred', f
                 'conf_server_port' => 454,
                 'conf_certificate' => 'conf-certif',
                 'conf_private_key' => 'conf-key'
-            ],
-            ConnectionModeEnum::SECURE
+            ]
         )
     );
 

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
@@ -69,24 +69,6 @@ foreach (
 foreach (
     [
         'otel_public_certificate',
-        'otel_private_key'
-    ] as $field
-) {
-    it(
-        "should throw an exception when a {$field} is too short",
-        function () use ($field) : void {
-            $this->parameters[$field] = '';
-
-            new CmaConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
-        }
-    )->throws(
-        AssertionException::notEmptyString("configuration.{$field}")->getMessage()
-    );
-}
-
-foreach (
-    [
-        'otel_public_certificate',
         'otel_ca_certificate',
         'otel_private_key'
     ] as $field

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/TelegrafConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/TelegrafConfigurationParametersTest.php
@@ -47,7 +47,7 @@ foreach (
         "should throw an exception when the {$field} is not valid",
         function () use ($field) : void {
             $this->parameters[$field] = 9999999999;
-            new TelegrafConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
+            new TelegrafConfigurationParameters($this->parameters);
         }
     )->throws(
         AssertionException::range(
@@ -56,26 +56,6 @@ foreach (
             65535,
             "configuration.{$field}"
         )->getMessage()
-    );
-}
-
-foreach (
-    [
-        'otel_public_certificate',
-        'otel_private_key',
-        'conf_certificate',
-        'conf_private_key',
-    ] as $field
-) {
-    it(
-        "should throw an exception when a {$field} is too short",
-        function () use ($field) : void {
-            $this->parameters[$field] = '';
-
-            new TelegrafConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
-        }
-    )->throws(
-        AssertionException::notEmptyString("configuration.{$field}")->getMessage()
     );
 }
 
@@ -94,7 +74,7 @@ foreach (
         function () use ($field, $tooLong) : void {
             $this->parameters[$field] = $tooLong;
 
-            new TelegrafConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
+            new TelegrafConfigurationParameters($this->parameters);
         }
     )->throws(
         AssertionException::maxLength(
@@ -120,7 +100,7 @@ foreach (
         function () use ($field) : void {
             $field === 'poller_ca_certificate' ? $this->parameters['hosts'][0][$field] = 'test.crt' : $this->parameters[$field] = 'test.crt';
 
-            $cmaConfig = new TelegrafConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
+            $cmaConfig = new TelegrafConfigurationParameters($this->parameters);
             $result = $cmaConfig->getData();
             $field === 'poller_ca_certificate'
                 ? $this->assertEquals($result['hosts'][0][$field], TelegrafConfigurationParameters::CERTIFICATE_BASE_PATH . 'test.crt')
@@ -143,7 +123,7 @@ foreach (
         function () use ($field) : void {
             $field === 'poller_ca_certificate' ? $this->parameters['hosts'][0][$field] = 'test.crt' : $this->parameters[$field] = '/etc/pki/test.crt';
 
-            $cmaConfig = new TelegrafConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
+            $cmaConfig = new TelegrafConfigurationParameters($this->parameters);
             $result = $cmaConfig->getData();
             $field === 'poller_ca_certificate'
                 ? $this->assertEquals($result['hosts'][0][$field], TelegrafConfigurationParameters::CERTIFICATE_BASE_PATH . 'test.crt')


### PR DESCRIPTION
## Description

This PR intends to set all certificate fields as optional in CMA / Telegraf Agent Configuration creation & update

**Fixes** # ([MON-172157](https://centreon.atlassian.net/browse/MON-172157))

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-172157]: https://centreon.atlassian.net/browse/MON-172157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ