### PR TITLE
fix(remote): correctly compute class name in config remote generation proccess (#7543) (#7553)

### DIFF
--- a/centreon/www/class/config-generate-remote/Generate.php
+++ b/centreon/www/class/config-generate-remote/Generate.php
@@ -299,7 +299,7 @@ class Generate
             if (file_exists($generateFile)) {
                 require_once $generateFile;
                 $module = $this->ucFirst(['-', '_', ' '], $module);
-                $class = '\\' . $module . \ConfigGenerateRemote\Generate::class;
+                $class = sprintf('\\%s\%s', $module, \ConfigGenerateRemote\Generate::class);
                 if (class_exists($class)) {
                     $this->moduleObjects[] = $class;
                 }


### PR DESCRIPTION
release-24.10-next backport of [MON-172415](https://centreon.atlassian.net/browse/MON-172415)

REF #7553

[MON-172415]: https://centreon.atlassian.net/browse/MON-172415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ