### PR TITLE
fix(remote): correctly compute class name in config remote generation proccess (#7543)

### DIFF
--- a/centreon/www/class/config-generate-remote/Generate.php
+++ b/centreon/www/class/config-generate-remote/Generate.php
@@ -282,7 +282,7 @@ class Generate
             if (file_exists($generateFile)) {
                 require_once $generateFile;
                 $module = $this->ucFirst(['-', '_', ' '], $module);
-                $class = '\\' . $module . '\ConfigGenerateRemote\\Generate';
+                $class = sprintf('\\%s\%s', $module, \ConfigGenerateRemote\Generate::class);
                 if (class_exists($class)) {
                     $this->moduleObjects[] = $class;
                 }


### PR DESCRIPTION
dev-24.04.x backport of [MON-172416](https://centreon.atlassian.net/browse/MON-172416)