### PR TITLE
Missing 23.10 migrations between 23.10.3 & 23.10.8

### DIFF
--- a/centreon/www/install/php/Update-23.10.4.php
+++ b/centreon/www/install/php/Update-23.10.4.php
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,3 +18,56 @@
  * For more information : contact@centreon.com
  *
  */
+
+require_once __DIR__ . '/../../../bootstrap.php';
+require_once __DIR__ . '/../../class/centreonLog.class.php';
+
+$centreonLog = new CentreonLog();
+
+//error specific content
+$versionOfTheUpgrade = 'UPGRADE - 23.10.4: ';
+$errorMessage = '';
+
+$dropColumnVersionFromDashboardWidgetsTable = function(CentreonDB $pearDB): void {
+    if($pearDB->isColumnExist('dashboard_widgets', 'version')) {
+        $pearDB->query(
+            <<<'SQL'
+                    ALTER TABLE dashboard_widgets
+                    DROP COLUMN `version`
+                SQL
+        );
+    }
+};
+
+$populateDashboardTables = function(CentreonDb $pearDB): void {
+  $statement = $pearDB->query(
+      <<<'SQL'
+          SELECT 1 FROM `dashboard_widgets` WHERE `name` = 'centreon-widget-statusgrid'
+          SQL
+  );
+  if (false === (bool) $statement->fetch(\PDO::FETCH_COLUMN)) {
+      $pearDB->query(
+          <<<'SQL'
+              INSERT INTO `dashboard_widgets` (`name`)
+              VALUES
+                  ('centreon-widget-statusgrid')
+              SQL
+      );
+  }
+};
+
+try {
+    $dropColumnVersionFromDashboardWidgetsTable($pearDB);
+    $populateDashboardTables($pearDB);
+} catch (\Exception $e) {
+
+    $centreonLog->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage
+        . ' - Code : ' . (int) $e->getCode()
+        . ' - Error : ' . $e->getMessage()
+        . ' - Trace : ' . $e->getTraceAsString()
+    );
+
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, (int) $e->getCode(), $e);
+}

--- a/centreon/www/install/php/Update-23.10.6.php
+++ b/centreon/www/install/php/Update-23.10.6.php
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,3 +18,56 @@
  * For more information : contact@centreon.com
  *
  */
+
+require_once __DIR__ . '/../../../bootstrap.php';
+require_once __DIR__ . '/../../class/centreonLog.class.php';
+
+$centreonLog = new CentreonLog();
+
+//error specific content
+$versionOfTheUpgrade = 'UPGRADE - 23.10.6: ';
+$errorMessage = '';
+
+$dropColumnVersionFromDashboardWidgetsTable = function(CentreonDB $pearDB): void {
+    if($pearDB->isColumnExist('dashboard_widgets', 'version')) {
+        $pearDB->query(
+            <<<'SQL'
+                    ALTER TABLE dashboard_widgets
+                    DROP COLUMN `version`
+                SQL
+        );
+    }
+};
+
+$populateDashboardTables = function(CentreonDb $pearDB): void {
+  $statement = $pearDB->query(
+      <<<'SQL'
+          SELECT 1 FROM `dashboard_widgets` WHERE `name` = 'centreon-widget-statusgrid'
+          SQL
+  );
+  if (false === (bool) $statement->fetch(\PDO::FETCH_COLUMN)) {
+      $pearDB->query(
+          <<<'SQL'
+              INSERT INTO `dashboard_widgets` (`name`)
+              VALUES
+                  ('centreon-widget-statusgrid')
+              SQL
+      );
+  }
+};
+
+try {
+    $dropColumnVersionFromDashboardWidgetsTable($pearDB);
+    $populateDashboardTables($pearDB);
+} catch (\Exception $e) {
+
+    $centreonLog->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage
+        . ' - Code : ' . (int) $e->getCode()
+        . ' - Error : ' . $e->getMessage()
+        . ' - Trace : ' . $e->getTraceAsString()
+    );
+
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, (int) $e->getCode(), $e);
+}

--- a/centreon/www/install/php/Update-23.10.7.php
+++ b/centreon/www/install/php/Update-23.10.7.php
@@ -7,7 +7,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,3 +18,56 @@
  * For more information : contact@centreon.com
  *
  */
+
+require_once __DIR__ . '/../../../bootstrap.php';
+require_once __DIR__ . '/../../class/centreonLog.class.php';
+
+$centreonLog = new CentreonLog();
+
+//error specific content
+$versionOfTheUpgrade = 'UPGRADE - 23.10.7: ';
+$errorMessage = '';
+
+$dropColumnVersionFromDashboardWidgetsTable = function(CentreonDB $pearDB): void {
+    if($pearDB->isColumnExist('dashboard_widgets', 'version')) {
+        $pearDB->query(
+            <<<'SQL'
+                    ALTER TABLE dashboard_widgets
+                    DROP COLUMN `version`
+                SQL
+        );
+    }
+};
+
+$populateDashboardTables = function(CentreonDb $pearDB): void {
+  $statement = $pearDB->query(
+      <<<'SQL'
+          SELECT 1 FROM `dashboard_widgets` WHERE `name` = 'centreon-widget-statusgrid'
+          SQL
+  );
+  if (false === (bool) $statement->fetch(\PDO::FETCH_COLUMN)) {
+      $pearDB->query(
+          <<<'SQL'
+              INSERT INTO `dashboard_widgets` (`name`)
+              VALUES
+                  ('centreon-widget-statusgrid')
+              SQL
+      );
+  }
+};
+
+try {
+    $dropColumnVersionFromDashboardWidgetsTable($pearDB);
+    $populateDashboardTables($pearDB);
+} catch (\Exception $e) {
+
+    $centreonLog->insertLog(
+        4,
+        $versionOfTheUpgrade . $errorMessage
+        . ' - Code : ' . (int) $e->getCode()
+        . ' - Error : ' . $e->getMessage()
+        . ' - Trace : ' . $e->getTraceAsString()
+    );
+
+    throw new \Exception($versionOfTheUpgrade . $errorMessage, (int) $e->getCode(), $e);
+}

--- a/centreon/www/install/php/Update-23.10.8.php
+++ b/centreon/www/install/php/Update-23.10.8.php
@@ -36,6 +36,23 @@ $dropColumnVersionFromDashboardWidgetsTable = function(CentreonDB $pearDB): void
     }
 };
 
+$populateDashboardTables = function(CentreonDb $pearDB): void {
+  $statement = $pearDB->query(
+      <<<'SQL'
+          SELECT 1 FROM `dashboard_widgets` WHERE `name` = 'centreon-widget-statusgrid'
+          SQL
+  );
+  if (false === (bool) $statement->fetch(\PDO::FETCH_COLUMN)) {
+      $pearDB->query(
+          <<<'SQL'
+              INSERT INTO `dashboard_widgets` (`name`)
+              VALUES
+                  ('centreon-widget-statusgrid')
+              SQL
+      );
+  }
+};
+
 $insertResourcesTableWidget = function(CentreonDB $pearDB) use(&$errorMessage): void {
     $errorMessage = 'Unable to insert centreon-widget-resourcestable in dashboard_widgets';
     $statement = $pearDB->query("SELECT 1 from dashboard_widgets WHERE name = 'centreon-widget-resourcestable'");
@@ -52,6 +69,7 @@ $insertResourcesTableWidget = function(CentreonDB $pearDB) use(&$errorMessage): 
 try {
     $errorMessage = '';
     $dropColumnVersionFromDashboardWidgetsTable($pearDB);
+    $populateDashboardTables($pearDB);
     // Transactional queries
     if (! $pearDB->inTransaction()) {
         $pearDB->beginTransaction();


### PR DESCRIPTION
## Description

Related Jira ticket : [MON-139725](https://centreon.atlassian.net/browse/MON-139725)

A migration was missing when upgrading to 23.10.3 and it has been fix only in 23.10.8 and it's related migration.

In the meantime, some clients may have upgraded in a version beween the two, and but the fixed past migration is no longer played for them.

This solution consists in copying the same idempotent migration in every version beween 23.10.3 & 23.10.8 so any client in a version in between will be able to upgrade past 23.10.8.

[MON-139725]: https://centreon.atlassian.net/browse/MON-139725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ