### PR TITLE
fix(upgrade): restore missing update file 24.10.8 & fix update-next (#7563)

### DIFF
--- a/centreon/www/install/php/Update-24.10.8.php
+++ b/centreon/www/install/php/Update-24.10.8.php
@@ -21,7 +21,7 @@
 
 require_once __DIR__ . '/../../../bootstrap.php';
 
-$version = 'xx.xx.x';
+$version = '24.10.8';
 $errorMessage = '';
 
 // -------------------------------------------- Agent Configuration -------------------------------------------- //


### PR DESCRIPTION
## Description

Backport of #7563 + removed Update-next.php from release branch

**Fixes** # ([MON-172474](https://centreon.atlassian.net/browse/MON-172474))

[MON-172474]: https://centreon.atlassian.net/browse/MON-172474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ