### PR TITLE
enh(configuration): filter out service accounts from find users in cloud

### DIFF
--- a/centreon/src/Core/User/Application/Repository/ReadUserRepositoryInterface.php
+++ b/centreon/src/Core/User/Application/Repository/ReadUserRepositoryInterface.php
@@ -68,4 +68,15 @@ interface ReadUserRepositoryInterface
      * @throws \Throwable
      */
     public function find(int $userId): ?User;
+
+    /**
+     * Checks if a user is a service user.
+     *
+     * @param int $userId
+     *
+     * throws \Throwable
+     *
+     * @return bool
+     */
+    public function isServiceUser(int $userId): bool;
 }

--- a/centreon/src/Core/User/Application/Repository/ReadUserRepositoryInterface.php
+++ b/centreon/src/Core/User/Application/Repository/ReadUserRepositoryInterface.php
@@ -68,15 +68,4 @@ interface ReadUserRepositoryInterface
      * @throws \Throwable
      */
     public function find(int $userId): ?User;
-
-    /**
-     * Checks if a user is a service user.
-     *
-     * @param int $userId
-     *
-     * throws \Throwable
-     *
-     * @return bool
-     */
-    public function isServiceUser(int $userId): bool;
 }

--- a/centreon/src/Core/User/Application/UseCase/FindUsers/FindUsers.php
+++ b/centreon/src/Core/User/Application/UseCase/FindUsers/FindUsers.php
@@ -92,7 +92,7 @@ final class FindUsers
                 // Filter out service users in cloud platform
                 $users = array_filter(
                     $users,
-                    fn(User $user): bool => ! $this->readUserRepository->isServiceUser($user->getId())
+                    fn(User $user): bool => ! $user->isServiceAccount()
                 );
             }
 

--- a/centreon/src/Core/User/Application/UseCase/FindUsers/FindUsers.php
+++ b/centreon/src/Core/User/Application/UseCase/FindUsers/FindUsers.php
@@ -92,7 +92,7 @@ final class FindUsers
                 // Filter out service users in cloud platform
                 $users = array_filter(
                     $users,
-                    fn(): bool => ! $this->readUserRepository->isServiceUser($this->user->getId())
+                    fn(User $user): bool => ! $this->readUserRepository->isServiceUser($user->getId())
                 );
             }
 

--- a/centreon/src/Core/User/Application/UseCase/FindUsers/FindUsers.php
+++ b/centreon/src/Core/User/Application/UseCase/FindUsers/FindUsers.php
@@ -88,6 +88,14 @@ final class FindUsers
                 );
             }
 
+            if ($this->isCloudPlatform) {
+                // Filter out service users in cloud platform
+                $users = array_filter(
+                    $users,
+                    fn(): bool => ! $this->readUserRepository->isServiceUser($this->user->getId())
+                );
+            }
+
             $presenter->presentResponse($this->createResponse($users));
         } catch (RequestParametersTranslatorException $ex) {
             $presenter->presentResponse(new ErrorResponse($ex->getMessage()));

--- a/centreon/src/Core/User/Domain/Model/User.php
+++ b/centreon/src/Core/User/Domain/Model/User.php
@@ -56,6 +56,7 @@ class User
      * @param string $theme
      * @param string $userInterfaceDensity
      * @param bool $canReachFrontend
+     * @param bool $isServiceAccount
      *
      * @throws \Assert\AssertionFailedException
      */
@@ -67,7 +68,8 @@ class User
         protected bool $isAdmin,
         protected string $theme,
         protected string $userInterfaceDensity,
-        protected bool $canReachFrontend
+        protected bool $canReachFrontend,
+        protected bool $isServiceAccount = false
     ) {
         Assertion::positiveInt($this->id, 'User::id');
 
@@ -292,5 +294,10 @@ class User
         $this->canReachFrontend = $canReachFrontend;
 
         return $this;
+    }
+
+    public function isServiceAccount(): bool
+    {
+        return $this->isServiceAccount;
     }
 }

--- a/centreon/src/Core/User/Infrastructure/Repository/DbReadUserRepository.php
+++ b/centreon/src/Core/User/Infrastructure/Repository/DbReadUserRepository.php
@@ -266,6 +266,26 @@ class DbReadUserRepository extends AbstractRepositoryRDB implements ReadUserRepo
     }
 
     /**
+     * @inheritDoc
+     */
+    public function isServiceUser(int $userId): bool
+    {
+        $statement = $this->db->prepare($this->translateDbName(
+            <<<'SQL'
+                SELECT is_service_account
+                FROM `:db`.contact
+                WHERE contact_id = :userId
+                SQL
+        ));
+        $statement->bindValue(':userId', $userId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        $result = $statement->fetchColumn();
+
+        return $result === 1;
+    }
+
+    /**
      * @param _UserRecord $user
      *
      * @throws \Assert\AssertionFailedException

--- a/centreon/src/Core/User/Infrastructure/Repository/DbReadUserRepository.php
+++ b/centreon/src/Core/User/Infrastructure/Repository/DbReadUserRepository.php
@@ -152,7 +152,8 @@ class DbReadUserRepository extends AbstractRepositoryRDB implements ReadUserRepo
                 SELECT /* Finds users belonging to associated contact groups in ACL group rules */
                     contact.contact_id, contact.contact_alias, contact.contact_name,
                     contact.contact_email, contact.contact_admin, contact.contact_theme,
-                    contact.user_interface_density, contact.contact_oreon AS `user_can_reach_frontend`
+                    contact.user_interface_density, contact.contact_oreon AS `user_can_reach_frontend`,
+                    contact.is_service_account
                 FROM `:db`.`contact`
                 INNER JOIN `:db`.`contactgroup_contact_relation` c_cg_rel
                     ON c_cg_rel.contact_contact_id = contact.contact_id
@@ -164,7 +165,8 @@ class DbReadUserRepository extends AbstractRepositoryRDB implements ReadUserRepo
                 SELECT /* Finds users belonging to the same contact groups as the user */
                     contact2.contact_id, contact2.contact_alias, contact2.contact_name,
                     contact2.contact_email, contact2.contact_admin, contact2.contact_theme,
-                    contact2.user_interface_density, contact2.contact_oreon AS `user_can_reach_frontend`
+                    contact2.user_interface_density, contact2.contact_oreon AS `user_can_reach_frontend`,
+                    contact.is_service_account
                 FROM `:db`.`contact`
                 INNER JOIN `:db`.`contactgroup_contact_relation` c_cg_rel
                     ON c_cg_rel.contact_contact_id = contact.contact_id


### PR DESCRIPTION
## Description

Filter out users flagged as service account (is_service_account in DB) in the FindUsers listing endpoint

Relates to MON-32817 and  MON-138514

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
