### PR TITLE
[Symfony 7][HttpKernel] Remove deprecation

### DIFF
--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -152,10 +152,11 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
     /**
      * @param string $cacheDir
+     * @param null|string $buildDir
      *
      * @return string[]
      */
-    public function warmUp(string $cacheDir)
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
         return [];
     }


### PR DESCRIPTION
## Description

remove deprecation for httpKernel

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
