### PR TITLE
Revert "enh(ci): add sync-deletes option to debian delivery (#7537)"

### DIFF
--- a/.github/actions/deb-delivery/action.yml
+++ b/.github/actions/deb-delivery/action.yml
@@ -76,10 +76,6 @@ runs:
 
           echo "[DEBUG] - Version: $VERSION"
 
-          if [[ "${{ inputs.stability }}" == "stable" ]]; then
-            echo "[DEBUG] - Stability is ${{ inputs.stability }}, not delivering."
-          else
-            jf rt upload "$FILE" "$ROOT_REPO_PATH/pool/${{ inputs.module_name }}/" --deb "${{ inputs.distrib }}/main/$ARCH" --sync-deletes="$ROOT_REPO_PATH/pool/${{ inputs.module_name }}/" --flat
-          fi
+          jf rt upload "$FILE" "$ROOT_REPO_PATH/pool/${{ inputs.module_name }}/" --deb "${{ inputs.distrib }}/main/$ARCH" --flat
         done
       shell: bash


### PR DESCRIPTION
This reverts commit f47fb5b13cc584ee23578645dd64df9331a64ce9.

## Description

* revert #7537 

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
