### PR TITLE
[Symfony7][FrameworkExtraBundle] update composer.lock centreon/centreon for awi, dsm and open-tickets

### DIFF
--- a/centreon-awie/composer.lock
+++ b/centreon-awie/composer.lock
@@ -4,9 +4,943 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "0e5095542f1a29042f139d3df33485d0",
+  "content-hash": "d1a739a6a6b256a0913aeea7e81d21b4",
   "packages": [],
   "packages-dev": [
+    {
+      "name": "amphp/amp",
+      "version": "v2.6.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/amp.git",
+        "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/amp/zipball/ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
+        "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "ext-json": "*",
+        "jetbrains/phpstorm-stubs": "^2019.3",
+        "phpunit/phpunit": "^7 | ^8 | ^9",
+        "react/promise": "^2",
+        "vimeo/psalm": "^3.12"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "lib/functions.php",
+          "lib/Internal/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Bob Weinand",
+          "email": "bobwei9@hotmail.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "A non-blocking concurrency framework for PHP applications.",
+      "homepage": "https://amphp.org/amp",
+      "keywords": [
+        "async",
+        "asynchronous",
+        "awaitable",
+        "concurrency",
+        "event",
+        "event-loop",
+        "future",
+        "non-blocking",
+        "promise"
+      ],
+      "support": {
+        "irc": "irc://irc.freenode.org/amphp",
+        "issues": "https://github.com/amphp/amp/issues",
+        "source": "https://github.com/amphp/amp/tree/v2.6.4"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T18:52:26+00:00"
+    },
+    {
+      "name": "amphp/byte-stream",
+      "version": "v1.8.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/byte-stream.git",
+        "reference": "4f0e968ba3798a423730f567b1b50d3441c16ddc"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/byte-stream/zipball/4f0e968ba3798a423730f567b1b50d3441c16ddc",
+        "reference": "4f0e968ba3798a423730f567b1b50d3441c16ddc",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.4",
+        "friendsofphp/php-cs-fixer": "^2.3",
+        "jetbrains/phpstorm-stubs": "^2019.3",
+        "phpunit/phpunit": "^6 || ^7 || ^8",
+        "psalm/phar": "^3.11.4"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "lib/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\ByteStream\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "A stream abstraction to make working with non-blocking I/O simple.",
+      "homepage": "https://amphp.org/byte-stream",
+      "keywords": [
+        "amp",
+        "amphp",
+        "async",
+        "io",
+        "non-blocking",
+        "stream"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/byte-stream/issues",
+        "source": "https://github.com/amphp/byte-stream/tree/v1.8.2"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-04-13T18:00:56+00:00"
+    },
+    {
+      "name": "amphp/cache",
+      "version": "v1.5.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/cache.git",
+        "reference": "fe78cfae2fb8c92735629b8cd1893029c73c9b63"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/cache/zipball/fe78cfae2fb8c92735629b8cd1893029c73c9b63",
+        "reference": "fe78cfae2fb8c92735629b8cd1893029c73c9b63",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/serialization": "^1",
+        "amphp/sync": "^1.2",
+        "php": ">=7.1"
+      },
+      "conflict": {
+        "amphp/file": "<0.2 || >=3"
+      },
+      "require-dev": {
+        "amphp/file": "^1 || ^2",
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.1",
+        "phpunit/phpunit": "^6 | ^7 | ^8 | ^9",
+        "vimeo/psalm": "^4"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Amp\\Cache\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        }
+      ],
+      "description": "A promise-aware caching API for Amp.",
+      "homepage": "https://github.com/amphp/cache",
+      "support": {
+        "irc": "irc://irc.freenode.org/amphp",
+        "issues": "https://github.com/amphp/cache/issues",
+        "source": "https://github.com/amphp/cache/tree/v1.5.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T19:35:02+00:00"
+    },
+    {
+      "name": "amphp/dns",
+      "version": "v1.2.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/dns.git",
+        "reference": "4a13ffdc5e088593eb01860fc5002ebd9316d562"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/dns/zipball/4a13ffdc5e088593eb01860fc5002ebd9316d562",
+        "reference": "4a13ffdc5e088593eb01860fc5002ebd9316d562",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.1",
+        "amphp/cache": "^1.2",
+        "amphp/parser": "^1",
+        "amphp/windows-registry": "^0.3",
+        "daverandom/libdns": "^2.0.1",
+        "ext-filter": "*",
+        "ext-json": "*",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "phpunit/phpunit": "^6 || ^7 || ^8 || ^9"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "lib/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Dns\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Chris Wright",
+          "email": "addr@daverandom.com"
+        },
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        },
+        {
+          "name": "Bob Weinand",
+          "email": "bobwei9@hotmail.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        }
+      ],
+      "description": "Async DNS resolution for Amp.",
+      "homepage": "https://github.com/amphp/dns",
+      "keywords": [
+        "amp",
+        "amphp",
+        "async",
+        "client",
+        "dns",
+        "resolve"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/dns/issues",
+        "source": "https://github.com/amphp/dns/tree/v1.2.4"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-12-08T15:06:32+00:00"
+    },
+    {
+      "name": "amphp/hpack",
+      "version": "v3.2.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/hpack.git",
+        "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/hpack/zipball/4f293064b15682a2b178b1367ddf0b8b5feb0239",
+        "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "^2",
+        "http2jp/hpack-test-case": "^1",
+        "nikic/php-fuzzer": "^0.0.10",
+        "phpunit/phpunit": "^7 | ^8 | ^9"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "3.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Amp\\Http\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        },
+        {
+          "name": "Bob Weinand"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        }
+      ],
+      "description": "HTTP/2 HPack implementation.",
+      "homepage": "https://github.com/amphp/hpack",
+      "keywords": [
+        "headers",
+        "hpack",
+        "http-2"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/hpack/issues",
+        "source": "https://github.com/amphp/hpack/tree/v3.2.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T19:00:16+00:00"
+    },
+    {
+      "name": "amphp/http",
+      "version": "v1.7.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/http.git",
+        "reference": "3a33e68a3b53f7279217238e89748cf0cb30b8a6"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/http/zipball/3a33e68a3b53f7279217238e89748cf0cb30b8a6",
+        "reference": "3a33e68a3b53f7279217238e89748cf0cb30b8a6",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/hpack": "^3",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "2.x-dev#3c24119d0377eed2093d5c0f0541478cb75ea72d",
+        "phpunit/phpunit": "^9 || ^8 || ^7"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Http\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Basic HTTP primitives which can be shared by servers and clients.",
+      "support": {
+        "issues": "https://github.com/amphp/http/issues",
+        "source": "https://github.com/amphp/http/tree/v1.7.3"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-04-03T17:45:14+00:00"
+    },
+    {
+      "name": "amphp/http-client",
+      "version": "v4.6.5",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/http-client.git",
+        "reference": "6cac9e172a66a04df305acc8de02b6c40832b269"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/http-client/zipball/6cac9e172a66a04df305acc8de02b6c40832b269",
+        "reference": "6cac9e172a66a04df305acc8de02b6c40832b269",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2.4",
+        "amphp/byte-stream": "^1.6",
+        "amphp/hpack": "^3",
+        "amphp/http": "^1.6",
+        "amphp/socket": "^1",
+        "amphp/sync": "^1.3",
+        "league/uri": "^6 | ^7",
+        "php": ">=7.2",
+        "psr/http-message": "^1 | ^2"
+      },
+      "conflict": {
+        "amphp/file": "<0.2 || >=3"
+      },
+      "require-dev": {
+        "amphp/file": "^0.2 || ^0.3 || ^1 || ^2",
+        "amphp/http-server": "^2",
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.1",
+        "amphp/react-adapter": "^2.1",
+        "clue/socks-react": "^1.0",
+        "ext-json": "*",
+        "kelunik/link-header-rfc5988": "^1.0",
+        "laminas/laminas-diactoros": "^2.3",
+        "phpunit/phpunit": "^7 || ^8 || ^9",
+        "vimeo/psalm": "^5"
+      },
+      "suggest": {
+        "amphp/file": "Required for file request bodies and HTTP archive logging",
+        "ext-json": "Required for logging HTTP archives",
+        "ext-zlib": "Allows using compression for response bodies."
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "4.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/Internal/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Http\\Client\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@gmail.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        }
+      ],
+      "description": "Asynchronous concurrent HTTP/2 and HTTP/1.1 client built on the Amp concurrency framework",
+      "homepage": "https://github.com/amphp/http-client",
+      "keywords": [
+        "async",
+        "client",
+        "concurrent",
+        "http",
+        "non-blocking",
+        "rest"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/http-client/issues",
+        "source": "https://github.com/amphp/http-client/tree/v4.6.5"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-12-13T15:50:23+00:00"
+    },
+    {
+      "name": "amphp/parser",
+      "version": "v1.1.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/parser.git",
+        "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+        "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.4"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "^2",
+        "phpunit/phpunit": "^9",
+        "psalm/phar": "^5.4"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Amp\\Parser\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "A generator parser to make streaming parsers simple.",
+      "homepage": "https://github.com/amphp/parser",
+      "keywords": [
+        "async",
+        "non-blocking",
+        "parser",
+        "stream"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/parser/issues",
+        "source": "https://github.com/amphp/parser/tree/v1.1.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T19:16:53+00:00"
+    },
+    {
+      "name": "amphp/process",
+      "version": "v1.1.9",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/process.git",
+        "reference": "55b837d4f1857b9bd7efb7bb859ae6b0e804f13f"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/process/zipball/55b837d4f1857b9bd7efb7bb859ae6b0e804f13f",
+        "reference": "55b837d4f1857b9bd7efb7bb859ae6b0e804f13f",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.4",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "phpunit/phpunit": "^6"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "lib/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Process\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Bob Weinand",
+          "email": "bobwei9@hotmail.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Asynchronous process manager.",
+      "homepage": "https://github.com/amphp/process",
+      "support": {
+        "issues": "https://github.com/amphp/process/issues",
+        "source": "https://github.com/amphp/process/tree/v1.1.9"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-12-13T17:38:25+00:00"
+    },
+    {
+      "name": "amphp/serialization",
+      "version": "v1.0.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/serialization.git",
+        "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
+        "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "phpunit/phpunit": "^9 || ^8 || ^7"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "src/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Serialization\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Serialization tools for IPC and data storage in PHP.",
+      "homepage": "https://github.com/amphp/serialization",
+      "keywords": [
+        "async",
+        "asynchronous",
+        "serialization",
+        "serialize"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/serialization/issues",
+        "source": "https://github.com/amphp/serialization/tree/master"
+      },
+      "time": "2020-03-25T21:39:07+00:00"
+    },
+    {
+      "name": "amphp/socket",
+      "version": "v1.2.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/socket.git",
+        "reference": "b00528bd75548b7ae06a502358bb3ff8b106f5ab"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/socket/zipball/b00528bd75548b7ae06a502358bb3ff8b106f5ab",
+        "reference": "b00528bd75548b7ae06a502358bb3ff8b106f5ab",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.6",
+        "amphp/dns": "^1 || ^0.9",
+        "ext-openssl": "*",
+        "kelunik/certificate": "^1.1",
+        "league/uri-parser": "^1.4",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "phpunit/phpunit": "^6 || ^7 || ^8",
+        "vimeo/psalm": "^3.9@dev"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/functions.php",
+          "src/Internal/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Socket\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@gmail.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Async socket connection / server tools for Amp.",
+      "homepage": "https://github.com/amphp/socket",
+      "keywords": [
+        "amp",
+        "async",
+        "encryption",
+        "non-blocking",
+        "sockets",
+        "tcp",
+        "tls"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/socket/issues",
+        "source": "https://github.com/amphp/socket/tree/v1.2.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T18:12:22+00:00"
+    },
+    {
+      "name": "amphp/sync",
+      "version": "v1.4.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/sync.git",
+        "reference": "85ab06764f4f36d63b1356b466df6111cf4b89cf"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/sync/zipball/85ab06764f4f36d63b1356b466df6111cf4b89cf",
+        "reference": "85ab06764f4f36d63b1356b466df6111cf4b89cf",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2.2",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.1",
+        "phpunit/phpunit": "^9 || ^8 || ^7"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "src/functions.php",
+          "src/ConcurrentIterator/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Sync\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Stephen Coakley",
+          "email": "me@stephencoakley.com"
+        }
+      ],
+      "description": "Mutex, Semaphore, and other synchronization tools for Amp.",
+      "homepage": "https://github.com/amphp/sync",
+      "keywords": [
+        "async",
+        "asynchronous",
+        "mutex",
+        "semaphore",
+        "synchronization"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/sync/issues",
+        "source": "https://github.com/amphp/sync/tree/v1.4.2"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2021-10-25T18:29:10+00:00"
+    },
+    {
+      "name": "amphp/windows-registry",
+      "version": "v0.3.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/windows-registry.git",
+        "reference": "0f56438b9197e224325e88f305346f0221df1f71"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/windows-registry/zipball/0f56438b9197e224325e88f305346f0221df1f71",
+        "reference": "0f56438b9197e224325e88f305346f0221df1f71",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.4",
+        "amphp/process": "^1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Amp\\WindowsRegistry\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Windows Registry Reader.",
+      "support": {
+        "issues": "https://github.com/amphp/windows-registry/issues",
+        "source": "https://github.com/amphp/windows-registry/tree/master"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2020-07-10T16:13:29+00:00"
+    },
     {
       "name": "beberlei/assert",
       "version": "v3.3.3",
@@ -413,16 +1347,18 @@
     },
     {
       "name": "centreon/centreon",
-      "version": "24.11",
+      "version": "25.07",
       "dist": {
         "type": "path",
         "url": "../centreon",
-        "reference": "db33a5637a4cc90921dbc1b5b60bd8660f31daa3"
+        "reference": "86e00cdbec213213a23ca036572fc92bf13f2919"
       },
       "require": {
+        "amphp/http-client": "^4.6",
         "beberlei/assert": "^3.3",
         "curl/curl": "^2.3",
         "doctrine/annotations": "^1.0",
+        "doctrine/dbal": "^4.2",
         "dragonmantank/cron-expression": "3.1.0",
         "enshrined/svg-sanitize": "^0.15",
         "ext-ctype": "*",
@@ -438,6 +1374,7 @@
         "ext-posix": "*",
         "ext-simplexml": "*",
         "ext-zip": "*",
+        "firebase/php-jwt": "^6.11",
         "friendsofsymfony/rest-bundle": "^3.0",
         "jms/serializer-bundle": "^5.4",
         "justinrainbow/json-schema": "^5.2",
@@ -449,7 +1386,6 @@
         "phpdocumentor/reflection-docblock": "5.4.*",
         "pimple/pimple": "3.5.*",
         "psr/container": "1.1.*",
-        "sensio/framework-extra-bundle": "6.2.*",
         "smarty-gettext/smarty-gettext": "1.7.*",
         "smarty/smarty": "4.5.*",
         "symfony/config": "6.4.*",
@@ -503,11 +1439,13 @@
         "friends-of-behat/mink": "1.11.*",
         "friends-of-behat/mink-extension": "2.7.*",
         "friendsofphp/php-cs-fixer": "3.64.*",
+        "mockery/mockery": "1.6.*",
         "pestphp/pest": "1.23.*",
         "php-vfs/php-vfs": "1.4.*",
         "phpcompatibility/php-compatibility": "9.3.*",
         "phpstan/phpstan": "1.12.*",
         "phpstan/phpstan-beberlei-assert": "1.1.*",
+        "phpstan/phpstan-mockery": "1.1.*",
         "rector/rector": "1.2.*",
         "robertfausk/mink-panther-driver": "1.1.*",
         "squizlabs/php_codesniffer": "3.10.*",
@@ -607,6 +1545,9 @@
         ],
         "rector:exec": [
           "rector process --debug"
+        ],
+        "symfony:check:ci": [
+          "php bin/console lint:yaml config src --parse-tags && php bin/console lint:container"
         ]
       },
       "license": [
@@ -1036,6 +1977,50 @@
       "time": "2022-12-14T13:27:59+00:00"
     },
     {
+      "name": "daverandom/libdns",
+      "version": "v2.1.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/DaveRandom/LibDNS.git",
+        "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+        "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+        "shasum": ""
+      },
+      "require": {
+        "ext-ctype": "*",
+        "php": ">=7.1"
+      },
+      "suggest": {
+        "ext-intl": "Required for IDN support"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "src/functions.php"
+        ],
+        "psr-4": {
+          "LibDNS\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "description": "DNS protocol implementation written in pure PHP",
+      "keywords": [
+        "dns"
+      ],
+      "support": {
+        "issues": "https://github.com/DaveRandom/LibDNS/issues",
+        "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
+      },
+      "time": "2024-04-12T12:12:48+00:00"
+    },
+    {
       "name": "dealerdirect/phpcodesniffer-composer-installer",
       "version": "v1.0.0",
       "source": {
@@ -1188,6 +2173,112 @@
         "source": "https://github.com/doctrine/annotations/tree/1.14.4"
       },
       "time": "2024-09-05T10:15:52+00:00"
+    },
+    {
+      "name": "doctrine/dbal",
+      "version": "4.2.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/doctrine/dbal.git",
+        "reference": "b37d160498ea91a2382a2ebe825c4ea6254fc0ec"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/doctrine/dbal/zipball/b37d160498ea91a2382a2ebe825c4ea6254fc0ec",
+        "reference": "b37d160498ea91a2382a2ebe825c4ea6254fc0ec",
+        "shasum": ""
+      },
+      "require": {
+        "doctrine/deprecations": "^0.5.3|^1",
+        "php": "^8.1",
+        "psr/cache": "^1|^2|^3",
+        "psr/log": "^1|^2|^3"
+      },
+      "require-dev": {
+        "doctrine/coding-standard": "13.0.0",
+        "fig/log-test": "^1",
+        "jetbrains/phpstorm-stubs": "2023.2",
+        "phpstan/phpstan": "2.1.17",
+        "phpstan/phpstan-phpunit": "2.0.6",
+        "phpstan/phpstan-strict-rules": "^2",
+        "phpunit/phpunit": "10.5.46",
+        "slevomat/coding-standard": "8.16.2",
+        "squizlabs/php_codesniffer": "3.13.1",
+        "symfony/cache": "^6.3.8|^7.0",
+        "symfony/console": "^5.4|^6.3|^7.0"
+      },
+      "suggest": {
+        "symfony/console": "For helpful console commands such as SQL execution and import of files."
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Doctrine\\DBAL\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Guilherme Blanco",
+          "email": "guilhermeblanco@gmail.com"
+        },
+        {
+          "name": "Roman Borschel",
+          "email": "roman@code-factory.org"
+        },
+        {
+          "name": "Benjamin Eberlei",
+          "email": "kontakt@beberlei.de"
+        },
+        {
+          "name": "Jonathan Wage",
+          "email": "jonwage@gmail.com"
+        }
+      ],
+      "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+      "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+      "keywords": [
+        "abstraction",
+        "database",
+        "db2",
+        "dbal",
+        "mariadb",
+        "mssql",
+        "mysql",
+        "oci8",
+        "oracle",
+        "pdo",
+        "pgsql",
+        "postgresql",
+        "queryobject",
+        "sasql",
+        "sql",
+        "sqlite",
+        "sqlserver",
+        "sqlsrv"
+      ],
+      "support": {
+        "issues": "https://github.com/doctrine/dbal/issues",
+        "source": "https://github.com/doctrine/dbal/tree/4.2.4"
+      },
+      "funding": [
+        {
+          "url": "https://www.doctrine-project.org/sponsorship.html",
+          "type": "custom"
+        },
+        {
+          "url": "https://www.patreon.com/phpdoctrine",
+          "type": "patreon"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2025-06-15T23:15:01+00:00"
     },
     {
       "name": "doctrine/deprecations",
@@ -1757,6 +2848,69 @@
         }
       ],
       "time": "2024-09-25T12:00:00+00:00"
+    },
+    {
+      "name": "firebase/php-jwt",
+      "version": "v6.11.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/firebase/php-jwt.git",
+        "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+        "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^8.0"
+      },
+      "require-dev": {
+        "guzzlehttp/guzzle": "^7.4",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.5",
+        "psr/cache": "^2.0||^3.0",
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0"
+      },
+      "suggest": {
+        "ext-sodium": "Support EdDSA (Ed25519) signatures",
+        "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Firebase\\JWT\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Neuman Vong",
+          "email": "neuman+pear@twilio.com",
+          "role": "Developer"
+        },
+        {
+          "name": "Anant Narayanan",
+          "email": "anant@php.net",
+          "role": "Developer"
+        }
+      ],
+      "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+      "homepage": "https://github.com/firebase/php-jwt",
+      "keywords": [
+        "jwt",
+        "php"
+      ],
+      "support": {
+        "issues": "https://github.com/firebase/php-jwt/issues",
+        "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+      },
+      "time": "2025-04-09T20:32:01+00:00"
     },
     {
       "name": "friends-of-behat/mink",
@@ -2803,6 +3957,64 @@
       "time": "2024-07-06T21:00:26+00:00"
     },
     {
+      "name": "kelunik/certificate",
+      "version": "v1.1.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/kelunik/certificate.git",
+        "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+        "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+        "shasum": ""
+      },
+      "require": {
+        "ext-openssl": "*",
+        "php": ">=7.0"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "^2",
+        "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Kelunik\\Certificate\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Access certificate details and transform between different formats.",
+      "keywords": [
+        "DER",
+        "certificate",
+        "certificates",
+        "openssl",
+        "pem",
+        "x509"
+      ],
+      "support": {
+        "issues": "https://github.com/kelunik/certificate/issues",
+        "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
+      },
+      "time": "2023-02-03T21:26:53+00:00"
+    },
+    {
       "name": "league/openapi-psr7-validator",
       "version": "0.17",
       "source": {
@@ -3033,6 +4245,76 @@
         }
       ],
       "time": "2021-06-28T04:27:21+00:00"
+    },
+    {
+      "name": "league/uri-parser",
+      "version": "1.4.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/thephpleague/uri-parser.git",
+        "reference": "671548427e4c932352d9b9279fdfa345bf63fa00"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/thephpleague/uri-parser/zipball/671548427e4c932352d9b9279fdfa345bf63fa00",
+        "reference": "671548427e4c932352d9b9279fdfa345bf63fa00",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.0.0"
+      },
+      "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.0",
+        "phpstan/phpstan": "^0.9.2",
+        "phpstan/phpstan-phpunit": "^0.9.4",
+        "phpstan/phpstan-strict-rules": "^0.9.0",
+        "phpunit/phpunit": "^6.0"
+      },
+      "suggest": {
+        "ext-intl": "Allow parsing RFC3987 compliant hosts",
+        "league/uri-schemes": "Allow validating and normalizing URI parsing results"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/functions_include.php"
+        ],
+        "psr-4": {
+          "League\\Uri\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Ignace Nyamagana Butera",
+          "email": "nyamsprod@gmail.com",
+          "homepage": "https://nyamsprod.com"
+        }
+      ],
+      "description": "userland URI parser RFC 3986 compliant",
+      "homepage": "https://github.com/thephpleague/uri-parser",
+      "keywords": [
+        "parse_url",
+        "parser",
+        "rfc3986",
+        "rfc3987",
+        "uri",
+        "url"
+      ],
+      "support": {
+        "issues": "https://github.com/thephpleague/uri-parser/issues",
+        "source": "https://github.com/thephpleague/uri-parser/tree/master"
+      },
+      "abandoned": "league/uri-interfaces",
+      "time": "2018-11-22T07:55:51+00:00"
     },
     {
       "name": "monolog/monolog",
@@ -7187,84 +8469,6 @@
         }
       ],
       "time": "2020-09-28T06:39:44+00:00"
-    },
-    {
-      "name": "sensio/framework-extra-bundle",
-      "version": "v6.2.10",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-        "reference": "2f886f4b31f23c76496901acaedfedb6936ba61f"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/2f886f4b31f23c76496901acaedfedb6936ba61f",
-        "reference": "2f886f4b31f23c76496901acaedfedb6936ba61f",
-        "shasum": ""
-      },
-      "require": {
-        "doctrine/annotations": "^1.0|^2.0",
-        "php": ">=7.2.5",
-        "symfony/config": "^4.4|^5.0|^6.0",
-        "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
-        "symfony/http-kernel": "^4.4|^5.0|^6.0"
-      },
-      "conflict": {
-        "doctrine/doctrine-cache-bundle": "<1.3.1",
-        "doctrine/persistence": "<1.3"
-      },
-      "require-dev": {
-        "doctrine/dbal": "^2.10|^3.0",
-        "doctrine/doctrine-bundle": "^1.11|^2.0",
-        "doctrine/orm": "^2.5",
-        "symfony/browser-kit": "^4.4|^5.0|^6.0",
-        "symfony/doctrine-bridge": "^4.4|^5.0|^6.0",
-        "symfony/dom-crawler": "^4.4|^5.0|^6.0",
-        "symfony/expression-language": "^4.4|^5.0|^6.0",
-        "symfony/finder": "^4.4|^5.0|^6.0",
-        "symfony/monolog-bridge": "^4.0|^5.0|^6.0",
-        "symfony/monolog-bundle": "^3.2",
-        "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0",
-        "symfony/security-bundle": "^4.4|^5.0|^6.0",
-        "symfony/twig-bundle": "^4.4|^5.0|^6.0",
-        "symfony/yaml": "^4.4|^5.0|^6.0",
-        "twig/twig": "^1.34|^2.4|^3.0"
-      },
-      "type": "symfony-bundle",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "6.1.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Sensio\\Bundle\\FrameworkExtraBundle\\": "src/"
-        },
-        "exclude-from-classmap": [
-          "/tests/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Fabien Potencier",
-          "email": "fabien@symfony.com"
-        }
-      ],
-      "description": "This bundle provides a way to configure your controllers with annotations",
-      "keywords": [
-        "annotations",
-        "controllers"
-      ],
-      "support": {
-        "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/v6.2.10"
-      },
-      "abandoned": "Symfony",
-      "time": "2023-02-24T14:57:12+00:00"
     },
     {
       "name": "smarty-gettext/smarty-gettext",
@@ -12144,7 +13348,7 @@
   },
   "prefer-stable": false,
   "prefer-lowest": false,
-  "platform": [],
+  "platform": {},
   "platform-dev": {
     "ext-json": "*"
   },

--- a/centreon-dsm/composer.lock
+++ b/centreon-dsm/composer.lock
@@ -4,9 +4,943 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "6185b7d7c2d7e81f5eac8885127fd1a8",
+  "content-hash": "fff5e4891b51f1befb042c8ed47f20b1",
   "packages": [],
   "packages-dev": [
+    {
+      "name": "amphp/amp",
+      "version": "v2.6.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/amp.git",
+        "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/amp/zipball/ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
+        "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "ext-json": "*",
+        "jetbrains/phpstorm-stubs": "^2019.3",
+        "phpunit/phpunit": "^7 | ^8 | ^9",
+        "react/promise": "^2",
+        "vimeo/psalm": "^3.12"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "lib/functions.php",
+          "lib/Internal/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Bob Weinand",
+          "email": "bobwei9@hotmail.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "A non-blocking concurrency framework for PHP applications.",
+      "homepage": "https://amphp.org/amp",
+      "keywords": [
+        "async",
+        "asynchronous",
+        "awaitable",
+        "concurrency",
+        "event",
+        "event-loop",
+        "future",
+        "non-blocking",
+        "promise"
+      ],
+      "support": {
+        "irc": "irc://irc.freenode.org/amphp",
+        "issues": "https://github.com/amphp/amp/issues",
+        "source": "https://github.com/amphp/amp/tree/v2.6.4"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T18:52:26+00:00"
+    },
+    {
+      "name": "amphp/byte-stream",
+      "version": "v1.8.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/byte-stream.git",
+        "reference": "4f0e968ba3798a423730f567b1b50d3441c16ddc"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/byte-stream/zipball/4f0e968ba3798a423730f567b1b50d3441c16ddc",
+        "reference": "4f0e968ba3798a423730f567b1b50d3441c16ddc",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.4",
+        "friendsofphp/php-cs-fixer": "^2.3",
+        "jetbrains/phpstorm-stubs": "^2019.3",
+        "phpunit/phpunit": "^6 || ^7 || ^8",
+        "psalm/phar": "^3.11.4"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "lib/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\ByteStream\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "A stream abstraction to make working with non-blocking I/O simple.",
+      "homepage": "https://amphp.org/byte-stream",
+      "keywords": [
+        "amp",
+        "amphp",
+        "async",
+        "io",
+        "non-blocking",
+        "stream"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/byte-stream/issues",
+        "source": "https://github.com/amphp/byte-stream/tree/v1.8.2"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-04-13T18:00:56+00:00"
+    },
+    {
+      "name": "amphp/cache",
+      "version": "v1.5.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/cache.git",
+        "reference": "fe78cfae2fb8c92735629b8cd1893029c73c9b63"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/cache/zipball/fe78cfae2fb8c92735629b8cd1893029c73c9b63",
+        "reference": "fe78cfae2fb8c92735629b8cd1893029c73c9b63",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/serialization": "^1",
+        "amphp/sync": "^1.2",
+        "php": ">=7.1"
+      },
+      "conflict": {
+        "amphp/file": "<0.2 || >=3"
+      },
+      "require-dev": {
+        "amphp/file": "^1 || ^2",
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.1",
+        "phpunit/phpunit": "^6 | ^7 | ^8 | ^9",
+        "vimeo/psalm": "^4"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Amp\\Cache\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        }
+      ],
+      "description": "A promise-aware caching API for Amp.",
+      "homepage": "https://github.com/amphp/cache",
+      "support": {
+        "irc": "irc://irc.freenode.org/amphp",
+        "issues": "https://github.com/amphp/cache/issues",
+        "source": "https://github.com/amphp/cache/tree/v1.5.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T19:35:02+00:00"
+    },
+    {
+      "name": "amphp/dns",
+      "version": "v1.2.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/dns.git",
+        "reference": "4a13ffdc5e088593eb01860fc5002ebd9316d562"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/dns/zipball/4a13ffdc5e088593eb01860fc5002ebd9316d562",
+        "reference": "4a13ffdc5e088593eb01860fc5002ebd9316d562",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.1",
+        "amphp/cache": "^1.2",
+        "amphp/parser": "^1",
+        "amphp/windows-registry": "^0.3",
+        "daverandom/libdns": "^2.0.1",
+        "ext-filter": "*",
+        "ext-json": "*",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "phpunit/phpunit": "^6 || ^7 || ^8 || ^9"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "lib/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Dns\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Chris Wright",
+          "email": "addr@daverandom.com"
+        },
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        },
+        {
+          "name": "Bob Weinand",
+          "email": "bobwei9@hotmail.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        }
+      ],
+      "description": "Async DNS resolution for Amp.",
+      "homepage": "https://github.com/amphp/dns",
+      "keywords": [
+        "amp",
+        "amphp",
+        "async",
+        "client",
+        "dns",
+        "resolve"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/dns/issues",
+        "source": "https://github.com/amphp/dns/tree/v1.2.4"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-12-08T15:06:32+00:00"
+    },
+    {
+      "name": "amphp/hpack",
+      "version": "v3.2.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/hpack.git",
+        "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/hpack/zipball/4f293064b15682a2b178b1367ddf0b8b5feb0239",
+        "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "^2",
+        "http2jp/hpack-test-case": "^1",
+        "nikic/php-fuzzer": "^0.0.10",
+        "phpunit/phpunit": "^7 | ^8 | ^9"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "3.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Amp\\Http\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        },
+        {
+          "name": "Bob Weinand"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        }
+      ],
+      "description": "HTTP/2 HPack implementation.",
+      "homepage": "https://github.com/amphp/hpack",
+      "keywords": [
+        "headers",
+        "hpack",
+        "http-2"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/hpack/issues",
+        "source": "https://github.com/amphp/hpack/tree/v3.2.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T19:00:16+00:00"
+    },
+    {
+      "name": "amphp/http",
+      "version": "v1.7.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/http.git",
+        "reference": "3a33e68a3b53f7279217238e89748cf0cb30b8a6"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/http/zipball/3a33e68a3b53f7279217238e89748cf0cb30b8a6",
+        "reference": "3a33e68a3b53f7279217238e89748cf0cb30b8a6",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/hpack": "^3",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "2.x-dev#3c24119d0377eed2093d5c0f0541478cb75ea72d",
+        "phpunit/phpunit": "^9 || ^8 || ^7"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Http\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Basic HTTP primitives which can be shared by servers and clients.",
+      "support": {
+        "issues": "https://github.com/amphp/http/issues",
+        "source": "https://github.com/amphp/http/tree/v1.7.3"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-04-03T17:45:14+00:00"
+    },
+    {
+      "name": "amphp/http-client",
+      "version": "v4.6.5",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/http-client.git",
+        "reference": "6cac9e172a66a04df305acc8de02b6c40832b269"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/http-client/zipball/6cac9e172a66a04df305acc8de02b6c40832b269",
+        "reference": "6cac9e172a66a04df305acc8de02b6c40832b269",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2.4",
+        "amphp/byte-stream": "^1.6",
+        "amphp/hpack": "^3",
+        "amphp/http": "^1.6",
+        "amphp/socket": "^1",
+        "amphp/sync": "^1.3",
+        "league/uri": "^6 | ^7",
+        "php": ">=7.2",
+        "psr/http-message": "^1 | ^2"
+      },
+      "conflict": {
+        "amphp/file": "<0.2 || >=3"
+      },
+      "require-dev": {
+        "amphp/file": "^0.2 || ^0.3 || ^1 || ^2",
+        "amphp/http-server": "^2",
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.1",
+        "amphp/react-adapter": "^2.1",
+        "clue/socks-react": "^1.0",
+        "ext-json": "*",
+        "kelunik/link-header-rfc5988": "^1.0",
+        "laminas/laminas-diactoros": "^2.3",
+        "phpunit/phpunit": "^7 || ^8 || ^9",
+        "vimeo/psalm": "^5"
+      },
+      "suggest": {
+        "amphp/file": "Required for file request bodies and HTTP archive logging",
+        "ext-json": "Required for logging HTTP archives",
+        "ext-zlib": "Allows using compression for response bodies."
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "4.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/Internal/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Http\\Client\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@gmail.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        }
+      ],
+      "description": "Asynchronous concurrent HTTP/2 and HTTP/1.1 client built on the Amp concurrency framework",
+      "homepage": "https://github.com/amphp/http-client",
+      "keywords": [
+        "async",
+        "client",
+        "concurrent",
+        "http",
+        "non-blocking",
+        "rest"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/http-client/issues",
+        "source": "https://github.com/amphp/http-client/tree/v4.6.5"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-12-13T15:50:23+00:00"
+    },
+    {
+      "name": "amphp/parser",
+      "version": "v1.1.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/parser.git",
+        "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+        "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.4"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "^2",
+        "phpunit/phpunit": "^9",
+        "psalm/phar": "^5.4"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Amp\\Parser\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "A generator parser to make streaming parsers simple.",
+      "homepage": "https://github.com/amphp/parser",
+      "keywords": [
+        "async",
+        "non-blocking",
+        "parser",
+        "stream"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/parser/issues",
+        "source": "https://github.com/amphp/parser/tree/v1.1.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T19:16:53+00:00"
+    },
+    {
+      "name": "amphp/process",
+      "version": "v1.1.9",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/process.git",
+        "reference": "55b837d4f1857b9bd7efb7bb859ae6b0e804f13f"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/process/zipball/55b837d4f1857b9bd7efb7bb859ae6b0e804f13f",
+        "reference": "55b837d4f1857b9bd7efb7bb859ae6b0e804f13f",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.4",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "phpunit/phpunit": "^6"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "lib/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Process\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Bob Weinand",
+          "email": "bobwei9@hotmail.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Asynchronous process manager.",
+      "homepage": "https://github.com/amphp/process",
+      "support": {
+        "issues": "https://github.com/amphp/process/issues",
+        "source": "https://github.com/amphp/process/tree/v1.1.9"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-12-13T17:38:25+00:00"
+    },
+    {
+      "name": "amphp/serialization",
+      "version": "v1.0.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/serialization.git",
+        "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
+        "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "phpunit/phpunit": "^9 || ^8 || ^7"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "src/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Serialization\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Serialization tools for IPC and data storage in PHP.",
+      "homepage": "https://github.com/amphp/serialization",
+      "keywords": [
+        "async",
+        "asynchronous",
+        "serialization",
+        "serialize"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/serialization/issues",
+        "source": "https://github.com/amphp/serialization/tree/master"
+      },
+      "time": "2020-03-25T21:39:07+00:00"
+    },
+    {
+      "name": "amphp/socket",
+      "version": "v1.2.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/socket.git",
+        "reference": "b00528bd75548b7ae06a502358bb3ff8b106f5ab"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/socket/zipball/b00528bd75548b7ae06a502358bb3ff8b106f5ab",
+        "reference": "b00528bd75548b7ae06a502358bb3ff8b106f5ab",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.6",
+        "amphp/dns": "^1 || ^0.9",
+        "ext-openssl": "*",
+        "kelunik/certificate": "^1.1",
+        "league/uri-parser": "^1.4",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "phpunit/phpunit": "^6 || ^7 || ^8",
+        "vimeo/psalm": "^3.9@dev"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/functions.php",
+          "src/Internal/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Socket\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@gmail.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Async socket connection / server tools for Amp.",
+      "homepage": "https://github.com/amphp/socket",
+      "keywords": [
+        "amp",
+        "async",
+        "encryption",
+        "non-blocking",
+        "sockets",
+        "tcp",
+        "tls"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/socket/issues",
+        "source": "https://github.com/amphp/socket/tree/v1.2.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T18:12:22+00:00"
+    },
+    {
+      "name": "amphp/sync",
+      "version": "v1.4.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/sync.git",
+        "reference": "85ab06764f4f36d63b1356b466df6111cf4b89cf"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/sync/zipball/85ab06764f4f36d63b1356b466df6111cf4b89cf",
+        "reference": "85ab06764f4f36d63b1356b466df6111cf4b89cf",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2.2",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.1",
+        "phpunit/phpunit": "^9 || ^8 || ^7"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "src/functions.php",
+          "src/ConcurrentIterator/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Sync\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Stephen Coakley",
+          "email": "me@stephencoakley.com"
+        }
+      ],
+      "description": "Mutex, Semaphore, and other synchronization tools for Amp.",
+      "homepage": "https://github.com/amphp/sync",
+      "keywords": [
+        "async",
+        "asynchronous",
+        "mutex",
+        "semaphore",
+        "synchronization"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/sync/issues",
+        "source": "https://github.com/amphp/sync/tree/v1.4.2"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2021-10-25T18:29:10+00:00"
+    },
+    {
+      "name": "amphp/windows-registry",
+      "version": "v0.3.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/windows-registry.git",
+        "reference": "0f56438b9197e224325e88f305346f0221df1f71"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/windows-registry/zipball/0f56438b9197e224325e88f305346f0221df1f71",
+        "reference": "0f56438b9197e224325e88f305346f0221df1f71",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.4",
+        "amphp/process": "^1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Amp\\WindowsRegistry\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Windows Registry Reader.",
+      "support": {
+        "issues": "https://github.com/amphp/windows-registry/issues",
+        "source": "https://github.com/amphp/windows-registry/tree/master"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2020-07-10T16:13:29+00:00"
+    },
     {
       "name": "beberlei/assert",
       "version": "v3.3.3",
@@ -349,16 +1283,18 @@
     },
     {
       "name": "centreon/centreon",
-      "version": "24.11",
+      "version": "25.07",
       "dist": {
         "type": "path",
         "url": "../centreon",
-        "reference": "db33a5637a4cc90921dbc1b5b60bd8660f31daa3"
+        "reference": "86e00cdbec213213a23ca036572fc92bf13f2919"
       },
       "require": {
+        "amphp/http-client": "^4.6",
         "beberlei/assert": "^3.3",
         "curl/curl": "^2.3",
         "doctrine/annotations": "^1.0",
+        "doctrine/dbal": "^4.2",
         "dragonmantank/cron-expression": "3.1.0",
         "enshrined/svg-sanitize": "^0.15",
         "ext-ctype": "*",
@@ -374,6 +1310,7 @@
         "ext-posix": "*",
         "ext-simplexml": "*",
         "ext-zip": "*",
+        "firebase/php-jwt": "^6.11",
         "friendsofsymfony/rest-bundle": "^3.0",
         "jms/serializer-bundle": "^5.4",
         "justinrainbow/json-schema": "^5.2",
@@ -385,7 +1322,6 @@
         "phpdocumentor/reflection-docblock": "5.4.*",
         "pimple/pimple": "3.5.*",
         "psr/container": "1.1.*",
-        "sensio/framework-extra-bundle": "6.2.*",
         "smarty-gettext/smarty-gettext": "1.7.*",
         "smarty/smarty": "4.5.*",
         "symfony/config": "6.4.*",
@@ -439,11 +1375,13 @@
         "friends-of-behat/mink": "1.11.*",
         "friends-of-behat/mink-extension": "2.7.*",
         "friendsofphp/php-cs-fixer": "3.64.*",
+        "mockery/mockery": "1.6.*",
         "pestphp/pest": "1.23.*",
         "php-vfs/php-vfs": "1.4.*",
         "phpcompatibility/php-compatibility": "9.3.*",
         "phpstan/phpstan": "1.12.*",
         "phpstan/phpstan-beberlei-assert": "1.1.*",
+        "phpstan/phpstan-mockery": "1.1.*",
         "rector/rector": "1.2.*",
         "robertfausk/mink-panther-driver": "1.1.*",
         "squizlabs/php_codesniffer": "3.10.*",
@@ -543,6 +1481,9 @@
         ],
         "rector:exec": [
           "rector process --debug"
+        ],
+        "symfony:check:ci": [
+          "php bin/console lint:yaml config src --parse-tags && php bin/console lint:container"
         ]
       },
       "license": [
@@ -972,6 +1913,50 @@
       "time": "2022-12-14T13:27:59+00:00"
     },
     {
+      "name": "daverandom/libdns",
+      "version": "v2.1.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/DaveRandom/LibDNS.git",
+        "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+        "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+        "shasum": ""
+      },
+      "require": {
+        "ext-ctype": "*",
+        "php": ">=7.1"
+      },
+      "suggest": {
+        "ext-intl": "Required for IDN support"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "src/functions.php"
+        ],
+        "psr-4": {
+          "LibDNS\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "description": "DNS protocol implementation written in pure PHP",
+      "keywords": [
+        "dns"
+      ],
+      "support": {
+        "issues": "https://github.com/DaveRandom/LibDNS/issues",
+        "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
+      },
+      "time": "2024-04-12T12:12:48+00:00"
+    },
+    {
       "name": "dealerdirect/phpcodesniffer-composer-installer",
       "version": "v1.0.0",
       "source": {
@@ -1124,6 +2109,112 @@
         "source": "https://github.com/doctrine/annotations/tree/1.14.4"
       },
       "time": "2024-09-05T10:15:52+00:00"
+    },
+    {
+      "name": "doctrine/dbal",
+      "version": "4.2.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/doctrine/dbal.git",
+        "reference": "b37d160498ea91a2382a2ebe825c4ea6254fc0ec"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/doctrine/dbal/zipball/b37d160498ea91a2382a2ebe825c4ea6254fc0ec",
+        "reference": "b37d160498ea91a2382a2ebe825c4ea6254fc0ec",
+        "shasum": ""
+      },
+      "require": {
+        "doctrine/deprecations": "^0.5.3|^1",
+        "php": "^8.1",
+        "psr/cache": "^1|^2|^3",
+        "psr/log": "^1|^2|^3"
+      },
+      "require-dev": {
+        "doctrine/coding-standard": "13.0.0",
+        "fig/log-test": "^1",
+        "jetbrains/phpstorm-stubs": "2023.2",
+        "phpstan/phpstan": "2.1.17",
+        "phpstan/phpstan-phpunit": "2.0.6",
+        "phpstan/phpstan-strict-rules": "^2",
+        "phpunit/phpunit": "10.5.46",
+        "slevomat/coding-standard": "8.16.2",
+        "squizlabs/php_codesniffer": "3.13.1",
+        "symfony/cache": "^6.3.8|^7.0",
+        "symfony/console": "^5.4|^6.3|^7.0"
+      },
+      "suggest": {
+        "symfony/console": "For helpful console commands such as SQL execution and import of files."
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Doctrine\\DBAL\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Guilherme Blanco",
+          "email": "guilhermeblanco@gmail.com"
+        },
+        {
+          "name": "Roman Borschel",
+          "email": "roman@code-factory.org"
+        },
+        {
+          "name": "Benjamin Eberlei",
+          "email": "kontakt@beberlei.de"
+        },
+        {
+          "name": "Jonathan Wage",
+          "email": "jonwage@gmail.com"
+        }
+      ],
+      "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+      "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+      "keywords": [
+        "abstraction",
+        "database",
+        "db2",
+        "dbal",
+        "mariadb",
+        "mssql",
+        "mysql",
+        "oci8",
+        "oracle",
+        "pdo",
+        "pgsql",
+        "postgresql",
+        "queryobject",
+        "sasql",
+        "sql",
+        "sqlite",
+        "sqlserver",
+        "sqlsrv"
+      ],
+      "support": {
+        "issues": "https://github.com/doctrine/dbal/issues",
+        "source": "https://github.com/doctrine/dbal/tree/4.2.4"
+      },
+      "funding": [
+        {
+          "url": "https://www.doctrine-project.org/sponsorship.html",
+          "type": "custom"
+        },
+        {
+          "url": "https://www.patreon.com/phpdoctrine",
+          "type": "patreon"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2025-06-15T23:15:01+00:00"
     },
     {
       "name": "doctrine/deprecations",
@@ -1693,6 +2784,69 @@
         }
       ],
       "time": "2024-09-25T12:00:00+00:00"
+    },
+    {
+      "name": "firebase/php-jwt",
+      "version": "v6.11.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/firebase/php-jwt.git",
+        "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+        "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^8.0"
+      },
+      "require-dev": {
+        "guzzlehttp/guzzle": "^7.4",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.5",
+        "psr/cache": "^2.0||^3.0",
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0"
+      },
+      "suggest": {
+        "ext-sodium": "Support EdDSA (Ed25519) signatures",
+        "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Firebase\\JWT\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Neuman Vong",
+          "email": "neuman+pear@twilio.com",
+          "role": "Developer"
+        },
+        {
+          "name": "Anant Narayanan",
+          "email": "anant@php.net",
+          "role": "Developer"
+        }
+      ],
+      "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+      "homepage": "https://github.com/firebase/php-jwt",
+      "keywords": [
+        "jwt",
+        "php"
+      ],
+      "support": {
+        "issues": "https://github.com/firebase/php-jwt/issues",
+        "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+      },
+      "time": "2025-04-09T20:32:01+00:00"
     },
     {
       "name": "friendsofphp/php-cs-fixer",
@@ -2545,6 +3699,64 @@
       "time": "2024-07-06T21:00:26+00:00"
     },
     {
+      "name": "kelunik/certificate",
+      "version": "v1.1.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/kelunik/certificate.git",
+        "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+        "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+        "shasum": ""
+      },
+      "require": {
+        "ext-openssl": "*",
+        "php": ">=7.0"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "^2",
+        "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Kelunik\\Certificate\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Access certificate details and transform between different formats.",
+      "keywords": [
+        "DER",
+        "certificate",
+        "certificates",
+        "openssl",
+        "pem",
+        "x509"
+      ],
+      "support": {
+        "issues": "https://github.com/kelunik/certificate/issues",
+        "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
+      },
+      "time": "2023-02-03T21:26:53+00:00"
+    },
+    {
       "name": "league/openapi-psr7-validator",
       "version": "0.17",
       "source": {
@@ -2775,6 +3987,76 @@
         }
       ],
       "time": "2021-06-28T04:27:21+00:00"
+    },
+    {
+      "name": "league/uri-parser",
+      "version": "1.4.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/thephpleague/uri-parser.git",
+        "reference": "671548427e4c932352d9b9279fdfa345bf63fa00"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/thephpleague/uri-parser/zipball/671548427e4c932352d9b9279fdfa345bf63fa00",
+        "reference": "671548427e4c932352d9b9279fdfa345bf63fa00",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.0.0"
+      },
+      "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.0",
+        "phpstan/phpstan": "^0.9.2",
+        "phpstan/phpstan-phpunit": "^0.9.4",
+        "phpstan/phpstan-strict-rules": "^0.9.0",
+        "phpunit/phpunit": "^6.0"
+      },
+      "suggest": {
+        "ext-intl": "Allow parsing RFC3987 compliant hosts",
+        "league/uri-schemes": "Allow validating and normalizing URI parsing results"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/functions_include.php"
+        ],
+        "psr-4": {
+          "League\\Uri\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Ignace Nyamagana Butera",
+          "email": "nyamsprod@gmail.com",
+          "homepage": "https://nyamsprod.com"
+        }
+      ],
+      "description": "userland URI parser RFC 3986 compliant",
+      "homepage": "https://github.com/thephpleague/uri-parser",
+      "keywords": [
+        "parse_url",
+        "parser",
+        "rfc3986",
+        "rfc3987",
+        "uri",
+        "url"
+      ],
+      "support": {
+        "issues": "https://github.com/thephpleague/uri-parser/issues",
+        "source": "https://github.com/thephpleague/uri-parser/tree/master"
+      },
+      "abandoned": "league/uri-interfaces",
+      "time": "2018-11-22T07:55:51+00:00"
     },
     {
       "name": "monolog/monolog",
@@ -6929,84 +8211,6 @@
         }
       ],
       "time": "2020-09-28T06:39:44+00:00"
-    },
-    {
-      "name": "sensio/framework-extra-bundle",
-      "version": "v6.2.10",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-        "reference": "2f886f4b31f23c76496901acaedfedb6936ba61f"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/2f886f4b31f23c76496901acaedfedb6936ba61f",
-        "reference": "2f886f4b31f23c76496901acaedfedb6936ba61f",
-        "shasum": ""
-      },
-      "require": {
-        "doctrine/annotations": "^1.0|^2.0",
-        "php": ">=7.2.5",
-        "symfony/config": "^4.4|^5.0|^6.0",
-        "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
-        "symfony/http-kernel": "^4.4|^5.0|^6.0"
-      },
-      "conflict": {
-        "doctrine/doctrine-cache-bundle": "<1.3.1",
-        "doctrine/persistence": "<1.3"
-      },
-      "require-dev": {
-        "doctrine/dbal": "^2.10|^3.0",
-        "doctrine/doctrine-bundle": "^1.11|^2.0",
-        "doctrine/orm": "^2.5",
-        "symfony/browser-kit": "^4.4|^5.0|^6.0",
-        "symfony/doctrine-bridge": "^4.4|^5.0|^6.0",
-        "symfony/dom-crawler": "^4.4|^5.0|^6.0",
-        "symfony/expression-language": "^4.4|^5.0|^6.0",
-        "symfony/finder": "^4.4|^5.0|^6.0",
-        "symfony/monolog-bridge": "^4.0|^5.0|^6.0",
-        "symfony/monolog-bundle": "^3.2",
-        "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0",
-        "symfony/security-bundle": "^4.4|^5.0|^6.0",
-        "symfony/twig-bundle": "^4.4|^5.0|^6.0",
-        "symfony/yaml": "^4.4|^5.0|^6.0",
-        "twig/twig": "^1.34|^2.4|^3.0"
-      },
-      "type": "symfony-bundle",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "6.1.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Sensio\\Bundle\\FrameworkExtraBundle\\": "src/"
-        },
-        "exclude-from-classmap": [
-          "/tests/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Fabien Potencier",
-          "email": "fabien@symfony.com"
-        }
-      ],
-      "description": "This bundle provides a way to configure your controllers with annotations",
-      "keywords": [
-        "annotations",
-        "controllers"
-      ],
-      "support": {
-        "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/v6.2.10"
-      },
-      "abandoned": "Symfony",
-      "time": "2023-02-24T14:57:12+00:00"
     },
     {
       "name": "smarty-gettext/smarty-gettext",
@@ -11821,7 +13025,7 @@
   },
   "prefer-stable": false,
   "prefer-lowest": false,
-  "platform": [],
+  "platform": {},
   "platform-dev": {
     "ext-json": "*"
   },

--- a/centreon-open-tickets/composer.lock
+++ b/centreon-open-tickets/composer.lock
@@ -4,9 +4,943 @@
     "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
     "This file is @generated automatically"
   ],
-  "content-hash": "1fff92865c52a68d7b587940a9525db8",
+  "content-hash": "cc0f7926297cd31f391e10dc60a08a48",
   "packages": [],
   "packages-dev": [
+    {
+      "name": "amphp/amp",
+      "version": "v2.6.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/amp.git",
+        "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/amp/zipball/ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
+        "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "ext-json": "*",
+        "jetbrains/phpstorm-stubs": "^2019.3",
+        "phpunit/phpunit": "^7 | ^8 | ^9",
+        "react/promise": "^2",
+        "vimeo/psalm": "^3.12"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "2.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "lib/functions.php",
+          "lib/Internal/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Bob Weinand",
+          "email": "bobwei9@hotmail.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "A non-blocking concurrency framework for PHP applications.",
+      "homepage": "https://amphp.org/amp",
+      "keywords": [
+        "async",
+        "asynchronous",
+        "awaitable",
+        "concurrency",
+        "event",
+        "event-loop",
+        "future",
+        "non-blocking",
+        "promise"
+      ],
+      "support": {
+        "irc": "irc://irc.freenode.org/amphp",
+        "issues": "https://github.com/amphp/amp/issues",
+        "source": "https://github.com/amphp/amp/tree/v2.6.4"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T18:52:26+00:00"
+    },
+    {
+      "name": "amphp/byte-stream",
+      "version": "v1.8.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/byte-stream.git",
+        "reference": "4f0e968ba3798a423730f567b1b50d3441c16ddc"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/byte-stream/zipball/4f0e968ba3798a423730f567b1b50d3441c16ddc",
+        "reference": "4f0e968ba3798a423730f567b1b50d3441c16ddc",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.4",
+        "friendsofphp/php-cs-fixer": "^2.3",
+        "jetbrains/phpstorm-stubs": "^2019.3",
+        "phpunit/phpunit": "^6 || ^7 || ^8",
+        "psalm/phar": "^3.11.4"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "lib/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\ByteStream\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "A stream abstraction to make working with non-blocking I/O simple.",
+      "homepage": "https://amphp.org/byte-stream",
+      "keywords": [
+        "amp",
+        "amphp",
+        "async",
+        "io",
+        "non-blocking",
+        "stream"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/byte-stream/issues",
+        "source": "https://github.com/amphp/byte-stream/tree/v1.8.2"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-04-13T18:00:56+00:00"
+    },
+    {
+      "name": "amphp/cache",
+      "version": "v1.5.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/cache.git",
+        "reference": "fe78cfae2fb8c92735629b8cd1893029c73c9b63"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/cache/zipball/fe78cfae2fb8c92735629b8cd1893029c73c9b63",
+        "reference": "fe78cfae2fb8c92735629b8cd1893029c73c9b63",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/serialization": "^1",
+        "amphp/sync": "^1.2",
+        "php": ">=7.1"
+      },
+      "conflict": {
+        "amphp/file": "<0.2 || >=3"
+      },
+      "require-dev": {
+        "amphp/file": "^1 || ^2",
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.1",
+        "phpunit/phpunit": "^6 | ^7 | ^8 | ^9",
+        "vimeo/psalm": "^4"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Amp\\Cache\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        }
+      ],
+      "description": "A promise-aware caching API for Amp.",
+      "homepage": "https://github.com/amphp/cache",
+      "support": {
+        "irc": "irc://irc.freenode.org/amphp",
+        "issues": "https://github.com/amphp/cache/issues",
+        "source": "https://github.com/amphp/cache/tree/v1.5.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T19:35:02+00:00"
+    },
+    {
+      "name": "amphp/dns",
+      "version": "v1.2.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/dns.git",
+        "reference": "4a13ffdc5e088593eb01860fc5002ebd9316d562"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/dns/zipball/4a13ffdc5e088593eb01860fc5002ebd9316d562",
+        "reference": "4a13ffdc5e088593eb01860fc5002ebd9316d562",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.1",
+        "amphp/cache": "^1.2",
+        "amphp/parser": "^1",
+        "amphp/windows-registry": "^0.3",
+        "daverandom/libdns": "^2.0.1",
+        "ext-filter": "*",
+        "ext-json": "*",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "phpunit/phpunit": "^6 || ^7 || ^8 || ^9"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "lib/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Dns\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Chris Wright",
+          "email": "addr@daverandom.com"
+        },
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        },
+        {
+          "name": "Bob Weinand",
+          "email": "bobwei9@hotmail.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        }
+      ],
+      "description": "Async DNS resolution for Amp.",
+      "homepage": "https://github.com/amphp/dns",
+      "keywords": [
+        "amp",
+        "amphp",
+        "async",
+        "client",
+        "dns",
+        "resolve"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/dns/issues",
+        "source": "https://github.com/amphp/dns/tree/v1.2.4"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-12-08T15:06:32+00:00"
+    },
+    {
+      "name": "amphp/hpack",
+      "version": "v3.2.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/hpack.git",
+        "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/hpack/zipball/4f293064b15682a2b178b1367ddf0b8b5feb0239",
+        "reference": "4f293064b15682a2b178b1367ddf0b8b5feb0239",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "^2",
+        "http2jp/hpack-test-case": "^1",
+        "nikic/php-fuzzer": "^0.0.10",
+        "phpunit/phpunit": "^7 | ^8 | ^9"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "3.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Amp\\Http\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@php.net"
+        },
+        {
+          "name": "Bob Weinand"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        }
+      ],
+      "description": "HTTP/2 HPack implementation.",
+      "homepage": "https://github.com/amphp/hpack",
+      "keywords": [
+        "headers",
+        "hpack",
+        "http-2"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/hpack/issues",
+        "source": "https://github.com/amphp/hpack/tree/v3.2.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T19:00:16+00:00"
+    },
+    {
+      "name": "amphp/http",
+      "version": "v1.7.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/http.git",
+        "reference": "3a33e68a3b53f7279217238e89748cf0cb30b8a6"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/http/zipball/3a33e68a3b53f7279217238e89748cf0cb30b8a6",
+        "reference": "3a33e68a3b53f7279217238e89748cf0cb30b8a6",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/hpack": "^3",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "2.x-dev#3c24119d0377eed2093d5c0f0541478cb75ea72d",
+        "phpunit/phpunit": "^9 || ^8 || ^7"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Http\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Basic HTTP primitives which can be shared by servers and clients.",
+      "support": {
+        "issues": "https://github.com/amphp/http/issues",
+        "source": "https://github.com/amphp/http/tree/v1.7.3"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-04-03T17:45:14+00:00"
+    },
+    {
+      "name": "amphp/http-client",
+      "version": "v4.6.5",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/http-client.git",
+        "reference": "6cac9e172a66a04df305acc8de02b6c40832b269"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/http-client/zipball/6cac9e172a66a04df305acc8de02b6c40832b269",
+        "reference": "6cac9e172a66a04df305acc8de02b6c40832b269",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2.4",
+        "amphp/byte-stream": "^1.6",
+        "amphp/hpack": "^3",
+        "amphp/http": "^1.6",
+        "amphp/socket": "^1",
+        "amphp/sync": "^1.3",
+        "league/uri": "^6 | ^7",
+        "php": ">=7.2",
+        "psr/http-message": "^1 | ^2"
+      },
+      "conflict": {
+        "amphp/file": "<0.2 || >=3"
+      },
+      "require-dev": {
+        "amphp/file": "^0.2 || ^0.3 || ^1 || ^2",
+        "amphp/http-server": "^2",
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.1",
+        "amphp/react-adapter": "^2.1",
+        "clue/socks-react": "^1.0",
+        "ext-json": "*",
+        "kelunik/link-header-rfc5988": "^1.0",
+        "laminas/laminas-diactoros": "^2.3",
+        "phpunit/phpunit": "^7 || ^8 || ^9",
+        "vimeo/psalm": "^5"
+      },
+      "suggest": {
+        "amphp/file": "Required for file request bodies and HTTP archive logging",
+        "ext-json": "Required for logging HTTP archives",
+        "ext-zlib": "Allows using compression for response bodies."
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "4.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/Internal/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Http\\Client\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@gmail.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        }
+      ],
+      "description": "Asynchronous concurrent HTTP/2 and HTTP/1.1 client built on the Amp concurrency framework",
+      "homepage": "https://github.com/amphp/http-client",
+      "keywords": [
+        "async",
+        "client",
+        "concurrent",
+        "http",
+        "non-blocking",
+        "rest"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/http-client/issues",
+        "source": "https://github.com/amphp/http-client/tree/v4.6.5"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-12-13T15:50:23+00:00"
+    },
+    {
+      "name": "amphp/parser",
+      "version": "v1.1.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/parser.git",
+        "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+        "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.4"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "^2",
+        "phpunit/phpunit": "^9",
+        "psalm/phar": "^5.4"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Amp\\Parser\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "A generator parser to make streaming parsers simple.",
+      "homepage": "https://github.com/amphp/parser",
+      "keywords": [
+        "async",
+        "non-blocking",
+        "parser",
+        "stream"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/parser/issues",
+        "source": "https://github.com/amphp/parser/tree/v1.1.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T19:16:53+00:00"
+    },
+    {
+      "name": "amphp/process",
+      "version": "v1.1.9",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/process.git",
+        "reference": "55b837d4f1857b9bd7efb7bb859ae6b0e804f13f"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/process/zipball/55b837d4f1857b9bd7efb7bb859ae6b0e804f13f",
+        "reference": "55b837d4f1857b9bd7efb7bb859ae6b0e804f13f",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.4",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "phpunit/phpunit": "^6"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "lib/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Process\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Bob Weinand",
+          "email": "bobwei9@hotmail.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Asynchronous process manager.",
+      "homepage": "https://github.com/amphp/process",
+      "support": {
+        "issues": "https://github.com/amphp/process/issues",
+        "source": "https://github.com/amphp/process/tree/v1.1.9"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-12-13T17:38:25+00:00"
+    },
+    {
+      "name": "amphp/serialization",
+      "version": "v1.0.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/serialization.git",
+        "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
+        "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "phpunit/phpunit": "^9 || ^8 || ^7"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "src/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Serialization\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Serialization tools for IPC and data storage in PHP.",
+      "homepage": "https://github.com/amphp/serialization",
+      "keywords": [
+        "async",
+        "asynchronous",
+        "serialization",
+        "serialize"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/serialization/issues",
+        "source": "https://github.com/amphp/serialization/tree/master"
+      },
+      "time": "2020-03-25T21:39:07+00:00"
+    },
+    {
+      "name": "amphp/socket",
+      "version": "v1.2.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/socket.git",
+        "reference": "b00528bd75548b7ae06a502358bb3ff8b106f5ab"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/socket/zipball/b00528bd75548b7ae06a502358bb3ff8b106f5ab",
+        "reference": "b00528bd75548b7ae06a502358bb3ff8b106f5ab",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.6",
+        "amphp/dns": "^1 || ^0.9",
+        "ext-openssl": "*",
+        "kelunik/certificate": "^1.1",
+        "league/uri-parser": "^1.4",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1",
+        "phpunit/phpunit": "^6 || ^7 || ^8",
+        "vimeo/psalm": "^3.9@dev"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/functions.php",
+          "src/Internal/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Socket\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Daniel Lowrey",
+          "email": "rdlowrey@gmail.com"
+        },
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Async socket connection / server tools for Amp.",
+      "homepage": "https://github.com/amphp/socket",
+      "keywords": [
+        "amp",
+        "async",
+        "encryption",
+        "non-blocking",
+        "sockets",
+        "tcp",
+        "tls"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/socket/issues",
+        "source": "https://github.com/amphp/socket/tree/v1.2.1"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2024-03-21T18:12:22+00:00"
+    },
+    {
+      "name": "amphp/sync",
+      "version": "v1.4.2",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/sync.git",
+        "reference": "85ab06764f4f36d63b1356b466df6111cf4b89cf"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/sync/zipball/85ab06764f4f36d63b1356b466df6111cf4b89cf",
+        "reference": "85ab06764f4f36d63b1356b466df6111cf4b89cf",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2.2",
+        "php": ">=7.1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master",
+        "amphp/phpunit-util": "^1.1",
+        "phpunit/phpunit": "^9 || ^8 || ^7"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "src/functions.php",
+          "src/ConcurrentIterator/functions.php"
+        ],
+        "psr-4": {
+          "Amp\\Sync\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Aaron Piotrowski",
+          "email": "aaron@trowski.com"
+        },
+        {
+          "name": "Stephen Coakley",
+          "email": "me@stephencoakley.com"
+        }
+      ],
+      "description": "Mutex, Semaphore, and other synchronization tools for Amp.",
+      "homepage": "https://github.com/amphp/sync",
+      "keywords": [
+        "async",
+        "asynchronous",
+        "mutex",
+        "semaphore",
+        "synchronization"
+      ],
+      "support": {
+        "issues": "https://github.com/amphp/sync/issues",
+        "source": "https://github.com/amphp/sync/tree/v1.4.2"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2021-10-25T18:29:10+00:00"
+    },
+    {
+      "name": "amphp/windows-registry",
+      "version": "v0.3.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/amphp/windows-registry.git",
+        "reference": "0f56438b9197e224325e88f305346f0221df1f71"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/amphp/windows-registry/zipball/0f56438b9197e224325e88f305346f0221df1f71",
+        "reference": "0f56438b9197e224325e88f305346f0221df1f71",
+        "shasum": ""
+      },
+      "require": {
+        "amphp/amp": "^2",
+        "amphp/byte-stream": "^1.4",
+        "amphp/process": "^1"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "dev-master"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Amp\\WindowsRegistry\\": "lib"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Windows Registry Reader.",
+      "support": {
+        "issues": "https://github.com/amphp/windows-registry/issues",
+        "source": "https://github.com/amphp/windows-registry/tree/master"
+      },
+      "funding": [
+        {
+          "url": "https://github.com/amphp",
+          "type": "github"
+        }
+      ],
+      "time": "2020-07-10T16:13:29+00:00"
+    },
     {
       "name": "beberlei/assert",
       "version": "v3.3.3",
@@ -349,16 +1283,18 @@
     },
     {
       "name": "centreon/centreon",
-      "version": "24.11",
+      "version": "25.07",
       "dist": {
         "type": "path",
         "url": "../centreon",
-        "reference": "db33a5637a4cc90921dbc1b5b60bd8660f31daa3"
+        "reference": "86e00cdbec213213a23ca036572fc92bf13f2919"
       },
       "require": {
+        "amphp/http-client": "^4.6",
         "beberlei/assert": "^3.3",
         "curl/curl": "^2.3",
         "doctrine/annotations": "^1.0",
+        "doctrine/dbal": "^4.2",
         "dragonmantank/cron-expression": "3.1.0",
         "enshrined/svg-sanitize": "^0.15",
         "ext-ctype": "*",
@@ -374,6 +1310,7 @@
         "ext-posix": "*",
         "ext-simplexml": "*",
         "ext-zip": "*",
+        "firebase/php-jwt": "^6.11",
         "friendsofsymfony/rest-bundle": "^3.0",
         "jms/serializer-bundle": "^5.4",
         "justinrainbow/json-schema": "^5.2",
@@ -385,7 +1322,6 @@
         "phpdocumentor/reflection-docblock": "5.4.*",
         "pimple/pimple": "3.5.*",
         "psr/container": "1.1.*",
-        "sensio/framework-extra-bundle": "6.2.*",
         "smarty-gettext/smarty-gettext": "1.7.*",
         "smarty/smarty": "4.5.*",
         "symfony/config": "6.4.*",
@@ -439,11 +1375,13 @@
         "friends-of-behat/mink": "1.11.*",
         "friends-of-behat/mink-extension": "2.7.*",
         "friendsofphp/php-cs-fixer": "3.64.*",
+        "mockery/mockery": "1.6.*",
         "pestphp/pest": "1.23.*",
         "php-vfs/php-vfs": "1.4.*",
         "phpcompatibility/php-compatibility": "9.3.*",
         "phpstan/phpstan": "1.12.*",
         "phpstan/phpstan-beberlei-assert": "1.1.*",
+        "phpstan/phpstan-mockery": "1.1.*",
         "rector/rector": "1.2.*",
         "robertfausk/mink-panther-driver": "1.1.*",
         "squizlabs/php_codesniffer": "3.10.*",
@@ -543,6 +1481,9 @@
         ],
         "rector:exec": [
           "rector process --debug"
+        ],
+        "symfony:check:ci": [
+          "php bin/console lint:yaml config src --parse-tags && php bin/console lint:container"
         ]
       },
       "license": [
@@ -972,6 +1913,50 @@
       "time": "2022-12-14T13:27:59+00:00"
     },
     {
+      "name": "daverandom/libdns",
+      "version": "v2.1.0",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/DaveRandom/LibDNS.git",
+        "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/DaveRandom/LibDNS/zipball/b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+        "reference": "b84c94e8fe6b7ee4aecfe121bfe3b6177d303c8a",
+        "shasum": ""
+      },
+      "require": {
+        "ext-ctype": "*",
+        "php": ">=7.1"
+      },
+      "suggest": {
+        "ext-intl": "Required for IDN support"
+      },
+      "type": "library",
+      "autoload": {
+        "files": [
+          "src/functions.php"
+        ],
+        "psr-4": {
+          "LibDNS\\": "src/"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "description": "DNS protocol implementation written in pure PHP",
+      "keywords": [
+        "dns"
+      ],
+      "support": {
+        "issues": "https://github.com/DaveRandom/LibDNS/issues",
+        "source": "https://github.com/DaveRandom/LibDNS/tree/v2.1.0"
+      },
+      "time": "2024-04-12T12:12:48+00:00"
+    },
+    {
       "name": "dealerdirect/phpcodesniffer-composer-installer",
       "version": "v1.0.0",
       "source": {
@@ -1124,6 +2109,112 @@
         "source": "https://github.com/doctrine/annotations/tree/1.14.4"
       },
       "time": "2024-09-05T10:15:52+00:00"
+    },
+    {
+      "name": "doctrine/dbal",
+      "version": "4.2.4",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/doctrine/dbal.git",
+        "reference": "b37d160498ea91a2382a2ebe825c4ea6254fc0ec"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/doctrine/dbal/zipball/b37d160498ea91a2382a2ebe825c4ea6254fc0ec",
+        "reference": "b37d160498ea91a2382a2ebe825c4ea6254fc0ec",
+        "shasum": ""
+      },
+      "require": {
+        "doctrine/deprecations": "^0.5.3|^1",
+        "php": "^8.1",
+        "psr/cache": "^1|^2|^3",
+        "psr/log": "^1|^2|^3"
+      },
+      "require-dev": {
+        "doctrine/coding-standard": "13.0.0",
+        "fig/log-test": "^1",
+        "jetbrains/phpstorm-stubs": "2023.2",
+        "phpstan/phpstan": "2.1.17",
+        "phpstan/phpstan-phpunit": "2.0.6",
+        "phpstan/phpstan-strict-rules": "^2",
+        "phpunit/phpunit": "10.5.46",
+        "slevomat/coding-standard": "8.16.2",
+        "squizlabs/php_codesniffer": "3.13.1",
+        "symfony/cache": "^6.3.8|^7.0",
+        "symfony/console": "^5.4|^6.3|^7.0"
+      },
+      "suggest": {
+        "symfony/console": "For helpful console commands such as SQL execution and import of files."
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Doctrine\\DBAL\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Guilherme Blanco",
+          "email": "guilhermeblanco@gmail.com"
+        },
+        {
+          "name": "Roman Borschel",
+          "email": "roman@code-factory.org"
+        },
+        {
+          "name": "Benjamin Eberlei",
+          "email": "kontakt@beberlei.de"
+        },
+        {
+          "name": "Jonathan Wage",
+          "email": "jonwage@gmail.com"
+        }
+      ],
+      "description": "Powerful PHP database abstraction layer (DBAL) with many features for database schema introspection and management.",
+      "homepage": "https://www.doctrine-project.org/projects/dbal.html",
+      "keywords": [
+        "abstraction",
+        "database",
+        "db2",
+        "dbal",
+        "mariadb",
+        "mssql",
+        "mysql",
+        "oci8",
+        "oracle",
+        "pdo",
+        "pgsql",
+        "postgresql",
+        "queryobject",
+        "sasql",
+        "sql",
+        "sqlite",
+        "sqlserver",
+        "sqlsrv"
+      ],
+      "support": {
+        "issues": "https://github.com/doctrine/dbal/issues",
+        "source": "https://github.com/doctrine/dbal/tree/4.2.4"
+      },
+      "funding": [
+        {
+          "url": "https://www.doctrine-project.org/sponsorship.html",
+          "type": "custom"
+        },
+        {
+          "url": "https://www.patreon.com/phpdoctrine",
+          "type": "patreon"
+        },
+        {
+          "url": "https://tidelift.com/funding/github/packagist/doctrine%2Fdbal",
+          "type": "tidelift"
+        }
+      ],
+      "time": "2025-06-15T23:15:01+00:00"
     },
     {
       "name": "doctrine/deprecations",
@@ -1693,6 +2784,69 @@
         }
       ],
       "time": "2024-09-25T12:00:00+00:00"
+    },
+    {
+      "name": "firebase/php-jwt",
+      "version": "v6.11.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/firebase/php-jwt.git",
+        "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+        "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+        "shasum": ""
+      },
+      "require": {
+        "php": "^8.0"
+      },
+      "require-dev": {
+        "guzzlehttp/guzzle": "^7.4",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.5",
+        "psr/cache": "^2.0||^3.0",
+        "psr/http-client": "^1.0",
+        "psr/http-factory": "^1.0"
+      },
+      "suggest": {
+        "ext-sodium": "Support EdDSA (Ed25519) signatures",
+        "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+      },
+      "type": "library",
+      "autoload": {
+        "psr-4": {
+          "Firebase\\JWT\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "BSD-3-Clause"
+      ],
+      "authors": [
+        {
+          "name": "Neuman Vong",
+          "email": "neuman+pear@twilio.com",
+          "role": "Developer"
+        },
+        {
+          "name": "Anant Narayanan",
+          "email": "anant@php.net",
+          "role": "Developer"
+        }
+      ],
+      "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+      "homepage": "https://github.com/firebase/php-jwt",
+      "keywords": [
+        "jwt",
+        "php"
+      ],
+      "support": {
+        "issues": "https://github.com/firebase/php-jwt/issues",
+        "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
+      },
+      "time": "2025-04-09T20:32:01+00:00"
     },
     {
       "name": "friendsofphp/php-cs-fixer",
@@ -2545,6 +3699,64 @@
       "time": "2024-07-06T21:00:26+00:00"
     },
     {
+      "name": "kelunik/certificate",
+      "version": "v1.1.3",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/kelunik/certificate.git",
+        "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/kelunik/certificate/zipball/7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+        "reference": "7e00d498c264d5eb4f78c69f41c8bd6719c0199e",
+        "shasum": ""
+      },
+      "require": {
+        "ext-openssl": "*",
+        "php": ">=7.0"
+      },
+      "require-dev": {
+        "amphp/php-cs-fixer-config": "^2",
+        "phpunit/phpunit": "^6 | 7 | ^8 | ^9"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "psr-4": {
+          "Kelunik\\Certificate\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Niklas Keller",
+          "email": "me@kelunik.com"
+        }
+      ],
+      "description": "Access certificate details and transform between different formats.",
+      "keywords": [
+        "DER",
+        "certificate",
+        "certificates",
+        "openssl",
+        "pem",
+        "x509"
+      ],
+      "support": {
+        "issues": "https://github.com/kelunik/certificate/issues",
+        "source": "https://github.com/kelunik/certificate/tree/v1.1.3"
+      },
+      "time": "2023-02-03T21:26:53+00:00"
+    },
+    {
       "name": "league/openapi-psr7-validator",
       "version": "0.17",
       "source": {
@@ -2775,6 +3987,76 @@
         }
       ],
       "time": "2021-06-28T04:27:21+00:00"
+    },
+    {
+      "name": "league/uri-parser",
+      "version": "1.4.1",
+      "source": {
+        "type": "git",
+        "url": "https://github.com/thephpleague/uri-parser.git",
+        "reference": "671548427e4c932352d9b9279fdfa345bf63fa00"
+      },
+      "dist": {
+        "type": "zip",
+        "url": "https://api.github.com/repos/thephpleague/uri-parser/zipball/671548427e4c932352d9b9279fdfa345bf63fa00",
+        "reference": "671548427e4c932352d9b9279fdfa345bf63fa00",
+        "shasum": ""
+      },
+      "require": {
+        "php": ">=7.0.0"
+      },
+      "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.0",
+        "phpstan/phpstan": "^0.9.2",
+        "phpstan/phpstan-phpunit": "^0.9.4",
+        "phpstan/phpstan-strict-rules": "^0.9.0",
+        "phpunit/phpunit": "^6.0"
+      },
+      "suggest": {
+        "ext-intl": "Allow parsing RFC3987 compliant hosts",
+        "league/uri-schemes": "Allow validating and normalizing URI parsing results"
+      },
+      "type": "library",
+      "extra": {
+        "branch-alias": {
+          "dev-master": "1.x-dev"
+        }
+      },
+      "autoload": {
+        "files": [
+          "src/functions_include.php"
+        ],
+        "psr-4": {
+          "League\\Uri\\": "src"
+        }
+      },
+      "notification-url": "https://packagist.org/downloads/",
+      "license": [
+        "MIT"
+      ],
+      "authors": [
+        {
+          "name": "Ignace Nyamagana Butera",
+          "email": "nyamsprod@gmail.com",
+          "homepage": "https://nyamsprod.com"
+        }
+      ],
+      "description": "userland URI parser RFC 3986 compliant",
+      "homepage": "https://github.com/thephpleague/uri-parser",
+      "keywords": [
+        "parse_url",
+        "parser",
+        "rfc3986",
+        "rfc3987",
+        "uri",
+        "url"
+      ],
+      "support": {
+        "issues": "https://github.com/thephpleague/uri-parser/issues",
+        "source": "https://github.com/thephpleague/uri-parser/tree/master"
+      },
+      "abandoned": "league/uri-interfaces",
+      "time": "2018-11-22T07:55:51+00:00"
     },
     {
       "name": "monolog/monolog",
@@ -6979,84 +8261,6 @@
         }
       ],
       "time": "2020-09-28T06:39:44+00:00"
-    },
-    {
-      "name": "sensio/framework-extra-bundle",
-      "version": "v6.2.10",
-      "source": {
-        "type": "git",
-        "url": "https://github.com/sensiolabs/SensioFrameworkExtraBundle.git",
-        "reference": "2f886f4b31f23c76496901acaedfedb6936ba61f"
-      },
-      "dist": {
-        "type": "zip",
-        "url": "https://api.github.com/repos/sensiolabs/SensioFrameworkExtraBundle/zipball/2f886f4b31f23c76496901acaedfedb6936ba61f",
-        "reference": "2f886f4b31f23c76496901acaedfedb6936ba61f",
-        "shasum": ""
-      },
-      "require": {
-        "doctrine/annotations": "^1.0|^2.0",
-        "php": ">=7.2.5",
-        "symfony/config": "^4.4|^5.0|^6.0",
-        "symfony/dependency-injection": "^4.4|^5.0|^6.0",
-        "symfony/framework-bundle": "^4.4|^5.0|^6.0",
-        "symfony/http-kernel": "^4.4|^5.0|^6.0"
-      },
-      "conflict": {
-        "doctrine/doctrine-cache-bundle": "<1.3.1",
-        "doctrine/persistence": "<1.3"
-      },
-      "require-dev": {
-        "doctrine/dbal": "^2.10|^3.0",
-        "doctrine/doctrine-bundle": "^1.11|^2.0",
-        "doctrine/orm": "^2.5",
-        "symfony/browser-kit": "^4.4|^5.0|^6.0",
-        "symfony/doctrine-bridge": "^4.4|^5.0|^6.0",
-        "symfony/dom-crawler": "^4.4|^5.0|^6.0",
-        "symfony/expression-language": "^4.4|^5.0|^6.0",
-        "symfony/finder": "^4.4|^5.0|^6.0",
-        "symfony/monolog-bridge": "^4.0|^5.0|^6.0",
-        "symfony/monolog-bundle": "^3.2",
-        "symfony/phpunit-bridge": "^4.4.9|^5.0.9|^6.0",
-        "symfony/security-bundle": "^4.4|^5.0|^6.0",
-        "symfony/twig-bundle": "^4.4|^5.0|^6.0",
-        "symfony/yaml": "^4.4|^5.0|^6.0",
-        "twig/twig": "^1.34|^2.4|^3.0"
-      },
-      "type": "symfony-bundle",
-      "extra": {
-        "branch-alias": {
-          "dev-master": "6.1.x-dev"
-        }
-      },
-      "autoload": {
-        "psr-4": {
-          "Sensio\\Bundle\\FrameworkExtraBundle\\": "src/"
-        },
-        "exclude-from-classmap": [
-          "/tests/"
-        ]
-      },
-      "notification-url": "https://packagist.org/downloads/",
-      "license": [
-        "MIT"
-      ],
-      "authors": [
-        {
-          "name": "Fabien Potencier",
-          "email": "fabien@symfony.com"
-        }
-      ],
-      "description": "This bundle provides a way to configure your controllers with annotations",
-      "keywords": [
-        "annotations",
-        "controllers"
-      ],
-      "support": {
-        "source": "https://github.com/sensiolabs/SensioFrameworkExtraBundle/tree/v6.2.10"
-      },
-      "abandoned": "Symfony",
-      "time": "2023-02-24T14:57:12+00:00"
     },
     {
       "name": "smarty-gettext/smarty-gettext",
@@ -11871,7 +13075,7 @@
   },
   "prefer-stable": false,
   "prefer-lowest": false,
-  "platform": [],
+  "platform": {},
   "platform-dev": {
     "ext-json": "*",
     "ext-openssl": "*"


### PR DESCRIPTION
## Description

update composer centreon/centreon dependency following removal of FrameworkExtraBundle

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
