### PR TITLE
fix(export) default centengine.cfg file version is legacy

### DIFF
--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -326,7 +326,7 @@ class Engine extends AbstractObject
         $pollerStmt->execute();
         $pollerVersion = $pollerStmt->fetchColumn();
 
-        if ($pollerVersion !== false && version_compare($pollerVersion, '25.05.0', '<')) {
+        if ($pollerVersion === false || version_compare($pollerVersion, '25.05.0', '<')) {
             $this->engine['broker_module'][] = '/usr/lib64/nagios/cbmod.so ' . $this->engine['broker_module_cfg_file'];
             unset($this->engine['broker_module_cfg_file']);
         }


### PR DESCRIPTION
## Description

Fix centengine.cfg generation to be legacy version when poller version is unknown

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
