### PR TITLE
[Symfony 7][Security-Bundle] remove deprecation for symfony/security-bundle

### DIFF
--- a/centreon/config/packages/security.yaml
+++ b/centreon/config/packages/security.yaml
@@ -1,6 +1,4 @@
 security:
-    # https://symfony.com/doc/current/security.html#where-do-users-come-from-user-providers
-    enable_authenticator_manager: true
     access_decision_manager:
         strategy: unanimous
         allow_if_all_abstain: false


### PR DESCRIPTION
## Description

Remove deprecation for symfony/security-bundle

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
