### PR TITLE
Fix a HTTP 500 error on view by host when there are no metrics

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/API/FindResourcesByParent/FindResourcesByParentPresenter.php
+++ b/centreon/src/Core/Resources/Infrastructure/API/FindResourcesByParent/FindResourcesByParentPresenter.php
@@ -172,7 +172,7 @@ class FindResourcesByParentPresenter extends AbstractPresenter implements FindRe
                 'downtime' => $endpoints['downtime'],
                 'check' => $endpoints['check'],
                 'forced_check' => $endpoints['forced_check'],
-                'metrics' => $endpoints['metrics'],
+                'metrics' => $endpoints['metrics'] ?? null,
             ],
             'uris' => $this->hypermediaCreator->createInternalUris($parameters),
             'externals' => [


### PR DESCRIPTION
## Description

Fix: [MON-174100](https://centreon.atlassian.net/browse/MON-174100)

[MON-174100]: https://centreon.atlassian.net/browse/MON-174100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ