### PR TITLE
test(e2e): Ignore large volume Notification Rule scenario in Cloud no…

### DIFF
--- a/centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature
+++ b/centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature
@@ -27,6 +27,7 @@ Feature: Creating a Notification Rule
       | contact_settings | resource_type                           |
       | two contacts     | host group and services for these hosts |
 
+  @ignore
   @TEST_MON-33204
   Scenario Outline: Creating a large volume Notification Rule for <contact_settings>
     Given a minimum of 1000 services linked to a host group and '<contact_settings>'


### PR DESCRIPTION
This pull request includes a small change to the `centreon/tests/e2e/features/Cloud-notifications/01-notification-create.feature` file. The change adds the `@ignore` tag to a specific scenario outline for creating a large-volume notification rule.
## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
