### PR TITLE
fix(ha-sudoers): add sudoers file to monitor the cluster

### DIFF
--- a/centreon-ha/etc/sudoers.d/centreon-cluster-monitoring
+++ b/centreon-ha/etc/sudoers.d/centreon-cluster-monitoring
@@ -1,0 +1,18 @@
+## BEGIN: CLUSTER-MONITORING SUDO
+
+User_Alias      CLUSTER-MONITORING=%centreon
+Defaults:CLUSTER-MONITORING !requiretty
+
+# crm_mon
+CLUSTER-MONITORING   ALL = NOPASSWD: /usr/sbin/crm_mon -1 -r -f 2>&1
+
+# clustat
+CLUSTER-MONITORING   ALL = NOPASSWD: /usr/sbin/clustat -x 2>&1
+
+# constraints
+CLUSTER-MONITORING   ALL = NOPASSWD: /usr/sbin/crm_resource --constraints -r centreon
+CLUSTER-MONITORING   ALL = NOPASSWD: /usr/sbin/crm_resource --constraints -r ms_mysql-clone
+CLUSTER-MONITORING   ALL = NOPASSWD: /usr/sbin/crm_resource --constraints -r php-clone
+CLUSTER-MONITORING   ALL = NOPASSWD: /usr/sbin/crm_resource --constraints -r cbd_rrd-clone
+
+## END: CLUSTER-MONITORING SUDO

--- a/centreon-ha/packaging/centreon-ha.spectemplate
+++ b/centreon-ha/packaging/centreon-ha.spectemplate
@@ -83,6 +83,7 @@ This package provides the scripts and config files necessary for database and ce
 %config(noreplace) %{_sysconfdir}/centreon-ha/mysql-resources.sh
 %{_sysconfdir}/logrotate.d/centreon-ha
 %{_sysconfdir}/sudoers.d/centreon-cluster-db
+%{_sysconfdir}/sudoers.d/centreon-cluster-monitoring
 
 # lib
 %defattr(-, root, root, -)

--- a/centreon-ha/packaging/debian/centreon-ha-common.install
+++ b/centreon-ha/packaging/debian/centreon-ha-common.install
@@ -1,5 +1,5 @@
 etc/centreon-ha/*                       etc/centreon-ha
-etc/sudoers.d/centreon-cluster-db       etc/sudoers.d
+etc/sudoers.d/centreon-cluster-*       etc/sudoers.d
 ocf-scripts/mariadb-centreon            usr/lib/ocf/resource.d/heartbeat
 ocf-scripts/mariadb-centreon-common.sh  usr/lib/ocf/lib/heartbeat
 bin/*                                   usr/share/centreon-ha/bin

--- a/centreon-ha/packaging/debian/centreon-ha-common.install
+++ b/centreon-ha/packaging/debian/centreon-ha-common.install
@@ -1,5 +1,5 @@
 etc/centreon-ha/*                       etc/centreon-ha
-etc/sudoers.d/centreon-cluster-*       etc/sudoers.d
+etc/sudoers.d/centreon-cluster-*        etc/sudoers.d
 ocf-scripts/mariadb-centreon            usr/lib/ocf/resource.d/heartbeat
 ocf-scripts/mariadb-centreon-common.sh  usr/lib/ocf/lib/heartbeat
 bin/*                                   usr/share/centreon-ha/bin


### PR DESCRIPTION
## Description

When monitoring the cluster with the Centreon plugin we can see errors in corosync.log.
Adding a dedicated sudoers avoid these errors.

**Fixes** # MON-15980

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
