### PR TITLE
enh(packaging): package console.new

### DIFF
--- a/centreon/packaging/centreon-web.yaml
+++ b/centreon/packaging/centreon-web.yaml
@@ -227,6 +227,13 @@ contents:
       group: "centreon"
       mode: 0755
 
+  - src: "../bin/console.new"
+    dst: "/usr/share/centreon/bin/console.new"
+    file_info:
+      owner: "centreon"
+      group: "centreon"
+      mode: 0755
+
   - src: "../bin/migration"
     dst: "/usr/share/centreon/bin/migration"
     file_info:


### PR DESCRIPTION
This PR intends to package the bin/console.new file that was missing from centreon-web package