### PR TITLE
[23.10.X] fix(core) Allow User Session to be empty

### DIFF
--- a/centreon/src/Core/Application/Configuration/User/UseCase/PatchUser/PatchUser.php
+++ b/centreon/src/Core/Application/Configuration/User/UseCase/PatchUser/PatchUser.php
@@ -135,12 +135,16 @@ final class PatchUser
 
         foreach ($userSessionIds as $sessionId) {
             /**
-             * @var \Centreon $centreon
+             * @var \Centreon|null $centreon
              */
             $centreon = $this->readSessionRepository->getValueFromSession(
                 $sessionId,
                 'centreon'
             );
+            if ($centreon === null) {
+                continue;
+            }
+
             $centreon->user->theme = $request->theme;
             $this->writeSessionRepository->updateSession(
                 $sessionId,


### PR DESCRIPTION
## Description

This PR fixes the session updateUserSessions function to allow use cases when session is empty.

**Fixes** #7704 

## Type of change

- [X] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [X] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

You can test this issue by ensuring that PHP session is empty (most likely by restarting php services), then trying to update the user profile like with the Dark/Light mode option on the top right of the centreon web.

## Checklist

#### Community contributors & Centreon team

- [X] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
