### PR TITLE
fix(packaging): fix centreon-web packaging dependency to centreon-per…

### DIFF
--- a/centreon/packaging/centreon-trap.yaml
+++ b/centreon/packaging/centreon-trap.yaml
@@ -74,7 +74,8 @@ scripts:
 overrides:
   rpm:
     depends:
-      - centreon-perl-libs
+      - centreon-perl-libs >= ${MAJOR_VERSION}
+      - centreon-perl-libs < ${NEXT_MAJOR_VERSION}
       - net-snmp
       - perl(SNMP)
     replaces:
@@ -82,7 +83,8 @@ overrides:
       - centreon-trap-poller
   deb:
     depends:
-      - centreon-perl-libs
+      - "centreon-perl-libs (>= ${MAJOR_VERSION}~)"
+      - "centreon-perl-libs (<< ${NEXT_MAJOR_VERSION}~)"
       - libsnmp-perl
       - snmptrapd
       - snmpd

--- a/centreon/packaging/centreon-web.yaml
+++ b/centreon/packaging/centreon-web.yaml
@@ -427,7 +427,8 @@ overrides:
     depends:
       - centreon-common >= ${MAJOR_VERSION}
       - centreon-common < ${NEXT_MAJOR_VERSION}
-      - centreon-perl-libs
+      - centreon-perl-libs >= ${MAJOR_VERSION}
+      - centreon-perl-libs < ${NEXT_MAJOR_VERSION}
       - centreon-poller = ${VERSION}-${RELEASE}${DIST}
       - centreon-broker-cbd >= ${MAJOR_VERSION}
       - centreon-broker-cbd < ${NEXT_MAJOR_VERSION}
@@ -514,7 +515,8 @@ overrides:
     depends:
       - "centreon-common (>= ${MAJOR_VERSION}~)"
       - "centreon-common (<< ${NEXT_MAJOR_VERSION}~)"
-      - centreon-perl-libs
+      - "centreon-perl-libs (>= ${MAJOR_VERSION}~)"
+      - "centreon-perl-libs (<< ${NEXT_MAJOR_VERSION}~)"
       - centreon-poller (= ${VERSION}-${RELEASE}${DIST})
       - "centreon-broker-cbd (>= ${MAJOR_VERSION}~)"
       - "centreon-broker-cbd (<< ${NEXT_MAJOR_VERSION}~)"


### PR DESCRIPTION
…l-libs

## Description

backport https://github.com/centreon/centreon/pull/7740

* fix dependency between centreon-web and centreon-perl-libs, to avoid requiring "any" major version of centreon-perl-libs
Fixes #MON-174686 #MON-174789

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
