### PR TITLE
fix(cfg) service deploy endpoint should not copy inherited command and args

### DIFF
--- a/centreon/src/Core/Service/Application/UseCase/DeployServices/DeployServices.php
+++ b/centreon/src/Core/Service/Application/UseCase/DeployServices/DeployServices.php
@@ -216,7 +216,7 @@ final class DeployServices
                     $service = new NewService(
                         $serviceTemplate->getAlias(),
                         $hostId,
-                        $serviceTemplate->getCommandId()
+                        null // command line must be inherited from template when you deploy services from a host
                     );
                     $service->setServiceTemplateParentId($serviceTemplate->getId());
                     $service->setActivated(true);


### PR DESCRIPTION
## Description

/deploy endpoint from api v2 is setting command on the service that it generates and it should not. 

it breaks $ARGn$ macro mechanism when the value is supposed to be set on a parent template of the service.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master
