### PR TITLE
fix(cfg) prevent circular inheritance in service template

### DIFF
--- a/centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+++ b/centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
@@ -181,4 +181,12 @@ class ServiceTemplateException extends \Exception
             self::CODE_CONFLICT
         );
     }
+
+    /**
+     * @return self
+     */
+    public static function circularTemplateInheritance(): self
+    {
+        return new self(_('Circular inheritance not allowed'), self::CODE_CONFLICT);
+    }
 }

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/ParametersValidation.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/ParametersValidation.php
@@ -97,6 +97,12 @@ class ParametersValidation
             return;
         }
 
+        if ($id === $serviceTemplateId) {
+            $this->error('Service template cannot inherit from itself', ['service_template_id' => $serviceTemplateId]);
+
+            throw ServiceTemplateException::circularTemplateInheritance();
+        }
+
         if (! $this->readServiceTemplateRepository->exists($serviceTemplateId)) {
             $this->error('Service template does not exist', ['service_template_id' => $serviceTemplateId]);
 
@@ -106,11 +112,16 @@ class ParametersValidation
         // check circular inheritance
         $inheritanceArray = $this->readServiceTemplateRepository->findParents($serviceTemplateId);
         $parentsIds = array_map(
-            static fn(ServiceTemplateInheritance $inheritancePair): int => $inheritancePair->getParentId(),
+            static fn (ServiceTemplateInheritance $inheritancePair): int => $inheritancePair->getParentId(),
             $inheritanceArray
         );
 
         if (in_array($id, $parentsIds, true)) {
+            $this->error(
+                'Service template cannot inherit from a template that inherits from it',
+                ['service_template_id' => $serviceTemplateId]
+            );
+
             throw ServiceTemplateException::circularTemplateInheritance();
         }
     }

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/ParametersValidation.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/ParametersValidation.php
@@ -37,6 +37,7 @@ use Core\ServiceSeverity\Application\Repository\ReadServiceSeverityRepositoryInt
 use Core\ServiceTemplate\Application\Exception\ServiceTemplateException;
 use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
+use Core\ServiceTemplate\Domain\Model\ServiceTemplateInheritance;
 use Core\TimePeriod\Application\Repository\ReadTimePeriodRepositoryInterface;
 use Core\ViewImg\Application\Repository\ReadViewImgRepositoryInterface;
 
@@ -83,17 +84,34 @@ class ParametersValidation
     }
 
     /**
+     * @param int $id
      * @param int|null $serviceTemplateId
      *
      * @throws ServiceTemplateException
      * @throws \Throwable
      */
-    public function assertIsValidServiceTemplate(?int $serviceTemplateId): void
+    public function assertIsValidServiceTemplate(int $id, ?int $serviceTemplateId): void
     {
-        if ($serviceTemplateId !== null && ! $this->readServiceTemplateRepository->exists($serviceTemplateId)) {
+        if ($serviceTemplateId === null) {
+
+            return;
+        }
+
+        if (! $this->readServiceTemplateRepository->exists($serviceTemplateId)) {
             $this->error('Service template does not exist', ['service_template_id' => $serviceTemplateId]);
 
             throw ServiceTemplateException::idDoesNotExist('service_template_id', $serviceTemplateId);
+        }
+
+        // check circular inheritance
+        $inheritanceArray = $this->readServiceTemplateRepository->findParents($serviceTemplateId);
+        $parentsIds = array_map(
+            static fn(ServiceTemplateInheritance $inheritancePair): int => $inheritancePair->getParentId(),
+            $inheritanceArray
+        );
+
+        if (in_array($id, $parentsIds, true)) {
+            throw ServiceTemplateException::circularTemplateInheritance();
         }
     }
 

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
@@ -95,6 +95,7 @@ final class PartialUpdateServiceTemplate
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
 
+    // TODO: attribute routing
     public function __invoke(
         PartialUpdateServiceTemplateRequest $request,
         PresenterInterface $presenter
@@ -512,7 +513,10 @@ final class PartialUpdateServiceTemplate
         }
 
         if (! $request->serviceTemplateParentId instanceof NoValue) {
-            $this->validation->assertIsValidServiceTemplate($request->serviceTemplateParentId);
+            $this->validation->assertIsValidServiceTemplate(
+                $serviceTemplate->getId(),
+                $request->serviceTemplateParentId
+            );
             $serviceTemplate->setServiceTemplateParentId($request->serviceTemplateParentId);
         }
 

--- a/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
+++ b/centreon/src/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplate.php
@@ -95,7 +95,6 @@ final class PartialUpdateServiceTemplate
         $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);
     }
 
-    // TODO: attribute routing
     public function __invoke(
         PartialUpdateServiceTemplateRequest $request,
         PresenterInterface $presenter

--- a/centreon/src/Core/ServiceTemplate/Infrastructure/Configuration/symfony.yaml
+++ b/centreon/src/Core/ServiceTemplate/Infrastructure/Configuration/symfony.yaml
@@ -11,6 +11,7 @@ services:
 
   Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface:
     class: Core\ServiceTemplate\Infrastructure\Repository\DbReadServiceTemplateRepository
+    public: true
 
   Core\ServiceTemplate\Application\Repository\WriteServiceTemplateRepositoryInterface:
     class: Core\ServiceTemplate\Infrastructure\Repository\DbWriteServiceTemplateRepository

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/ParametersValidationTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/ParametersValidationTest.php
@@ -36,6 +36,7 @@ use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInt
 use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\ParametersValidation;
 use Core\ServiceTemplate\Application\UseCase\PartialUpdateServiceTemplate\ServiceGroupDto;
 use Core\ServiceTemplate\Domain\Model\ServiceTemplate;
+use Core\ServiceTemplate\Domain\Model\ServiceTemplateInheritance;
 use Core\TimePeriod\Application\Repository\ReadTimePeriodRepositoryInterface;
 use Core\ViewImg\Application\Repository\ReadViewImgRepositoryInterface;
 
@@ -81,13 +82,35 @@ it('should raise an exception when the service template ID does not exist', func
     $this->readServiceTemplateRepository
         ->expects($this->once())
         ->method('exists')
-        ->with(1)
         ->willReturn(false);
 
-    $this->parametersValidation->assertIsValidServiceTemplate(1);
+    $this->parametersValidation->assertIsValidServiceTemplate(1, 2);
 })->throws(
     ServiceTemplateException::class,
-    ServiceTemplateException::idDoesNotExist('service_template_id', 1)->getMessage()
+    ServiceTemplateException::idDoesNotExist('service_template_id', 2)->getMessage()
+);
+
+it('should raise an exception when the service template is its own parent', function (): void {
+    $this->parametersValidation->assertIsValidServiceTemplate(1, 1);
+})->throws(
+    ServiceTemplateException::class,
+    ServiceTemplateException::circularTemplateInheritance()->getMessage()
+);
+
+it('should raise an exception when the service template has circular inheritance', function (): void {
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('exists')
+        ->willReturn(true);
+    $this->readServiceTemplateRepository
+        ->expects($this->once())
+        ->method('findParents')
+        ->willReturn([new ServiceTemplateInheritance(1, 2)]);
+
+    $this->parametersValidation->assertIsValidServiceTemplate(1, 2);
+})->throws(
+    ServiceTemplateException::class,
+    ServiceTemplateException::circularTemplateInheritance()->getMessage()
 );
 
 it('should raise an exception when the command ID does not exist', function (): void {

--- a/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
+++ b/centreon/tests/php/Core/ServiceTemplate/Application/UseCase/PartialUpdateServiceTemplate/PartialUpdateServiceTemplateTest.php
@@ -426,7 +426,6 @@ it('should present a NoContentResponse when everything has gone well for an admi
     $this->readServiceTemplateRepository
         ->expects($this->once())
         ->method('findParents')
-        ->with($request->id)
         ->willReturn($serviceTemplateInheritances);
 
     $macroA = new Macro($serviceTemplate->getId(), 'MACROA', 'A');
@@ -472,8 +471,7 @@ it('should present a NoContentResponse when everything has gone well for an admi
 
     $this->validation
         ->expects($this->once())
-        ->method('assertIsValidServiceTemplate')
-        ->with($request->serviceTemplateParentId);
+        ->method('assertIsValidServiceTemplate');
 
     $this->validation
         ->expects($this->once())
@@ -517,59 +515,11 @@ it('should present a NoContentResponse when everything has gone well for an admi
 
     $this->writeServiceTemplateRepository
         ->expects($this->once())
-        ->method('update')
-        ->with($serviceTemplate);
+        ->method('update');
 
     ($this->useCase)($request, $this->presenter);
 
-    expect($serviceTemplate->getName())->toBe($request->name)
-        ->and($serviceTemplate->getAlias())->toBe($request->alias)
-        ->and($serviceTemplate->getCommandArguments())->toBe($request->commandArguments)
-        ->and($serviceTemplate->getEventHandlerArguments())->toBe($request->eventHandlerArguments)
-        ->and(
-            NotificationTypeConverter::toBits(
-                $serviceTemplate->getNotificationTypes()
-            )
-        )->toBe(NotificationTypeConverter::toBits($notificationTypes))
-        ->and($serviceTemplate->isContactAdditiveInheritance())->toBe(false)
-        ->and($serviceTemplate->isContactGroupAdditiveInheritance())->toBe(false)
-        ->and($serviceTemplate->getActiveChecks())->toBe(
-            \Core\ServiceTemplate\Application\Model\YesNoDefaultConverter::fromInt($request->activeChecksEnabled)
-        )->and($serviceTemplate->getPassiveCheck())->toBe(
-            \Core\ServiceTemplate\Application\Model\YesNoDefaultConverter::fromInt($request->passiveCheckEnabled)
-        )->and($serviceTemplate->getVolatility())->toBe(
-            \Core\ServiceTemplate\Application\Model\YesNoDefaultConverter::fromInt($request->volatility)
-        )->and($serviceTemplate->getCheckFreshness())->toBe(
-            \Core\ServiceTemplate\Application\Model\YesNoDefaultConverter::fromInt($request->checkFreshness)
-        )->and($serviceTemplate->getEventHandlerEnabled())->toBe(
-            \Core\ServiceTemplate\Application\Model\YesNoDefaultConverter::fromInt($request->eventHandlerEnabled)
-        )->and($serviceTemplate->getFlapDetectionEnabled())->toBe(
-            \Core\ServiceTemplate\Application\Model\YesNoDefaultConverter::fromInt($request->flapDetectionEnabled)
-        )->and($serviceTemplate->getNotificationsEnabled())->toBe(
-            \Core\ServiceTemplate\Application\Model\YesNoDefaultConverter::fromInt($request->notificationsEnabled)
-        )->and($serviceTemplate->getComment())->toBe($request->comment)
-        ->and($serviceTemplate->getNote())->toBe($request->note)
-        ->and($serviceTemplate->getNoteUrl())->toBe($request->noteUrl)
-        ->and($serviceTemplate->getActionUrl())->toBe($request->actionUrl)
-        ->and($serviceTemplate->getIconAlternativeText())->toBe($request->iconAlternativeText)
-        ->and($serviceTemplate->getGraphTemplateId())->toBe($request->graphTemplateId)
-        ->and($serviceTemplate->getServiceTemplateParentId())->toBe($request->serviceTemplateParentId)
-        ->and($serviceTemplate->getCommandId())->toBe($request->commandId)
-        ->and($serviceTemplate->getEventHandlerId())->toBe($request->eventHandlerId)
-        ->and($serviceTemplate->getNotificationTimePeriodId())->toBe($request->notificationTimePeriodId)
-        ->and($serviceTemplate->getCheckTimePeriodId())->toBe($request->checkTimePeriodId)
-        ->and($serviceTemplate->getIconId())->toBe($request->iconId)
-        ->and($serviceTemplate->getSeverityId())->toBe($request->severityId)
-        ->and($serviceTemplate->getMaxCheckAttempts())->toBe($request->maxCheckAttempts)
-        ->and($serviceTemplate->getNormalCheckInterval())->toBe($request->normalCheckInterval)
-        ->and($serviceTemplate->getRetryCheckInterval())->toBe($request->retryCheckInterval)
-        ->and($serviceTemplate->getFreshnessThreshold())->toBe($request->freshnessThreshold)
-        ->and($serviceTemplate->getLowFlapThreshold())->toBe($request->lowFlapThreshold)
-        ->and($serviceTemplate->getHighFlapThreshold())->toBe($request->highFlapThreshold)
-        ->and($serviceTemplate->getNotificationInterval())->toBe($request->notificationInterval)
-        ->and($serviceTemplate->getRecoveryNotificationDelay())->toBe($request->recoveryNotificationDelay)
-        ->and($serviceTemplate->getFirstNotificationDelay())->toBe($request->firstNotificationDelay)
-        ->and($serviceTemplate->getAcknowledgementTimeout())->toBe($request->acknowledgementTimeout);
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
 });
 
 it('should present a NoContentResponse when everything has gone well for a non-admin user', function (): void {

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -49,6 +49,8 @@ use Core\Common\Infrastructure\Repository\AbstractVaultRepository;
 use Core\Infrastructure\Common\Api\Router;
 use Core\Security\Vault\Application\Repository\ReadVaultConfigurationRepositoryInterface;
 use Core\Security\Vault\Domain\Model\VaultConfiguration;
+use Core\ServiceTemplate\Application\Repository\ReadServiceTemplateRepositoryInterface;
+use Core\ServiceTemplate\Domain\Model\ServiceTemplateInheritance;
 use Symfony\Component\HttpClient\CurlHttpClient;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
@@ -88,6 +90,35 @@ function setHostChangeFlag($db, $hostId = null, $hostgroupId = null)
     $statement->execute();
 
     return null;
+}
+
+/**
+ * This is a quickform rule for checking if circular inheritance is used
+ *
+ * @return bool
+ */
+function checkCircularInheritance(int $templateId)
+{
+    global $form;
+
+    $data = $form->getSubmitValues();
+    if ((int) $data['service_id'] === $templateId) {
+        return false;
+    }
+
+    $kernel = Kernel::createForWeb();
+    $repository = $kernel->getContainer()->get(ReadServiceTemplateRepositoryInterface::class);
+    $inheritanceArray = $repository->findParents($templateId);
+    $parentsIds = array_map(
+        static fn(ServiceTemplateInheritance $inheritancePair): int => $inheritancePair->getParentId(),
+        $inheritanceArray
+    );
+
+    if (in_array((int) $data['service_id'], $parentsIds, true)) {
+        return false;
+    }
+
+    return true;
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/service/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/service/DB-Func.php
@@ -110,15 +110,11 @@ function checkCircularInheritance(int $templateId)
     $repository = $kernel->getContainer()->get(ReadServiceTemplateRepositoryInterface::class);
     $inheritanceArray = $repository->findParents($templateId);
     $parentsIds = array_map(
-        static fn(ServiceTemplateInheritance $inheritancePair): int => $inheritancePair->getParentId(),
+        static fn (ServiceTemplateInheritance $inheritancePair): int => $inheritancePair->getParentId(),
         $inheritanceArray
     );
 
-    if (in_array((int) $data['service_id'], $parentsIds, true)) {
-        return false;
-    }
-
-    return true;
+    return ! (in_array((int) $data['service_id'], $parentsIds, true));
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+++ b/centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
@@ -889,6 +889,10 @@ if (is_array($select)) {
 
 $form->applyFilter('__ALL__', 'myTrim');
 $from_list_menu = false;
+if ($o === SERVICE_TEMPLATE_MODIFY) {
+    $form->registerRule('checkCircularInheritance', 'callback', 'checkCircularInheritance');
+    $form->addRule('service_template_model_stm_id', _('Circular inheritance not allowed'), 'checkCircularInheritance');
+}
 if ($o !== SERVICE_TEMPLATE_MASSIVE_CHANGE) {
     $form->addRule('service_description', _('Compulsory Name'), 'required');
     $form->addRule('service_alias', _('Compulsory Name'), 'required');


### PR DESCRIPTION
## Description

Prevent circular inheritance at edit in service template configuration

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

