### PR TITLE
fix(agent configuration): edit error message for invalid field name to be more generic

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -6960,7 +6960,7 @@ msgstr ""
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #, php-format
-msgid "Filename '%s' (%s) is invalid"
+msgid "File path or format '%s' (%s) is invalid"
 msgstr ""
 
 #: centreon/www/include/configuration/configNagios/formNagios.php

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -8188,7 +8188,7 @@ msgstr ""
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #, php-format
-msgid "Filename '%s' (%s) is invalid"
+msgid "File path or format '%s' (%s) is invalid"
 msgstr ""
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
@@ -16844,7 +16844,7 @@ msgstr "Reconocimiento persistente en caso de cambio de estado no correcto"
 #  msgstr ""
 #  msgid "Changing the type of an existing poller/agent configuration is not allowed"
 #  msgstr ""
-#  msgid "Filename '%s' (%s) is invalid"
+#  msgid "File path or format '%s' (%s) is invalid"
 #  msgstr ""
 #  msgid "Poller ID #%d is the only one linked to poller/agent configuration ID #%d"
 #  msgstr ""

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -7061,7 +7061,7 @@ msgstr "La taille du fichier est trop grande"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #, php-format
-msgid "Filename '%s' (%s) is invalid"
+msgid "File path or format '%s' (%s) is invalid"
 msgstr "Le nom de fichier '%s' (%s) est invalide"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php

--- a/centreon/lang/messages.pot
+++ b/centreon/lang/messages.pot
@@ -7408,7 +7408,7 @@ msgstr ""
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #, php-format
-msgid "Filename '%s' (%s) is invalid"
+msgid "File path or format '%s' (%s) is invalid"
 msgstr ""
 
 #: centreon/www/include/configuration/configNagios/formNagios.php

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -7200,7 +7200,7 @@ msgstr ""
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #, php-format
-msgid "Filename '%s' (%s) is invalid"
+msgid "File path or format '%s' (%s) is invalid"
 msgstr ""
 
 #: centreon/www/include/configuration/configNagios/formNagios.php

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -7189,7 +7189,7 @@ msgstr ""
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #, php-format
-msgid "Filename '%s' (%s) is invalid"
+msgid "File path or format '%s' (%s) is invalid"
 msgstr ""
 
 #: centreon/www/include/configuration/configNagios/formNagios.php

--- a/centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
@@ -137,7 +137,7 @@ class AgentConfigurationException extends \Exception
     public static function invalidFilename(string $name, string $value): self
     {
         return new self(
-            sprintf(_("Filename '%s' (%s) is invalid"), $value, $name),
+            sprintf(_("File path or format '%s' (%s) is invalid"), $value, $name),
             self::CODE_CONFLICT
         );
     }


### PR DESCRIPTION
## Description

This PR intends to make error message for invalid paths for certificates and private keys fields

**Fixes** # ([MON-176301](https://centreon.atlassian.net/browse/MON-176301))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-176301]: https://centreon.atlassian.net/browse/MON-176301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ