### PR TITLE
enh(install/upgrade): manage creation of encryption ready column and writing in engine file

### DIFF
--- a/.github/docker/centreon-web/alma8/entrypoint/container.d/15-installation.sh
+++ b/.github/docker/centreon-web/alma8/entrypoint/container.d/15-installation.sh
@@ -35,6 +35,7 @@ if [ ! -f /etc/centreon/centreon.conf.php ] && [ -d /usr/share/centreon/www/inst
     fi
   fi
 
+  su apache -s /bin/bash -c "php createEngineContextConfiguration.php"
   su apache -s /bin/bash -c "php generationCache.php"
   cd -
 fi

--- a/.github/docker/centreon-web/alma9/entrypoint/container.d/15-installation.sh
+++ b/.github/docker/centreon-web/alma9/entrypoint/container.d/15-installation.sh
@@ -35,6 +35,7 @@ if [ ! -f /etc/centreon/centreon.conf.php ] && [ -d /usr/share/centreon/www/inst
     fi
   fi
 
+  su apache -s /bin/bash -c "php createEngineContextConfiguration.php"
   su apache -s /bin/bash -c "php generationCache.php"
   cd -
 fi

--- a/.github/docker/centreon-web/bookworm/entrypoint/container.d/15-installation.sh
+++ b/.github/docker/centreon-web/bookworm/entrypoint/container.d/15-installation.sh
@@ -35,6 +35,7 @@ if [ ! -f /etc/centreon/centreon.conf.php ] && [ -d /usr/share/centreon/www/inst
     fi
   fi
 
+  su www-data -s /bin/bash -c "php createEngineContextConfiguration.php"
   su www-data -s /bin/bash -c "php generationCache.php"
   cd -
 fi

--- a/.github/docker/centreon-web/jammy/entrypoint/container.d/15-installation.sh
+++ b/.github/docker/centreon-web/jammy/entrypoint/container.d/15-installation.sh
@@ -35,6 +35,7 @@ if [ ! -f /etc/centreon/centreon.conf.php ] && [ -d /usr/share/centreon/www/inst
     fi
   fi
 
+  su www-data -s /bin/bash -c "php createEngineContextConfiguration.php"
   su www-data -s /bin/bash -c "php generationCache.php"
   cd -
 fi

--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -123,6 +123,14 @@ services:
               arguments: ['%env(APP_SECRET)%']
         public: true
 
+    Core\Installation\Infrastructure\InstallationHelper:
+        public: true
+        arguments:
+          $appSecret: '%env(APP_SECRET)%'
+
+    Core\Engine\Application\Repository\EngineRepositoryInterface:
+        class: Core\Engine\Infrastructure\Repository\FsEngineRepository
+        public: true
 
     Core\Common\Application\Repository\WriteVaultRepositoryInterface:
         class: Core\Common\Infrastructure\Repository\WriteVaultRepository

--- a/centreon/config/packages/Centreon.yaml
+++ b/centreon/config/packages/Centreon.yaml
@@ -130,6 +130,8 @@ services:
 
     Core\Engine\Application\Repository\EngineRepositoryInterface:
         class: Core\Engine\Infrastructure\Repository\FsEngineRepository
+        arguments:
+            $engineContextPath: '%engine_context_path%'
         public: true
 
     Core\Common\Application\Repository\WriteVaultRepositoryInterface:

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -132,10 +132,6 @@ services:
         arguments:
             $defaultRedirectUri: '/monitoring/resources'
 
-    Core\Engine\Infrastructure\Repository\FsEngineRepository:
-        arguments:
-            $engineContextPath: '%engine_context_path%'
-
     EventSubscriber\CentreonEventSubscriber:
         arguments:
             $apiVersionLatest: '%api.version.latest%'

--- a/centreon/config/services.yaml
+++ b/centreon/config/services.yaml
@@ -18,6 +18,7 @@ parameters:
     validation_path: "%env(_CENTREON_PATH_)%config/packages/validator"
     centreon_path: "%env(_CENTREON_PATH_)%"
     centreon_etc_path: "%env(_CENTREON_ETC_)%"
+    engine_context_path: "/etc/centreon-engine/engine-context.json"
     vault_conf_path: "%centreon_var_lib%/vault/vault.json"
     centreon_install_path: "%centreon_path%/www/install"
     translation_path: "%centreon_path%/www/locale"
@@ -130,6 +131,10 @@ services:
     Core\Security\Authentication\Application\UseCase\Login\Login:
         arguments:
             $defaultRedirectUri: '/monitoring/resources'
+
+    Core\Engine\Infrastructure\Repository\FsEngineRepository:
+        arguments:
+            $engineContextPath: '%engine_context_path%'
 
     EventSubscriber\CentreonEventSubscriber:
         arguments:

--- a/centreon/config/symfony_serializer/Engine/EngineSecrets.yaml
+++ b/centreon/config/symfony_serializer/Engine/EngineSecrets.yaml
@@ -1,0 +1,6 @@
+Core\Engine\Domain\Model\EngineSecrets:
+    attributes:
+        firstKey:
+            serialized_name: app_secret
+        secondKey:
+            serialized_name: salt

--- a/centreon/src/Core/Engine/Application/Repository/EngineRepositoryInterface.php
+++ b/centreon/src/Core/Engine/Application/Repository/EngineRepositoryInterface.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\Engine\Application\Repository;
 
+use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\Common\Domain\Exception\RepositoryException;
 use Core\Engine\Domain\Model\EngineSecrets;
 
@@ -31,7 +32,7 @@ interface EngineRepositoryInterface
     /**
      * Get engine secrets.
      *
-     * @throws RepositoryException
+     * @throws RepositoryException|AssertionException
      * @return EngineSecrets
      */
     public function getEngineSecrets(): EngineSecrets;

--- a/centreon/src/Core/Engine/Application/Repository/EngineRepositoryInterface.php
+++ b/centreon/src/Core/Engine/Application/Repository/EngineRepositoryInterface.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Engine\Application\Repository;
+
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Engine\Domain\Model\EngineSecrets;
+
+interface EngineRepositoryInterface
+{
+    /**
+     * Get engine secrets.
+     *
+     * @return EngineSecrets
+     *
+     * @throws RepositoryException
+     */
+    public function getEngineSecrets(): EngineSecrets;
+
+    /**
+     * Update engine secrets.
+     *
+     * @throws RepositoryException
+     */
+    public function writeEngineSecrets(EngineSecrets $engineSecrets): void;
+
+    /**
+     * Check that Engine Context has content.
+     *
+     * @throws RepositoryException
+     */
+    public function engineSecretsHasContent(): bool;
+}
+

--- a/centreon/src/Core/Engine/Application/Repository/EngineRepositoryInterface.php
+++ b/centreon/src/Core/Engine/Application/Repository/EngineRepositoryInterface.php
@@ -31,9 +31,8 @@ interface EngineRepositoryInterface
     /**
      * Get engine secrets.
      *
-     * @return EngineSecrets
-     *
      * @throws RepositoryException
+     * @return EngineSecrets
      */
     public function getEngineSecrets(): EngineSecrets;
 
@@ -51,4 +50,3 @@ interface EngineRepositoryInterface
      */
     public function engineSecretsHasContent(): bool;
 }
-

--- a/centreon/src/Core/Engine/Domain/Model/EngineKey.php
+++ b/centreon/src/Core/Engine/Domain/Model/EngineKey.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Engine\Domain\Model;
+
+use Centreon\Domain\Common\Assertion\Assertion;
+
+final readonly class EngineKey
+{
+    public function __construct(public string $key) {
+        Assertion::notEmptyString($key, 'EngineSecrets::key');
+    }
+}
+

--- a/centreon/src/Core/Engine/Domain/Model/EngineKey.php
+++ b/centreon/src/Core/Engine/Domain/Model/EngineKey.php
@@ -27,8 +27,8 @@ use Centreon\Domain\Common\Assertion\Assertion;
 
 final readonly class EngineKey
 {
-    public function __construct(public string $key) {
+    public function __construct(public string $key)
+    {
         Assertion::notEmptyString($key, 'EngineSecrets::key');
     }
 }
-

--- a/centreon/src/Core/Engine/Domain/Model/EngineKey.php
+++ b/centreon/src/Core/Engine/Domain/Model/EngineKey.php
@@ -29,6 +29,6 @@ final readonly class EngineKey
 {
     public function __construct(public string $key)
     {
-        Assertion::notEmptyString($key, 'EngineSecrets::key');
+        Assertion::notEmptyString($key, 'EngineKey::key');
     }
 }

--- a/centreon/src/Core/Engine/Domain/Model/EngineSecrets.php
+++ b/centreon/src/Core/Engine/Domain/Model/EngineSecrets.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Engine\Domain\Model;
+
+final readonly class EngineSecrets
+{
+    public function __construct(
+        public EngineKey $firstKey,
+        public EngineKey $secondKey
+    ) {}
+}
+

--- a/centreon/src/Core/Engine/Domain/Model/EngineSecrets.php
+++ b/centreon/src/Core/Engine/Domain/Model/EngineSecrets.php
@@ -28,6 +28,6 @@ final readonly class EngineSecrets
     public function __construct(
         public EngineKey $firstKey,
         public EngineKey $secondKey
-    ) {}
+    ) {
+    }
 }
-

--- a/centreon/src/Core/Engine/Infrastructure/Repository/FsEngineRepository.php
+++ b/centreon/src/Core/Engine/Infrastructure/Repository/FsEngineRepository.php
@@ -43,12 +43,12 @@ final readonly class FsEngineRepository implements EngineRepositoryInterface
     ) {
         $this->filesystem = new Filesystem();
     }
+
     /**
      * Get engine secrets.
      *
-     * @return EngineSecrets
-     *
      * @throws RepositoryException|AssertionException
+     * @return EngineSecrets
      */
     public function getEngineSecrets(): EngineSecrets
     {
@@ -89,8 +89,7 @@ final readonly class FsEngineRepository implements EngineRepositoryInterface
                 'Unable to write content of engine-context file. check that file exists',
                 [
                     'path' => $this->engineContextPath,
-                    'content' => $engineContent,
-                    'exception' => $ex
+                    'exception' => $ex,
                 ]
             );
         } catch (ExceptionInterface $ex) {
@@ -104,7 +103,7 @@ final readonly class FsEngineRepository implements EngineRepositoryInterface
     public function engineSecretsHasContent(): bool
     {
         try {
-            return !empty($this->filesystem->readFile($this->engineContextPath));
+            return ! empty($this->filesystem->readFile($this->engineContextPath));
         } catch (IOException $ex) {
             throw new RepositoryException(
                 'Unable to get content of engine-context file. check that file exists',
@@ -113,4 +112,3 @@ final readonly class FsEngineRepository implements EngineRepositoryInterface
         }
     }
 }
-

--- a/centreon/src/Core/Engine/Infrastructure/Repository/FsEngineRepository.php
+++ b/centreon/src/Core/Engine/Infrastructure/Repository/FsEngineRepository.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 
 namespace Core\Engine\Infrastructure\Repository;
 
-use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\Common\Domain\Exception\RepositoryException;
 use Core\Engine\Application\Repository\EngineRepositoryInterface;
 use Core\Engine\Domain\Model\EngineKey;
@@ -44,12 +43,6 @@ final readonly class FsEngineRepository implements EngineRepositoryInterface
         $this->filesystem = new Filesystem();
     }
 
-    /**
-     * Get engine secrets.
-     *
-     * @throws RepositoryException|AssertionException
-     * @return EngineSecrets
-     */
     public function getEngineSecrets(): EngineSecrets
     {
         try {

--- a/centreon/src/Core/Engine/Infrastructure/Repository/FsEngineRepository.php
+++ b/centreon/src/Core/Engine/Infrastructure/Repository/FsEngineRepository.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Engine\Infrastructure\Repository;
+
+use Centreon\Domain\Common\Assertion\AssertionException;
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Engine\Application\Repository\EngineRepositoryInterface;
+use Core\Engine\Domain\Model\EngineKey;
+use Core\Engine\Domain\Model\EngineSecrets;
+use Symfony\Component\Filesystem\Exception\IOException;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Serializer\SerializerInterface;
+
+final readonly class FsEngineRepository implements EngineRepositoryInterface
+{
+    private Filesystem $filesystem;
+
+    public function __construct(
+        private string $engineContextPath,
+        private SerializerInterface $serializer
+    ) {
+        $this->filesystem = new Filesystem();
+    }
+    /**
+     * Get engine secrets.
+     *
+     * @return EngineSecrets
+     *
+     * @throws RepositoryException|AssertionException
+     */
+    public function getEngineSecrets(): EngineSecrets
+    {
+        try {
+            $engineContextContent = $this->filesystem->readFile($this->engineContextPath);
+            $engineContext = json_decode($engineContextContent, true, flags: JSON_THROW_ON_ERROR);
+
+            return new EngineSecrets(
+                new EngineKey($engineContext['app_secret']),
+                new EngineKey($engineContext['salt'])
+            );
+        } catch (IOException $ex) {
+            throw new RepositoryException(
+                'Unable to get content of engine-context file. check that file exists',
+                ['path' => $this->engineContextPath, 'exception' => $ex]
+            );
+        } catch (\JsonException $ex) {
+            throw new RepositoryException(
+                'engine-context file exists but JSON content is not well formated',
+                ['path' => $this->engineContextPath, 'exception' => $ex]
+            );
+        }
+    }
+
+    public function writeEngineSecrets(EngineSecrets $engineSecrets): void
+    {
+        try {
+            if ($this->engineSecretsHasContent()) {
+                throw new RepositoryException(
+                    'engine-context already has content, unable to write in the file',
+                    ['path' => $this->engineContextPath]
+                );
+            }
+            $engineContent = $this->serializer->serialize($engineSecrets, 'json');
+            $this->filesystem->dumpFile($this->engineContextPath, $engineContent);
+        } catch (IOException $ex) {
+            throw new RepositoryException(
+                'Unable to write content of engine-context file. check that file exists',
+                [
+                    'path' => $this->engineContextPath,
+                    'content' => $engineContent,
+                    'exception' => $ex
+                ]
+            );
+        }
+    }
+
+    public function engineSecretsHasContent(): bool
+    {
+        try {
+            return !empty($this->filesystem->readFile($this->engineContextPath));
+        } catch (IOException $ex) {
+            throw new RepositoryException(
+                'Unable to get content of engine-context file. check that file exists',
+                ['path' => $this->engineContextPath, 'exception' => $ex]
+            );
+        }
+    }
+}
+

--- a/centreon/src/Core/Engine/Infrastructure/Repository/FsEngineRepository.php
+++ b/centreon/src/Core/Engine/Infrastructure/Repository/FsEngineRepository.php
@@ -30,6 +30,7 @@ use Core\Engine\Domain\Model\EngineKey;
 use Core\Engine\Domain\Model\EngineSecrets;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 final readonly class FsEngineRepository implements EngineRepositoryInterface
@@ -91,6 +92,11 @@ final readonly class FsEngineRepository implements EngineRepositoryInterface
                     'content' => $engineContent,
                     'exception' => $ex
                 ]
+            );
+        } catch (ExceptionInterface $ex) {
+            throw new RepositoryException(
+                'Unable to serialize content for engine-context file',
+                ['path' => $this->engineContextPath, 'exception' => $ex]
             );
         }
     }

--- a/centreon/src/Core/Engine/Infrastructure/Serializer/EngineSecretsNormalizer.php
+++ b/centreon/src/Core/Engine/Infrastructure/Serializer/EngineSecretsNormalizer.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Engine\Infrastructure\Serializer;
+
+use Core\Engine\Domain\Model\EngineSecrets;
+use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class EngineSecretsNormalizer implements NormalizerInterface
+{
+    public function __construct(
+        #[Autowire(service: 'serializer.normalizer.object')]
+        private readonly NormalizerInterface $normalizer,
+    ) {
+    }
+
+    /**
+     * @param AgentConfiguration $object
+     * @param string|null $format
+     * @param array<string, mixed> $context
+     *
+     * @throws \Throwable
+     *
+     * @return array<string, mixed>
+     */
+    public function normalize(
+        mixed $object,
+        ?string $format = null,
+        array $context = []
+    ): array {
+        /** @var array<string, bool|float|int|string> $data */
+        $data = $this->normalizer->normalize($object, $format, $context);
+        $data = array_map(fn($property) => $property['key'], $data);
+
+        return $data;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     * @param mixed $data
+     * @param ?string $format
+     */
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
+    {
+        return $data instanceof EngineSecrets;
+    }
+
+    /**
+     * @param ?string $format
+     * @return array<class-string|'*'|'object'|string, bool|null>
+     */
+    public function getSupportedTypes(?string $format): array
+    {
+        return [
+            EngineSecrets::class => true,
+        ];
+    }
+}
+

--- a/centreon/src/Core/Engine/Infrastructure/Serializer/EngineSecretsNormalizer.php
+++ b/centreon/src/Core/Engine/Infrastructure/Serializer/EngineSecretsNormalizer.php
@@ -36,7 +36,7 @@ class EngineSecretsNormalizer implements NormalizerInterface
     }
 
     /**
-     * @param AgentConfiguration $object
+     * @param EngineSecrets $object
      * @param string|null $format
      * @param array<string, mixed> $context
      *
@@ -49,11 +49,10 @@ class EngineSecretsNormalizer implements NormalizerInterface
         ?string $format = null,
         array $context = []
     ): array {
-        /** @var array<string, bool|float|int|string> $data */
+        /** @var array{app_secret: array{key: string}, salt: array{key: string}} $data */
         $data = $this->normalizer->normalize($object, $format, $context);
-        $data = array_map(fn($property) => $property['key'], $data);
 
-        return $data;
+        return array_map(fn ($property) => $property['key'], $data);
     }
 
     /**
@@ -77,4 +76,3 @@ class EngineSecretsNormalizer implements NormalizerInterface
         ];
     }
 }
-

--- a/centreon/src/Core/Installation/Infrastructure/InstallationHelper.php
+++ b/centreon/src/Core/Installation/Infrastructure/InstallationHelper.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Installation\Infrastructure;
+
+use Core\Engine\Application\Repository\EngineRepositoryInterface;
+use Core\Engine\Domain\Model\EngineKey;
+use Core\Engine\Domain\Model\EngineSecrets;
+use Security\Interfaces\EncryptionInterface;
+
+final readonly class InstallationHelper
+{
+    public function __construct(
+        private EngineRepositoryInterface $engineRepository,
+        private EncryptionInterface $encryption,
+        private string $appSecret
+    ) {
+    }
+
+    /**
+     * Write Engine Secrets content in EngineContext File.
+     */
+    public function writeEngineContextFile(): void
+    {
+        $engineSecrets = new EngineSecrets(
+            firstKey: new EngineKey($this->appSecret),
+            secondKey: new EngineKey($this->encryption->generateRandomString())
+        );
+
+        $this->engineRepository->writeEngineSecrets($engineSecrets);
+    }
+
+}
+

--- a/centreon/src/Core/Installation/Infrastructure/InstallationHelper.php
+++ b/centreon/src/Core/Installation/Infrastructure/InstallationHelper.php
@@ -49,6 +49,4 @@ final readonly class InstallationHelper
 
         $this->engineRepository->writeEngineSecrets($engineSecrets);
     }
-
 }
-

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -1650,6 +1650,7 @@ CREATE TABLE `nagios_server` (
   `remote_id` int(11) NULL,
   `remote_server_use_as_proxy` enum('0','1') NOT NULL DEFAULT '1',
   `updated` enum('1','0') NOT NULL DEFAULT '0',
+  `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   CONSTRAINT `nagios_server_remote_id_id` FOREIGN KEY (`remote_id`) REFERENCES `nagios_server` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/centreon/www/install/installBroker.sql
+++ b/centreon/www/install/installBroker.sql
@@ -408,7 +408,7 @@ CREATE TABLE `instances` (
   `version` varchar(16) DEFAULT NULL,
   `deleted` boolean NOT NULL default false,
   `outdated` boolean NOT NULL default false,
-  `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '1',
+  `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '0',
   PRIMARY KEY (`instance_id`),
   KEY `instances_name_idx` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/centreon/www/install/installBroker.sql
+++ b/centreon/www/install/installBroker.sql
@@ -408,6 +408,7 @@ CREATE TABLE `instances` (
   `version` varchar(16) DEFAULT NULL,
   `deleted` boolean NOT NULL default false,
   `outdated` boolean NOT NULL default false,
+  `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '1',
   PRIMARY KEY (`instance_id`),
   KEY `instances_name_idx` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -61,15 +61,15 @@ $setEncryptionReadyToFalseByDefaultOnInstances = function () use ($pearDB, $pear
     $errorMessage = "Unable to update 'is_encryption_ready' column on 'nagios_server' table";
     /** @var CentreonDB $pearDB */
     $configDatabaseName = $pearDB->getConnectionConfig()->getDatabaseNameConfiguration();
-    $pearDBO->prepare(
+   $statement = $pearDBO->prepare(
         <<<'SQL'
             UPDATE instances SET `is_encryption_ready` = '0' WHERE `instance_id` IN (
                 SELECT `id` FROM `:db`.nagios_server WHERE `localhost` = '0'
             );
             SQL
     );
-    $pearDBO->bindValue(':db', $configDatabaseName, PDO::PARAM_STR);
-    $pearDBO->execute();
+    $statement->bindValue(':db', $configDatabaseName, PDO::PARAM_STR);
+    $statement->execute();
 };
 
 try {

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -61,7 +61,7 @@ $setEncryptionReadyToFalseByDefaultOnInstances = function () use ($pearDB, $pear
     $errorMessage = "Unable to update 'is_encryption_ready' column on 'nagios_server' table";
     /** @var CentreonDB $pearDB */
     $configDatabaseName = $pearDB->getConnectionConfig()->getDatabaseNameConfiguration();
-   $statement = $pearDBO->prepare(
+    $statement = $pearDBO->prepare(
         <<<'SQL'
             UPDATE instances SET `is_encryption_ready` = '0' WHERE `instance_id` IN (
                 SELECT `id` FROM `:db`.nagios_server WHERE `localhost` = '0'

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -31,7 +31,7 @@ $errorMessage = '';
 /**
  * Add Column Encryption ready for poller configuration
  */
-$addIsEncryptionReadyColumn = function () use ($pearDB, $pearDBO, &$errorMessage) {
+$addIsEncryptionReadyColumn = function () use ($pearDB, $pearDBO, &$errorMessage): void {
     if ($pearDB->isColumnExist('nagios_server', 'is_encryption_ready') !== 1) {
         $errorMessage = "Unable to add 'is_encryption_ready' column to 'nagios_server' table";
         $pearDB->query("ALTER TABLE `nagios_server` ADD COLUMN `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '1'");
@@ -45,7 +45,7 @@ $addIsEncryptionReadyColumn = function () use ($pearDB, $pearDBO, &$errorMessage
 /**
  * Set encryption ready to false by default for all existing pollers to ensure retrocompatibility
  */
-$setEncryptionReadyToFalseByDefaultOnNagiosServer = function () use ($pearDB, &$errorMessage) {
+$setEncryptionReadyToFalseByDefaultOnNagiosServer = function () use ($pearDB, &$errorMessage): void {
     $errorMessage = "Unable to update 'is_encryption_ready' column on 'nagios_server' table";
     $pearDB->executeQuery(
         <<<'SQL'
@@ -57,9 +57,9 @@ $setEncryptionReadyToFalseByDefaultOnNagiosServer = function () use ($pearDB, &$
 /**
  * Set encryption ready to false by default for all existing pollers to ensure retrocompatibility
  */
-$setEncryptionReadyToFalseByDefaultOnInstances = function () use ($pearDB, $pearDBO, &$errorMessage) {
+$setEncryptionReadyToFalseByDefaultOnInstances = function () use ($pearDB, $pearDBO, &$errorMessage): void {
     $errorMessage = "Unable to update 'is_encryption_ready' column on 'nagios_server' table";
-    /**@var \CentreonDB $pearDB */
+    /** @var CentreonDB $pearDB */
     $configDatabaseName = $pearDB->getConnectionConfig()->getDatabaseNameConfiguration();
     $pearDBO->prepare(
         <<<'SQL'
@@ -68,7 +68,7 @@ $setEncryptionReadyToFalseByDefaultOnInstances = function () use ($pearDB, $pear
             );
             SQL
     );
-    $pearDBO->bindValue(':db', $configDatabaseName, \PDO::PARAM_STR);
+    $pearDBO->bindValue(':db', $configDatabaseName, PDO::PARAM_STR);
     $pearDBO->execute();
 };
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -66,6 +66,10 @@ $setEncryptionReadyToFalseByDefaultOnInstances = function () use ($pearDB, $pear
                 SELECT `id` FROM nagios_server WHERE `localhost` = '0';
             SQL
     );
+    if (empty($instanceIds)) {
+        return;
+    }
+
     $instanceIdsAsString = implode(',', $instanceIds);
     $statement = $pearDBO->prepare(
         <<<SQL

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -38,7 +38,7 @@ $addIsEncryptionReadyColumn = function () use ($pearDB, $pearDBO, &$errorMessage
     }
     if ($pearDBO->isColumnExist('instances', 'is_encryption_ready') !== 1) {
         $errorMessage = "Unable to add 'is_encryption_ready' column to 'instances' table";
-        $pearDBO->query("ALTER TABLE `instances` ADD COLUMN `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '1'");
+        $pearDBO->query("ALTER TABLE `instances` ADD COLUMN `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '0'");
     }
 };
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -28,23 +28,66 @@ require_once __DIR__ . '/../../../bootstrap.php';
 $version = 'xx.xx.x';
 $errorMessage = '';
 
-// TODO add your functions here
+/**
+ * Add Column Encryption ready for poller configuration
+ */
+$addIsEncryptionReadyColumn = function () use ($pearDB, $pearDBO, &$errorMessage) {
+    if ($pearDB->isColumnExist('nagios_server', 'is_encryption_ready') !== 1) {
+        $errorMessage = "Unable to add 'is_encryption_ready' column to 'nagios_server' table";
+        $pearDB->query("ALTER TABLE `nagios_server` ADD COLUMN `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '1'");
+    }
+    if ($pearDBO->isColumnExist('instances', 'is_encryption_ready') !== 1) {
+        $errorMessage = "Unable to add 'is_encryption_ready' column to 'instances' table";
+        $pearDBO->query("ALTER TABLE `instances` ADD COLUMN `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '1'");
+    }
+};
+
+/**
+ * Set encryption ready to false by default for all existing pollers to ensure retrocompatibility
+ */
+$setEncryptionReadyToFalseByDefaultOnNagiosServer = function () use ($pearDB, &$errorMessage) {
+    $errorMessage = "Unable to update 'is_encryption_ready' column on 'nagios_server' table";
+    $pearDB->executeQuery(
+        <<<'SQL'
+            UPDATE nagios_server SET `is_encryption_ready` = '0' WHERE `localhost` = '0';
+            SQL
+    );
+};
+
+/**
+ * Set encryption ready to false by default for all existing pollers to ensure retrocompatibility
+ */
+$setEncryptionReadyToFalseByDefaultOnInstances = function () use ($pearDB, $pearDBO, &$errorMessage) {
+    $errorMessage = "Unable to update 'is_encryption_ready' column on 'nagios_server' table";
+    /**@var \CentreonDB $pearDB */
+    $configDatabaseName = $pearDB->getConnectionConfig()->getDatabaseNameConfiguration();
+    $pearDBO->prepare(
+        <<<'SQL'
+            UPDATE instances SET `is_encryption_ready` = '0' WHERE `instance_id` IN (
+                SELECT `id` FROM `:db`.nagios_server WHERE `localhost` = '0'
+            );
+            SQL
+    );
+    $pearDBO->bindValue(':db', $configDatabaseName, \PDO::PARAM_STR);
+    $pearDBO->execute();
+};
 
 try {
-    // DDL statements for real time database
-    // TODO add your function calls to update the real time database structure here
+    $addIsEncryptionReadyColumn();
 
-    // DDL statements for configuration database
-    // TODO add your function calls to update the configuration database structure here
-
-    // Transactional queries for configuration database
     if (! $pearDB->inTransaction()) {
         $pearDB->beginTransaction();
     }
 
-    // TODO add your function calls to update the configuration database data here
+    if (! $pearDBO->inTransaction()) {
+        $pearDBO->beginTransaction();
+    }
+
+    $setEncryptionReadyToFalseByDefaultOnNagiosServer();
+    $setEncryptionReadyToFalseByDefaultOnInstances();
 
     $pearDB->commit();
+    $pearDBO->commit();
 
 } catch (Throwable $exception) {
     CentreonLog::create()->error(
@@ -54,6 +97,9 @@ try {
     );
     try {
         if ($pearDB->inTransaction()) {
+            $pearDB->rollBack();
+        }
+        if ($pearDBO->inTransaction()) {
             $pearDB->rollBack();
         }
     } catch (PDOException $rollbackException) {

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -60,14 +60,13 @@ $setEncryptionReadyToFalseByDefaultOnNagiosServer = function () use ($pearDB, &$
 $setEncryptionReadyToFalseByDefaultOnInstances = function () use ($pearDB, $pearDBO, &$errorMessage): void {
     $errorMessage = "Unable to update 'is_encryption_ready' column on 'nagios_server' table";
 
-
     /** @var CentreonDB $pearDB */
     $instanceIds = $pearDB->fetchFirstColumn(
         <<<'SQL'
-            SELECT `id` FROM nagios_server WHERE `localhost` = '0';
-        SQL
+                SELECT `id` FROM nagios_server WHERE `localhost` = '0';
+            SQL
     );
-    $instanceIdsAsString = implode(",", $instanceIds);
+    $instanceIdsAsString = implode(',', $instanceIds);
     $statement = $pearDBO->prepare(
         <<<SQL
             UPDATE instances SET `is_encryption_ready` = '0' WHERE `instance_id` IN ({$instanceIdsAsString});

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -59,16 +59,20 @@ $setEncryptionReadyToFalseByDefaultOnNagiosServer = function () use ($pearDB, &$
  */
 $setEncryptionReadyToFalseByDefaultOnInstances = function () use ($pearDB, $pearDBO, &$errorMessage): void {
     $errorMessage = "Unable to update 'is_encryption_ready' column on 'nagios_server' table";
+
+
     /** @var CentreonDB $pearDB */
-    $configDatabaseName = $pearDB->getConnectionConfig()->getDatabaseNameConfiguration();
-    $statement = $pearDBO->prepare(
+    $instanceIds = $pearDB->fetchFirstColumn(
         <<<'SQL'
-            UPDATE instances SET `is_encryption_ready` = '0' WHERE `instance_id` IN (
-                SELECT `id` FROM `:db`.nagios_server WHERE `localhost` = '0'
-            );
+            SELECT `id` FROM nagios_server WHERE `localhost` = '0';
+        SQL
+    );
+    $instanceIdsAsString = implode(",", $instanceIds);
+    $statement = $pearDBO->prepare(
+        <<<SQL
+            UPDATE instances SET `is_encryption_ready` = '0' WHERE `instance_id` IN ({$instanceIdsAsString});
             SQL
     );
-    $statement->bindValue(':db', $configDatabaseName, PDO::PARAM_STR);
     $statement->execute();
 };
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -107,7 +107,7 @@ try {
             $pearDB->rollBack();
         }
         if ($pearDBO->inTransaction()) {
-            $pearDB->rollBack();
+            $pearDBO->rollBack();
         }
     } catch (PDOException $rollbackException) {
         CentreonLog::create()->error(

--- a/centreon/www/install/step_upgrade/step4.php
+++ b/centreon/www/install/step_upgrade/step4.php
@@ -163,6 +163,7 @@ $template->display('content.tpl');
                     if (data['next']) {
                         nextStep(data['current'], data['next']);
                     } else {
+                        generateEngineContextConfiguration();
                         generationCache();
                     }
                 } else {
@@ -170,6 +171,32 @@ $template->display('content.tpl');
                     jQuery('#refresh').show();
                 }
             });
+    }
+
+    function generateEngineContextConfiguration() {
+      stepContent.append('<tr>');
+      stepContent.append('<td>Engine Context Configuration Creation</td>');
+      stepContent.append(
+        '<td style="font-weight: bold;" name="engine.context"><img src="../img/misc/ajax-loader.gif"></td>'
+      );
+      stepContent.append('</tr>');
+      doProcess(
+        true,
+        './steps/process/createEngineContextConfiguration.php',
+        null,
+        function (response) {
+        let data = jQuery.parseJSON(response);
+          if (data['result'] === 0) {
+            jQuery('td[name="engine.context"]').html("<span style='color:#88b917;'>" + data['msg'] + '</span>');
+            jQuery('#troubleshoot').hide();
+            jQuery('#next').show();
+            result = true;
+          } else {
+            jQuery('td[name="engine.context"]').html("<span style='color:red;'>" + data['msg'] + '</span>');
+            jQuery('#refresh').show();
+          }
+        }
+      )
     }
 
     function generationCache() {

--- a/centreon/www/install/steps/process/createEngineContextConfiguration.php
+++ b/centreon/www/install/steps/process/createEngineContextConfiguration.php
@@ -36,18 +36,17 @@ $installationHelper = $kernel->getContainer()->get(InstallationHelper::class);
 $engineRepository = $kernel->getContainer()->get(EngineRepositoryInterface::class);
 
 try {
-    //This file should not be touched if it has content.
+    // This file should not be touched if it has content.
     if ($engineRepository->engineSecretsHasContent() === false) {
         $installationHelper->writeEngineContextFile();
     }
 
     $return['result'] = 0;
-    $return['msg'] = "OK";
-} catch (\Throwable $ex) {
+    $return['msg'] = 'OK';
+} catch (Throwable $ex) {
     $return['result'] = 1;
     $return['msg'] = $ex->getMessage();
 }
 echo json_encode($return);
 
 exit;
-

--- a/centreon/www/install/steps/process/createEngineContextConfiguration.php
+++ b/centreon/www/install/steps/process/createEngineContextConfiguration.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * Copyright 2005 - 2019 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+use App\Kernel;
+use Core\Engine\Application\Repository\EngineRepositoryInterface;
+use Core\Installation\Infrastructure\InstallationHelper;
+
+set_time_limit(0);
+require __DIR__ . '/../../../../vendor/autoload.php';
+
+$return = [];
+
+$kernel = Kernel::createForWeb();
+/** @var InstallationHelper $installationHelper */
+$installationHelper = $kernel->getContainer()->get(InstallationHelper::class);
+
+/** @var EngineRepositoryInterface $engineRepository */
+$engineRepository = $kernel->getContainer()->get(EngineRepositoryInterface::class);
+
+try {
+    //This file should not be touched if it has content.
+    if ($engineRepository->engineSecretsHasContent() === false) {
+        $installationHelper->writeEngineContextFile();
+    }
+
+    $return['result'] = 0;
+    $return['msg'] = "OK";
+} catch (\Throwable $ex) {
+    $return['result'] = 1;
+    $return['msg'] = $ex->getMessage();
+}
+echo json_encode($return);
+
+exit;
+

--- a/centreon/www/install/steps/process/process_step9.php
+++ b/centreon/www/install/steps/process/process_step9.php
@@ -41,6 +41,7 @@ require_once __DIR__ . '/../../../include/common/vault-functions.php';
 use App\Kernel;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
 use Core\Common\Infrastructure\FeatureFlags;
+use Core\Installation\Infrastructure\InstallationHelper;
 use Symfony\Component\Dotenv\Dotenv;
 
 $step = new CentreonLegacy\Core\Install\Step\Step9($dependencyInjector);
@@ -68,8 +69,8 @@ try {
     $featuresFileContent = file_get_contents(__DIR__ . '/../../../../config/features.json');
     $featureFlagManager = new FeatureFlags($isCloudPlatform, $featuresFileContent);
     $isVaultFeatureEnable = $featureFlagManager->isEnabled('vault');
+    $kernel = Kernel::createForWeb();
     if ($isVaultFeatureEnable && file_exists(_CENTREON_VARLIB_ . '/vault/vault.json')) {
-        $kernel = Kernel::createForWeb();
         $writeVaultRepository = $kernel->getContainer()->get(WriteVaultRepositoryInterface::class);
         $writeVaultRepository->setCustomPath('database');
         $databaseVaultPaths = migrateDatabaseCredentialsToVault($writeVaultRepository);
@@ -84,6 +85,9 @@ try {
         }
     }
 
+    /** @var InstallationHelper $installationHelper */
+    $installationHelper = $kernel->getContainer()->get(InstallationHelper::class);
+    $installationHelper->writeEngineContextFile();
     $backupDir = _CENTREON_VARLIB_ . '/installs/'
         . '/install-' . $version . '-' . date('Ymd_His');
     $installDir = realpath(__DIR__ . '/../..');

--- a/centreon/www/widgets/httploader/index.php
+++ b/centreon/www/widgets/httploader/index.php
@@ -80,6 +80,7 @@ try {
     }
 } catch (Exception $e) {
     showError($e->getMessage(), $theme);
+
     exit;
 }
 
@@ -88,22 +89,22 @@ function showError(string $message, string $theme)
     $escapedMessage = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
     $escapedTheme = htmlspecialchars($theme, ENT_QUOTES, 'UTF-8');
     echo <<<HTML
-    <!DOCTYPE html>
-    <html>
-        <head>
-            <meta charset="UTF-8">
-            <title>Error</title>
-            <link href="../../Themes/Generic-theme/style.css" rel="stylesheet" type="text/css"/>
-            <link href="../../Themes/Generic-theme/color.css" rel="stylesheet" type="text/css"/>
-            <link href="../../Themes/{$escapedTheme}/variables.css" rel="stylesheet" type="text/css"/>
-        </head>
-        <body>
-            <div class="update" style="text-align: center; width: 350px; margin: 0 auto;">
-                {$escapedMessage}
-            </div>
-        </body>
-    </html>
-    HTML;
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <meta charset="UTF-8">
+                <title>Error</title>
+                <link href="../../Themes/Generic-theme/style.css" rel="stylesheet" type="text/css"/>
+                <link href="../../Themes/Generic-theme/color.css" rel="stylesheet" type="text/css"/>
+                <link href="../../Themes/{$escapedTheme}/variables.css" rel="stylesheet" type="text/css"/>
+            </head>
+            <body>
+                <div class="update" style="text-align: center; width: 350px; margin: 0 auto;">
+                    {$escapedMessage}
+                </div>
+            </body>
+        </html>
+        HTML;
 }
 
 ?>


### PR DESCRIPTION
## Description

This PR intends to manage manage : 

- creation of column
    - `is_encryption_ready` in nagios_server
    - `is_encryption_ready` in instances

- write engine secrets during install
- write engine secrets during upgrade if engine context is empty

**Fixes** # MON-176779

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
