### PR TITLE
fix(RS): fix notif contacts and cg doubled in list

### DIFF
--- a/centreon/src/Core/Infrastructure/Configuration/NotificationPolicy/Repository/AbstractDbReadNotificationRepository.php
+++ b/centreon/src/Core/Infrastructure/Configuration/NotificationPolicy/Repository/AbstractDbReadNotificationRepository.php
@@ -130,7 +130,7 @@ abstract class AbstractDbReadNotificationRepository extends AbstractRepositoryDR
 
         $request = $this->translateDbName(
             <<<SQL
-                SELECT
+                SELECT DISTINCT
                     c.contact_id,
                     c.contact_alias,
                     c.contact_name,
@@ -258,7 +258,7 @@ abstract class AbstractDbReadNotificationRepository extends AbstractRepositoryDR
 
         $request = $this->translateDbName(
             <<<SQL
-                SELECT
+                SELECT DISTINCT
                     cg_id AS `id`,
                     cg_name AS `name`,
                     cg_alias AS `alias`,


### PR DESCRIPTION
## Description

This PR intends to fix  Resources Status  Notification tab displaying a same user/user group multiple times when user with ACLs is connected

**Fixes** # ([MON-168466](https://centreon.atlassian.net/browse/MON-168466))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- Login the Centreon Platform
- Create a user:
  - enable all the options related to the notification
  - link him to the access group ALL and another one (random)
- Create a host, enable the notification and link it to the adminLike user
- Connect to the UI with adminLike user
- Go to the resources status page, click on this host and go to the notification tab
  - Contacts and contact groups lists should be unique

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-168466]: https://centreon.atlassian.net/browse/MON-168466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ