### PR TITLE
chore: add phpstan rules

### DIFF
--- a/centreon/phpstan.new.neon
+++ b/centreon/phpstan.new.neon
@@ -18,3 +18,38 @@ parameters:
         - config.new
         - src/Adaptation
         - src/App
+
+rules:
+    - Tools\PhpStan\CustomRules\ArchitectureRules\EnumAreSuffixedRule
+    - Tools\PhpStan\CustomRules\MiscRules\CommandHandlerCannotUseCommandBus
+
+services:
+    - class: Tools\PhpStan\CustomRules\ArchitectureRules\MarkedClassesAreFinalRule
+      arguments:
+          attributes:
+              - App\Shared\Application\Command\AsCommandHandler
+              - App\Shared\Domain\Event\AsEventHandler
+              - ApiPlatform\Metadata\ApiResource
+          classes:
+              - ApiPlatform\State\ProcessorInterface
+              - App\Shared\Infrastructure\Doctrine\DoctrineRepository
+              - App\ResourceConfiguration\Infrastructure\Legacy\LegacyServiceCategoryPermissionVoter
+              - App\Shared\Infrastructure\ApiPlatform\Transformer\TransformerInterface
+      tags: [phpstan.rules.rule]
+
+    - class: Tools\PhpStan\CustomRules\MiscRules\MarkedClassesHaveTestRule
+      arguments:
+          attributes:
+              - App\Shared\Application\Command\AsCommandHandler
+              - App\Shared\Domain\Event\AsEventHandler
+          classes:
+              - ApiPlatform\State\ProcessorInterface
+              - App\Shared\Infrastructure\Doctrine\DoctrineRepository
+      tags: [phpstan.rules.rule]
+
+    - class: Tools\PhpStan\CustomRules\ArchitectureRules\MarkedClassesAreOnlyInvokableRule
+      arguments:
+          attributes:
+              - App\Shared\Application\Command\AsCommandHandler
+              - App\Shared\Domain\Event\AsEventHandler
+      tags: [phpstan.rules.rule]

--- a/centreon/tests/php/App/ResourceConfiguration/Application/Command/CreateServiceCategoryCommandHandlerTest.php
+++ b/centreon/tests/php/App/ResourceConfiguration/Application/Command/CreateServiceCategoryCommandHandlerTest.php
@@ -32,7 +32,7 @@ use PHPUnit\Framework\TestCase;
 use Tests\App\ResourceConfiguration\Infrastructure\Double\FakeServiceCategoryRepository;
 use Tests\App\Shared\Double\EventBusSpy;
 
-final class CreateServiceCategoryCommandTest extends TestCase
+final class CreateServiceCategoryCommandHandlerTest extends TestCase
 {
     public function testCreateServiceCategory(): void
     {

--- a/php-tools/phpstan.neon
+++ b/php-tools/phpstan.neon
@@ -1,6 +1,7 @@
 parameters:
 
     level: max
+    treatPhpDocTypesAsCertain: false
 
     scanFiles:
         - .php-cs-fixer.php
@@ -9,6 +10,9 @@ parameters:
     paths:
         - phpstan
         - php-cs-fixer
+
+    scanDirectories:
+        - ../centreon/src/App/Shared/
 
     ignoreErrors:
         # To fix the following errors, you need to update the custom rules:

--- a/php-tools/phpstan/src/CustomRules/ArchitectureRules/EnumAreSuffixedRule.php
+++ b/php-tools/phpstan/src/CustomRules/ArchitectureRules/EnumAreSuffixedRule.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tools\PhpStan\CustomRules\ArchitectureRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Enum_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Enum_>
+ */
+final readonly class EnumAreSuffixedRule implements Rule
+{
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Enum_::class;
+    }
+
+    /**
+     * @param Enum_ $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $className = (string) $node->namespacedName;
+        $reflection = $this->reflectionProvider->getClass($className)->getNativeReflection();
+
+        if (str_ends_with($reflection->getName(), 'Enum')) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(\sprintf('The enum %s name must end with "Enum"', $className))
+                ->identifier('enum.suffix')
+                ->build(),
+        ];
+    }
+}

--- a/php-tools/phpstan/src/CustomRules/ArchitectureRules/MarkedClassesAreFinalRule.php
+++ b/php-tools/phpstan/src/CustomRules/ArchitectureRules/MarkedClassesAreFinalRule.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tools\PhpStan\CustomRules\ArchitectureRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Class_>
+ */
+final readonly class MarkedClassesAreFinalRule implements Rule
+{
+    /**
+     * @param list<class-string> $attributes
+     * @param list<class-string> $classes
+     */
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private array $attributes = [],
+        private array $classes = [],
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $className = (string) $node->namespacedName;
+        $reflection = $this->reflectionProvider->getClass($className);
+
+        if (! $this->isEligible($reflection)) {
+            return [];
+        }
+
+        if ($reflection->isFinal()) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(\sprintf('The class %s is not final', $className))
+                ->identifier('final.class')
+                ->build(),
+        ];
+    }
+
+    private function isEligible(ClassReflection $reflection): bool
+    {
+        if ($reflection->getName() === 'App\Shared\Infrastructure\Doctrine\DoctrineRepository') {
+            return false;
+        }
+
+        foreach ($this->attributes as $attribute) {
+            if ($reflection->getNativeReflection()->getAttributes($attribute)) {
+                return true;
+            }
+        }
+
+        foreach ($this->classes as $class) {
+            if ($reflection->getName() === $class || $reflection->isSubclassOfClass($this->reflectionProvider->getClass($class))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/php-tools/phpstan/src/CustomRules/ArchitectureRules/MarkedClassesAreOnlyInvokableRule.php
+++ b/php-tools/phpstan/src/CustomRules/ArchitectureRules/MarkedClassesAreOnlyInvokableRule.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tools\PhpStan\CustomRules\ArchitectureRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassMethod;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Class_>
+ */
+final readonly class MarkedClassesAreOnlyInvokableRule implements Rule
+{
+    /**
+     * @param list<class-string> $attributes
+     * @param list<class-string> $classes
+     */
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private array $attributes = [],
+        private array $classes = [],
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $className = (string) $node->namespacedName;
+        $reflection = $this->reflectionProvider->getClass($className);
+
+        if (! $this->isEligible($reflection)) {
+            return [];
+        }
+
+        $errors = [];
+
+        $hasInvokableMethod = (bool) array_filter(
+            $node->getMethods(),
+            static fn (ClassMethod $method): bool => $method->isPublic() && '__invoke' !== (string) $method->name,
+        );
+
+        if (! $hasInvokableMethod) {
+            $errors[] = RuleErrorBuilder::message(\sprintf('The class %s must have "__invoke" method', $className))
+                ->identifier('invokable.missing')
+                ->build();
+        }
+
+        $extraPublicMethodsCount = \count(
+            array_values(
+                array_filter(
+                    $node->getMethods(),
+                    static fn (ClassMethod $method): bool => $method->isPublic() && ('__construct' !== (string) $method->name && '__invoke' !== (string) $method->name),
+                ),
+            ),
+        );
+
+        if ($extraPublicMethodsCount !== 0) {
+            $errors[] = RuleErrorBuilder::message(\sprintf('The class %s has public methods other than "__construct" and "__invoke"', $className))
+                ->identifier('invokable.extra')
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function isEligible(ClassReflection $reflection): bool
+    {
+        foreach ($this->attributes as $attribute) {
+            if ($reflection->getNativeReflection()->getAttributes($attribute)) {
+                return true;
+            }
+        }
+
+        foreach ($this->classes as $class) {
+            if (! $reflection->isAbstract() && ($reflection->getName() === $class || $reflection->isSubclassOfClass($this->reflectionProvider->getClass($class)))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/php-tools/phpstan/src/CustomRules/MiscRules/CommandHandlerCannotUseCommandBus.php
+++ b/php-tools/phpstan/src/CustomRules/MiscRules/CommandHandlerCannotUseCommandBus.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tools\PhpStan\CustomRules\MiscRules;
+
+use App\Shared\Application\Command\AsCommandHandler;
+use PhpParser\Node;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Class_>
+ */
+final readonly class CommandHandlerCannotUseCommandBus implements Rule
+{
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $reflection = $this->reflectionProvider->getClass((string) $node->namespacedName)->getNativeReflection();
+
+        if (! $reflection->getAttributes(AsCommandHandler::class)) {
+            return [];
+        }
+
+        if (! $constructor = $node->getMethod('__construct')) {
+            return [];
+        }
+
+        foreach ($constructor->getParams() as $param) {
+            if (($param->type instanceof Identifier || $param->type instanceof Name) && 'App\Shared\Application\Command\CommandBus' === $param->type->toString()) {
+                return [
+                    RuleErrorBuilder::message('A command handler class cannot use command bus.')
+                        ->identifier('command.handler.bus')
+                        ->build(),
+                ];
+            }
+        }
+
+        return [];
+    }
+}

--- a/php-tools/phpstan/src/CustomRules/MiscRules/MarkedClassesHaveTestRule.php
+++ b/php-tools/phpstan/src/CustomRules/MiscRules/MarkedClassesHaveTestRule.php
@@ -1,0 +1,110 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tools\PhpStan\CustomRules\MiscRules;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Class_;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+
+/**
+ * @implements Rule<Class_>
+ */
+final readonly class MarkedClassesHaveTestRule implements Rule
+{
+    /**
+     * @param list<class-string> $attributes
+     * @param list<class-string> $classes
+     */
+    public function __construct(
+        private ReflectionProvider $reflectionProvider,
+        private array $attributes = [],
+        private array $classes = [],
+    ) {
+    }
+
+    public function getNodeType(): string
+    {
+        return Class_::class;
+    }
+
+    /**
+     * @param Class_ $node
+     */
+    public function processNode(Node $node, Scope $scope): array
+    {
+        $reflection = $this->reflectionProvider->getClass((string) $node->namespacedName);
+
+        if (! $this->isEligible($reflection)) {
+            return [];
+        }
+
+        $parts = explode('src', $scope->getFile());
+
+        $projectPath = trim($parts[0], '/');
+        $pathFromProject = trim($parts[1], '/');
+
+        $classUnderTestPath = \sprintf('/%s/tests/php/%s', $projectPath, $pathFromProject);
+        $classUnderTestPath = str_replace(
+            ['.php'],
+            ['Test.php'],
+            $classUnderTestPath,
+        );
+
+        $pathFromTest = \sprintf(
+            'tests/%s',
+            ltrim(explode('tests', $classUnderTestPath)[1], '/'),
+        );
+
+        if (file_exists($classUnderTestPath)) {
+            return [];
+        }
+
+        return [
+            RuleErrorBuilder::message(\sprintf('The test class %s is missing', $pathFromTest))
+                ->identifier('test.class')
+                ->build(),
+        ];
+    }
+
+    private function isEligible(ClassReflection $reflection): bool
+    {
+        foreach ($this->attributes as $attribute) {
+            if ($reflection->getNativeReflection()->getAttributes($attribute)) {
+                return true;
+            }
+        }
+
+        foreach ($this->classes as $class) {
+            if (! $reflection->isAbstract() && ($reflection->getName() === $class || $reflection->isSubclassOfClass($this->reflectionProvider->getClass($class)))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Description

Add PHPStan rules to make sure that the new code is compliant with our architecture aimed standards:
1. Final classes: `AsCommandHandler`, `AsEventHandler`, `ApiResource`, `DoctrineRepository`, `LegacyServiceCategoryPermissionVoter`, `TransformerInterface`. This makes sure that such services aren't relying on inheritance which in this case is considered as a bad practice.
2. Enforce tests for `AsCommandHandler`, `ProcessorInterface`, `ProcessorInterface`, `DoctrineRepository`. Theses classes are the heart of our application logic, so it's mandatory to have them tested
3. Make sure that `AsCommandHandler` and `AsEventHandler` are only invokables. Their purpose is only to be handlers, so any other public method is not logical
4. Enforce command handlers to not use the command bus. Instead they should rely on event dispatching, which makes the system more responsive and robust
5. Suffix enums by `Enum` to avoid any confusion

**Fixes** # MON-173025

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master