### PR TITLE
Fix(Dashboard):Error When Setting Time Period to "Customized" in Metrics Graph Widget

### DIFF
--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/TimePeriod/useTimePeriod.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/AddEditWidget/WidgetProperties/Inputs/TimePeriod/useTimePeriod.ts
@@ -109,8 +109,8 @@ const useTimePeriod = (propertyName: string): UseTimePeriodState => {
 
     if (equals(newType, -1)) {
       setFieldValue(`options.${propertyName}`, {
-        end: dayjs(),
-        start: dayjs().subtract(1, 'hour'),
+        end: dayjs().toISOString(),
+        start: dayjs().subtract(1, 'hour').toISOString(),
         timePeriodType: newType
       });
 


### PR DESCRIPTION
**Description**: set value to iso for default custom period

https://github.com/centreon/centreon/pull/7903

**Video**

[screen-capture (9).webm](https://github.com/user-attachments/assets/83d40c39-fc3b-4c6f-9c82-5220ee3c33ab)
