### PR TITLE
fix(web): host alias encoding fixed

### DIFF
--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -2748,10 +2748,16 @@ function sanitizeFormHostParameters(array $ret): array
                     ];
                 }
                 break;
+            case 'host_alias':
+                $bindParams[':' . $inputName] = [
+                    \PDO::PARAM_STR => ($inputValue === '' || $inputValue === false)
+                        ? null
+                        : $inputValue
+                ];
+                break;
             case 'host_address':
             case 'command_command_id_arg1':
             case 'command_command_id_arg2':
-            case 'host_alias':
             case 'host_snmp_community':
             case 'host_snmp_version':
             case 'host_comment':


### PR DESCRIPTION
## Description

### Fixed

* host alias had a bad encoding with special caracters which caused a bad display when we list hosts

<img width="877" height="349" alt="image" src="https://github.com/user-attachments/assets/43f1cb23-7078-4912-8e71-4a3a00f685da" />

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.10.x

<h2> How this pull request can be tested ? </h2>

* Add a host with this alias : "Ceci est l'alias" and save
* Got to host listing, you must to have "Ceci est l'alias" and not this "Ceci est l&#39;alias"
* Check with an update
* Check with this value to be sure that not have XSS vulnerabilities : "<script>alert('coucou');</script>, you must not have an alert with the message 'coucou'

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
