### PR TITLE
Prevent empty name on host & host group on creation via clapi

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonHost.class.php
+++ b/centreon/www/class/centreon-clapi/centreonHost.class.php
@@ -96,6 +96,7 @@ class CentreonHost extends CentreonObject
     public const INVALID_GEO_COORDS = 'Invalid geo coords';
     public const UNKNOWN_TIMEZONE = 'Invalid timezone';
     public const HOST_LOCATION = 'timezone';
+    public const NAME_IS_EMPTY = 'Host name is mandatory and cannot be left empty';
 
     /** @var string[] */
     public static $aDepends = ['CMD', 'TP', 'TRAP', 'INSTANCE', 'HTPL'];
@@ -366,6 +367,9 @@ class CentreonHost extends CentreonObject
         }
         $addParams = [];
         $addParams[$this->object->getUniqueLabelField()] = $this->checkIllegalChar($params[self::ORDER_UNIQUENAME]);
+        if ($addParams[$this->object->getUniqueLabelField()] === '') {
+            throw new CentreonClapiException(self::NAME_IS_EMPTY);
+        }
         $addParams['host_alias'] = $params[self::ORDER_ALIAS];
         $addParams['host_address'] = $params[self::ORDER_ADDRESS];
         $templates = explode('|', $params[self::ORDER_TEMPLATE]);

--- a/centreon/www/class/centreon-clapi/centreonHostGroup.class.php
+++ b/centreon/www/class/centreon-clapi/centreonHostGroup.class.php
@@ -58,6 +58,7 @@ class CentreonHostGroup extends CentreonObject
     public const ORDER_UNIQUENAME = 0;
     public const ORDER_ALIAS = 1;
     public const INVALID_GEO_COORDS = 'Invalid geo coords';
+    public const NAME_IS_EMPTY = 'Host group name is mandatory and cannot be left empty';
 
     /** @var string[] */
     public static $aDepends = ['HOST'];
@@ -214,6 +215,10 @@ class CentreonHostGroup extends CentreonObject
         }
         $addParams = [];
         $addParams[$this->object->getUniqueLabelField()] = $this->checkIllegalChar($params[self::ORDER_UNIQUENAME]);
+        if ($addParams[$this->object->getUniqueLabelField()] === '') {
+            throw new CentreonClapiException(self::NAME_IS_EMPTY);
+        }
+
         $addParams['hg_alias'] = $params[self::ORDER_ALIAS];
         $this->params = array_merge($this->params, $addParams);
         $this->checkParameters();


### PR DESCRIPTION
## Description

Prevent empty name to be inserted on host name & host group name when using CLAPI.

Fix [MON-168703](https://centreon.atlassian.net/browse/MON-168703)
Backported by https://github.com/centreon/centreon/pull/7918

[MON-168703]: https://centreon.atlassian.net/browse/MON-168703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ