### PR TITLE
fix(sql): Group also by version

### DIFF
--- a/centreon/www/class/centreonVersion.class.php
+++ b/centreon/www/class/centreonVersion.class.php
@@ -176,7 +176,7 @@ class CentreonVersion
         $query = 'SELECT wm.title AS name, version, COUNT(widget_id) AS count
             FROM widgets AS w
             INNER JOIN widget_models AS wm ON (w.widget_model_id = wm.widget_model_id)
-            GROUP BY name';
+            GROUP BY name, version';
         $result = $this->db->query($query);
         while ($row = $result->fetch()) {
             $data[] = ['name' => $row['name'], 'version' => $row['version'], 'used' => $row['count']];


### PR DESCRIPTION
## Description

Using MySQL 8 and the SQL mode "only_full_group_by" (default mode), we need to aggregate the column version.
If not it returns this error:
`ERROR 1055 (42000): Expression #2 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'centreon.wm.version' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by`

**Fixes** # MON-178435

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
