### PR TITLE
Fix MON-37301 - Poller is seen as not enable, so we can't generate the configuration files

### DIFF
--- a/centreon/www/include/configuration/configServers/DB-Func.php
+++ b/centreon/www/include/configuration/configServers/DB-Func.php
@@ -999,6 +999,11 @@ function updateServer(int $id, array $data): void
     }
     $stmt->execute();
 
+    // if the poller is activated, always keep cfg file activated
+    if (isset($data['ns_activate']['ns_activate']) && $data['ns_activate']['ns_activate'] == 1) {
+        enableServerInDB($id);
+    }
+
     updateRemoteServerInformation($data, $id);
     try {
         updateServerIntoPlatformTopology($retValue, $id);
@@ -1325,14 +1330,17 @@ function isValidStopCommandSyntax(string $command): bool
 {
     return (bool) preg_match(MonitoringServer::VALID_COMMAND_STOP_REGEX, $command);
 }
+
 function isValidRestartCommandSyntax(string $command): bool
 {
     return (bool) preg_match(MonitoringServer::VALID_COMMAND_RESTART_REGEX, $command);
 }
+
 function isValidReloadCommandSyntax(string $command): bool
 {
     return (bool) preg_match(MonitoringServer::VALID_COMMAND_RELOAD_REGEX, $command);
 }
+
 function isValidPath(string $path): bool
 {
     return (bool) preg_match(

--- a/centreon/www/include/configuration/configServers/DB-Func.php
+++ b/centreon/www/include/configuration/configServers/DB-Func.php
@@ -999,11 +999,9 @@ function updateServer(int $id, array $data): void
     }
     $stmt->execute();
 
-    // Ensure cfg file stays enabled whenever the poller ends up enabled,
-    // even when the ns_activate field is omitted in the request.
-    $finalActivationState = (int)($data['ns_activate']['ns_activate'] ?? 1);
-    if ($finalActivationState === 1) {
-        enableServerInDB($id); // updates cfg_nagios + audit log
+    // if the poller is activated, always keep cfg file activated
+    if (isset($data['ns_activate']['ns_activate']) && $data['ns_activate']['ns_activate'] === 1) {
+        enableServerInDB($id);
     }
 
     updateRemoteServerInformation($data, $id);

--- a/centreon/www/include/configuration/configServers/DB-Func.php
+++ b/centreon/www/include/configuration/configServers/DB-Func.php
@@ -999,9 +999,11 @@ function updateServer(int $id, array $data): void
     }
     $stmt->execute();
 
-    // if the poller is activated, always keep cfg file activated
-    if (isset($data['ns_activate']['ns_activate']) && $data['ns_activate']['ns_activate'] == 1) {
-        enableServerInDB($id);
+    // Ensure cfg file stays enabled whenever the poller ends up enabled,
+    // even when the ns_activate field is omitted in the request.
+    $finalActivationState = (int)($data['ns_activate']['ns_activate'] ?? 1);
+    if ($finalActivationState === 1) {
+        enableServerInDB($id); // updates cfg_nagios + audit log
     }
 
     updateRemoteServerInformation($data, $id);

--- a/centreon/www/include/configuration/configServers/listServers.php
+++ b/centreon/www/include/configuration/configServers/listServers.php
@@ -198,7 +198,7 @@ foreach ($servers as $config) {
         && $nagiosInfo[$config['id']]['last_alive'])
         ? $nagiosInfo[$config['id']]['last_alive']
         : '-';
-    $serverType = $config['localhost'] ? _('Central') : _('Distant Poller');
+    $serverType = $config['localhost'] ? _('Central') : _('Poller');
     $serverType = in_array($config['ns_ip_address'], $remotesServerIPs)
         ? _('Remote Server')
         : $serverType;


### PR DESCRIPTION
## Description

Poller is seen as not enable, so we can't generate the configuration files
==> poller enable / disable button in the poller listing is ok. Only the enable / disable option in the form is not working properly.

**Fixes** # (issue)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please read the ticket MON-37301, everything is explained. Note that it's not really a bug but an enhancement.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
