### PR TITLE
fix(sql) make all foreign key unique

### DIFF
--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -1946,7 +1946,7 @@ CREATE TABLE `topology` (
   `readonly` enum('0','1') NOT NULL DEFAULT '1',
   `is_react` enum('0','1') NOT NULL DEFAULT '0',
   PRIMARY KEY (`topology_id`),
-  KEY `topology_page` (`topology_page`),
+  UNIQUE KEY `topology_page` (`topology_page`),
   KEY `topology_parent` (`topology_parent`),
   KEY `topology_order` (`topology_order`),
   KEY `topology_group` (`topology_group`)
@@ -1996,7 +1996,7 @@ CREATE TABLE `traps` (
   `traps_customcode` text,
   `traps_comments` text,
   UNIQUE KEY `traps_name` (`traps_name`,`traps_oid`),
-  KEY `traps_id` (`traps_id`),
+  UNIQUE KEY `traps_id` (`traps_id`),
   KEY `traps_ibfk_1` (`manufacturer_id`),
   KEY `traps_ibfk_2` (`severity_id`),
   CONSTRAINT `traps_ibfk_1` FOREIGN KEY (`manufacturer_id`) REFERENCES `traps_vendor` (`id`) ON DELETE CASCADE,


### PR DESCRIPTION
## Description

Prepare mysql migration:
- Update traps.traps_id and topology.topology_page to make them unique at table creation

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
