### PR TITLE
fix(routing): prefix base uri and api version for modules with only one route

### DIFF
--- a/centreon/src/Core/Common/Infrastructure/Routing/ModuleRouteLoader.php
+++ b/centreon/src/Core/Common/Infrastructure/Routing/ModuleRouteLoader.php
@@ -62,6 +62,10 @@ abstract readonly class ModuleRouteLoader implements RouteLoaderInterface
 
         // Modules with only one route will return directly a route collection
         if ($routeCollections instanceof RouteCollection) {
+            $routeCollections->addPrefix('/{base_uri}api/{version}');
+            $routeCollections->addDefaults(['base_uri' => 'centreon/', 'version' => 'latest']);
+            $routeCollections->addRequirements(['base_uri' => '(.+/)|.{0}']);
+
             return $routeCollections;
         }
         foreach ($routeCollections as $routeCollection) {


### PR DESCRIPTION
## Description

This PR intends to correctly prefix the base uri and api version for the modules with only one route (e.g CCE)

**Fixes** # MON-178795

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
