### PR TITLE
fix(cloud notifications): fix user count related to a notification

### DIFF
--- a/centreon/src/Core/Notification/Infrastructure/Repository/DbReadNotificationRepository.php
+++ b/centreon/src/Core/Notification/Infrastructure/Repository/DbReadNotificationRepository.php
@@ -411,7 +411,7 @@ class DbReadNotificationRepository extends AbstractRepositoryRDB implements Read
         $statement = $this->db->prepare(
             $this->translateDbName(
                 <<<SQL
-                    SELECT result.id, COUNT(result.contact_id)
+                    SELECT result.id, COUNT(DISTINCT result.contact_id)
                     FROM (
                         SELECT notif.id, contact.contact_id
                         FROM `:db`.notification notif


### PR DESCRIPTION
## Description

This PR intends to fix the number of users in notification rules.

**Fixes** # ([MON-174620](https://centreon.atlassian.net/browse/MON-174620))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-174620]: https://centreon.atlassian.net/browse/MON-174620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ