### PR TITLE
fix(resource status): notification tab displays wrong contact

### DIFF
--- a/centreon/src/Core/Infrastructure/Configuration/NotificationPolicy/Repository/LegacyReadServiceNotificationRepository.php
+++ b/centreon/src/Core/Infrastructure/Configuration/NotificationPolicy/Repository/LegacyReadServiceNotificationRepository.php
@@ -120,9 +120,7 @@ class LegacyReadServiceNotificationRepository extends AbstractDbReadNotification
 
         /**
          * @var array{
-         *      service_use_only_contacts_from_host:string,
-         *      contacts_cache?: int[],
-         *      contact_groups_cache?: int[]
+         *      service_use_only_contacts_from_host:string
          * }|null $service
          */
         $service = $serviceInstance->getServiceFromCache($serviceId);
@@ -132,8 +130,7 @@ class LegacyReadServiceNotificationRepository extends AbstractDbReadNotification
             && (
                 $service['service_use_only_contacts_from_host'] === '1'
                 || (
-                    array_key_exists('contacts_cache', $service) && $service['contacts_cache'] === []
-                    && array_key_exists('contact_groups_cache', $service) && $service['contact_groups_cache'] === []
+                    empty($notifiedContactIds) && empty($notifiedContactGroupIds)
                 )
             )
         ) {


### PR DESCRIPTION
## Description

This PR intends to fix notification tab not displaying the good contact if defined on service template, it displays the one from the host even if host inheritence only is not chosen

**Fixes** # ([MON-167422](https://centreon.atlassian.net/browse/MON-167422))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-167422]: https://centreon.atlassian.net/browse/MON-167422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ