### PR TITLE
feat(contact/profile) : add confirm current password field to change a user password

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -8232,3 +8232,7 @@ msgid "snmpttconvertmib binary with complete path."
 msgstr ""
 "Chemin d'accès complet vers le script snmpttconvertmib. Ce dernier permet "
 "de convertir les fichiers MIBs importés dans Centreon."
+
+#: centreon/www/include/configuration/configObject/contact/help.php
+msgid "For security reasons, to be able to change this user's password, you (the currently logged-in administrator) must verify your identity by entering your own password."
+msgstr "Pour des raisons de sécurité, afin de pouvoir changer le mot de passe de cet utilisateur, vous (l'administrateur actuellement connecté) devez vérifier votre identité en saisissant votre propre mot de passe."

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/help.po
@@ -8234,5 +8234,5 @@ msgstr ""
 "de convertir les fichiers MIBs importés dans Centreon."
 
 #: centreon/www/include/configuration/configObject/contact/help.php
-msgid "For security reasons, to be able to change this user's password, you (the currently logged-in administrator) must verify your identity by entering your own password."
-msgstr "Pour des raisons de sécurité, afin de pouvoir changer le mot de passe de cet utilisateur, vous (l'administrateur actuellement connecté) devez vérifier votre identité en saisissant votre propre mot de passe."
+msgid "For security reasons, to be able to change this user's password, you (the currently logged-in user) must verify your identity by entering your own password."
+msgstr "Pour des raisons de sécurité, afin de pouvoir changer le mot de passe de cet utilisateur, vous (l'utilisateur actuellement connecté) devez vérifier votre identité en saisissant votre propre mot de passe."

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24356,4 +24356,4 @@ msgstr "Votre mot de passe actuel"
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "Please fill in all password fields"
-msgstr "Veuillez remplir tous les champs du mot de passe"
+msgstr "Veuillez remplir tous les champs mot de passe"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -1714,6 +1714,8 @@ msgid "Authentication denied"
 msgstr "Authentification refusée"
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/AuthenticationException.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Authentication failed"
 msgstr "Echec de l'authentification"
 
@@ -24348,21 +24350,10 @@ msgid "will display resources with host name starting by'"
 msgstr "affichera les ressources avec un nom d'hôte commençant par"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
-msgid "Your current administrator password"
-msgstr "Votre mot de passe administrateur actuel"
+msgid "Your current password"
+msgstr "Votre mot de passe actuel"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
-msgid "Your current administrator password is incorrect"
-msgstr "Votre mot de passe administrateur actuel est incorrect"
-
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-msgid "Your current administrator password is required to change the user password"
-msgstr "Votre mot de passe administrateur actuel est requis pour changer le mot de passe de l'utilisateur"
-
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
-msgid "Your current password is incorrect"
-msgstr "Votre mot de passe actuel est incorrect"
-
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
-msgid "Your current password is required to change your password"
-msgstr "Votre mot de passe actuel est requis pour changer votre mot de passe"
+msgid "Please fill in both password fields"
+msgstr "Veuillez remplir les deux champs du mot de passe"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24350,3 +24350,19 @@ msgstr "affichera les ressources avec un nom d'hôte commençant par"
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Your current administrator password"
 msgstr "Votre mot de passe administrateur actuel"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Your current administrator password is incorrect"
+msgstr "Votre mot de passe administrateur actuel est incorrect"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Your current administrator password is required to change the user password"
+msgstr "Votre mot de passe administrateur actuel est requis pour changer le mot de passe de l'utilisateur"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Your current password is incorrect"
+msgstr "Votre mot de passe actuel est incorrect"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Your current password is required to change your password"
+msgstr "Votre mot de passe actuel est requis pour changer votre mot de passe"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3855,6 +3855,7 @@ msgid "Current page only"
 msgstr "Page courante seulement"
 
 #: centreon/www/install/front_translate.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "Current password"
 msgstr "Mot de passe actuel"
 
@@ -24345,10 +24346,6 @@ msgstr "alerte"
 #: unknown
 msgid "will display resources with host name starting by'"
 msgstr "affichera les ressources avec un nom d'hôte commençant par"
-
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
-msgid "Current password"
-msgstr "Mot de passe actuel"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Your current administrator password"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24345,3 +24345,11 @@ msgstr "alerte"
 #: unknown
 msgid "will display resources with host name starting by'"
 msgstr "affichera les ressources avec un nom d'hôte commençant par"
+
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+msgid "Current password"
+msgstr "Mot de passe actuel"
+
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+msgid "Your current administrator password"
+msgstr "Votre mot de passe administrateur actuel"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24355,5 +24355,5 @@ msgstr "Votre mot de passe actuel"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
-msgid "Please fill in both password fields"
-msgstr "Veuillez remplir les deux champs du mot de passe"
+msgid "Please fill in all password fields"
+msgstr "Veuillez remplir tous les champs du mot de passe"

--- a/centreon/tests/e2e/features/Authentication/Login/02-local-authentication/index.ts
+++ b/centreon/tests/e2e/features/Authentication/Login/02-local-authentication/index.ts
@@ -170,6 +170,7 @@ Then(
     cy.getIframeBody()
       .find('form')
       .within(() => {
+        cy.get('#current_password').should('be.visible').type('Centreon!2021User1');
         cy.get('#passwd1').should('be.visible').type('azerty');
         cy.get('#passwd2').should('be.visible').type('azerty');
       });
@@ -302,6 +303,7 @@ Then('user can not change password unless the minimum time has passed', () => {
   cy.getIframeBody()
     .find('form')
     .within(() => {
+      cy.get('#current_password').should('be.visible').type('Centreon!2021User1');
       cy.get('#passwd1').should('be.visible').type('@zerty!976=Centreon');
       cy.get('#passwd2').should('be.visible').type('@zerty!976=Centreon');
     });
@@ -317,6 +319,7 @@ Then('user can not change password unless the minimum time has passed', () => {
   cy.getIframeBody()
     .find('#Form')
     .within(() => {
+      cy.get('#current_password').should('be.visible').type('@zerty!976=Centreon');
       cy.get('#passwd1').should('be.visible').type('@zerty!976=Centreon');
       cy.get('#passwd2').should('be.visible').type('@zerty!976=Centreon');
     });
@@ -348,6 +351,7 @@ Then('user can not reuse the last passwords more than 3 times', () => {
   cy.getIframeBody()
     .find('#Form')
     .within(() => {
+      cy.get('#current_password').should('be.visible').type('@zerty!976=Centreon');
       cy.get('#passwd1').should('be.visible').type('@zerty!976=Centreon');
       cy.get('#passwd2').should('be.visible').type('@zerty!976=Centreon');
     });

--- a/centreon/www/class/centreonUser.class.php
+++ b/centreon/www/class/centreonUser.class.php
@@ -232,7 +232,7 @@ class CentreonUser
         }
     }
 
-    // Get
+    // Getters
 
     /**
      * @return int|mixed|string|null
@@ -331,17 +331,7 @@ class CentreonUser
         return $this->showDeprecatedCustomViews;
     }
 
-    /**
-     * @param bool $showDeprecatedPages
-     *
-     * @return void
-     */
-    public function setShowDeprecatedPages(bool $showDeprecatedPages): void
-    {
-        $this->showDeprecatedPages = $showDeprecatedPages;
-    }
-
-    // Set
+    // Setters
 
     /**
      * @param $id
@@ -407,6 +397,18 @@ class CentreonUser
     {
         $this->passwd = $passwd;
     }
+
+    public function setShowDeprecatedPages(bool $showDeprecatedPages): void
+    {
+        $this->showDeprecatedPages = $showDeprecatedPages;
+    }
+
+    public function setShowDeprecatedCustomViews(bool $showDeprecatedCustomViews): void
+    {
+        $this->showDeprecatedCustomViews = $showDeprecatedCustomViews;
+    }
+
+    // Methods
 
     /**
      * @return mixed|null

--- a/centreon/www/class/centreonUser.class.php
+++ b/centreon/www/class/centreonUser.class.php
@@ -403,6 +403,11 @@ class CentreonUser
         $this->version = $version;
     }
 
+    public function setPasswd(string $passwd): void
+    {
+        $this->passwd = $passwd;
+    }
+
     /**
      * @return mixed|null
      */

--- a/centreon/www/include/Administration/myAccount/DB-Func.php
+++ b/centreon/www/include/Administration/myAccount/DB-Func.php
@@ -99,19 +99,18 @@ function updateContact($contactId = null)
         return;
     }
 
-    $ret = [];
-    $ret = $form->getSubmitValues();
+    $submitValues = $form->getSubmitValues();
     // remove illegal chars in data sent by the user
-    $ret['contact_name'] = CentreonUtils::escapeSecure($ret['contact_name'], CentreonUtils::ESCAPE_ILLEGAL_CHARS);
-    $ret['contact_alias'] = CentreonUtils::escapeSecure($ret['contact_alias'], CentreonUtils::ESCAPE_ILLEGAL_CHARS);
-    $ret['contact_email'] = ! empty($ret['contact_email'])
-        ? CentreonUtils::escapeSecure($ret['contact_email'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
-    $ret['contact_pager'] = ! empty($ret['contact_pager'])
-        ? CentreonUtils::escapeSecure($ret['contact_pager'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
-    $ret['contact_autologin_key'] = ! empty($ret['contact_autologin_key'])
-        ? CentreonUtils::escapeSecure($ret['contact_autologin_key'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
-    $ret['contact_lang'] = ! empty($ret['contact_lang'])
-        ? CentreonUtils::escapeSecure($ret['contact_lang'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
+    $submitValues['contact_name'] = CentreonUtils::escapeSecure($submitValues['contact_name'], CentreonUtils::ESCAPE_ILLEGAL_CHARS);
+    $submitValues['contact_alias'] = CentreonUtils::escapeSecure($submitValues['contact_alias'], CentreonUtils::ESCAPE_ILLEGAL_CHARS);
+    $submitValues['contact_email'] = ! empty($submitValues['contact_email'])
+        ? CentreonUtils::escapeSecure($submitValues['contact_email'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
+    $submitValues['contact_pager'] = ! empty($submitValues['contact_pager'])
+        ? CentreonUtils::escapeSecure($submitValues['contact_pager'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
+    $submitValues['contact_autologin_key'] = ! empty($submitValues['contact_autologin_key'])
+        ? CentreonUtils::escapeSecure($submitValues['contact_autologin_key'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
+    $submitValues['contact_lang'] = ! empty($submitValues['contact_lang'])
+        ? CentreonUtils::escapeSecure($submitValues['contact_lang'], CentreonUtils::ESCAPE_ILLEGAL_CHARS) : '';
 
     $rq = 'UPDATE contact SET '
           . 'contact_name = :contactName, '
@@ -127,74 +126,93 @@ function updateContact($contactId = null)
     $rq .= ' WHERE contact_id = :contactId';
 
     $stmt = $pearDB->prepare($rq);
-    $stmt->bindValue(':contactName', $ret['contact_name'], PDO::PARAM_STR);
-    $stmt->bindValue(':contactAlias', $ret['contact_alias'], PDO::PARAM_STR);
-    $stmt->bindValue(':contactLang', $ret['contact_lang'], PDO::PARAM_STR);
+    $stmt->bindValue(':contactName', $submitValues['contact_name'], PDO::PARAM_STR);
+    $stmt->bindValue(':contactAlias', $submitValues['contact_alias'], PDO::PARAM_STR);
+    $stmt->bindValue(':contactLang', $submitValues['contact_lang'], PDO::PARAM_STR);
     $stmt->bindValue(
         ':contactEmail',
-        ! empty($ret['contact_email']) ? $ret['contact_email'] : null,
+        ! empty($submitValues['contact_email']) ? $submitValues['contact_email'] : null,
         PDO::PARAM_STR
     );
     $stmt->bindValue(
         ':contactPager',
-        ! empty($ret['contact_pager']) ? $ret['contact_pager'] : null,
+        ! empty($submitValues['contact_pager']) ? $submitValues['contact_pager'] : null,
         PDO::PARAM_STR
     );
     $stmt->bindValue(
         ':contactAutologinKey',
-        ! empty($ret['contact_autologin_key']) ? $ret['contact_autologin_key'] : null,
+        ! empty($submitValues['contact_autologin_key']) ? $submitValues['contact_autologin_key'] : null,
         PDO::PARAM_STR
     );
     $stmt->bindValue(
         ':contactLocation',
-        ! empty($ret['contact_location']) ? $ret['contact_location'] : null,
+        ! empty($submitValues['contact_location']) ? $submitValues['contact_location'] : null,
         PDO::PARAM_INT
     );
-    $stmt->bindValue(':defaultPage', ! empty($ret['default_page']) ? $ret['default_page'] : null, PDO::PARAM_INT);
-    $stmt->bindValue(':showDeprecatedPages', isset($ret['show_deprecated_pages']) ? 1 : 0, PDO::PARAM_STR);
+    $stmt->bindValue(':defaultPage', ! empty($submitValues['default_page']) ? $submitValues['default_page'] : null, PDO::PARAM_INT);
+    $stmt->bindValue(':showDeprecatedPages', isset($submitValues['show_deprecated_pages']) ? 1 : 0, PDO::PARAM_STR);
     $stmt->bindValue(
         ':showDeprecatedCustomViews',
-        isset($ret['show_deprecated_custom_views']) ? '1' : '0',
+        isset($submitValues['show_deprecated_custom_views']) ? '1' : '0',
         PDO::PARAM_STR
     );
     $stmt->bindValue(':contactId', $contactId, PDO::PARAM_INT);
     $stmt->execute();
 
-    if (isset($ret['contact_passwd']) && ! empty($ret['contact_passwd'])) {
-        $hashedPassword = password_hash($ret['contact_passwd'], CentreonAuth::PASSWORD_HASH_ALGORITHM);
+    if (isset($submitValues['contact_passwd']) && ! empty($submitValues['contact_passwd'])) {
+        $hashedPassword = password_hash($submitValues['contact_passwd'], CentreonAuth::PASSWORD_HASH_ALGORITHM);
         $contact = new CentreonContact($pearDB);
         $contact->renewPasswordByContactId($contactId, $hashedPassword);
+        $centreon->user->setPasswd($hashedPassword);
     }
 
     // Update user object..
-    $centreon->user->name = $ret['contact_name'];
-    $centreon->user->alias = $ret['contact_alias'];
-    $centreon->user->lang = $ret['contact_lang'];
-    $centreon->user->email = $ret['contact_email'];
-    $centreon->user->setToken($ret['contact_autologin_key'] ?? "''");
+    $centreon->user->name = $submitValues['contact_name'];
+    $centreon->user->alias = $submitValues['contact_alias'];
+    $centreon->user->lang = $submitValues['contact_lang'];
+    $centreon->user->email = $submitValues['contact_email'];
+    $centreon->user->setToken($submitValues['contact_autologin_key'] ?? "''");
 }
 
 /**
  * @param array<string,mixed> $fields
+ *
+ * @return array<string,string>|true
  */
-function validatePasswordModification(array $fields)
+function validatePasswordModification(array $fields): array|true
 {
     global $pearDB, $centreon;
-    $errors = [];
-    $password = $fields['contact_passwd'];
+    $newPassword = $fields['contact_passwd'];
+    $currentPassword = $fields['current_password'];
     $contactId = (int) $centreon->user->get_id();
-    if (empty($password)) {
+
+    // If the user does not want to change his password, we do not need to check it
+    if (empty($newPassword) && empty($currentPassword)) {
+        return true;
+    }
+
+    // If the user wants to change his password, he must provide his current password
+    if (!empty($newPassword) && empty($currentPassword)) {
+        return ['current_password' => _('You must enter your current password')];
+    }
+
+    // If the user provided a current password, we check if it matches the one in the database
+    if (!empty($currentPassword) && password_verify($currentPassword, $centreon->user->passwd) === false) {
+        return ['current_password' => _('Your current password is incorrect')];
+    }
+
+    // If the user does not want to change his password, we do not need to check the new password
+    if (empty($newPassword)) {
         return true;
     }
 
     try {
         $contact = new CentreonContact($pearDB);
-        $contact->respectPasswordPolicyOrFail($password, $contactId);
+        $contact->respectPasswordPolicyOrFail($newPassword, $contactId);
+        return true;
     } catch (Throwable $e) {
-        $errors['contact_passwd'] = $e->getMessage();
+        return ['contact_passwd' => $e->getMessage()];
     }
-
-    return $errors !== [] ? $errors : true;
 }
 
 /**

--- a/centreon/www/include/Administration/myAccount/DB-Func.php
+++ b/centreon/www/include/Administration/myAccount/DB-Func.php
@@ -192,24 +192,24 @@ function validatePasswordModification(array $fields): array|true
         return true;
     }
 
-    // If the user only provided a confirmation password, we return a message indicating that it is not necessary
+    // If the user only provided a confirmation password, he must provide a new password and a current password
     if (empty($newPassword) && ! empty($confirmPassword) && empty($currentPassword)) {
-        return ['contact_passwd2' => _('The password field is empty, so confirmation is not necessary')];
+        return ['contact_passwd2' => _('Please fill in both password fields')];
     }
 
-    // If the user only provided his current password, we return a message indicating that it is not necessary
+    // If the user only provided his current password, he must provide a new password
     if (empty($newPassword) && ! empty($currentPassword)) {
-        return ['current_password' => _('The password field is empty, so your current password is not necessary')];
+        return ['current_password' => _('Please fill in both password fields')];
     }
 
     // If the user wants to change his password, he must provide his current password
     if (! empty($newPassword) && empty($currentPassword)) {
-        return ['current_password' => _('Your current password is required to change your password')];
+        return ['current_password' => _('Please fill in both password fields')];
     }
 
     // If the user provided a current password, we check if it matches the one in the database
     if (! empty($currentPassword) && password_verify($currentPassword, $centreon->user->passwd) === false) {
-        return ['current_password' => _('Your current password is incorrect')];
+        return ['current_password' => _('Authentication failed')];
     }
 
     try {

--- a/centreon/www/include/Administration/myAccount/DB-Func.php
+++ b/centreon/www/include/Administration/myAccount/DB-Func.php
@@ -194,17 +194,17 @@ function validatePasswordModification(array $fields): array|true
 
     // If the user only provided a confirmation password, he must provide a new password and a current password
     if (empty($newPassword) && ! empty($confirmPassword) && empty($currentPassword)) {
-        return ['contact_passwd2' => _('Please fill in both password fields')];
+        return ['contact_passwd2' => _('Please fill in all password fields')];
     }
 
     // If the user only provided his current password, he must provide a new password
     if (empty($newPassword) && ! empty($currentPassword)) {
-        return ['current_password' => _('Please fill in both password fields')];
+        return ['current_password' => _('Please fill in all password fields')];
     }
 
     // If the user wants to change his password, he must provide his current password
     if (! empty($newPassword) && empty($currentPassword)) {
-        return ['current_password' => _('Please fill in both password fields')];
+        return ['current_password' => _('Please fill in all password fields')];
     }
 
     // If the user provided a current password, we check if it matches the one in the database

--- a/centreon/www/include/Administration/myAccount/DB-Func.php
+++ b/centreon/www/include/Administration/myAccount/DB-Func.php
@@ -183,12 +183,23 @@ function validatePasswordModification(array $fields): array|true
 {
     global $pearDB, $centreon;
     $newPassword = $fields['contact_passwd'];
+    $confirmPassword = $fields['contact_passwd2'];
     $currentPassword = $fields['current_password'];
     $contactId = (int) $centreon->user->get_id();
 
     // If the user does not want to change his password, we do not need to check it
-    if (empty($newPassword) && empty($currentPassword)) {
+    if (empty($newPassword) && empty($confirmPassword) && empty($currentPassword)) {
         return true;
+    }
+
+    // If the user only provided a confirmation password, we return a message indicating that it is not necessary
+    if (empty($newPassword) && ! empty($confirmPassword) && empty($currentPassword)) {
+        return ['contact_passwd2' => _('The password field is empty, so confirmation is not necessary')];
+    }
+
+    // If the user only provided his current password, we return a message indicating that it is not necessary
+    if (empty($newPassword) && ! empty($currentPassword)) {
+        return ['current_password' => _('The password field is empty, so your current password is not necessary')];
     }
 
     // If the user wants to change his password, he must provide his current password
@@ -199,11 +210,6 @@ function validatePasswordModification(array $fields): array|true
     // If the user provided a current password, we check if it matches the one in the database
     if (! empty($currentPassword) && password_verify($currentPassword, $centreon->user->passwd) === false) {
         return ['current_password' => _('Your current password is incorrect')];
-    }
-
-    // If the user does not want to change his password, we do not need to check the new password
-    if (empty($newPassword)) {
-        return true;
     }
 
     try {

--- a/centreon/www/include/Administration/myAccount/DB-Func.php
+++ b/centreon/www/include/Administration/myAccount/DB-Func.php
@@ -193,7 +193,7 @@ function validatePasswordModification(array $fields): array|true
 
     // If the user wants to change his password, he must provide his current password
     if (!empty($newPassword) && empty($currentPassword)) {
-        return ['current_password' => _('You must enter your current password')];
+        return ['current_password' => _('Your current password is required to change your password')];
     }
 
     // If the user provided a current password, we check if it matches the one in the database

--- a/centreon/www/include/Administration/myAccount/DB-Func.php
+++ b/centreon/www/include/Administration/myAccount/DB-Func.php
@@ -192,12 +192,12 @@ function validatePasswordModification(array $fields): array|true
     }
 
     // If the user wants to change his password, he must provide his current password
-    if (!empty($newPassword) && empty($currentPassword)) {
+    if (! empty($newPassword) && empty($currentPassword)) {
         return ['current_password' => _('Your current password is required to change your password')];
     }
 
     // If the user provided a current password, we check if it matches the one in the database
-    if (!empty($currentPassword) && password_verify($currentPassword, $centreon->user->passwd) === false) {
+    if (! empty($currentPassword) && password_verify($currentPassword, $centreon->user->passwd) === false) {
         return ['current_password' => _('Your current password is incorrect')];
     }
 
@@ -209,6 +209,7 @@ function validatePasswordModification(array $fields): array|true
     try {
         $contact = new CentreonContact($pearDB);
         $contact->respectPasswordPolicyOrFail($newPassword, $contactId);
+
         return true;
     } catch (Throwable $e) {
         return ['contact_passwd' => $e->getMessage()];

--- a/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
@@ -46,8 +46,9 @@
                     <h4>{t}Password Management{/t}</h4>
                 </td>
             </tr>
-            <tr class="list_one"><td class="FormRowField">{$form.contact_passwd.label}</td><td class="FormRowValue">{$form.contact_passwd.html} {if $o}{$form.contact_gen_passwd.html}{if $expirationMessage}<span style="color:red;">&nbsp;{$expirationMessage}</span>{/if}{/if}</td></tr>
-    		<tr class="list_two"><td class="FormRowField">{$form.contact_passwd2.label}</td><td class="FormRowValue">{$form.contact_passwd2.html}</td></tr>
+            <tr class="list_one"><td class="FormRowField">{$form.current_password.label}</td><td class="FormRowValue">{$form.current_password.html}</td></tr>
+            <tr class="list_two"><td class="FormRowField">{$form.contact_passwd.label}</td><td class="FormRowValue">{$form.contact_passwd.html} {if $o}{$form.contact_gen_passwd.html}{if $expirationMessage}<span style="color:red;">&nbsp;{$expirationMessage}</span>{/if}{/if}</td></tr>
+    		<tr class="list_one"><td class="FormRowField">{$form.contact_passwd2.label}</td><td class="FormRowValue">{$form.contact_passwd2.html}</td></tr>
             {/if}
     		<tr class="list_lvl_1">
                 <td class="ListColLvl1_name" colspan="2">

--- a/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.ihtml
@@ -4,7 +4,7 @@
         <ul id="mainnav">
             <li class="a" id='c1'><a href="#"  style='cursor:pointer' onclick="javascript:montre('1');">{t}General Information{/t}</a></li>
             {if $cct.contact_auth_type === 'local'}
-            <li class="b" id='c2'><a href="#" style='cursor:pointer' onclick="javascript:montre('2');">{t}UI Notifications{/t}</a></li>
+                <li class="b" id='c2'><a href="#" style='cursor:pointer' onclick="javascript:montre('2');">{t}UI Notifications{/t}</a></li>
             {/if}
         </ul>
         <div id="validFormTop">
@@ -41,14 +41,14 @@
             <tr class="list_one"><td class="FormRowField">{$form.contact_lang.label}</td><td class="FormRowValue">{$form.contact_lang.html}</td></tr>
             <tr class="list_two"><td class="FormRowField">{$form.contact_location.label}</td><td class="FormRowValue">{$form.contact_location.html}</td></tr>
             {if $cct.contact_auth_type === 'local'}
-            <tr class="list_lvl_1">
-                <td class="ListColLvl1_name" colspan="2">
-                    <h4>{t}Password Management{/t}</h4>
-                </td>
-            </tr>
-            <tr class="list_one"><td class="FormRowField">{$form.current_password.label}</td><td class="FormRowValue">{$form.current_password.html}</td></tr>
-            <tr class="list_two"><td class="FormRowField">{$form.contact_passwd.label}</td><td class="FormRowValue">{$form.contact_passwd.html} {if $o}{$form.contact_gen_passwd.html}{if $expirationMessage}<span style="color:red;">&nbsp;{$expirationMessage}</span>{/if}{/if}</td></tr>
-    		<tr class="list_one"><td class="FormRowField">{$form.contact_passwd2.label}</td><td class="FormRowValue">{$form.contact_passwd2.html}</td></tr>
+                <tr class="list_lvl_1">
+                    <td class="ListColLvl1_name" colspan="2">
+                        <h4>{t}Password Management{/t}</h4>
+                    </td>
+                </tr>
+                <tr class="list_one"><td class="FormRowField">{$form.current_password.label}</td><td class="FormRowValue">{$form.current_password.html}</td></tr>
+                <tr class="list_two"><td class="FormRowField">{$form.contact_passwd.label}</td><td class="FormRowValue">{$form.contact_passwd.html} {if $o}{$form.contact_gen_passwd.html}{if $expirationMessage}<span style="color:red;">&nbsp;{$expirationMessage}</span>{/if}{/if}</td></tr>
+                <tr class="list_one"><td class="FormRowField">{$form.contact_passwd2.label}</td><td class="FormRowValue">{$form.contact_passwd2.html}</td></tr>
             {/if}
     		<tr class="list_lvl_1">
                 <td class="ListColLvl1_name" colspan="2">
@@ -58,33 +58,33 @@
             <tr class="list_two"><td class="FormRowField">{$form.default_page.label}</td><td class="FormRowValue">{$form.default_page.html}</td></tr>
             <tr class="list_one"><td class="FormRowField">{if $form.show_deprecated_pages.label}<img class="helpTooltip" name="show_deprecated_pages">{$form.show_deprecated_pages.label}</td><td class="FormRowValue">{$form.show_deprecated_pages.html}</td>{/if}</tr>
             <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="show_deprecated_custom_views">{$form.show_deprecated_custom_views.label}</td><td class="FormRowValue">{$form.show_deprecated_custom_views.html}</td></tr>
-        {if $cct.contact_auth_type === 'local'}
-            <tr class="list_lvl_1">
-                <td class="ListColLvl1_name" colspan="2">
-                    <h4>{t}Authentication{/t}</h4>
-                </td>
-            </tr>
-            <tr class="list_one">
-                <td class="FormRowField">{$form.contact_autologin_key.label}</td>
-                <td class="FormRowValue">{$form.contact_autologin_key.html} {if $o}{$form.contact_gen_akey.html}{/if}</td>
-            </tr>
+            {if $cct.contact_auth_type === 'local'}
+                <tr class="list_lvl_1">
+                    <td class="ListColLvl1_name" colspan="2">
+                        <h4>{t}Authentication{/t}</h4>
+                    </td>
+                </tr>
+                <tr class="list_one">
+                    <td class="FormRowField">{$form.contact_autologin_key.label}</td>
+                    <td class="FormRowValue">{$form.contact_autologin_key.html} {if $o}{$form.contact_gen_akey.html}{/if}</td>
+                </tr>
             {/if}
             {if $featuresFlipping}
-            <tr class="list_lvl_1">
-                <td class="ListColLvl1_name" colspan="2">
-                    <h4>{t}Features flipping{/t}</h4>
-                </td>
-            </tr>
-            {foreach item=feature from=$form.features name=features}
-            {if $smarty.foreach.features.index % 2 == 0}
-            <tr class="list_one">
-            {else}
-            <tr class="list_two">
-            {/if}
-                <td class="FormRowField">{$feature.label}</td>
-                <td class="FormRowValue">{$feature.html}</td>
-            </tr>
-            {/foreach}
+                <tr class="list_lvl_1">
+                    <td class="ListColLvl1_name" colspan="2">
+                        <h4>{t}Features flipping{/t}</h4>
+                    </td>
+                </tr>
+                {foreach item=feature from=$form.features name=features}
+                    {if $smarty.foreach.features.index % 2 == 0}
+                        <tr class="list_one">
+                    {else}
+                        <tr class="list_two">
+                    {/if}
+                    <td class="FormRowField">{$feature.label}</td>
+                    <td class="FormRowValue">{$feature.html}</td>
+                    </tr>
+                {/foreach}
             {/if}
         </table>
     </div>
@@ -118,13 +118,13 @@
             <tr class="list_one"><td class="FormRowField">{$form.monitoring_sound_svc_notification_2.label}</td><td class="FormRowValue">{$form.monitoring_sound_svc_notification_2.html}</td></tr>
             <tr class="list_two"><td class="FormRowField">{$form.monitoring_sound_svc_notification_3.label}</td><td class="FormRowValue">{$form.monitoring_sound_svc_notification_3.html}</td></tr>
             {if $o == "c"}
-            <tr class="list_lvl_1">
-                <td class="ListColLvl1_name" colspan="2">
-                {if isset($form.required)}
-                    {$form.required._note}
-                {/if}
-                </td>
-            </tr>
+                <tr class="list_lvl_1">
+                    <td class="ListColLvl1_name" colspan="2">
+                    {if isset($form.required)}
+                        {$form.required._note}
+                    {/if}
+                    </td>
+                </tr>
             {/if}
 	    </table>
     </div>

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -125,14 +125,14 @@ if ($cct['contact_auth_type'] === 'local') {
         }
     }
     $form->addElement(
-            'password',
-            'current_password',
-            _('Current password'),
-            [
-                    'size' => '30',
-                    'autocomplete' => 'off',
-                    'id' => 'current_password'
-            ]
+        'password',
+        'current_password',
+        _('Current password'),
+        [
+            'size' => '30',
+            'autocomplete' => 'off',
+            'id' => 'current_password',
+        ]
     );
     $form->addElement(
         'password',

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -444,14 +444,12 @@ if ($form->validate()) {
             || $showDeprecatedPages !== $cct['show_deprecated_pages']
             || $showDeprecatedCustomViews !== $cct['show_deprecated_custom_views']
     ) {
-        $contactStatement = $pearDB->prepare(
-            'SELECT * FROM contact WHERE contact_id = :contact_id'
-        );
-        $contactStatement->bindValue(':contact_id', $centreon->user->get_id(), PDO::PARAM_INT);
-        $contactStatement->execute();
-        if ($contact = $contactStatement->fetch()) {
-            $_SESSION['centreon'] = new Centreon($contact);
-        }
+        /** @var Centreon $centreon */
+        $centreon = $_SESSION['centreon'];
+        $centreon->user->set_lang($form->getSubmitValue('contact_lang'));
+        $centreon->user->setShowDeprecatedPages($showDeprecatedPages);
+        $centreon->user->setShowDeprecatedCustomViews($showDeprecatedCustomViews);
+        $_SESSION['centreon'] = $centreon;
         $_SESSION[$sessionKeyFreeze] = true;
         echo '<script>parent.location.href = "main.php?p=' . $p . '&o=c";</script>';
 

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -447,8 +447,8 @@ if ($form->validate()) {
         /** @var Centreon $centreon */
         $centreon = $_SESSION['centreon'];
         $centreon->user->set_lang($form->getSubmitValue('contact_lang'));
-        $centreon->user->setShowDeprecatedPages($showDeprecatedPages);
-        $centreon->user->setShowDeprecatedCustomViews($showDeprecatedCustomViews);
+        $centreon->user->setShowDeprecatedPages((bool) $showDeprecatedPages);
+        $centreon->user->setShowDeprecatedCustomViews((bool) $showDeprecatedCustomViews);
         $_SESSION['centreon'] = $centreon;
         $_SESSION[$sessionKeyFreeze] = true;
         echo '<script>parent.location.href = "main.php?p=' . $p . '&o=c";</script>';

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -97,6 +97,9 @@ if ($cct['contact_auth_type'] === 'local') {
     $form->addElement('text', 'contact_email', _('Email'), $attrsText)->freeze();
 }
 $form->addElement('text', 'contact_pager', _('Pager'), $attrsText);
+
+// Password Management
+
 if ($cct['contact_auth_type'] === 'local') {
     $form->addFormRule('validatePasswordModification');
     $statement = $pearDB->prepare(
@@ -121,6 +124,12 @@ if ($cct['contact_auth_type'] === 'local') {
             }
         }
     }
+    $form->addElement(
+            'password',
+            'current_password',
+            _('Current Password'),
+            ['size' => '30', 'autocomplete' => 'off', 'id' => 'current_password']
+    );
     $form->addElement(
         'password',
         'contact_passwd',
@@ -150,13 +159,16 @@ $form->addElement(
         'id' => 'generateAutologinKeyButton',
         'data-testid' => _('Generate')]
 );
+
+// Preferences
+
 $form->addElement('select', 'contact_lang', _('Language'), $langs);
 if (! isCloudPlatform()) {
     $form->addElement('checkbox', 'show_deprecated_pages', _('Use deprecated monitoring pages'), null, $attrsText);
 }
 $form->addElement('checkbox', 'show_deprecated_custom_views', _('Use deprecated custom views'), null, $attrsText);
 
-// ------------------------ Topoogy ----------------------------
+// ------------------------ Topology ----------------------------
 $pages = [];
 $aclUser = $centreon->user->lcaTStr;
 if (! empty($aclUser)) {
@@ -372,7 +384,7 @@ $form->registerRule('exist', 'callback', 'testExistence');
 $form->addRule('contact_name', _('Name already in use'), 'exist');
 $form->registerRule('existAlias', 'callback', 'testAliasExistence');
 $form->addRule('contact_alias', _('Name already in use'), 'existAlias');
-$form->setRequiredNote("<font style='color: red;'>*</font>" . _('Required fields'));
+$form->setRequiredNote("<span style='color: red;'>*</span>" . _('Required fields'));
 $form->addFormRule('checkAutologinValue');
 
 // Smarty template initialization

--- a/centreon/www/include/Administration/myAccount/formMyAccount.php
+++ b/centreon/www/include/Administration/myAccount/formMyAccount.php
@@ -127,8 +127,12 @@ if ($cct['contact_auth_type'] === 'local') {
     $form->addElement(
             'password',
             'current_password',
-            _('Current Password'),
-            ['size' => '30', 'autocomplete' => 'off', 'id' => 'current_password']
+            _('Current password'),
+            [
+                    'size' => '30',
+                    'autocomplete' => 'off',
+                    'id' => 'current_password'
+            ]
     );
     $form->addElement(
         'password',

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1625,12 +1625,12 @@ function validatePasswordModification(array $fields): array|true
     }
 
     // If the admin wants to change the user password, he must provide his current password
-    if (!empty($newPassword) && empty($currentAdminPassword)) {
+    if (! empty($newPassword) && empty($currentAdminPassword)) {
         return ['current_admin_password' => _('Your current administrator password is required to change the user password')];
     }
 
     // If the admin provided a current password, we check if it matches the one in the database
-    if (!empty($currentAdminPassword) && password_verify($currentAdminPassword, $centreon->user->passwd) === false) {
+    if (! empty($currentAdminPassword) && password_verify($currentAdminPassword, $centreon->user->passwd) === false) {
         return ['current_admin_password' => _('Your current administrator password is incorrect')];
     }
 
@@ -1642,6 +1642,7 @@ function validatePasswordModification(array $fields): array|true
     try {
         $contact = new CentreonContact($pearDB);
         $contact->respectPasswordPolicyOrFail($newPassword, $contactId);
+
         return true;
     } catch (Throwable $e) {
         return ['contact_passwd' => $e->getMessage()];

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1616,27 +1616,33 @@ function validatePasswordModification(array $fields): array|true
 {
     global $pearDB, $centreon;
     $newPassword = $fields['contact_passwd'];
+    $confirmPassword = $fields['contact_passwd2'];
     $currentAdminPassword = $fields['current_admin_password'];
     $contactId = $fields['contact_id'];
 
-    // If the admin does not want to change the user password, we do not need to check it
-    if (empty($newPassword) && empty($currentAdminPassword)) {
+    // If the user does not want to change his password, we do not need to check it
+    if (empty($newPassword) && empty($confirmPassword) && empty($currentAdminPassword)) {
         return true;
     }
 
-    // If the admin wants to change the user password, he must provide his current password
+    // If the user only provided a confirmation password, we return a message indicating that it is not necessary
+    if (empty($newPassword) && ! empty($confirmPassword) && empty($currentAdminPassword)) {
+        return ['contact_passwd2' => _('The password field is empty, so confirmation is not necessary')];
+    }
+
+    // If the user only provided his current password, we return a message indicating that it is not necessary
+    if (empty($newPassword) && ! empty($currentAdminPassword)) {
+        return ['current_password' => _('The password field is empty, so your current password is not necessary')];
+    }
+
+    // If the user wants to change his password, he must provide his current password
     if (! empty($newPassword) && empty($currentAdminPassword)) {
-        return ['current_admin_password' => _('Your current administrator password is required to change the user password')];
+        return ['current_password' => _('Your current password is required to change your password')];
     }
 
-    // If the admin provided a current password, we check if it matches the one in the database
+    // If the user provided a current password, we check if it matches the one in the database
     if (! empty($currentAdminPassword) && password_verify($currentAdminPassword, $centreon->user->passwd) === false) {
-        return ['current_admin_password' => _('Your current administrator password is incorrect')];
-    }
-
-    // If the admin does not want to change his password, we do not need to check the new password
-    if (empty($newPassword)) {
-        return true;
+        return ['current_password' => _('Your current password is incorrect')];
     }
 
     try {

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1627,17 +1627,17 @@ function validatePasswordModification(array $fields): array|true
 
     // If the user only provided a confirmation password, he must provide a new password and a current password
     if (empty($newPassword) && ! empty($confirmPassword) && empty($currentPassword)) {
-        return ['contact_passwd2' => _('Please fill in both password fields')];
+        return ['contact_passwd2' => _('Please fill in all password fields')];
     }
 
     // If the user only provided his current password, he must provide a new password
     if (empty($newPassword) && ! empty($currentPassword)) {
-        return ['current_password' => _('Please fill in both password fields')];
+        return ['current_password' => _('Please fill in all password fields')];
     }
 
     // If the user wants to change his password, he must provide his current password
     if (! empty($newPassword) && empty($currentPassword)) {
-        return ['current_password' => _('Please fill in both password fields')];
+        return ['current_password' => _('Please fill in all password fields')];
     }
 
     // If the user provided a current password, we check if it matches the one in the database

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1617,32 +1617,32 @@ function validatePasswordModification(array $fields): array|true
     global $pearDB, $centreon;
     $newPassword = $fields['contact_passwd'];
     $confirmPassword = $fields['contact_passwd2'];
-    $currentAdminPassword = $fields['current_admin_password'];
+    $currentPassword = $fields['current_password'];
     $contactId = $fields['contact_id'];
 
     // If the user does not want to change his password, we do not need to check it
-    if (empty($newPassword) && empty($confirmPassword) && empty($currentAdminPassword)) {
+    if (empty($newPassword) && empty($confirmPassword) && empty($currentPassword)) {
         return true;
     }
 
-    // If the user only provided a confirmation password, we return a message indicating that it is not necessary
-    if (empty($newPassword) && ! empty($confirmPassword) && empty($currentAdminPassword)) {
-        return ['contact_passwd2' => _('The password field is empty, so confirmation is not necessary')];
+    // If the user only provided a confirmation password, he must provide a new password and a current password
+    if (empty($newPassword) && ! empty($confirmPassword) && empty($currentPassword)) {
+        return ['contact_passwd2' => _('Please fill in both password fields')];
     }
 
-    // If the user only provided his current password, we return a message indicating that it is not necessary
-    if (empty($newPassword) && ! empty($currentAdminPassword)) {
-        return ['current_password' => _('The password field is empty, so your current password is not necessary')];
+    // If the user only provided his current password, he must provide a new password
+    if (empty($newPassword) && ! empty($currentPassword)) {
+        return ['current_password' => _('Please fill in both password fields')];
     }
 
     // If the user wants to change his password, he must provide his current password
-    if (! empty($newPassword) && empty($currentAdminPassword)) {
-        return ['current_password' => _('Your current password is required to change your password')];
+    if (! empty($newPassword) && empty($currentPassword)) {
+        return ['current_password' => _('Please fill in both password fields')];
     }
 
     // If the user provided a current password, we check if it matches the one in the database
-    if (! empty($currentAdminPassword) && password_verify($currentAdminPassword, $centreon->user->passwd) === false) {
-        return ['current_password' => _('Your current password is incorrect')];
+    if (! empty($currentPassword) && password_verify($currentPassword, $centreon->user->passwd) === false) {
+        return ['current_password' => _('Authentication failed')];
     }
 
     try {

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1626,12 +1626,12 @@ function validatePasswordModification(array $fields): array|true
 
     // If the admin wants to change the user password, he must provide his current password
     if (!empty($newPassword) && empty($currentAdminPassword)) {
-        return ['current_password' => _('You must enter your current password')];
+        return ['current_password' => _('Your current administrator password is required to change the user password')];
     }
 
     // If the admin provided a current password, we check if it matches the one in the database
     if (!empty($currentAdminPassword) && password_verify($currentAdminPassword, $centreon->user->passwd) === false) {
-        return ['current_password' => _('Your current password is incorrect')];
+        return ['current_password' => _('Your current administrator password is incorrect')];
     }
 
     // If the admin does not want to change his password, we do not need to check the new password

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1626,12 +1626,12 @@ function validatePasswordModification(array $fields): array|true
 
     // If the admin wants to change the user password, he must provide his current password
     if (!empty($newPassword) && empty($currentAdminPassword)) {
-        return ['current_password' => _('Your current administrator password is required to change the user password')];
+        return ['current_admin_password' => _('Your current administrator password is required to change the user password')];
     }
 
     // If the admin provided a current password, we check if it matches the one in the database
     if (!empty($currentAdminPassword) && password_verify($currentAdminPassword, $centreon->user->passwd) === false) {
-        return ['current_password' => _('Your current administrator password is incorrect')];
+        return ['current_admin_password' => _('Your current administrator password is incorrect')];
     }
 
     // If the admin does not want to change his password, we do not need to check the new password

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -1609,28 +1609,43 @@ function validatePasswordCreation(array $fields)
  * Validate password creation using defined security policy.
  *
  * @param array<string,mixed> $fields
- * @return mixed
+ *
+ * @return array<string,string>|true
  */
-function validatePasswordModification(array $fields)
+function validatePasswordModification(array $fields): array|true
 {
-    global $pearDB;
-    $errors = [];
+    global $pearDB, $centreon;
+    $newPassword = $fields['contact_passwd'];
+    $currentAdminPassword = $fields['current_admin_password'];
+    $contactId = $fields['contact_id'];
 
-    if (empty($fields['contact_passwd'])) {
+    // If the admin does not want to change the user password, we do not need to check it
+    if (empty($newPassword) && empty($currentAdminPassword)) {
         return true;
     }
 
-    $password = $fields['contact_passwd'];
-    $contactId = $fields['contact_id'];
+    // If the admin wants to change the user password, he must provide his current password
+    if (!empty($newPassword) && empty($currentAdminPassword)) {
+        return ['current_password' => _('You must enter your current password')];
+    }
+
+    // If the admin provided a current password, we check if it matches the one in the database
+    if (!empty($currentAdminPassword) && password_verify($currentAdminPassword, $centreon->user->passwd) === false) {
+        return ['current_password' => _('Your current password is incorrect')];
+    }
+
+    // If the admin does not want to change his password, we do not need to check the new password
+    if (empty($newPassword)) {
+        return true;
+    }
 
     try {
         $contact = new CentreonContact($pearDB);
-        $contact->respectPasswordPolicyOrFail($password, $contactId);
+        $contact->respectPasswordPolicyOrFail($newPassword, $contactId);
+        return true;
     } catch (Throwable $e) {
-        $errors['contact_passwd'] = $e->getMessage();
+        return ['contact_passwd' => $e->getMessage()];
     }
-
-    return $errors !== [] ? $errors : true;
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/contact/formContact.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/formContact.ihtml
@@ -153,7 +153,7 @@
         </tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreon_login"> {$form.contact_oreon.label}</td><td class="FormRowValue">{$form.contact_oreon.html}</td></tr>
         {if $auth_type != 'ldap' && $o != "mc"}
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="current_admin_password"> {$form.current_admin_password.label}</td><td class="FormRowValue">{$form.current_admin_password.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="current_password"> {$form.current_password.label}</td><td class="FormRowValue">{$form.current_password.html}</td></tr>
         <tr class="list_one">
             <td class="FormRowField"><img class="helpTooltip" name="password"> {$form.contact_passwd.label}</td>
             <td class="FormRowValue">{$form.contact_passwd.html} {$form.contact_gen_passwd.html}</td>

--- a/centreon/www/include/configuration/configObject/contact/formContact.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/formContact.ihtml
@@ -153,13 +153,14 @@
         </tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreon_login"> {$form.contact_oreon.label}</td><td class="FormRowValue">{$form.contact_oreon.html}</td></tr>
         {if $auth_type != 'ldap' && $o != "mc"}
-        <tr class="list_two">
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="current_admin_password"> {$form.current_admin_password.label}</td><td class="FormRowValue">{$form.current_admin_password.html}</td></tr>
+        <tr class="list_one">
             <td class="FormRowField"><img class="helpTooltip" name="password"> {$form.contact_passwd.label}</td>
             <td class="FormRowValue">{$form.contact_passwd.html} {$form.contact_gen_passwd.html}</td>
         </tr>
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="password2"> {$form.contact_passwd2.label}</td><td class="FormRowValue">{$form.contact_passwd2.html}</td></tr>
+        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="password2"> {$form.contact_passwd2.label}</td><td class="FormRowValue">{$form.contact_passwd2.html}</td></tr>
         {/if}
-        <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="language"> {$form.contact_lang.label}</td><td class="FormRowValue">{$form.contact_lang.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="language"> {$form.contact_lang.label}</td><td class="FormRowValue">{$form.contact_lang.html}</td></tr>
         <tr class="list_two"><td class="FormRowField"><img class="helpTooltip" name="default_page"> {$form.default_page.label}</td><td class="FormRowValue">{$form.default_page.html}</td></tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="location"> {$form.contact_location.label}</td><td class="FormRowValue">{$form.contact_location.html}</td></tr>
         {if $o != "mc"}

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -65,8 +65,13 @@ $dbResult->closeCursor();
  */
 try {
     $passwordSecurityPolicy = (new CentreonContact($pearDB))->getPasswordSecurityPolicy();
-    $encodedPasswordPolicy = json_encode($passwordSecurityPolicy);
-} catch (PDOException $e) {
+    $encodedPasswordPolicy = json_encode($passwordSecurityPolicy, JSON_THROW_ON_ERROR);
+} catch (PDOException|JsonException $e) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error while retrieving password security policy: ' . $e->getMessage(),
+        exception: $e
+    );
     return false;
 }
 

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -399,12 +399,12 @@ $form->addGroup($tab, 'contact_oreon', _('Reach Centreon Front-end'), '&nbsp;');
 if ($o !== MASSIVE_CHANGE) {
     $form->addElement(
         'password',
-        'current_admin_password',
-        _('Your current administrator password'),
+        'current_password',
+        _('Your current password'),
         [
             'size' => '30',
             'autocomplete' => 'off',
-            'id' => 'current_admin_password',
+            'id' => 'current_password',
         ]
     );
     $form->addElement(

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -392,6 +392,16 @@ $form->addGroup($tab, 'contact_oreon', _('Reach Centreon Front-end'), '&nbsp;');
 
 if ($o !== MASSIVE_CHANGE) {
     $form->addElement(
+            'password',
+            'current_admin_password',
+            _('Your current administrator password'),
+            [
+                    'size' => '30',
+                    'autocomplete' => 'off',
+                    'id' => 'current_admin_password',
+            ]
+    );
+    $form->addElement(
         'password',
         'contact_passwd',
         _('Password'),

--- a/centreon/www/include/configuration/configObject/contact/formContact.php
+++ b/centreon/www/include/configuration/configObject/contact/formContact.php
@@ -72,6 +72,7 @@ try {
         message: 'Error while retrieving password security policy: ' . $e->getMessage(),
         exception: $e
     );
+
     return false;
 }
 
@@ -397,14 +398,14 @@ $form->addGroup($tab, 'contact_oreon', _('Reach Centreon Front-end'), '&nbsp;');
 
 if ($o !== MASSIVE_CHANGE) {
     $form->addElement(
-            'password',
-            'current_admin_password',
-            _('Your current administrator password'),
-            [
-                    'size' => '30',
-                    'autocomplete' => 'off',
-                    'id' => 'current_admin_password',
-            ]
+        'password',
+        'current_admin_password',
+        _('Your current administrator password'),
+        [
+            'size' => '30',
+            'autocomplete' => 'off',
+            'id' => 'current_admin_password',
+        ]
     );
     $form->addElement(
         'password',

--- a/centreon/www/include/configuration/configObject/contact/formContactLight.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/formContactLight.ihtml
@@ -39,7 +39,7 @@
         </tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreon_login"> {$form.contact_oreon.label}</td><td class="FormRowValue">{$form.contact_oreon.html}</td></tr>
         {if $auth_type != 'ldap' && $o != "mc"}
-        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="current_admin_password"> {$form.current_admin_password.label}</td><td class="FormRowValue">{$form.current_admin_password.html}</td></tr>
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="current_password"> {$form.current_password.label}</td><td class="FormRowValue">{$form.current_password.html}</td></tr>
         <tr class="list_two">
             <td class="FormRowField"><img class="helpTooltip" name="password"> {$form.contact_passwd.label}</td>
             <td class="FormRowValue">{$form.contact_passwd.html} {$form.contact_gen_passwd.html}</td>

--- a/centreon/www/include/configuration/configObject/contact/formContactLight.ihtml
+++ b/centreon/www/include/configuration/configObject/contact/formContactLight.ihtml
@@ -39,6 +39,7 @@
         </tr>
         <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="centreon_login"> {$form.contact_oreon.label}</td><td class="FormRowValue">{$form.contact_oreon.html}</td></tr>
         {if $auth_type != 'ldap' && $o != "mc"}
+        <tr class="list_one"><td class="FormRowField"><img class="helpTooltip" name="current_admin_password"> {$form.current_admin_password.label}</td><td class="FormRowValue">{$form.current_admin_password.html}</td></tr>
         <tr class="list_two">
             <td class="FormRowField"><img class="helpTooltip" name="password"> {$form.contact_passwd.label}</td>
             <td class="FormRowValue">{$form.contact_passwd.html} {$form.contact_gen_passwd.html}</td>

--- a/centreon/www/include/configuration/configObject/contact/help.php
+++ b/centreon/www/include/configuration/configObject/contact/help.php
@@ -93,6 +93,7 @@ $help['ldap_group'] = dgettext('help', 'LDAP groups of user, for informative pur
 
 // Centreon specific authentication
 $help['centreon_login'] = dgettext('help', 'Specify if the contact is allowed to login into centreon.');
+$help['current_password'] = dgettext('help', "For security reasons, to be able to change this user's password, you (the currently logged-in administrator) must verify your identity by entering your own password.");
 $help['password'] = dgettext('help', 'Define the password for the centreon login here.');
 $help['password2'] = dgettext('help', 'Enter the password again.');
 $help['language'] = dgettext('help', 'Define the default language for the user for the centreon front-end here.');

--- a/centreon/www/include/configuration/configObject/contact/help.php
+++ b/centreon/www/include/configuration/configObject/contact/help.php
@@ -93,7 +93,7 @@ $help['ldap_group'] = dgettext('help', 'LDAP groups of user, for informative pur
 
 // Centreon specific authentication
 $help['centreon_login'] = dgettext('help', 'Specify if the contact is allowed to login into centreon.');
-$help['current_admin_password'] = dgettext('help', "For security reasons, to be able to change this user's password, you (the currently logged-in administrator) must verify your identity by entering your own password.");
+$help['current_password'] = dgettext('help', "For security reasons, to be able to change this user's password, you (the currently logged-in user) must verify your identity by entering your own password.");
 $help['password'] = dgettext('help', 'Define the password for the centreon login here.');
 $help['password2'] = dgettext('help', 'Enter the password again.');
 $help['language'] = dgettext('help', 'Define the default language for the user for the centreon front-end here.');

--- a/centreon/www/include/configuration/configObject/contact/help.php
+++ b/centreon/www/include/configuration/configObject/contact/help.php
@@ -93,7 +93,7 @@ $help['ldap_group'] = dgettext('help', 'LDAP groups of user, for informative pur
 
 // Centreon specific authentication
 $help['centreon_login'] = dgettext('help', 'Specify if the contact is allowed to login into centreon.');
-$help['current_password'] = dgettext('help', "For security reasons, to be able to change this user's password, you (the currently logged-in administrator) must verify your identity by entering your own password.");
+$help['current_admin_password'] = dgettext('help', "For security reasons, to be able to change this user's password, you (the currently logged-in administrator) must verify your identity by entering your own password.");
 $help['password'] = dgettext('help', 'Define the password for the centreon login here.');
 $help['password2'] = dgettext('help', 'Enter the password again.');
 $help['language'] = dgettext('help', 'Define the default language for the user for the centreon front-end here.');

--- a/centreon/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
+++ b/centreon/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
@@ -162,7 +162,7 @@ class HTML_QuickFormCustom extends HTML_QuickForm
      * To validate grouped elements as separated entities,
      * use addGroupRule instead of addRule.
      *
-     * @param string $element Form element name
+     * @param string|string[] $element Form element name
      * @param string $message Message to display for invalid data
      * @param string $type Rule type, use getRegisteredRules() to get types
      * @param string $format (optional)Required for extra rule data


### PR DESCRIPTION
## Description

### Added

* A new field named Current Password has been added and is required to change your password, or a user password when we are an administrator. Only for the contact and profile pages.

### Fixed

* Previously, when we changed lang, deprecated pages or deprecated custom views page, we lost the Password management and Authentication sections. This bug has now been fixed.

Jira tickets :
- [MON-178256](https://centreon.atlassian.net/browse/MON-178256)
- [MON-178255](https://centreon.atlassian.net/browse/MON-178255)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] develop

<h2> How this pull request can be tested ? </h2>

Please, see test file in the tickets.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-178256]: https://centreon.atlassian.net/browse/MON-178256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-178255]: https://centreon.atlassian.net/browse/MON-178255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ