### PR TITLE
Fix(tranlsation): several french translations are missing from the interface

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24043,5 +24043,5 @@ msgid "CA"
 msgstr "CA"
 
 #: unknown
-msgid "CA"
-msgstr "CA"
+msgid "CA Common Name (CN)"
+msgstr "Nom commun CA (CN)"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -3,26 +3,26 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#: centreon/www/install/centreon_broker_translation.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/centreon_broker_translation.php
 msgid ""
 msgstr ""
 "Project-Id-Version: Centreon web\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-01-01 00:00+0000\n"
-"PO-Revision-Date: 2017-03-17 09:57+0100\n"
-"Last-Translator: Laurent Pinsivy <lpinsivy@centreon.com>\n"
+"PO-Revision-Date: 2025-07-02 11:28+0000\n"
+"Last-Translator: Weblate Admin <weblate.admin@example.com>\n"
 "Language-Team: Centreon Team\n"
-"Language: fr\n"
+"Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.7.7\n"
+"X-Generator: Weblate 5.12.1\n"
 
 #: centreon/www/install/smarty_translate.php
 msgid " + Add a new entry"
-msgstr "+ Ajouter une nouvelle entrée"
+msgstr " + Ajouter une nouvelle entrée"
 
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
 msgid " Required fields"
@@ -30,16 +30,17 @@ msgstr " Champs requis"
 
 #: centreon/www/install/smarty_translate.php
 msgid " Table is not partitioned "
-msgstr ""
+msgstr " La table n'est pas partitionnée "
 
 #: centreon/www/include/monitoring/downtime/AddDowntime.php
 msgid " The timezone used is configured on your user settings"
 msgstr ""
-"Le fuseau horaire utilisé est celui configuré dans vos paramètres utilisateur"
+" Le fuseau horaire utilisé est celui configuré dans vos paramètres "
+"utilisateur"
 
 #: centreon/www/install/step_upgrade/step3.php
 msgid " to "
-msgstr ""
+msgstr " à la "
 
 #: centreon/www/install/react_translation.php
 #, php-format
@@ -75,11 +76,11 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "/*+&"
-msgstr ""
+msgstr "/*+&"
 
 #: centreon/www/install/front_translate.php
 msgid "0-9"
-msgstr ""
+msgstr "0-9"
 
 #: centreon/www/include/home/customViews/index.php
 msgid "1 Column"
@@ -91,7 +92,7 @@ msgstr "1 jour"
 
 #: centreon/www/install/smarty_translate.php
 msgid "1 minute"
-msgstr ""
+msgstr "1 minute"
 
 #: centreon/www/install/front_translate.php
 msgid "12 hours"
@@ -99,7 +100,7 @@ msgstr "12 heures"
 
 #: centreon/www/install/smarty_translate.php
 msgid "15 minutes"
-msgstr ""
+msgstr "15 minutes"
 
 #: centreon/www/include/home/customViews/index.php
 msgid "2 Columns"
@@ -119,7 +120,7 @@ msgstr "3 Colonnes"
 
 #: centreon/www/install/smarty_translate.php
 msgid "30 minutes"
-msgstr ""
+msgstr "30 minutes"
 
 #: centreon/www/install/front_translate.php
 msgid "31 days"
@@ -127,7 +128,7 @@ msgstr "31 jours"
 
 #: centreon/www/install/smarty_translate.php
 msgid "5 minutes"
-msgstr ""
+msgstr "5 minutes"
 
 #: centreon/www/install/front_translate.php
 msgid "7 days"
@@ -174,21 +175,28 @@ msgstr "<br><b>Centreon : </b>Une commande de rechargement a été envoyée vers
 msgid "<br><b>Centreon : </b>A restart signal has been sent to "
 msgstr "<br><b>Centreon : </b>Une commande de redémarrage a été envoyée vers "
 
+#: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+msgid "<br><b>Centreon : </b>All configuration will be send to "
+msgstr "<br><b>Centreon : </b>Toute la configuration sera envoyée vers "
+
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
 msgid ""
 "<br><i><b><font color=\"#B22222\">Notes </font>:</b></i><br>- Do not mix "
 "metrics of different sources.<br>- Only aggregation functions work in VDEF "
 "rpn expressions."
 msgstr ""
+"<br><i><b><font color=\"#B22222\">Notes </font>:</b></i><br>- Ne mélangez "
+"pas des métriques de différentes sources.<br>- Seules les fonctions "
+"d'agrégation fonctionnent dans les expressions VDEF rpn."
 
 #: centreon/www/install/step_upgrade/step4.php
 msgid "<p>Currently upgrading... please do not interrupt this process.</p>"
-msgstr ""
+msgstr "<p>Montée de version en cours... N'interrompez pas le processus.</p>"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
 msgid "A '%s': '%s'@'%s' is already saved"
-msgstr "Un '%s': '%s'@'%s' est déjà enregistré"
+msgstr "Un '%s' : '%s'@'%s' est déjà enregistré"
 
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
@@ -201,7 +209,7 @@ msgstr ""
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "A macro is malformated."
-msgstr ""
+msgstr "Une macro est formatée de façon incorrecte."
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
@@ -218,7 +226,7 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "A-Z"
-msgstr ""
+msgstr "A-Z"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
@@ -232,6 +240,10 @@ msgstr "ACL"
 #: centreon/www/install/smarty_translate.php
 msgid "ACL Actions"
 msgstr "Groupe d'accès aux actions"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "ACL Definition"
+msgstr "Nom de l'ACL"
 
 #: centreon/www/install/smarty_translate.php
 msgid "ACL Group"
@@ -257,9 +269,13 @@ msgstr "Le nom de la Resource ACL ne peut pas être vide"
 msgid "ACL access group"
 msgstr "Groupe d'accès ACL"
 
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+msgid "ACL reloaded"
+msgstr "ACL rechargées"
+
 #: centreon/www/include/configuration/configObject/command/listCommand.php
 msgid "ADD"
-msgstr ""
+msgstr "AJOUTER"
 
 #: centreon/www/install/smarty_translate.php
 msgid "API Access Configuration"
@@ -267,7 +283,7 @@ msgstr "Configuration d'accès à l'API"
 
 #: centreon/www/install/smarty_translate.php
 msgid "API Options"
-msgstr ""
+msgstr "Options d'API"
 
 #: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/Exception/PlatformTopologyRepositoryException.php
 msgid "API calling the Central returned a Client exception"
@@ -289,8 +305,8 @@ msgstr "Avorté."
 msgid "About"
 msgstr "À propos"
 
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 msgid "Access"
 msgstr "Accès"
 
@@ -322,16 +338,20 @@ msgstr "Nom de la liste d'accès"
 msgid "Access lists"
 msgstr "Listes d'accès"
 
-#: centreon/www/widgets/host-monitoring/src/action.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Accessible Pages"
+msgstr "Pages disponibles"
+
 #: centreon/www/widgets/host-monitoring/src/toolbar.php
+#: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/install/front_translate.php
 msgid "Acknowledge"
 msgstr "Acquitter"
 
@@ -376,21 +396,21 @@ msgstr "Acquitter les problèmes sélectionnés"
 msgid "Acknowledge services attached to host"
 msgstr "Acquitter les services attachés à l'hôte"
 
-#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
-#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
 #: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
 msgid "Acknowledge services attached to hosts"
 msgstr "Acquitter les services liés à l'hôte"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "Acknowledge services of hosts"
-msgstr ""
+msgstr "Acquitter les services pour ces hôtes"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Acknowledged"
 msgstr "Acquitté"
 
@@ -400,16 +420,16 @@ msgstr "Acquitté par"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
 #, php-format
 msgid "Acknowledged by %s"
 msgstr "Acquitté par %s"
 
 #: centreon/www/install/front_translate.php
 msgid "Acknowledgement"
-msgstr ""
+msgstr "Acquittement"
 
 #: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
 msgid "Acknowledgement already cancelled for this host"
@@ -417,24 +437,23 @@ msgstr "Acquittement déjà annulé pour cet hôte"
 
 #: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
 msgid "Acknowledgement already cancelled for this meta service"
-msgstr ""
+msgstr "L'acquittement a déjà été annulé pour ce métaservice"
 
 #: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
 msgid "Acknowledgement already cancelled for this service"
 msgstr "Acquittement déjà annulé pour ce service"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Acknowledgement timeout"
 msgstr "Durée maximale d'un acquittement"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/options/media/images/formImg.php
-#: centreon/www/include/options/media/images/formDirectory.php
-#: centreon/www/include/Administration/configChangelog/viewLogs.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/install/front_translate.php
 msgid "Action"
 msgstr "Action"
 
@@ -455,10 +474,10 @@ msgid "Action Name"
 msgstr "Nom de l'action"
 
 #: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Action URL"
@@ -470,7 +489,7 @@ msgstr "Liens vers les actions autorisées"
 
 #: centreon/src/Centreon/Infrastructure/ActionLog/ActionLogRepositoryRDB.php
 msgid "Action log id can not be null"
-msgstr ""
+msgstr "L'ID du journal d'actions ne peut pas être vide"
 
 #: centreon/src/Centreon/Domain/ActionLog/ActionLogService.php
 msgid "Action log id cannot be null"
@@ -485,15 +504,16 @@ msgstr "Action non autorisée"
 msgid "Action not permitted for output of type '%s'"
 msgstr "Action non autorisée pour une sortie de type '%s'"
 
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
-#: centreon/www/include/configuration/configObject/command/listCommand.php
-#: centreon/www/include/configuration/configKnowledge/display-services.php
-#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
-#: centreon/www/include/configuration/configKnowledge/display-hosts.php
-#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Actions"
 msgstr "Actions"
 
@@ -509,8 +529,8 @@ msgstr "Actions autorisées"
 msgid "Activation"
 msgstr "Activation"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/front_translate.php
 msgid "Active"
 msgstr "Actif"
 
@@ -523,10 +543,10 @@ msgstr "Actif / Inactif"
 msgid "Active Checks"
 msgstr "Contrôles actifs"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Active Checks Enabled"
 msgstr "Contrôle actif activé"
 
@@ -546,51 +566,54 @@ msgstr "Actuellement"
 msgid "Actual End"
 msgstr "Fin Actuelle"
 
-#: centreon/www/class/centreonConfigCentreonBroker.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
-#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
 #: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 #: centreon/www/include/configuration/configObject/connector/listConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
 #: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
 #: centreon/www/include/configuration/configResources/listResources.php
 #: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
-#: centreon/www/include/options/media/images/listImg.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/class/centreonConfigCentreonBroker.php
 msgid "Add"
 msgstr "Ajouter"
 
@@ -604,12 +627,12 @@ msgstr "Ajouter un commentaire pour cet hôte"
 
 #: centreon/www/install/front_translate.php
 msgid "Add Contact..."
-msgstr ""
+msgstr "Ajouter un contact..."
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Add Data Processing"
 msgstr "Ajouter le traitement des données"
 
@@ -617,17 +640,13 @@ msgstr "Ajouter le traitement des données"
 msgid "Add Group"
 msgstr "Ajouter un groupe"
 
-#: centreon/www/include/options/media/images/formImg.php
-msgid "Add Image(s)"
-msgstr "Ajout d'image(s)"
-
 #: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
 msgid "Add Vendor"
 msgstr "Ajouter un constructeur"
 
 #: centreon/www/install/menu_translation.php
 msgid "Add View"
-msgstr ""
+msgstr "Ajouter une vue"
 
 #: centreon/www/install/menu_translation.php
 msgid "Add Widget"
@@ -663,9 +682,9 @@ msgstr "Ajouter un groupe de contact"
 msgid "Add a Data Source Template"
 msgstr "Ajouter un modèle de source de données"
 
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 msgid "Add a Dependency"
@@ -740,12 +759,16 @@ msgstr "Ajouter une définition de Trap"
 msgid "Add a User"
 msgstr "Ajouter un utilisateur"
 
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Add a User Template"
+msgstr "Ajouter un modèle utilisateur"
+
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
 msgid "Add a Virtual Metric"
 msgstr "Ajouter une métrique virtuelle"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/install/front_translate.php
 msgid "Add a comment"
 msgstr "Ajouter un commentaire"
 
@@ -770,21 +793,22 @@ msgid "Add a contact group"
 msgstr "Ajouter un contact group"
 
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "Add a downtime"
 msgstr "Ajouter une plage de maintenance"
 
 #: centreon/www/install/front_translate.php
 msgid "Add a host"
-msgstr ""
+msgstr "Ajouter un hôte"
 
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 msgid "Add a host category"
 msgstr "Ajouter une catégorie d'hôte"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Add a new macro"
 msgstr "Ajouter une nouvelle macro"
 
@@ -804,9 +828,14 @@ msgstr "Ajouter widget"
 
 #: centreon/www/install/front_translate.php
 msgid "Add advanced server configuration"
-msgstr ""
+msgstr "Ajouter une configuration avancée de serveur"
+
+#: centreon/www/install/front_translate.php
+msgid "Add agent configuration"
+msgstr "Ajouter une configuration d'agent"
 
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 msgid "Add an ACL"
 msgstr "Ajouter une ACL"
 
@@ -818,14 +847,14 @@ msgstr "Ajouter une action"
 msgid "Add an Escalation"
 msgstr "Ajouter une escalade"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Add an Extended Info"
 msgstr "Ajouter une information supplémentaire"
 
 #: centreon/www/install/front_translate.php
 msgid "Add an advanced configuration"
-msgstr ""
+msgstr "Ajouter une configuration avancée"
 
 #: centreon/www/install/front_translate.php
 msgid "Add at least 1 contact"
@@ -837,7 +866,7 @@ msgstr "Ajouter des colonnes"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Add comment"
-msgstr ""
+msgstr "Ajouter un commentaire"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Add downtime"
@@ -855,10 +884,10 @@ msgstr ""
 "Ajouter la propriété innodb_file_per_table=1 dans le fichier my.cnf dans "
 "l'encart [mysql] et redémarrez le serveur MySQL."
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Add macros"
 msgstr "Ajouter des macros"
 
@@ -886,20 +915,16 @@ msgstr "Ajouter une nouvelle période"
 msgid "Add parameter"
 msgstr "Ajouter un paramètre"
 
-#: centreon/www/install/front_translate.php
-msgid "Add poller/agent configuration"
-msgstr "Ajouter une configuration collecteur/agent"
-
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Add relations"
 msgstr "Ajouter des relations"
 
 #: centreon/www/install/front_translate.php
 msgid "Add resource datasets"
-msgstr ""
+msgstr "Ajouter des ressources"
 
 #: centreon/www/install/react_translation.php
 msgid "Add server with wizard"
@@ -934,35 +959,38 @@ msgstr "Ajouter/Supprimer un commentaire pour un hôte"
 msgid "Add/Delete a comment for a service"
 msgstr "Ajouter/Supprimer un commentaire pour un service"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/install/front_translate.php
 msgid "Added"
 msgstr "Ajouté"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Additional Addresses"
 msgstr "Adresses complémentaires"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Additional Configurations"
 msgstr "Configurations additionnelles"
 
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/command/formCommand.php
-#: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configResources/formResources.php
 msgid "Additional Information"
 msgstr "Informations supplémentaires"
 
@@ -986,33 +1014,57 @@ msgstr "Configuration additionnelle mise à jour"
 msgid "Additional freshness latency"
 msgstr "Latence additionnelle du contrôle de fraicheur"
 
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Address"
 msgstr "Adresse"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address1"
+msgstr "Adresse n°1"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address2"
+msgstr "Adresse n°2"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address3"
+msgstr "Adresse n°3"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address4"
+msgstr "Adresse n°4"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address5"
+msgstr "Adresse n°5"
+
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Address6"
+msgstr "Adresse n°6"
+
+#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/configuration/configObject/contact/listContact.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/install/front_translate.php
 msgid "Admin"
-msgstr "Administrateur"
+msgstr "Admin"
 
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/src/CentreonLegacy/Core/Install/Step/Step5.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/smarty_translate.php
 msgid "Admin information"
 msgstr "Informations de l'administrateur"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/install/menu_translation.php
 msgid "Administration"
 msgstr "Administration"
 
 #: centreon/www/install/menu_translation.php
 msgid "Administrator"
-msgstr ""
+msgstr "Administrateur"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Administrator Email Address"
@@ -1022,8 +1074,8 @@ msgstr "Adresse mail de l'administrateur"
 msgid "Administrator Pager"
 msgstr "Numéro de téléphone mobile de l'administrateur"
 
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Advanced"
 msgstr "Avancé"
 
@@ -1054,7 +1106,7 @@ msgstr "Paramètres avancés"
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
 msgid "Advanced: reverse Centreon Broker communication flow"
-msgstr "Avancé: inversé le flux de communication du broker Centreon"
+msgstr "Avancé : inverser le flux de communication du broker Centreon"
 
 #: centreon/www/include/Administration/configChangelog/viewLogs.php
 msgid "After"
@@ -1062,8 +1114,17 @@ msgstr "Après"
 
 #: centreon/www/install/front_translate.php
 msgid "Agent"
-msgstr ""
+msgstr "Agent"
 
+#: centreon/www/install/front_translate.php
+msgid "Agent configuration created"
+msgstr "Configuration d'agent créée"
+
+#: centreon/www/install/front_translate.php
+msgid "Agent configuration updated"
+msgstr "Configuration d'agent mise à jour"
+
+#: centreon/www/install/front_translate.php
 #: centreon/www/install/menu_translation.php
 msgid "Agent configurations"
 msgstr "Configurations d'agent"
@@ -1072,19 +1133,15 @@ msgstr "Configurations d'agent"
 msgid "Agent type"
 msgstr "Type d'agent"
 
-#: centreon/www/install/front_translate.php
-msgid "Agent types"
-msgstr "Types d'agent"
-
-#: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
-#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/viewHostLog.php
-#: centreon/www/include/reporting/dashboard/xmlInformations/common-Func.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/common-Func.php
+#: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
+#: centreon/www/include/reporting/dashboard/viewHostLog.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
 msgid "Alert"
 msgstr "Alerte"
 
@@ -1093,56 +1150,60 @@ msgstr "Alerte"
 msgid "Alerts"
 msgstr "Alertes"
 
-#: centreon/www/install/front_translate.php
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 #: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
 #: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
-#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/install/front_translate.php
 msgid "Alias"
 msgstr "Alias"
 
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
 #: centreon/www/include/configuration/configObject/contact/listContact.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Alias / Login"
 msgstr "Alias / Login"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Alias already exists"
 msgstr "L'alias existe déjà"
 
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
 #: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
-#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/class/centreonLogAction.class.php
 msgid "All"
 msgstr "Toutes"
 
@@ -1272,12 +1333,13 @@ msgstr ""
 "vouloir que ce contact exécute unesynchronisation lors de sa prochaine "
 "connexion ?"
 
-#: centreon/www/include/Administration/parameters/remote/formRemote.php
 #: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
 msgid "Allow self signed certificate"
 msgstr "Autoriser les certificats auto-signés"
 
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 msgid "Already exists"
 msgstr "Déjà éxistant"
 
@@ -1288,10 +1350,10 @@ msgstr ""
 "Demande enregistrée, merci d'attendre la prochaine exécution du CRON ou "
 "connexion du contact"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Alt icon"
 msgstr "Icône alternative"
 
@@ -1305,6 +1367,8 @@ msgid ""
 "An additional configuration of type '%s' is already associated with poller "
 "ID(s) '%s'"
 msgstr ""
+"Une configuration additionnelle de type '%s' est déjà associée à l'ID de "
+"collecteur '%s'"
 
 #: centreon/www/install/front_translate.php
 msgid ""
@@ -1317,6 +1381,8 @@ msgstr ""
 #: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
 msgid "An error occured while decoding Identity Provider ID Token"
 msgstr ""
+"Une erreur s'est produite lors du décodage du jeton d'identification du "
+"fournisseur d'identité"
 
 #: centreon/src/CentreonModule/Infrastructure/Source/ModuleException.php
 #, php-format
@@ -1324,6 +1390,10 @@ msgid "An error occured while retrieving details of module \"%s\""
 msgstr ""
 "Une erreur s'est produite lors de la récupération des informations "
 "détaillées du module \"%s\""
+
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+msgid "An error occurred"
+msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "An error occurred during authentication"
@@ -1344,7 +1414,7 @@ msgstr ""
 #: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
 #, php-format
 msgid "An error occurred when applying the update (%s)"
-msgstr ""
+msgstr "Une erreur s'est produite lors de la mise à jour (%s)"
 
 #: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
 msgid "An error occurred when retrieving available updates"
@@ -1373,11 +1443,11 @@ msgstr "Une erreur est survenue lors de la suppression de la plateforme"
 
 #: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
 msgid "An error occurred while disabling the central menus"
-msgstr ""
+msgstr "Une erreur s'est produite lors de la désactivation des menus centraux"
 
 #: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
 msgid "An error occurred while enabling the central menus"
-msgstr ""
+msgstr "Une erreur s'est produite lors de l'activation des menus centraux"
 
 #: centreon/www/class/centreonCustomView.class.php
 msgid "An error occurred while retrieving groups linked to ViewId on database"
@@ -1388,6 +1458,8 @@ msgstr ""
 #: centreon/src/Core/Notification/Application/UseCase/FindNotifications/FindNotifications.php
 msgid "An error occurred while retrieving the notifications listing"
 msgstr ""
+"Une erreur s'est produite lors de la récupération de la liste des "
+"notifications"
 
 #: centreon/www/class/centreonCustomView.class.php
 msgid "An error occurred while retrieving users linked to ViewId on database"
@@ -1398,6 +1470,8 @@ msgstr ""
 #: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
 msgid "An error occurred while searching any remote children"
 msgstr ""
+"Une erreur s'est produite lors de la recherche de serveurs distants enfants "
+"du central"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
 msgid "An error occurred while updating the platform"
@@ -1406,6 +1480,8 @@ msgstr "Une erreur est survenue lors de la mise à jour de la plateforme"
 #: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
 msgid "An error occurred while updating the platform topology"
 msgstr ""
+"Une erreur s'est produite pendant la mise à jour de la topologie de la "
+"plateforme"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "An integer with a minimum value of 1 is required"
@@ -1417,13 +1493,13 @@ msgstr "Et bien d'autres..."
 
 #: centreon/www/install/front_translate.php
 msgid "Anomaly detection"
-msgstr ""
+msgstr "Anomaly detection"
 
-#: centreon/www/api/class/centreon_home_customview.class.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/views/graphs/graphs.php
 #: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/api/class/centreon_home_customview.class.php
 msgid "Apply"
 msgstr "Appliquer"
 
@@ -1453,6 +1529,8 @@ msgid ""
 "Are you sure you want to change the size of the envelope? The new envelope "
 "size will be applied immediately."
 msgstr ""
+"Êtes-vous sûr de vouloir modifier la taille de l'enveloppe ? La nouvelle "
+"taille d'enveloppe sera appliquée immédiatement."
 
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHost.php
@@ -1463,10 +1541,10 @@ msgstr "Êtes-vous sûr de vouloir détacher le service ?"
 msgid "Area color"
 msgstr "Couleur de l'aire"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Args"
 msgstr "Arguments"
 
@@ -1505,7 +1583,7 @@ msgstr "Au moins une colonne doit être sélectionnée"
 
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 msgid "At least one contact or contactgroup should be linked to the rule"
-msgstr ""
+msgstr "Au moins un contact ou un groupe de contacts doit être lié à la règle."
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
@@ -1513,7 +1591,7 @@ msgid ""
 "At least one illegal character in '%s' was found in platform's name: '%s'"
 msgstr ""
 "Au moins un caractère illégal parmi '%s' a été trouvé dans le nom de la "
-"plateforme: '%s'"
+"plateforme : '%s'"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
@@ -1522,7 +1600,7 @@ msgid ""
 "'%s'"
 msgstr ""
 "Au moins un caractère ne respecte pas la norme RFC dans le nom de domaine de "
-"la plateforme: '%s'"
+"la plateforme : '%s'"
 
 #: centreon/www/install/front_translate.php
 msgid "At least one of the two following fields must be filled"
@@ -1538,7 +1616,7 @@ msgstr "Au moins un vCenter est requis"
 
 #: centreon/www/install/front_translate.php
 msgid "At least three columns must be selected"
-msgstr ""
+msgstr "Sélectionnez au moins 3 colonnes"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Attach additional Remote Servers"
@@ -1573,7 +1651,7 @@ msgstr "Authentification"
 
 #: centreon/src/Security/TokenAPIAuthenticator.php
 msgid "Authentication Required"
-msgstr ""
+msgstr "Authentification requise"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Authentication Source"
@@ -1581,7 +1659,7 @@ msgstr "Source d'authentification"
 
 #: centreon/www/install/menu_translation.php
 msgid "Authentication Tokens"
-msgstr ""
+msgstr "Jetons d'authentification"
 
 #: centreon/www/install/front_translate.php
 msgid "Authentication conditions"
@@ -1593,7 +1671,7 @@ msgstr "Enregistrer les authentifications"
 
 #: centreon/www/install/front_translate.php
 msgid "Authentication denied"
-msgstr ""
+msgstr "Authentification refusée"
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/AuthenticationException.php
 msgid "Authentication failed"
@@ -1609,7 +1687,7 @@ msgstr "Propriétés d'authentification"
 
 #: centreon/www/install/front_translate.php
 msgid "Authentication token copied to the clipboard"
-msgstr ""
+msgstr "Jeton copié dans le presse-papiers"
 
 #: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
 msgid "Authentication token expired"
@@ -1625,12 +1703,13 @@ msgstr "Jetons d'authentification"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Author"
 msgstr "Auteur"
 
@@ -1671,8 +1750,8 @@ msgstr "Auteurs"
 msgid "Auto Rescheduling"
 msgstr "Ré-ordonnancement automatique"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/install/front_translate.php
 msgid "Auto import users"
 msgstr "Import automatique des utilisateurs"
 
@@ -1688,8 +1767,8 @@ msgstr "Ré-ordonnancement automatique"
 msgid "Auto-Rescheduling Window"
 msgstr "Fenêtre de ré-ordonnancement automatique"
 
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Autologin Key"
 msgstr "Clé d'auto-connexion"
 
@@ -1705,11 +1784,12 @@ msgstr "Contacts autorisés"
 msgid "Availability"
 msgstr "Disponibilité"
 
-#: centreon/www/class/centreonConfigCentreonBroker.php
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/options/media/images/listImg.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/class/centreonConfigCentreonBroker.php
 msgid "Available"
 msgstr "Disponible"
 
@@ -1726,10 +1806,10 @@ msgstr "Moy"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "BBDO version"
-msgstr ""
+msgstr "Version de BBDO"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/core/header/htmlHeader.php
+#: centreon/www/install/smarty_translate.php
 msgid "Back"
 msgstr "Retour"
 
@@ -1739,7 +1819,7 @@ msgstr "Couleur d'arrière plan"
 
 #: centreon/www/install/menu_translation.php
 msgid "Backup"
-msgstr ""
+msgstr "Sauvegarde"
 
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
 msgid "Backup configuration files"
@@ -1759,7 +1839,7 @@ msgstr "Répertoire des sauvegardes"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Backup directory for partitioning"
-msgstr ""
+msgstr "Répertoire de sauvegarde pour le partitionnement"
 
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
 msgid "Backup enabled"
@@ -1767,7 +1847,7 @@ msgstr "Activer la sauvegarde"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Backup properties"
-msgstr ""
+msgstr "Propriétés de la sauvegarde"
 
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
 msgid "Backup retention"
@@ -1789,14 +1869,18 @@ msgstr "Mauvais format : la couleur doit commencer par #"
 msgid "Bad OID Format"
 msgstr "Mauvais Format d'OID"
 
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/src/Centreon/Infrastructure/Monitoring/MonitoringRepositoryRDB.php
+msgid "Bad SQL request"
+msgstr "Mauvaise requête SQL"
+
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "Bad Session ID"
-msgstr ""
+msgstr "ID de session incorrect"
 
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "Bad host ID"
-msgstr ""
+msgstr "ID d'hôte incorrect"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 #, php-format
@@ -1815,14 +1899,14 @@ msgstr "Mauvais opérateur de recherche"
 
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 msgid "Bad service ID"
-msgstr ""
+msgstr "ID de service incorrect"
 
 #: centreon/www/install/front_translate.php
 msgid "Bar chart"
 msgstr "Diagramme à barres"
 
-#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 msgid "Base"
 msgstr "Base"
 
@@ -1851,9 +1935,9 @@ msgid "Before last year"
 msgstr "Avant l'année dernière"
 
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 msgid "Begin date"
 msgstr "Date de début"
 
@@ -1867,7 +1951,7 @@ msgstr "Mot de passe"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Bind user"
-msgstr "Utilisateur du domaine"
+msgstr "Utilisateur Bind"
 
 #: centreon/www/install/front_translate.php
 msgid "Blacklist client addresses"
@@ -1952,7 +2036,7 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "By"
-msgstr ""
+msgstr "Par"
 
 #: centreon/www/install/menu_translation.php
 msgid "By Host"
@@ -1991,16 +2075,16 @@ msgid ""
 msgstr ""
 "En exécutant ce script, votre plateforme sera verrouillée and vous ne "
 "pourrez plus <strong>rien modifier</strong> durant le processus de migration "
-"(exemple: déployer la configuration, modifier les paramètres "
+"(exemple : déployer la configuration, modifier les paramètres "
 "d'administration, etc...)."
-
-#: centreon/www/install/front_translate.php
-msgid "CA"
-msgstr "CA"
 
 #: centreon/www/install/front_translate.php
 msgid "CA Common Name (CN)"
 msgstr "Nom commun CA (CN)"
+
+#: centreon/www/install/front_translate.php
+msgid "CA(.crt,.cer)"
+msgstr "CA(.crt,.cer)"
 
 #: centreon/www/install/front_translate.php
 msgid "CMA authentication token(s)"
@@ -2021,7 +2105,7 @@ msgstr "Cache"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Cache directory"
-msgstr ""
+msgstr "Répertoire du cache"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Cached Check"
@@ -2058,8 +2142,8 @@ msgstr "Type de calcul"
 msgid "Can't Use This Virtual Metric '"
 msgstr "Impossible d'utiliser cette métrique virtuelle '"
 
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 msgid "Can't be equal to 0"
 msgstr "Ne peut être égal à 0"
 
@@ -2074,25 +2158,25 @@ msgstr ""
 "Impossible de résoudre le nom d'utilisateur à partir de la déclaration de "
 "connexion en utilisant l'expression régulière configurée"
 
-#: centreon/www/include/Administration/parameters/general/form.php
 #: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
 msgid "Can't write in directory"
 msgstr "Impossible d'écrire dans le répertoire"
 
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/options/media/images/formImg.php
-#: centreon/www/include/options/media/images/formDirectory.php
 msgid "Cancel"
 msgstr "Annuler"
 
 #: centreon/www/install/front_translate.php
 msgid "Cancel notification creation"
-msgstr ""
+msgstr "Annuler la création de la notification"
 
 #: centreon/www/install/front_translate.php
 msgid "Cancel notification update"
-msgstr ""
+msgstr "Annuler la modification de la notification"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Cancelled"
@@ -2105,19 +2189,19 @@ msgstr "Impossible de construire une uri vers un onglet inconnu : %s"
 
 #: centreon/www/install/front_translate.php
 msgid "Cannot enter fullscreen mode"
-msgstr ""
+msgstr "Impossible d'entrer en mode plein écran"
 
 #: centreon/www/install/steps/process/insertBaseConf.php
 msgid "Cannot get Centreon version"
-msgstr ""
+msgstr "Impossible de récupérer la version de Centreon"
 
 #: centreon/www/install/steps/process/insertBaseConf.php
 msgid "Cannot get timezone information"
-msgstr ""
+msgstr "Impossible de récupérer le fuseau horaire"
 
 #: centreon/www/install/front_translate.php
 msgid "Cannot load module"
-msgstr ""
+msgstr "Impossible de charger le module"
 
 #: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
 msgid "Cannot open statistics file"
@@ -2142,7 +2226,7 @@ msgstr ""
 #: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformRegistered.php
 #: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformPending.php
 msgid "Cannot set parent id to a central server"
-msgstr ""
+msgstr "Il n'est pas possible d'attribuer un ID de parent à un serveur central"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformRegistered.php
 #: centreon/src/Centreon/Domain/PlatformTopology/Model/PlatformPending.php
@@ -2151,8 +2235,8 @@ msgstr ""
 "Il n'est pas possible d'utiliser l'adresse d'une plateforme parente sur un "
 "serveur de type Central"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Categories"
 msgstr "Catégories"
 
@@ -2171,17 +2255,19 @@ msgstr "Central"
 
 #: centreon/src/Centreon/Domain/Repository/CfgCentreonBrokerRepository.php
 msgid "Central broker config id not found"
-msgstr ""
+msgstr "ID de la configuration centrale du Broker non trouvé"
 
 #: centreon/src/Centreon/Domain/PlatformInformation/Exception/PlatformInformationException.php
 msgid ""
 "Central platform's API data is not consistent. Please check the 'Remote "
 "Access' form."
 msgstr ""
+"Les données de l'API de la plateforme centrale ne sont pas cohérentes. "
+"Veuillez vérifier le formulaire “Accès à distance”."
 
 #: centreon/www/include/Administration/parameters/remote/formRemote.php
 msgid "Central's API URI"
-msgstr ""
+msgstr "URI de l'API du serveur central"
 
 #: centreon/www/include/Administration/parameters/remote/formRemote.php
 msgid "Central's API credentials"
@@ -2193,14 +2279,16 @@ msgid ""
 "Central's credentials are missing on: '%s'@'%s'. Please check the Remote "
 "Access form"
 msgstr ""
-"Les identifiants du Central sont manquants pour: '%s'@'%s'. Veuillez "
-"vérifier le formulaire 'Accès du Remote'"
+"Les identifiants du central sont manquants pour : '%s'@'%s'. Veuillez "
+"vérifier le formulaire 'Accès au serveur distant'"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
 msgid ""
 "Central's path is missing on: '%s'@'%s'. Please check the Remote Access form"
 msgstr ""
+"Le chemin d'accès au serveur central est manquant sur : '%s'@“%s”. Veuillez "
+"vérifier le formulaire 'Accès à distance'"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
@@ -2208,8 +2296,8 @@ msgid ""
 "Central's protocol port is missing on: '%s'@'%s'. Please check the Remote "
 "Access form"
 msgstr ""
-"Le port du Central, de la plateforme: '%s'@'%s est manquant. Veuillez "
-"vérifier le formulaire 'Accès du Remote'"
+"Le port du central, de la plateforme : '%s'@'%s est manquant. Veuillez "
+"vérifier le formulaire 'Accès au serveur distant'"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
@@ -2217,27 +2305,28 @@ msgid ""
 "Central's protocol scheme is missing on: '%s'@'%s'. Please check the Remote "
 "Access form"
 msgstr ""
-"Le schéma du Central, de la plateforme: '%s'@'%s est manquant. Veuillez "
-"vérifier le formulaire 'Accès du Remote'"
+"Le schéma du central, de la plateforme : '%s'@'%s est manquant. Veuillez "
+"vérifier le formulaire 'Accès au serveur distant'"
 
 #: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/PlatformTopologyRegisterRepositoryAPI.php
 msgid "Central's response => Code : "
-msgstr ""
+msgstr "Réponse du serveur central => Code : "
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/install/front_translate.php
 msgid "Centreon"
 msgstr "Centreon"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Centreon Authentication"
 msgstr "Authentification Centreon"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/install/smarty_translate.php
 msgid "Centreon Broker"
 msgstr "Centreon Broker"
 
@@ -2298,14 +2387,14 @@ msgstr "Chemin d'accès aux connecteurs"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Centreon Databases Statistics"
-msgstr ""
+msgstr "Statistiques des bases de données Centreon"
 
 #: centreon/www/include/Administration/parameters/debug/form.php
 msgid "Centreon Gorgone debug"
-msgstr "Débogage de Centreon Gorgone "
+msgstr "Débogage de Centreon Gorgone"
 
-#: centreon/www/install/step_upgrade/index.php
 #: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/index.php
 msgid "Centreon Installation"
 msgstr "Installation de Centreon"
 
@@ -2315,11 +2404,11 @@ msgstr "Logo de Centreon"
 
 #: centreon/www/install/front_translate.php
 msgid "Centreon Monitoring Agent"
-msgstr ""
+msgstr "Agent de supervision Centreon"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Centreon Storage Path"
-msgstr ""
+msgstr "Chemin du stockage Centreon"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Centreon Support Email"
@@ -2379,7 +2468,7 @@ msgstr "Github de Centreon"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Centreon-Broker "
-msgstr "Centreon-Broker"
+msgstr "Centreon-Broker "
 
 #: centreon/www/include/Administration/parameters/debug/form.php
 msgid "Centreontrapd debug"
@@ -2399,11 +2488,11 @@ msgstr "Chemin du certificat serveur"
 
 #: centreon/www/install/front_translate.php
 msgid "Change end date"
-msgstr ""
+msgstr "Changer la date de fin"
 
 #: centreon/www/install/front_translate.php
 msgid "Change end time"
-msgstr ""
+msgstr "Changer l'heure de fin"
 
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "Change my settings"
@@ -2424,6 +2513,8 @@ msgstr "Modifié"
 #: centreon/www/install/front_translate.php
 msgid "Changes to the envelope size will be applied immediately"
 msgstr ""
+"Les modifications apportées à la taille de l'enveloppe seront appliquées "
+"immédiatement"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 msgid ""
@@ -2437,6 +2528,8 @@ msgid ""
 "Changing type of an existing additional connector configuration is not "
 "allowed"
 msgstr ""
+"Il n'est pas permis de modifier le type d'une configuration de connecteur "
+"supplémentaire existante"
 
 #: centreon/www/install/front_translate.php
 msgid "Channels"
@@ -2448,7 +2541,7 @@ msgstr "Graphiques"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Chart Filters"
-msgstr ""
+msgstr "Filtrer sur les graphiques"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Chart options"
@@ -2456,23 +2549,23 @@ msgstr "Paramètres des graphiques"
 
 #: centreon/www/install/menu_translation.php
 msgid "Chart periods"
-msgstr ""
+msgstr "Graphiques par période"
 
 #: centreon/www/install/menu_translation.php
 msgid "Chart split"
-msgstr ""
+msgstr "Un graphique par courbe"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/command/commandType.php
-#: centreon/www/include/configuration/configObject/command/listCommand.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/command/commandType.php
+#: centreon/www/install/front_translate.php
 msgid "Check"
 msgstr "Vérifier"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Check Command"
 msgstr "Commande de vérification"
 
@@ -2484,10 +2577,10 @@ msgstr "Contrôle si le service est en plage de maintenance"
 msgid "Check Duration"
 msgstr "Temps d'exécution"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Check Freshness"
 msgstr "Contrôler la fraicheur du résultat"
 
@@ -2495,11 +2588,11 @@ msgstr "Contrôler la fraicheur du résultat"
 msgid "Check Options"
 msgstr "Options de contrôle"
 
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Check Period"
 msgstr "Période de contrôle"
 
@@ -2519,7 +2612,7 @@ msgstr "Commande de contrôle de l'id de service %d non trouvée"
 
 #: centreon/www/install/front_translate.php
 msgid "Check command sent !"
-msgstr ""
+msgstr "Commande de contrôle envoyée !"
 
 #: centreon/www/install/front_translate.php
 msgid "Check command sent ! Please refresh the listing to update the data."
@@ -2535,8 +2628,8 @@ msgstr "Commande de vérification envoyée !"
 msgid "Check duration"
 msgstr "Temps d'exécution"
 
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "Check information"
 msgstr "Informations sur le contrôle"
 
@@ -2565,13 +2658,16 @@ msgstr ""
 #: centreon/www/install/front_translate.php
 msgid "Check this resource even outside configured check period"
 msgstr ""
+"Contrôler cette ressource même en dehors de la période de contrôle configurée"
 
 #: centreon/www/install/front_translate.php
 msgid "Check this resource only within configured check period"
 msgstr ""
+"Contrôler cette ressource uniquement pendant la période de contrôle "
+"configurée"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/menu_translation.php
 msgid "Checks"
 msgstr "Contrôles"
 
@@ -2638,33 +2734,35 @@ msgstr "Choisir la source"
 msgid "Choose the source to graph"
 msgstr "Choisissez la source à grapher"
 
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 msgid "Circular Definition"
 msgstr "Définition circulaire"
 
-#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
 #: centreon/src/Core/Host/Application/Exception/HostException.php
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Circular inheritance not allowed"
 msgstr "Héritage circulaire non autorisé"
 
 #: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
 #, php-format
 msgid "Class %s has to implement %s to be DataRepresenter"
-msgstr ""
+msgstr "La classe %s doit implémenter %s pour être DataRepresenter"
 
 #: centreon/src/Centreon/Infrastructure/Serializer/Exception/SerializerException.php
 #, php-format
 msgid "Class %s not found"
-msgstr ""
+msgstr "Classe %s introuvable"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Classification"
 msgstr "Classification"
 
@@ -2700,10 +2798,10 @@ msgstr "Adresses de client"
 msgid "Client secret"
 msgstr "Secret de client"
 
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/options/media/images/syncDir.php
 #: centreon/www/include/configuration/configObject/command/formArguments.php
 #: centreon/www/include/configuration/configObject/command/formMacros.php
-#: centreon/www/include/options/media/images/syncDir.php
+#: centreon/www/install/front_translate.php
 msgid "Close"
 msgstr "Fermer"
 
@@ -2713,7 +2811,7 @@ msgstr "Fermer un ticket"
 
 #: centreon/www/install/front_translate.php
 msgid "Close edit modal"
-msgstr ""
+msgstr "Fermer la fenêtre d'édition"
 
 #: centreon/www/install/front_translate.php
 msgid "Close the panel"
@@ -2721,11 +2819,11 @@ msgstr "Fermer le panneau"
 
 #: centreon/www/install/front_translate.php
 msgid "Close ticket"
-msgstr ""
+msgstr "Fermer le ticket"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Closest Value"
-msgstr ""
+msgstr "Valeur la plus proche"
 
 #: centreon/www/install/front_translate.php
 msgid "Collapse"
@@ -2745,18 +2843,19 @@ msgstr "Couleurs"
 
 #: centreon/www/install/front_translate.php
 msgid "Columns"
-msgstr ""
+msgstr "Colonnes"
 
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/eventLogs/xml/data.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configServers/formServers.php
 msgid "Command"
 msgstr "Commande"
 
 #: centreon/www/include/configuration/configObject/connector/formConnector.php
-#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
-#: centreon/www/include/configuration/configObject/command/formCommand.php
 #: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
 msgid "Command Line"
 msgstr "Ligne de commande"
 
@@ -2775,7 +2874,7 @@ msgstr "Type de commande"
 
 #: centreon/www/install/front_translate.php
 msgid "Command copied"
-msgstr ""
+msgstr "Commande copiée"
 
 #: centreon/www/install/front_translate.php
 msgid "Command copied to clipboard"
@@ -2789,10 +2888,10 @@ msgstr "Problème d'exécution de la commande"
 msgid "Command file"
 msgstr "Chemin d'accès au socket Unix de Centreon Broker"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Command inheritance"
 msgstr "Hérité depuis la commande"
 
@@ -2801,8 +2900,8 @@ msgstr "Hérité depuis la commande"
 msgid "Command sent"
 msgstr "Commande envoyée"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/menu_translation.php
 msgid "Commands"
 msgstr "Commandes"
 
@@ -2812,22 +2911,22 @@ msgstr ""
 "Les définitions de commandes peuvent contenir des macros mais ces dernières "
 "doivent être valides."
 
-#: centreon/www/class/centreonGraphPoller.class.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/class/centreonGraphPoller.class.php
 msgid "Commands in buffer"
 msgstr "Commandes dans le tampon"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/options/media/images/listImg.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
 #: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/options/media/images/listImg.php
-#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 #: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/install/front_translate.php
 msgid "Comment"
 msgstr "Commentaire"
 
@@ -2835,10 +2934,10 @@ msgstr "Commentaire"
 msgid "Comment added"
 msgstr "Commentaire ajouté"
 
-#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 msgid "Comment is required"
 msgstr "Un commentaire est nécessaire"
 
@@ -2846,49 +2945,54 @@ msgstr "Un commentaire est nécessaire"
 msgid "Comment type"
 msgstr "Type de commantaire"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/metric.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/media/images/formImg.php
-#: centreon/www/include/options/media/images/formDirectory.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/comments/AddComment.php
-#: centreon/www/include/monitoring/comments/AddSvcComment.php
 #: centreon/www/include/monitoring/comments/AddHostComment.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
 msgid "Comments"
 msgstr "Commentaires"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Common Options"
-msgstr ""
+msgstr "Options communes"
 
 #: centreon/www/install/front_translate.php
 msgid "Common properties"
 msgstr "Propriétés communes"
+
+#: centreon/www/install/front_translate.php
+msgid "Compact"
+msgstr "Compact"
 
 #: centreon/www/install/front_translate.php
 msgid "Compact time period"
@@ -2914,20 +3018,22 @@ msgstr "Niveau de compression"
 msgid "Compulsory Address"
 msgstr "Adresse obligatoire"
 
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
 #: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 #: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
 msgid "Compulsory Alias"
 msgstr "Alias obligatoire"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Compulsory Command"
 msgstr "Commande obligatoire"
 
@@ -2939,8 +3045,8 @@ msgstr "Ligne de commande obligatoire"
 msgid "Compulsory Description"
 msgstr "Description obligatoire"
 
-#: centreon/www/include/configuration/configObject/meta_service/metric.php
 #: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
 msgid "Compulsory Field"
 msgstr "Champ Obligatoire"
 
@@ -2952,46 +3058,49 @@ msgstr "Groupes obligatoires"
 msgid "Compulsory Instance"
 msgstr "Collecteur obligatoire"
 
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 #: centreon/www/include/configuration/configResources/formResources.php
 #: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/media/images/formDirectory.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
 msgid "Compulsory Name"
 msgstr "Nom obligatoire"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Compulsory Option"
 msgstr "Option obligatoire"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Compulsory Period"
 msgstr "Période obligatoire"
 
@@ -3003,14 +3112,10 @@ msgstr "Sélection du collecteur obligatoire"
 msgid "Compulsory alias"
 msgstr "Alias obligatoire"
 
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
 #: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
 msgid "Compulsory field"
 msgstr "Champ obligatoire"
-
-#: centreon/www/include/options/media/images/formImg.php
-msgid "Compulsory image name"
-msgstr "Nom de l'image obligatoire"
 
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "Compulsory name"
@@ -3036,9 +3141,9 @@ msgstr "Nom du fichier de configuration"
 msgid "Config information"
 msgstr "Informations sur la configuration"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Configuration"
 msgstr "Configuration"
 
@@ -3048,7 +3153,7 @@ msgstr "Export des fichiers de configuration du moteur de supervision"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Configuration Files Options"
-msgstr ""
+msgstr "Options des fichiers de configuration"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Configuration Name"
@@ -3096,7 +3201,7 @@ msgstr "Configurer"
 
 #: centreon/www/install/front_translate.php
 msgid "Configure a server"
-msgstr ""
+msgstr "Configurer un serveur"
 
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Configure host"
@@ -3118,16 +3223,16 @@ msgstr "Configurer le service"
 
 #: centreon/www/install/front_translate.php
 msgid "Confirm"
-msgstr ""
+msgstr "Confirmer"
 
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Confirm Password"
 msgstr "Confirmation du mot de passe"
 
 #: centreon/www/install/front_translate.php
 msgid "Confirm notification creation"
-msgstr ""
+msgstr "Confirmer la création de la notification"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Confirm password"
@@ -3150,9 +3255,13 @@ msgstr ""
 msgid "Connect"
 msgstr "Se connecter"
 
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+msgid "Connected users"
+msgstr "Utilisateurs connectés"
+
 #: centreon/www/api/class/centreon_proxy.class.php
 msgid "Connection Successful"
-msgstr ""
+msgstr "Connexion réussie"
 
 #: centreon/www/class/centreonDB.class.php
 msgid "Connection failed, please contact your administrator"
@@ -3160,7 +3269,7 @@ msgstr "Connexion échouée, contactez votre administrateur"
 
 #: centreon/www/install/front_translate.php
 msgid "Connection initiated by poller"
-msgstr ""
+msgstr "Connexion initiée par le collecteur"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Connection port"
@@ -3178,8 +3287,8 @@ msgstr "Nom du connecteur"
 msgid "Connector Status"
 msgstr "Statut du connecteur"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/install/menu_translation.php
 msgid "Connectors"
 msgstr "Connecteurs"
 
@@ -3187,10 +3296,12 @@ msgstr "Connecteurs"
 msgid "Console"
 msgstr "Console"
 
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+#: centreon/www/include/eventLogs/xml/data.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
-#: centreon/www/include/configuration/configObject/contact/displayNotification.php
 msgid "Contact"
 msgstr "Contact"
 
@@ -3198,9 +3309,9 @@ msgstr "Contact"
 msgid "Contact Group Name"
 msgstr "Nom du groupe de contacts"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Contact Groups"
 msgstr "Groupes de contacts"
 
@@ -3208,14 +3319,15 @@ msgstr "Groupes de contacts"
 msgid "Contact Name"
 msgstr "Nom de l'utilisateur"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Contact additive inheritance"
 msgstr "Contacts hérités additionnels"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Contact already exists"
 msgstr "Le contact existe déjà"
 
@@ -3224,16 +3336,16 @@ msgstr "Le contact existe déjà"
 msgid "Contact group"
 msgstr "Groupe de contacts"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Contact group additive inheritance"
 msgstr "Groupes de contacts hérités additionnels"
 
 #: centreon/www/install/front_translate.php
 msgid "Contact groups"
-msgstr ""
+msgstr "Groupes de contacts"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Contact groups notified for this host"
@@ -3248,13 +3360,14 @@ msgstr "Groupes de contacts notifiés pour ce service"
 msgid "Contact not found"
 msgstr "Contact non trouvé"
 
+#: centreon/www/include/Administration/parameters/ldap/form.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Contact template"
 msgstr "Modèle de contact"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Contact template used"
 msgstr "Modèle de contact utilisé"
 
@@ -3263,11 +3376,11 @@ msgid "Contact your Centreon administrator or update the following file"
 msgstr ""
 "Contactez votre administrateur Centreon ou mettez à jour le fichier suivant"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid ""
 "Contactgroups exists. If you try to use a LDAP contactgroup, please verified "
 "if a Centreon contactgroup has the same name."
@@ -3275,16 +3388,16 @@ msgstr ""
 "Ce groupe de contacts existe. Si vous utiliser un group de contact LDAP, "
 "vérifier qu'un groupe de contact local à Centreon n'utilise pas le même nom."
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
 #: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/install/front_translate.php
 msgid "Contacts"
 msgstr "Contacts"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Contacts & Contact groups method calculation"
-msgstr ""
+msgstr "Méthode de calcul pour les contacts et groupes de contacts"
 
 #: centreon/www/install/menu_translation.php
 msgid "Contacts / Users"
@@ -3349,7 +3462,7 @@ msgstr "Copier/coller le certificat x.509"
 
 #: centreon/www/api/class/centreon_proxy.class.php
 msgid "Could not establish connection to Centreon IMP servers ("
-msgstr ""
+msgstr "Impossible d'établir une connexion avec les serveurs Centreon IMP ("
 
 #: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
 #, php-format
@@ -3362,8 +3475,9 @@ msgstr ""
 "                                 Merci de vérifier le chemin du répertoire "
 "ou de le créer"
 
-#: centreon/www/include/configuration/configGenerate/xml/restartPollers.php
 #: centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
+#: centreon/www/include/configuration/configGenerate/xml/restartPollers.php
+#: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
 msgid "Could not write into centcore.cmd. Please check file permissions."
 msgstr ""
 "Impossible d'écrire dans le fichier centcore.cmd. Vérifier les permissions "
@@ -3399,7 +3513,7 @@ msgid ""
 msgstr ""
 "Impossible d'écrire dans le fichier '%s' du moteur de supervision '%s'. "
 "Merci de vérifier les permissions d'écriture pour l'utilisateur du serveur "
-"Wev"
+"web"
 
 #: centreon/www/install/front_translate.php
 msgid "Create"
@@ -3451,7 +3565,7 @@ msgstr "Créer un nouveau jeton CMA"
 
 #: centreon/www/install/front_translate.php
 msgid "Create new Poller"
-msgstr ""
+msgstr "Créer un nouveau collecteur"
 
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
@@ -3460,11 +3574,11 @@ msgstr "Créer un nouveau serveur distant"
 
 #: centreon/www/include/home/customViews/index.php
 msgid "Create new view "
-msgstr "Créer une nouvelle vue"
+msgstr "Créer une nouvelle vue "
 
 #: centreon/www/install/front_translate.php
 msgid "Create notification for the first time"
-msgstr ""
+msgstr "Créer une notification pour la première fois"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Create wiki page"
@@ -3487,8 +3601,8 @@ msgstr "Date de création"
 msgid "Creation time"
 msgstr "Date de création"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Creator"
 msgstr "Créateur"
 
@@ -3496,26 +3610,27 @@ msgstr "Créateur"
 msgid "Criterias"
 msgstr "Critères"
 
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
-#: centreon/www/include/monitoring/status/Services/service.php
-#: centreon/www/include/Administration/performance/viewMetrics.php
 msgid "Critical"
 msgstr "Critique"
 
@@ -3538,7 +3653,7 @@ msgstr "Seuil critique"
 
 #: centreon/www/install/react_translation.php
 msgid "Critical services"
-msgstr ""
+msgstr "Services critiques"
 
 #: centreon/www/install/front_translate.php
 msgid "Critical status services"
@@ -3554,25 +3669,25 @@ msgstr "Criticité"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Cumulative inheritance"
-msgstr ""
+msgstr "Héritage cumulatif"
 
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "Current Attempt"
 msgstr "Tentative"
 
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 msgid "Current Notification Number"
 msgstr "Numéro de notification actuel"
 
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 msgid "Current State Duration"
 msgstr "Durée de l'état actuel"
 
@@ -3598,7 +3713,7 @@ msgid ""
 "interrupt this process."
 msgstr ""
 "Installation en cours de la base de données et génération du cache... ne pas "
-"interrompre le processus.<br/><br/>"
+"interrompre le processus."
 
 #: centreon/www/install/smarty_translate.php
 msgid "Curve"
@@ -3620,10 +3735,10 @@ msgstr "Vues personnalisées"
 msgid "Custom code"
 msgstr "Code personnalisé"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Custom macros"
 msgstr "Macros personnalisées"
 
@@ -3670,12 +3785,12 @@ msgstr "Type DEF"
 
 #: centreon/www/install/front_translate.php
 msgid "DNS/IP"
-msgstr ""
+msgstr "DNS/IP"
 
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "DOWN"
 msgstr "INDISPONIBLE"
@@ -3686,7 +3801,7 @@ msgstr "Propriétés d'intégration du tableau de bord"
 
 #: centreon/www/install/front_translate.php
 msgid "Dashboard created"
-msgstr ""
+msgstr "Tableau de bord créé"
 
 #: centreon/www/install/front_translate.php
 msgid "Dashboard deleted"
@@ -3704,13 +3819,13 @@ msgstr "Intervalle global du tableau de bord"
 msgid "Dashboard updated"
 msgstr "Tableau de bord mis à jour"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Dashboards"
 msgstr "Tableaux de bord"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/menu_translation.php
 msgid "Data"
 msgstr "Données"
 
@@ -3718,11 +3833,11 @@ msgstr "Données"
 msgid "Data Count"
 msgstr "Nombre de données"
 
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/install/smarty_translate.php
 msgid "Data Processing"
 msgstr "Traitement des données"
 
@@ -3732,8 +3847,8 @@ msgstr "Traitement des données"
 msgid "Data Source Name"
 msgstr "Nom de la source de données"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/install/smarty_translate.php
 msgid "Data Source Type"
 msgstr "Type de source de données"
 
@@ -3761,11 +3876,11 @@ msgstr "Type de source de données"
 #: centreon/tests/php/Centreon/Domain/MetaServiceConfiguration/Model/MetaServiceConfigurationTest.php
 #, php-format
 msgid "Data source type provided not supported (%s)"
-msgstr ""
+msgstr "Le type de source de données fourni n'est pas pris en charge (%s)"
 
 #: centreon/www/install/front_translate.php
 msgid "Database"
-msgstr ""
+msgstr "Base de données"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Database Engine"
@@ -3777,7 +3892,7 @@ msgstr "Adresse de l'hôte de la base de données (par défaut : localhost)"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Database Options"
-msgstr ""
+msgstr "Options de base de données"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Database Port (default: 3306)"
@@ -3787,8 +3902,8 @@ msgstr "Port d'accès à la base de données (par défaut : 3306)"
 msgid "Database generation"
 msgstr "Génération de la base de données"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/src/CentreonLegacy/Core/Install/Step/Step6.php
+#: centreon/www/install/smarty_translate.php
 msgid "Database information"
 msgstr "Information de la base de données"
 
@@ -3822,8 +3937,8 @@ msgstr "Bases de données"
 msgid "Dataset selection"
 msgstr "Sélection d'un jeu de données"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/smarty_translate.php
 msgid "Date"
 msgstr "Date"
 
@@ -3831,26 +3946,27 @@ msgstr "Date"
 msgid "Date Format"
 msgstr "Format de date"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/reporting/dashboard/xmlInformations/common-Func.php
+#: centreon/www/include/eventLogs/xml/data.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/common-Func.php
+#: centreon/www/install/front_translate.php
 msgid "Day"
 msgstr "Jour"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/install/front_translate.php
 msgid "Days"
 msgstr "Jours"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/menu_translation.php
 msgid "Debug"
 msgstr "Débogage"
 
@@ -3880,27 +3996,28 @@ msgstr "Taille maximale du fichier de débogage"
 
 #: centreon/www/include/Administration/parameters/debug/form.php
 msgid "Debug level"
-msgstr ""
+msgstr "Niveau de débug"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Debug messages"
 msgstr "Événements de débogage"
 
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/install/front_translate.php
 msgid "Default"
 msgstr "Défaut"
 
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 msgid "Default Centreon Graph Template"
-msgstr "Modèle graphique par défaut de Centreon ?"
+msgstr "Modèle de graphique par défaut de Centreon"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Default Language"
@@ -3926,8 +4043,9 @@ msgstr "Groupe de contacts par défaut"
 msgid "Default downtime settings"
 msgstr "Options de la plage de maintenance par défaut"
 
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Default page"
 msgstr "Page par défaut"
 
@@ -3949,7 +4067,7 @@ msgstr "Définir les valeurs des conditions autorisées"
 
 #: centreon/www/install/front_translate.php
 msgid "Define relations between roles and ACL access groups"
-msgstr ""
+msgstr "Définir les relations entre les rôles et les groupes d'accès ACL"
 
 #: centreon/www/install/front_translate.php
 msgid "Define the password security policy"
@@ -3972,55 +4090,59 @@ msgstr "Définir la relation entre les rôles et les groupes d'accès ACL"
 msgid "Define your endpoint"
 msgstr "Définissez votre point d'entrée"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
 #: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/connector/listConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
 #: centreon/www/include/configuration/configResources/listResources.php
 #: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
-#: centreon/www/include/options/media/images/listImg.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
 #: centreon/www/include/monitoring/comments/listComment.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Delete"
 msgstr "Supprimer"
 
@@ -4031,15 +4153,15 @@ msgstr "Supprimer l'acquittement du problème"
 
 #: centreon/www/install/menu_translation.php
 msgid "Delete View"
-msgstr ""
+msgstr "Supprimer une vue"
 
 #: centreon/www/install/front_translate.php
 msgid "Delete additional configuration"
 msgstr "Supprimer la configuration additionnelle"
 
 #: centreon/www/install/front_translate.php
-msgid "Delete agent"
-msgstr "Supprimer un agent"
+msgid "Delete agent configuration"
+msgstr "Supprimer une configuration d'agent"
 
 #: centreon/www/install/front_translate.php
 msgid "Delete dashboard"
@@ -4047,9 +4169,10 @@ msgstr "Supprimer le tableau de bord"
 
 #: centreon/www/install/front_translate.php
 msgid "Delete filter?"
-msgstr "Supprimer le filtre?"
+msgstr "Supprimer le filtre ?"
 
 #: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/Administration/performance/viewData.php
 msgid "Delete graphs"
 msgstr "Supprimer des graphiques"
 
@@ -4099,14 +4222,14 @@ msgstr "Supprimer le widget"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Delete wiki page"
-msgstr ""
+msgstr "Supprimer la page de wiki"
 
 #: centreon/www/include/Administration/configChangelog/viewLogs.php
 msgid "Deleted"
 msgstr "Supprimé"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/home/customViews/index.php
+#: centreon/www/install/smarty_translate.php
 msgid ""
 "Deleting this view might impact other users. Are you sure you want to do it?"
 msgstr ""
@@ -4119,32 +4242,32 @@ msgid ""
 "Are you sure you want to do it?"
 msgstr ""
 "Supprimer ce widget pourrait impacter les utilisateurs avec lesquels vous "
-"partagez cette vue. Êtes-vous sûr de vouloir faire cela?"
+"partagez cette vue. Êtes-vous sûr de vouloir faire cela ?"
 
 #: centreon/www/install/menu_translation.php
 msgid "Dependencies"
 msgstr "Dépendances"
 
-#: centreon/www/install/step_upgrade/step2.php
 #: centreon/src/CentreonLegacy/Core/Install/Step/Step2.php
+#: centreon/www/install/step_upgrade/step2.php
 msgid "Dependency check up"
 msgstr "Vérification des dépendances"
 
+#: centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/DB-Func.php
 #: centreon/www/include/configuration/configObject/host_dependency/DB-Func.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
 #: centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
 msgid "Dependency description can't be empty"
-msgstr ""
+msgstr "La description de la dépendance ne peut pas être vide"
 
+#: centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/DB-Func.php
 #: centreon/www/include/configuration/configObject/host_dependency/DB-Func.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/DB-Func.php
 #: centreon/www/include/configuration/configObject/service_dependency/DB-Func.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/DB-Func.php
 msgid "Dependency name can't be empty"
-msgstr ""
+msgstr "Le nom de la dépendance ne peut pas être vide"
 
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 msgid "Dependent Host Groups Name"
@@ -4164,12 +4287,16 @@ msgstr "Nom des Meta-services liés"
 
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 msgid "Dependent Servicegroups"
-msgstr ""
+msgstr "Groupes de services dépendants"
 
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 msgid "Dependent Services"
 msgstr "Services dépendants"
+
+#: centreon/www/include/configuration/configObject/host/listHost.php
+msgid "Deploy Service"
+msgstr "Déployer les services"
 
 #: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
 msgid "Deploy configuration"
@@ -4187,34 +4314,34 @@ msgstr "Décrire les arguments"
 msgid "Describe macros"
 msgstr "Décrire les macros"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
 #: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
 #: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
-#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 #: centreon/www/include/configuration/configResources/listResources.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
-#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/install/front_translate.php
 msgid "Description"
 msgstr "Description"
 
@@ -4234,15 +4361,19 @@ msgstr "Détacher les services du groupe d'hôtes"
 msgid "Detailed Graph"
 msgstr "Graphique détaillé"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/install/front_translate.php
 msgid "Details"
 msgstr "Détails"
+
+#: centreon/www/include/common/common-Func.php
+msgid "Detection by browser"
+msgstr "Détection via le navigateur"
 
 #: centreon/www/install/front_translate.php
 msgid "Developed by"
@@ -4252,9 +4383,8 @@ msgstr "Développé par"
 msgid "Developers"
 msgstr "Developpeurs"
 
-#: centreon/www/include/options/media/images/listImg.php
-#: centreon/www/include/options/media/images/formImg.php
 #: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/options/media/images/listImg.php
 msgid "Directory"
 msgstr "Répertoire"
 
@@ -4276,23 +4406,25 @@ msgstr ""
 "Répertoire de stockage de la base SQLite contenant la définition des traps "
 "SNMP"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/command/listCommand.php
-#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
 #: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
 #: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configServers/formServers.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/install/front_translate.php
 msgid "Disable"
 msgstr "Désactiver"
 
@@ -4313,11 +4445,11 @@ msgstr "Désactiver la détection de bagotage des statuts"
 
 #: centreon/www/widgets/host-monitoring/src/toolbar.php
 msgid "Disable Host Check"
-msgstr ""
+msgstr "Désactiver les contrôles sur les hôtes"
 
 #: centreon/www/widgets/host-monitoring/src/toolbar.php
 msgid "Disable Host Notification"
-msgstr ""
+msgstr "Désactiver les notifications d'hôtes"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Disable Host Notifications"
@@ -4338,7 +4470,7 @@ msgstr "Désactiver les contrôles passifs"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Disable Service Checks When Host Down"
-msgstr ""
+msgstr "Désactiver les contrôles de service lorsque l'hôte est indisponible"
 
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Disable Service Notifications"
@@ -4364,58 +4496,60 @@ msgstr "Désactiver le jeton"
 msgid "Disable verify peer"
 msgstr "Désactiver la vérification du pair"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
-#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
-#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/connector/formConnector.php
-#: centreon/www/include/configuration/configObject/connector/listConnector.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
-#: centreon/www/include/configuration/configObject/meta_service/metric.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/host/listHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/command/formCommand.php
-#: centreon/www/include/configuration/configObject/command/listCommand.php
-#: centreon/www/include/configuration/configResources/listResources.php
-#: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
 #: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
-#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/install/front_translate.php
 msgid "Disabled"
 msgstr "Désactivé"
 
 #: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 msgid "Disabled Hosts"
 msgstr "Hôtes désactivés"
 
@@ -4451,30 +4585,30 @@ msgstr "Annuler"
 msgid "Disconnect user"
 msgstr "Déconnecter l'utilisateur"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/include/configuration/configObject/command/commandType.php
 #: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/command/commandType.php
+#: centreon/www/install/menu_translation.php
 msgid "Discovery"
 msgstr "Découverte"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/install/front_translate.php
 msgid "Display"
 msgstr "Afficher"
 
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
 msgid "Display "
-msgstr "Afficher"
+msgstr "Afficher "
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Display Autologin shortcut"
@@ -4483,6 +4617,10 @@ msgstr "Afficher le raccourci de connexion automatique"
 #: centreon/www/install/smarty_translate.php
 msgid "Display Chart"
 msgstr "Afficher le graphique"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "Display Finished Downtimes"
+msgstr "Afficher les plages de maintenance terminés"
 
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 msgid "Display Only The Legend"
@@ -4496,6 +4634,10 @@ msgstr "Paramètres d'apparence optionnels"
 msgid "Display Poller Listing"
 msgstr "Afficher la liste des collecteurs"
 
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "Display Recurring Downtimes"
+msgstr "Afficher les plages de maintenance cycliques"
+
 #: centreon/www/include/views/graphs/graphs.php
 msgid "Display Status"
 msgstr "Affichage de l'état"
@@ -4508,6 +4650,10 @@ msgstr "Afficher les statistiques des hôtes et services dans le bandeau"
 msgid "Display Top Counter pollers statistics"
 msgstr "Afficher les statistiques des collecteurs dans le bandeau"
 
+#: centreon/www/include/configuration/configObject/host/listHost.php
+msgid "Display all Services for this host"
+msgstr "Afficher tous les services de cet hôte"
+
 #: centreon/www/install/front_translate.php
 msgid "Display as"
 msgstr "Afficher sous forme de"
@@ -4516,12 +4662,12 @@ msgstr "Afficher sous forme de"
 msgid "Display comment on chart"
 msgstr "Afficher les commentaires sur le graphique"
 
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
 msgid "Display details"
 msgstr "Afficher les détails"
 
@@ -4540,7 +4686,7 @@ msgstr "Afficher la commande exécutée par le moteur de supervision"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Display multiple periods"
-msgstr ""
+msgstr "Afficher des périodes multiples"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Display properties"
@@ -4572,13 +4718,13 @@ msgstr "Supprimer l'associatino de cette vue ?"
 
 #: centreon/www/include/configuration/configServers/listServers.php
 msgid "Distant Poller"
-msgstr ""
+msgstr "Collecteur distant"
 
+#: centreon/www/include/configuration/configServers/formServers.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
-#: centreon/www/include/configuration/configServers/formServers.php
 msgid "Do not check SSL certificate validation"
-msgstr ""
+msgstr "Ne pas vérifier la validation du certificat SSL"
 
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
@@ -4587,7 +4733,11 @@ msgstr "Ne pas utiliser le proxy configuré pour se connecter à ce serveur"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Do not use proxy defined in global configuration"
-msgstr ""
+msgstr "Ne pas utiliser le proxy défini dans la configuration globale"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "Do you confirm the cancellation ?"
+msgstr "Confirmez-vous l'annulation ?"
 
 #: centreon/www/include/Administration/performance/viewMetrics.php
 msgid ""
@@ -4597,83 +4747,88 @@ msgstr ""
 "Confirmer le changement de type de source de données ? Si oui, il est "
 "nécessaire de reconstruire la base de données RRD."
 
-#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/parameters/ldap/listFunction.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
 #: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/connector/listConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
 #: centreon/www/include/configuration/configResources/listResources.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
-#: centreon/www/include/options/media/images/listImg.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
 #: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
 #: centreon/www/include/monitoring/comments/listComment.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
-#: centreon/www/include/Administration/parameters/ldap/listFunction.php
-#: centreon/www/include/Administration/performance/viewMetrics.php
 msgid "Do you confirm the deletion ?"
 msgstr "Confirmez-vous cette suppression ?"
 
-#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
-#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/connector/listConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
-#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/command/listCommand.php
-#: centreon/www/include/configuration/configResources/listResources.php
-#: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
 #: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
 #: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/listServers.php
 #: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
 msgid "Do you confirm the duplication ?"
 msgstr "Confirmez-vous la duplication ?"
@@ -4688,7 +4843,7 @@ msgstr "Voulez-vous vraiment débloquer cet utilisateur ?"
 
 #: centreon/www/install/front_translate.php
 msgid "Do you want to leave this page?"
-msgstr "Voulez-vous quitter cette page?"
+msgstr "Voulez-vous quitter cette page ?"
 
 #: centreon/www/install/front_translate.php
 msgid "Do you want to quit the form without saving the changes?"
@@ -4707,10 +4862,11 @@ msgstr "Voulez-vous réinitialiser le formulaire ?"
 msgid "Do you want to save the changes?"
 msgstr "Voulez-vous enregistrer les modifications ?"
 
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Documentation"
 msgstr "Documentation"
 
@@ -4718,16 +4874,17 @@ msgstr "Documentation"
 msgid "Done"
 msgstr "Terminé"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/install/front_translate.php
 msgid "Down"
 msgstr "Indisponible"
 
@@ -4755,11 +4912,12 @@ msgstr "Plage de maintenance"
 msgid "Downtime Configuration"
 msgstr "Configuration des plages de maintenance"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Downtime Scheduled"
 msgstr "Plages de maintenance programmées"
 
@@ -4790,75 +4948,77 @@ msgstr "Plage de maintenance programmée par"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #, php-format
 msgid "Downtime set by %s"
 msgstr "Plage de maintenance fixée par %s"
 
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 msgid "Downtime type"
 msgstr "Type de plage de maintenance"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/menu_translation.php
 msgid "Downtimes"
 msgstr "Planifier des plages de maintenance"
 
 #: centreon/www/install/front_translate.php
 msgid "Drag handle"
-msgstr ""
+msgstr "Poignée de déplacement"
 
 #: centreon/www/install/front_translate.php
 msgid "Drop or"
-msgstr ""
+msgstr "Faire glisser ou"
 
 #: centreon/www/install/front_translate.php
 msgid "Drop or select a file"
-msgstr ""
+msgstr "Faire glisser ou sélectionner un fichier"
 
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
 msgid "Dump"
 msgstr "Dump"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
-#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/connector/listConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
-#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/command/listCommand.php
-#: centreon/www/include/configuration/configResources/listResources.php
-#: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
 #: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
 #: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/listServers.php
 #: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/install/front_translate.php
 msgid "Duplicate"
 msgstr "Dupliquer"
 
@@ -4872,47 +5032,47 @@ msgstr "Dupliquer le tableau de bord"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
-#, fuzzy, php-format
+#, php-format
 msgid "Duplicates not allowed for property '%s'"
-msgstr "Doublons non autorisés pour la propriété '%'"
+msgstr "Doublons non autorisés pour la propriété '%s'"
 
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/xmlInformations/common-Func.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceJS.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/service.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
-#: centreon/www/include/monitoring/status/Hosts/hostJS.php
-#: centreon/www/include/monitoring/status/Hosts/host.php
-#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
 #: centreon/www/include/Administration/parameters/general/form.php
 #: centreon/www/include/Administration/parameters/engine/form.php
-#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/common-Func.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Duration"
 msgstr "Durée"
 
 #: centreon/www/install/front_translate.php
 msgid "E-mail"
-msgstr ""
+msgstr "Email"
 
 #: centreon/www/install/menu_translation.php
 msgid "Edit View"
-msgstr ""
+msgstr "Éditer la vue"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Edit a view"
@@ -4932,11 +5092,11 @@ msgstr "Éditer le tableau de bord"
 
 #: centreon/www/install/front_translate.php
 msgid "Edit link"
-msgstr ""
+msgstr "Éditer le lien"
 
 #: centreon/www/install/front_translate.php
 msgid "Edit modal"
-msgstr ""
+msgstr "Fenêtre d'édition"
 
 #: centreon/www/install/front_translate.php
 msgid "Edit name"
@@ -4967,17 +5127,17 @@ msgstr "Éditer le widget"
 msgid ""
 "Edit wiki\n"
 "                    page"
-msgstr ""
+msgstr "Éditer la page de wiki"
 
 #: centreon/www/install/front_translate.php
 msgid "Editor"
 msgstr "Editor"
 
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
 #: centreon/www/include/configuration/configObject/contact/listContact.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/install/smarty_translate.php
 msgid "Email"
 msgstr "Mail"
 
@@ -5001,24 +5161,26 @@ msgstr "Ligne vide après cette légende"
 msgid "Empty directory"
 msgstr "Répertoire vide"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/command/listCommand.php
-#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
 #: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
 #: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configServers/formServers.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/install/front_translate.php
 msgid "Enable"
 msgstr "Activer"
 
@@ -5033,7 +5195,7 @@ msgstr "Activer la connexion automatique"
 
 #: centreon/www/include/Administration/parameters/api/api.php
 msgid "Enable Broker Statistics Collection"
-msgstr ""
+msgstr "Activer la collecte des statistiques Broker"
 
 #: centreon/www/include/Administration/parameters/gorgone/gorgone.php
 msgid "Enable Broker statistics collection"
@@ -5051,11 +5213,11 @@ msgstr "Activer la détection de bagotage des statuts"
 
 #: centreon/www/widgets/host-monitoring/src/toolbar.php
 msgid "Enable Host Check"
-msgstr ""
+msgstr "Activer les contrôles sur les hôtes"
 
 #: centreon/www/widgets/host-monitoring/src/toolbar.php
 msgid "Enable Host Notification"
-msgstr ""
+msgstr "Activer les notifications sur les hôtes"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Enable Host Notifications"
@@ -5070,6 +5232,7 @@ msgid "Enable LDAP synchronization on login"
 msgstr "Synchronisation LDAP lors du login"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Enable Notifications"
 msgstr "Activer les notifications"
 
@@ -5148,7 +5311,7 @@ msgstr "Activer l'enregistrement des informations du pid"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Enable macro filtering"
-msgstr ""
+msgstr "Activer le filtrage sur les macros"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Enable negotiation"
@@ -5269,58 +5432,60 @@ msgid "Enable/disable resource"
 msgstr "Activer/désactiver la ressource"
 
 # This string must be in html format to work in Scheduling queue monitoring!
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
-#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
-#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/connector/formConnector.php
-#: centreon/www/include/configuration/configObject/connector/listConnector.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
-#: centreon/www/include/configuration/configObject/meta_service/metric.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/host/listHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/command/formCommand.php
-#: centreon/www/include/configuration/configObject/command/listCommand.php
-#: centreon/www/include/configuration/configResources/listResources.php
-#: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
 #: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configObject/connector/listConnector.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
-#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/install/front_translate.php
 msgid "Enabled"
 msgstr "Activé"
 
 #: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 msgid "Enabled Hosts"
 msgstr "Hôtes activés"
 
@@ -5334,18 +5499,18 @@ msgstr "Niveau de chiffrement"
 msgid "End"
 msgstr "Fin"
 
-#: centreon/www/install/smarty_translate.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 #: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/install/smarty_translate.php
 msgid "End Time"
 msgstr "Fin"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/install/front_translate.php
 msgid "End date"
 msgstr "Date de fin"
 
@@ -5381,9 +5546,9 @@ msgstr "Statut de l'ordonnanceur"
 msgid "Engine configuration"
 msgstr "Configuration du moteur de collecte"
 
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
 msgid "Entry Time"
 msgstr "Date de saisie"
 
@@ -5401,10 +5566,10 @@ msgstr "Erreur"
 msgid "Error during creation of the CentCore command file (%s)"
 msgstr "Erreur lors de la création du fichier de commande Centcore (%s)"
 
-#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
 #: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/Exception/PlatformTopologyRepositoryException.php
+#: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
 msgid "Error from Central's register API"
-msgstr ""
+msgstr "Erreur de l'enregistrement via API sur le serveur central"
 
 #: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
 msgid "Error in getting stats filename"
@@ -5430,7 +5595,7 @@ msgstr "Erreur lors de l'ajout d'un hôte (Raison : %s)"
 #: centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
 #, php-format
 msgid "Error on monitoring server #%d: %s"
-msgstr "Erreur sur le serveur de supervision #%d: %s"
+msgstr "Erreur sur le serveur de supervision #%d : %s"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostMacroServiceException.php
 #, php-format
@@ -5445,7 +5610,7 @@ msgstr "Erreur lors de la suppression des services de l'hôte #%d"
 #: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
 #, php-format
 msgid "Error on removing services from the host #%d (Reason: %s)"
-msgstr ""
+msgstr "Erreur lors de la suppression des services de l'hôte #%d (raison : %s)"
 
 #: centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
 msgid "Error on retrieving monitoring servers"
@@ -5471,7 +5636,7 @@ msgstr "Erreur lors de la mise à jour d'un utilisateur"
 #: centreon/src/Core/Media/Infrastructure/API/Exception/MediaException.php
 #, php-format
 msgid "Error uploading file '%s'"
-msgstr ""
+msgstr "Erreur lors de l'upload du fichier '%s'"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostCategoryException.php
 msgid "Error when adding a host category"
@@ -5479,7 +5644,7 @@ msgstr "Erreur lors de l'ajout d'une catégorie hôte"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostGroupException.php
 msgid "Error when adding a host groups"
-msgstr ""
+msgstr "Erreur lors de l'ajout d'un groupe d'hôtes"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostMacroServiceException.php
 msgid "Error when adding a host macro"
@@ -5487,7 +5652,7 @@ msgstr "Erreur lors de l'ajout d'une macro hôte"
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "Error when adding a notification configuration"
-msgstr ""
+msgstr "Erreur lors de l'ajout d'une configuration de notification"
 
 #: centreon/src/Centreon/Domain/ActionLog/ActionLogService.php
 msgid "Error when adding an entry in the action log"
@@ -5526,9 +5691,9 @@ msgstr "Erreur lors du changement de statut de l'hôte (%d à %s)"
 msgid "Error when connecting to the Gorgone server"
 msgstr "Erreur de connexion avec le serveur Gorgone"
 
-#: centreon/src/Centreon/Application/Controller/FilterController.php
 #: centreon/src/Centreon/Application/Controller/PlatformTopologyController.php
 #: centreon/src/Centreon/Application/Controller/PlatformController.php
+#: centreon/src/Centreon/Application/Controller/FilterController.php
 msgid "Error when decoding sent data"
 msgstr "Erreur lors du décodage des données envoyées"
 
@@ -5544,7 +5709,7 @@ msgstr "Erreur lors de la suppression de la période de temps %d"
 
 #: centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/Exception/MonitoringServerConfigurationRepositoryException.php
 msgid "Error when initializing the api uri"
-msgstr ""
+msgstr "Erreur lors de l'initialisation de l'URI de l'API"
 
 #: centreon/src/Centreon/Domain/Option/OptionService.php
 msgid "Error when retrieving selected options"
@@ -5566,7 +5731,7 @@ msgstr "Erreur lors de la recherche des filtres"
 #: centreon/src/Centreon/Domain/MonitoringServer/MonitoringServerService.php
 #, php-format
 msgid "Error when searching for a monitoring server %s"
-msgstr ""
+msgstr "Erreur lors de la recherche du serveur de supervision %s"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
 msgid "Error when searching for already used host names"
@@ -5598,7 +5763,7 @@ msgstr "Erreur lors de la recherche des hôtes"
 
 #: centreon/src/Centreon/Domain/Monitoring/Comment/CommentService.php
 msgid "Error when searching for meta services"
-msgstr ""
+msgstr "Erreur lors de la recherche de métaservices"
 
 #: centreon/src/Centreon/Domain/MonitoringServer/Exception/RealTimeMonitoringServerException.php
 msgid "Error when searching for real time monitoring servers"
@@ -5626,7 +5791,7 @@ msgstr ""
 #: centreon/src/Centreon/Domain/Engine/Exception/EngineConfigurationException.php
 #, php-format
 msgid "Error when searching for the engine configuration (%s)"
-msgstr ""
+msgstr "Erreur lors de la recherche de la configuration du moteur (%s)"
 
 #: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
 #, php-format
@@ -5651,12 +5816,12 @@ msgstr "Erreur lors de la recherche de la sévérité d'hôtes #%d"
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostSeverityException.php
 #, php-format
 msgid "Error when searching for the host severity (%s)"
-msgstr ""
+msgstr "Erreur lors de la recherche de la criticité d'hôte (%s)"
 
 #: centreon/src/Centreon/Domain/Monitoring/MetaService/Exception/MetaServiceMetricException.php
 #, php-format
 msgid "Error when searching for the meta service (%d) metrics"
-msgstr ""
+msgstr "Erreur lors de la recherche des métriques du métaservice (%d)"
 
 #: centreon/src/Centreon/Domain/MetaServiceConfiguration/Exception/MetaServiceConfigurationException.php
 #, php-format
@@ -5679,11 +5844,11 @@ msgstr "Erreur lors de la recherche de périodes de temps"
 
 #: centreon/src/Centreon/Domain/Monitoring/HostGroup/HostGroupService.php
 msgid "Error when searching hostgroups"
-msgstr ""
+msgstr "Erreur lors de la recherche de groupes d'hôtes"
 
 #: centreon/src/Centreon/Domain/Monitoring/ServiceGroup/ServiceGroupService.php
 msgid "Error when searching servicegroups"
-msgstr ""
+msgstr "Erreur lors de la recherche de groupes de services"
 
 #: centreon/src/Centreon/Domain/Filter/FilterService.php
 #, php-format
@@ -5725,7 +5890,7 @@ msgstr "Erreur lors de l'ajout de la configuration collecteur/agent"
 
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 msgid "Error while adding a resource access rule"
-msgstr ""
+msgstr "Erreur lors de l'ajout d'une règle d'accès aux ressources"
 
 #: centreon/src/Core/ServiceGroup/Application/Exception/ServiceGroupException.php
 msgid "Error while adding a service group"
@@ -5829,11 +5994,11 @@ msgstr "Erreur lors de la suppression de la session"
 
 #: centreon/src/Core/Host/Application/Exception/HostException.php
 msgid "Error while deleting the host"
-msgstr ""
+msgstr "Erreur lors de la suppression de l'hôte"
 
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 msgid "Error while deleting the resource access rule"
-msgstr ""
+msgstr "Erreur lors de la suppression de la règle d'accès aux ressources"
 
 #: centreon/src/Core/Service/Application/Exception/ServiceException.php
 msgid "Error while deleting the service"
@@ -5845,11 +6010,11 @@ msgstr "Erreur lors de la suppression du modèle de service"
 
 #: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
 msgid "Error while editing service severity"
-msgstr ""
+msgstr "Erreur lors de l'édition de la criticité du service"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 msgid "Error while linking a dashboard to its thumbnail"
-msgstr ""
+msgstr "Erreur lors de la liaison d'un tableau de bord à sa vignette"
 
 #: centreon/src/Core/Host/Application/Exception/HostException.php
 msgid "Error while linking host categories to a host"
@@ -5858,6 +6023,16 @@ msgstr "Erreur lors de l'association de catégories d'hôte à un hôte"
 #: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
 msgid "Error while linking host categories to a host template"
 msgstr "Erreur lors de la liaison de catégories d'hôte à un modèle d'hôte"
+
+#: centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
+#, php-format
+msgid "Error while linking template %s to host (id: %d)"
+msgstr "Erreur lors de la liaison du modèle %s à l'hôte (id: %d)"
+
+#: centreon/src/Centreon/Infrastructure/HostConfiguration/Repository/HostConfigurationRepositoryRDB.php
+#, php-format
+msgid "Error while linking template (id: %d) to host (id: %d)"
+msgstr "Erreur lors de la liaison du modèle (id: %d) à l'hôte (id: %d)"
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "Error while listing notification resources"
@@ -5886,7 +6061,7 @@ msgstr "Erreur lors de la lecture de la configuration du fournisseur local"
 
 #: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
 msgid "Error while refresh token"
-msgstr ""
+msgstr "Erreur lors du rafraîchissement du jeton"
 
 #: centreon/src/Core/Command/Application/Exception/CommandException.php
 msgid "Error while retrieving a command"
@@ -5914,7 +6089,7 @@ msgstr "Error lors de la récupération d'un modèle d'hôtes"
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "Error while retrieving a notification configuration"
-msgstr ""
+msgstr "Erreur lors de la récupération d'une configuration de notifications"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 msgid "Error while retrieving a poller/agent configuration"
@@ -5922,7 +6097,7 @@ msgstr "Erreur durant la récupération d'une configuration collecteur/agent"
 
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 msgid "Error while retrieving a resource access rule"
-msgstr ""
+msgstr "Erreur lors de la récupération d'une règle d'accès aux données"
 
 #: centreon/src/Core/Service/Application/Exception/ServiceException.php
 msgid "Error while retrieving a service"
@@ -5940,9 +6115,18 @@ msgstr "Erreur lors de la récupération du token"
 msgid "Error while retrieving an additional configuration"
 msgstr "Erreur durant la récupération d'une configuration additionnelle"
 
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid ""
+"Error while retrieving contact groups allowed to receive a dashboard share"
+msgstr ""
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while retrieving contacts allowed to receive a dashboard share"
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 msgid "Error while retrieving host dependencies"
-msgstr ""
+msgstr "Erreur lors de la récupération des dépendances de l'hôte"
 
 #: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
 msgid "Error while retrieving host severity"
@@ -5950,7 +6134,7 @@ msgstr "Error lors de la récupération d'une sévérité d'hôtes"
 
 #: centreon/src/Core/Host/Application/Exception/HostException.php
 msgid "Error while retrieving host statuses distribution"
-msgstr ""
+msgstr "Erreur lors de la récupération du statut des hôtes"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 msgid "Error while retrieving multiple poller/agent configurations"
@@ -5982,7 +6166,7 @@ msgstr ""
 
 #: centreon/src/Core/Service/Application/Exception/ServiceException.php
 msgid "Error while retrieving service statuses distribution"
-msgstr ""
+msgstr "Erreur lors de la récupération du statut des services"
 
 #: centreon/src/Core/Resources/Application/Exception/ResourceException.php
 msgid "Error while retrieving the number of hosts by status"
@@ -5994,7 +6178,7 @@ msgstr "Erreur lors de la récupération du nombre de services par statut"
 
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 msgid "Error while search resource access rules"
-msgstr ""
+msgstr "Erreur lors de la recherche de règles d'accès aux ressources"
 
 #: centreon/src/Security/Domain/Authentication/Exceptions/AuthenticationTokenException.php
 #: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
@@ -6117,34 +6301,35 @@ msgstr "Erreur lors de la recherche de l'utilisateur"
 
 #: centreon/src/Core/Security/Token/Application/Exception/TokenException.php
 msgid "Error while searching for tokens"
-msgstr ""
+msgstr "Erreur lors de la recherche de jetons"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 msgid "Error while searching for user favorite dashboards"
 msgstr ""
+"Erreur lors de la recherche des tableaux de bord favoris de l'utilisateur"
 
 #: centreon/src/Core/User/Application/Exception/UserException.php
 msgid "Error while searching for users"
-msgstr ""
+msgstr "Erreur lors de la recherche d'utilisateurs"
 
 #: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
 msgid "Error while searching host categories in real time context"
-msgstr ""
+msgstr "Erreur lors de la recherche de catégories d'hôtes"
 
 #: centreon/src/Security/Domain/Authentication/Exceptions/ProviderException.php
 #, php-format
 msgid "Error while searching provider configuration: '%s'"
 msgstr ""
 "Erreur pendant la recherche de configuration du fournisseur "
-"d'identification: '%s'"
+"d'identification : '%s'"
 
 #: centreon/src/Security/Domain/Authentication/Exceptions/ProviderException.php
 msgid "Error while searching providers configurations"
-msgstr ""
+msgstr "Erreur lors de la recherche des configurations de fournisseurs"
 
 #: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
 msgid "Error while searching service categories in real time context"
-msgstr ""
+msgstr "Erreur lors de la recherche de catégories de services"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 msgid ""
@@ -6175,7 +6360,7 @@ msgstr "Erreur lors de la mise à jour d'un groupe d'hôtes"
 
 #: centreon/src/Core/Media/Application/Exception/MediaException.php
 msgid "Error while updating a media"
-msgstr ""
+msgstr "Erreur lors de la modification d'un média"
 
 #: centreon/src/Core/Notification/Application/UseCase/UpdateNotification/UpdateNotification.php
 msgid "Error while updating a notification configuration"
@@ -6191,7 +6376,7 @@ msgstr "Erreur lors de la mise à jour d'un service"
 
 #: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
 msgid "Error while updating a service template"
-msgstr ""
+msgstr "Erreur lors de la modification d'un modèle de services"
 
 #: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
 msgid "Error while updating an additional configuration"
@@ -6205,25 +6390,29 @@ msgstr "Erreur lors de la mise à jour des jetons d'authentification"
 msgid "Error while updating host severity"
 msgstr "Erreur lors de la mise à jour de la sévérité d'hôtes"
 
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+msgid "Error while updating the dashboard share"
+msgstr "Erreur durant la mise à jour d'un partage de tableau de bord"
+
 #: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
 msgid "Error while updating the host category"
 msgstr "Erreur lors de la mise à jour de la catégorie d'hôte"
 
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 msgid "Error while updating the resource access rule"
-msgstr ""
+msgstr "Erreur lors de la modification d'une règle d'accès aux ressources"
 
 #: centreon/www/include/eventLogs/viewLog.php
 msgid "Errors"
 msgstr "Erreurs"
 
-#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 #: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 msgid "Escalated Hosts"
 msgstr "Hôtes escaladés"
 
-#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 #: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 msgid "Escalated Services"
 msgstr "Services escaladés"
 
@@ -6243,25 +6432,25 @@ msgstr "Période d'escalade"
 msgid "Escalations"
 msgstr "Escalades"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/front_translate.php
 msgid "Event"
 msgstr "Évènement"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Event Handler"
 msgstr "Gestionnaire d'évènements"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Event Handler Enabled"
 msgstr "Gestionnaire d'évènements activé"
 
@@ -6280,6 +6469,10 @@ msgstr "Temps maximum d'exécution d'une commande du gestionnaire d'évènements
 #: centreon/www/install/menu_translation.php
 msgid "Event Logs"
 msgstr "Journaux d'évènements"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Event Type"
+msgstr "Type d'évènement"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Event broker directive"
@@ -6353,21 +6546,21 @@ msgstr "Exécuter ce script en tant que root sur le serveur central."
 msgid "Executed Check Command Line"
 msgstr "Commande exécutée par le moteur"
 
-#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
 #: centreon/www/include/configuration/configGenerate/xml/postcommand.php
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
 msgid "Executing command"
 msgstr "Exécution de la commande"
 
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 msgid "Execution Failure Criteria"
 msgstr "Critères d'échec d'exécution"
 
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Execution Time"
 msgstr "Temps d'exécution"
 
@@ -6386,10 +6579,6 @@ msgstr "Type d'exécution"
 #: centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/Exception/MonitoringServerConfigurationRepositoryException.php
 msgid "Execution was too long and reached timeout"
 msgstr "L'exécution a été trop longue et a atteint le délai d'attente"
-
-#: centreon/www/include/options/media/images/formImg.php
-msgid "Existing or new directory"
-msgstr "Nouveau dossier ou dossier existant"
 
 #: centreon/www/install/front_translate.php
 msgid "Exit"
@@ -6415,8 +6604,8 @@ msgstr "Agrandir le panneau d'informations"
 msgid "Expiration date"
 msgstr "Date d'expiration"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/install/front_translate.php
 msgid "Export"
 msgstr "Exporter"
 
@@ -6428,8 +6617,8 @@ msgstr "Exporter et recharger"
 msgid "Export CSV"
 msgstr "Exporter au format CSV"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+#: centreon/www/install/smarty_translate.php
 msgid "Export Options"
 msgstr "Options d'export"
 
@@ -6441,20 +6630,20 @@ msgstr "Export et recharger la configuration ?"
 msgid "Export as"
 msgstr "Exporter en tant que"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Export configuration"
 msgstr "Exporter la configuration"
 
 #: centreon/www/install/front_translate.php
 msgid "Export generation timeout"
-msgstr ""
+msgstr "Expiration du délai de génération de l'export"
 
 #: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
-#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
 #: centreon/www/include/reporting/dashboard/viewHostLog.php
 #: centreon/www/include/reporting/dashboard/viewServicesLog.php
+#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
 msgid "Export in CSV format"
 msgstr "Exporter au format CSV"
 
@@ -6496,6 +6685,10 @@ msgstr ""
 msgid "Expression in"
 msgstr "Expression en"
 
+#: centreon/www/install/front_translate.php
+msgid "Extended"
+msgstr "Étendu"
+
 #: centreon/www/install/smarty_translate.php
 msgid "Extended Info"
 msgstr "Informations complémentaires"
@@ -6512,8 +6705,8 @@ msgstr "Options avancées"
 msgid "Extended Status Information"
 msgstr "Informations étendues de statut"
 
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "Extended information"
 msgstr "Informations supplémentaires"
 
@@ -6552,7 +6745,7 @@ msgstr "Journalisation des commandes externes"
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "External Command successfully submitted... Exiting window..."
-msgstr ""
+msgstr "Commande externe soumise avec succès... La fenêtre va se fermer..."
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "External Commands"
@@ -6562,8 +6755,8 @@ msgstr "Commandes externes"
 msgid "External commands"
 msgstr "Commandes externes"
 
-#: centreon/www/install/front_translate.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/front_translate.php
 msgid "FQDN / Address"
 msgstr "FQDN / Adresse"
 
@@ -6573,7 +6766,7 @@ msgstr "Échec de la copie du fil d'Ariane"
 
 #: centreon/www/install/front_translate.php
 msgid "Failed to copy command"
-msgstr ""
+msgstr "La commande n'a pas pu être copiée"
 
 #: centreon/www/install/front_translate.php
 msgid "Failed to copy link"
@@ -6581,11 +6774,11 @@ msgstr "Échec de la copie du lien"
 
 #: centreon/www/install/front_translate.php
 msgid "Failed to create the dashboard"
-msgstr ""
+msgstr "Le tableau de bord n'a pas pu être créé"
 
 #: centreon/www/install/front_translate.php
 msgid "Failed to delete the dashboard"
-msgstr ""
+msgstr "Le tableau de bord n'a pas pu être supprimé"
 
 #: centreon/www/install/front_translate.php
 msgid "Failed to delete the notification"
@@ -6597,7 +6790,7 @@ msgstr "Les notifications n'ont pas pu être supprimées"
 
 #: centreon/www/install/front_translate.php
 msgid "Failed to delete the resource access rule"
-msgstr ""
+msgstr "La règle d'accès aux ressources n'a pas pu être supprimée"
 
 #: centreon/www/install/front_translate.php
 msgid "Failed to delete the selected notifications"
@@ -6633,6 +6826,8 @@ msgstr "L'export et le rechargement de la configuration a echoué"
 #, php-format
 msgid "Failed to get the auth token from Central : '%s''"
 msgstr ""
+"Le jeton d'authentification n'a pas pu être récupéré depuis le serveur "
+"central : \"%s\""
 
 #: centreon/www/install/front_translate.php
 msgid "Failed to save OpenID Connect configuration"
@@ -6656,7 +6851,7 @@ msgstr "La sauvegarde des partages a échoué"
 
 #: centreon/www/install/front_translate.php
 msgid "Failed to update the dashboard"
-msgstr ""
+msgstr "Le tableau de bord n'a pas pu être modifié"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Failover name"
@@ -6664,7 +6859,7 @@ msgstr "Nom du processus de bascule (failover)"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Features flipping"
-msgstr ""
+msgstr "Activation de fonctionnalités"
 
 #: centreon/www/include/Administration/configChangelog/viewLogs.php
 msgid "Field Name"
@@ -6674,9 +6869,9 @@ msgstr "Nom du champ"
 msgid "Field Value"
 msgstr "Valeur du champ"
 
-#: centreon/www/install/step_upgrade/step2.php
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step2.php
 msgid "File"
 msgstr "Fichier"
 
@@ -6704,14 +6899,14 @@ msgstr "Fichier non trouvé"
 msgid "File path"
 msgstr "Localisation du fichier"
 
-#: centreon/www/install/front_translate.php
-msgid "File too big"
-msgstr ""
-
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #, php-format
-msgid "Filename '%s' (%s) is invalid"
+msgid "File path or format '%s' (%s) is invalid"
 msgstr "Le nom de fichier '%s' (%s) est invalide"
+
+#: centreon/www/install/front_translate.php
+msgid "File too big"
+msgstr "La taille du fichier est trop grande"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Files"
@@ -6722,8 +6917,8 @@ msgstr "Fichiers"
 msgid "Filling"
 msgstr "Remplissage"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+#: centreon/www/install/front_translate.php
 msgid "Filter"
 msgstr "Filtre"
 
@@ -6760,9 +6955,9 @@ msgid "Filter deleted"
 msgstr "Filtre supprimé"
 
 #: centreon/src/Centreon/Application/Controller/FilterController.php
-#, fuzzy, php-format
+#, php-format
 msgid "Filter id %d not found"
-msgstr "Filtre id %s non trouvé"
+msgstr "L'ID de filtre %d n'a pas été trouvé"
 
 #: centreon/src/Centreon/Domain/Filter/FilterService.php
 msgid "Filter name already used"
@@ -6788,10 +6983,10 @@ msgstr "Filtrer les services"
 msgid "Filter updated"
 msgstr "Filtre actualisé"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 #: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Filters"
 msgstr "Filtres"
 
@@ -6806,7 +7001,7 @@ msgstr "Trouvez des explications et des exemples"
 
 #: centreon/www/install/front_translate.php
 msgid "Finish the setup"
-msgstr ""
+msgstr "Terminer l'installation"
 
 #: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 msgid "First Notification"
@@ -6816,10 +7011,10 @@ msgstr "Première notification"
 msgid "First name"
 msgstr "Prénom"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "First notification delay"
 msgstr "Délai de première notification"
 
@@ -6827,22 +7022,22 @@ msgstr "Délai de première notification"
 msgid "First of month"
 msgstr "Premier du mois"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/common/pagination.php
 #: centreon/www/include/configuration/configKnowledge/pagination.php
+#: centreon/www/install/front_translate.php
 msgid "First page"
 msgstr "Première page"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
-#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Fixed"
 msgstr "Fixe"
 
@@ -6851,10 +7046,10 @@ msgstr "Fixe"
 msgid "Flap Detection"
 msgstr "Détection de bagotage des statuts"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Flap Detection Enabled"
 msgstr "Détection de bagotage des statuts"
 
@@ -6862,13 +7057,14 @@ msgstr "Détection de bagotage des statuts"
 msgid "Flap Detection Option"
 msgstr "Détection de bagotage des statuts"
 
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/front_translate.php
 msgid "Flapping"
 msgstr "En bagotage"
 
@@ -6876,15 +7072,15 @@ msgstr "En bagotage"
 msgid "Flapping Options"
 msgstr "Détection de bagotage des statuts"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Flapping options"
 msgstr "Options de détection de bagotage des statuts"
 
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Flexible"
 msgstr "Flexible"
 
@@ -6919,8 +7115,8 @@ msgstr "Forcer le contrôle actif"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/install/front_translate.php
 msgid "Force active checks"
 msgstr "Forcer les contrôles actifs"
 
@@ -6930,7 +7126,7 @@ msgstr "Vérification forcée"
 
 #: centreon/www/install/front_translate.php
 msgid "Forced check command sent !"
-msgstr ""
+msgstr "Commande de vérification forcée envoyée"
 
 #: centreon/www/install/front_translate.php
 msgid ""
@@ -6943,10 +7139,10 @@ msgstr ""
 msgid "Forced check command sent!"
 msgstr "Commande de vérification forcée envoyée !"
 
-#: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/options/media/images/formDirectory.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configResources/formResources.php
 msgid "Form"
 msgstr "Formulaire"
 
@@ -6956,53 +7152,54 @@ msgstr "En avant"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Forward provisioning"
-msgstr ""
+msgstr "Provisionnement à l'avance"
 
 #: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Fourth of month"
-msgstr ""
+msgstr "Le quatrième du mois"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Freshness"
 msgstr "Fraicheur"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Freshness Control options"
 msgstr "Options de contrôle de la fraicheur du résultat"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Freshness Threshold"
 msgstr "Seuil de fraicheur du résultat"
 
-#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Friday"
 msgstr "Vendredi"
 
-#: centreon/www/class/centreonWidget/Params/Date.class.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/views/graphs/graphs.php
 #: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
-#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
-#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/reporting/dashboard/viewHostLog.php
 #: centreon/www/include/reporting/dashboard/viewServicesLog.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/class/centreonWidget/Params/Date.class.php
 msgid "From"
 msgstr "Du"
 
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/contact/listContact.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Full Name"
 msgstr "Nom complet"
 
@@ -7047,39 +7244,41 @@ msgstr "Jauge"
 msgid "General"
 msgstr "Général"
 
-#: centreon/www/api/class/centreon_home_customview.class.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
-#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
-#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
 #: centreon/www/include/home/customViews/formLoad.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/api/class/centreon_home_customview.class.php
 msgid "General Information"
 msgstr "Informations générales"
 
 #: centreon/www/install/smarty_translate.php
 msgid "General Options"
-msgstr ""
+msgstr "Options générales"
 
+#: centreon/www/include/Administration/parameters/ldap/form.php
 #: centreon/www/include/configuration/configObject/connector/formConnector.php
 #: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "General information"
 msgstr "Informations générales"
 
@@ -7087,10 +7286,10 @@ msgstr "Informations générales"
 msgid "General informations"
 msgstr "Informations générales"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+#: centreon/www/install/menu_translation.php
 msgid "Generate"
 msgstr "Générer"
 
@@ -7108,7 +7307,7 @@ msgstr "Générer un jeton"
 
 #: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
 msgid "Generate trap database "
-msgstr "Générer la base de définition des traps SNMP"
+msgstr "Générer la base de définition des traps SNMP "
 
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
@@ -7117,7 +7316,7 @@ msgstr "Génération de fichiers d'exportation"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Generating application cache"
-msgstr ""
+msgstr "Génération du cache de l'application"
 
 #: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
 msgid "Generating files"
@@ -7157,7 +7356,7 @@ msgstr "Gestionnaire global d’évènements de service"
 
 #: centreon/www/install/front_translate.php
 msgid "Global refresh interval"
-msgstr ""
+msgstr "Délai de rafraîchissement global"
 
 #: centreon/www/install/front_translate.php
 msgid "Go to performance page"
@@ -7169,7 +7368,7 @@ msgstr "Bon"
 
 #: centreon/www/install/menu_translation.php
 msgid "Gorgone"
-msgstr ""
+msgstr "Gorgone"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Gorgone Information"
@@ -7177,7 +7376,7 @@ msgstr "Informations Gorgone"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Gorgone connection port"
-msgstr ""
+msgstr "Port de connexion à Gorgone"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Gorgone connection protocol"
@@ -7185,10 +7384,11 @@ msgstr "Protocole de connexion utilisé par Gorgone"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Gorgone properties"
-msgstr ""
+msgstr "Propriétés de Gorgone"
 
-#: centreon/www/class/centreonGraphNg.class.php
 #: centreon/www/install/front_translate.php
+#: centreon/www/class/centreonGraph.class.php
+#: centreon/www/class/centreonGraphNg.class.php
 msgid "Graph"
 msgstr "Graphique"
 
@@ -7196,15 +7396,15 @@ msgstr "Graphique"
 msgid "Graph Choice"
 msgstr "Choix du graphique"
 
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 msgid "Graph Period"
 msgstr "Période de visualisation"
 
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 msgid "Graph Template"
 msgstr "Modèle de graphique"
 
@@ -7216,20 +7416,19 @@ msgstr "Options de graphe"
 msgid "Graph per page for Performances"
 msgstr "Graphique de performance par page"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/install/smarty_translate.php
 msgid "Graph template"
 msgstr "Modèle de graphique"
 
+#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 #: centreon/www/install/menu_translation.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
-#: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 msgid "Graphs"
 msgstr "Graphiques"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Group"
 msgstr "Groupe"
 
@@ -7241,8 +7440,8 @@ msgstr "Informations générales"
 msgid "Group Ldap"
 msgstr "Groupe Ldap"
 
-#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
 msgid "Group Name"
 msgstr "Nom du groupe"
 
@@ -7252,15 +7451,15 @@ msgstr "Membre des groupes"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Group attribute"
-msgstr "L'attribut pour le nom du groupe"
+msgstr "Attribut du groupe"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Group filter"
-msgstr "Le filtre de recherche pour les groupes"
+msgstr "Filtre de groupe"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Group member attribute"
-msgstr "La relation des utilisateurs appartenant à un groupe"
+msgstr "Attribut des membres du groupe"
 
 #: centreon/www/install/front_translate.php
 msgid "Group value"
@@ -7282,13 +7481,22 @@ msgstr "Association des groupes"
 msgid "HARD"
 msgstr "HARD"
 
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+#: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+msgid "HTTP Action Link"
+msgstr "Lien HTTP externe"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "HTTP Link"
+msgstr "Lien HTTP"
+
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "HTTP Method"
-msgstr ""
+msgstr "Méthode HTTP"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "HTTP Port"
-msgstr ""
+msgstr "Port HTTP"
 
 #: centreon/www/install/front_translate.php
 msgid "Hard"
@@ -7296,9 +7504,11 @@ msgstr "Hard"
 
 #: centreon/www/include/eventLogs/viewLog.php
 msgid "Hard Only"
-msgstr "Etat validés (Hard) seulement"
+msgstr "États validés (Hard) seulement"
 
 #: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+#: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
 #: centreon/www/include/monitoring/status/Hosts/hostJS.php
 msgid "Hard State Duration"
 msgstr "Validé depuis"
@@ -7316,40 +7526,42 @@ msgid "Height"
 msgstr "Hauteur"
 
 #: centreon/www/include/core/footer/footerPart.php
-#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
 #: centreon/www/include/configuration/configObject/connector/formConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
-#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/media/images/formImg.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
 msgid "Help"
 msgstr "Aide"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
 #: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/install/smarty_translate.php
 msgid "Hidden"
 msgstr "Masquées"
 
@@ -7358,6 +7570,7 @@ msgid "Hidden Graph And Legend"
 msgstr "Masquer le graphique et la légende"
 
 #: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/Administration/performance/viewData.php
 msgid "Hide graphs of selected Services"
 msgstr "Cacher les graphiques des services sélectionnés"
 
@@ -7365,10 +7578,10 @@ msgstr "Cacher les graphiques des services sélectionnés"
 msgid "Hide the password"
 msgstr "Cacher le mot de passe"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "High Flap Threshold"
 msgstr "Seuil haut de détection de bagotage des statuts"
 
@@ -7388,10 +7601,10 @@ msgstr "Informations très détaillées"
 msgid "History"
 msgstr "Historisé (recherche en base)"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "History Options"
 msgstr "Options de l'historique"
 
@@ -7399,25 +7612,27 @@ msgstr "Options de l'historique"
 msgid "Home"
 msgstr "Accueil"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
-#: centreon/www/include/configuration/configObject/meta_service/metric.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/Administration/performance/viewData.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 #: centreon/www/include/configuration/configKnowledge/search.php
-#: centreon/www/include/reporting/dashboard/viewHostLog.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/viewHostLog.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/comments/AddComment.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Host"
 msgstr "Hôte"
 
@@ -7426,24 +7641,24 @@ msgstr "Hôte"
 msgid "Host #%d not found"
 msgstr "Hôte #%d introuvable"
 
+#: centreon/src/Centreon/Application/Controller/DowntimeController.php
+#: centreon/src/Centreon/Application/Controller/Monitoring/MetricController.php
 #: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
+#: centreon/src/Centreon/Domain/Check/CheckService.php
 #: centreon/src/Centreon/Domain/Monitoring/Comment/CommentService.php
 #: centreon/src/Centreon/Domain/Monitoring/SubmitResult/SubmitResultService.php
-#: centreon/src/Centreon/Domain/Check/CheckService.php
-#: centreon/src/Centreon/Application/Controller/Monitoring/MetricController.php
-#: centreon/src/Centreon/Application/Controller/DowntimeController.php
 #, php-format
 msgid "Host %d not found"
 msgstr "Hôte %d non trouvé"
 
 #: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Host / Service Required"
-msgstr ""
+msgstr "Hôte/service requis"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "Host Acknowledgement"
-msgstr ""
+msgstr "Acquitter un hôte"
 
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
@@ -7458,7 +7673,7 @@ msgstr "Relation avec les catégories d'hôtes"
 
 #: centreon/www/install/front_translate.php
 msgid "Host Category"
-msgstr ""
+msgstr "Catégorie d'hôtes"
 
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 msgid "Host Category Filter"
@@ -7468,8 +7683,8 @@ msgstr "Filtrer par catégorie d'hôte"
 msgid "Host Check Execution Option"
 msgstr "Contrôle actif des hôtes"
 
-#: centreon/www/class/centreonGraphPoller.class.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/class/centreonGraphPoller.class.php
 msgid "Host Check Execution Time"
 msgstr "Durée de contrôle de l'hôte"
 
@@ -7502,7 +7717,7 @@ msgstr "Configuration de l'hôte"
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "Host Downtime"
-msgstr ""
+msgstr "Plage de maintenance sur un hôte"
 
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
@@ -7517,18 +7732,18 @@ msgstr "Intervalle contrôle de la fraicheur du résultat de l'hôte"
 msgid "Host Freshness Check Option"
 msgstr "Option de contrôle de la fraicheur du résultat de l'hôte"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
 #: centreon/www/include/monitoring/status/HostGroups/hostGroupJS.php
+#: centreon/www/install/front_translate.php
 msgid "Host Group"
 msgstr "Groupe d'hôtes"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/menu_translation.php
 msgid "Host Groups"
 msgstr "Groupes d'hôtes"
 
@@ -7543,7 +7758,7 @@ msgstr "Groupes d'hôtes partagés"
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #, php-format
 msgid "Host ID #%d is invalid"
-msgstr ""
+msgstr "L'ID d'hôte #%d est invalide"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Host Information"
@@ -7553,14 +7768,15 @@ msgstr "Informations sur l'hôte"
 msgid "Host Inter-Check Delay Method"
 msgstr "Méthode du délai inter-contrôles des hôtes"
 
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
-#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
 #: centreon/www/include/monitoring/comments/AddHostComment.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/install/smarty_translate.php
 msgid "Host Name"
 msgstr "Nom de l'hôte"
 
@@ -7569,16 +7785,19 @@ msgid "Host Names"
 msgstr "Noms d'hôtes"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Host Notification Commands"
 msgstr "Commandes de notification d'hôte"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Host Notification Options"
 msgstr "Options de notification d'hôte"
 
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/contact/listContact.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Host Notification Period"
 msgstr "Période de notification d'hôte"
 
@@ -7598,10 +7817,10 @@ msgstr "Journalisation des tests de confirmation d'hôte"
 msgid "Host Shortcuts"
 msgstr "Racourcis d'hôte"
 
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Host Status"
 msgstr "Statut de l'hôte"
 
@@ -7609,8 +7828,8 @@ msgstr "Statut de l'hôte"
 msgid "Host Template"
 msgstr "Modèle de l'hôte"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/menu_translation.php
 msgid "Host Templates"
 msgstr "Modèles d'hôte"
 
@@ -7643,8 +7862,8 @@ msgstr "Catégorie de l'hôte (%s) non trouvé"
 msgid "Host category name already exists"
 msgstr "Ce nom de catégorie d'hôtes existe déjà"
 
-#: centreon/www/class/centreonGraphPoller.class.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/class/centreonGraphPoller.class.php
 msgid "Host check latency"
 msgstr "Latence du contrôle de l'hôte"
 
@@ -7656,16 +7875,12 @@ msgstr "Options de contrôle de l'hôte"
 msgid "Host commands and shortcuts"
 msgstr "Commandes et racourcis d'hôte"
 
-#: centreon/www/install/front_translate.php
-msgid "Host configurations"
-msgstr ""
-
 #: centreon/www/install/smarty_translate.php
 msgid "Host dependency"
 msgstr "Dépendance d'hôte"
 
-#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 #: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 msgid "Host escalations"
 msgstr "Escalades d'hôtes"
 
@@ -7685,7 +7900,7 @@ msgstr "Groupes d'hôtes "
 #: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
 #, php-format
 msgid "Host id %d not found"
-msgstr ""
+msgstr "L'ID d'hôte %d n'a pas été trouvé"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/HostConfigurationService.php
 #: centreon/src/Centreon/Domain/Monitoring/Exception/MonitoringServiceException.php
@@ -7695,6 +7910,14 @@ msgstr "L'id de l'hôte ne peut être nul"
 #: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 msgid "Host inheritance to services"
 msgstr "Hériter des proriétés de l'hôte pour les services"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "Host is currently on downtime"
+msgstr "L'hôte est actuellement en période d'arrêt"
+
+#: centreon/www/widgets/host-monitoring/src/index.php
+msgid "Host is flapping"
+msgstr ""
 
 #: centreon/www/include/configuration/configObject/command/listCommand.php
 msgid "Host links (host template links)"
@@ -7712,10 +7935,10 @@ msgstr "Hôte lié au meta %d non trouvé"
 #: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
 #, php-format
 msgid "Host meta for meta service %d not found"
-msgstr ""
+msgstr "Problème lors de la récupération du métaservice %d"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/smarty_translate.php
 msgid "Host name"
 msgstr "Nom de l'hôte"
 
@@ -7723,15 +7946,15 @@ msgstr "Nom de l'hôte"
 msgid "Host name already exists"
 msgstr "Le nom d'hôte existe déjà"
 
-#: centreon/src/Centreon/Domain/Engine/EngineService.php
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostConfigurationServiceException.php
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
 msgid "Host name can not be empty"
 msgstr "Le nom d'hôte ne peut être vide"
 
 #: centreon/src/Centreon/Domain/Engine/EngineService.php
 #, php-format
 msgid "Host name can not be empty for host (id: %d)"
-msgstr ""
+msgstr "Le nom de l'hôte ne doit pas être vide (ID de l'hôte : %d)"
 
 #: centreon/src/Centreon/Domain/Engine/EngineService.php
 msgid "Host name cannot be empty"
@@ -7749,34 +7972,34 @@ msgstr "Le nom de l'hôte existe déjà"
 #: centreon/src/Centreon/Domain/Engine/EngineService.php
 #, php-format
 msgid "Host name of service (id: %d) can not be empty"
-msgstr "Le nom d'hôte du service (id: %d) ne peut pas être vide"
+msgstr "Le nom d'hôte du service (id : %d) ne peut pas être vide"
 
 #: centreon/src/Core/Host/Application/Exception/HostException.php
 msgid "Host name should not start with '_Module_'"
 msgstr "Le nom d'hôte ne doit pas commencer par '_Module_'"
 
-#: centreon/www/api/class/centreon_monitoring_externalcmd.class.php
+#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
 #: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
 #: centreon/src/Centreon/Domain/Check/CheckService.php
-#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
+#: centreon/www/api/class/centreon_monitoring_externalcmd.class.php
 msgid "Host not found"
 msgstr "Hôte non trouvé"
 
-#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 #: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 msgid "Host notifications"
 msgstr "Notifications d'hôte"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/install/front_translate.php
 msgid "Host severity"
 msgstr "Criticité d'hôte"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostSeverityException.php
 #, php-format
 msgid "Host severity (%s) not found"
-msgstr ""
+msgstr "La criticité d'hôte (%s) n'a pas été trouvée"
 
 #: centreon/www/install/front_translate.php
 msgid "Host severity level"
@@ -7788,12 +8011,12 @@ msgstr "Ce nom de sévérité d'hôtes existe déjà"
 
 #: centreon/www/include/reporting/dashboard/viewHostLog.php
 msgid "Host state"
-msgstr "Etat de l'hôte"
+msgstr "État de l'hôte"
 
-#: centreon/www/class/centreonGraphPoller.class.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/class/centreonGraphPoller.class.php
 msgid "Host status"
-msgstr "Etat des hôtes"
+msgstr "Statut des hôtes"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Host template"
@@ -7828,31 +8051,31 @@ msgstr "Informations sur le contrôle des Hôtes/Services"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Host: Acknowledge"
-msgstr ""
+msgstr "Hôte : acquitter"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Host: Disable Host Check"
-msgstr ""
+msgstr "Hôte : désactiver les contrôles sur l'hôte"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Host: Disable Host Notification"
-msgstr ""
+msgstr "Hôte : désactiver les notifications pour l'hôte"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Host: Enable Host Check"
-msgstr ""
+msgstr "Hôte : activer les contrôles sur l'hôte"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Host: Enable Host Notification"
-msgstr ""
+msgstr "Hôte : activer les notifications pour l'hôte"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Host: Remove Acknowledgement"
-msgstr ""
+msgstr "Hôte : supprimer l'acquittement"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Host: Set Downtime"
-msgstr ""
+msgstr "Hôte : définir une plage de maintenance"
 
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 msgid "HostGroup"
@@ -7866,15 +8089,17 @@ msgstr "Groupe d'hôtes ou hôte requis"
 msgid "HostGroups"
 msgstr "Groupes d'hôtes"
 
+#: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configKnowledge/search.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
 #: centreon/www/include/monitoring/comments/listComment.php
 msgid "Hostgroup"
 msgstr "Groupe d'hôtes"
@@ -7896,8 +8121,8 @@ msgstr "Hériter les propriétés du groupe d'hôtes pour les services"
 msgid "Hostgroups"
 msgstr "Groupe d'hôtes"
 
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHGJS.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHGJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHGJS.php
 msgid "Hostgroups / Hosts"
 msgstr "Groupes d'hôtes / Hôtes"
 
@@ -7906,83 +8131,85 @@ msgid "Hostgroups Summary"
 msgstr "Résumé des statuts par groupes d'hôtes"
 
 #: centreon/www/widgets/global-health/src/global_health.php
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/contact/displayNotification.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configKnowledge/display-services.php
-#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/parameters/general/form.php
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
+#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
 #: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/serviceSummaryJS.php
-#: centreon/www/include/monitoring/status/Services/service.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
-#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
-#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/comments/AddComment.php
-#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Hosts"
 msgstr "Hôtes"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
 msgid "Hosts : Acknowledge"
 msgstr "Hôtes : Acquitter"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
 msgid "Hosts : Disable Check"
 msgstr "Hôtes : Désactiver la vérification"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
 msgid "Hosts : Disable Notification"
 msgstr "Hôtes : Désactiver la notification"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
 msgid "Hosts : Disacknowledge"
 msgstr "Hôtes : Dés-acquitter"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
 msgid "Hosts : Enable Check"
 msgstr "Hôtes : Activer la vérification"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
 msgid "Hosts : Enable Notification"
 msgstr "Hôtes : Activer la notification"
@@ -8006,8 +8233,8 @@ msgstr "Hôtes : Ajouter une plage de maintenance"
 msgid "Hosts Actions Access"
 msgstr "Accès aux actions sur les hôtes"
 
-#: centreon/www/class/centreonGraphPoller.class.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/class/centreonGraphPoller.class.php
 msgid "Hosts Actively Checked"
 msgstr "Hôtes actuellement contrôlés"
 
@@ -8037,9 +8264,9 @@ msgstr ""
 msgid "Hour"
 msgstr "Heure"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/install/front_translate.php
 msgid "Hours"
 msgstr "Heures"
 
@@ -8051,36 +8278,41 @@ msgstr "Survoler la chronologie pour obtenir plus d'informations"
 msgid "Human readable"
 msgstr "Lisible par l'humain"
 
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
-#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
 msgid "IP"
 msgstr "IP"
 
-#: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
 #: centreon/www/include/options/session/connected_user.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
 #: centreon/www/include/monitoring/status/Hosts/hostJS.php
 msgid "IP Address"
 msgstr "Adresse IP"
+
+#: centreon/www/include/configuration/configObject/host/listHost.php
+msgid "IP Address / DNS"
+msgstr "Adresse IP / DNS"
 
 #: centreon/www/include/Administration/parameters/gorgone/gorgone.php
 msgid "IP address or hostname"
 msgstr "Adresse IP ou nom d'hôte"
 
 #: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Icon"
 msgstr "Icône"
 
@@ -8135,6 +8367,7 @@ msgstr ""
 #: centreon/www/install/front_translate.php
 msgid "If you click on Discard, your changes will not be saved."
 msgstr ""
+"Si vous cliquez sur Annuler, vos changements ne seront pas sauvegardés."
 
 #: centreon/www/install/front_translate.php
 msgid "If you leave the edition mode, your changes will not be saved."
@@ -8155,7 +8388,7 @@ msgstr ""
 
 #: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
 msgid "Ignore ssl certificate"
-msgstr ""
+msgstr "Ignorer le certificat SSL"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Illegal Macro Output Characters"
@@ -8170,24 +8403,15 @@ msgid "Illegal characters for Gorgone commands"
 msgstr "Caractères illégaux pour les commandes Gorgone"
 
 #: centreon/www/include/options/media/images/listImg.php
-#: centreon/www/include/options/media/images/formImg.php
 msgid "Image"
 msgstr "Image"
-
-#: centreon/www/include/options/media/images/formImg.php
-msgid "Image Name"
-msgstr "Nom de l'image"
 
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 msgid "Image Type"
 msgstr "Type d'image"
 
-#: centreon/www/include/options/media/images/formImg.php
-msgid "Image or archive"
-msgstr "Image ou archive"
-
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/install/menu_translation.php
 msgid "Images"
 msgstr "Images"
 
@@ -8199,14 +8423,14 @@ msgstr "Impact appliqué quand :"
 msgid "Impacted Resources"
 msgstr "Ressources impactées"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Implied Contact Groups"
 msgstr "Groupes de contacts liés"
 
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 msgid "Implied Contacts"
 msgstr "Contacts liés"
 
@@ -8214,8 +8438,8 @@ msgstr "Contacts liés"
 msgid "Implied Server"
 msgstr "Serveur lié"
 
-#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
 #: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
 msgid "Import"
 msgstr "Importer"
 
@@ -8239,12 +8463,13 @@ msgstr ""
 #: centreon/src/Core/Contact/Application/Exception/ContactGroupException.php
 msgid "Impossible to get contact groups from data storage"
 msgstr ""
+"Impossible d'obtenir les groupes de contacts à partir de la base de données"
 
-#: centreon/www/include/Administration/parameters/general/form.php
-#: centreon/www/include/Administration/parameters/rrdtool/form.php
-#: centreon/www/include/Administration/parameters/ldap/form.php
-#: centreon/www/include/Administration/parameters/debug/form.php
 #: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
 msgid "Impossible to validate, one or more field is incorrect"
 msgstr "Impossible de valider, un ou plusieurs champs sont incorrects"
 
@@ -8252,12 +8477,12 @@ msgstr "Impossible de valider, un ou plusieurs champs sont incorrects"
 msgid "In Downtime"
 msgstr "En maintenance"
 
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 msgid "In Scheduled Downtime?"
-msgstr "Planification d'arrêt en cours?"
+msgstr "En maintenance ?"
 
 #: centreon/www/install/front_translate.php
 msgid "In downtime"
@@ -8299,13 +8524,14 @@ msgstr "Type de ressource incorrect"
 #: centreon/src/Centreon/Domain/Check/CheckService.php
 #, php-format
 msgid "Incorrect Resource type: %s"
-msgstr "Type de ressource incorrect: %s"
+msgstr "Type de ressource incorrect : %s"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Incremental"
 msgstr "Incrémentale"
 
@@ -8318,17 +8544,17 @@ msgstr "Taille de index"
 msgid "Info"
 msgstr "Information"
 
-#: centreon/www/install/front_translate.php
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/install/front_translate.php
 msgid "Information"
 msgstr "Informations"
 
@@ -8373,7 +8599,7 @@ msgstr "Insertion dans la table index_data"
 
 #: centreon/www/install/front_translate.php
 msgid "Insert link"
-msgstr ""
+msgstr "Insérer un lien"
 
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Insert trap's information into database"
@@ -8381,14 +8607,14 @@ msgstr "Insérer les traps SNMP reçu en base de données"
 
 #: centreon/www/install/front_translate.php
 msgid "Install"
-msgstr ""
+msgstr "Installer"
 
 #: centreon/www/install/front_translate.php
 msgid "Install all"
-msgstr ""
+msgstr "Tout installer"
 
-#: centreon/www/install/step_upgrade/step4.php
 #: centreon/src/CentreonLegacy/Core/Install/Step/Step7.php
+#: centreon/www/install/step_upgrade/step4.php
 msgid "Installation"
 msgstr "Installation"
 
@@ -8430,20 +8656,16 @@ msgstr "Point d'entrée de jeton d'introspection"
 
 #: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
 msgid "Invalid Credentials"
-msgstr ""
+msgstr "Identifiants invalides"
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 #, php-format
 msgid "Invalid ID provided for %s"
-msgstr ""
+msgstr "L'ID fourni pour %s est invalide"
 
 #: centreon/www/install/front_translate.php
 msgid "Invalid IP Address"
 msgstr "Adresse IP invalide"
-
-#: centreon/www/include/options/media/images/formImg.php
-msgid "Invalid Image Format."
-msgstr "Format d'image invalide."
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Invalid LDAP Host parameters"
@@ -8451,7 +8673,7 @@ msgstr "Paramètres du serveur LDAP invalides"
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/AuthenticationConditionsException.php
 msgid "Invalid Provider authentication conditions"
-msgstr ""
+msgstr "Conditions d'authentification du fournisseur non valides"
 
 #: centreon/www/install/front_translate.php
 msgid "Invalid URL"
@@ -8463,11 +8685,11 @@ msgstr "Adresse invalide"
 
 #: centreon/src/Core/Domain/Exception/InvalidGeoCoordException.php
 msgid "Invalid coordinates format specified"
-msgstr ""
+msgstr "Format de coordonnées invalide"
 
 #: centreon/src/Core/Domain/Exception/InvalidGeoCoordException.php
 msgid "Invalid coordinates values specified"
-msgstr ""
+msgstr "Valeurs de coordonnées invalides"
 
 #: centreon/src/Core/Domain/Configuration/Notification/Exception/NotificationException.php
 #, php-format
@@ -8480,20 +8702,20 @@ msgstr "Extension invalide"
 
 #: centreon/www/install/front_translate.php
 msgid "Invalid file type"
-msgstr ""
+msgstr "Type de fichier invalide"
 
 #: centreon/www/install/front_translate.php
 msgid "Invalid filename"
-msgstr ""
+msgstr "Nom de fichier invalide"
 
 #: centreon/www/install/front_translate.php
 msgid "Invalid format"
-msgstr ""
+msgstr "Format invalide"
 
-#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 msgid "Invalid information entered"
 msgstr "Informations saisies invalides"
 
@@ -8503,7 +8725,7 @@ msgstr "Json invalide reçu"
 
 #: centreon/www/install/front_translate.php
 msgid "Invalid license"
-msgstr ""
+msgstr "Licence invalide"
 
 #: centreon/src/Core/Metric/Application/Exception/MetricException.php
 msgid "Invalid metric format"
@@ -8511,17 +8733,17 @@ msgstr "Format de métrique invalide"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Invalid name or description"
-msgstr ""
+msgstr "Nom ou description invalide"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
 #, php-format
 msgid "Invalid notification option (%d)"
-msgstr ""
+msgstr "Option de notification (%d) invalide"
 
 #: centreon/src/Centreon/Application/Controller/FilterController.php
 #, php-format
 msgid "Invalid page name. Valid page names are: %s"
-msgstr "Nom de page invalide. Les noms de page valident sont: %s"
+msgstr "Nom de page invalide. Les noms de page valides sont : %s"
 
 #: centreon/www/install/front_translate.php
 msgid "Invalid path"
@@ -8537,16 +8759,16 @@ msgstr "Regex invalide"
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "Invalid resource type"
-msgstr ""
+msgstr "Type de ressource invalide"
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/AclConditionsException.php
 msgid "Invalid roles mapping fetched from provider"
-msgstr "Les roles récupérés depuis le serveur d'identité sont incorrects"
+msgstr "Les rôles récupérés depuis le serveur d'identité sont incorrects"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
 #, php-format
 msgid "Invalid stalking option (%d)"
-msgstr ""
+msgstr "Option de stalking invalide (%d)"
 
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 msgid "Invert"
@@ -8596,6 +8818,8 @@ msgstr ""
 msgid ""
 "It will be permanently deleted and users will no longer have this permission."
 msgstr ""
+"La règle sera définitivement supprimée et les utilisateurs ne disposeront "
+"plus de cette autorisation."
 
 #: centreon/www/install/front_translate.php
 msgid ""
@@ -8603,7 +8827,7 @@ msgid ""
 "the following syntax:"
 msgstr ""
 "Il est possible de spécifier les critères que vous voulez rechercher de "
-"manière précise, en utilisant la syntaxe suivante:"
+"manière précise, en utilisant la syntaxe suivante :"
 
 #: centreon/www/install/menu_translation.php
 msgid "Knowledge Base"
@@ -8611,11 +8835,11 @@ msgstr "Base de connaissance"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Knowledge base"
-msgstr ""
+msgstr "Base de connaissances"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Knowledge base configuration"
-msgstr ""
+msgstr "Configuration de la base de connaissances"
 
 #: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
 msgid "Knowledge base url"
@@ -8624,8 +8848,8 @@ msgstr "URL d'accès à la base de connaissance"
 #: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
 msgid "Knowledge wiki account (with delete right)"
 msgstr ""
-"Compte d'administration de la base de connaissance possédant les droits de "
-"suppression."
+"Compte d'administration de la base de connaissances possédant les droits de "
+"suppression"
 
 #: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
 msgid "Knowledge wiki account password"
@@ -8637,10 +8861,10 @@ msgstr "LDAP"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "LDAP DN (Distinguished Name)"
-msgstr "LDAP DN (Distinguished Name)"
+msgstr "DN LDAP (Distinguished Name)"
 
-#: centreon/www/include/configuration/configObject/contact/listContact.php
 #: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
 msgid "LDAP Import"
 msgstr "Importation LDAP"
 
@@ -8656,8 +8880,8 @@ msgstr "Propriétés LDAP"
 msgid "LDAP Server"
 msgstr "Serveur LDAP"
 
-#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
 #: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
 msgid "LDAP Servers"
 msgstr "Serveurs LDAP"
 
@@ -8687,19 +8911,19 @@ msgstr "Intervalle (en heures), entre les synchronisations LDAP"
 
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
 msgid "LVM Snapshot"
-msgstr "LVM Snapshot"
+msgstr "Snapshot LVM"
 
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 msgid "Language"
 msgstr "Langue"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
 msgid "Last 12 hours"
 msgstr "Les 12 dernières heures"
 
@@ -8707,39 +8931,39 @@ msgstr "Les 12 dernières heures"
 msgid "Last 12 months"
 msgstr "Les 12 derniers mois"
 
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
 msgid "Last 14 days"
 msgstr "Les 14 derniers jours"
 
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
 msgid "Last 2 days"
 msgstr "Les 2 derniers jours"
 
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
 msgid "Last 2 months"
 msgstr "Les 2 derniers mois"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
 msgid "Last 24 hours"
 msgstr "Les 24 dernières heures"
 
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
 msgid "Last 28 days"
 msgstr "Les 28 derniers jours"
 
@@ -8748,12 +8972,12 @@ msgstr "Les 28 derniers jours"
 msgid "Last 3 days"
 msgstr "Les 3 derniers jours"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
 msgid "Last 3 hours"
 msgstr "Les 3 dernières heures"
 
@@ -8767,36 +8991,36 @@ msgstr "Les 3 derniers mot de passe peuvent être réutilisés"
 
 #: centreon/www/include/reporting/dashboard/common-Func.php
 msgid "Last 30 Days"
-msgstr ""
+msgstr "Les 30 derniers jours"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
 msgid "Last 30 days"
 msgstr "Les 30 derniers jours"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
 msgid "Last 31 days"
 msgstr "Les 31 derniers jours"
 
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/eventLogs/viewLog.php
 msgid "Last 4 days"
 msgstr "Les 4 derniers jours"
 
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
 msgid "Last 4 months"
 msgstr "Les 4 derniers mois"
 
@@ -8805,51 +9029,51 @@ msgstr "Les 4 derniers mois"
 msgid "Last 5 days"
 msgstr "Les 5 derniers jours"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
 msgid "Last 6 hours"
 msgstr "Les 6 dernières heures"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
 msgid "Last 6 months"
 msgstr "Les 6 derniers mois"
 
 #: centreon/www/include/reporting/dashboard/common-Func.php
 msgid "Last 7 Days"
-msgstr ""
+msgstr "Les 7 derniers jours"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
 msgid "Last 7 days"
 msgstr "Les 7 derniers jours"
 
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceJS.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/service.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
-#: centreon/www/include/monitoring/status/Hosts/hostJS.php
-#: centreon/www/include/monitoring/status/Hosts/host.php
-#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
-#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Last Check"
 msgstr "Dernier contrôle"
 
@@ -8863,12 +9087,12 @@ msgstr "Dernière synchro LDAP"
 
 #: centreon/www/include/reporting/dashboard/common-Func.php
 msgid "Last Month"
-msgstr ""
+msgstr "Le mois dernier"
 
 #: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Last Notification"
 msgstr "Dernière notification"
 
@@ -8876,31 +9100,31 @@ msgstr "Dernière notification"
 msgid "Last Service Notification"
 msgstr "Dernière notification du service"
 
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 msgid "Last State Change"
 msgstr "Changement du dernier état"
 
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "Last Status Change"
 msgstr "Dernier changement de statut"
 
 #: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "Last Update"
 msgstr "Dernière mise à jour"
 
 #: centreon/www/include/reporting/dashboard/common-Func.php
 msgid "Last Year"
-msgstr ""
+msgstr "L'année dernière"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/install/front_translate.php
 msgid "Last check"
 msgstr "Dernier contrôle"
 
@@ -8928,8 +9152,8 @@ msgstr "Dernier évènement à"
 msgid "Last hour"
 msgstr "La dernière heure"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/install/front_translate.php
 msgid "Last month"
 msgstr "Le dernier mois"
 
@@ -8945,9 +9169,9 @@ msgstr "Dernière notification"
 msgid "Last of month"
 msgstr "Dernier du mois"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/common/pagination.php
 #: centreon/www/include/configuration/configKnowledge/pagination.php
+#: centreon/www/install/front_translate.php
 msgid "Last page"
 msgstr "Dernière page"
 
@@ -8959,34 +9183,34 @@ msgstr "Heure de la dernière requête"
 msgid "Last status change"
 msgstr "Dernier changement de statut"
 
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "Last time in "
 msgstr "Dernière fois "
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+#: centreon/www/install/front_translate.php
 msgid "Last update"
 msgstr "Dernière mise à jour"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/install/front_translate.php
 msgid "Last week"
 msgstr "La dernière semaine"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/graphs/graph-split.php
 #: centreon/www/include/views/graphs/graphs.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
 msgid "Last year"
 msgstr "Les 12 derniers mois"
 
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/install/front_translate.php
 msgid "Latency"
 msgstr "Latence"
 
@@ -9006,7 +9230,7 @@ msgstr "Quitter"
 
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "Legacy version"
-msgstr ""
+msgstr "Version legacy"
 
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
@@ -9020,10 +9244,10 @@ msgstr "Légende"
 
 #: centreon/www/install/front_translate.php
 msgid "Less"
-msgstr ""
+msgstr "Moins"
 
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 msgid "Level"
 msgstr "Niveau"
 
@@ -9037,15 +9261,15 @@ msgstr "Licence expirée"
 
 #: centreon/www/install/front_translate.php
 msgid "License invalid or expired !"
-msgstr ""
+msgstr "La licence est invalide ou expirée"
 
 #: centreon/www/install/front_translate.php
 msgid "License not valid"
-msgstr ""
+msgstr "Licence invalide"
 
 #: centreon/www/install/front_translate.php
 msgid "License required"
-msgstr ""
+msgstr "Une licence est nécessaire"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Limit per page (default)"
@@ -9065,30 +9289,31 @@ msgstr "Lien copié"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Link to cbd service"
-msgstr ""
+msgstr "Lien vers le service cbd"
 
 #: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
 msgid "Linked ACL groups"
 msgstr "Groupes d'accès liés"
 
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
 msgid "Linked Contact Groups"
 msgstr "Groupes de contacts liés"
 
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
 #: centreon/www/include/Administration/parameters/api/api.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Linked Contacts"
 msgstr "Contacts liés"
 
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 #: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 msgid "Linked Groups"
 msgstr "Groupes liés"
 
@@ -9174,10 +9399,10 @@ msgstr "Liens"
 msgid "Links Management"
 msgstr "Gestion des liaisons"
 
-#: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/options/media/images/formDirectory.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configResources/formResources.php
 msgid "List"
 msgstr "Liste"
 
@@ -9197,8 +9422,8 @@ msgstr "Charger une vue publique"
 msgid "Load from existing view"
 msgstr "A partir d'une vue existante"
 
-#: centreon/www/install/step_upgrade/step2.php
 #: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step2.php
 msgid "Loaded"
 msgstr "Chargé"
 
@@ -9211,11 +9436,13 @@ msgid "Localhost ?"
 msgstr "Hôte local ?"
 
 #: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/Administration/performance/viewData.php
 msgid "Lock Services"
 msgstr "Verrouiller les services"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/install/smarty_translate.php
 msgid "Locked"
 msgstr "Verrouillé"
 
@@ -9225,11 +9452,11 @@ msgstr "Eléments verrouillés"
 
 #: centreon/www/include/home/customViews/index.php
 msgid "Locked user groups"
-msgstr ""
+msgstr "Groupes d'utilisateurs verrouillés"
 
 #: centreon/www/include/home/customViews/index.php
 msgid "Locked users"
-msgstr ""
+msgstr "Utilisateurs verrouillés"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Log Options"
@@ -9245,7 +9472,7 @@ msgstr "Destination du journal"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Log directory"
-msgstr ""
+msgstr "Répertoire des journaux"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Log everything"
@@ -9257,7 +9484,7 @@ msgstr "Fichier de journalisation"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Log filename"
-msgstr ""
+msgstr "Nom des fichiers de journaux"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Log nothing (default)"
@@ -9269,7 +9496,7 @@ msgstr "Options de journalisation"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Logger version"
-msgstr ""
+msgstr "Version du logger"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Logging Options"
@@ -9286,7 +9513,7 @@ msgstr "Connexion"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Login attribute"
-msgstr "L'attribut pour l'identifiant de l'utilisateur"
+msgstr "Attribut de l'identifiant utilisateur (login)"
 
 #: centreon/www/install/front_translate.php
 msgid "Login attribute path"
@@ -9304,8 +9531,8 @@ msgstr "Connexion réussie"
 msgid "Login with"
 msgstr "Se connecter avec"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/common/mobile_menu.php
+#: centreon/www/install/front_translate.php
 msgid "Logout"
 msgstr "Déconnexion"
 
@@ -9335,16 +9562,16 @@ msgstr "Logs pour "
 
 #: centreon/www/install/front_translate.php
 msgid "Lost in space?"
-msgstr ""
+msgstr "Perdu(e) dans l'espace ?"
 
 #: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
 msgid "Lotus Domino :"
 msgstr "Lotus Domino :"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Low Flap Threshold"
 msgstr "Seuil bas de détection de bagotage des statuts"
 
@@ -9390,12 +9617,12 @@ msgstr "Les macros de type mot de passe ne peuvent pas être détectées"
 msgid "Macro value"
 msgstr "Valeur de la macro"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/command/formMacros.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/command/formMacros.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Macros"
 msgstr "Macros"
 
@@ -9405,11 +9632,11 @@ msgstr "Description des macros"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Macros Filters Configuration"
-msgstr ""
+msgstr "Configuration des filtres sur les macros"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Macros whitelist"
-msgstr ""
+msgstr "Liste blanche des macros"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Mail Type"
@@ -9422,6 +9649,10 @@ msgstr "Envoi d'emails"
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Main"
 msgstr "Options générales"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Main Menu"
+msgstr "Menu principal"
 
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Main information"
@@ -9453,7 +9684,7 @@ msgstr "Gestionnaire"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Mandatory cache directory"
-msgstr ""
+msgstr "Répertoire de cache obligatoire"
 
 #: centreon/src/Centreon/Domain/Common/Exception/FactoryException.php
 #, php-format
@@ -9462,20 +9693,20 @@ msgstr "Les données obligatoires pour créer l'entité '%s' sont manquantes"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Mandatory directory"
-msgstr ""
+msgstr "Répertoire obligatoire"
 
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
 #: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
-#: centreon/www/include/Administration/parameters/general/form.php
 #: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
 msgid "Mandatory field"
 msgstr "Champ obligatoire"
 
 #: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Mandatory field for ACL purpose."
-msgstr "Ce champs est obligatoire pour l'utilisation des ACL"
+msgstr "Ce champ est obligatoire pour l'utilisation des ACL"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Mandatory filename"
@@ -9495,7 +9726,7 @@ msgstr "Rafraîchissement manuel"
 
 #: centreon/www/install/front_translate.php
 msgid "Manual refresh only"
-msgstr ""
+msgstr "Rafraîchir uniquement manuellement"
 
 #: centreon/www/include/configuration/configObject/contact/listContact.php
 msgid "Manually request to synchronize this contact with his LDAP"
@@ -9518,35 +9749,37 @@ msgstr "Icône pour la carte"
 msgid "MariaDB version %s required (%s installed)"
 msgstr "La version %s de MariaDB est requise (%s installée)"
 
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
 #: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Mass Change"
 msgstr "Changement massif"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Max"
 msgstr "Maximum"
 
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Max Check Attempts"
 msgstr "Nombre de contrôles avant validation de l'état"
 
@@ -9557,7 +9790,7 @@ msgstr "Taille maximale en octets (Bytes)"
 #: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
 #, php-format
 msgid "Max value of limit has to be %d instead %d"
-msgstr ""
+msgstr "La valeur maximale de la limite doit être %d plutôt que %d"
 
 #: centreon/www/install/front_translate.php
 msgid "Maximum"
@@ -9581,7 +9814,7 @@ msgstr "Délai maximum de répartition des contrôles initiaux de services"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Maximum files size (in bytes)"
-msgstr ""
+msgstr "Taille maximale des fichiers (en octets)"
 
 #: centreon/www/include/Administration/parameters/engine/form.php
 msgid "Maximum number of hosts to show"
@@ -9603,11 +9836,11 @@ msgstr "Nombre maximum de requêtes par transaction"
 msgid "Maximum size of file"
 msgstr "Taille maximale du fichier"
 
-#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 msgid "Mean Time"
 msgstr "Temps significatif"
 
@@ -9660,10 +9893,10 @@ msgstr "Message tronqué (dépassant les %s caractères)"
 #: centreon/src/Centreon/Domain/Monitoring/SubmitResult/SubmitResultService.php
 #, php-format
 msgid "Meta Host %d not found"
-msgstr ""
+msgstr "Le métahôte %d n'a pas été trouvé"
 
-#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
 #: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Meta Service"
 msgstr "Méta-Service"
@@ -9672,7 +9905,7 @@ msgstr "Méta-Service"
 #: centreon/src/Centreon/Domain/Monitoring/SubmitResult/SubmitResultService.php
 #, php-format
 msgid "Meta Service %d not found"
-msgstr ""
+msgstr "Le métaservice %d n'a pas été trouvé"
 
 #: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 msgid "Meta Service Names"
@@ -9680,50 +9913,50 @@ msgstr "Nom du méta-services"
 
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 msgid "Meta Service State"
-msgstr "Etat du Meta Service"
+msgstr "État du Meta Service"
 
-#: centreon/src/Centreon/Application/Controller/Monitoring/MetricController.php
 #: centreon/src/Centreon/Application/Controller/DowntimeController.php
+#: centreon/src/Centreon/Application/Controller/Monitoring/MetricController.php
 #, php-format
 msgid "Meta Service linked to service %d not found"
 msgstr "Meta Service lié au service %d non trouvé"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/install/menu_translation.php
 msgid "Meta Services"
 msgstr "Méta-Services"
 
 #: centreon/src/Centreon/Domain/Monitoring/Comment/CommentService.php
 #, php-format
 msgid "Meta host %d not found"
-msgstr ""
+msgstr "Le métahôte %d n'a pas été trouvé"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/install/front_translate.php
 msgid "Meta service"
-msgstr ""
+msgstr "Métaservice"
 
-#: centreon/src/Centreon/Application/Controller/Monitoring/CommentController.php
 #: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
+#: centreon/src/Centreon/Application/Controller/Monitoring/CommentController.php
 #, php-format
 msgid "Meta service %d not found"
-msgstr ""
+msgstr "Le métaservice %d n'a pas été trouvé"
 
 #: centreon/src/Centreon/Domain/MetaServiceConfiguration/Exception/MetaServiceConfigurationException.php
 #, php-format
 msgid "Meta service configuration (%s) not found"
-msgstr ""
+msgstr "La configuration du métaservice (%s) n'a pas été trouvée"
 
+#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
 #: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
 #: centreon/src/Centreon/Domain/Check/CheckService.php
-#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
 msgid "Meta service not found"
-msgstr ""
+msgstr "Le métaservice n'a pas été trouvé"
 
 #: centreon/src/Centreon/Domain/Monitoring/MetaService/Exception/MetaServiceMetricException.php
 #, php-format
 msgid "Meta service with ID %d not found"
-msgstr ""
+msgstr "Le métaservice avec l'ID %d n'a pas été trouvé"
 
 #: centreon/www/install/front_translate.php
 msgid "Meta-Service"
@@ -9741,14 +9974,14 @@ msgstr "Métaservice"
 msgid "Method"
 msgstr "Méthode"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/install/front_translate.php
 msgid "Metric"
 msgstr "Métrique"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/install/smarty_translate.php
 msgid "Metric Name"
 msgstr "Nom de la métrique"
 
@@ -9764,14 +9997,15 @@ msgstr "Nom de la métrique"
 msgid "Metric naming"
 msgstr "Nom de la métrique"
 
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/Administration/performance/viewData.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/install/front_translate.php
 msgid "Metrics"
 msgstr "Métriques"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Metrics column"
-msgstr ""
+msgstr "Colonne qui stockera les métriques"
 
 #: centreon/src/Core/Metric/Application/Exception/MetricException.php
 msgid "Metrics not found"
@@ -9779,7 +10013,7 @@ msgstr "Métriques non trouvées"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Metrics timeseries"
-msgstr ""
+msgstr "Série chronologique des métriques"
 
 #: centreon/www/install/front_translate.php
 msgid "Migrate"
@@ -9789,18 +10023,18 @@ msgstr "Migrer"
 msgid "Migration script"
 msgstr "Script de migration"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Min"
 msgstr "Minimum"
 
 #: centreon/www/install/front_translate.php
 msgid "Mini Centreon Logo"
-msgstr ""
+msgstr "Mini logo Centreon"
 
 #: centreon/www/install/front_translate.php
 msgid "Minimum"
@@ -9821,25 +10055,25 @@ msgstr "Durée minimum entre chaque changement de mot de passe"
 #: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
 #, php-format
 msgid "Minimum value of limit has to be 1 instead %d"
-msgstr ""
+msgstr "La valeur minimale de la limite doit être 1 plutôt que %d"
 
 #: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
 #, php-format
 msgid "Minimum value of offset has to be 1 instead %d"
-msgstr ""
+msgstr "La valeur minimale du décalage doit être 1 plutôt que %d"
 
 #: centreon/www/install/front_translate.php
 msgid "Minute"
 msgstr "Minute"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/install/front_translate.php
 msgid "Minutes"
 msgstr "Minutes"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configObject/command/commandType.php
+#: centreon/www/install/smarty_translate.php
 msgid "Misc"
 msgstr "Divers"
 
@@ -9847,9 +10081,9 @@ msgstr "Divers"
 msgid "Misc Options"
 msgstr "Autres options"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/configuration/configObject/command/listCommand.php
 #: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/install/menu_translation.php
 msgid "Miscellaneous"
 msgstr "Divers"
 
@@ -9861,7 +10095,7 @@ msgstr "Paramètre d'entrée/sortie manquant : %s"
 #: centreon/src/Security/Infrastructure/Repository/Model/ProviderConfigurationFactoryRdb.php
 #, php-format
 msgid "Missing mandatory parameter: '%s'"
-msgstr "Paramètre obligatoire manquant: '%s'"
+msgstr "Paramètre obligatoire manquant : '%s'"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
 #, php-format
@@ -9873,7 +10107,7 @@ msgstr ""
 #: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
 #, php-format
 msgid "Missing mandatory platform address of: '%s'"
-msgstr "Adresse de la plateforme: '%s' manquante"
+msgstr "Adresse de la plateforme '%s' manquante"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
 msgid "Missing mandatory platform name"
@@ -9902,63 +10136,64 @@ msgstr "Mixte"
 
 #: centreon/www/install/front_translate.php
 msgid "Modal confirmation"
-msgstr ""
+msgstr "Fenêtre de confirmation"
 
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Mode"
-msgstr ""
+msgstr "Mode"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Modificaton type"
 msgstr "Type de modification"
 
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
-#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/connector/formConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/command/formCommand.php
-#: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/media/images/formImg.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
 #: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
-#: centreon/www/include/Administration/parameters/api/api.php
-#: centreon/www/include/Administration/parameters/remote/formRemote.php
-#: centreon/www/include/Administration/parameters/general/form.php
-#: centreon/www/include/Administration/parameters/rrdtool/form.php
-#: centreon/www/include/Administration/parameters/ldap/form.php
-#: centreon/www/include/Administration/parameters/debug/form.php
-#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
-#: centreon/www/include/Administration/parameters/engine/form.php
 #: centreon/www/include/Administration/parameters/centstorage/form.php
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/api/api.php
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 msgid "Modify"
 msgstr "Modifier"
 
@@ -9966,33 +10201,29 @@ msgstr "Modifier"
 msgid "Modify Centcore options"
 msgstr "Modifier les options de Centcore"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Modify Data Processing"
 msgstr "Modifier le traitement des données"
 
-#: centreon/www/include/Administration/parameters/general/form.php
-#: centreon/www/include/Administration/parameters/rrdtool/form.php
-#: centreon/www/include/Administration/parameters/ldap/form.php
-#: centreon/www/include/Administration/parameters/debug/form.php
-#: centreon/www/include/Administration/parameters/engine/form.php
 #: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
 msgid "Modify General Options"
 msgstr "Modifier les options générales"
 
 #: centreon/www/include/Administration/parameters/gorgone/gorgone.php
 msgid "Modify Gorgone options"
-msgstr ""
+msgstr "Modifier les options de Gorgone"
 
 #: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
 msgid "Modify Group"
 msgstr "Modifier un groupe"
-
-#: centreon/www/include/options/media/images/formImg.php
-msgid "Modify Image"
-msgstr "Modifier l'image"
 
 #: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
 msgid "Modify Vendor"
@@ -10022,9 +10253,9 @@ msgstr "Modifier un groupe de contact"
 msgid "Modify a Data Source Template"
 msgstr "Modifier un modèle de source de données"
 
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 msgid "Modify a Dependency"
@@ -10099,6 +10330,10 @@ msgstr "Modifier une définition de Trap"
 msgid "Modify a User"
 msgstr "Modifier un utilisateur"
 
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "Modify a User Template"
+msgstr "Modifier un modèle utilisateur"
+
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
 msgid "Modify a Virtual Metric"
 msgstr "Modifier une Métrique Virtuelle"
@@ -10112,6 +10347,7 @@ msgid "Modify a poller Configuration"
 msgstr "Modifier la configuration d'un collecteur"
 
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 msgid "Modify an ACL"
 msgstr "Modifier une ACL"
 
@@ -10123,8 +10359,8 @@ msgstr "Modifier une action"
 msgid "Modify an Escalation"
 msgstr "Modifier une escalade"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Modify an Extended Info"
 msgstr "Modifier une information supplémentaire"
 
@@ -10132,32 +10368,32 @@ msgstr "Modifier une information supplémentaire"
 msgid "Modify directory"
 msgstr "Modifier le répertoire"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Modify macros"
 msgstr "Modifier les macros"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Modify relations"
 msgstr "Modifier des relations"
 
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
 msgid "Module"
-msgstr ""
+msgstr "Module"
 
 #: centreon/src/CentreonModule/Infrastructure/Source/ModuleException.php
 #, php-format
 msgid "Module \"%s\" is missing"
 msgstr "Le module \"%s\" est manquant"
 
-#: centreon/www/install/step_upgrade/step2.php
 #: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step2.php
 msgid "Module name"
 msgstr "Nom du module"
 
@@ -10167,24 +10403,28 @@ msgstr "Modules"
 
 #: centreon/src/CentreonLegacy/Core/Install/Step/Step8.php
 msgid "Modules installation"
-msgstr ""
+msgstr "Installation des modules"
 
-#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Monday"
 msgstr "Lundi"
+
+#: centreon/www/install/front_translate.php
+msgid "Monitored hosts"
+msgstr "Hôtes supervisés"
 
 #: centreon/www/install/menu_translation.php
 msgid "Monitoring"
 msgstr "Supervision"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/install/menu_translation.php
 msgid "Monitoring Engine"
 msgstr "Moteur de supervision"
 
@@ -10198,7 +10438,7 @@ msgstr "Débogage du moteur de supervision"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Monitoring Engine Information"
-msgstr ""
+msgstr "Informations sur le moteur de supervision"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Monitoring Engine Statistics Binary"
@@ -10206,7 +10446,7 @@ msgstr "Binaire de statistiques du moteur de supervision"
 
 #: centreon/www/include/Administration/parameters/engine/form.php
 msgid "Monitoring Engine information"
-msgstr ""
+msgstr "Informations sur le moteur de supervision"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "Monitoring Engine reload command"
@@ -10237,14 +10477,14 @@ msgstr "Moteur de supervision"
 msgid "Monitoring engine config"
 msgstr "Configuration du moteur de supervision"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/src/CentreonLegacy/Core/Install/Step/Step3.php
+#: centreon/www/install/smarty_translate.php
 msgid "Monitoring engine information"
 msgstr "Information sur le moteur de supervision"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/install/front_translate.php
 msgid "Monitoring server"
 msgstr "Serveur de supervision"
 
@@ -10272,9 +10512,9 @@ msgstr "Serveur de supervision non trouvé (#%d)"
 msgid "Monitoring server with id %d not found"
 msgstr "Le serveur de supervision avec l'id %d n'a pas été trouvé"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/install/smarty_translate.php
 msgid "Monitoring settings"
 msgstr "Paramètres de supervision"
 
@@ -10282,8 +10522,8 @@ msgstr "Paramètres de supervision"
 msgid "Month"
 msgstr "Mois"
 
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Monthly basis"
 msgstr "Mensuel"
 
@@ -10297,53 +10537,57 @@ msgstr "Étendre"
 
 #: centreon/www/widgets/host-monitoring/src/toolbar.php
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/options/media/images/listImg.php
 #: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
 #: centreon/www/include/configuration/configResources/listResources.php
-#: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/install/front_translate.php
 msgid "More actions"
 msgstr "Plus d'actions"
 
-#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
 #: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/connector/listConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
 #: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
-#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
 msgid "More actions..."
 msgstr "Plus d'actions..."
 
@@ -10377,19 +10621,19 @@ msgstr "Déplacement des fichiers"
 
 #: centreon/www/install/front_translate.php
 msgid "Multi Connected Autocomplete"
-msgstr ""
+msgstr "Autocomplétion multi-connectée"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Multiple Broker Module"
 msgstr "Multiple module broker"
 
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/Administration/parameters/backup/formBackup.php
-#: centreon/www/include/Administration/parameters/general/form.php
 #: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
 #: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 msgid "Must be a number"
 msgstr "doit être un nombre"
 
@@ -10400,12 +10644,12 @@ msgstr "Doit être un nombre compris entre 1 et 65335 inclus"
 #: centreon/src/Core/Security/ProviderConfiguration/Domain/Exception/ConfigurationException.php
 #, php-format
 msgid "Must not Happen, got unexpected CustomConfiguration type %s"
-msgstr ""
+msgstr "Le type de la valeur de CustomConfiguration %s est invalide"
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/ProviderException.php
 #, php-format
 msgid "Must not Happen, got unexpected Provider type %s"
-msgstr ""
+msgstr "Type de fournisseur %s invalide"
 
 #: centreon/www/install/menu_translation.php
 msgid "My Account"
@@ -10419,69 +10663,70 @@ msgstr "Mes filtres"
 msgid "MySQL configuration file path"
 msgstr "Chemin d'accès au fichier de configuration MySQL"
 
+#: centreon/src/CentreonLegacy/Core/Widget/Information.php
+#: centreon/src/CentreonLegacy/Core/Module/Information.php
 #: centreon/www/include/configuration/configServers/listServers.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
-#: centreon/src/CentreonLegacy/Core/Module/Information.php
-#: centreon/src/CentreonLegacy/Core/Widget/Information.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "N/A"
 msgstr "N/A"
 
-#: centreon/www/class/centreonConfigCentreonBroker.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/centreon_broker_translation.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
+#: centreon/www/include/home/customViews/index.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
-#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
-#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/connector/formConnector.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
-#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/command/listCommand.php
-#: centreon/www/include/configuration/configResources/listResources.php
-#: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
 #: centreon/www/include/options/media/images/listImg.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
 #: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
 #: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
-#: centreon/www/include/home/customViews/index.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configObject/connector/formConnector.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configServers/listServers.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/centreon_broker_translation.php
+#: centreon/www/class/centreonConfigCentreonBroker.php
 msgid "Name"
 msgstr "Nom"
 
@@ -10499,29 +10744,29 @@ msgid "Name cannot be empty"
 msgstr "Le nom ne peut pas être vide"
 
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/connector/formConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 #: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 msgid "Name is already in use"
 msgstr "Le nom est déjà utilisé"
@@ -10531,8 +10776,12 @@ msgid "Name of the logger"
 msgstr "Nom du journal d'évènements"
 
 #: centreon/www/install/front_translate.php
-msgid "Need help using the search bar ?"
+msgid "Need help with search bar usage?"
 msgstr "Besoin d'aide pour utiliser la barre de recherche ?"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "Never Started"
+msgstr "Jamais démarré"
 
 #: centreon/www/install/front_translate.php
 msgid "Never expire"
@@ -10564,14 +10813,14 @@ msgstr "Les nouveaux mots de passe doivent correspondre"
 
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "New version"
-msgstr ""
+msgstr "Nouvelle version"
 
 #: centreon/www/install/front_translate.php
 msgid "Next"
 msgstr "Suivant"
 
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Next Check"
 msgstr "Prochain contrôle"
 
@@ -10587,42 +10836,44 @@ msgstr "Prochain contrôle actif planifié"
 msgid "Next check"
 msgstr "Prochain contrôle"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/common/pagination.php
 #: centreon/www/include/configuration/configKnowledge/pagination.php
+#: centreon/www/install/front_translate.php
 msgid "Next page"
 msgstr "Page suivante"
 
-#: centreon/www/class/centreonXMLBGRequest.class.php
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
-#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
-#: centreon/www/include/monitoring/comments/listComment.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
 #: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/class/centreonXMLBGRequest.class.php
 msgid "No"
 msgstr "Non"
 
@@ -10656,9 +10907,13 @@ msgstr "Sans étape"
 msgid "No TLS"
 msgstr ""
 
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "No access"
+msgstr "Pas d'accès"
+
 #: centreon/www/install/front_translate.php
 msgid "No access rights"
-msgstr ""
+msgstr "Vous n'avez pas les droits d'accès nécessaires"
 
 #: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
 msgid "No acknowledgement found for this host"
@@ -10666,7 +10921,7 @@ msgstr "Aucun acquittement trouvé pour cet hôte"
 
 #: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
 msgid "No acknowledgement found for this meta service"
-msgstr ""
+msgstr "Aucun acquittement n'a été trouvé pour ce métaservice"
 
 #: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
 msgid "No acknowledgement found for this service"
@@ -10690,15 +10945,15 @@ msgstr "Aucun contact configuré pour cette ressource"
 
 #: centreon/www/install/front_translate.php
 msgid "No contacts found"
-msgstr ""
+msgstr "Aucun contact n'a été trouvé"
 
 #: centreon/www/install/front_translate.php
 msgid "No data available for this period"
-msgstr ""
+msgstr "Pas de données disponibles pour cette période"
 
 #: centreon/www/install/front_translate.php
 msgid "No data for"
-msgstr ""
+msgstr "Pas de données pour"
 
 #: centreon/www/install/front_translate.php
 msgid "No data found"
@@ -10759,20 +11014,24 @@ msgstr "Aucun fichier de statistiques défini pour ce collecteur"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 #, php-format
-msgid "No sufficient access rights to contact group [%d] to give role [%s]"
+msgid "No sufficient access rights to contact group [%s] to give role [%s]"
 msgstr ""
+"Le groupe de contacts [%s] n'a pas les droits d'accès suffisants pour donner "
+"le rôle [%s]"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 #, php-format
-msgid "No sufficient access rights to user [%d] to give role [%s]"
+msgid "No sufficient access rights to user [%s] to give role [%s]"
 msgstr ""
+"L'utilisateur [%s] n'a pas les droits d'accès suffisants pour donner le rôle "
+"[%s]"
 
 #: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
 msgid "No time period selected"
 msgstr "Aucune période temporelle sélectionnée"
 
-#: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
 #: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
+#: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
 msgid "No top level platform found to link the child platforms"
 msgstr "Aucune platforme principale trouvée pour lier les plateformes enfants"
 
@@ -10799,45 +11058,46 @@ msgstr ""
 msgid "No widget found"
 msgstr "Aucun widget trouvé"
 
-#: centreon/www/include/configuration/configKnowledge/display-services.php
-#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
 #: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
 #: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
 msgid "No wiki page defined"
 msgstr "Aucune page définie"
 
 #: centreon/www/install/front_translate.php
 msgid "No {{type}} found with this status"
-msgstr ""
+msgstr "Aucun {{type}} n'a ce statut"
 
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/install/smarty_translate.php
 msgid "None"
 msgstr "Aucune"
 
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Normal Check Interval"
 msgstr "Intervalle normal de contrôle"
 
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
 msgid "Not Acknowledged"
 msgstr "Non acquittés"
 
@@ -10848,14 +11108,14 @@ msgstr "Adresse IP non valide"
 #: centreon/src/Centreon/Infrastructure/Service/Traits/ServiceContainerTrait.php
 #, php-format
 msgid "Not found exporter with name: %d"
-msgstr ""
+msgstr "Aucun exporter %d n'a été trouvé"
 
 #: centreon/www/install/step_upgrade/step2.php
 msgid "Not initialized"
 msgstr "Non initialisé"
 
-#: centreon/www/install/step_upgrade/step2.php
 #: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step2.php
 msgid "Not loaded"
 msgstr "Non chargé"
 
@@ -10863,25 +11123,25 @@ msgstr "Non chargé"
 msgid "Not yet implemented"
 msgstr "Pas encore implémenté"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Note"
 msgstr "Note"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Note URL"
 msgstr "URL de la note"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/install/front_translate.php
 msgid "Notes"
 msgstr "Notes"
 
@@ -10897,17 +11157,18 @@ msgstr "Rien à afficher, utiliser le bouton \"Add\""
 msgid "Notif"
 msgstr "Notification"
 
-#: centreon/www/install/front_translate.php
+#: centreon/src/Core/Notification/Application/UseCase/FindNotification/FindNotification.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/command/commandType.php
 #: centreon/www/include/configuration/configObject/command/listCommand.php
-#: centreon/www/include/Administration/parameters/general/form.php
-#: centreon/src/Core/Notification/Application/UseCase/FindNotification/FindNotification.php
+#: centreon/www/include/configuration/configObject/command/commandType.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/install/front_translate.php
 msgid "Notification"
 msgstr "Notification"
 
@@ -10916,17 +11177,17 @@ msgstr "Notification"
 msgid "Notification #%d should have at least one user"
 msgstr "La notification #%d doit avoir au moins un utilisateur"
 
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Notification Enabled"
 msgstr "Notification activée"
 
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 msgid "Notification Failure Criteria"
@@ -10936,12 +11197,12 @@ msgstr "Critères d'échec de notification"
 msgid "Notification Information"
 msgstr "Informations sur la notification"
 
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Notification Interval"
 msgstr "Intervalle de notification"
 
@@ -10958,11 +11219,11 @@ msgstr "Notification"
 msgid "Notification Options"
 msgstr "Options de notifications"
 
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Notification Period"
 msgstr "Période de notification"
 
@@ -10970,9 +11231,9 @@ msgstr "Période de notification"
 msgid "Notification Timeout"
 msgstr "Temps maximum d'exécution d'une commande de notification"
 
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 msgid "Notification Type"
 msgstr "Type de notification"
 
@@ -10993,6 +11254,11 @@ msgstr "Notification dupliquée"
 msgid "Notification information"
 msgstr "Informations sur la notification"
 
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+#: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+msgid "Notification is disabled"
+msgstr "Notifications désactivées"
+
 #: centreon/www/install/front_translate.php
 msgid "Notification name"
 msgstr "Nom de la notification"
@@ -11004,7 +11270,7 @@ msgstr "Options de notification"
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateFactoryException.php
 #, php-format
 msgid "Notification options not allowed (%s)"
-msgstr ""
+msgstr "Options de notification non autorisées (%s)"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Notification receivers"
@@ -11025,24 +11291,24 @@ msgstr "Paramètres de notification"
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
 msgid "Notification status"
-msgstr "Etat de la notification"
+msgstr "État de la notification"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
 msgid "Notifications"
 msgstr "Notifications"
 
-#: centreon/www/install/front_translate.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/front_translate.php
 msgid "Notifications disabled"
 msgstr "Notifications désactivées"
 
-#: centreon/www/install/front_translate.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/front_translate.php
 msgid "Notifications enabled"
 msgstr "Notifications activées"
 
@@ -11056,17 +11322,17 @@ msgstr "Notifié"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
-#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
 #: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/install/front_translate.php
 msgid "Notify"
 msgstr "Notifier"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
 msgid "Number \"%s\" was expected to be at least \"%d\" and at most \"%d\""
-msgstr ""
+msgstr "Le nombre \"%s\" doit être compris entre \"%d\" et \"%d\""
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Number between 5 and 600"
@@ -11078,7 +11344,7 @@ msgstr "Nombre de tentatives avant que l'utilisateur soit bloqué"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Number of connections to the database"
-msgstr ""
+msgstr "Nombre de connexions à la base de données"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Number of elements loaded in select"
@@ -11096,31 +11362,31 @@ msgstr "Nombre de services liés"
 msgid "Number of rows"
 msgstr "Nombre de lignes"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/install/front_translate.php
 msgid "Number of values"
 msgstr "Nombre de valeurs"
 
 #: centreon/src/Centreon/Domain/Entity/EntityCreator.php
 msgid "Numeric value expected"
-msgstr ""
+msgstr "Une valeur numérique est attendue"
 
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "OID"
 msgstr "OID"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
+#: centreon/www/install/front_translate.php
 msgid "OK"
 msgstr "OK"
 
@@ -11130,29 +11396,29 @@ msgstr "Services au statut OK"
 
 #: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
 msgid "OK: A reload signal has been sent to '"
-msgstr "OK: Une commande de rechargement a été envoyée vers '"
+msgstr "OK : Une commande de rechargement a été envoyée vers '"
 
 #: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
 msgid "OK: A restart signal has been sent to '"
-msgstr "OK: Une commande de redémarrage a été envoyée vers '"
+msgstr "OK : Une commande de redémarrage a été envoyée vers '"
 
 #: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
 msgid "OK: All configuration files copied with success."
-msgstr "OK: Toutes les configurations ont été copiées avec succès."
+msgstr "OK : Toutes les configurations ont été copiées avec succès."
 
 #: centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
 msgid "OK: All configuration will be send to '"
-msgstr "OK: Toutes les configurations ont été envoyées vers '"
+msgstr "OK : Toutes les configurations ont été envoyées vers '"
 
 #: centreon/www/install/front_translate.php
 msgid "OK: all database poller updates are active"
 msgstr ""
-"OK: toutes les mises à jour des bases de données de vos collecteurs sont "
+"OK : toutes les mises à jour des bases de données de vos collecteurs sont "
 "actives"
 
 #: centreon/www/install/front_translate.php
 msgid "OK: no latency detected on your platform"
-msgstr "OK: aucune latence détectée sur votre plateforme"
+msgstr "OK : aucune latence détectée sur votre plateforme"
 
 #: centreon/www/install/front_translate.php
 msgid "OTLP Receiver"
@@ -11162,15 +11428,19 @@ msgstr ""
 msgid "OTLP receiver"
 msgstr "Receveur OTLP"
 
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Object"
+msgstr "Objet"
+
 #: centreon/src/Centreon/Infrastructure/Service/CentreonWebserviceService.php
 #, php-format
 msgid "Object %s must extend %s class or %s class"
-msgstr ""
+msgstr "L'objet %s doit étendre la classe %s ou la classe %s"
 
 #: centreon/src/Centreon/Infrastructure/Service/CentreonClapiService.php
 #, php-format
 msgid "Object %s must implement %s"
-msgstr ""
+msgstr "L'objet %s doit implémenter %s"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Object Configuration Directory"
@@ -11189,41 +11459,49 @@ msgid "Object Name"
 msgstr "Nom de l'objet"
 
 #: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "Object Type"
+msgstr "Type d'objet"
+
+#: centreon/www/include/eventLogs/xml/data.php
+msgid "Object name"
+msgstr "Nom de l'objet :"
+
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
 msgid "Object name : "
-msgstr "Nom de l'objet"
+msgstr "Nom de l'objet "
 
 #: centreon/www/include/Administration/configChangelog/viewLogs.php
 msgid "Object type : "
-msgstr "Type d'objet :"
+msgstr "Type d'objet : "
 
 #: centreon/www/install/smarty_translate.php
 msgid "Objects"
-msgstr ""
+msgstr "Objets"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Obsess Over Host"
 msgstr "Contrôle de vérification de l'hôte"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Obsess Over Service"
 msgstr "Exécuter une commande post contrôle"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/front_translate.php
 msgid "Ok"
 msgstr "Ok"
 
 #: centreon/www/install/react_translation.php
 msgid "Ok services"
-msgstr ""
+msgstr "Services au statut OK"
 
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 msgid "Ok/Up"
@@ -11231,19 +11509,19 @@ msgstr "Ok/Disponible"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Okta"
-msgstr ""
+msgstr "Okta"
 
 #: centreon/src/Core/Security/User/Domain/Model/UserPasswordFactory.php
 msgid "Old password usage is disable"
-msgstr ""
+msgstr "Vous ne pouvez pas réutiliser un ancien mot de passe"
 
 #: centreon/src/Core/Media/Infrastructure/API/Exception/MediaException.php
 msgid "On media update, only one file is allowed"
-msgstr ""
+msgstr "Lors de la mise à jour des médias, un seul fichier est autorisé"
 
 #: centreon/www/install/smarty_translate.php
 msgid "One column"
-msgstr ""
+msgstr "Une colonne"
 
 #: centreon/src/Centreon/Domain/Monitoring/Resource.php
 msgid "One of the elements provided is not a ResourceGroup type"
@@ -11267,14 +11545,17 @@ msgid ""
 "order to calculate this status. If you modify a template, it won't tell you "
 "the configuration had changed."
 msgstr ""
+"Seuls les services, les groupes de services, les hôtes et les groupes "
+"d'hôtes sont pris en compte pour calculer ce statut. Si vous modifiez un "
+"modèle, il ne sera pas indiqué que la configuration a changé."
 
 #: centreon/www/install/front_translate.php
 msgid "Oops"
-msgstr ""
+msgstr "Oups"
 
 #: centreon/www/install/front_translate.php
 msgid "Oops !"
-msgstr ""
+msgstr "Oups !"
 
 #: centreon/www/install/front_translate.php
 msgid "Oops, something went wrong"
@@ -11316,45 +11597,45 @@ msgstr "Ouvert le"
 msgid "Optimization"
 msgstr "Optimisation"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
 #: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/connector/listConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
 #: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetric.php
 #: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
 #: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/listEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
 #: centreon/www/include/configuration/configResources/listResources.php
 #: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/install/menu_translation.php
 msgid "Options"
 msgstr "Options"
 
@@ -11365,7 +11646,7 @@ msgstr "Ordre"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Order sort "
-msgstr "Choix de tri"
+msgstr "Ordre de tri "
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Order sort problems"
@@ -11373,7 +11654,7 @@ msgstr "Ordre de tri des problèmes"
 
 #: centreon/www/install/front_translate.php
 msgid "Ordered List"
-msgstr ""
+msgstr "Liste ordonnée"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Orphaned Host Check Option"
@@ -11393,22 +11674,24 @@ msgstr "Statut détaillé"
 
 #: centreon/www/install/front_translate.php
 msgid "Outdated"
-msgstr ""
+msgstr "Obsolète"
 
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/eventLogs/xml/data.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/comments/listComment.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
-#: centreon/www/include/monitoring/status/Services/service.php
-#: centreon/www/include/monitoring/comments/listComment.php
-#: centreon/www/include/Administration/parameters/general/form.php
-#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
 msgid "Output"
 msgstr "Statut détaillé"
 
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Output Message"
 msgstr "Message de sortie"
 
@@ -11467,8 +11750,8 @@ msgstr "Page"
 msgid "Page refresh interval"
 msgstr "Intervalle de rafraîchissement de la page"
 
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Pager"
 msgstr "Bipeur"
 
@@ -11490,14 +11773,14 @@ msgstr "Le paramètre '%s' (%s) est invalide"
 msgid "Parameter '%s' of type %s is invalid"
 msgstr "Le paramètre '%s' de type %s est invalide"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Parameters"
 msgstr "Paramètres"
 
 #: centreon/www/install/front_translate.php
 msgid "Parameters tooltip"
-msgstr ""
+msgstr "Infobulle de paramètres"
 
 #: centreon/www/install/front_translate.php
 msgid "Parent"
@@ -11519,18 +11802,18 @@ msgstr "Statut de la ressource parent"
 msgid "Parent Resource Type"
 msgstr "Type de ressource parent"
 
-#: centreon/www/install/front_translate.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/front_translate.php
 msgid "Parent alias"
 msgstr "Alias parent"
 
 #: centreon/www/install/front_translate.php
 msgid "Parent name"
-msgstr ""
+msgstr "Nom du parent"
 
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 msgid "Parent relationship"
@@ -11554,7 +11837,7 @@ msgstr "Tables partitionnées"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Partitioning retention options"
-msgstr ""
+msgstr "Options de rétention du partitionnement"
 
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Passive"
@@ -11569,10 +11852,10 @@ msgstr "Journalisation des états passifs"
 msgid "Passive Checks"
 msgstr "Contrôles passifs"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Passive Checks Enabled"
 msgstr "Contrôle passif activé"
 
@@ -11584,17 +11867,17 @@ msgstr "Contrôle passif des hôtes"
 msgid "Passive Service Check Acceptance Option"
 msgstr "Contrôle passif des services"
 
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configResources/formResources.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/Administration/parameters/remote/formRemote.php
-#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -11624,7 +11907,7 @@ msgstr "Votre mot de passe a expiré"
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/PasswordExpiredException.php
 msgid "Password is expired"
-msgstr ""
+msgstr "Le mot de passe a expiré"
 
 #: centreon/www/install/front_translate.php
 msgid "Password must contain lower case"
@@ -11654,14 +11937,14 @@ msgstr "Politique de sécurité de mot de passe"
 msgid "Password security policy saved"
 msgstr "Politique de sécurité de mot de passe sauvegardée"
 
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Passwords do not match"
 msgstr "Les mots de passe ne correspondent pas"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Path"
-msgstr ""
+msgstr "Chemin"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Path to RRDTool Database For Metrics"
@@ -11689,20 +11972,20 @@ msgstr "Remplacement du login (regex)"
 msgid "Peers"
 msgstr "Pairs"
 
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/install/front_translate.php
 msgid "Pending"
 msgstr "En attente"
 
 #: centreon/www/install/react_translation.php
 msgid "Pending services"
-msgstr ""
+msgstr "Services au statut \"En attente\""
 
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 msgid "People linked to this Access list"
@@ -11713,8 +11996,8 @@ msgstr "Utilisateurs liés à cette liste d'accès"
 msgid "Percent State Change"
 msgstr "Pourcentage de changement d'état"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 msgid "Perfdata Options"
 msgstr "Options des données de performance"
 
@@ -11722,9 +12005,9 @@ msgstr "Options des données de performance"
 msgid "Perfdata file"
 msgstr "Fichier des données de performance"
 
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 msgid "Performance Data"
 msgstr "Données de performance"
 
@@ -11736,9 +12019,9 @@ msgstr "Gestion des données de performance"
 msgid "Performance Management"
 msgstr "Gestion des données de performance"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
 #: centreon/www/include/monitoring/submitPassivResults/servicePassiveCheck.php
+#: centreon/www/install/front_translate.php
 msgid "Performance data"
 msgstr "Données de performance"
 
@@ -11747,10 +12030,10 @@ msgstr "Données de performance"
 msgid "Performances"
 msgstr "Informations de performance"
 
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
-#: centreon/www/include/Administration/corePerformance/nagiosStats.php
 msgid "Period"
 msgstr "Période"
 
@@ -11760,17 +12043,17 @@ msgstr "Périodes"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
 #: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
-#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
 #: centreon/www/include/monitoring/comments/AddComment.php
-#: centreon/www/include/monitoring/comments/AddSvcComment.php
 #: centreon/www/include/monitoring/comments/AddHostComment.php
-#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Persistent"
 msgstr "Persistant"
 
@@ -11789,11 +12072,11 @@ msgstr "Statut de la plateforme"
 
 #: centreon/src/Centreon/Domain/PlatformInformation/Model/PlatformInformation.php
 msgid "Platform name can't be empty"
-msgstr ""
+msgstr "Le nom de la plateforme ne peut pas être vide"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/PlatformTopologyService.php
 msgid "Platform not found"
-msgstr ""
+msgstr "La plateforme n'a pas été trouvée"
 
 #: centreon/www/install/step_upgrade/step4.php
 #, php-format
@@ -11801,6 +12084,8 @@ msgid ""
 "Please check the \"upgrade.log\" and the \"sql-error.log\" located in \"%s\" "
 "for more details"
 msgstr ""
+"Veuillez consulter les fichiers \"upgrade.log\" et \"sql-error.log\" situés "
+"dans \"%s\" pour plus de détails"
 
 #: centreon/www/include/monitoring/downtime/AddDowntime.php
 #, php-format
@@ -11813,12 +12098,12 @@ msgstr "Veuillez contacter votre administrateur pour plus d'informations."
 
 #: centreon/www/install/front_translate.php
 msgid "Please contact your administrator."
-msgstr ""
+msgstr "Veuillez contacter votre administrateur"
 
-#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 msgid "Please correct these fields"
 msgstr "Merci de corriger ces champs"
 
@@ -11832,7 +12117,7 @@ msgstr "Veuillez entrer un nom pour la notification dupliquée"
 
 #: centreon/www/install/front_translate.php
 msgid "Please enter a name for the duplicated resource access rule"
-msgstr ""
+msgstr "Veuillez saisir un nom pour la règle d'accès aux ressources dupliquée"
 
 #: centreon/www/install/front_translate.php
 msgid "Please enter a valid URL or IP address"
@@ -11841,11 +12126,15 @@ msgstr "Entrez une URL ou une adresse IP valide"
 #: centreon/www/install/steps/functions.php
 #, php-format
 msgid "Please install MariaDB version %s instead of %s."
-msgstr ""
+msgstr "Veuillez installer la version %s de MariaDB plutôt que la version %s"
 
 #: centreon/www/install/steps/functions.php
 #, php-format
 msgid "Please install PHP version %s instead of %s."
+msgstr "Veuillez installer la version %s de PHP plutôt que la version %s"
+
+#: centreon/www/widgets/graph-monitoring/index.php
+msgid "Please select a graph period"
 msgstr ""
 
 #: centreon/www/install/front_translate.php
@@ -11856,46 +12145,53 @@ msgstr "Veuillez sélectionner une métrique"
 msgid "Please select a resource"
 msgstr "Veuillez sélectionner une ressource"
 
-#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+#: centreon/www/widgets/graph-monitoring/index.php
+msgid "Please select a resource first"
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 msgid "Please select a user in order to view his notifications"
 msgstr "Veuillez sélectionner un utilisateur pour visualiser ses notifications"
 
 #: centreon/www/widgets/host-monitoring/src/toolbar.php
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 #: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/connector/listConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
-#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
 #: centreon/www/include/configuration/configObject/escalation/listEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
 #: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
 msgid "Please select one or more items"
 msgstr "Merci de sélectionner un ou plusieurs objets"
 
 #: centreon/www/install/step_upgrade/step4.php
 msgid "Please upgrade to an intermediate release (ie. 2.8.x) first."
 msgstr ""
+"Veuillez d'abord passer à une version intermédiaire (c'est-à-dire 2.8.x)"
 
 #: centreon/src/EventSubscriber/UpdateEventSubscriber.php
 msgid "Please use Web UI to install Centreon."
@@ -11908,10 +12204,10 @@ msgstr "Veuillez utiliser l'interface Web pour mettre à jour Centreon."
 
 #: centreon/www/install/front_translate.php
 msgid "Please, select a valid countdown"
-msgstr ""
+msgstr "Veuillez définir une valeur de compte à rebours valide"
 
-#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/command/minHelpCommand.php
 msgid "Plugin Help"
 msgstr "Aide de la sonde"
 
@@ -11919,32 +12215,35 @@ msgstr "Aide de la sonde"
 msgid "Plugins Directory"
 msgstr "Répertoire des sondes"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
+#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
 #: centreon/www/include/configuration/configKnowledge/search.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/eventLogs/xml/data.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
-#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
-#: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Poller"
 msgstr "Collecteur"
 
 #: centreon/www/install/front_translate.php
 msgid "Poller CA certificate file name"
 msgstr ""
+"Nom du fichier du certificat de l'autorité de certification du collecteur"
 
 #: centreon/www/install/front_translate.php
 msgid "Poller CA name"
-msgstr ""
+msgstr "Nom du CA pour le collecteur"
 
 #: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
 msgid "Poller Configuration Actions / Poller Management"
@@ -11962,36 +12261,25 @@ msgstr ""
 "L'ID de collecteur #%d est le seul lié à l'ID de configuration collecteur/"
 "agent #%d"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/install/smarty_translate.php
 msgid "Poller Name"
 msgstr "Nom du collecteur"
 
 #: centreon/src/Centreon/Domain/Repository/CfgCentreonBrokerRepository.php
 msgid "Poller broker config id not found"
-msgstr ""
+msgstr "L'ID de la configuration Broker pour ce collecteur n'a pas été trouvé"
 
 #: centreon/www/install/front_translate.php
 msgid "Poller configuration"
 msgstr "Configuration du collecteur"
 
-#: centreon/www/install/front_translate.php
-msgid "Poller/agent configuration"
-msgstr "Configuration collecteur/agent"
-
-#: centreon/www/install/front_translate.php
-msgid "Poller/agent configuration created"
-msgstr "Configuration collecteur/agent créée"
-
-#: centreon/www/install/front_translate.php
-msgid "Poller/agent configuration updated"
-msgstr "Configuration collecteur/agent mise à jour"
-
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/Administration/performance/viewData.php
 #: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Pollers"
 msgstr "Collecteurs"
 
@@ -12009,27 +12297,28 @@ msgstr "Instances de collecte"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Pool size"
-msgstr ""
+msgstr "Taille du pool"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Popup notifications"
 msgstr "Notifications visuelles"
 
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
 #: centreon/www/include/Administration/parameters/remote/formRemote.php
 #: centreon/www/include/Administration/parameters/ldap/form.php
-#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/install/front_translate.php
 msgid "Port"
 msgstr "Port"
 
 #: centreon/www/install/front_translate.php
 msgid "Port number must be at least 1"
-msgstr ""
+msgstr "Le numéro de port doit être au moins 1"
 
 #: centreon/www/install/front_translate.php
 msgid "Port number must be at most 65535"
 msgstr "Le numéro du port ne doit pas excéder 65535"
 
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
 #: centreon/www/include/options/session/connected_user.php
 msgid "Position"
 msgstr "Position"
@@ -12038,11 +12327,11 @@ msgstr "Position"
 msgid "Posix"
 msgstr "Posix"
 
-#: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configResources/formResources.php
 msgid "Post Validation"
-msgstr "Post Validation"
+msgstr "Post-validation"
 
 #: centreon/www/include/configuration/configGenerate/xml/postcommand.php
 msgid "Post execution command results"
@@ -12066,7 +12355,7 @@ msgstr "Commande pré-traitement"
 
 #: centreon/www/install/front_translate.php
 msgid "Predefined rows selection menu"
-msgstr ""
+msgstr "Sélectionner le nombre de lignes à afficher"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Predictive Host Dependency Checks"
@@ -12096,9 +12385,9 @@ msgstr "Appuyer sur Entrée pour accepter"
 msgid "Previous"
 msgstr "Précédent"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/common/pagination.php
 #: centreon/www/include/configuration/configKnowledge/pagination.php
+#: centreon/www/install/front_translate.php
 msgid "Previous page"
 msgstr "Page précédente"
 
@@ -12122,10 +12411,6 @@ msgstr "Afficher la valeur minimale"
 msgid "Print Total Value"
 msgstr "Afficher la valeur totale"
 
-#: centreon/www/install/front_translate.php
-msgid "Private key"
-msgstr "Clé privée"
-
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Private key file."
 msgstr "Clé privée SSH."
@@ -12134,16 +12419,24 @@ msgstr "Clé privée SSH."
 msgid "Private key path"
 msgstr "Chemin de la clé privée"
 
+#: centreon/www/install/front_translate.php
+msgid "Private key(.key)"
+msgstr "Clé privée(.key)"
+
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Problem display properties"
-msgstr "Propriétés des problèmes d'affichage"
+msgstr "Propriétés d'affichage des problèmes"
 
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "Problem has been acknowledged"
+msgstr "Le problème a été acquitté"
+
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
 msgid "Problems"
 msgstr "Problèmes"
 
@@ -12151,8 +12444,8 @@ msgstr "Problèmes"
 msgid "Process"
 msgstr "Processus"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 msgid "Process Perf Data"
 msgstr "Traitement des données de performance"
 
@@ -12173,7 +12466,6 @@ msgid "Project leaders"
 msgstr "Responsables du projet"
 
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
-#: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 msgid "Properties"
 msgstr "Propriétés"
@@ -12191,11 +12483,11 @@ msgstr "Version du protocole"
 #: centreon/src/Security/Domain/Authentication/Exceptions/ProviderException.php
 #, php-format
 msgid "Provider configuration (%s) not found"
-msgstr ""
+msgstr "La configuration du fournisseur (%s) n'a pas été trouvée"
 
 #: centreon/src/Security/Domain/Authentication/Exceptions/ProviderException.php
 msgid "Provider not found"
-msgstr ""
+msgstr "Le fournisseur n'a pas été trouvé"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Proxy URL"
@@ -12207,7 +12499,7 @@ msgstr "Paramètres du proxy internet"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Proxy password"
-msgstr ""
+msgstr "Mot de passe pour le proxy"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Proxy port"
@@ -12215,16 +12507,19 @@ msgstr "Port d'accès au proxy internet"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Proxy user"
-msgstr ""
+msgstr "Utilisateur pour le proxy"
 
 #: centreon/www/include/home/customViews/index.php
 msgid "Public"
 msgstr "Public"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Public certificate"
-msgstr "Certificat public"
+msgstr ""
+
+#: centreon/www/install/front_translate.php
+msgid "Public certificate(.crt,.cer)"
+msgstr "Certificat public(.crt,cer)"
 
 #: centreon/www/include/home/customViews/formLoad.php
 msgid "Public views list"
@@ -12268,7 +12563,7 @@ msgstr "Rétention des fichiers RRD"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "RRDCacheD listening socket/port"
-msgstr ""
+msgstr "Port/socket d'écoute pour RRDCacheD"
 
 #: centreon/www/install/menu_translation.php
 msgid "RRDTool"
@@ -12326,9 +12621,25 @@ msgstr "Accès à l'API de temps réel"
 msgid "Reach Centreon Front-end"
 msgstr "Autoriser l'utilisateur à se connecter à l'interface web"
 
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Read Only"
+msgstr "Lecture seulement"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Read/Write"
+msgstr "Lecture/Ecriture"
+
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Real-Time"
 msgstr "Temps réel"
+
+#: centreon/www/include/Administration/performance/viewData.php
+msgid "Rebuild RRD Database"
+msgstr "Regénérer les bases de données RRD"
+
+#: centreon/www/include/Administration/performance/viewData.php
+msgid "Rebuild Waiting"
+msgstr "En attente de reconstruction"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Rebuild check interval in seconds"
@@ -12336,13 +12647,14 @@ msgstr ""
 "Intervalle de contrôle des demandes de reconstruction des graphiques de "
 "performance"
 
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Recovery"
 msgstr "Récupération"
 
@@ -12350,10 +12662,10 @@ msgstr "Récupération"
 msgid "Recovery Step"
 msgstr "Etape de récuperation"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Recovery notification delay"
 msgstr "Délai de première notification de recouvrement"
 
@@ -12367,10 +12679,10 @@ msgstr "URL de redirection"
 
 #: centreon/www/install/front_translate.php
 msgid "Redo"
-msgstr ""
+msgstr "Rétablir"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/install/front_translate.php
 msgid "Refresh"
 msgstr "Actualiser"
 
@@ -12402,8 +12714,8 @@ msgstr "L'intervalle de rafraîchissement doit être un nombre"
 msgid "Regexp"
 msgstr "Expression régulière"
 
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 msgid "Regular"
 msgstr "Ordinaire"
 
@@ -12414,20 +12726,20 @@ msgstr "Activation de la gestion des expressions rationnelles"
 #: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 msgid "Relation"
-msgstr ""
+msgstr "Relation"
 
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/install/smarty_translate.php
 msgid "Relations"
 msgstr "Relations"
 
@@ -12439,11 +12751,12 @@ msgstr "Les chemins relatifs ne sont pas autorisés"
 msgid "Release notes"
 msgstr "Notes de version"
 
-#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
 #: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
 msgid "Reload"
 msgstr "Recharger"
 
+#: centreon/www/include/options/accessLists/reloadACL/reloadACL.php
 #: centreon/www/install/menu_translation.php
 msgid "Reload ACL"
 msgstr "Recharger les ACL"
@@ -12455,15 +12768,15 @@ msgstr "Erreur de rechargement sur le serveur de supervision #%d : %s"
 
 #: centreon/www/include/configuration/configServers/listServers.php
 msgid "Remote Server"
-msgstr ""
+msgstr "Serveur distant"
 
-#: centreon/www/install/react_translation.php
 #: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/install/react_translation.php
 msgid "Remote Server Configuration"
 msgstr "Configuration du serveur distant"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/install/menu_translation.php
 msgid "Remote access"
 msgstr "Accès du Remote"
 
@@ -12483,16 +12796,17 @@ msgstr "URL de connexion distante"
 msgid "Remote user"
 msgstr "Utilisateurs"
 
-#: centreon/www/class/centreonConfigCentreonBroker.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/class/centreonConfigCentreonBroker.php
 msgid "Remove"
 msgstr "Supprimer"
 
 #: centreon/www/widgets/host-monitoring/src/toolbar.php
 msgid "Remove Acknowledgement"
-msgstr ""
+msgstr "Supprimer l'acquittement"
 
 #: centreon/www/install/front_translate.php
 msgid "Remove from favorites"
@@ -12510,11 +12824,12 @@ msgstr "Supprimé"
 msgid "Rename"
 msgstr "Renommer"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Replacement"
 msgstr "Remplacement"
 
@@ -12533,7 +12848,7 @@ msgstr "Période de génération"
 #: centreon/src/Centreon/Infrastructure/Service/CentreonPaginationService.php
 #, php-format
 msgid "Repository class %s has to implement %s"
-msgstr ""
+msgstr "Le référentiel %s doit implémenter %s"
 
 #: centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/Exception/MonitoringServerConfigurationRepositoryException.php
 #, php-format
@@ -12543,7 +12858,7 @@ msgstr "La requête a échoué (%d)"
 #: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
 msgid "Request for authentication conditions custom endpoint has failed"
 msgstr ""
-"La demande d'endpoint personnalisé  de conditions d'authentification a échoué"
+"La demande d'endpoint personnalisé de conditions d'authentification a échoué"
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
 msgid "Request for connection token to external provider has failed"
@@ -12564,7 +12879,7 @@ msgstr "La demande d'information utilisateur à un fournisseur externe a échou�
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
 msgid "Request on custom endpoint failed"
-msgstr ""
+msgstr "Échec de la requête sur l'endpoint personnalisé"
 
 #: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/Exception/PlatformTopologyRepositoryException.php
 msgid "Request to the Central's API failed"
@@ -12576,82 +12891,85 @@ msgstr "Contexte d'authentification requis"
 
 #: centreon/src/Core/Application/Configuration/User/UseCase/PatchUser/PatchUser.php
 msgid "Requested theme not found"
-msgstr ""
+msgstr "Le thème demandé n'a pas été trouvé"
 
 #: centreon/src/Core/Application/Configuration/User/UseCase/PatchUser/PatchUser.php
 msgid "Requested user interface view mode not handled"
 msgstr ""
+"Le mode d'affichage demandé pour l'interface utilisateur n'est pas supporté"
 
-#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 #: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Requester"
 msgstr "Collecteur"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/install/front_translate.php
 msgid "Required"
 msgstr "Requis"
 
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/media/images/formImg.php
-#: centreon/www/include/options/media/images/formDirectory.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/comments/AddComment.php
-#: centreon/www/include/monitoring/comments/AddSvcComment.php
 #: centreon/www/include/monitoring/comments/AddHostComment.php
-#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
 msgid "Required Field"
 msgstr "Champ requis"
 
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 msgid "Required field"
 msgstr "Champ requis"
 
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/configuration/configObject/connector/formConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 #: centreon/www/include/configuration/configResources/formResources.php
 #: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
-#: centreon/www/include/Administration/parameters/remote/formRemote.php
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
 msgid "Required fields"
 msgstr "Champs requis"
 
@@ -12663,65 +12981,66 @@ msgstr "Service requis"
 msgid "Reschedule associated services"
 msgstr "Reprogrammer les services associés"
 
-#: centreon/www/api/class/centreon_home_customview.class.php
-#: centreon/www/install/front_translate.php
+#: centreon/www/include/home/customViews/formLoad.php
+#: centreon/www/include/home/customViews/index.php
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/api/api.php
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/connector/formConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/metric.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 #: centreon/www/include/configuration/configResources/formResources.php
 #: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
-#: centreon/www/include/home/customViews/index.php
-#: centreon/www/include/home/customViews/formLoad.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
 #: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
 #: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 #: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
 #: centreon/www/include/monitoring/submitPassivResults/servicePassiveCheck.php
-#: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
-#: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/comments/AddComment.php
-#: centreon/www/include/monitoring/comments/AddSvcComment.php
 #: centreon/www/include/monitoring/comments/AddHostComment.php
-#: centreon/www/include/Administration/parameters/backup/formBackup.php
-#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
-#: centreon/www/include/Administration/parameters/api/api.php
-#: centreon/www/include/Administration/parameters/remote/formRemote.php
-#: centreon/www/include/Administration/parameters/general/form.php
-#: centreon/www/include/Administration/parameters/rrdtool/form.php
-#: centreon/www/include/Administration/parameters/ldap/form.php
-#: centreon/www/include/Administration/parameters/debug/form.php
-#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
-#: centreon/www/include/Administration/parameters/engine/form.php
-#: centreon/www/include/Administration/parameters/centstorage/form.php
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/api/class/centreon_home_customview.class.php
 msgid "Reset"
 msgstr "Réinitialiser"
 
@@ -12754,18 +13073,22 @@ msgstr "Résoudre"
 msgid "Resource"
 msgstr "Ressource"
 
-#: centreon/www/install/menu_translation.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+msgid "Resource Access"
+msgstr ""
+
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/install/menu_translation.php
 msgid "Resource Access Management"
 msgstr "Gestion de l'accès aux ressources"
 
 #: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
 msgid "Resource Access Rule"
-msgstr ""
+msgstr "Règle d'accès aux ressources"
 
-#: centreon/www/include/configuration/configResources/formResources.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configResources/formResources.php
 msgid "Resource Name"
 msgstr "Nom de la ressource"
 
@@ -12797,10 +13120,11 @@ msgstr "Type de ressource"
 msgid "Resource used by one of the instances"
 msgstr "Ressource utilisée par une des instances"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
 msgid "Resources"
 msgstr "Ressources"
 
@@ -12808,12 +13132,12 @@ msgstr "Ressources"
 msgid "Resources Access"
 msgstr "Gestion des accès aux ressources"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Resources Status"
 msgstr "Statut des ressources"
 
@@ -12833,13 +13157,13 @@ msgstr "Stockage des ressources"
 msgid "Response empty"
 msgstr "Réponse vide"
 
-#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
 #: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
 msgid "Restart"
 msgstr "Redémarrer"
 
-#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
 #: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
 msgid "Restart Monitoring Engine"
 msgstr "Redémarrer l'ordonnanceur"
 
@@ -12855,13 +13179,13 @@ msgstr "Résultat"
 msgid "Resulting Time Period with inclusions"
 msgstr "Période Temporelle résultante avec les inclusions"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Retain Non Status Information"
 msgstr "Rétention des informations ne concernant pas le statut"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Retain Status Information"
 msgstr "Conserver les informations d'état"
 
@@ -12871,41 +13195,47 @@ msgstr "Durée de rétention pour les logs d'actions"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Retention duration for comments"
-msgstr ""
+msgstr "Durée de rétention des commentaires"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Retention duration for downtimes"
-msgstr ""
+msgstr "Durée de rétention des plages de maintenance"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Retention duration for logs"
-msgstr ""
+msgstr "Durée de rétention des journaux"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Retention duration for partitioning"
-msgstr ""
+msgstr "Durée de rétention des partitions"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Retention duration for performance data in MySQL database"
-msgstr ""
+msgstr "Durée de rétention des données de performance dans la base de données"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Retention duration for performance data in RRDTool databases"
 msgstr ""
+"Durée de rétention des données de performance dans les bases de données "
+"RRDTool"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Retention duration for reporting data (Dashboard)"
-msgstr ""
+msgstr "Durée de rétention pour les données de reporting (tableaux de bord)"
 
 #: centreon/www/include/Administration/parameters/centstorage/form.php
 msgid "Retention durations"
 msgstr "Durées de rétention"
 
+#: centreon/www/include/eventLogs/xml/data.php
+msgid "Retry"
+msgstr "Relancer"
+
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Retry Check Interval"
 msgstr "Intervalle non-régulier de contrôle"
 
@@ -12915,15 +13245,7 @@ msgstr "Intervalle entre 2 tentatives"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Retry interval (seconds)"
-msgstr ""
-
-#: centreon/www/include/options/media/images/formImg.php
-msgid "Return to list"
-msgstr "Retourner à la liste"
-
-#: centreon/www/include/options/media/images/formImg.php
-msgid "Review form after save"
-msgstr "Revoir le formulaire après la sauvegarde"
+msgstr "Délai de réessai (en secondes)"
 
 #: centreon/www/install/front_translate.php
 msgid "Revoked"
@@ -12939,7 +13261,7 @@ msgstr "Role ID"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Role Id"
-msgstr ""
+msgstr "ID du rôle"
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/AclConditionsException.php
 msgid "Role mapping conditions do not match"
@@ -12967,7 +13289,7 @@ msgstr "Chemin de la racine"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Root user (default: root)"
-msgstr ""
+msgstr "Utilisateur root (par défaut : root)"
 
 #: centreon/www/install/menu_translation.php
 #: centreon/www/install/smarty_translate.php
@@ -13029,10 +13351,10 @@ msgstr "Configuration SAML sauvegardée"
 msgid "SAML only"
 msgstr "SAML uniquement"
 
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 msgid "SCHEDULED DOWNTIME"
 msgstr "TEMPS EN ARRÊT PLANIFIÉ"
 
@@ -13049,9 +13371,9 @@ msgstr "Communauté SNMP"
 msgid "SNMP Trap Generation"
 msgstr "Génération des traps SNMP"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/install/menu_translation.php
 msgid "SNMP Traps"
 msgstr "Traps SNMP"
 
@@ -13073,11 +13395,11 @@ msgstr "Recherche SQL"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "SSH"
-msgstr ""
+msgstr "SSH"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "SSH Legacy port"
-msgstr ""
+msgstr "Port SSH pour le mode legacy"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "SSL"
@@ -13097,73 +13419,74 @@ msgstr "Configuration du collecteur"
 msgid "Satellites"
 msgstr "Collecteurs"
 
-#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Saturday"
 msgstr "Samedi"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
+#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
+#: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/include/Administration/parameters/debug/form.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/Administration/parameters/api/api.php
+#: centreon/www/include/Administration/parameters/rrdtool/form.php
+#: centreon/www/include/options/media/images/formDirectory.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/connector/formConnector.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
 #: centreon/www/include/configuration/configObject/meta_service/metric.php
 #: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/command/formArguments.php
 #: centreon/www/include/configuration/configObject/command/formCommand.php
 #: centreon/www/include/configuration/configObject/command/formMacros.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 #: centreon/www/include/configuration/configResources/formResources.php
 #: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/media/images/formImg.php
-#: centreon/www/include/options/media/images/formDirectory.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/include/monitoring/submitPassivResults/hostPassiveCheck.php
 #: centreon/www/include/monitoring/submitPassivResults/servicePassiveCheck.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/comments/AddComment.php
-#: centreon/www/include/monitoring/comments/AddSvcComment.php
 #: centreon/www/include/monitoring/comments/AddHostComment.php
-#: centreon/www/include/Administration/parameters/backup/formBackup.php
-#: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
-#: centreon/www/include/Administration/parameters/api/api.php
-#: centreon/www/include/Administration/parameters/remote/formRemote.php
-#: centreon/www/include/Administration/parameters/general/form.php
-#: centreon/www/include/Administration/parameters/rrdtool/form.php
-#: centreon/www/include/Administration/parameters/ldap/form.php
-#: centreon/www/include/Administration/parameters/debug/form.php
-#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
-#: centreon/www/include/Administration/parameters/engine/form.php
-#: centreon/www/include/Administration/parameters/centstorage/form.php
-#: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/monitoring/comments/AddSvcComment.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Save"
 msgstr "Sauvegarder"
 
@@ -13189,7 +13512,7 @@ msgstr "Sauvegardé"
 
 #: centreon/www/install/front_translate.php
 msgid "Saved link"
-msgstr ""
+msgstr "Lien sauvegardé"
 
 #: centreon/www/install/front_translate.php
 msgid "Saving..."
@@ -13199,9 +13522,9 @@ msgstr "En cours de sauvegarde..."
 msgid "Scale Graph Values"
 msgstr "Mise à l'échelle"
 
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 #: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 msgid "Scale of time"
 msgstr "Echelle de temps"
 
@@ -13239,10 +13562,10 @@ msgid "Schedule the check for a host (Forced)"
 msgstr "Planifier la vérification pour un hôte (Forcé)"
 
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 msgid "Scheduled Downtimes"
-msgstr ""
+msgstr "Plages de maintenance programmées"
 
 #: centreon/www/include/reporting/dashboard/initReport.php
 msgid "Scheduled downtime"
@@ -13252,9 +13575,9 @@ msgstr "Plage de maintenance planifiée"
 msgid "Scheduled event information"
 msgstr "Informations sur l'ordonnancement"
 
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
 msgid "Scheduling"
 msgstr "Planification"
 
@@ -13270,45 +13593,47 @@ msgstr "Portées"
 msgid "Scroll to top"
 msgstr "Défiler vers le haut"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
+#: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
-#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
-#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/Administration/parameters/ldap/list.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/listMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/contact/ldapImportContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
 #: centreon/www/include/configuration/configObject/escalation/listEscalation.php
-#: centreon/www/include/configuration/configObject/traps-groups/listGroups.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/listHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/timeperiod/listTimeperiod.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/host_dependency/listHostDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
 #: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/service_dependency/listServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/listServiceGroupDependency.php
 #: centreon/www/include/configuration/configKnowledge/search.php
-#: centreon/www/include/monitoring/downtime/listDowntime.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
 #: centreon/www/include/monitoring/comments/listComment.php
-#: centreon/www/include/Administration/parameters/ldap/list.php
-#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Search"
 msgstr "Rechercher"
 
@@ -13326,7 +13651,7 @@ msgstr "Résultat de la recherche"
 
 #: centreon/www/install/front_translate.php
 msgid "Search bar"
-msgstr ""
+msgstr "Barre de recherche"
 
 #: centreon/www/install/front_translate.php
 msgid "Search contacts"
@@ -13334,7 +13659,7 @@ msgstr "Rechercher des contacts"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Search group base DN"
-msgstr "Base de recherche de groupe DN"
+msgstr "Rechercher la base DN du groupe"
 
 #: centreon/www/install/front_translate.php
 msgid "Search help"
@@ -13350,7 +13675,7 @@ msgstr "Rechercher des groupes de service"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "Search user base DN"
-msgstr "Base de recherche d'utilisateur DN"
+msgstr "Rechercher la base DN utilisateur"
 
 #: centreon/www/install/front_translate.php
 msgid "Second"
@@ -13358,12 +13683,16 @@ msgstr "Seconde"
 
 #: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Second of month"
-msgstr ""
+msgstr "Le deuxième du mois"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+msgid "Secondary Priority Hosts"
+msgstr "Hôtes secondaires"
+
 #: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/install/front_translate.php
 msgid "Seconds"
 msgstr "Secondes"
 
@@ -13373,7 +13702,7 @@ msgstr "Secret ID"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Secret Id"
-msgstr ""
+msgstr "Secret ID"
 
 #: centreon/www/install/front_translate.php
 msgid "Security acknowledgement"
@@ -13382,6 +13711,10 @@ msgstr "Remerciements pour la sécurité"
 #: centreon/www/install/front_translate.php
 msgid "See Documentation"
 msgstr "Voir la documentation"
+
+#: centreon/www/widgets/host-monitoring/src/index.php
+msgid "See Graphs of this host"
+msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "See more information in the geoview"
@@ -13393,7 +13726,7 @@ msgstr "Voir plus dans la page Statut des ressources"
 
 #: centreon/www/install/front_translate.php
 msgid "See more on the {{ page }} page"
-msgstr ""
+msgstr "Plus d'informations à la page {{ page }}"
 
 #: centreon/www/install/front_translate.php
 msgid "Seems that your Apache configuration is not up-to-date"
@@ -13405,7 +13738,7 @@ msgstr "Sélectionnez une IP"
 
 #: centreon/www/install/front_translate.php
 msgid "Select Pending Poller IP"
-msgstr ""
+msgstr "Sélectionner l'IP du collecteur en attente"
 
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
@@ -13422,7 +13755,7 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "Select a Poller"
-msgstr ""
+msgstr "Sélectionner un collecteur"
 
 #: centreon/www/install/front_translate.php
 msgid "Select a Remote Server"
@@ -13438,12 +13771,12 @@ msgstr "Sélectionnez un jeu de données pour afficher l'aperçu."
 
 #: centreon/www/install/front_translate.php
 msgid "Select a server type"
-msgstr ""
+msgstr "Sélectionner un type de serveur"
 
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Select a template"
-msgstr ""
+msgstr "Sélectionner un modèle"
 
 #: centreon/www/install/front_translate.php
 msgid "Select a widget type"
@@ -13464,6 +13797,10 @@ msgstr "Sélectionner les colonnes"
 #: centreon/www/install/front_translate.php
 msgid "Select criterias"
 msgstr "Sélectionner les critères"
+
+#: centreon/www/install/front_translate.php
+msgid "Select existing CMA token"
+msgstr "Sélectionner un jeton CMA existant"
 
 #: centreon/www/install/front_translate.php
 msgid "Select existing CMA token(s)"
@@ -13512,7 +13849,7 @@ msgstr "Sélectionner un format d'heure"
 
 #: centreon/www/install/front_translate.php
 msgid "Select time period"
-msgstr ""
+msgstr "Sélectionner une période temporelle"
 
 #: centreon/www/install/front_translate.php
 msgid "Select time zone"
@@ -13526,9 +13863,10 @@ msgstr "Sélectionner un type"
 msgid "Select users"
 msgstr "Sélectionner les utilisateurs"
 
-#: centreon/www/class/centreonConfigCentreonBroker.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 #: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/class/centreonConfigCentreonBroker.php
 msgid "Selected"
 msgstr "Sélectionné"
 
@@ -13538,7 +13876,7 @@ msgstr "Mode de sélection"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Send anonymous statistics"
-msgstr ""
+msgstr "Envoyer des statistiques anonymisées"
 
 #: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
 msgid "Send signal"
@@ -13585,24 +13923,27 @@ msgstr "Port de connexion"
 
 #: centreon/www/include/configuration/configServers/listServers.php
 msgid "Server type"
-msgstr ""
+msgstr "Type de serveur"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 #: centreon/www/include/configuration/configKnowledge/search.php
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/viewServicesLog.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
-#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/viewServicesLog.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
 #: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Service"
 msgstr "Service"
 
@@ -13610,38 +13951,38 @@ msgstr "Service"
 #: centreon/src/Centreon/Domain/Check/CheckService.php
 #, php-format
 msgid "Service %d (parent: %d) not found"
-msgstr ""
+msgstr "Le service %d (parent : %d) n'a pas été trouvé"
 
+#: centreon/src/Centreon/Application/Controller/Monitoring/MetricController.php
 #: centreon/src/Centreon/Domain/Monitoring/Comment/CommentService.php
 #: centreon/src/Centreon/Domain/Monitoring/SubmitResult/SubmitResultService.php
-#: centreon/src/Centreon/Application/Controller/Monitoring/MetricController.php
 #, php-format
 msgid "Service %d not found"
 msgstr "Service %d non trouvé"
 
-#: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
 #: centreon/src/Centreon/Application/Controller/DowntimeController.php
+#: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
 #, php-format
 msgid "Service %d on host %d not found"
 msgstr "Service %d de l'hôte %d non trouvé"
 
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "Service Acknowledgement"
-msgstr ""
+msgstr "Acquitter un service"
 
 #: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Service Basic Information"
 msgstr "Informations sur le service"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Service Categories"
 msgstr "Catégories de service"
 
 #: centreon/www/install/front_translate.php
 msgid "Service Category"
-msgstr ""
+msgstr "Catégorie de services"
 
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
 msgid "Service Category Filter"
@@ -13651,13 +13992,13 @@ msgstr "Filtrer par catégorie de service"
 msgid "Service Check Execution Option"
 msgstr "Contrôle actif des services"
 
-#: centreon/www/class/centreonGraphPoller.class.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/class/centreonGraphPoller.class.php
 msgid "Service Check Execution Time"
 msgstr "Durée de contrôle du service"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/install/smarty_translate.php
 msgid "Service Check Options"
 msgstr "Options de contrôle des services"
 
@@ -13681,14 +14022,14 @@ msgstr "Commandes du service"
 msgid "Service Configuration"
 msgstr "Configuration du service"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/install/smarty_translate.php
 msgid "Service Description"
 msgstr "Description du service"
 
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "Service Downtime"
-msgstr ""
+msgstr "Plage de maintenance sur un service"
 
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 msgid "Service Extended Info"
@@ -13702,15 +14043,15 @@ msgstr "Intervalle de contrôle de la fraicheur du résultat du service"
 msgid "Service Freshness Check Option"
 msgstr "Option de contrôle de la fraicheur du résultat du service"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 #: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
+#: centreon/www/install/front_translate.php
 msgid "Service Group"
 msgstr "Groupe de services"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/install/menu_translation.php
 msgid "Service Groups"
 msgstr "Groupes de services"
 
@@ -13727,14 +14068,17 @@ msgid "Service List"
 msgstr "Sélectionner les services manuellement"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Service Notification Commands"
 msgstr "Commandes de notification de service"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Service Notification Options"
 msgstr "Options de notifications de service"
 
 #: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
 msgid "Service Notification Period"
 msgstr "Période de notification de service"
 
@@ -13758,14 +14102,14 @@ msgstr "Options d'ordonnancement des services"
 msgid "Service Shortcuts"
 msgstr "Raccourcis de service"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Service State"
-msgstr "Etat du service"
+msgstr "État du service"
 
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 #: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/smarty_translate.php
 msgid "Service Status"
 msgstr "Statut du service"
 
@@ -13777,8 +14121,8 @@ msgstr "Modèle de service"
 msgid "Service Templates"
 msgstr "Modèle de service"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 msgid "Service Trap Relation"
 msgstr "Traps SNMP reliés au service"
 
@@ -13790,8 +14134,8 @@ msgstr "Catégorie de service"
 msgid "Service category name already exists"
 msgstr "Ce nom de catégorie de services existe déjà"
 
-#: centreon/www/class/centreonGraphPoller.class.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/class/centreonGraphPoller.class.php
 msgid "Service check latency"
 msgstr "Latence du contrôle du service"
 
@@ -13803,8 +14147,8 @@ msgstr "Dépendance de service"
 msgid "Service description cannot be empty"
 msgstr "La description du service ne peut pas être vide"
 
-#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 #: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 msgid "Service escalations"
 msgstr "Escalades de service"
 
@@ -13818,17 +14162,21 @@ msgstr "Groupe de services"
 
 #: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
 msgid "Service group state"
-msgstr "Etat du groupe de services"
+msgstr "État du groupe de services"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/front_translate.php
 msgid "Service groups"
 msgstr "Groupes de services"
 
 #: centreon/src/Centreon/Domain/Monitoring/Exception/MonitoringServiceException.php
 msgid "Service id cannot be null"
 msgstr "L'id du service ne peut pas être nul"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "Service is currently on Downtime"
+msgstr "Le service est actuellement en période d'arrêt"
 
 #: centreon/www/include/configuration/configObject/command/listCommand.php
 msgid "Service links (service template links)"
@@ -13838,21 +14186,21 @@ msgstr "Modèles de services liés"
 msgid "Service name"
 msgstr "Nom du service"
 
-#: centreon/www/api/class/centreon_monitoring_externalcmd.class.php
+#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
 #: centreon/src/Centreon/Domain/Acknowledgement/AcknowledgementService.php
 #: centreon/src/Centreon/Domain/Check/CheckService.php
-#: centreon/src/Centreon/Domain/Downtime/DowntimeService.php
+#: centreon/www/api/class/centreon_monitoring_externalcmd.class.php
 msgid "Service not found"
 msgstr "Service non trouvé"
 
-#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 #: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
 msgid "Service notifications"
 msgstr "Notifications de service"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/install/front_translate.php
 msgid "Service severity"
 msgstr "Criticité du service"
 
@@ -13866,12 +14214,12 @@ msgstr "Ce nom de sévérité de services existe déjà"
 
 #: centreon/www/include/reporting/dashboard/viewServicesLog.php
 msgid "Service state"
-msgstr "Etat du service"
+msgstr "État du service"
 
-#: centreon/www/class/centreonGraphPoller.class.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/class/centreonGraphPoller.class.php
 msgid "Service status"
-msgstr "Etat du service"
+msgstr "Statut du service"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Service template"
@@ -13879,49 +14227,49 @@ msgstr "Modèle de service"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Service: Acknowledge"
-msgstr ""
+msgstr "Service : acquitter"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Service: Disable Check"
-msgstr ""
+msgstr "Service : désactiver les contrôles"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Service: Disable Notification"
-msgstr ""
+msgstr "Service : désactiver les notifications"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Service: Enable Check"
-msgstr ""
+msgstr "Service : activer les contrôles"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Service: Enable Notification"
-msgstr ""
+msgstr "Service : activer les notifications"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Service: Remove Acknowledgement"
-msgstr ""
+msgstr "Service : désacquitter"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Service: Schedule Immediate Check"
-msgstr ""
+msgstr "Service : lancer un contrôle immédiatement"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Service: Schedule Immediate Forced Check"
-msgstr ""
+msgstr "Service : lancer un contrôle forcé immédiatement"
 
 #: centreon/www/widgets/service-monitoring/src/toolbar.php
 msgid "Service: Set Downtime"
-msgstr ""
+msgstr "Service : définir une plage de maintenance"
 
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
 msgid "ServiceGroup"
 msgstr "Groupe de services"
 
 #: centreon/www/include/configuration/configKnowledge/search.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 msgid "Servicegroup"
 msgstr "Groupes de services"
 
@@ -13934,74 +14282,76 @@ msgstr "Dépendance de groupe de services"
 msgid "Servicegroups"
 msgstr "Groupes de services"
 
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySGJS.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySGJS.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySGJS.php
 msgid "Servicegroups / Hosts"
 msgstr "Groupes de services / Hôtes"
 
 #: centreon/www/widgets/global-health/src/global_health.php
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/Administration/performance/viewData.php
+#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configObject/contact/displayNotification.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/contact/displayNotification.php
+#: centreon/www/include/configuration/configObject/contactgroup/displayNotification.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configKnowledge/display-services.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/xml/serviceGridByHGXML.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceGridBySGXML.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/xml/serviceSummaryBySGXML.php
-#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/comments/AddComment.php
 #: centreon/www/include/monitoring/comments/AddSvcComment.php
-#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
+#: centreon/www/install/smarty_translate.php
 msgid "Services"
 msgstr "Services"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 msgid "Services : Acknowledge"
 msgstr "Services : Acquitter"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 msgid "Services : Disable Check"
 msgstr "Services : Désactiver la vérification"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 msgid "Services : Disable Notification"
 msgstr "Services : Désactiver la notification"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 msgid "Services : Disacknowledge"
 msgstr "Services : Dés-acquitter"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 msgid "Services : Enable Check"
 msgstr "Services : Activer la vérification"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 msgid "Services : Enable Notification"
 msgstr "Services : Activer la notification"
 
@@ -14021,14 +14371,18 @@ msgstr "Services : Ajouter une plage de maintenance"
 msgid "Services Actions Access"
 msgstr "Accès aux actions sur les services"
 
-#: centreon/www/class/centreonGraphPoller.class.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/class/centreonGraphPoller.class.php
 msgid "Services Actively Checked"
 msgstr "Services actuellement contrôlés"
 
 #: centreon/www/include/monitoring/comments/listComment.php
 msgid "Services Comments"
 msgstr "Commentaires sur les services"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "Services Downtimes"
+msgstr "Plages de maintenance des services"
 
 #: centreon/www/include/configuration/configObject/escalation/formEscalation.php
 msgid "Services Escalation Options"
@@ -14038,8 +14392,8 @@ msgstr "Options d'escalade des services"
 msgid "Services Grid"
 msgstr "Regroupement par hôte"
 
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 msgid "Services Notification Period"
 msgstr "Périodes de notification de service"
 
@@ -14075,15 +14429,15 @@ msgstr "Services par hôte"
 msgid "Services by host group"
 msgstr "Services par groupe d'hôtes"
 
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHGJS.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHGJS.php
-#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
 #: centreon/www/include/monitoring/status/Services/serviceSummaryJS.php
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHGJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHGJS.php
 msgid "Services information"
 msgstr "Informations sur les services"
 
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySGJS.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySGJS.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySGJS.php
 msgid "Services informations"
 msgstr "Informations sur les services"
 
@@ -14096,7 +14450,7 @@ msgstr ""
 
 #: centreon/www/api/class/centreon_keepalive.class.php
 msgid "Session is expired"
-msgstr ""
+msgstr "La session a expiré"
 
 #: centreon/www/install/menu_translation.php
 msgid "Sessions"
@@ -14112,13 +14466,13 @@ msgstr "Propriétés des sessions"
 
 #: centreon/www/install/menu_translation.php
 msgid "Set Default"
-msgstr ""
+msgstr "Définir comme vue par défaut"
 
-#: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/host-monitoring/src/toolbar.php
+#: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "Set Downtime"
-msgstr ""
+msgstr "Définir une plage de maintenance"
 
 #: centreon/www/include/Administration/performance/viewMetrics.php
 msgid "Set RRD Data Source Type to ABSOLUTE"
@@ -14140,8 +14494,8 @@ msgstr "Fixer le type de source de données RRD à GAUGE"
 msgid "Set default"
 msgstr "Configurer par défaut"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/install/front_translate.php
 msgid "Set downtime"
 msgstr "Planifier une maintenance"
 
@@ -14160,29 +14514,29 @@ msgstr "Programmer une plage de maintenance sur les services attachés à l'hôt
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
 msgid "Set downtime on services of hosts"
-msgstr ""
+msgstr "Définir une plage de maintenance sur les services de ces hôtes"
 
 #: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 msgid "Set downtimes"
 msgstr "Configurer des plages de maintenance"
 
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 #: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 msgid "Set downtimes on services attached to hosts"
 msgstr "Fixer des plages de maintenance aux services attachés aux hôtes"
 
-#: centreon/www/install/step_upgrade/step2.php
 #: centreon/src/CentreonLegacy/Core/Install/Step/Step2.php
+#: centreon/www/install/step_upgrade/step2.php
 msgid "Set the default timezone in php.ini file"
 msgstr "Définir le fuseau horaire par défaut dans le fichier php.ini"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Set this view as your default view"
-msgstr "Configurer cette vue comme celle par défaut ?"
+msgstr "Configurer cette vue comme celle par défaut"
 
 #: centreon/www/include/home/customViews/index.php
 msgid "Set this view as your default view?"
-msgstr "Configurer cette vue comme celle par défaut?"
+msgstr "Configurer cette vue comme celle par défaut ?"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Setting up basic configuration"
@@ -14196,33 +14550,33 @@ msgstr "Installation des fichiers de configurations"
 msgid "Settings"
 msgstr "Paramètres"
 
-#: centreon/www/install/front_translate.php
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
 #: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
-#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/install/front_translate.php
 msgid "Severity"
 msgstr "Criticité"
 
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 #: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
 msgid "Severity type"
 msgstr "Type de criticité"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/home/customViews/index.php
+#: centreon/www/install/front_translate.php
 msgid "Share"
 msgstr "Partage"
 
 #: centreon/www/install/menu_translation.php
 msgid "Share View"
-msgstr ""
+msgstr "Partager la vue"
 
 #: centreon/www/install/front_translate.php
 msgid "Share the dashboard"
-msgstr ""
+msgstr "Partager le tableau de bord"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Share view"
@@ -14331,7 +14685,7 @@ msgstr "Taille max"
 
 #: centreon/www/install/front_translate.php
 msgid "Slider"
-msgstr ""
+msgstr "Glissière"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Snmp Traps"
@@ -14357,12 +14711,12 @@ msgstr "Vérification des dépendances de service"
 #: centreon/www/install/react_translation.php
 msgid "Some database poller updates are not active; check your configuration"
 msgstr ""
-"Certains collecteurs ne sont pas à jour en base de données; vérifiez votre "
+"Certains collecteurs ne sont pas à jour en base de données ; vérifiez votre "
 "configuration"
 
 #: centreon/www/install/front_translate.php
 msgid "Some examples:"
-msgstr "Quelques exemples:"
+msgstr "Quelques exemples :"
 
 #: centreon/www/include/configuration/configObject/command/formArguments.php
 msgid "Sorry, your command line does not contain any $ARGn$ macro."
@@ -14378,7 +14732,7 @@ msgstr ""
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Sort by  "
-msgstr "Trier par"
+msgstr "Trier par  "
 
 #: centreon/www/include/monitoring/status/Services/serviceGridJS.php
 msgid "Sort by Host Name"
@@ -14430,13 +14784,13 @@ msgstr "Trier par statut"
 msgid "Sort problems by"
 msgstr "Trier les problèmes par"
 
-#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
 #: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
 msgid "Sort results (ascendant)"
 msgstr "Trier les résultats (ascendant)"
 
-#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
 #: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
 msgid "Sort results (descendant)"
 msgstr "Trier les résultats (descendant)"
 
@@ -14480,8 +14834,8 @@ msgstr "Notifications sonores"
 msgid "Special Command"
 msgstr "Commande spéciale"
 
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Specific date"
 msgstr "Date spécifique"
 
@@ -14491,7 +14845,7 @@ msgstr "Séparer les courbes"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Split chart"
-msgstr ""
+msgstr "Un graphique par métrique"
 
 #: centreon/www/include/views/componentTemplates/formComponentTemplate.php
 msgid "Stack"
@@ -14505,16 +14859,16 @@ msgstr "Empilée"
 msgid "Stacking"
 msgstr "Empiler"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 msgid "Stalking Options"
 msgstr "Options à enregistrer"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateFactoryException.php
 #, php-format
 msgid "Stalking options not allowed (%s)"
-msgstr ""
+msgstr "Options de stalking non autorisées (%s)"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
@@ -14522,10 +14876,10 @@ msgstr ""
 msgid "Start"
 msgstr "Début"
 
-#: centreon/www/install/smarty_translate.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
 #: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_downtime.php
+#: centreon/www/install/smarty_translate.php
 msgid "Start Time"
 msgstr "Début"
 
@@ -14541,11 +14895,11 @@ msgstr "Heure de début"
 msgid "Started"
 msgstr "Démarré"
 
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
-#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
 msgid "State"
 msgstr "État"
 
@@ -14561,10 +14915,10 @@ msgstr "Fichier de rétention des états"
 msgid "State Retention Option"
 msgstr "Rétention d'états"
 
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 msgid "State Type"
 msgstr "Type d'état"
 
@@ -14580,91 +14934,93 @@ msgstr "Information de l'état"
 msgid "States Retention"
 msgstr "Rétention des états"
 
-#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 #: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Statistics"
 msgstr "Activer les statistiques"
 
-#: centreon/www/install/step_upgrade/step4.php
-#: centreon/www/install/step_upgrade/step2.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
-#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
-#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
-#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
-#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
-#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
-#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
-#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
-#: centreon/www/include/configuration/configObject/meta_service/metric.php
-#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
-#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
-#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
-#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
-#: centreon/www/include/configuration/configObject/command/formCommand.php
-#: centreon/www/include/configuration/configResources/listResources.php
-#: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/configuration/configKnowledge/display-services.php
-#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
-#: centreon/www/include/configuration/configKnowledge/display-hosts.php
-#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
-#: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/listNagios.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
-#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
-#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
-#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
-#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySGJS.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHGJS.php
-#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
-#: centreon/www/include/monitoring/status/Services/serviceJS.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/serviceSummaryJS.php
-#: centreon/www/include/monitoring/status/Services/service.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
-#: centreon/www/include/monitoring/status/Hosts/hostJS.php
-#: centreon/www/include/monitoring/status/Hosts/host.php
-#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
 #: centreon/www/include/Administration/parameters/general/form.php
 #: centreon/www/include/Administration/parameters/ldap/list.php
-#: centreon/www/include/Administration/brokerPerformance/brokerPerformance.php
-#: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/options/accessLists/groupsACL/listGroupConfig.php
+#: centreon/www/include/options/accessLists/groupsACL/formGroupConfig.php
+#: centreon/www/include/options/accessLists/actionsACL/listsActionsAccess.php
+#: centreon/www/include/options/accessLists/actionsACL/formActionsAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+#: centreon/www/include/options/accessLists/menusACL/listsMenusAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configNagios/listNagios.php
+#: centreon/www/include/configuration/configCentreonBroker/listCentreonBroker.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configObject/hostgroup/listHostGroup.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_categories/formServiceCategories.php
+#: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/contactgroup/listContactGroup.php
+#: centreon/www/include/configuration/configObject/contactgroup/formContactGroup.php
+#: centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/meta_service/metric.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetric.php
+#: centreon/www/include/configuration/configObject/meta_service/listMetaService.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+#: centreon/www/include/configuration/configObject/command/formCommand.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/servicegroup/listServiceGroup.php
+#: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configResources/formResources.php
+#: centreon/www/include/configuration/configResources/listResources.php
+#: centreon/www/include/configuration/configGenerateTraps/formGenerateTraps.php
+#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySGJS.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/Services/serviceSummaryJS.php
+#: centreon/www/include/monitoring/status/Services/serviceGridJS.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
+#: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHGJS.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step2.php
+#: centreon/www/install/step_upgrade/step4.php
 msgid "Status"
 msgstr "Statut"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/menu_translation.php
 msgid "Status Details"
 msgstr "Détails des statuts"
 
@@ -14676,8 +15032,8 @@ msgstr "Intervalle de mise à jour du fichier des statuts"
 msgid "Status Graph"
 msgstr "Graphique des statuts"
 
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "Status Information"
 msgstr "Statut détaillé"
 
@@ -14692,26 +15048,26 @@ msgstr "Pourcentage de changement de statut"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Status column"
-msgstr ""
+msgstr "Colonne contenant les statuts"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Status file"
 msgstr "Fichier d'état"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceJS.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/service.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
-#: centreon/www/include/monitoring/status/Hosts/hostJS.php
-#: centreon/www/include/monitoring/status/Hosts/host.php
-#: centreon/www/include/monitoring/status/HostGroups/hostGroup.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/install/front_translate.php
 msgid "Status information"
 msgstr "Statut détaillé"
 
@@ -14722,7 +15078,7 @@ msgstr "Nom du statut"
 #: centreon/src/Centreon/Domain/Monitoring/SubmitResult/SubmitResult.php
 #, php-format
 msgid "Status provided %d is invalid"
-msgstr ""
+msgstr "Le statut %d est invalide"
 
 #: centreon/www/install/front_translate.php
 msgid "Status submitted"
@@ -14730,7 +15086,7 @@ msgstr "Statut soumis"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Status timeseries"
-msgstr ""
+msgstr "Séries chronologiques des statuts"
 
 #: centreon/www/install/front_translate.php
 msgid "Status type"
@@ -14744,24 +15100,29 @@ msgstr "Statut :"
 msgid "Stay"
 msgstr "Rester"
 
-#: centreon/www/install/step_upgrade/step4.php
 #: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step4.php
 msgid "Step"
 msgstr "Étape"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/include/Administration/parameters/engine/form.php
 #: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
 #: centreon/www/include/monitoring/acknowlegement/hostAcknowledge.php
-#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/external_cmd/popup/massive_ack.php
+#: centreon/www/install/front_translate.php
 msgid "Sticky"
-msgstr ""
+msgstr "Sticky"
 
 #: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/Administration/performance/viewData.php
 msgid "Stop hiding graphs of selected Services"
 msgstr "Ne plus cacher les graphiques des services sélectionnés"
+
+#: centreon/www/include/Administration/performance/viewData.php
+msgid "Stop rebuilding RRD Databases"
+msgstr "Arrêter la regénération des bases de données RRD"
 
 #: centreon/www/install/front_translate.php
 msgid "Stop sharing"
@@ -14790,6 +15151,10 @@ msgstr "Type de base de données"
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Storage DB user"
 msgstr "Utilisateur ayant accès à la base de données"
+
+#: centreon/www/include/Administration/performance/viewData.php
+msgid "Storage Type"
+msgstr "Type de sauvegarde"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Storage database"
@@ -14823,9 +15188,9 @@ msgstr "Fort"
 msgid "Subject"
 msgstr "Sujet"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/home/customViews/index.php
 #: centreon/www/include/home/customViews/formLoad.php
+#: centreon/www/include/home/customViews/index.php
+#: centreon/www/install/front_translate.php
 msgid "Submit"
 msgstr "Soumettre"
 
@@ -14864,20 +15229,20 @@ msgstr "Soumettre un résultat pour ce service"
 msgid "Sum"
 msgstr "Somme"
 
-#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
+#: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceGridBySG.php
+#: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceGridByHG.php
 #: centreon/www/include/monitoring/status/ServicesHostGroups/serviceSummaryByHG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
-#: centreon/www/include/monitoring/status/Services/serviceGrid.php
 msgid "Summary"
 msgstr "Résumé"
 
-#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Sunday"
 msgstr "Dimanche"
 
@@ -14897,8 +15262,8 @@ msgstr "Basculer vers le mode liste"
 msgid "Synchronization Options"
 msgstr "Options de Synchronisation"
 
-#: centreon/www/include/configuration/configObject/contact/listContact.php
 #: centreon/www/include/options/session/connected_user.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
 msgid "Synchronize LDAP"
 msgstr "Synchroniser avec le LDAP"
 
@@ -14908,7 +15273,7 @@ msgstr "Synchroniser le répertoire des images"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Syslog"
-msgstr ""
+msgstr "Syslog"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Syslog Logging Option"
@@ -14918,14 +15283,14 @@ msgstr "Journalisation syslog"
 msgid "System Logs"
 msgstr "Evenements liés à la collecte des données"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/install/front_translate.php
 msgid "TLS"
 msgstr "TLS"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "TLS Host name"
-msgstr ""
+msgstr "Nom d'hôte pour TLS"
 
 #: centreon/www/include/Administration/parameters/engine/form.php
 msgid "Tactical Overview"
@@ -14933,17 +15298,18 @@ msgstr "Vue d'ensemble"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Tag"
-msgstr ""
+msgstr "Tag"
 
-#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configKnowledge/display-services.php
-#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
-#: centreon/www/include/configuration/configKnowledge/display-hosts.php
-#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
 #: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
+#: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
+#: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
 msgid "Template"
 msgstr "Modèle"
 
@@ -14952,10 +15318,10 @@ msgstr "Modèle"
 msgid "Template Name"
 msgstr "Nom du modèle"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Template inheritance"
 msgstr "Hérité depuis un modèle"
 
@@ -14964,13 +15330,14 @@ msgstr "Hérité depuis un modèle"
 msgid "Template name is already in use"
 msgstr "Ce nom de modèle est déjà utilisé"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHostGroup.php
 #: centreon/www/include/configuration/configObject/service/listServiceByHost.php
+#: centreon/www/include/configuration/configObject/host_template_model/listHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/listHost.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/listServiceTemplateModel.php
+#: centreon/www/install/menu_translation.php
 msgid "Templates"
 msgstr "Modèles"
 
@@ -14987,10 +15354,10 @@ msgid "Text"
 msgstr "Texte"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
-#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
-#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 #: centreon/src/Core/Host/Application/Exception/HostException.php
+#: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
 #, php-format
 msgid "The %s does not exist with ID(s) '%s'"
 msgstr "Le champ %s n'existe pas avec le(s) ID(s) '%s'"
@@ -14998,14 +15365,14 @@ msgstr "Le champ %s n'existe pas avec le(s) ID(s) '%s'"
 #: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
 #, php-format
 msgid "The %s does not exist with id(s) '%s'"
-msgstr ""
+msgstr "L'objet %s avec l'identifiant '%s' n'existe pas"
 
-#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
-#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
 #: centreon/src/Core/Broker/Application/Exception/BrokerException.php
-#: centreon/src/Core/Host/Application/Exception/HostException.php
 #: centreon/src/Core/Service/Application/Exception/ServiceException.php
+#: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
+#: centreon/src/Core/Host/Application/Exception/HostException.php
 #: centreon/src/Core/Command/Application/Exception/CommandException.php
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
 #, php-format
 msgid "The %s with value '%d' does not exist"
 msgstr "Le champ %s avec la valeur '%d' n'existe pas"
@@ -15025,16 +15392,20 @@ msgstr "L'adresse IP est déjà enregistrée sur un autre collecteur"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "The IP address is incorrect"
-msgstr ""
+msgstr "L'adresse IP est incorrecte"
 
 #: centreon/src/Centreon/Domain/Service/JsonValidator/Validator.php
 msgid "The JSON cannot be decoded"
-msgstr ""
+msgstr "La réponse au format JSON ne peut pas être décodée"
 
 #: centreon/www/install/step_upgrade/step4.php
 #, php-format
 msgid "The SQL files are located in \"%s\""
-msgstr ""
+msgstr "Les fichiers SQL sont situés dans \"%s\""
+
+#: centreon/www/widgets/httploader/index.php
+msgid "The URL provided for the website does not use a valid URL pattern."
+msgstr "L'URL fournie pour le site web n'utilise pas un modèle d'URL valide."
 
 #: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
 #, php-format
@@ -15069,6 +15440,10 @@ msgstr ""
 #: centreon/src/Centreon/Domain/Entity/EntityCreator.php
 #, php-format
 msgid "The class %s does not exist"
+msgstr "La classe %s n'existe pas"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The command format is invalid"
 msgstr ""
 
 #: centreon/src/Centreon/Domain/Engine/EngineService.php
@@ -15079,26 +15454,31 @@ msgstr "L'alias du contact est vide"
 #, php-format
 msgid "The contact groups [%s] are not in your contact groups"
 msgstr ""
+"Les groupes de contacts [%s] n'appartiennent pas à vos groupes de contacts"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 #, php-format
 msgid "The contact groups [%s] do not exist"
-msgstr ""
+msgstr "Les groupes de contacts suivants n'existent pas : [%s]"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 #, php-format
 msgid "The contact groups [%s] do not have any dashboard Access rights"
 msgstr ""
+"Les groupes de contacts suivants n'ont pas le droit d'accéder aux tableaux "
+"de bord : [%s]"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 #, php-format
 msgid "The contacts [%s] do not exist"
-msgstr ""
+msgstr "Les contacts suivants n'existent pas : [%s]"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 #, php-format
 msgid "The contacts [%s] do not have any dashboard Access rights"
 msgstr ""
+"Les contacts suivants n'ont pas le droit d'accéder aux tableaux de bord : "
+"[%s]"
 
 #: centreon/www/install/front_translate.php
 msgid "The corresponding connectors will not work anymore."
@@ -15107,12 +15487,12 @@ msgstr "Les connecteurs correspondants ne fonctionneront plus."
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 #, php-format
 msgid "The dashboard [%d] does not exist"
-msgstr ""
+msgstr "Le tableau de bord [%d] n'existe pas"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 #, php-format
 msgid "The dashboard [%d] is already set as favorite"
-msgstr ""
+msgstr "Le tableau de bord [%d] a déjà été ajouté aux favoris"
 
 #: centreon/www/install/front_translate.php
 msgid "The dashboard has been added to your favorites."
@@ -15133,11 +15513,12 @@ msgstr ""
 msgid ""
 "The definition model \"%s\" to validate the JSON does not exist or is empty"
 msgstr ""
+"Le modèle de définition \"%s\" pour valider le JSON n'existe pas ou est vide"
 
 #: centreon/src/Centreon/Domain/Engine/EngineService.php
 #, php-format
 msgid "The description of service (id: %d) can not be empty"
-msgstr "La description du service (id: %d) ne peut pas être vide"
+msgstr "La description du service (id : %d) ne peut pas être vide"
 
 #: centreon/www/include/Administration/parameters/engine/form.php
 msgid "The directory isn't valid"
@@ -15145,7 +15526,7 @@ msgstr "Le répertoire n'est pas valide"
 
 #: centreon/www/install/front_translate.php
 msgid "The duration must be less than a year"
-msgstr ""
+msgstr "La durée doit être inférieure à un an"
 
 #: centreon/www/install/front_translate.php
 msgid "The end date must be greater than the current date by at least one day"
@@ -15160,8 +15541,8 @@ msgstr "La date de fin doit être supérieure à la date de début"
 msgid "The end time must be greater than the start time."
 msgstr "La date de fin doit être plus grande que la date de début."
 
-#: centreon/www/install/step_upgrade/step1.php
 #: centreon/www/install/smarty_translate.php
+#: centreon/www/install/step_upgrade/step1.php
 msgid "The entire process should take around ten minutes."
 msgstr "Le processus complet devrait prendre environ dix minutes."
 
@@ -15172,7 +15553,7 @@ msgstr "Ce champ est requis"
 #: centreon/src/Core/Command/Application/Exception/CommandException.php
 #, php-format
 msgid "The following arguments are not valid: %s"
-msgstr "Les arguments suivants ne sont pas valides: %s"
+msgstr "Les arguments suivants ne sont pas valides : %s"
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
 #, php-format
@@ -15182,7 +15563,7 @@ msgstr "Les attributs liés suivants sont manquants : %s"
 #: centreon/src/Core/Command/Application/Exception/CommandException.php
 #, php-format
 msgid "The following macros are not valid: %s"
-msgstr "Les macros suivantes ne sont pas valides: %s"
+msgstr "Les macros suivantes ne sont pas valides : %s"
 
 #: centreon/www/install/front_translate.php
 msgid ""
@@ -15193,6 +15574,7 @@ msgstr ""
 "ainsi que de la base de données."
 
 #: centreon/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
+#: centreon/www/include/common/common-Func.php
 msgid ""
 "The form has not been submitted since 15 minutes. Please retry to resubmit"
 msgstr ""
@@ -15216,15 +15598,15 @@ msgstr "L'icône '%s' avec l'identifiant '%d' n'existe pas"
 msgid "The host group name '%s' already exists"
 msgstr "Le groupe d'hôtes '%s' existe déjà"
 
-#: centreon/src/Centreon/Domain/Engine/EngineService.php
 #: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
+#: centreon/src/Centreon/Domain/Engine/EngineService.php
 msgid "The host id cannot be null"
 msgstr "L'id de l'hôte ne peut pas être nul"
 
 #: centreon/src/Centreon/Domain/Engine/EngineService.php
 #, php-format
 msgid "The host of service (id: %d) is not defined"
-msgstr "L'hôte du service (id: %d) n'est pas défini"
+msgstr "L'hôte du service (id : %d) n'est pas défini"
 
 #: centreon/src/Core/HostSeverity/Application/Exception/HostSeverityException.php
 #, php-format
@@ -15247,18 +15629,19 @@ msgstr ""
 msgid "The minimum allowed value is 10"
 msgstr "La valeur minimale autorisée est 10"
 
-#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 #: centreon/src/Core/Host/Application/Exception/HostException.php
+#: centreon/src/Core/HostTemplate/Application/Exception/HostTemplateException.php
 #, php-format
 msgid "The name %s (original name: %s) already exists"
-msgstr "Le nom %s (nom original: %s) existe déjà"
+msgstr "Le nom %s (nom original : %s) existe déjà"
 
 #: centreon/www/install/front_translate.php
 msgid "The name can be at most 50 characters long"
 msgstr "Le nom peut comporter au maximum 50 caractères"
 
 #: centreon/www/api/class/centreon_configuration_broker.class.php
+#: centreon/www/class/centreonConfigCentreonBroker.php
 msgid "The name of block configuration"
 msgstr "Nom de l'objet configuré"
 
@@ -15280,12 +15663,12 @@ msgstr "Le nouveau mot de passe est identique au mot de passe actuel"
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "The notification configuration name already exists"
-msgstr ""
+msgstr "Ce nom de configuration de notifications existe déjà"
 
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
 #, php-format
 msgid "The notification interval must be greater than or equal to 0"
-msgstr ""
+msgstr "L'intervalle de notification doit être supérieur ou égal à 0"
 
 #: centreon/www/install/front_translate.php
 msgid "The notification was successfully added"
@@ -15301,7 +15684,7 @@ msgstr "L'ordre des intervalles de temps n'est pas cohérent"
 
 #: centreon/www/install/front_translate.php
 msgid "The page cannot be loaded"
-msgstr ""
+msgstr "La page ne peut pas être chargée"
 
 #: centreon/src/Centreon/Domain/RequestParameters/RequestParametersException.php
 #, php-format
@@ -15329,6 +15712,10 @@ msgstr ""
 
 #: centreon/src/Centreon/Infrastructure/Event/FileLoader.php
 msgid "The path does not exist"
+msgstr "Ce chemin n'existe pas"
+
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The path format is invalid"
 msgstr ""
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
@@ -15347,22 +15734,23 @@ msgstr "Le type de la plateforme '%s'@'%s' n'est pas cohérent"
 msgid ""
 "The platform: '%s'@'%s' cannot be added to the Central linked to this Remote"
 msgstr ""
-"La plateforme: '%s'@'%s' ne peut pas être ajoutée au Central lié à ce Remote"
+"La plateforme '%s'@'%s' ne peut pas être ajoutée au central lié à ce serveur "
+"distant"
 
 #: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/PlatformTopologyRegisterRepositoryAPI.php
 #, php-format
 msgid "The platform: '%s'@'%s' cannot be delete from the Central"
-msgstr "La plateforme: '%s'@'%s' ne peut pas être supprimé depuis le Central"
+msgstr "La plateforme '%s'@'%s' ne peut pas être supprimée depuis le central"
 
 #: centreon/src/Centreon/Infrastructure/PlatformTopology/Repository/PlatformTopologyRegisterRepositoryAPI.php
 #, php-format
 msgid "The platform: '%s'@'%s' cannot be found on the Central"
-msgstr "La plateforme: '%s'@'%s' ne peut pas être trouvé sur le Central"
+msgstr "La plateforme '%s'@'%s' ne peut pas être trouvée sur le central"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
 msgid "The platform: '%s'@'%s' is not declared as a 'remote'"
-msgstr "La plateforme: '%s'@'%s' n'est pas déclarée comme un 'remote'"
+msgstr "La plateforme '%s'@'%s' n'est pas déclarée comme un serveur distant"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
@@ -15370,7 +15758,7 @@ msgid ""
 "The platform: '%s'@'%s' is not linked to a Central. Please use the wizard "
 "first"
 msgstr ""
-"La plateforme: '%s'@'%s n'est pas liée à un Central. Veuillez d'abord "
+"La plateforme '%s'@'%s n'est pas liée à un central. Veuillez d'abord "
 "utiliser l'assistant"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
@@ -15385,7 +15773,7 @@ msgstr "Le port ne peut être compris qu'entre 0 et 65535 inclus"
 
 #: centreon/src/Centreon/Infrastructure/RequestParameters/SqlRequestParametersTranslator.php
 msgid "The property name of the normalizer cannot be empty."
-msgstr ""
+msgstr "Le nom de la propriété du normalisateur ne peut pas être vide."
 
 #: centreon/src/Centreon/Domain/Entity/EntityCreator.php
 #, php-format
@@ -15413,7 +15801,7 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "The resource access rule has been successfully deleted"
-msgstr ""
+msgstr "La règle d'accès aux ressources a bien été supprimée"
 
 #: centreon/www/install/front_translate.php
 msgid "The resource access rule has been successfully duplicated"
@@ -15427,6 +15815,18 @@ msgstr "La règle d'accès aux ressources a été créée avec succès"
 msgid "The resource access rule was successfully updated"
 msgstr "La règle d'accès aux ressources a été modifiée avec succès"
 
+#: centreon/www/include/configuration/configServers/formServers.php
+msgid "The script path is invalid"
+msgstr ""
+
+#: centreon/www/include/configuration/configObject/service/DB-Func.php
+msgid ""
+"The selected inherited service template does not contain any check command. "
+"You must select one here."
+msgstr ""
+"Le modèle de service hérité sélectionné ne comporte pas de commande de "
+"vérification. Vous devez en sélectionner une ici."
+
 #: centreon/www/install/front_translate.php
 msgid "The selected notifications have been deleted successfully"
 msgstr "Les notifications sélectionnées ont été supprimées avec succès"
@@ -15439,7 +15839,7 @@ msgstr ""
 
 #: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
 msgid "The selected template has the same time period as a template"
-msgstr ""
+msgstr "Le modèle sélectionné est identique au modèle actuel"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
@@ -15477,7 +15877,7 @@ msgstr "La liste de partages est vide"
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 #, php-format
 msgid "The thumbnail provided for dashboard [%d] was not found"
-msgstr ""
+msgstr "La vignette du tableau de bord [%d] n'a pas été trouvée"
 
 #: centreon/www/install/front_translate.php
 msgid ""
@@ -15488,7 +15888,7 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "The time period field should not be empty!"
-msgstr ""
+msgstr "Le champ \"Période temporelle\" ne peut pas être vide"
 
 #: centreon/src/Core/TimePeriod/Application/Exception/TimePeriodException.php
 #, php-format
@@ -15510,6 +15910,7 @@ msgid "The token name '%s' already exists"
 msgstr "Le nom de token '%s' existe déjà"
 
 #: centreon/www/api/class/centreon_configuration_broker.class.php
+#: centreon/www/class/centreonConfigCentreonBroker.php
 msgid "The type of block configuration"
 msgstr "Le type du bloc de configuration"
 
@@ -15526,15 +15927,23 @@ msgstr "Ces utilisateurs seront débloqués. Confirmez-vous l\\'action ?"
 #, php-format
 msgid "The users [%s] are not in your access groups"
 msgstr ""
+"Les utilisateurs suivants n'appartiennent pas à vos groupes d'accès : [%s]"
+
+#: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
+#, php-format
+msgid "The users [%s] are not in your contact groups"
+msgstr ""
+"Les utilisateurs suivants n'appartiennent pas à vos groupes de contacts : "
+"[%s]"
 
 #: centreon/src/Centreon/Application/Validation/CentreonValidatorFactory.php
 #, php-format
 msgid "The validator \"%s\" is not found"
-msgstr ""
+msgstr "Le validateur \"%s\" n'a pas été trouvé"
 
 #: centreon/src/Centreon/Domain/Entity/EntityCreator.php
 msgid "The value cannot be null"
-msgstr ""
+msgstr "La valeur ne peut pas être vide"
 
 #: centreon/www/install/front_translate.php
 msgid "The widget will be permanently deleted."
@@ -15564,7 +15973,7 @@ msgstr "Le widget {{name}} sera définitivement supprimé."
 #: centreon/src/Centreon/Infrastructure/Serializer/Exception/SerializerException.php
 #, php-format
 msgid "There are not enough arguments to build the object %s"
-msgstr ""
+msgstr "Il n'y a pas assez d'arguments pour construire l'objet %s"
 
 #: centreon/www/install/front_translate.php
 msgid ""
@@ -15581,7 +15990,7 @@ msgstr "Epaisseur"
 
 #: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Third of month"
-msgstr ""
+msgstr "Le troisième du mois"
 
 #: centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
 msgid "This IP Address already exist"
@@ -15594,7 +16003,11 @@ msgstr "Ce mois ci"
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
 #, php-format
 msgid "This SNMP version (%s) is not allowed"
-msgstr ""
+msgstr "La version %s de SNMP n'est pas autorisée"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "This Service is flapping"
+msgstr "Le statut du service bagote"
 
 #: centreon/www/include/reporting/dashboard/common-Func.php
 msgid "This Week"
@@ -15611,7 +16024,7 @@ msgstr "Cette action est irréversible."
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
 #, php-format
 msgid "This active checks status (%d) is not allowed"
-msgstr ""
+msgstr "Le statut de contrôles actifs %d n'est pas autorisé"
 
 #: centreon/www/include/configuration/configObject/service/formService.php
 msgid ""
@@ -15627,9 +16040,17 @@ msgstr ""
 "Cette directive peut être utilisée plusieurs fois, se reporter à la "
 "documentation de nagios."
 
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "This host is never checked"
+msgstr "Cet hôte n'est jamais vérifié"
+
 #: centreon/src/Centreon/Domain/HostConfiguration/Host.php
 msgid "This host is not a host template"
 msgstr "Cet hôte n'est pas un modèle d'hôte"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "This host is only checked in passive mode"
+msgstr "L'hôte est contrôlé uniquement en mode passif"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid ""
@@ -15647,8 +16068,8 @@ msgstr ""
 "Cet installeur vous aidera à paramétrer votre base de données et la "
 "configuration de votre supervision."
 
-#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 #: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact_template_model/listContactTemplateModel.php
 msgid "This is a contact template."
 msgstr "Ceci est un modèle de contact."
 
@@ -15659,7 +16080,7 @@ msgstr "Ce nom existe déjà"
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
 #, php-format
 msgid "This notifications status (%d) is not allowed"
-msgstr ""
+msgstr "Le statut de notification %d n'est pas autorisé"
 
 #: centreon/src/Core/Media/Application/Exception/MediaException.php
 msgid "This operation requires an admin user"
@@ -15674,8 +16095,7 @@ msgstr ""
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "This option must be enabled for Centreon Dashboard module."
 msgstr ""
-"Cette option doit être activée pour le module module de Tableau de bord "
-"Centreon "
+"Cette option doit être activée pour le module de Tableaux de bord Centreon."
 
 #: centreon/www/install/front_translate.php
 msgid "This page could not be found"
@@ -15684,7 +16104,7 @@ msgstr "Cette page n'a pas pu être trouvée"
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostTemplateArgumentException.php
 #, php-format
 msgid "This passive checks status (%d) is not allowed"
-msgstr ""
+msgstr "Le statut de contrôles passifs %d n'est pas autorisé"
 
 #: centreon/www/install/front_translate.php
 msgid "This resource is flapping"
@@ -15695,9 +16115,9 @@ msgid ""
 "This search bar will search matching occurences you type, contained in: host "
 "name or alias or address or service description"
 msgstr ""
-"Cette barre de recherche va rechercher les ressources correspondantes aux "
-"occurences que vous tapez, contenues dans: le nom de l'hôte, l'alias, "
-"l'adresse, ou bien la description du service"
+"Cette barre de recherche va rechercher les ressources correspondant aux "
+"occurrences que vous tapez, contenues dans : le nom de l'hôte, son alias, "
+"son adresse, ou bien la description du service"
 
 #: centreon/www/install/front_translate.php
 msgid ""
@@ -15710,6 +16130,14 @@ msgstr ""
 #: centreon/src/CentreonRemote/Application/Webservice/CentreonConfigurationRemote.php
 msgid "This server is already registered"
 msgstr "Ce serveur est déjà enregistré"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "This service is neither active nor passive"
+msgstr "Ce service n'est ni actif ni passif"
+
+#: centreon/www/include/monitoring/status/Services/xml/serviceXML.php
+msgid "This service is only checked in passive mode"
+msgstr "Le service est contrôlé uniquement en mode passif"
 
 #: centreon/www/include/configuration/configObject/contact/listContact.php
 msgid "This user is a simple user."
@@ -15752,7 +16180,7 @@ msgstr ""
 
 #: centreon/www/install/smarty_translate.php
 msgid "Three columns"
-msgstr ""
+msgstr "Trois colonnes"
 
 #: centreon/www/install/front_translate.php
 msgid "Thresholds"
@@ -15771,13 +16199,13 @@ msgid ""
 "Thumbnails show a snapshot of your data, taken when the dashboard is saved"
 msgstr ""
 "Les vignettes affichent un instantané de vos données, pris au moment de la "
-"sauvegarde."
+"sauvegarde"
 
-#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Thursday"
 msgstr "Jeudi"
 
@@ -15799,8 +16227,10 @@ msgstr "Sujet du ticket"
 
 #: centreon/www/install/front_translate.php
 msgid "Tickets"
-msgstr ""
+msgstr "Tickets"
 
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+#: centreon/www/include/eventLogs/xml/data.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
 msgid "Time"
 msgstr "Heures"
@@ -15813,8 +16243,8 @@ msgstr "Nom de la période temporelle"
 msgid "Time Periods"
 msgstr "Périodes temporelles"
 
-#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
 #: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
 msgid "Time Range"
 msgstr "Période de temps"
 
@@ -15834,11 +16264,11 @@ msgstr "Unité de temps de référence"
 msgid "Time Zone"
 msgstr "Fuseau horaire"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
+#: centreon/www/install/front_translate.php
 msgid "Time period"
-msgstr ""
+msgstr "Période temporelle"
 
 #: centreon/www/install/front_translate.php
 msgid "Time that must pass before new connection is allowed"
@@ -15852,8 +16282,8 @@ msgstr "Historique"
 msgid "Timeout"
 msgstr "Temps d'exécution maximum"
 
-#: centreon/www/include/Administration/parameters/api/api.php
 #: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/api/api.php
 msgid "Timeout value for Gorgone commands"
 msgstr "Temps maximum d'exécution des commandes Gorgone"
 
@@ -15885,18 +16315,18 @@ msgstr "Périodes de temps"
 msgid "Timerange Overlaps"
 msgstr "Les périodes temporelles se superposent"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
+#: centreon/www/include/Administration/parameters/general/form.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
-#: centreon/www/include/Administration/parameters/general/form.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Timezone"
 msgstr "Fuseau horaire"
 
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Timezone / Location"
 msgstr "Fuseau horaire / Localisation"
 
@@ -15904,14 +16334,14 @@ msgstr "Fuseau horaire / Localisation"
 msgid "Tips"
 msgstr "Conseils"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/home/customViews/index.php
+#: centreon/www/install/front_translate.php
 msgid "Title"
 msgstr "Titre"
 
-#: centreon/www/class/centreonWidget/Params/Date.class.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
+#: centreon/www/class/centreonWidget/Params/Date.class.php
 msgid "To"
 msgstr "Au"
 
@@ -15926,8 +16356,8 @@ msgstr ""
 "Un Remote Server principal doit être sélectionné, avant d'utiliser des "
 "Remote Server additionnels."
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/install/front_translate.php
 msgid "Today"
 msgstr "Aujourd'hui"
 
@@ -15967,10 +16397,11 @@ msgstr "Le jeton a été créé"
 #, php-format
 msgid "Token with name \"%s\" and creator ID \"%d\" is not valid"
 msgstr ""
+"Le jeton suivant n'est pas valide. Nom du jeton \"%s\", ID du créateur \"%d\""
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 msgid "Tokens are mandatory"
-msgstr ""
+msgstr "Les jetons sont obligatoires"
 
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Tools"
@@ -15980,15 +16411,23 @@ msgstr "Outils"
 msgid "Top"
 msgstr "Top"
 
+#: centreon/www/include/monitoring/status/Hosts/xml/hostXML.php
+msgid "Top Priority Hosts"
+msgstr "Hôtes prioritaires"
+
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Topology"
+msgstr "Topologie"
+
 #: centreon/www/include/reporting/dashboard/initReport.php
 msgid "Total"
 msgstr "Total"
 
-#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 msgid "Total Time"
 msgstr "Temps total"
 
@@ -15998,7 +16437,7 @@ msgstr "Taille totale"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Trace"
-msgstr ""
+msgstr "Trace"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Transaction commit timeout"
@@ -16025,11 +16464,11 @@ msgstr "Nom du Trap"
 msgid "Traps"
 msgstr "Traps SNMP"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/monitoring/status/Services/serviceJS.php
-#: centreon/www/include/monitoring/status/Hosts/hostJS.php
-#: centreon/www/include/monitoring/status/Hosts/host.php
 #: centreon/src/Core/Resources/Infrastructure/API/ExportResources/ExportResourcesPresenterCsv.php
+#: centreon/www/include/monitoring/status/Services/serviceJS.php
+#: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/status/Hosts/hostJS.php
+#: centreon/www/install/front_translate.php
 msgid "Tries"
 msgstr "Tentatives"
 
@@ -16039,7 +16478,7 @@ msgstr "Activation de la gestion systématique des expressions rationnelles"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Trusted CA"
-msgstr ""
+msgstr "CA de confiance"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Trusted CA's certificate path (optional)"
@@ -16049,11 +16488,11 @@ msgstr "Chemin du certificat de l’autorité de certification (optionnel)"
 msgid "Trusted client addresses"
 msgstr "Adresses des clients de confiance"
 
-#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Tuesday"
 msgstr "Mardi"
 
@@ -16063,20 +16502,20 @@ msgstr "Optimisation"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Two columns"
-msgstr ""
+msgstr "Deux colonnes"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/centreon_broker_translation.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
 #: centreon/www/include/configuration/configObject/service_categories/listServiceCategories.php
 #: centreon/www/include/configuration/configObject/command/listCommand.php
+#: centreon/www/include/eventLogs/xml/data.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
+#: centreon/www/install/centreon_broker_translation.php
 msgid "Type"
 msgstr "Type"
 
 #: centreon/src/Centreon/Domain/ActionLog/ActionLog.php
 msgid "Type of action not recognized"
-msgstr ""
+msgstr "Type d'action non reconnue"
 
 #: centreon/www/install/front_translate.php
 msgid "Type of resource"
@@ -16094,10 +16533,10 @@ msgstr "Types"
 msgid "UI Notifications"
 msgstr "Notifications visible dans l'interface"
 
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 msgid "UNDETERMINED"
 msgstr "INDÉTERMINÉ"
 
@@ -16106,18 +16545,18 @@ msgstr "INDÉTERMINÉ"
 msgid "UNKNOWN"
 msgstr "INCONNU"
 
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "UNREACHABLE"
 msgstr "INJOIGNABLE"
 
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 msgid "UP"
 msgstr "DISPONIBLE"
 
@@ -16131,7 +16570,7 @@ msgstr "Lien d'information"
 
 #: centreon/www/install/front_translate.php
 msgid "Unable to copy the link"
-msgstr ""
+msgstr "Impossible de copier le lien"
 
 #: centreon/src/Centreon/Infrastructure/PlatformInformation/Repository/Model/PlatformInformationFactoryRDB.php
 msgid ""
@@ -16148,39 +16587,41 @@ msgstr "Impossible de décoder la réponse de L'API provenant du Central"
 #: centreon/src/Centreon/Application/Controller/Monitoring/TimelineController.php
 #, php-format
 msgid "Unable to find host by service id %d"
-msgstr ""
+msgstr "Impossible de trouver l'hôte dont le service a l'ID %d"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
 msgid "Unable to find local monitoring server name"
 msgstr "Impossible de trouver le nom du serveur local de supervision"
 
+#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #: centreon/src/Centreon/Domain/ServiceConfiguration/ServiceConfigurationService.php
 #: centreon/src/Centreon/Domain/HostConfiguration/Exception/HostConfigurationServiceException.php
-#: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
 msgid "Unable to find the Engine configuration"
 msgstr "Impossible de trouver la configuration du moteur de supervision"
 
-#: centreon/src/Centreon/Domain/PlatformInformation/Model/PlatformInformationFactory.php
 #: centreon/src/Centreon/Infrastructure/PlatformInformation/Repository/Model/PlatformInformationFactoryRDB.php
+#: centreon/src/Centreon/Domain/PlatformInformation/Model/PlatformInformationFactory.php
 msgid "Unable to find the encryption key."
-msgstr ""
+msgstr "Impossible de trouver la clé de chiffrement."
 
 #: centreon/src/Core/Application/RealTime/UseCase/FindHost/FindHost.php
 #: centreon/src/Core/Application/RealTime/UseCase/FindService/FindService.php
 #, php-format
 msgid "Unable to hide passwords in command (Reason: %s)"
-msgstr "Impossible de cacher les mots de passe dans la commande (Raison: %s)"
+msgstr "Impossible de cacher les mots de passe dans la commande (raison : %s)"
 
 #: centreon/src/Centreon/Domain/PlatformTopology/Exception/PlatformTopologyException.php
 #, php-format
 msgid "Unable to link a 'remote': '%s'@'%s' to another remote platform"
 msgstr ""
+"Impossible de rattacher le serveur distant '%s'@'%s' à un autre serveur "
+"distant"
 
+#: centreon/www/include/configuration/configGenerate/xml/generateFiles.php
 #: centreon/www/include/configuration/configGenerate/xml/restartPollers.php
 #: centreon/www/include/configuration/configGenerate/xml/moveFiles.php
-#: centreon/www/include/configuration/configGenerate/xml/generateFiles.php
 msgid "Unable to load the Symfony container"
 msgstr "Impossible de charger le conteneur Symfony"
 
@@ -16198,26 +16639,26 @@ msgstr "Impossible de récupérer les données d'information sur la plateforme."
 
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 msgid "Unauthorized value"
-msgstr ""
+msgstr "Valeur non autorisée"
 
 #: centreon/www/include/configuration/configObject/contact/listContact.php
 msgid "Unblock"
 msgstr "Débloquer"
 
-#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 msgid "Undetermined"
 msgstr "Indéterminé"
 
 #: centreon/www/install/front_translate.php
 msgid "Undo"
-msgstr ""
+msgstr "Annuler"
 
 #: centreon/www/install/front_translate.php
 msgid "Unhandled"
@@ -16234,42 +16675,43 @@ msgstr "Alertes non traitées"
 
 #: centreon/www/install/front_translate.php
 msgid "Uninstalled"
-msgstr ""
+msgstr "Désinstallé"
 
 #: centreon/www/include/configuration/configObject/traps/formTraps.php
 msgid "Unique"
-msgstr ""
+msgstr "Unique"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/views/virtualMetrics/listVirtualMetrics.php
 #: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "Unit"
 msgstr "Unité"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/monitoring/status/Services/service.php
+#: centreon/www/install/front_translate.php
 msgid "Unknown"
 msgstr "Inconnu"
 
 #: centreon/www/install/react_translation.php
 msgid "Unknown services"
-msgstr ""
+msgstr "Services inconnus"
 
 #: centreon/www/install/front_translate.php
 msgid "Unknown status services"
@@ -16278,34 +16720,36 @@ msgstr "Services au statut Inconnu"
 #: centreon/src/Centreon/Domain/Monitoring/MetaService/Exception/MetaServiceMetricException.php
 #, php-format
 msgid "Unkown meta metrics selection mode provided for %d"
-msgstr ""
+msgstr "Méthode de calcul inconnue pour le métaservice %d"
 
 #: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/Administration/performance/viewData.php
 msgid "Unlock Services"
 msgstr "Déverrouiller les services"
 
 #: centreon/www/include/home/customViews/index.php
 msgid "Unlocked user groups"
-msgstr ""
+msgstr "Groupes d'utilisateurs déverrouillés"
 
 #: centreon/www/include/home/customViews/index.php
 msgid "Unlocked users"
-msgstr ""
+msgstr "Utilisateurs déverrouillés"
 
 #: centreon/www/install/front_translate.php
 msgid "Unordered List"
-msgstr ""
+msgstr "Liste à puces"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/install/front_translate.php
 msgid "Unreachable"
 msgstr "Injoignable"
 
@@ -16333,12 +16777,12 @@ msgstr "Périodes temporelles indéfinies"
 msgid "Until"
 msgstr "Jusqu'à"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
+#: centreon/www/include/eventLogs/viewLog.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/install/front_translate.php
 msgid "Up"
 msgstr "Disponible"
 
@@ -16356,7 +16800,7 @@ msgstr "Hôtes au statut Disponible"
 
 #: centreon/www/install/front_translate.php
 msgid "Up to date"
-msgstr ""
+msgstr "À jour"
 
 #: centreon/www/install/front_translate.php
 msgid "Update"
@@ -16367,8 +16811,12 @@ msgid "Update additional configuration"
 msgstr "Mettre à jour la configuration additionnelle"
 
 #: centreon/www/install/front_translate.php
+msgid "Update agent configuration"
+msgstr "Mettre à jour la configuration d'agent"
+
+#: centreon/www/install/front_translate.php
 msgid "Update all"
-msgstr ""
+msgstr "Tout mettre à jour"
 
 #: centreon/src/Core/Platform/Application/UseCase/UpdateVersions/UpdateVersionsException.php
 msgid "Update already in progress"
@@ -16380,19 +16828,16 @@ msgstr "Mettre à jour le tableau de bord"
 
 #: centreon/www/install/front_translate.php
 msgid "Update filter"
-msgstr ""
+msgstr "Mettre à jour le filtre"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "Update mode"
 msgstr "Mode de mise à jour"
-
-#: centreon/www/install/front_translate.php
-msgid "Update poller/agent configuration"
-msgstr "Mettre à jour la configuration collecteur/agent"
 
 #: centreon/www/install/front_translate.php
 msgid "Updated"
@@ -16408,7 +16853,7 @@ msgstr "Mise à jour terminée"
 
 #: centreon/www/install/step_upgrade/step4.php
 msgid "Upgrade to this release requires Centreon >= 2.8.0-beta1."
-msgstr ""
+msgstr "La mise à jour vers cette version nécessite Centreon >= 2.8.0-beta1."
 
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 msgid "Upper Limit"
@@ -16416,7 +16861,7 @@ msgstr "Limite supérieure"
 
 #: centreon/www/include/configuration/configServers/listServers.php
 msgid "Uptime"
-msgstr ""
+msgstr "Uptime"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "Use Retained Program State Option"
@@ -16452,6 +16897,7 @@ msgstr "Utiliser le Remote Server comme proxy"
 msgid "Used by command"
 msgstr "Utilisé par la commande"
 
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
 #: centreon/www/install/front_translate.php
 msgid "User"
 msgstr "Utilisateur"
@@ -16467,7 +16913,7 @@ msgstr "L'utilisateur ne peut pas être déconnecté"
 
 #: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
 msgid "User cannot be retrieved from the provider"
-msgstr ""
+msgstr "L'utilisateur n'a pas pu être récupéré depuis le fournisseur"
 
 #: centreon/www/install/front_translate.php
 msgid "User deleted"
@@ -16487,15 +16933,15 @@ msgstr "L'attribut pour l'adresse email de l'utilisateur"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "User filter"
-msgstr "Le filtre de recherche pour les utilisateurs"
+msgstr "Filtre utilisateur"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "User firstname attribute"
-msgstr "L'attribut pour le prénom de l'utilisateur"
+msgstr "Attribut du prénom de l'utilisateur"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "User group attribute"
-msgstr "L'attribut pour la relation des groupes à un utilisateur"
+msgstr "Attribut du groupe d'utilisateurs"
 
 #: centreon/www/install/front_translate.php
 msgid "User information"
@@ -16515,30 +16961,31 @@ msgstr "L'utilisateur n'est pas autorisé à joindre l'application web"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "User lastname attribute"
-msgstr "L'attribut pour le nom de famille de l'utilisateur"
+msgstr "Attribut du nom de famille de l'utilisateur"
 
 #: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
 msgid "User not found and cannot be created"
-msgstr ""
+msgstr "L'utilisateur n'a pas été trouvé et n'a pas pu être créé"
 
 #: centreon/www/include/Administration/parameters/ldap/form.php
 msgid "User pager attribute"
-msgstr "L'attribut pour le numéro de bipper/mobile de l'utilisateur"
+msgstr "Attribut du numéro de téléphone de l'utilisateur"
 
 #: centreon/www/install/front_translate.php
 msgid "User rights"
 msgstr "Droits d'utilisateur"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/Administration/parameters/remote/formRemote.php
 #: centreon/www/include/Administration/parameters/gorgone/gorgone.php
+#: centreon/www/include/Administration/parameters/remote/formRemote.php
+#: centreon/www/install/front_translate.php
 msgid "Username"
 msgstr "Utilisateur"
 
-#: centreon/www/install/menu_translation.php
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/options/session/connected_user.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
 #: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Users"
 msgstr "Utilisateurs"
 
@@ -16558,33 +17005,33 @@ msgstr "Utiliser un modèle permet d'éviter de remplir les champs requis"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "V1 (legacy, with epoch timestamps)"
-msgstr ""
+msgstr "V1 (ancienne version, avec horodatage)"
 
 #: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "V2 (ISO-8601, with log level fine tuning)"
-msgstr ""
+msgstr "V2 (ISO-8601, avec réglage fin du niveau de journalisation)"
 
 #: centreon/www/install/smarty_translate.php
 msgid "VAULT INFORMATION"
-msgstr ""
+msgstr "Accès au coffre-fort"
 
-#: centreon/www/include/configuration/configObject/contact/formContact.php
 #: centreon/www/include/Administration/myAccount/formMyAccount.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
 msgid "Valid Email"
 msgstr "Email valide"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/centreon_broker_translation.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
 #: centreon/www/include/configuration/configObject/service/xml/argumentsXml.php
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/centreon_broker_translation.php
 msgid "Value"
 msgstr "Valeur"
 
 #: centreon/www/install/front_translate.php
 msgid "Value defined by the {{metric}} metric"
-msgstr ""
+msgstr "Valeur définie par la métrique {{metric}}"
 
 #: centreon/www/install/front_translate.php
 msgid "Value defined by {{metric}} metric"
@@ -16596,7 +17043,7 @@ msgstr "Format de la valeur"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Value must be a positive numeric"
-msgstr ""
+msgstr "La valeur doit être un nombre positif"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Value must be numeric"
@@ -16612,15 +17059,15 @@ msgstr "Valeur"
 
 #: centreon/www/install/menu_translation.php
 msgid "Vault"
-msgstr ""
+msgstr "Coffre-fort"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Vault Address"
-msgstr ""
+msgstr "Adresse du coffre-fort"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Vault Port (default: 443)"
-msgstr ""
+msgstr "Port de connexion au coffre-fort (par défaut : 443)"
 
 #: centreon/www/install/front_translate.php
 msgid "Vault address"
@@ -16636,38 +17083,38 @@ msgstr "La configuration du Vault a été mise à jour"
 
 #: centreon/src/CentreonLegacy/Core/Install/Step/Step6Vault.php
 msgid "Vault information"
-msgstr ""
+msgstr "Accès au coffre-fort"
 
-#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
-#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
-#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
 #: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/traps-mibs/formMibs.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/listMnftr.php
+#: centreon/www/include/configuration/configObject/traps-manufacturer/formMnftr.php
 msgid "Vendor Name"
 msgstr "Nom du constructeur"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 msgid "Verification Check"
 msgstr "Vérification du contrôle"
 
 #: centreon/www/include/monitoring/status/ServicesServiceGroups/serviceSummaryBySG.php
-#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 #: centreon/www/include/monitoring/status/Services/serviceGrid.php
+#: centreon/www/include/monitoring/status/Services/serviceSummary.php
 msgid "Verification Check (Forced)"
 msgstr "Vérification du contrôle (Forcé)"
 
-#: centreon/www/install/smarty_translate.php
 #: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/install/smarty_translate.php
 msgid "Version"
 msgstr "Version"
 
 #: centreon/www/include/Administration/parameters/general/form.php
 msgid "Vertical Inheritance Only"
-msgstr ""
+msgstr "Héritage vertical uniquement"
 
 #: centreon/www/include/views/graphTemplates/formGraphTemplate.php
 msgid "Vertical Label"
@@ -16681,28 +17128,24 @@ msgstr "Visualiser"
 msgid ""
 "View\n"
 "                    History"
-msgstr ""
+msgstr "Voir l'historique de la page"
 
 #: centreon/www/install/smarty_translate.php
 msgid ""
 "View\n"
 "                    history"
-msgstr ""
+msgstr "Voir l'historique de la page"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "View Data Processing"
 msgstr "Visualiser le traitement des données"
 
 #: centreon/www/include/configuration/configObject/traps-groups/formGroups.php
 msgid "View Group"
 msgstr "Visualiser un groupe"
-
-#: centreon/www/include/options/media/images/formImg.php
-msgid "View Image"
-msgstr "Voir l'image"
 
 #: centreon/www/include/configuration/configResources/formResources.php
 msgid "View Resource"
@@ -16736,9 +17179,9 @@ msgstr "Visualiser un groupe de contact"
 msgid "View a Data Source Template"
 msgstr "Visualiser un modèle de source de données"
 
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
 #: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
 #: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
 #: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
 msgid "View a Dependency"
@@ -16805,6 +17248,10 @@ msgstr "View une définition de Trap"
 msgid "View a User"
 msgstr "Visualiser un utilisateur"
 
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+msgid "View a User Template"
+msgstr "Visualiser un modèle utilisateur"
+
 #: centreon/www/include/views/virtualMetrics/formVirtualMetrics.php
 msgid "View a Virtual Metric"
 msgstr "Voir une Métrique Virtuelle"
@@ -16822,6 +17269,7 @@ msgid "View all resources"
 msgstr "Afficher toutes les ressources"
 
 #: centreon/www/include/options/accessLists/resourcesACL/formResourcesAccess.php
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
 msgid "View an ACL"
 msgstr "Visualiser une ACL"
 
@@ -16833,8 +17281,8 @@ msgstr "Visualiser une action"
 msgid "View an Escalation"
 msgstr "Visualiser une escalade"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 msgid "View an Extended Info"
 msgstr "Visualiser une information supplémentaire"
 
@@ -16866,6 +17314,10 @@ msgstr "Afficher les groupes de contacts de notification"
 msgid "View contact notifications"
 msgstr "Afficher les notifications du contact"
 
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "View downtimes of hosts"
+msgstr "Visualiser les plages de maintenance des hôtes"
+
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 #, php-format
@@ -16891,10 +17343,10 @@ msgstr "Visualiser les évènements de l'hôte %s"
 msgid "View logs for service %s"
 msgstr "Visualiser les journaux pour le service %s"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "View macros"
 msgstr "Visualiser les macros"
 
@@ -16902,10 +17354,10 @@ msgstr "Visualiser les macros"
 msgid "View properties"
 msgstr "Voir les propriétés"
 
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "View relations"
 msgstr "Visualiser les relations"
 
@@ -16938,14 +17390,14 @@ msgstr "Voir les propriétés du widget"
 msgid ""
 "View wiki\n"
 "                    page"
-msgstr ""
+msgstr "Voir la page de wiki"
 
 #: centreon/www/install/smarty_translate.php
 msgid "View wiki page"
-msgstr ""
+msgstr "Voir la page de wiki"
 
-#: centreon/www/install/menu_translation.php
 #: centreon/www/install/front_translate.php
+#: centreon/www/install/menu_translation.php
 msgid "Viewer"
 msgstr "Viewer"
 
@@ -16955,7 +17407,7 @@ msgstr "Vues"
 
 #: centreon/www/install/menu_translation.php
 msgid "Virtual Metrics"
-msgstr ""
+msgstr "Métriques virtuelles"
 
 #: centreon/www/install/smarty_translate.php
 msgid "Virtual metrics"
@@ -16965,31 +17417,36 @@ msgstr "Métriques/courbes virtuelles"
 msgid "Visible columns only"
 msgstr "Colonnes visibles seulement"
 
+#: centreon/www/include/options/accessLists/menusACL/formMenusAccess.php
+msgid "Visible page"
+msgstr "Pages visibles"
+
 #: centreon/www/include/reporting/dashboard/xmlInformations/initXmlFeed.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
 msgid "WARNING"
 msgstr "ALERTE"
 
+#: centreon/www/include/Administration/performance/viewMetrics.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/traps/listTraps.php
+#: centreon/www/include/configuration/configObject/traps/formTraps.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/eventLogs/viewLog.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/eventLogs/viewLog.php
-#: centreon/www/include/configuration/configObject/traps/formTraps.php
-#: centreon/www/include/configuration/configObject/traps/listTraps.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/reporting/dashboard/initReport.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
-#: centreon/www/include/monitoring/status/Services/service.php
-#: centreon/www/include/Administration/performance/viewMetrics.php
 msgid "Warning"
 msgstr "Alerte"
 
@@ -17008,7 +17465,7 @@ msgstr "Seuil d'alerte"
 
 #: centreon/www/install/react_translation.php
 msgid "Warning services"
-msgstr ""
+msgstr "Services au statut alerte"
 
 #: centreon/www/install/front_translate.php
 msgid "Warning status services"
@@ -17025,7 +17482,7 @@ msgid ""
 "Warning, maximum size exceeded for input '%s' (max: %d), it will be "
 "truncated upon saving"
 msgstr ""
-"Attention, taille maximale dépassée pour le champ '%s' (max: %d), il sera "
+"Attention, taille maximale dépassée pour le champ '%s' (max : %d), il sera "
 "tronqué à l'enregistrement"
 
 #: centreon/www/include/configuration/configObject/service/formService.php
@@ -17067,18 +17524,18 @@ msgstr "Aperçu de la page web"
 
 #: centreon/www/install/front_translate.php
 msgid "Webpage Display"
-msgstr ""
+msgstr "Page web"
 
-#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
-#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
+#: centreon/www/include/configuration/configObject/timeperiod/formTimeperiod.php
+#: centreon/www/include/configuration/configObject/timeperiod/renderTimeperiod.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Wednesday"
 msgstr "Mercredi"
 
-#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/recurrentDowntime/ajaxForms.php
 msgid "Weekly basis"
 msgstr "Hebdomadaire"
 
@@ -17091,12 +17548,12 @@ msgid "Welcome to the Dashboards interface!"
 msgstr "Bienvenue dans l'interface des tableaux de bord !"
 
 #: centreon/www/install/front_translate.php
-msgid "Welcome to the notifications interface"
-msgstr "Bienvenue dans l'interface de gestion des notifications"
+msgid "Welcome to the agent configuration page"
+msgstr "Bienvenue sur la page des configurations d'agent"
 
 #: centreon/www/install/front_translate.php
-msgid "Welcome to the poller/agent configuration page"
-msgstr "Bienvenue sur la page des configurations collecteur/agent"
+msgid "Welcome to the notifications interface"
+msgstr "Bienvenue dans l'interface de gestion des notifications"
 
 #: centreon/www/install/front_translate.php
 msgid "Which endpoint does the conditions attribute path come from?"
@@ -17112,15 +17569,15 @@ msgid "Which endpoint does the roles attribute path come from?"
 msgstr ""
 "De quel point d'entrée provient le chemin d'accès de l'attribut de rôles ?"
 
+#: centreon/www/include/home/customViews/index.php
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/smarty_translate.php
-#: centreon/www/include/home/customViews/index.php
 msgid "Widget"
 msgstr "Widget"
 
 #: centreon/www/install/menu_translation.php
 msgid "Widget Parameters"
-msgstr ""
+msgstr "Paramètres du widget"
 
 #: centreon/www/api/class/centreon_home_customview.class.php
 msgid "Widget Preferences"
@@ -17143,10 +17600,10 @@ msgstr "Type de widget"
 msgid "Width"
 msgstr "Largeur"
 
-#: centreon/www/include/configuration/configKnowledge/display-services.php
-#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
 #: centreon/www/include/configuration/configKnowledge/display-hosts.php
+#: centreon/www/include/configuration/configKnowledge/display-serviceTemplates.php
 #: centreon/www/include/configuration/configKnowledge/display-hostTemplates.php
+#: centreon/www/include/configuration/configKnowledge/display-services.php
 msgid "Wiki page defined"
 msgstr "Page définie"
 
@@ -17160,11 +17617,11 @@ msgstr "Générer les graphiques de statut"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Write thread id (deprecated)"
-msgstr ""
+msgstr "Écrire l'ID du thread (déprécié)"
 
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 msgid "Write timestamp (deprecated)"
-msgstr ""
+msgstr "Horodatage d'écriture (déprécié)"
 
 #: centreon/www/include/monitoring/objectDetails/hostDetails.php
 msgid "Y/m/d - H:i:s"
@@ -17174,42 +17631,44 @@ msgstr "d/m/Y - H:i:s"
 msgid "Y/m/d H:i:s"
 msgstr "d/m/Y - H:i:s"
 
-#: centreon/www/class/centreonXMLBGRequest.class.php
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/views/graphTemplates/listGraphTemplates.php
 #: centreon/www/include/views/componentTemplates/listComponentTemplates.php
-#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
-#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
-#: centreon/www/include/configuration/configObject/contact/listContact.php
-#: centreon/www/include/configuration/configObject/contact/formContact.php
-#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
-#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configServers/listServers.php
-#: centreon/www/include/configuration/configServers/formServers.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
-#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
-#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
-#: centreon/www/include/monitoring/comments/listComment.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
 #: centreon/www/include/Administration/parameters/ldap/form.php
+#: centreon/www/include/options/accessLists/resourcesACL/listsResourcesAccess.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+#: centreon/www/include/configuration/configObject/metaservice_dependency/formMetaServiceDependency.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/contact/listContact.php
+#: centreon/www/include/configuration/configObject/contact/formContact.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/hostgroup_dependency/formHostGroupDependency.php
+#: centreon/www/include/configuration/configObject/host_dependency/formHostDependency.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/contact_template_model/formContactTemplateModel.php
+#: centreon/www/include/configuration/configObject/service_dependency/formServiceDependency.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/servicegroup_dependency/formServiceGroupDependency.php
+#: centreon/www/include/configuration/configServers/formServers.php
+#: centreon/www/include/configuration/configServers/listServers.php
+#: centreon/www/include/monitoring/acknowlegement/xml/broker/makeXMLForAck.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/include/monitoring/downtime/xml/broker/makeXMLForDowntime.php
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+#: centreon/www/include/monitoring/comments/listComment.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/class/centreonXMLBGRequest.class.php
 msgid "Yes"
 msgstr "Oui"
 
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/reporting/dashboard/common-Func.php
 #: centreon/www/include/Administration/corePerformance/nagiosStats.php
+#: centreon/www/include/reporting/dashboard/common-Func.php
+#: centreon/www/install/front_translate.php
 msgid "Yesterday"
 msgstr "Hier"
 
@@ -17274,6 +17733,30 @@ msgid ""
 "You are going to delete <strong>{{name}}</strong> from the user list. This "
 "user will no longer access the dashboard."
 msgstr ""
+"Vous allez supprimer <strong>{{nom}}</strong> de la liste des utilisateurs. "
+"Cet utilisateur n'aura plus accès au tableau de bord."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You are going to delete the <strong>{{ agent }}</strong> agent "
+"configuration. All parameters for this agent configuration will be deleted. "
+"This action cannot be undone."
+msgstr ""
+"Vous allez supprimer la configuration de l'agent <strong>{{ agent }}</"
+"strong>. Tous les paramètres de configuration de cet agent seront supprimés. "
+"Cette action est irréversible."
+
+#: centreon/www/install/front_translate.php
+msgid ""
+"You are going to delete the configuration for the <strong>{{ poller }}</"
+"strong> poller from the <strong>{{ agent }}</strong> agent configuration. "
+"All configuration parameters for this poller will be deleted. This action "
+"cannot be undone."
+msgstr ""
+"Vous allez supprimer la configuration du collecteur <strong>{{ poller }}</"
+"strong> de l'agent <strong>{{ agent }}</strong>. Tous les paramètres de "
+"configuration de ce collecteur seront supprimés. Cette action est "
+"irréversible."
 
 #: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
 msgid "You are not allowed to access additional configurations"
@@ -17381,9 +17864,9 @@ msgstr "Vous n'êtes pas autorisé à accéder à ce méta-service"
 msgid "You are not allowed to access this monitoring instance"
 msgstr "Vous n'êtes pas autorisé à accéder à cette instance de supervision"
 
+#: centreon/www/include/configuration/configNagios/formNagios.php
 #: centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
 #: centreon/www/include/configuration/configResources/formResources.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
 msgid "You are not allowed to access this object configuration"
 msgstr "Vous n'êtes pas autorisé à accéder à la définition de l'objet"
 
@@ -17405,7 +17888,7 @@ msgstr "Vous n'êtes pas autorisé à accéder aux périodes de temps"
 
 #: centreon/src/Core/User/Application/Exception/UserException.php
 msgid "You are not allowed to access users"
-msgstr ""
+msgstr "Vous n'avez pas la permission d'accéder à la liste des utilisateurs"
 
 #: centreon/src/Core/Command/Application/Exception/CommandException.php
 msgid "You are not allowed to add a command"
@@ -17414,6 +17897,7 @@ msgstr "Vous n'êtes pas autorisé à créer une commande"
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "You are not allowed to add a notification configuration"
 msgstr ""
+"Vous n'avez pas la permission d'ajouter une configuration de notifications"
 
 #: centreon/src/Core/Service/Application/Exception/ServiceException.php
 msgid "You are not allowed to add a service"
@@ -17443,6 +17927,7 @@ msgstr "Vous n'êtes pas autorisé à ajouter des tokens"
 #, php-format
 msgid "You are not allowed to add tokens linked to user ID %d"
 msgstr ""
+"Vous n'avez pas la permission d'ajouter des jetons liés à l'ID utilisateur %d"
 
 #: centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
 msgid "You are not allowed to create service categories"
@@ -17458,11 +17943,11 @@ msgstr "Vous n'êtes pas autorisé à créer/modifier des sévérités d'hôtes"
 
 #: centreon/src/Core/HostCategory/Application/Exception/HostCategoryException.php
 msgid "You are not allowed to create/modify host categories"
-msgstr ""
+msgstr "Vous n'avez pas la permission de créer/modifier des catégories d'hôtes"
 
 #: centreon/src/Core/Host/Application/Exception/HostException.php
 msgid "You are not allowed to delete a host"
-msgstr ""
+msgstr "Vous n'avez pas la permission de supprimer un hôte"
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "You are not allowed to delete a notification configuration"
@@ -17508,7 +17993,7 @@ msgstr ""
 
 #: centreon/www/include/options/session/connected_user.php
 msgid "You are not allowed to disconnect this user"
-msgstr "Vous n'êtes pas autorisé à déconnecter cet utilisateur."
+msgstr "Vous n'avez pas la permission de déconnecter cet utilisateur"
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "You are not allowed to display the details of the notification"
@@ -17534,7 +18019,7 @@ msgstr ""
 
 #: centreon/src/Core/ServiceSeverity/Application/Exception/ServiceSeverityException.php
 msgid "You are not allowed to edit service severities"
-msgstr ""
+msgstr "Vous n'avez pas la permission d'éditer les criticités de services"
 
 #: centreon/src/Core/TimePeriod/Application/Exception/TimePeriodException.php
 msgid "You are not allowed to edit time periods"
@@ -17563,6 +18048,8 @@ msgstr "Vous n'êtes pas autorisé à lister les configurations de notifications
 #: centreon/src/Core/ResourceAccess/Application/Exception/RuleException.php
 msgid "You are not allowed to list resource access rules"
 msgstr ""
+"Vous n'avez pas la permission de voir la liste des règles d'accès aux "
+"ressources"
 
 #: centreon/www/install/front_translate.php
 msgid "You are not allowed to log in"
@@ -17613,11 +18100,11 @@ msgstr "Vous n'êtes pas autorisé à voir cette page"
 
 #: centreon/src/Core/ServiceTemplate/Application/Exception/ServiceTemplateException.php
 msgid "You are not allowed to update a service template"
-msgstr ""
+msgstr "Vous n'avez pas la permission de mettre à jour un modèle de service"
 
 #: centreon/src/Core/Media/Application/Exception/MediaException.php
 msgid "You are not allowed to update media"
-msgstr ""
+msgstr "Vous n'avez pas la permission de mettre à jour des médias"
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 msgid "You are not allowed to update the notification configuration"
@@ -17626,7 +18113,7 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "You are not authorized to access the configuration"
-msgstr ""
+msgstr "Vous n'avez pas la permission d'accéder à la configuration"
 
 #: centreon/www/install/front_translate.php
 msgid "You can choose only one resource for each resource type."
@@ -17635,7 +18122,7 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "You can see the full list on"
-msgstr ""
+msgstr "Vous pouvez voir la liste complète sur"
 
 #: centreon/www/install/front_translate.php
 msgid "You can use regular expression syntax to retrieve more relevant results"
@@ -17670,6 +18157,8 @@ msgstr ""
 #: centreon/www/install/smarty_translate.php
 msgid "You cannot add more charts. The maximum charts is "
 msgstr ""
+"Vous ne pouvez pas ajouter d'autres graphiques. Le nombre maximum de "
+"graphiques est de "
 
 #: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/host/formHost.php
@@ -17679,10 +18168,14 @@ msgstr "Vous ne pouvez pas redéfinir les macros réservées"
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 msgid "You cannot share the same dashboard to a contact group several times"
 msgstr ""
+"Vous ne pouvez pas partager plusieurs fois le même tableau de bord avec un "
+"groupe de contacts"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 msgid "You cannot share the same dashboard to a contact several times"
 msgstr ""
+"Vous ne pouvez pas partager plusieurs fois le même tableau de bord avec un "
+"contact"
 
 #: centreon/src/Core/Dashboard/Application/Exception/DashboardException.php
 #, php-format
@@ -17693,12 +18186,12 @@ msgstr ""
 
 #: centreon/src/Centreon/Domain/PlatformInformation/Exception/PlatformInformationException.php
 msgid "You do not have sufficent rights for this action."
-msgstr ""
+msgstr "Vous n'avez pas la permission d'effectuer cette action."
 
-#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 #: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneService.php
+#: centreon/www/include/monitoring/status/Services/xml/makeXMLForOneHost.php
 msgid "You don't have access to this resource"
-msgstr ""
+msgstr "Vous n'avez pas accès à cette ressource"
 
 #: centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
 #: centreon/src/Core/AdditionalConnectorConfiguration/Application/Exception/AccException.php
@@ -17740,27 +18233,32 @@ msgid ""
 "You may refer to the line in the specified file in order to correct the "
 "issue."
 msgstr ""
+"Référez-vous à la ligne du fichier spécifié afin de corriger le problème."
 
 #: centreon/src/Centreon/Application/Controller/MonitoringResourceController.php
 msgid "You must add at least one provider"
-msgstr ""
+msgstr "Vous devez ajouter au moins un fournisseur"
 
 #: centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
 msgid "You must add at least one resource provider"
-msgstr ""
+msgstr "Vous devez ajouter au moins un fournisseur de ressources"
 
 #: centreon/src/Security/Domain/Authentication/Exceptions/ProviderException.php
 msgid "You must at least add one authentication provider"
-msgstr ""
+msgstr "Vous devez ajouter au moins un fournisseur d'authentification"
 
-#: centreon/www/include/configuration/configObject/service/formService.php
 #: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
 msgid "You must either fill all the arguments or leave them all empty"
 msgstr "Vous devez saisir tous les arguments ou laisser vide"
 
 #: centreon/src/Core/Notification/Application/Exception/NotificationException.php
 #, php-format
 msgid "You must provide at least one %s"
+msgstr "Vous devez ajouter au moins un %s"
+
+#: centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+msgid "You must provide at least one ACL provider"
 msgstr ""
 
 #: centreon/www/include/configuration/configGenerate/formGenerateFiles.php
@@ -17778,11 +18276,11 @@ msgstr "Il semble qu'il y ait un problème avec votre mise à jour."
 
 #: centreon/www/install/front_translate.php
 msgid "You will be disconnected"
-msgstr ""
+msgstr "Vous allez être déconnecté"
 
 #: centreon/www/api/class/centreon_topcounter.class.php
 msgid "You're not authorized to access poller data"
-msgstr ""
+msgstr "Vous n'avez pas la permission d'accéder aux données du collecteur"
 
 #: centreon/src/Centreon/Domain/RemoteServer/RemoteServerService.php
 msgid ""
@@ -17804,8 +18302,9 @@ msgstr "Votre adresse IP est sur liste noire"
 msgid "Your IP is not whitelisted"
 msgstr "Votre adresse IP n'est pas sur liste blanche"
 
-#: centreon/www/include/Administration/myAccount/DB-Func.php
 #: centreon/lib/Centreon/Object/Contact/Contact.php
+#: centreon/www/include/Administration/myAccount/DB-Func.php
+#: centreon/www/include/configuration/configObject/contact/DB-Func.php
 msgid "Your autologin key must be different than your current password"
 msgstr ""
 "Votre clé d'autologin doit être différente de votre mot de passe actuel"
@@ -17814,8 +18313,8 @@ msgstr ""
 msgid "Your changes will not be saved if you leave this page."
 msgstr "Vos changements ne seront pas sauvegardés si vous quittez la page."
 
-#: centreon/www/include/monitoring/external_cmd/functions.php
 #: centreon/www/include/monitoring/external_cmd/functionsPopup.php
+#: centreon/www/include/monitoring/external_cmd/functions.php
 msgid "Your command has been sent"
 msgstr "Votre commande a été envoyée"
 
@@ -17830,7 +18329,7 @@ msgstr "Vos informations d'identification sont incorrectes."
 #: centreon/www/install/step_upgrade/step4.php
 #, php-format
 msgid "Your current version is %s."
-msgstr ""
+msgstr "Votre version actuelle est la %s."
 
 #: centreon/www/install/front_translate.php
 msgid "Your dashboard has been saved"
@@ -17889,7 +18388,7 @@ msgstr "Vos droits ne vous permettent que de voir les propriétés d'un widget."
 
 #: centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php
 msgid "Your session has expired"
-msgstr ""
+msgstr "Votre session a expiré"
 
 #: centreon/www/install/front_translate.php
 msgid "Your widget has been created successfully!"
@@ -17901,7 +18400,7 @@ msgstr "Votre widget a été modifié avec succès !"
 
 #: centreon/www/include/configuration/configServers/formServers.php
 msgid "ZMQ"
-msgstr ""
+msgstr "ZMQ"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
@@ -17911,12 +18410,12 @@ msgstr "[%s] (%s) devait être une instance de la classe '%s'"
 #: centreon/src/Core/Media/Infrastructure/API/Exception/MediaException.php
 #, php-format
 msgid "[%s] Empty value found, but a string is required"
-msgstr ""
+msgstr "[%s] Valeur vide trouvée : une chaîne de caractères est requise"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
 msgid "[%s] The date \"%s\" was expected to be at least %s"
-msgstr ""
+msgstr "[%s] La date \" %s\" devrait être au moins %s"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
@@ -17926,17 +18425,17 @@ msgstr "[%s] La date \"%s\" devait être au maximum au %s"
 #: centreon/src/Core/Media/Infrastructure/API/Exception/MediaException.php
 #, php-format
 msgid "[%s] The property %s is required"
-msgstr ""
+msgstr "[%s] La propriété %s est requise"
 
 #: centreon/src/Core/Media/Infrastructure/API/Exception/MediaException.php
 #, php-format
 msgid "[%s] The property does not contain the file"
-msgstr ""
+msgstr "[%s] L'extension du fichier n'est pas autorisée"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
 msgid "[%s] The string is empty, but non empty string was expected"
-msgstr ""
+msgstr "[%s] La chaîne est vide : une chaîne non vide était attendue"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
@@ -17976,32 +18475,34 @@ msgstr ""
 msgid ""
 "[%s] The value \"%s\" was expected to be a valid URL, IP address or domain"
 msgstr ""
+"[%s] La valeur \"%s\" n'est pas une URL, une adresse IP ou un domaine valide"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
 msgid "[%s] The value \"%s\" was expected to be a valid e-mail address"
-msgstr ""
+msgstr "[%s] La valeur \"%s\" n'est pas une adresse email valide"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
 msgid ""
 "[%s] The value \"%s\" was expected to be a valid ip address or domain name"
 msgstr ""
+"[%s] La valeur \"%s\" n'est pas une adresse IP ou un nom de domaine valide"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
 msgid "[%s] The value '%s' was expected to be a valid ip address"
-msgstr ""
+msgstr "[%s] La valeur '%s' n'est pas une adresse IP valide"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
 msgid "[%s] The value (%s) doesn't match the regex '%s'"
-msgstr ""
+msgstr "[%s] La valeur (%s) ne correspond pas à la regex '%s'"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
 msgid "[%s] The value cannot be encoded to a valid JSON string"
-msgstr ""
+msgstr "[%s] La valeur ne peut pas être encodée en une chaîne JSON valide"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
@@ -18016,17 +18517,17 @@ msgstr "[%s] La valeur est vide, mais une valeur non vide était attendue"
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
 msgid "[%s] The value is not a valid JSON string"
-msgstr ""
+msgstr "[%s] La valeur n'est pas une chaîne JSON valide"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
-#, fuzzy, php-format
+#, php-format
 msgid "[%s] The value is null, but non null value was expected"
-msgstr "[%] La valeur est nulle, mais une valeur non nulle était attendue"
+msgstr "[%s] La valeur est nulle : une valeur non nulle était attendue"
 
 #: centreon/src/Centreon/Domain/Common/Assertion/AssertionException.php
 #, php-format
 msgid "[%s] The value provided (%s) was not expected. Possible values %s"
-msgstr ""
+msgstr "[%s] Valeur fournie (%s) invalide. Valeurs possibles : %s"
 
 #: centreon/src/Core/Security/Authentication/Domain/Exception/SSOAuthenticationException.php
 #, php-format
@@ -18051,10 +18552,10 @@ msgid "[%s]: No authorization code return by external provider"
 msgstr ""
 "[%s] : Aucun code d'autorisation n'a été retourné par le fournisseur externe"
 
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 #: centreon/www/include/monitoring/status/Services/service.php
 #: centreon/www/include/monitoring/status/Hosts/host.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid ""
 "[Page deprecated] This page will be removed in the next major version. "
 "Please use the new page: "
@@ -18068,15 +18569,15 @@ msgstr "_Module_ n'est pas une expression autorisée"
 
 #: centreon/www/install/front_translate.php
 msgid "a-z"
-msgstr ""
+msgstr "a-z"
 
 #: centreon/www/install/front_translate.php
 msgid "added"
-msgstr ""
+msgstr "ajouté"
 
 #: centreon/www/install/front_translate.php
 msgid "align picker"
-msgstr ""
+msgstr "Aligner la sélection"
 
 #: centreon/www/install/front_translate.php
 msgid "and"
@@ -18096,7 +18597,7 @@ msgstr "et doit contenir"
 
 #: centreon/www/include/Administration/parameters/remote/formRemote.php
 msgid "apiPath"
-msgstr ""
+msgstr "Chemin de l'API"
 
 #: centreon/www/install/front_translate.php
 msgid "are working fine."
@@ -18132,7 +18633,7 @@ msgstr "centreon n'est pas correctement installé"
 
 #: centreon/www/install/front_translate.php
 msgid "characters"
-msgstr ""
+msgstr "caractères"
 
 #: centreon/www/include/monitoring/acknowlegement/serviceAcknowledge.php
 msgid "comment"
@@ -18143,44 +18644,46 @@ msgid "create or load"
 msgstr "créer ou charger"
 
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
-#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
 #: centreon/www/include/reporting/dashboard/csvExport/csv_ServiceLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostLogs.php
+#: centreon/www/include/reporting/dashboard/csvExport/csv_HostGroupLogs.php
 msgid "d/m/Y H:i:s"
 msgstr "d/m/Y - H:i:s"
 
 #: centreon/www/install/front_translate.php
 msgid "day"
-msgstr ""
+msgstr "jour"
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/Administration/parameters/engine/form.php
 #: centreon/www/include/Administration/parameters/centstorage/form.php
+#: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/install/smarty_translate.php
 msgid "days"
 msgstr "jours"
 
 #: centreon/www/install/front_translate.php
 msgid "delete multiple notifications"
-msgstr ""
+msgstr "Supprimer plusieurs notifications"
 
 #: centreon/www/lib/HTML/QuickForm/select2.php
 msgid "disabled"
-msgstr ""
+msgstr "désactivé"
 
+#: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
 #: centreon/www/include/monitoring/recurrentDowntime/formDowntime.php
 msgid "error"
 msgstr "erreur"
 
 #: centreon/www/include/configuration/configObject/hostgroup/formHostGroup.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
 #: centreon/www/include/configuration/configObject/servicegroup/formServiceGroup.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
 msgid "geo coords are not valid"
-msgstr ""
+msgstr "Les coordonnées géographiques ne sont pas valides"
 
 #: centreon/www/install/front_translate.php
 msgid "get some help while creating your regular expression query at"
@@ -18193,14 +18696,14 @@ msgstr "graphique de l'hôte"
 
 #: centreon/www/install/front_translate.php
 msgid "group"
-msgstr ""
+msgstr "groupe"
 
 #: centreon/www/install/front_translate.php
 msgid "groups"
-msgstr ""
+msgstr "groupes"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/lib/HTML/QuickForm/HTML_QuickFormCustom.php
+#: centreon/www/install/front_translate.php
 msgid "here"
 msgstr "ici"
 
@@ -18214,16 +18717,16 @@ msgstr ""
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
 msgid "hours"
 msgstr "heures"
 
+#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
 #: centreon/www/include/Administration/parameters/backup/formBackup.php
 #: centreon/www/include/Administration/parameters/knowledgeBase/formKnowledgeBase.php
-#: centreon/www/include/Administration/parameters/api/api.php
-#: centreon/www/include/Administration/parameters/gorgone/gorgone.php
 #: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/Administration/parameters/api/api.php
 msgid "impossible to validate, one or more field is incorrect"
 msgstr "impossible de valider, un ou plusieurs champs sont incorrects"
 
@@ -18236,6 +18739,8 @@ msgid ""
 "is the selected metric by default. Refine filters to select another specific "
 "resource."
 msgstr ""
+"est la métrique sélectionnée par défaut. Affinez les filtres pour "
+"sélectionner une autre ressource spécifique."
 
 #: centreon/www/install/front_translate.php
 msgid "is used to allow users to access resources."
@@ -18243,19 +18748,19 @@ msgstr "est utilisée pour permettre aux utilisateurs d'accéder aux resources."
 
 #: centreon/www/include/views/graphs/graph-periods.php
 msgid "last day"
-msgstr ""
+msgstr "Le dernier jour"
 
 #: centreon/www/include/views/graphs/graph-periods.php
 msgid "last month"
-msgstr ""
+msgstr "Le mois dernier"
 
 #: centreon/www/include/views/graphs/graph-periods.php
 msgid "last week"
-msgstr ""
+msgstr "La semaine dernière"
 
 #: centreon/www/include/views/graphs/graph-periods.php
 msgid "last year"
-msgstr ""
+msgstr "L'année dernière"
 
 #: centreon/www/class/centreonContact.class.php
 msgid "lowercase characters"
@@ -18263,11 +18768,11 @@ msgstr "caractères minuscules"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "lua parameter"
-msgstr ""
+msgstr "paramètre lua"
 
 #: centreon/www/install/front_translate.php
 msgid "manual"
-msgstr ""
+msgstr "manuel"
 
 #: centreon/www/install/front_translate.php
 msgid "minute"
@@ -18275,11 +18780,11 @@ msgstr ""
 
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
 #: centreon/www/include/Administration/parameters/general/form.php
 #: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/install/front_translate.php
 msgid "minutes"
 msgstr "minutes"
 
@@ -18311,9 +18816,9 @@ msgstr "de"
 msgid "on host"
 msgstr "sur l'hôte"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/views/graphs/graphs.php
 #: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/install/front_translate.php
 msgid "or"
 msgstr "ou"
 
@@ -18327,34 +18832,39 @@ msgstr "points hors enveloppe"
 
 #: centreon/www/install/front_translate.php
 msgid "removed"
-msgstr ""
+msgstr "supprimé"
+
+#: centreon/www/include/monitoring/downtime/listDowntime.php
+msgid "s"
+msgstr "s"
 
 #: centreon/www/install/front_translate.php
 msgid "second"
 msgstr "seconde"
 
+#: centreon/cron/centAcl.php
 #: centreon/www/widgets/host-monitoring/src/action.php
 #: centreon/www/widgets/service-monitoring/src/action.php
-#: centreon/www/install/front_translate.php
-#: centreon/www/install/smarty_translate.php
-#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
-#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
-#: centreon/www/include/configuration/configObject/service/formService.php
-#: centreon/www/include/configuration/configObject/host/formHost.php
-#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
-#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
-#: centreon/www/include/configuration/configNagios/formNagios.php
-#: centreon/www/include/monitoring/downtime/AddDowntime.php
-#: centreon/www/include/monitoring/objectDetails/hostDetails.php
-#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 #: centreon/www/include/Administration/parameters/general/form.php
 #: centreon/www/include/Administration/parameters/engine/form.php
+#: centreon/www/include/configuration/configNagios/formNagios.php
+#: centreon/www/include/configuration/configObject/service_template_model/formServiceTemplateModel.php
+#: centreon/www/include/configuration/configObject/service/formService.php
+#: centreon/www/include/configuration/configObject/escalation/formEscalation.php
+#: centreon/www/include/configuration/configObject/host_template_model/formHostTemplateModel.php
+#: centreon/www/include/configuration/configObject/meta_service/formMetaService.php
+#: centreon/www/include/configuration/configObject/host/formHost.php
+#: centreon/www/include/monitoring/objectDetails/hostDetails.php
+#: centreon/www/include/monitoring/objectDetails/serviceDetails.php
+#: centreon/www/include/monitoring/downtime/AddDowntime.php
+#: centreon/www/install/front_translate.php
+#: centreon/www/install/smarty_translate.php
 msgid "seconds"
 msgstr "secondes"
 
 #: centreon/www/install/front_translate.php
 msgid "select a file"
-msgstr ""
+msgstr "sélectionner un fichier"
 
 #: centreon/www/install/front_translate.php
 #: centreon/www/install/react_translation.php
@@ -18372,7 +18882,7 @@ msgstr "Acquittement persistant en cas de changement de statut non-OK"
 
 #: centreon/www/install/front_translate.php
 msgid "technical"
-msgstr ""
+msgstr "technique"
 
 #: centreon/src/Centreon/Domain/PlatformInformation/UseCase/V20/UpdatePartiallyPlatformInformation.php
 #, php-format
@@ -18400,19 +18910,23 @@ msgstr "la communauté"
 msgid "tiles"
 msgstr "tuiles"
 
-#: centreon/www/install/front_translate.php
 #: centreon/www/include/views/graphs/graphs.php
 #: centreon/www/include/reporting/dashboard/viewServicesGroupLog.php
-#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
-#: centreon/www/include/reporting/dashboard/initReport.php
 #: centreon/www/include/reporting/dashboard/viewHostLog.php
 #: centreon/www/include/reporting/dashboard/viewServicesLog.php
+#: centreon/www/include/reporting/dashboard/initReport.php
+#: centreon/www/include/reporting/dashboard/viewHostGroupLog.php
+#: centreon/www/install/front_translate.php
 msgid "to"
 msgstr "à"
 
+#: centreon/www/include/Administration/configChangelog/viewLogs.php
+msgid "unknown"
+msgstr "inconnu"
+
 #: centreon/www/install/front_translate.php
 msgid "updated"
-msgstr ""
+msgstr "mis à jour"
 
 #: centreon/www/class/centreonContact.class.php
 msgid "uppercase characters"
@@ -18428,7 +18942,7 @@ msgstr "affichera les ressources avec un FQDN ne contenant pas"
 
 #: centreon/www/install/front_translate.php
 msgid "will display resources with host name starting by"
-msgstr ""
+msgstr "affichera les ressources dont le nom d'hôte commence par"
 
 #: centreon/www/install/front_translate.php
 msgid "will display resources with service description finishing by"
@@ -18440,19 +18954,19 @@ msgstr ""
 
 #: centreon/www/install/front_translate.php
 msgid "{{label}} can be at most {{max}} characters"
-msgstr ""
+msgstr "{{label}} peut contenir au maximum {{max}} caractères"
 
 #: centreon/www/install/front_translate.php
 msgid "{{label}} should be at least {{min}} characters long"
-msgstr ""
+msgstr "{{label}} doit comporter au moins {{min}} caractères"
 
 #: unknown
 msgid " element(s) found"
-msgstr "élément(s) trouvé(s)"
+msgstr " élément(s) trouvé(s)"
 
 #: unknown
 msgid " elements to selection ?"
-msgstr "éléments à sélectioner?"
+msgstr " éléments à sélectionner ?"
 
 #: unknown
 msgid "$HOSTADDRESS$"
@@ -18473,6 +18987,10 @@ msgstr ""
 "transmises"
 
 #: unknown
+msgid "24x7"
+msgstr "24x7"
+
+#: unknown
 msgid "2d Coords"
 msgstr "Coordonnées 2D"
 
@@ -18484,11 +19002,7 @@ msgstr "Coordonnées 3D"
 msgid "<br><b>Centreon : </b>A force-reload signal has been sent to "
 msgstr ""
 "<br><b>Centreon : </b>Une commande de redémarrage forcée a été envoyée "
-"vers"
-
-#: unknown
-msgid "<br><b>Centreon : </b>All configuration will be send to "
-msgstr "<br><b>Centreon : </b>Toute la configuration sera envoyée vers "
+"vers "
 
 #: unknown
 msgid "<br><b>Centreon : </b>Cannot send signal to "
@@ -18496,14 +19010,15 @@ msgstr "<br><b>Centreon : </b>Impossible d'envoyer le signal vers "
 
 #: unknown
 msgid ""
-"<br><i><b><font color=\"#B22222\">Notes </font>:</b></i><br>&nbsp;&nbsp;"
-"&nbsp;- Do not mix metrics of different sources.<br>&nbsp;&nbsp;&nbsp;- "
-"Only aggregation functions work in VDEF rpn expressions."
+"<br><i><b><font color=\"#B22222\">Notes </font>:</b></"
+"i><br>&nbsp;&nbsp;&nbsp;- Do not mix metrics of different sources."
+"<br>&nbsp;&nbsp;&nbsp;- Only aggregation functions work in VDEF rpn "
+"expressions."
 msgstr ""
-"<br><i><b><font color=\"#B22222\">Notes </font>:</b></i><br>&nbsp;&nbsp;"
-"&nbsp;- Ne pas mélanger les métriques de différentes sources.<br>&nbsp;"
-"&nbsp;&nbsp;- Seules les fonctions d'agrégation fonctionnent avec les "
-"expressions VDEF."
+"<br><i><b><font color=\"#B22222\">Notes </font>:</b></"
+"i><br>&nbsp;&nbsp;&nbsp;- Ne pas mélanger les métriques de différentes "
+"sources.<br>&nbsp;&nbsp;&nbsp;- Seules les fonctions d'agrégation "
+"fonctionnent avec les expressions VDEF."
 
 #: unknown
 msgid ""
@@ -18512,14 +19027,6 @@ msgid ""
 msgstr ""
 "<p>En cours de mise à jour de la base de données... Merci de ne pas "
 "interrompre ce processus.</p>"
-
-#: unknown
-msgid "ACL Definition"
-msgstr "Nom de l'ACL"
-
-#: unknown
-msgid "ACL reloaded"
-msgstr "ACL rechargées"
 
 #: unknown
 msgid "ACL rules"
@@ -18535,11 +19042,7 @@ msgstr "Jeton d'API"
 
 #: unknown
 msgid "Access not allowed"
-msgstr " Accès non autorisé"
-
-#: unknown
-msgid "Accessible Pages"
-msgstr "Pages disponibles"
+msgstr "Accès non autorisé"
 
 #: unknown
 msgid "Acknowledge host or service Color"
@@ -18571,7 +19074,11 @@ msgstr "Actif/Révoqué"
 
 #: unknown
 msgid "Add "
-msgstr "Ajouter"
+msgstr "Ajouter "
+
+#: unknown
+msgid "Add Image(s)"
+msgstr "Ajout d'image(s)"
 
 #: unknown
 msgid "Add a Host downtime"
@@ -18590,16 +19097,24 @@ msgid "Add a Service downtime"
 msgstr "Planifier pour un service"
 
 #: unknown
-msgid "Add a User Template"
-msgstr "Ajouter un modèle utilisateur"
-
-#: unknown
 msgid "Add a host downtime"
 msgstr "Planifier pour un hôte"
 
 #: unknown
 msgid "Add a service downtime"
 msgstr "Planifier pour service"
+
+#: unknown
+msgid "Add additional configurations"
+msgstr "Ajouter des configurations additionnelles"
+
+#: unknown
+msgid "Add an additional configuration"
+msgstr "Ajouter une configuration additionnelle"
+
+#: unknown
+msgid "Add host group"
+msgstr "Ajouter un groupe d'hôtes"
 
 #: unknown
 msgid ""
@@ -18622,6 +19137,10 @@ msgid "Add viewer / viewer group"
 msgstr "Ajouter utilisateurs / groupes d'utilisateurs"
 
 #: unknown
+msgid "Additional configurations"
+msgstr "Configurations additionnelles"
+
+#: unknown
 msgid "Additional daemon"
 msgstr "Démon supplémentaire"
 
@@ -18634,36 +19153,16 @@ msgid "Additionnal Information"
 msgstr "Informations complémentaires"
 
 #: unknown
-msgid "Address1"
-msgstr "Adresse n°1"
-
-#: unknown
-msgid "Address2"
-msgstr "Adresse n°2"
-
-#: unknown
-msgid "Address3"
-msgstr "Adresse n°3"
-
-#: unknown
-msgid "Address4"
-msgstr "Adresse n°4"
-
-#: unknown
-msgid "Address5"
-msgstr "Adresse n°5"
-
-#: unknown
-msgid "Address6"
-msgstr "Adresse n°6"
-
-#: unknown
 msgid "Advanced mode"
 msgstr "Mode avancé"
 
 #: unknown
 msgid "Agent configuration"
 msgstr "Configuration d'agent"
+
+#: unknown
+msgid "Agent types"
+msgstr "Types d'agent"
 
 #: unknown
 msgid "Aggressive Host Checks"
@@ -18774,7 +19273,7 @@ msgid ""
 "that the new envelope size will only be applied from now on. The old "
 "envelope will stay the same."
 msgstr ""
-"Souhaitez-vous vraiment modifier la taille de l'enveloppe? Notez que la "
+"Souhaitez-vous vraiment modifier la taille de l'enveloppe ? Notez que la "
 "nouvelle taille d'enveloppe s’appliquera seulement à partir de "
 "maintenant. L’ancienne enveloppe restera inchangée."
 
@@ -18788,7 +19287,7 @@ msgstr ""
 
 #: unknown
 msgid "Are you sure you want to uninstall this widget?"
-msgstr "Êtes-vous sûr de vouloir désinstaller ce widget?"
+msgstr "Êtes-vous sûr de vouloir désinstaller ce widget ?"
 
 #: unknown
 msgid "Area"
@@ -18855,10 +19354,6 @@ msgid "Bad JSON schema path"
 msgstr "Mauvais chemin de JSON Schema"
 
 #: unknown
-msgid "Bad SQL request"
-msgstr "Mauvaise requête SQL"
-
-#: unknown
 msgid "Bad arguments for wizard."
 msgstr "Mauvais arguments pour l'assistant."
 
@@ -18923,6 +19418,10 @@ msgid "Bottom color"
 msgstr "Couleur du bas"
 
 #: unknown
+msgid "Broker Module Configuration File"
+msgstr "Fichier de configuration du module Broker"
+
+#: unknown
 msgid "Broker Module information"
 msgstr "Information du module broker"
 
@@ -18953,6 +19452,22 @@ msgstr "Historique du statut d’une Activité Métier"
 #: unknown
 msgid "Business Intelligence"
 msgstr "Business Intelligence"
+
+#: unknown
+msgid "Button 1"
+msgstr "Bouton 1"
+
+#: unknown
+msgid "Button 2"
+msgstr "Bouton 2"
+
+#: unknown
+msgid "Button 3"
+msgstr "Bouton 3"
+
+#: unknown
+msgid "Button 4"
+msgstr "Bouton 4"
 
 #: unknown
 msgid "By name"
@@ -19003,6 +19518,10 @@ msgid "CSS configuration"
 msgstr "Configuration CSS"
 
 #: unknown
+msgid "Calculations based on time period"
+msgstr "Calculs basés sur la période temporelle"
+
+#: unknown
 msgid "Can't get file'"
 msgstr "Impossible d'obtenir le fichier"
 
@@ -19033,8 +19552,8 @@ msgstr "Impossible d'obtenir la dernière version"
 #: unknown
 msgid "Cannot link a 'remote': '%s'@'%s' to another Remote server type"
 msgstr ""
-"Il n'est pas possible de lier un 'remote': '%s'@'%s' à un autre serveur "
-"de type 'Remote'"
+"Il n'est pas possible de lier le serveur distant '%s'@'%s' à un autre "
+"serveur distant"
 
 #: unknown
 msgid "Cannot set parent id on a central server"
@@ -19081,8 +19600,8 @@ msgid ""
 "Central platform's data are not consistent. Please check the 'Remote "
 "Access' form"
 msgstr ""
-"Des données de la plateforme ne sont pas cohérentes. Veuillez vérifier le "
-"formulaire 'Accès du Remote'."
+"Les données sur le serveur central ne sont pas cohérentes. Veuillez "
+"vérifier le formulaire 'Accès au serveur distant'"
 
 #: unknown
 msgid "Central's API URI."
@@ -19093,8 +19612,8 @@ msgid ""
 "Central's path is missing on: '%s'@'%s'. Please check the Remote Access "
 "form."
 msgstr ""
-"Le chemin vers le Central, de la plateforme: '%s'@'%s est manquant. "
-"Veuillez vérifier le formulaire 'Accès du Remote'."
+"Le chemin vers le central de la plateforme '%s'@'%s est manquant. "
+"Veuillez vérifier le formulaire 'Accès au serveur distant'."
 
 #: unknown
 msgid "Central's response : "
@@ -19114,7 +19633,7 @@ msgstr "Statistiques sur les bases de données de Centreon"
 
 #: unknown
 msgid "Centreon Map"
-msgstr "Centreon Map"
+msgstr "Centreon MAP"
 
 #: unknown
 msgid "Centreon Map Client (admin)"
@@ -19126,7 +19645,7 @@ msgstr "Client Centreon Map (utilisateur)"
 
 #: unknown
 msgid "Centreon Map WS"
-msgstr "Centreon Map WS"
+msgstr "Centreon MAP WS"
 
 #: unknown
 msgid "Centreon Users"
@@ -19227,7 +19746,7 @@ msgstr "Création de deux processus enfants pour chaque contrôle"
 
 #: unknown
 msgid "Choose a configuration template:"
-msgstr "Choisissez le modèle de configuration"
+msgstr "Choisissez un modèle de configuration"
 
 #: unknown
 msgid "Choose a duration between 1 hour and 12 months"
@@ -19244,6 +19763,10 @@ msgstr "Veuillez sélectionner au moins 1 utilisateur"
 #: unknown
 msgid "Client Secret"
 msgstr "Secret client"
+
+#: unknown
+msgid "Clock"
+msgstr "Horloge"
 
 #: unknown
 msgid "Clock / Timer"
@@ -19282,6 +19805,10 @@ msgid "Compulsory Contact Group"
 msgstr "Groupe de contacts obligatoire"
 
 #: unknown
+msgid "Compulsory image name"
+msgstr "Nom de l'image obligatoire"
+
+#: unknown
 msgid "Condensed"
 msgstr "Condensé"
 
@@ -19301,14 +19828,10 @@ msgstr "Configuration sauvegardée."
 msgid "Congratulations, you have successfully installed Centreon!"
 msgstr ""
 "Félicitations, vous avez installé avec succès Centreon en version <b>%s</"
-"b>."
+"b> !"
 
 #: unknown
 msgid "Connected Users"
-msgstr "Utilisateurs connectés"
-
-#: unknown
-msgid "Connected users"
 msgstr "Utilisateurs connectés"
 
 #: unknown
@@ -19320,7 +19843,7 @@ msgid ""
 "Connection to Wiki database failed, please contact your administrator or "
 "read the Centreon online documentation to configure wiki access"
 msgstr ""
-"Echec de connexion à la base de connaissance, veuillez contacter votre "
+"Échec de connexion à la base de connaissances. Veuillez contacter votre "
 "administrateur ou consulter la documentation en ligne Centreon pour "
 "configurer les accès."
 
@@ -19342,10 +19865,9 @@ msgstr ""
 "Groupe de contact : Définir un groupe de contact pour l'utilisateur "
 "importé."
 
-#, fuzzy
 #: unknown
 msgid "Contact templace"
-msgstr "Modèle de contact"
+msgstr "Modèle de contacts"
 
 #: unknown
 msgid "Correlation"
@@ -19357,7 +19879,7 @@ msgstr "Fichier de corrélation"
 
 #: unknown
 msgid "Correlation passive"
-msgstr "Correlation passive"
+msgstr "Corrélation passive"
 
 #: unknown
 msgid "Could not find CENTREON_ETC. Session probably expired."
@@ -19368,13 +19890,13 @@ msgstr ""
 msgid "Could not find configuration database. Session probably expired."
 msgstr ""
 "Impossible de trouver la base de données de configuration. La session a "
-"probablement expirée"
+"probablement expiré."
 
 #: unknown
 msgid "Could not find database user. Session probably expired."
 msgstr ""
 "Impossible de trouver l'utilisateur ayant accès aux bases de données. La "
-"session a probablement expirée"
+"session a probablement expiré."
 
 #: unknown
 msgid "Could not find macro "
@@ -19383,14 +19905,13 @@ msgstr "Ne peut pas trouver la macro "
 #: unknown
 msgid "Could not find storage database. Session probably expired."
 msgstr ""
-"Base de données de stockage non trouvée. La session a probablement "
-"expirée."
+"Base de données de stockage non trouvée. La session a probablement expiré."
 
 #: unknown
 msgid "Could not find utils database. Session probably expired."
 msgstr ""
 "Impossible de trouver la base de données du broker. La session a "
-"probablement expirée"
+"probablement expiré."
 
 #: unknown
 msgid "Could not import ndo2db"
@@ -19515,14 +20036,6 @@ msgid "Dependencies Management"
 msgstr "Gestion des dépendances"
 
 #: unknown
-msgid "Deploy Service"
-msgstr "Déployer les services"
-
-#: unknown
-msgid "Detection by browser"
-msgstr "Détection via le navigateur"
-
-#: unknown
 msgid ""
 "Different number of tokens between configuration and monitoring command "
 "line"
@@ -19575,24 +20088,12 @@ msgid "Disabled HostGroups"
 msgstr "Désactiver le groupe d'hôtes"
 
 #: unknown
-msgid "Display Finished Downtimes"
-msgstr "Afficher les plages de maintenance terminés"
-
-#: unknown
 msgid "Display Options"
 msgstr "Options d'affichage"
 
 #: unknown
-msgid "Display Recurring Downtimes"
-msgstr "Afficher les plages de maintenance cycliques"
-
-#: unknown
 msgid "Display Template"
 msgstr "Utiliser le modèle"
-
-#: unknown
-msgid "Display all Services for this host"
-msgstr "Afficher tous les services de cet hôte"
 
 #: unknown
 msgid "Display average as"
@@ -19663,6 +20164,14 @@ msgid "Displays a web page"
 msgstr "Affiche une page web"
 
 #: unknown
+msgid ""
+"Displays availability and alerts of a Business Activity for a given "
+"period."
+msgstr ""
+"Affiche la disponibilité et les alertes d'une activité métier pour une "
+"période donnée."
+
+#: unknown
 msgid "Displays data on resource status and events, centralized in a table."
 msgstr ""
 "Affiche des données sur le statut des ressources et les événements, "
@@ -19697,6 +20206,11 @@ msgstr ""
 "sélectionnés, sous forme de tableau."
 
 #: unknown
+msgid "Displays the future evolution of a metric, based on its history."
+msgstr ""
+"Affiche l'évolution future d'une métrique, sur la base de son historique."
+
+#: unknown
 msgid "Displays the time according to the selected time zone, or a timer."
 msgstr ""
 "Affiche l'heure en fonction du fuseau horaire sélectionné, ou un minuteur."
@@ -19719,10 +20233,6 @@ msgstr "Confirmez-vous la duplication ?"
 
 #: unknown
 msgid "Do you confirm the cancelation?"
-msgstr "Confirmez-vous l'annulation?"
-
-#: unknown
-msgid "Do you confirm the cancellation ?"
 msgstr "Confirmez-vous l'annulation ?"
 
 #: unknown
@@ -19960,7 +20470,7 @@ msgstr "Erreur durant la suppression d'un partage de tableau de bord"
 
 #: unknown
 msgid "Error while getting the local requester."
-msgstr "Erreur durant la récupération du poller central"
+msgstr "Erreur durant la récupération du collecteur local."
 
 #: unknown
 msgid "Error while inserting central-broker configuration"
@@ -19983,14 +20493,6 @@ msgid "Error while inserting poller-module configuration"
 msgstr ""
 "Erreur durant l'insertion de la configuration du module Centreon Broker "
 "du collecteur"
-
-#: unknown
-msgid "Error while linking template %s to host (id: %d)"
-msgstr "Erreur lors de la liaison du modèle %s à l'hôte (id: %d)"
-
-#: unknown
-msgid "Error while linking template (id: %d) to host (id: %d)"
-msgstr "Erreur lors de la liaison du modèle (id: %d) à l'hôte (id: %d)"
 
 #: unknown
 msgid "Error while listing the playlist shares"
@@ -20052,13 +20554,9 @@ msgid "Error while updating playlist shares"
 msgstr "Erreur lors de la mise à jour des partages de la liste de diffusion"
 
 #: unknown
-msgid "Error while updating the dashboard share"
-msgstr "Erreur durant la mise à jour d'un partage de tableau de bord"
-
-#: unknown
 msgid "Error: Cannot Execute this command due to a path security problem."
 msgstr ""
-"Erreur: Impossible d'exécuter cette commande en raison d'un problème de "
+"Erreur : Impossible d'exécuter cette commande en raison d'un problème de "
 "sécurité sur le chemin."
 
 #: unknown
@@ -20070,16 +20568,16 @@ msgid "Event Handlers Enabled?"
 msgstr "Gestionnaire d'évènements activé ?"
 
 #: unknown
-msgid "Event Type"
-msgstr "Type d'évènement"
-
-#: unknown
 msgid "Exclude Timeperiods"
 msgstr "Exclure les périodes"
 
 #: unknown
 msgid "Execution start"
 msgstr "Début de l'exécution"
+
+#: unknown
+msgid "Existing or new directory"
+msgstr "Nouveau dossier ou dossier existant"
 
 #: unknown
 msgid "Export XML"
@@ -20114,8 +20612,29 @@ msgid "Failed to delete resource access rule"
 msgstr "Échec de la suppression de la règle d'accès aux ressources"
 
 #: unknown
+msgid "Failed to delete the additional configuration"
+msgstr "Échec de la suppression de la configuration additionnelle"
+
+#: unknown
+msgid "Failed to delete the host group"
+msgstr "Échec de la suppression du groupe d'hôtes"
+
+#: unknown
+msgid "Failed to disable the host group"
+msgstr "Échec de la désactivation du groupe d'hôtes"
+
+#: unknown
+msgid "Failed to duplicate the host group"
+msgstr "Échec de la duplication du groupe d'hôtes"
+
+#: unknown
+msgid "Failed to enable the host group"
+msgstr "Échec de l'activation du groupe d'hôtes"
+
+#: unknown
 msgid "Failed to get the auth token from Central : '%s'"
-msgstr "Echec d'obtention du token d'auth. sur le Central: '%s'@'%s'"
+msgstr ""
+"Échec d'obtention du jeton d'authentification sur le central '%s'@'%s'"
 
 #: unknown
 msgid "Failover"
@@ -20228,6 +20747,15 @@ msgstr ""
 "fois. Stockez-le soigneusement."
 
 #: unknown
+msgid ""
+"For some connectors, you must define on the poller the credentials "
+"required to access the monitored hosts. You can do it easily from here."
+msgstr ""
+"Pour certains connecteurs, vous devez définir sur le collecteur les "
+"identifiants nécessaires pour accéder aux hôtes supervisés. Vous pouvez "
+"le faire facilement depuis cette page."
+
+#: unknown
 msgid "Force Reload"
 msgstr "Forcer le rechargement"
 
@@ -20264,8 +20792,28 @@ msgid "Generated in "
 msgstr "Généré en "
 
 #: unknown
+msgid "Generic data (example)"
+msgstr "Données d'exemple"
+
+#: unknown
+msgid "Generic data for single metric (example)"
+msgstr "Données d'exemple pour une métrique unique"
+
+#: unknown
+msgid "Generic input (example)"
+msgstr "Données d'entrée d'exemple"
+
+#: unknown
 msgid "Generic text"
 msgstr "Texte générique"
+
+#: unknown
+msgid "Generic text (example)"
+msgstr "Texte d'exemple"
+
+#: unknown
+msgid "Generic widgets"
+msgstr "Widgets génériques"
 
 #: unknown
 msgid "Geolocation"
@@ -20296,6 +20844,10 @@ msgid "Graph style"
 msgstr "Style de graphe"
 
 #: unknown
+msgid "Graph style for average"
+msgstr "Style du graphique de moyenne"
+
+#: unknown
 msgid "Graph type"
 msgstr "Type de graphique"
 
@@ -20316,8 +20868,16 @@ msgid "Group member update behavior"
 msgstr "Comportement de mise à jour des membres du groupe"
 
 #: unknown
+msgid "Group members"
+msgstr "Membres du groupe"
+
+#: unknown
 msgid "Group monitoring"
 msgstr "Group monitoring"
+
+#: unknown
+msgid "Group name"
+msgstr "Nom du groupe"
 
 #: unknown
 msgid "H:i:s"
@@ -20326,14 +20886,6 @@ msgstr "H:i:s"
 #: unknown
 msgid "HTTP"
 msgstr "HTTP"
-
-#: unknown
-msgid "HTTP Action Link"
-msgstr "Lien HTTP externe"
-
-#: unknown
-msgid "HTTP Link"
-msgstr "Lien HTTP"
 
 #: unknown
 msgid "HTTPS"
@@ -20448,10 +21000,6 @@ msgid "Host group not found"
 msgstr "Groupe d'hôtes non trouvé"
 
 #: unknown
-msgid "Host is currently on downtime"
-msgstr "L'hôte est actuellement en période d'arrêt"
-
-#: unknown
 msgid "Host of downtime not found"
 msgstr "L'hôte associé à la plage de maintenance n'a pas été trouvé"
 
@@ -20497,7 +21045,7 @@ msgstr "Couleurs pour le statut des hôtes"
 
 #: unknown
 msgid "Hosts: Set Downtime"
-msgstr "Hôtes: Planifier une plage de maintenance"
+msgstr "Hôtes : Planifier une plage de maintenance"
 
 #: unknown
 msgid "Hourly"
@@ -20508,15 +21056,19 @@ msgid "Huge"
 msgstr "Très grande"
 
 #: unknown
-msgid "IP Address / DNS"
-msgstr "Adresse IP / DNS"
-
-#: unknown
 msgid ""
 "If ticket management is enabled, only the “by service” view is available."
 msgstr ""
 "Si la gestion des tickets est activée, seule la vue par service est "
 "disponible."
+
+#: unknown
+msgid "Image Name"
+msgstr "Nom de l'image"
+
+#: unknown
+msgid "Image or archive"
+msgstr "Image ou archive"
 
 #: unknown
 msgid "Images Directory"
@@ -20660,7 +21212,7 @@ msgstr "Information sur la commande"
 
 #: unknown
 msgid "Informational messages "
-msgstr "Événements de type information"
+msgstr "Évènements de type information "
 
 #: unknown
 msgid "Init System"
@@ -20685,6 +21237,10 @@ msgstr "Vue interactive"
 #: unknown
 msgid "Introspection Token Endpoint"
 msgstr "Point de terminaison d'introspection du jeton"
+
+#: unknown
+msgid "Invalid Image Format."
+msgstr "Format d'image invalide."
 
 #: unknown
 msgid "Invalid credentials"
@@ -20768,11 +21324,11 @@ msgstr "Les 90 derniers jours"
 
 #: unknown
 msgid "Last External Command Check:"
-msgstr "Heure de la dernière commande externe:"
+msgstr "Heure de la dernière commande externe :"
 
 #: unknown
 msgid "Last Log File Rotation:"
-msgstr "Dernière rotation du fichier de journalisation:"
+msgstr "Dernière rotation du fichier de journalisation :"
 
 #: unknown
 msgid "Last critical time"
@@ -20802,7 +21358,7 @@ msgstr "Derniere fois dans un état warning"
 #: unknown
 msgid "Latency detected on %s; check configuration for better optimisation"
 msgstr ""
-"Latence détecté pour %s, contrôler la configuration pour améliorer les "
+"Latence détectée pour %s, contrôler la configuration pour améliorer les "
 "performances"
 
 #: unknown
@@ -20839,7 +21395,7 @@ msgstr "Linéaire"
 
 #: unknown
 msgid "Link has been copied!"
-msgstr "Lien copié!"
+msgstr "Lien copié"
 
 #: unknown
 msgid "Link types"
@@ -20883,7 +21439,7 @@ msgstr "Fichier de verrou"
 
 #: unknown
 msgid "Locked?"
-msgstr "Verrouillée?"
+msgstr "Verrouillé ?"
 
 #: unknown
 msgid "Log Archive Path"
@@ -20907,7 +21463,7 @@ msgstr "Valeur de la déclaration de connexion"
 
 #: unknown
 msgid "Login:"
-msgstr "Pseudo:"
+msgstr "Pseudo :"
 
 #: unknown
 msgid "Logos"
@@ -20930,8 +21486,8 @@ msgid "Low Flap threshold"
 msgstr "Seuil bas de détection de bagotage des statuts"
 
 #: unknown
-msgid "Main Menu"
-msgstr "Menu principal"
+msgid "MBI reporting widgets"
+msgstr "Widgets de rapports MBI"
 
 #: unknown
 msgid "Main grid color"
@@ -20986,6 +21542,10 @@ msgid "Metaservices"
 msgstr "Méta-Service"
 
 #: unknown
+msgid "Metric capacity planning"
+msgstr "Metric capacity planning"
+
+#: unknown
 msgid "Metrics dataset selection"
 msgstr "Sélection du jeu de données de métriques"
 
@@ -21000,15 +21560,19 @@ msgstr ""
 
 #: unknown
 msgid "Missing required property: %s"
-msgstr "propriété requise manquante: %s"
+msgstr "Propriété requise manquante : %s"
 
 #: unknown
 msgid "Mminutes"
 msgstr "Minutes"
 
 #: unknown
-msgid "Modify a User Template"
-msgstr "Modifier un modèle utilisateur"
+msgid "Modify Image"
+msgstr "Modifier l'image"
+
+#: unknown
+msgid "Modify an additional configuration"
+msgstr "Modifier une configuration additionnelle"
 
 #: unknown
 msgid "Module Information"
@@ -21083,10 +21647,6 @@ msgid "NA"
 msgstr "NA"
 
 #: unknown
-msgid "Never Started"
-msgstr "Jamais démarré"
-
-#: unknown
 msgid "New Color"
 msgstr "Nouvelle couleur"
 
@@ -21101,10 +21661,6 @@ msgstr "Pas de données disponibles"
 #: unknown
 msgid "No LDAP configuration enabled !"
 msgstr "Aucune configuration LDAP active !"
-
-#: unknown
-msgid "No access"
-msgstr "Pas d'accès"
 
 #: unknown
 msgid "No active poller is defined in Centreon."
@@ -21167,10 +21723,6 @@ msgid "Notification command"
 msgstr "Commande de notification"
 
 #: unknown
-msgid "Notification is disabled"
-msgstr "Notifications désactivées"
-
-#: unknown
 msgid "Nullable property is not allowed"
 msgstr "Les propriétés nullable ne sont pas autorisées"
 
@@ -21196,27 +21748,11 @@ msgstr "Temps état OK"
 
 #: unknown
 msgid "OK: all pollers are running"
-msgstr "OK: tous les collecteurs sont en cours d'exécution"
-
-#: unknown
-msgid "Object"
-msgstr "Objet"
+msgstr "OK : tous les collecteurs sont en cours d'exécution"
 
 #: unknown
 msgid "Object Cache File"
 msgstr "Fichier de cache des objets"
-
-#: unknown
-msgid "Object Type"
-msgstr "Type d'objet"
-
-#: unknown
-msgid "Object name"
-msgstr "Nom de l'objet :"
-
-#: unknown
-msgid "Objets"
-msgstr "Objets"
 
 #: unknown
 msgid "Obsess Over Hosts Option"
@@ -21228,7 +21764,7 @@ msgstr "Activation de l'exécution des commandes post contrôle de service"
 
 #: unknown
 msgid "Obsessing Over Hosts?"
-msgstr "Exécution des commandes post contrôle d'hôtes?"
+msgstr "Exécution des commandes post contrôle d'hôtes ?"
 
 #: unknown
 msgid "Obsessing Over Services?"
@@ -21264,7 +21800,7 @@ msgstr "Une seule"
 
 #: unknown
 msgid "Only one option must be set."
-msgstr "Une seule option peut être renseignée"
+msgstr "Une seule option peut être renseignée."
 
 #: unknown
 msgid ""
@@ -21287,6 +21823,14 @@ msgstr "Ouvrir un ticket"
 #: unknown
 msgid "Optimize"
 msgstr "Optimiser"
+
+#: unknown
+msgid "Option 1"
+msgstr "Option 1"
+
+#: unknown
+msgid "Option 2"
+msgstr "Option 2"
 
 #: unknown
 msgid "Orientation"
@@ -21456,7 +22000,7 @@ msgstr "Test de la sonde"
 
 #: unknown
 msgid "Plugin has to be in : "
-msgstr "La sonde doit être dans :"
+msgstr "La sonde doit être dans : "
 
 #: unknown
 msgid "Plugin test"
@@ -21508,7 +22052,7 @@ msgstr "Préfixe des tables"
 
 #: unknown
 msgid "Private key file. "
-msgstr "Clé privée SSH"
+msgstr "Clé privée SSH "
 
 #: unknown
 msgid "Private/Public"
@@ -21521,10 +22065,6 @@ msgstr "Problème (Critique)"
 #: unknown
 msgid "Problem (Down/Critical)"
 msgstr "Problème (Indisponible/Critique)"
-
-#: unknown
-msgid "Problem has been acknowledged"
-msgstr "Le problème a été acquitté"
 
 #: unknown
 msgid "Process Commands"
@@ -21587,16 +22127,20 @@ msgid "RRDTool database size"
 msgstr "Durée de rétention des données dans les bases RRD"
 
 #: unknown
+msgid "Radio"
+msgstr "Radio"
+
+#: unknown
+msgid "Radio 1"
+msgstr "Radio 1"
+
+#: unknown
+msgid "Radio 2"
+msgstr "Radio 2"
+
+#: unknown
 msgid "Reach API"
 msgstr "Accès à l'API"
-
-#: unknown
-msgid "Read Only"
-msgstr "Lecture seulement"
-
-#: unknown
-msgid "Read/Write"
-msgstr "Lecture/Ecriture"
 
 #: unknown
 msgid "Real Name"
@@ -21607,16 +22151,12 @@ msgid "Real name"
 msgstr "Nom réel"
 
 #: unknown
-msgid "Rebuild RRD Database"
-msgstr "Regénérer les bases de données RRD"
-
-#: unknown
-msgid "Rebuild Waiting"
-msgstr "En attente de reconstruction"
-
-#: unknown
 msgid "Redirect Url"
 msgstr "Adresse de redirection vers Centreon"
+
+#: unknown
+msgid "Reduce"
+msgstr "Réduire"
 
 #: unknown
 msgid "Refine filter"
@@ -21763,12 +22303,16 @@ msgid "Retention path"
 msgstr "Chemin des fichiers de rétention"
 
 #: unknown
-msgid "Retry"
-msgstr "Relancer"
-
-#: unknown
 msgid "Retry interval (in seconds)"
 msgstr "Intervalle entre deux tentatives (en secondes)"
+
+#: unknown
+msgid "Return to list"
+msgstr "Retourner à la liste"
+
+#: unknown
+msgid "Review form after save"
+msgstr "Revoir le formulaire après la sauvegarde"
 
 #: unknown
 msgid "Right"
@@ -21895,10 +22439,6 @@ msgid "Search contact groups"
 msgstr "Rechercher des groupes de contacts"
 
 #: unknown
-msgid "Secondary Priority Hosts"
-msgstr "Hôtes secondaires"
-
-#: unknown
 msgid "Secondary grid color"
 msgstr "Couleur secondaire de la grille"
 
@@ -21928,6 +22468,10 @@ msgstr "Sélectionner une ressource"
 #: unknown
 msgid "Select contacts and contact groups"
 msgstr "Sélectionner les contacts et les groupes de contacts"
+
+#: unknown
+msgid "Select field"
+msgstr "Sélectionner un champ"
 
 #: unknown
 msgid "Select host severities"
@@ -22023,10 +22567,6 @@ msgid "Service comments"
 msgstr "Commentaires pour ce service"
 
 #: unknown
-msgid "Service is currently on Downtime"
-msgstr "Le service est actuellement en période d'arrêt"
-
-#: unknown
 msgid "Service list"
 msgstr "Liste des services"
 
@@ -22047,10 +22587,6 @@ msgid "Services (simplified)"
 msgstr "Services (simplifiés)"
 
 #: unknown
-msgid "Services Downtimes"
-msgstr "Plages de maintenance des services"
-
-#: unknown
 msgid "Services Escalation"
 msgstr "Escalades des services"
 
@@ -22060,7 +22596,7 @@ msgstr "Couleurs pour le statut des services"
 
 #: unknown
 msgid "Services: Set Downtime"
-msgstr "Services: Planifier une plage de maintenance"
+msgstr "Services : Planifier une plage de maintenance"
 
 #: unknown
 msgid "Setup"
@@ -22139,8 +22675,8 @@ msgid ""
 "Some database poller updates are not active; check your Monitoring "
 "platform"
 msgstr ""
-"Certains collecteurs ne mettent pas à jour la base de données; contrôler "
-"votre plate-forme de supervision"
+"Certains collecteurs ne mettent pas à jour la base de données. Contrôlez "
+"votre plateforme de supervision"
 
 #: unknown
 msgid "Sort by"
@@ -22263,16 +22799,20 @@ msgid "Stop obsessing over services"
 msgstr "Arrêter l'exécution des commandes post contrôle"
 
 #: unknown
-msgid "Stop rebuilding RRD Databases"
-msgstr "Arrêter la regénération des bases de données RRD"
-
-#: unknown
-msgid "Storage Type"
-msgstr "Type de sauvegarde"
-
-#: unknown
 msgid "Store performance data in data_bin"
 msgstr "Enregistrement des données de performance dans la table 'data_bin'"
+
+#: unknown
+msgid "Sub input 1"
+msgstr "Chaîne réduite 1"
+
+#: unknown
+msgid "Sub input 2"
+msgstr "Chaîne réduite 2"
+
+#: unknown
+msgid "Sub input 3"
+msgstr "Chaîne réduite 3"
 
 #: unknown
 msgid "Subscription"
@@ -22373,7 +22913,7 @@ msgid ""
 "is not"
 msgstr ""
 "La ligne de commande dans la configuration est vide alors que celle de la "
-"supervision ne l'est pas."
+"supervision ne l'est pas"
 
 #: unknown
 msgid "The config name already exists"
@@ -22426,7 +22966,7 @@ msgstr "La liste de diffusion suivante existe déjà : %s."
 
 #: unknown
 msgid "The following playlist does not exist: [%d]"
-msgstr "La liste de diffusion suivante n'existe  : [%d]"
+msgstr "La liste de diffusion suivante n'existe pas : [%d]"
 
 #: unknown
 msgid "The following playlist is not shared with you: [%d]"
@@ -22465,14 +23005,6 @@ msgstr "La règle d'accès aux ressouces a été supprimée avec succès"
 #: unknown
 msgid "The rrdcached configuration must have a option."
 msgstr "La configuration du module RRDCached doit avoir une option"
-
-#: unknown
-msgid ""
-"The selected inherited service template does not contain any check "
-"command. You must select one here."
-msgstr ""
-"Le modèle de service hérité sélectionné ne comporte pas de commande de "
-"vérification. Vous devez en sélectionner une ici."
 
 #: unknown
 msgid "The selected user didn't see any resources"
@@ -22523,28 +23055,24 @@ msgstr ""
 "sans résoudre les erreurs ?"
 
 #: unknown
-msgid "This Service is flapping"
-msgstr "Le statut du service bagote"
-
-#: unknown
 msgid "This field is required"
 msgstr "Ce champ est obligatoire"
 
 #: unknown
-msgid "This host is never checked"
-msgstr "Cet hôte n'est jamais vérifié"
+msgid "This is the description of the data widget"
+msgstr "Description du widget Données"
 
 #: unknown
-msgid "This host is only checked in passive mode"
-msgstr "L'hôte est contrôlé uniquement en mode passif"
+msgid "This is the description of the generic input widget"
+msgstr "Description du widget input générique"
 
 #: unknown
-msgid "This service is neither active nor passive"
-msgstr "Ce service n'est ni actif ni passif"
+msgid "This is the description of the text widget"
+msgstr "Description du widget texte"
 
 #: unknown
-msgid "This service is only checked in passive mode"
-msgstr "Le service est contrôlé uniquement en mode passif"
+msgid "This month"
+msgstr "Ce mois"
 
 #: unknown
 msgid "Threshold"
@@ -22603,8 +23131,8 @@ msgid "Tooltips"
 msgstr "Infobulles"
 
 #: unknown
-msgid "Top Priority Hosts"
-msgstr "Hôtes prioritaires"
+msgid "Top Bottom Settings"
+msgstr "Paramètres Top/bottom"
 
 #: unknown
 msgid "Top color"
@@ -22613,10 +23141,6 @@ msgstr "Couleur du haut"
 #: unknown
 msgid "Top/bottom"
 msgstr "Top/bottom"
-
-#: unknown
-msgid "Topology"
-msgstr "Topologie"
 
 #: unknown
 msgid "Traceroute"
@@ -22892,12 +23416,12 @@ msgid "Vertical bar chart"
 msgstr "Diagramme à barres verticales"
 
 #: unknown
-msgid "View a Meta Service indicator"
-msgstr "Visualiser un indicateur de Méta-Service"
+msgid "View Image"
+msgstr "Voir l'image"
 
 #: unknown
-msgid "View a User Template"
-msgstr "Visualiser un modèle utilisateur"
+msgid "View a Meta Service indicator"
+msgstr "Visualiser un indicateur de Méta-Service"
 
 #: unknown
 msgid "View command definition"
@@ -22906,10 +23430,6 @@ msgstr "Voir la définition de la commande"
 #: unknown
 msgid "View comments of services"
 msgstr "Visualiser les commentaires des services"
-
-#: unknown
-msgid "View downtimes of hosts"
-msgstr "Visualiser les plages de maintenance des hôtes"
 
 #: unknown
 msgid "View downtimes of services"
@@ -22934,10 +23454,6 @@ msgstr "Restrictions d'accès aux vues"
 #: unknown
 msgid "Virtuals"
 msgstr "Métriques virtuelles"
-
-#: unknown
-msgid "Visible page"
-msgstr "Pages visibles"
 
 #: unknown
 msgid "Visualisation"
@@ -22965,7 +23481,7 @@ msgstr "WARNING (Temps connu)"
 
 #: unknown
 msgid "Warning: "
-msgstr "Warning:"
+msgstr "Attention : "
 
 #: unknown
 msgid "Warnings"
@@ -22994,6 +23510,14 @@ msgstr "Bienvenue"
 #: unknown
 msgid "Welcome to Centreon Broker configuration"
 msgstr "Bienvenu dans la configuration de Centreon Broker"
+
+#: unknown
+msgid "Welcome to the additional configurations page"
+msgstr "Bienvenue sur la page des configurations additionnelles"
+
+#: unknown
+msgid "Welcome to the host groups page"
+msgstr "Bienvenue sur la page des groupes d'hôtes"
 
 #: unknown
 msgid "Widget Information"
@@ -23025,11 +23549,11 @@ msgstr "Assistant de configuration"
 
 #: unknown
 msgid "Would you like to install this widget?"
-msgstr "Souhaitez-vous installer ce widget?"
+msgstr "Souhaitez-vous installer ce widget ?"
 
 #: unknown
 msgid "Would you like to upgrade this widget?"
-msgstr "Souhaitez-vous monter en version ce widget?"
+msgstr "Souhaitez-vous monter en version ce widget ?"
 
 #: unknown
 msgid "Write"
@@ -23073,6 +23597,31 @@ msgstr "Vous êtes"
 
 #: unknown
 msgid ""
+"You are about to delete <strong>{{ count }} host groups.</strong> This "
+"action cannot be undone. Do you want to delete them?"
+msgstr ""
+"Vous êtes sur le point de supprimer <strong>{{ count }} groupes d'hôtes</"
+"strong>. Cette action est irréversible. Voulez-vous les supprimer ?"
+
+#: unknown
+msgid ""
+"You are about to delete the <strong>{{ name }}</strong> additional "
+"configuration. This action cannot be undone. Do you want to delete it?"
+msgstr ""
+"Vous êtes sur le point de supprimer la configuration additionnelle "
+"<strong>{{ name }}</strong>. Cette action est irréversible. Voulez-vous "
+"la supprimer ?"
+
+#: unknown
+msgid ""
+"You are about to delete the <strong>{{ name }}</strong> host group. This "
+"action cannot be undone. Do you want to delete it?"
+msgstr ""
+"Vous êtes sur le point de supprimer le groupe d'hôtes <strong>{{ name }}</"
+"strong>. Cette action est irréversible. Voulez-vous le supprimer ?"
+
+#: unknown
+msgid ""
 "You are about to delete the token <b> {{tokenName}}</b>. This action <br> "
 "cannot be undone. If you proceed, all requests made using this token will "
 "be <br> rejected. Do you want to delete the token?"
@@ -23081,6 +23630,22 @@ msgstr ""
 "action est <br> irréversible. Si vous le supprimez, toutes les requêtes "
 "effectuées avec ce jeton seront <br> rejetées. Voulez-vous supprimer le "
 "jeton ?"
+
+#: unknown
+msgid ""
+"You are about to duplicate <strong>{{ count }} host groups.</strong> How "
+"many duplications would you like to make?"
+msgstr ""
+"Vous êtes sur le point de dupliquer <strong>{{ count }} groupes d'hôtes</"
+"strong>. Combien de duplications souhaitez-vous effectuer ?"
+
+#: unknown
+msgid ""
+"You are about to duplicate the <strong>{{ name }}</strong> host group. "
+"How many duplications would you like to make?"
+msgstr ""
+"Vous êtes sur le point de dupliquer le groupe d'hôtes <strong>{{ name }}</"
+"strong>. Combien de duplications souhaitez-vous effectuer ?"
 
 #: unknown
 msgid ""
@@ -23160,7 +23725,7 @@ msgstr ""
 #: unknown
 msgid "You have unsaved changes, do you want to proceed?"
 msgstr ""
-"Vous avez des modifications non enregistrées, voulez-vous continuer?"
+"Vous avez des modifications non enregistrées, voulez-vous continuer ?"
 
 #: unknown
 msgid ""
@@ -23188,11 +23753,15 @@ msgstr "Vou devez spécifier un nom d'utilisateur"
 
 #: unknown
 msgid "Your session is expired."
-msgstr "Votre session a expirée"
+msgstr "Votre session a expiré"
 
 #: unknown
 msgid "Zero-centered"
 msgstr "Centré sur zéro"
+
+#: unknown
+msgid "areaOpacity"
+msgstr "areaOpacity"
 
 #: unknown
 msgid "cgi"
@@ -23223,12 +23792,24 @@ msgid "d/m/Y H:i"
 msgstr "d/m/Y H:i"
 
 #: unknown
+msgid "dashLength"
+msgstr "Longueur des tirets"
+
+#: unknown
+msgid "dashOffset"
+msgstr "dashOffset"
+
+#: unknown
 msgid "default"
 msgstr "défaut"
 
 #: unknown
 msgid "deprecated"
 msgstr "déprécié"
+
+#: unknown
+msgid "dotOffset"
+msgstr "dotOffset"
 
 #: unknown
 msgid "down"
@@ -23241,6 +23822,10 @@ msgstr "escalade"
 #: unknown
 msgid "false"
 msgstr "faux"
+
+#: unknown
+msgid "gridLinesType"
+msgstr "gridLinesType"
 
 #: unknown
 msgid "host"
@@ -23275,6 +23860,18 @@ msgid "launch %s with root permissions.\n"
 msgstr "lancer %s avec les permissions root.\n"
 
 #: unknown
+msgid "legendDisplayMode"
+msgstr "legendDisplayMode"
+
+#: unknown
+msgid "legendPlacement"
+msgstr "legendPlacement"
+
+#: unknown
+msgid "lineWidth"
+msgstr "lineWidth"
+
+#: unknown
 msgid "looks like a CLAPI action"
 msgstr "Probablement une action réalisée par CLAPI"
 
@@ -23307,6 +23904,10 @@ msgid "platform not found"
 msgstr "plateforme non trouvée"
 
 #: unknown
+msgid "px"
+msgstr "px"
+
+#: unknown
 msgid "resource.cfg"
 msgstr "resource.cfg"
 
@@ -23315,8 +23916,8 @@ msgid "resources"
 msgstr "ressources"
 
 #: unknown
-msgid "s"
-msgstr "s"
+msgid "scaleLogarithmicBase"
+msgstr "scaleLogarithmicBase"
 
 #: unknown
 msgid "service"
@@ -23343,6 +23944,22 @@ msgid "snmpttconvertmib Directory + Binary"
 msgstr "Chemin complet de l'exécutable snmpttconvertmib"
 
 #: unknown
+msgid "sub1"
+msgstr "sub1"
+
+#: unknown
+msgid "sub2"
+msgstr "sub2"
+
+#: unknown
+msgid "sub3"
+msgstr "sub3"
+
+#: unknown
+msgid "threshold"
+msgstr "seuil"
+
+#: unknown
 msgid "timeperiod"
 msgstr "période de temps"
 
@@ -23353,10 +23970,6 @@ msgstr "Nom de la topologie"
 #: unknown
 msgid "true"
 msgstr "vrai"
-
-#: unknown
-msgid "unknown"
-msgstr "inconnu"
 
 #: unknown
 msgid "unreachable"
@@ -23371,6 +23984,10 @@ msgid "vCenter name"
 msgstr "Nom du vCenter"
 
 #: unknown
+msgid "vCenter/ESX"
+msgstr "vCenter/ESX"
+
+#: unknown
 msgid "warning"
 msgstr "alerte"
 
@@ -23379,28 +23996,5 @@ msgid "will display resources with host name starting by'"
 msgstr "affichera les ressources avec un nom d'hôte commençant par"
 
 #: unknown
-msgid "Monitored hosts"
-msgstr "Hôtes supervisés"
-
-#: unknown
-msgid "Select existing CMA token"
-msgstr "Sélectionner un jeton CMA existant"
-
-#: centreon/www/include/Administration/parameters/general/form.php
-msgid "Full search"
-msgstr "Recherche étendue"
-
-#: centreon/www/include/Administration/parameters/general/form.php
-msgid "Limited search"
-msgstr "Recherche restreinte"
-
-#: centreon/www/include/Administration/parameters/general/form.php
-msgid "Free text search behavior"
-msgstr "Comportement de la recherche texte libre"
-
-#: centreon/www/include/Administration/parameters/general/form.php
-msgid "Resource status performance"
-msgstr "Performances de la page Statut des ressources"
-
-msgid "Free text search behavior can be configured in the Administration > Parameters > Centreon UI page."
-msgstr "Le comportement de la recherche texte libre peut être configuré à la page Administration > Paramètres > Centreon web page."
+msgid "{{total}} element(s) found"
+msgstr "{{total}} élément(s) trouvé(s)"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -12511,7 +12511,7 @@ msgstr "Public"
 
 #: centreon/www/install/centreon_broker_translation.php
 msgid "Public certificate"
-msgstr ""
+msgstr "Certificat public"
 
 #: centreon/www/install/front_translate.php
 msgid "Public certificate(.crt,.cer)"
@@ -24035,17 +24035,9 @@ msgid "Poller/agent configuration"
 msgstr "Configuration du poller/agent"
 
 #: unknown
-msgid "Public certificate"
-msgstr "Certificat public"
-
-#: unknown
 msgid "Private key"
 msgstr "Clé privée"
 
 #: unknown
 msgid "CA"
 msgstr "CA"
-
-#: unknown
-msgid "CA Common Name (CN)"
-msgstr "Nom commun CA (CN)"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24017,3 +24017,31 @@ msgstr "Performances de la page Statut des ressources"
 
 msgid "Free text search behavior can be configured in the Administration > Parameters > Centreon UI page."
 msgstr "Le comportement de la recherche texte libre peut être configuré à la page Administration > Paramètres > Centreon web page."
+
+#: unknown
+msgid "Add poller/agent configuration"
+msgstr "Ajouter une configuration de poller/agent"
+
+#: unknown
+msgid "Welcome to the poller/agent configuration page"
+msgstr "Bienvenue sur la page de configuration du poller/agent"
+
+#: unknown
+msgid "Poller/agent configuration"
+msgstr "Configuration du poller/agent"
+
+#: unknown
+msgid "Public certificate"
+msgstr "Certificat public"
+
+#: unknown
+msgid "Private key"
+msgstr "Clé privée"
+
+#: unknown
+msgid "CA"
+msgstr "CA"
+
+#: unknown
+msgid "CA"
+msgstr "CA"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24023,6 +24023,10 @@ msgid "Add poller/agent configuration"
 msgstr "Ajouter une configuration de poller/agent"
 
 #: unknown
+msgid "Update poller/agent configuration"
+msgstr "Modifier une configuration de poller/agent"
+
+#: unknown
 msgid "Welcome to the poller/agent configuration page"
 msgstr "Bienvenue sur la page de configuration du poller/agent"
 

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24041,3 +24041,11 @@ msgstr "Clé privée"
 #: unknown
 msgid "CA"
 msgstr "CA"
+
+#: unknown
+msgid "Poller/agent configuration created"
+msgstr "Configuration d'agent créée"
+
+#: unknown
+msgid "Poller/agent configuration updated"
+msgstr "Configuration d'agent mise à jour"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -23998,3 +23998,30 @@ msgstr "affichera les ressources avec un nom d'hôte commençant par"
 #: unknown
 msgid "{{total}} element(s) found"
 msgstr "{{total}} élément(s) trouvé(s)"
+
+#: unknown
+msgid "Compact"
+msgstr "Compact"
+
+#: unknown
+msgid "Extended"
+msgstr "Étendu"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Full search"
+msgstr "Recherche étendue"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Limited search"
+msgstr "Recherche restreinte"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Free text search behavior"
+msgstr "Comportement de la recherche texte libre"
+
+#: centreon/www/include/Administration/parameters/general/form.php
+msgid "Resource status performance"
+msgstr "Performances de la page Statut des ressources"
+
+msgid "Free text search behavior can be configured in the Administration > Parameters > Centreon UI page."
+msgstr "Le comportement de la recherche texte libre peut être configuré à la page Administration > Paramètres > Centreon web page."

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -6685,10 +6685,6 @@ msgstr ""
 msgid "Expression in"
 msgstr "Expression en"
 
-#: centreon/www/install/front_translate.php
-msgid "Extended"
-msgstr "Étendu"
-
 #: centreon/www/install/smarty_translate.php
 msgid "Extended Info"
 msgstr "Informations complémentaires"
@@ -23998,10 +23994,6 @@ msgstr "affichera les ressources avec un nom d'hôte commençant par"
 #: unknown
 msgid "{{total}} element(s) found"
 msgstr "{{total}} élément(s) trouvé(s)"
-
-#: unknown
-msgid "Compact"
-msgstr "Compact"
 
 #: unknown
 msgid "Extended"

--- a/centreon/www/front_src/src/AgentConfiguration/Listing/DeleteModal.tsx
+++ b/centreon/www/front_src/src/AgentConfiguration/Listing/DeleteModal.tsx
@@ -10,7 +10,9 @@ import {
   labelCancel,
   labelDelete,
   labelDeleteAgent,
-  labelDeletePoller
+  labelDeleteAgentConfirmation,
+  labelDeletePoller,
+  labelDeletePollerConfirmation
 } from '../translatedLabels';
 
 const DeleteModal = (): JSX.Element => {
@@ -54,21 +56,15 @@ const DeleteModal = (): JSX.Element => {
       </Modal.Header>
       <Modal.Body>
         <Typography>
-          {hasPoller ? (
-            <Trans t={t}>
-              You are going to delete the configuration for the{' '}
-              <strong>{{ poller }}</strong> poller from the{' '}
-              <strong>{{ agent }}</strong> agent configuration. All
-              configuration parameters for this poller will be deleted. This
-              action cannot be undone.
-            </Trans>
-          ) : (
-            <Trans t={t}>
-              You are going to delete the <strong>{{ agent }}</strong> agent
-              configuration. All configuration parameters for this agent will be
-              deleted. This action cannot be undone.
-            </Trans>
-          )}
+          <Trans
+            defaults={
+              hasPoller
+                ? labelDeletePollerConfirmation
+                : labelDeleteAgentConfirmation
+            }
+            values={hasPoller ? { poller, agent } : { agent }}
+            components={{ bold: <strong /> }}
+          />
         </Typography>
       </Modal.Body>
       <Box

--- a/centreon/www/front_src/src/AgentConfiguration/Specs/AgentConfigurations.cypress.spec.tsx
+++ b/centreon/www/front_src/src/AgentConfiguration/Specs/AgentConfigurations.cypress.spec.tsx
@@ -222,7 +222,7 @@ describe('Agent configurations', () => {
     cy.contains('You are going to delete the').should('be.visible');
     cy.contains('AC 0').should('be.visible');
     cy.contains(
-      'agent configuration. All configuration parameters for this agent will be deleted. This action cannot be undone.'
+      'agent configuration. All parameters for this agent configuration will be deleted. This action cannot be undone.'
     ).should('be.visible');
 
     cy.contains(labelCancel).click();
@@ -247,7 +247,7 @@ describe('Agent configurations', () => {
     cy.contains('You are going to delete the').should('be.visible');
     cy.contains('AC 0').should('be.visible');
     cy.contains(
-      'agent configuration. All configuration parameters for this agent will be deleted. This action cannot be undone.'
+      'agent configuration. All parameters for this agent configuration will be deleted. This action cannot be undone.'
     ).should('be.visible');
 
     cy.contains(/^Delete$/).click();

--- a/centreon/www/front_src/src/AgentConfiguration/translatedLabels.tsx
+++ b/centreon/www/front_src/src/AgentConfiguration/translatedLabels.tsx
@@ -15,7 +15,7 @@ export const labelAgentTypes = 'Agent types';
 export const labelPollers = 'Pollers';
 export const labelClear = 'Clear';
 export const labelDeletePoller = 'Delete poller';
-export const labelDeleteAgent = 'Delete agent';
+export const labelDeleteAgent = 'Delete agent configuration';
 export const labelCancel = 'Cancel';
 export const labelDelete = 'Delete';
 export const labelPollerConfiguration = 'Poller configuration';
@@ -75,3 +75,9 @@ export const labelCMAauthenticationToken = 'CMA authentication token(s)';
 export const labelSelectExistingCMATokens = 'Select existing CMA token(s)';
 export const labelSelectExistingCMAToken = 'Select existing CMA token';
 export const labelCreateNewCMAToken = 'Create new CMA token';
+
+export const labelDeletePollerConfirmation =
+  'You are going to delete the configuration for the <strong>{{ poller }}</strong> poller from the <strong>{{ agent }}</strong> agent configuration. All configuration parameters for this poller will be deleted. This action cannot be undone.';
+
+export const labelDeleteAgentConfirmation =
+  'You are going to delete the <strong>{{ agent }}</strong> agent configuration. All parameters for this agent configuration will be deleted. This action cannot be undone.';

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/components/DashboardSaveBlockerModal.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/components/DashboardSaveBlockerModal.tsx
@@ -2,6 +2,7 @@ import { useSetAtom } from 'jotai';
 
 import { ConfirmationModal } from '@centreon/ui/components';
 
+import { useTranslation } from 'react-i18next';
 import { DashboardPanel } from '../../../api/models';
 import { isEditingAtom, isRedirectionBlockedAtom } from '../atoms';
 import useDashboardSaveBlocker from '../hooks/useDashboardSaveBlocker';
@@ -18,6 +19,8 @@ interface Props {
 }
 
 const DashboardSaveBlockerModal = ({ panels }: Props): JSX.Element => {
+  const { t } = useTranslation();
+
   const { proceedNavigation, blockNavigation } =
     useDashboardSaveBlocker(panels);
   const { saveDashboard } = useSaveDashboard();
@@ -41,13 +44,14 @@ const DashboardSaveBlockerModal = ({ panels }: Props): JSX.Element => {
 
   return (
     <ConfirmationModal
+      size="medium"
       hasCloseButton
       atom={isRedirectionBlockedAtom}
       labels={{
-        cancel: labelDiscard,
-        confirm: labelSave,
-        description: labelIfYouClickOnDiscard,
-        title: labelDoYouWantToSaveChanges
+        cancel: t(labelDiscard),
+        confirm: t(labelSave),
+        description: t(labelIfYouClickOnDiscard),
+        title: t(labelDoYouWantToSaveChanges)
       }}
       onCancel={cancel}
       onClose={close}

--- a/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardConfig/useDashboardConfig.tsx
+++ b/centreon/www/front_src/src/Dashboards/components/DashboardLibrary/DashboardConfig/useDashboardConfig.tsx
@@ -10,6 +10,7 @@ import {
 
 import { useSnackbar } from '@centreon/ui';
 
+import { useTranslation } from 'react-i18next';
 import routeMap from '../../../../reactRoutes/routeMap';
 import { resetDashboardDerivedAtom } from '../../../SingleInstancePage/Dashboard/atoms';
 import { Dashboard, isDashboard } from '../../../api/models';
@@ -42,6 +43,7 @@ type UseDashboardConfig = {
 };
 
 const useDashboardConfig = (): UseDashboardConfig => {
+  const { t } = useTranslation();
   const [dialogState, setDialogState] = useAtom(dialogStateAtom);
 
   const resetDashboard = useSetAtom(resetDashboardDerivedAtom);
@@ -117,7 +119,7 @@ const useDashboardConfig = (): UseDashboardConfig => {
 
   const submitForm = (dashboard: Dashboard): void => {
     submit(dashboard).then(() => {
-      showSuccessMessage(labelDashboardUpdated);
+      showSuccessMessage(t(labelDashboardUpdated));
     });
   };
 

--- a/centreon/www/front_src/src/Resources/Listing/index.tsx
+++ b/centreon/www/front_src/src/Resources/Listing/index.tsx
@@ -37,6 +37,8 @@ import {
 import { rowColorConditions } from '../colors';
 import { type Resource, type SortOrder, Visualization } from '../models';
 import {
+  labelCompact,
+  labelExtended,
   labelForcedCheckCommandSent,
   labelSelectAtLeastOneColumn,
   labelStatus
@@ -289,7 +291,11 @@ const ResourceListing = (): JSX.Element => {
       viewerModeConfiguration={{
         disabled: isPending,
         onClick: changeViewModeTableResources,
-        title: user_interface_density
+        title: t(
+          equals(user_interface_density, 'compact')
+            ? labelCompact
+            : labelExtended
+        )
       }}
       widthToMoveTablePagination={panelWidth}
       onLimitChange={changeLimit}

--- a/centreon/www/front_src/src/Resources/translatedLabels.ts
+++ b/centreon/www/front_src/src/Resources/translatedLabels.ts
@@ -330,4 +330,3 @@ export const labelExtended = 'Extended';
 
 export const labelFreeTextSearchBehavior =
   'Free text search behavior can be configured in the Administration > Parameters > Centreon UI page.';
-


### PR DESCRIPTION
## Description

backport from MON-177350-dev-24-10-x-clean-up-labels-in-agent-configuration-screens :  https://github.com/centreon/centreon/pull/7908    

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
