### PR TITLE
fix(recurrent downtime): correctly escape characters

### DIFF
--- a/centreon/www/include/monitoring/recurrentDowntime/listDowntime.html
+++ b/centreon/www/include/monitoring/recurrentDowntime/listDowntime.html
@@ -44,8 +44,8 @@
 	{section name=elem loop=$elemArr}
 	<tr class={$elemArr[elem].MenuClass}>
 		<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-		<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-		<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
+		<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name|escape:"html"}</a></td>
+		<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc|escape:"html"}</a></td>
 		<td class="ListColCenter">{$elemArr[elem].RowMenu_status}</td>
 		<td class="ListColRight">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
 	</tr>
@@ -69,7 +69,7 @@
 
 <input type='hidden' name='o' id='o' value='42'>
 
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
+<input type='hidden' id='limit' name='limit' value='{$limit}'>
 {$form.hidden}
 </form>
 {literal}


### PR DESCRIPTION
## Description

This PR intends to correctly escape characters in recurrent downtime

**Fixes** # MON-178590

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
