### PR TITLE
fix(commands): fix command_line field in connectors

### DIFF
--- a/centreon/www/include/configuration/configObject/connector/formConnector.php
+++ b/centreon/www/include/configuration/configObject/connector/formConnector.php
@@ -138,8 +138,8 @@ try {
         $cntObj = new CentreonConnector($pearDB);
         $tab = $form->getSubmitValues();
         $connectorValues = [];
-        $connectorValues['name'] = HtmlAnalyzer::sanitizeAndRemoveTags($tab['connector_name']);
-        $connectorValues['description'] = HtmlAnalyzer::sanitizeAndRemoveTags($tab['connector_description']);
+        $connectorValues['name'] = $tab['connector_name'];
+        $connectorValues['description'] = $tab['connector_description'];
         $connectorValues['enabled'] = $tab['connector_status']['connector_status'] === '0' ? 0 : 1;
         $connectorValues['command_id'] = $tab['command_id'] ?? null;
         $connectorValues['command_line'] = $tab['command_line'];

--- a/centreon/www/include/configuration/configObject/connector/listConnector.ihtml
+++ b/centreon/www/include/configuration/configObject/connector/listConnector.ihtml
@@ -31,9 +31,9 @@
             {section name=elem loop=$elemArr}
             <tr class={cycle values="list_one,list_two"}>
                 <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-                <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-                <td class="ListColLeft">{$elemArr[elem].RowMenu_description}</td>
-                <td class="ListColLeft">{$elemArr[elem].RowMenu_command_line}</td>
+                <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name|escape:"html"}</a></td>
+                <td class="ListColLeft">{$elemArr[elem].RowMenu_description|escape:"html"}</td>
+                <td class="ListColLeft">{$elemArr[elem].RowMenu_command_line|escape:"html"}</td>
                 <td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_enabled}</span></td>
                 <td class="ListColRight">{$elemArr[elem].RowMenu_options}</td>
             </tr>


### PR DESCRIPTION
## Description

This PR intends to fix field command_line in commands->connectors

**Fixes** # ([MON-178094](https://centreon.atlassian.net/browse/MON-178094))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-178094]: https://centreon.atlassian.net/browse/MON-178094?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ