### PR TITLE
fix(snmp): fix field name in form

### DIFF
--- a/centreon/www/include/configuration/configObject/traps-groups/listGroups.ihtml
+++ b/centreon/www/include/configuration/configObject/traps-groups/listGroups.ihtml
@@ -42,12 +42,12 @@
 		{section name=elem loop=$elemArr}
 		<tr class={$elemArr[elem].MenuClass}>
 			<td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
+			<td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name|escape:"html"}</a></td>
 			<td class="ListColRight" align="right">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
 		</tr>
-		{/section}	
+		{/section}
 	</table>
-	
+
 	<table class="ToolbarTable table">
 		<tr class="ToolbarTR">
 			{ if $mode_access == 'w' }
@@ -65,6 +65,6 @@
 
 <input type='hidden' name='o' id='o' value='42'>
 
-<input type='hidden' id='limit' name='limit' value='{$limit}'>	
+<input type='hidden' id='limit' name='limit' value='{$limit}'>
 {$form.hidden}
 </form>


### PR DESCRIPTION
## Description

Thir PR intends to fix field name in snmp traps -> groups.

**Fixes** # ([MON-178096](https://centreon.atlassian.net/browse/MON-178096))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-178096]: https://centreon.atlassian.net/browse/MON-178096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ