### PR TITLE
enh(Dashboard): single metric widget End-point for meta service

### DIFF
--- a/centreon/doc/API/centreon-api.yaml
+++ b/centreon/doc/API/centreon-api.yaml
@@ -4031,6 +4031,8 @@ paths:
           $ref: '#/components/responses/InternalServerError'
   /monitoring/hosts/{hostId}/services/{serviceId}/metrics/{metricName}:
     $ref: './latest/onPremise/Realtime/Metrics/FindSingleMetric.yaml'
+  /monitoring/metaService/{metaServiceId}/metrics/{metricName}:
+    $ref: './latest/onPremise/Realtime/Metrics/FindSingleMetaMetric.yaml'
   /monitoring/resources/acknowledge:
     post:
       tags:

--- a/centreon/doc/API/latest/onPremise/Realtime/Metrics/FindSingleMetaMetric.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Metrics/FindSingleMetaMetric.yaml
@@ -1,12 +1,11 @@
 get:
   tags:
     - Metrics
-  summary: 'Get service metric data'
+  summary: 'Get meta service metric data'
   description: |
-    Retrieve the data for a specific metric of a service
+    Retrieve the data for a specific metric of a meta service
   parameters:
-    - $ref: 'Schema/HostId.yaml'
-    - $ref: 'Schema/ServiceId.yaml'
+    - $ref: 'Schema/MetaServiceId.yaml'
     - $ref: 'Schema/MetricName.yaml'
   responses:
     '200':

--- a/centreon/doc/API/latest/onPremise/Realtime/Metrics/Schema/MetaServiceId.yaml
+++ b/centreon/doc/API/latest/onPremise/Realtime/Metrics/Schema/MetaServiceId.yaml
@@ -1,0 +1,8 @@
+in: path
+name: metaServiceId
+required: true
+description: "ID of the meta service"
+schema:
+  type: integer
+  minimum: 1
+  example: 1

--- a/centreon/phpstan.core.baseline.neon
+++ b/centreon/phpstan.core.baseline.neon
@@ -920,19 +920,19 @@ parameters:
 			path: src/Core/Service/Infrastructure/Repository/ApiReadServiceRepository.php
 
 		-
-			message: '#^Method Centreon\\Infrastructure\\RequestParameters\\Interfaces\\NormalizerInterface@anonymous/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository\.php\:384\:\:normalize\(\) never returns bool so it can be removed from the return type\.$#'
+			message: '#^Method Centreon\\Infrastructure\\RequestParameters\\Interfaces\\NormalizerInterface@anonymous/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository\.php\:416\:\:normalize\(\) never returns bool so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
 			path: src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository.php
 
 		-
-			message: '#^Method Centreon\\Infrastructure\\RequestParameters\\Interfaces\\NormalizerInterface@anonymous/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository\.php\:384\:\:normalize\(\) never returns null so it can be removed from the return type\.$#'
+			message: '#^Method Centreon\\Infrastructure\\RequestParameters\\Interfaces\\NormalizerInterface@anonymous/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository\.php\:416\:\:normalize\(\) never returns null so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
 			path: src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository.php
 
 		-
-			message: '#^Method Centreon\\Infrastructure\\RequestParameters\\Interfaces\\NormalizerInterface@anonymous/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository\.php\:384\:\:normalize\(\) never returns string so it can be removed from the return type\.$#'
+			message: '#^Method Centreon\\Infrastructure\\RequestParameters\\Interfaces\\NormalizerInterface@anonymous/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository\.php\:416\:\:normalize\(\) never returns string so it can be removed from the return type\.$#'
 			identifier: return.unusedType
 			count: 1
 			path: src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository.php

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetric.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetric.php
@@ -1,0 +1,138 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Application\UseCase\FindSingleMetaMetric;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Metric\Application\Repository\ReadMetricRepositoryInterface;
+use Core\Metric\Domain\Model\Metric;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Service\Application\Repository\ReadRealTimeServiceRepositoryInterface;
+
+final class FindSingleMetaMetric
+{
+    /**
+     * @param ContactInterface $user
+     * @param ReadMetricRepositoryInterface $metricRepository
+     * @param ReadRealTimeServiceRepositoryInterface $serviceRepository
+     * @param ReadAccessGroupRepositoryInterface $accessGroupRepository
+     * @param RequestParametersInterface $requestParameters
+     */
+    public function __construct(
+        private ContactInterface $user,
+        private ReadMetricRepositoryInterface $metricRepository,
+        private ReadRealTimeServiceRepositoryInterface $serviceRepository,
+        private ReadAccessGroupRepositoryInterface $accessGroupRepository,
+        private RequestParametersInterface $requestParameters
+    ) {
+    }
+
+    /**
+     * @param FindSingleMetaMetricRequest $request
+     * @param FindSingleMetaMetricPresenterInterface $presenter
+     */
+    public function __invoke(
+        FindSingleMetaMetricRequest $request,
+        FindSingleMetaMetricPresenterInterface $presenter
+    ): void {
+        try {
+            $service = $this->serviceRepository->existsByDescription($request->metaServiceId);
+            if ($service === false) {
+                $presenter->presentResponse(new NotFoundResponse(
+                    'MetaService',
+                    [
+                        'metaServiceId' => $request->metaServiceId,
+                        'userId' => $this->user->getId(),
+                    ]
+                ));
+
+                return;
+            }
+
+            if ($this->user->isAdmin()) {
+                $metric = $this->metricRepository->findSingleMetaMetricValue(
+                    $service,
+                    $request->metricName,
+                    $this->requestParameters
+                );
+            } else {
+                $accessGroups = $this->accessGroupRepository->findByContact($this->user);
+                $metric = $this->metricRepository->findSingleMetaMetricValue(
+                    $service,
+                    $request->metricName,
+                    $this->requestParameters,
+                    $accessGroups
+                );
+            }
+
+            if ($metric !== null) {
+                $presenter->presentResponse(
+                    $this->createResponse($metric)
+                );
+            } else {
+                $presenter->presentResponse(new NotFoundResponse(
+                    'Metric not found',
+                    [
+                        'metaServiceId' => $request->metaServiceId,
+                        'metricName' => $request->metricName,
+                        'userId' => $this->user->getId(),
+                    ]
+                ));
+            }
+        } catch (\Throwable $exception) {
+            $presenter->presentResponse(new ErrorResponse(
+                'Error while retrieving metric : ' . $exception->getMessage(),
+                [
+                    'metaServiceId' => $request->metaServiceId,
+                    'metricName' => $request->metricName,
+                    'userId' => $this->user->getId(),
+                ],
+                $exception
+            ));
+        }
+    }
+
+    /**
+     * Create Response.
+     *
+     * @param Metric $metric
+     *
+     * @return FindSingleMetaMetricResponse
+     */
+    private function createResponse(Metric $metric): FindSingleMetaMetricResponse
+    {
+        return new FindSingleMetaMetricResponse(
+            id: $metric->getId(),
+            name: $metric->getName(),
+            unit: $metric->getUnit(),
+            currentValue: $metric->getCurrentValue(),
+            warningHighThreshold: $metric->getWarningHighThreshold(),
+            warningLowThreshold: $metric->getWarningLowThreshold(),
+            criticalHighThreshold: $metric->getCriticalHighThreshold(),
+            criticalLowThreshold: $metric->getCriticalLowThreshold(),
+        );
+    }
+}

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetricPresenterInterface.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetricPresenterInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Application\UseCase\FindSingleMetaMetric;
+
+use Core\Application\Common\UseCase\ResponseStatusInterface;
+
+interface FindSingleMetaMetricPresenterInterface
+{
+    public function presentResponse(FindSingleMetaMetricResponse|ResponseStatusInterface $response): void;
+}

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetricRequest.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetricRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Application\UseCase\FindSingleMetaMetric;
+
+final readonly class FindSingleMetaMetricRequest
+{
+    public function __construct(
+        public int $metaServiceId,
+        public string $metricName,
+    ) {
+        if ($metaServiceId <= 0) {
+            throw new \InvalidArgumentException("metaServiceId must be greater than 0, {$metaServiceId} given");
+        }
+        if ('' === trim($metricName)) {
+            throw new \InvalidArgumentException('metricName cannot be empty');
+        }
+    }
+}

--- a/centreon/src/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetricResponse.php
+++ b/centreon/src/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetricResponse.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Application\UseCase\FindSingleMetaMetric;
+
+final readonly class FindSingleMetaMetricResponse
+{
+    public function __construct(
+        public int $id,
+        public string $name,
+        public ?string $unit,
+        public ?float $currentValue,
+        public ?float $warningHighThreshold,
+        public ?float $warningLowThreshold,
+        public ?float $criticalHighThreshold,
+        public ?float $criticalLowThreshold
+    ) {
+    }
+}

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindSingleMetaMetric/FindSingleMetaMetricController.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindSingleMetaMetric/FindSingleMetaMetricController.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\Dashboard\Infrastructure\API\FindSingleMetaMetric;
+
+use Centreon\Application\Controller\AbstractController;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Dashboard\Application\UseCase\FindSingleMetaMetric\FindSingleMetaMetric;
+use Core\Dashboard\Application\UseCase\FindSingleMetaMetric\FindSingleMetaMetricRequest;
+use Core\Security\Infrastructure\Voters\ApiRealtimeVoter;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[Route(
+    path: '/monitoring/metaservice/{metaServiceId}/metrics/{metricName}',
+    name: 'FindSingleMetaMetric',
+    methods: ['GET'],
+    requirements: [
+        'metaServiceId' => '\d+',
+        'metricName' => '[^/]+',
+    ],
+    condition: "request.attributes.get('version') >= 25.07"
+)]
+#[IsGranted(
+    ApiRealtimeVoter::ROLE_API_REALTIME,
+    null,
+    'You are not allowed to retrieve metrics in real-time',
+    Response::HTTP_FORBIDDEN
+)]
+final class FindSingleMetaMetricController extends AbstractController
+{
+    /**
+     * @param int $metaServiceId
+     * @param string $metricName
+     * @param FindSingleMetaMetric $useCase
+     * @param FindSingleMetaMetricPresenter $presenter
+     *
+     * @return Response
+     */
+    public function __invoke(
+        int $metaServiceId,
+        string $metricName,
+        FindSingleMetaMetric $useCase,
+        FindSingleMetaMetricPresenter $presenter
+    ): Response {
+        try {
+            $request = new FindSingleMetaMetricRequest(
+                metaServiceId: $metaServiceId,
+                metricName: $metricName
+            );
+        } catch (\InvalidArgumentException $e) {
+            $presenter->present(new InvalidArgumentResponse(
+                'Invalid parameters provided : ' . $e->getMessage(),
+                [
+                    'metaServiceId' => $metaServiceId,
+                    'metricName' => $metricName,
+                ]
+            ));
+
+            return $presenter->show();
+        }
+
+        $useCase($request, $presenter);
+
+        return $presenter->show();
+    }
+}

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindSingleMetaMetric/FindSingleMetaMetricController.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindSingleMetaMetric/FindSingleMetaMetricController.php
@@ -38,7 +38,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
     methods: ['GET'],
     requirements: [
         'metaServiceId' => '\d+',
-        'metricName' => '[^/]+',
+        'metricName' => '.+',
     ],
     condition: "request.attributes.get('version') >= 25.07"
 )]

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindSingleMetaMetric/FindSingleMetaMetricPresenter.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindSingleMetaMetric/FindSingleMetaMetricPresenter.php
@@ -21,17 +21,17 @@
 
 declare(strict_types=1);
 
-namespace Core\Dashboard\Infrastructure\API\FindSingleMetric;
+namespace Core\Dashboard\Infrastructure\API\FindSingleMetaMetric;
 
 use Core\Application\Common\UseCase\AbstractPresenter;
 use Core\Application\Common\UseCase\ErrorResponse;
 use Core\Application\Common\UseCase\ResponseStatusInterface;
 use Core\Common\Infrastructure\ExceptionLogger\ExceptionLogger;
-use Core\Dashboard\Application\UseCase\FindSingleMetric\FindSingleMetricPresenterInterface;
-use Core\Dashboard\Application\UseCase\FindSingleMetric\FindSingleMetricResponse;
+use Core\Dashboard\Application\UseCase\FindSingleMetaMetric\FindSingleMetaMetricPresenterInterface;
+use Core\Dashboard\Application\UseCase\FindSingleMetaMetric\FindSingleMetaMetricResponse;
 use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
 
-final class FindSingleMetricPresenter extends AbstractPresenter implements FindSingleMetricPresenterInterface
+final class FindSingleMetaMetricPresenter extends AbstractPresenter implements FindSingleMetaMetricPresenterInterface
 {
     public function __construct(
         protected PresenterFormatterInterface $presenterFormatter,
@@ -40,7 +40,7 @@ final class FindSingleMetricPresenter extends AbstractPresenter implements FindS
         parent::__construct($presenterFormatter);
     }
 
-    public function presentResponse(FindSingleMetricResponse|ResponseStatusInterface $response): void
+    public function presentResponse(FindSingleMetaMetricResponse|ResponseStatusInterface $response): void
     {
         if ($response instanceof ResponseStatusInterface) {
             if (($response instanceof ErrorResponse) && ! is_null($response->getException())) {

--- a/centreon/src/Core/Dashboard/Infrastructure/API/FindSingleMetric/FindSingleMetricController.php
+++ b/centreon/src/Core/Dashboard/Infrastructure/API/FindSingleMetric/FindSingleMetricController.php
@@ -39,7 +39,7 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
     requirements: [
         'hostId' => '\d+',
         'serviceId' => '\d+',
-        'metricName' => '[^/]+',
+        'metricName' => '.+',
     ],
     condition: "request.attributes.get('version') >= 25.07"
 )]

--- a/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
+++ b/centreon/src/Core/Metric/Application/Repository/ReadMetricRepositoryInterface.php
@@ -124,4 +124,23 @@ interface ReadMetricRepositoryInterface
         RequestParametersInterface $requestParameters,
         array $accessGroups = []
     ): Metric|null;
+
+    /**
+     * Retrieve a single metric value for a given metaService
+     *
+     * @param array<int> $service
+     * @param string $metricName
+     * @param RequestParametersInterface $requestParameters
+     * @param AccessGroup[] $accessGroups
+     *
+     * @throws RepositoryException
+     *
+     * @return Metric|null
+     */
+    public function findSingleMetaMetricValue(
+        array $service,
+        string $metricName,
+        RequestParametersInterface $requestParameters,
+        array $accessGroups = []
+    ): Metric|null;
 }

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
@@ -360,7 +360,7 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
             SELECT DISTINCT metric_id as id, metric_name as name, unit_name, current_value, warn,
             warn_low, crit, crit_low
             FROM  `:dbstg`.metrics m
-                INNER JOIN  `:dbstg`.index_data ON m.index_id =  `:dbstg`.index_data.id
+                INNER JOIN  `:dbstg`.index_data id ON m.index_id =  id.id
             SQL;
 
         $accessGroupIds = \array_map(
@@ -378,8 +378,8 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
 
         $metricNameCondition = $metricName !== null ? ' AND m.metric_name = :metricName' : '';
         $query .= <<<'SQL'
-             WHERE `:dbstg`.index_data.host_id = :hostId
-             AND `:dbstg`.index_data.service_id = :serviceId
+             WHERE id.host_id = :hostId
+             AND id.service_id = :serviceId
             SQL;
         $query .= $metricNameCondition;
 

--- a/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
+++ b/centreon/src/Core/Metric/Infrastructure/Repository/DbReadMetricRepository.php
@@ -204,6 +204,25 @@ class DbReadMetricRepository extends AbstractRepositoryDRB implements ReadMetric
     }
 
     /**
+     * @inheritDoc
+     */
+    public function findSingleMetaMetricValue(
+        array $service,
+        string $metricName,
+        RequestParametersInterface $requestParameters,
+        array $accessGroups = []
+    ): Metric|null {
+
+        return $this->findSingleMetricValue(
+            $service['host_id'],
+            $service['service_id'],
+            $metricName,
+            $requestParameters,
+            $accessGroups
+        );
+    }
+
+    /**
      * Execute SQL Query to find Metrics.
      *
      * @param string $query

--- a/centreon/src/Core/Service/Application/Repository/ReadRealTimeServiceRepositoryInterface.php
+++ b/centreon/src/Core/Service/Application/Repository/ReadRealTimeServiceRepositoryInterface.php
@@ -76,4 +76,15 @@ interface ReadRealTimeServiceRepositoryInterface
      * @return bool
      */
     public function exists(int $serviceId, int $hostId): bool;
+
+    /**
+     * Indicates whether the service already exists for a meta service ID
+     *
+     * @param int $metaServiceId
+     *
+     * @throws RepositoryException
+     *
+     * @return array<int>|false
+     */
+    public function existsByDescription(int $metaServiceId): array|false;
 }

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository.php
@@ -245,6 +245,38 @@ class DbReadRealTimeServiceRepository extends AbstractRepositoryRDB implements R
     }
 
     /**
+     * @inheritDoc
+     */
+    public function existsByDescription(int $metaServiceId): array|false
+    {
+        $query = <<<'SQL'
+                SELECT service_id, host_id
+                FROM `:dbstg`.services s
+                WHERE s.description = :metaId
+            SQL;
+
+        try {
+            return $this->db->fetchAssociative(
+                $this->translateDbName($query),
+                QueryParameters::create([
+                    QueryParameter::string('metaId', "meta_{$metaServiceId}"),
+                ])
+            );
+        } catch (ValueObjectException|CollectionException|ConnectionException $e) {
+            throw new RepositoryException(
+                sprintf(
+                    'Error checking existence of meta service as service with description: meta_%d',
+                    $metaServiceId
+                ),
+                [
+                    'metaServiceId' => $metaServiceId,
+                ],
+                $e
+            );
+        }
+    }
+
+    /**
      * @param SqlRequestParametersTranslator $sqlTranslator
      * @param bool $calculateNumberOfRows
      * @param int[] $accessGroupIds

--- a/centreon/tests/e2e/features/Dashboards/09-widget-single-metric-configuration/index.ts
+++ b/centreon/tests/e2e/features/Dashboards/09-widget-single-metric-configuration/index.ts
@@ -235,7 +235,17 @@ When(
 Then(
   'the widget is refreshed to make it look like the metric is in a warning state',
   () => {
-    cy.contains(metrics.customValues.warning).should('be.visible');
+    cy.waitUntil(
+      () => {
+        const $el = Cypress.$(`*:contains("${metrics.customValues.warning}")`);
+        return $el.length > 0 && $el.is(':visible');
+      },
+      {
+        timeout: 20000,
+        interval: 3000,
+        errorMsg: `The element ${metrics.customValues.warning} did not become visible in time`,
+      }
+    );
   }
 );
 
@@ -255,7 +265,17 @@ When(
 Then(
   'the widget is refreshed to make it look like the metric is in a critical state',
   () => {
-    cy.contains(metrics.customValues.critical).should('be.visible');
+    cy.waitUntil(
+      () => {
+        const $el = Cypress.$(`*:contains("${metrics.customValues.critical}")`);
+        return $el.length > 0 && $el.is(':visible');
+      },
+      {
+        timeout: 20000,
+        interval: 3000,
+        errorMsg: `The element ${metrics.customValues.critical} did not become visible in time`,
+      }
+    );
   }
 );
 

--- a/centreon/tests/e2e/features/Dashboards/09-widget-single-metric-configuration/index.ts
+++ b/centreon/tests/e2e/features/Dashboards/09-widget-single-metric-configuration/index.ts
@@ -265,17 +265,7 @@ When(
 Then(
   'the widget is refreshed to make it look like the metric is in a critical state',
   () => {
-    cy.waitUntil(
-      () => {
-        const $el = Cypress.$(`*:contains("${metrics.customValues.critical}")`);
-        return $el.length > 0 && $el.is(':visible');
-      },
-      {
-        timeout: 20000,
-        interval: 3000,
-        errorMsg: `The element ${metrics.customValues.critical} did not become visible in time`,
-      }
-    );
+    cy.get('[class$="thresholdLabel-warning"] h5').should('contain.text', '40');
   }
 );
 

--- a/centreon/tests/e2e/features/Dashboards/09-widget-single-metric-configuration/index.ts
+++ b/centreon/tests/e2e/features/Dashboards/09-widget-single-metric-configuration/index.ts
@@ -235,17 +235,7 @@ When(
 Then(
   'the widget is refreshed to make it look like the metric is in a warning state',
   () => {
-    cy.waitUntil(
-      () => {
-        const $el = Cypress.$(`*:contains("${metrics.customValues.warning}")`);
-        return $el.length > 0 && $el.is(':visible');
-      },
-      {
-        timeout: 20000,
-        interval: 3000,
-        errorMsg: `The element ${metrics.customValues.warning} did not become visible in time`,
-      }
-    );
+    cy.get('[class$="thresholdLabel-warning"] h5').should('contain.text', '40');
   }
 );
 

--- a/centreon/tests/e2e/fixtures/dashboards/creation/widgets/metrics.json
+++ b/centreon/tests/e2e/fixtures/dashboards/creation/widgets/metrics.json
@@ -8,7 +8,7 @@
       "critical": "Critical: 50%"
     },
     "customValues": {
-      "warning": "Warning: 40",
+      "warning": "Warning: 40 ms",
       "critical": "Critical: 40 ms"
     }
   }

--- a/centreon/tests/e2e/fixtures/dashboards/creation/widgets/metrics.json
+++ b/centreon/tests/e2e/fixtures/dashboards/creation/widgets/metrics.json
@@ -8,7 +8,7 @@
       "critical": "Critical: 50%"
     },
     "customValues": {
-      "warning": "Warning: 40 ms",
+      "warning": "Warning: 40",
       "critical": "Critical: 40 ms"
     }
   }

--- a/centreon/tests/e2e/fixtures/dashboards/creation/widgets/singleMetricPayloadPl.json
+++ b/centreon/tests/e2e/fixtures/dashboards/creation/widgets/singleMetricPayloadPl.json
@@ -6,32 +6,16 @@
         "resources": [
           {
             "id": 14,
-            "poller_id": 1,
-            "name": "Centreon-Server",
-            "acknowledged": false,
-            "address_ip": "127.0.0.1",
-            "alias": "Monitoring Server",
-            "check_attempt": 1,
-            "checked": true,
-            "display_name": "Centreon-Server",
-            "execution_time": 0.025543,
-            "icon_image": "",
-            "icon_image_alt": "",
-            "last_check": "2023-11-03T13:22:59+01:00",
-            "last_hard_state_change": "2023-11-03T13:19:14+01:00",
-            "last_state_change": "2023-11-03T13:19:14+01:00",
-            "last_time_down": null,
-            "last_time_unreachable": null,
-            "last_time_up": "2023-11-03T13:23:04+01:00",
-            "last_update": "2023-11-03T13:17:59+01:00",
-            "max_check_attempts": 5,
-            "output": "OK - 127.0.0.1 rta 0.035ms lost 0%\n",
-            "passive_checks": false,
-            "state": 0,
-            "state_type": 1,
-            "timezone": "",
-            "scheduled_downtime_depth": 0,
-            "criticality": null
+            "name": "Centreon-Server"
+          }
+        ]
+      },
+      {
+        "resourceType": "service",
+        "resources": [
+          {
+            "id": "Ping",
+            "name": "Ping"
           }
         ]
       }
@@ -40,16 +24,28 @@
       {
         "criticalHighThreshold": 50,
         "criticalLowThreshold": 0,
-        "id": 2,
+        "id": 15,
         "name": "pl",
         "unit": "%",
         "warningHighThreshold": 20,
-        "warningLowThreshold": 0
+        "warningLowThreshold": 0,
+        "serviceId": 26,
+        "serviceName": "Ping",
+        "excludedMetrics": [],
+        "includeAllMetrics": true
+      }
+    ],
+    "services": [
+      {
+        "uuid": "h14-s26",
+        "id": 26,
+        "name": "Ping",
+        "parentName": "Centreon-Server"
       }
     ]
   },
   "options": {
-    "singleMetricGraphType": "text",
+    "displayType": "text",
     "threshold": {
       "enabled": true,
       "customCritical": null,
@@ -61,7 +57,7 @@
     "refreshInterval": "default",
     "valueFormat": "human",
     "description": {
-      "content": "{\"root\":{\"children\":[{\"children\":[],\"direction\":null,\"format\":\"center\",\"indent\":0,\"type\":\"paragraph\",\"version\":1}],\"direction\":null,\"format\":\"\",\"indent\":0,\"type\":\"root\",\"version\":1}}",
+      "content": "{\"root\":{\"children\":[{\"children\":[],\"direction\":null,\"format\":\"\",\"indent\":0,\"type\":\"paragraph\",\"version\":1,\"textFormat\":0,\"textStyle\":\"\"}],\"direction\":null,\"format\":\"\",\"indent\":0,\"type\":\"root\",\"version\":1}}",
       "enabled": true
     }
   }

--- a/centreon/tests/e2e/fixtures/dashboards/creation/widgets/singleMetricPayloadRta.json
+++ b/centreon/tests/e2e/fixtures/dashboards/creation/widgets/singleMetricPayloadRta.json
@@ -6,32 +6,16 @@
         "resources": [
           {
             "id": 14,
-            "poller_id": 1,
-            "name": "Centreon-Server",
-            "acknowledged": false,
-            "address_ip": "127.0.0.1",
-            "alias": "Monitoring Server",
-            "check_attempt": 1,
-            "checked": true,
-            "display_name": "Centreon-Server",
-            "execution_time": 0.025543,
-            "icon_image": "",
-            "icon_image_alt": "",
-            "last_check": "2023-11-03T13:22:59+01:00",
-            "last_hard_state_change": "2023-11-03T13:19:14+01:00",
-            "last_state_change": "2023-11-03T13:19:14+01:00",
-            "last_time_down": null,
-            "last_time_unreachable": null,
-            "last_time_up": "2023-11-03T13:23:04+01:00",
-            "last_update": "2023-11-03T13:17:59+01:00",
-            "max_check_attempts": 5,
-            "output": "OK - 127.0.0.1 rta 0.035ms lost 0%\n",
-            "passive_checks": false,
-            "state": 0,
-            "state_type": 1,
-            "timezone": "",
-            "scheduled_downtime_depth": 0,
-            "criticality": null
+            "name": "Centreon-Server"
+          }
+        ]
+      },
+      {
+        "resourceType": "service",
+        "resources": [
+          {
+            "id": "Ping",
+            "name": "Ping"
           }
         ]
       }
@@ -40,16 +24,28 @@
       {
         "criticalHighThreshold": 400,
         "criticalLowThreshold": 0,
-        "id": 1,
+        "id": 14,
         "name": "rta",
         "unit": "ms",
         "warningHighThreshold": 200,
-        "warningLowThreshold": 0
+        "warningLowThreshold": 0,
+        "serviceId": 26,
+        "serviceName": "Ping",
+        "excludedMetrics": [],
+        "includeAllMetrics": true
+      }
+    ],
+    "services": [
+      {
+        "uuid": "h14-s26",
+        "id": 26,
+        "name": "Ping",
+        "parentName": "Centreon-Server"
       }
     ]
   },
   "options": {
-    "singleMetricGraphType": "text",
+    "displayType": "text",
     "threshold": {
       "enabled": true,
       "customCritical": null,
@@ -61,7 +57,7 @@
     "refreshInterval": "default",
     "valueFormat": "human",
     "description": {
-      "content": "{\"root\":{\"children\":[{\"children\":[],\"direction\":null,\"format\":\"center\",\"indent\":0,\"type\":\"paragraph\",\"version\":1}],\"direction\":null,\"format\":\"\",\"indent\":0,\"type\":\"root\",\"version\":1}}",
+      "content": "{\"root\":{\"children\":[{\"children\":[],\"direction\":null,\"format\":\"\",\"indent\":0,\"type\":\"paragraph\",\"version\":1,\"textFormat\":0,\"textStyle\":\"\"}],\"direction\":null,\"format\":\"\",\"indent\":0,\"type\":\"root\",\"version\":1}}",
       "enabled": true
     }
   }

--- a/centreon/tests/php/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetricTest.php
+++ b/centreon/tests/php/Core/Dashboard/Application/UseCase/FindSingleMetaMetric/FindSingleMetaMetricTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\Dashboard\Application\UseCase\FindSingleMetaMetric;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\RequestParameters\Interfaces\RequestParametersInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Dashboard\Application\UseCase\FindSingleMetaMetric\{
+    FindSingleMetaMetric,
+    FindSingleMetaMetricPresenterInterface,
+    FindSingleMetaMetricRequest,
+    FindSingleMetaMetricResponse
+};
+use Core\Metric\Application\Repository\ReadMetricRepositoryInterface;
+use Core\Metric\Domain\Model\Metric;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Service\Application\Repository\ReadRealTimeServiceRepositoryInterface;
+use Mockery;
+
+beforeEach(function (): void {
+    $this->contact = Mockery::mock(ContactInterface::class);
+    $this->metricRepo = Mockery::mock(ReadMetricRepositoryInterface::class);
+    $this->serviceRepo = Mockery::mock(ReadRealTimeServiceRepositoryInterface::class);
+    $this->accessGroupRepo = Mockery::mock(ReadAccessGroupRepositoryInterface::class);
+    $this->requestParameters = Mockery::mock(RequestParametersInterface::class);
+    $this->contact->shouldReceive('getId')->andReturn(1);
+
+    $this->presenter = new class () implements FindSingleMetaMetricPresenterInterface {
+        public mixed $response = null;
+
+        public function presentResponse(mixed $response): void
+        {
+            $this->response = $response;
+        }
+    };
+    $this->service = [
+        'host_id' => 15,
+        'service_id' => 29,
+    ];
+});
+
+it('returns a FindSingleMetaMetricResponse for an admin user', function (): void {
+    $this->contact->shouldReceive('isAdmin')->once()->andReturn(true);
+    $metaServiceId = 20;
+    $service = $this->serviceRepo
+        ->shouldReceive('existsByDescription')
+        ->once()
+        ->with($metaServiceId)
+        ->andReturn($this->service);
+
+    $metric = new Metric(
+        id: 1,
+        name: 'cpu'
+    );
+    $metric->setCurrentValue(12.34);
+    $metric->setUnit('%');
+
+    $this->metricRepo
+        ->shouldReceive('findSingleMetaMetricValue')
+        ->once()
+        ->with($this->service, 'cpu', $this->requestParameters)
+        ->andReturn($metric);
+
+    $this->accessGroupRepo->shouldNotReceive('findByContact');
+
+    $useCase = new FindSingleMetaMetric(
+        $this->contact,
+        $this->metricRepo,
+        $this->serviceRepo,
+        $this->accessGroupRepo,
+        $this->requestParameters,
+    );
+
+    $useCase(new FindSingleMetaMetricRequest($metaServiceId, 'cpu'), $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(FindSingleMetaMetricResponse::class)
+        ->and($this->presenter->response->id)->toBe(1)
+        ->and($this->presenter->response->name)->toBe('cpu')
+        ->and($this->presenter->response->currentValue)->toBe(12.34);
+});
+
+it('passes access groups to the repository for non-admin users', function (): void {
+    $this->contact->shouldReceive('isAdmin')->once()->andReturn(false);
+    $metaServiceId = 22;
+    $service = $this->serviceRepo
+        ->shouldReceive('existsByDescription')
+        ->once()
+        ->with($metaServiceId)
+        ->andReturn($this->service);
+
+    $fakeGroups = ['g1', 'g2'];
+    $this->accessGroupRepo
+        ->shouldReceive('findByContact')
+        ->once()
+        ->with($this->contact)
+        ->andReturn($fakeGroups);
+
+    $metric = new Metric(
+        id: 2,
+        name: 'mem'
+    );
+    $metric->setUnit('MB');
+    $metric->setCurrentValue(256.0);
+
+    $this->metricRepo
+        ->shouldReceive('findSingleMetaMetricValue')
+        ->once()
+        ->with($this->service, 'mem', $this->requestParameters, $fakeGroups)
+        ->andReturn($metric);
+
+    $useCase = new FindSingleMetaMetric(
+        $this->contact,
+        $this->metricRepo,
+        $this->serviceRepo,
+        $this->accessGroupRepo,
+        $this->requestParameters
+    );
+
+    $useCase(new FindSingleMetaMetricRequest($metaServiceId, 'mem'), $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(FindSingleMetaMetricResponse::class)
+        ->and($this->presenter->response->id)->toBe(2)
+        ->and($this->presenter->response->name)->toBe('mem');
+});
+
+it('returns NotFoundResponse when service does not exist', function (): void {
+    $metaServiceId = 6;
+    $service = $this->serviceRepo
+        ->shouldReceive('existsByDescription')
+        ->once()
+        ->with($metaServiceId)
+        ->andReturn(false);
+
+    $useCase = new FindSingleMetaMetric(
+        $this->contact,
+        $this->metricRepo,
+        $this->serviceRepo,
+        $this->accessGroupRepo,
+        $this->requestParameters
+    );
+
+    $useCase(new FindSingleMetaMetricRequest($metaServiceId, 'disk'), $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(NotFoundResponse::class)
+        ->and($this->presenter->response->getMessage())->toBe('MetaService not found');
+});
+
+it('maps a "not found" exception to NotFoundResponse', function (): void {
+    $metaServiceId = 6;
+    $this->contact->shouldReceive('isAdmin')->once()->andReturn(true);
+    $this->serviceRepo->shouldReceive('existsByDescription')->once()->andReturn($this->service);
+
+    $this->metricRepo
+        ->shouldReceive('FindSingleMetaMetricValue')
+        ->once()
+        ->andReturn(null);
+
+    $useCase = new FindSingleMetaMetric(
+        $this->contact,
+        $this->metricRepo,
+        $this->serviceRepo,
+        $this->accessGroupRepo,
+        $this->requestParameters
+    );
+
+    $useCase(new FindSingleMetaMetricRequest($metaServiceId, 'foo'), $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(NotFoundResponse::class);
+});
+
+it('maps other exceptions to ErrorResponse', function (): void {
+    $metaServiceId = 6;
+    $this->contact->shouldReceive('isAdmin')->once()->andReturn(true);
+    $service = $this->serviceRepo->shouldReceive('existsByDescription')->once()->andReturn($this->service);
+
+    $this->metricRepo
+        ->shouldReceive('findSingleMetaMetricValue')
+        ->once()
+        ->andThrow(new RepositoryException(
+            "Error retrieving metric 'foo' for host 1, service 2",
+            ['metricName' => 'bar', 'hostId' => 1, 'serviceId' => 2]
+        ));
+
+    $useCase = new FindSingleMetaMetric(
+        $this->contact,
+        $this->metricRepo,
+        $this->serviceRepo,
+        $this->accessGroupRepo,
+        $this->requestParameters
+    );
+
+    $useCase(new FindSingleMetaMetricRequest($metaServiceId, 'bar'), $this->presenter);
+
+    expect($this->presenter->response)
+        ->toBeInstanceOf(ErrorResponse::class);
+});
+
+it('throws InvalidArgumentException for non-positive metaServiceId', function (): void {
+    $this->expectException(\InvalidArgumentException::class);
+    new FindSingleMetaMetricRequest(0, 'metric');
+});
+
+it('throws InvalidArgumentException for empty metricName', function (): void {
+    $this->expectException(\InvalidArgumentException::class);
+    new FindSingleMetaMetricRequest(1, '');
+});


### PR DESCRIPTION
## Description

single metric widget End-point for meta service

**Added**

- FindSingleMetaMetric application use case:

     1. Request (FindSingleMetaMetricRequest), Response (FindSingleMetaMetricResponse), Presenter interface, and Metric DTO 

- Infrastructure/API:

1.     FindSingleMetaMetricController
2.     FindSingleMetaMetricPresenter (Presenter)
3.     FindSingleMetaMetricRoute.yaml (Route definition)

- OpenAPI specifications:

1.     New path /monitoring/metaservice/{metaServiceId}/metrics/{metricName} in FindSingleMetaMetric.yaml
2.     MetaServiceId.yaml schema for the metaServiceId parameter 

- Tests:

1.     FindSingleMetaMetricTest 

**Changed**

- centreon-api.yaml updated to include the new single-metric endpoint under the Realtime/Metrics section 
- repos : add existsByDescription method on DbReadRealTimeServiceRepository

## Unit Tests

<img width="1210" height="334" alt="image" src="https://github.com/user-attachments/assets/31e687eb-a022-4550-bb9a-ce39e23f2a92" />


## Examples

<img width="1591" height="523" alt="image" src="https://github.com/user-attachments/assets/8fbefb81-f7c9-4e8b-a032-f297e1dd43a5" />


## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] MON-147357

<h2> How this pull request can be tested ? </h2>

Check [Ticket](https://centreon.atlassian.net/browse/MON-177836)

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).