### PR TITLE
save saml session info before removing them

### DIFF
--- a/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Provider/SAML.php
@@ -422,17 +422,18 @@ class SAML implements ProviderAuthenticationInterface
     }
 
     /**
+     * @param ?array $logoutOptions
      * @throws Error
      */
-    public function logout(): void
+    public function logout($logoutOptions = null): void
     {
         $returnTo = '/login';
 
-        $samlNameId = $_SESSION['saml']['samlNameId'] ?? null;
-        $samlSessionIndex = $_SESSION['saml']['samlSessionIndex'] ?? null;
-        $samlNameIdFormat = $_SESSION['saml']['samlNameIdFormat'] ?? null;
-        $samlNameIdNameQualifier = $_SESSION['saml']['samlNameIdNameQualifier'] ?? null;
-        $samlNameIdSPNameQualifier = $_SESSION['saml']['samlNameIdSPNameQualifier'] ?? null;
+        $samlNameId = $logoutOptions['session']['samlNameId'] ?? null;
+        $samlSessionIndex = $logoutOptions['session']['samlSessionIndex'] ?? null;
+        $samlNameIdFormat = $logoutOptions['session']['samlNameIdFormat'] ?? null;
+        $samlNameIdNameQualifier = $logoutOptions['session']['samlNameIdNameQualifier'] ?? null;
+        $samlNameIdSPNameQualifier = $logoutOptions['session']['samlNameIdSPNameQualifier'] ?? null;
 
         $this->loginLogger->info(Provider::SAML, 'logout from SAML and redirect');
 

--- a/centreon/src/Core/Security/Authentication/Infrastructure/Repository/WriteSessionRepository.php
+++ b/centreon/src/Core/Security/Authentication/Infrastructure/Repository/WriteSessionRepository.php
@@ -55,6 +55,11 @@ class WriteSessionRepository implements WriteSessionRepositoryInterface
     {
         $this->writeSessionTokenRepository->deleteSession($this->requestStack->getSession()->getId());
         $centreon = $this->requestStack->getSession()->get('centreon');
+
+        if ($centreon && $centreon->user->authType === Provider::SAML) {
+            $logoutOptions = ['session' => $_SESSION['saml']];
+        }
+
         $this->requestStack->getSession()->invalidate();
 
         if ($centreon && $centreon->user->authType === Provider::SAML) {
@@ -68,7 +73,7 @@ class WriteSessionRepository implements WriteSessionRepositoryInterface
                 && $customConfiguration->getLogoutFrom() === CustomConfiguration::LOGOUT_FROM_CENTREON_AND_IDP
             ) {
                 $this->info('Logout from Centreon and SAML IDP...');
-                $provider->logout(); // The redirection is done here by the IDP
+                $provider->logout($logoutOptions); // The redirection is done here by the IDP
             }
         }
     }


### PR DESCRIPTION
## Description

php session is cleared before we call logout() from the saml auth provider that is using $_SESSION

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
