### PR TITLE
fix(RS): access to details page of a service which have a service group fixed

### DIFF
--- a/centreon/www/front_src/src/Resources/decoders.ts
+++ b/centreon/www/front_src/src/Resources/decoders.ts
@@ -213,6 +213,9 @@ const downtimeDecoder = JsonDecoder.object<Downtime>(
 
 const groupDecoder = JsonDecoder.object<Group>(
   {
+    configuration_uri: JsonDecoder.optional(
+      JsonDecoder.nullable(JsonDecoder.string)
+    ),
     configuration_endpoint: JsonDecoder.optional(
       JsonDecoder.nullable(JsonDecoder.string)
     ),


### PR DESCRIPTION
## Description

### Fixed

* access to details page of a service which have a service group fixed

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] develop

<h2> How this pull request can be tested ? </h2>

* Add a service group to a service
* On the resource status page, open the service details
* The details should be displayed

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
