### PR TITLE
fix(internationalization): browser language detection not working properly

### DIFF
--- a/centreon/src/Centreon/Domain/Service/I18nService.php
+++ b/centreon/src/Centreon/Domain/Service/I18nService.php
@@ -37,6 +37,7 @@ namespace Centreon\Domain\Service;
 use CentreonLegacy\Core\Module\Information;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Class to manage translation of centreon and its extensions
@@ -74,6 +75,63 @@ class I18nService
         $this->initLang();
         $this->finder = $finder;
         $this->filesystem = $filesystem;
+    }
+
+    /**
+     * Retrieves all available locales in format xy_XY
+     * en_US will always be present in the first place
+     * @return array
+     */
+    public static function getAvailableCentreonLanguages(): array
+    {
+        $dirs = (new Finder())
+            ->directories()
+            ->in(__DIR__ . "/../../../../www/locale")
+            ->depth('== 0')
+            ->sortByName();
+        $locales = [];
+        foreach ($dirs as $dir) {
+            if (!preg_match('/^([a-z]{2}_[A-Z]{2})/', $dir->getBasename(), $matches) || empty($matches[1])) continue;
+            $locales[] = $matches[1];
+        }
+        $enUSIndex = array_search("en_US", $locales, true);
+        if ($enUSIndex !== false) {
+            array_splice($locales, $enUSIndex, 1);
+        }
+        $locales = array_merge(["en_US"], $locales);
+        return array_values(array_unique($locales));
+    }
+
+    /**
+     * Guesses locale from a provided request or from current HEADERS (create request from globals)
+     * @param Request|null $request
+     * @return string
+     */
+    public static function guessLocaleFromRequest(?Request $request = null): string
+    {
+        if (!isset($request)) {
+            $request = Request::createFromGlobals();
+        }
+
+        $localeMap = [];
+        $locales = self::getAvailableCentreonLanguages();
+        foreach ($locales as $locale) {
+            [$short, $country] = explode("_", $locale);
+            // when short notation already set only overwrite when short = country
+            if (!isset($localeMap[$short]) || strtolower($short) === strtolower($country)) {
+                $localeMap[$short] = $locale;
+            }
+            $localeMap[$locale] = $locale;
+        }
+
+        // getPreferredLanguage will always return a value
+        // if no preferred value can be extracted from the request headers, the first provided locale is returned
+        // e.g., the request accepts es-CO - it will be matched with es
+        // the more specific case pt-BR is also matched, in any other pt case the standard pt (pt_PT) is matched
+        // getPreferredLanguage normalizes the provided locales automatically (_ to -, casing ecc.)
+        $preferredLanguage = $request->getPreferredLanguage(array_keys($localeMap));
+
+        return $localeMap[$preferredLanguage] ?? $localeMap[array_key_first($localeMap)];
     }
 
     /**
@@ -150,7 +208,9 @@ class I18nService
     {
         $data = [];
 
-        $languages = array('fr_FR.UTF-8', 'de_DE.UTF-8', 'es_ES.UTF-8', 'pt-PT.UTF-8', 'pt_BR.UTF-8');
+        $languages = array_map(static function ($i) {
+            return $i . ".UTF-8";
+        }, self::getAvailableCentreonLanguages());
 
         foreach ($languages as $language) {
             $translationPath = __DIR__ . "/../../../../www/locale/{$language}/LC_MESSAGES";
@@ -210,7 +270,9 @@ class I18nService
     {
         $data = [];
 
-        $languages = array('fr_FR.UTF-8', 'de_DE.UTF-8', 'es_ES.UTF-8', 'pt-PT.UTF-8', 'pt_BR.UTF-8');
+        $languages = array_map(static function ($i) {
+            return $i . ".UTF-8";
+        }, self::getAvailableCentreonLanguages());
 
         foreach ($languages as $language) {
             // loop over each installed modules to get translation

--- a/centreon/src/EventSubscriber/CentreonEventSubscriber.php
+++ b/centreon/src/EventSubscriber/CentreonEventSubscriber.php
@@ -29,6 +29,7 @@ use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Centreon\Domain\Entity\EntityCreator;
 use Centreon\Domain\Entity\EntityValidator;
 use Centreon\Domain\Exception\EntityNotFoundException;
+use Centreon\Domain\Service\I18nService;
 use Centreon\Domain\RequestParameters\{Interfaces\RequestParametersInterface,
     RequestParameters,
     RequestParametersException};
@@ -413,39 +414,17 @@ class CentreonEventSubscriber implements EventSubscriberInterface
         if ($user === null) {
             return;
         }
-        
+
         $request = $event->getRequest();
-        $locale = $user->getLocale();
         if ($user->getLang() === 'browser') {
-            $locale = $this->guessLocale($request);
-            // set locale to null in case detection by browser is enabled so the frontend can handle it by itself
-            $user->setLocale(null);
+            $locale = I18nService::guessLocaleFromRequest($request);
+            $user->setLocale($locale);
         }
 
         EntityCreator::setContact($user);
-        
-        $this->initLanguage($locale);
+
+        $this->initLanguage($user);
         $this->initGlobalContact($user);
-    }
-
-    /**
-     * Guess the locale to use according to the provided Accept-Language header (sent by browser or http client)
-     * 
-     * @todo improve this by moving the logic in a dedicated service
-     * @todo improve the array of supported locales by INJECTING them instead
-     * @param Request $request
-     */
-    private function guessLocale(Request $request): string
-    {
-        // getPreferredLanguage always returns a value
-        // if no preferred value can be extracted from the request headers, the first provided locale is returned
-        $preferredLanguage = $request->getPreferredLanguage(['en_US', 'fr_FR', 'es_ES', 'pr_BR', 'pt_PT', 'de_DE']);
-        
-        // Reformating is necessary as the standard format uses "-" and we decided to store "_"
-        $locale = $preferredLanguage ? str_replace('-', '_', $preferredLanguage): 'en_US';
-
-        // Also Safari has its own format "fr-fr" instead of "fr-FR" hence the strtoupper
-        return substr($locale, 0, -2) . strtoupper(substr($locale, -2));
     }
 
     /**
@@ -470,11 +449,11 @@ class CentreonEventSubscriber implements EventSubscriberInterface
     /**
      * Init language to manage translation.
      *
-     * @param string $locale
+     * @param ContactInterface $user
      */
-    private function initLanguage(string $locale): void
+    private function initLanguage(ContactInterface $user): void
     {
-        $lang = $locale . '.' . Contact::DEFAULT_CHARSET;
+        $lang = $user->getLocale() . '.' . Contact::DEFAULT_CHARSET;
 
         putenv('LANG=' . $lang);
         setlocale(LC_ALL, $lang);

--- a/centreon/src/EventSubscriber/CentreonEventSubscriber.php
+++ b/centreon/src/EventSubscriber/CentreonEventSubscriber.php
@@ -415,14 +415,16 @@ class CentreonEventSubscriber implements EventSubscriberInterface
         }
         
         $request = $event->getRequest();
+        $locale = $user->getLocale();
         if ($user->getLang() === 'browser') {
             $locale = $this->guessLocale($request);
-            $user->setLocale($locale);
+            // set locale to null in case detection by browser is enabled so the frontend can handle it by itself
+            $user->setLocale(null);
         }
 
         EntityCreator::setContact($user);
         
-        $this->initLanguage($user);
+        $this->initLanguage($locale);
         $this->initGlobalContact($user);
     }
 
@@ -435,7 +437,9 @@ class CentreonEventSubscriber implements EventSubscriberInterface
      */
     private function guessLocale(Request $request): string
     {
-        $preferredLanguage = $request->getPreferredLanguage(['fr-FR', 'en-US', 'es-ES', 'pr-BR', 'pt-PT', 'de-DE']);
+        // getPreferredLanguage always returns a value
+        // if no preferred value can be extracted from the request headers, the first provided locale is returned
+        $preferredLanguage = $request->getPreferredLanguage(['en_US', 'fr_FR', 'es_ES', 'pr_BR', 'pt_PT', 'de_DE']);
         
         // Reformating is necessary as the standard format uses "-" and we decided to store "_"
         $locale = $preferredLanguage ? str_replace('-', '_', $preferredLanguage): 'en_US';
@@ -466,11 +470,11 @@ class CentreonEventSubscriber implements EventSubscriberInterface
     /**
      * Init language to manage translation.
      *
-     * @param ContactInterface $user
+     * @param string $locale
      */
-    private function initLanguage(ContactInterface $user): void
+    private function initLanguage(string $locale): void
     {
-        $lang = $user->getLocale() . '.' . Contact::DEFAULT_CHARSET;
+        $lang = $locale . '.' . Contact::DEFAULT_CHARSET;
 
         putenv('LANG=' . $lang);
         setlocale(LC_ALL, $lang);

--- a/centreon/www/class/centreonLang.class.php
+++ b/centreon/www/class/centreonLang.class.php
@@ -142,10 +142,20 @@ class CentreonLang
     {
         $fullLocale = '';
 
-        $as = ['fr' => 'fr_FR', 'fr_FR' => 'fr_FR', 'en' => 'en_US', 'en_US' => 'en_US'];
+        $as = [
+            'en' => 'en_US',
+            'fr' => 'fr_FR',
+            'de' => 'de_DE',
+            'es' => 'es_ES',
+            'pt' => 'pt_PT'
+        ];
+        foreach ($as as $short => $long) {
+            $as[$long] = $short;
+        }
+        $as['pt_BR'] = 'pt_BR';
 
         if (isset($as[$shortLocale])) {
-            $fullLocale .= $as[$shortLocale];
+            $fullLocale = $as[$shortLocale];
         } else {
             $fullLocale = 'en_US';
         }

--- a/centreon/www/class/centreonLang.class.php
+++ b/centreon/www/class/centreonLang.class.php
@@ -33,6 +33,8 @@
  *
  */
 
+use Centreon\Domain\Service\I18nService;
+
 /**
  * Class
  *
@@ -120,49 +122,8 @@ class CentreonLang
      */
     private function getBrowserDefaultLanguage()
     {
-        $currentLocale = '';
-        
-        if (version_compare(PHP_VERSION, '5.2.0') >= 0 && isset($_SERVER['HTTP_ACCEPT_LANGUAGE'])) {
-            $browserLocale = $_SERVER['HTTP_ACCEPT_LANGUAGE'];
-            $currentLocale .= Locale::acceptFromHttp($browserLocale);
-        } else {
-            $currentLocale .= $this->parseHttpAcceptHeader();
-        }
-
-        return $this->getFullLocale($currentLocale);
+        return I18nService::guessLocaleFromRequest();
     }
-
-    /**
-     * Used to convert the browser language's from a short string to a string
-     *
-     * @param string $shortLocale
-     * @return string $fullLocale
-     */
-    private function getFullLocale($shortLocale)
-    {
-        $fullLocale = '';
-
-        $as = [
-            'en' => 'en_US',
-            'fr' => 'fr_FR',
-            'de' => 'de_DE',
-            'es' => 'es_ES',
-            'pt' => 'pt_PT'
-        ];
-        foreach ($as as $short => $long) {
-            $as[$long] = $short;
-        }
-        $as['pt_BR'] = 'pt_BR';
-
-        if (isset($as[$shortLocale])) {
-            $fullLocale = $as[$shortLocale];
-        } else {
-            $fullLocale = 'en_US';
-        }
-
-        return $fullLocale;
-    }
-
 
     /**
      *  Sets list of charsets

--- a/centreon/www/front_src/src/Main/useInitializeTranslation.ts
+++ b/centreon/www/front_src/src/Main/useInitializeTranslation.ts
@@ -32,6 +32,7 @@ const useInitializeTranslation = (): UseInitializeTranslationState => {
     i18next.use(initReactI18next).init({
       fallbackLng: 'en',
       keySeparator: false,
+      returnEmptyString: false,
       lng: locale?.substring(0, 2) || getBrowserLocale(),
       nsSeparator: false,
       resources: pipe(


### PR DESCRIPTION
## Description

With the current hotfix version 24.10.10 the language by browser detection is not working properly. Actually it never really did before the versions 24.10.9 and 24.10.10. Now the browser detection is active, but is missing some important points.

As far as I understood, the detection is done in the backend (for old php pages and the current user) and in the frontend (for react pages). The react frontend handles the detection when `locale: null` is returned from the API for the current users parameters.

### Problems

1. The current implementation is missing newer translations like "de_DE" or "es_ES"
2. The current automated workflow for translations (serializing .po files) is keeping non-translated labels (empty translation) which results also in empty labels in the frontend
3. The language-by-browser-detection did not handle the supported locales properly

### Solution

I introduced some new static functions in the I18nService to dynamically load all available centreon locales and also a function which guesses the best supported locale by the current request. This function is then used by the CentreonEventSubscriber to set the current user's locale and by the centreonLang class (for the old php pages) to set the language.

### Open questions

IMO and as far as I understood the frontend handles the locale itself if detection by browser is enabled for the user. In that case FindCurrentUserParameters (centreon/api/latest/configuration/users/current/parameters) should return null for the locale so the react frontend can manage the browser detection by itself. Please let me know if I should/can also implement such exception for this usecase. This could be done like this in file `src/Core/User/Application/UseCase/FindCurrentUserParameters/FindCurrentUserParameters.php`:
<img width="757" height="345" alt="image" src="https://github.com/user-attachments/assets/2f37638f-b75f-4b5f-8b9e-44c293713f1b" />


**Fixes** #8024 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

1. I presume that you have already changed your centreon user language settings to "detection by browser" before.
2. Change the language of your browser to German (Germany) / Deutsch (Deutschland).
4. Open Centreon (not logged in), you should now see (already on the login form) "Benutzername" instead of "Username".
5. After logging in, also all other (translated...) strings are in german.
6. Navigate to the Resource status page and verify, that the labels are written in german
<img width="1853" height="177" alt="image" src="https://github.com/user-attachments/assets/40fa313c-4b45-4ce2-a7c8-fd188e1b5230" />
7. Verify using the network tab of your devtools, that the "paramters" endpoint (/centreon/api/latest/configuration/users/current/parameters) returns "null" for "locale"
8. Navigate to a php page (e.g. configuration -> hosts)
9. Verify that also there all labels are written in german
<img width="620" height="167" alt="image" src="https://github.com/user-attachments/assets/90a7cf24-afd7-4ffc-9979-cfb506084e9c" />


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
