### PR TITLE
[WIP] fix(AC): Add an upgrade script to realign correctly CMA Configurations

### DIFF
--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -251,6 +251,9 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
             if (! array_key_exists('tokens', $configuration)) {
                 $configuration['tokens'] = [];
             }
+             if (! isset($configuration['hosts']) || ! is_array($configuration['hosts'])) {
+                 $configuration['hosts'] = [];
+            }
             foreach ($configuration['hosts'] as &$host) {
                 if (! array_key_exists('token', $host)) {
                     $host['token'] = $tokenInformation;

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -178,7 +178,7 @@ $generateToken = function () use ($pearDB): array {
     $token = new NewJwtToken(
         name: new TrimmedString('cma-hotfix'),
         creatorId: $admin['contact_id'],
-        creatorName: $admin['contact_name'],
+        creatorName: new TrimmedString($admin['contact_name']),
         expirationDate: null
     );
 
@@ -199,7 +199,7 @@ $generateToken = function () use ($pearDB): array {
         ])
     );
 
-    return ['token_name' => 'cma-hotfix', 'creator_id' => $admin['contact_id']];
+    return ['name' => 'cma-hotfix', 'creator_id' => $admin['contact_id']];
 };
 
 /**

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -176,7 +176,7 @@ $generateToken = function () use ($pearDB): array {
     );
 
     $token = new NewJwtToken(
-        name: new TrimmedString('cma-hotfix'),
+        name: new TrimmedString('cma-default'),
         creatorId: $admin['contact_id'],
         creatorName: new TrimmedString($admin['contact_name']),
         expirationDate: null
@@ -199,7 +199,7 @@ $generateToken = function () use ($pearDB): array {
         ])
     );
 
-    return ['name' => 'cma-hotfix', 'creator_id' => $admin['contact_id']];
+    return ['name' => 'cma-default', 'creator_id' => $admin['contact_id']];
 };
 
 /**

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -23,8 +23,6 @@ use Adaptation\Database\Connection\Collection\QueryParameters;
 use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use Core\Common\Domain\TrimmedString;
 use Core\Security\Token\Domain\Model\NewJwtToken;
-use Core\Security\Token\Domain\Model\TokenFactory;
-use Core\Security\Token\Domain\Model\TokenTypeEnum;
 
 require_once __DIR__ . '/../../../bootstrap.php';
 
@@ -197,7 +195,7 @@ $generateToken = function () use ($pearDB): array {
             QueryParameter::string(':encoding_key', $token->getEncodingKey()),
             QueryParameter::bool(':is_revoked', false),
             QueryParameter::int(':creation_date', $token->getCreationDate()->getTimestamp()),
-            QueryParameter::null(':expiration_date')
+            QueryParameter::null(':expiration_date'),
         ])
     );
 
@@ -220,7 +218,7 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
             WHERE `type` = 'centreon-agent'
             SQL
     );
-    if (empty($agentConfigurations)) {
+    if ($agentConfigurations === []) {
         return;
     }
     $tokenInformation = $generateToken();
@@ -241,7 +239,7 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
                 }
                 if (! array_key_exists('id', $host)) {
                     $hostId = $pearDB->fetchOne(
-                        <<<SQL
+                        <<<'SQL'
                             SELECT host_id
                             FROM host
                             WHERE host_address = :hostAddress
@@ -253,7 +251,7 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
                 }
             }
         } else {
-            // `hosts` should be an empty array for reverse connection
+            // `hosts` should be an empty array for not reverse connection
             if (! array_key_exists('hosts', $configuration)) {
                 $configuration['hosts'] = [];
             }
@@ -263,19 +261,18 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
         }
 
         $pearDB->update(
-            <<<SQL
+            <<<'SQL'
                 UPDATE agent_configuration
                 SET configuration = :configuration
                 WHERE id = :id
                 SQL,
             QueryParameters::create([
                 QueryParameter::string(':configuration', json_encode($configuration)),
-                QueryParameter::int(':id', $agentConfiguration['id'])
+                QueryParameter::int(':id', $agentConfiguration['id']),
             ])
         );
     }
 };
-
 
 try {
     // DDL statements for real time database
@@ -289,13 +286,13 @@ try {
         $pearDB->beginTransaction();
     }
 
+    $alignCMAAgentConfigurationWithNewSchema();
     $updateDashboardAndCustomViewsTopology();
     $updateContactsShowDeprecatedCustomViews();
     $updateCfgParameters();
     $bbdoCfgUpdate();
     $addResourceStatusSearchModeOption();
     $flagContactsAsServiceAccount();
-    $alignCMAAgentConfigurationWithNewSchema();
 
     $pearDB->commit();
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -178,17 +178,17 @@ $generateToken = function () use ($pearDB): array {
     // Reuse an existing cma-default token if available for this creator
     $existing = $pearDB->fetchAssociative(
         <<<'SQL'
-            SELECT token_name, creator_id
-            FROM jwt_tokens
-            WHERE token_name = :token_name AND creator_id = :creator_id
-            LIMIT 1
-        SQL,
+                SELECT token_name, creator_id
+                FROM jwt_tokens
+                WHERE token_name = :token_name AND creator_id = :creator_id
+                LIMIT 1
+            SQL,
         QueryParameters::create([
             QueryParameter::string(':token_name', 'cma-default'),
             QueryParameter::int(':creator_id', (int) $admin['contact_id']),
         ])
     );
-    if (!empty($existing)) {
+    if (! empty($existing)) {
         return ['name' => 'cma-default', 'creator_id' => (int) $admin['contact_id']];
     }
 
@@ -201,9 +201,9 @@ $generateToken = function () use ($pearDB): array {
 
     $pearDB->executeStatement(
         <<<'SQL'
-            INSERT INTO `jwt_tokens` (token_string,token_name,creator_id,creator_name,encoding_key,is_revoked,creation_date,expiration_date)
-            VALUES (:token_string,:token_name,:creator_id,:creator_name,:encoding_key,:is_revoked,:creation_date,:expiration_date)
-        SQL,
+                INSERT INTO `jwt_tokens` (token_string,token_name,creator_id,creator_name,encoding_key,is_revoked,creation_date,expiration_date)
+                VALUES (:token_string,:token_name,:creator_id,:creator_name,:encoding_key,:is_revoked,:creation_date,:expiration_date)
+            SQL,
         QueryParameters::create([
             QueryParameter::string(':token_string', (string) $token->getToken()),
             QueryParameter::string(':token_name', (string) $token->getName()),
@@ -217,6 +217,7 @@ $generateToken = function () use ($pearDB): array {
     );
 
     return ['name' => 'cma-default', 'creator_id' => (int) $admin['contact_id']];
+
     return ['name' => 'cma-default', 'creator_id' => $admin['contact_id']];
 };
 
@@ -251,8 +252,8 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
             if (! array_key_exists('tokens', $configuration)) {
                 $configuration['tokens'] = [];
             }
-             if (! isset($configuration['hosts']) || ! is_array($configuration['hosts'])) {
-                 $configuration['hosts'] = [];
+            if (! isset($configuration['hosts']) || ! is_array($configuration['hosts'])) {
+                $configuration['hosts'] = [];
             }
             foreach ($configuration['hosts'] as &$host) {
                 if (! array_key_exists('token', $host)) {
@@ -283,10 +284,10 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
 
         $pearDB->update(
             <<<'SQL'
-                UPDATE agent_configuration
-                SET configuration = :configuration
-                WHERE id = :id
-            SQL,
+                    UPDATE agent_configuration
+                    SET configuration = :configuration
+                    WHERE id = :id
+                SQL,
             QueryParameters::create([
                 QueryParameter::string(':configuration', json_encode($configuration, JSON_THROW_ON_ERROR)),
                 QueryParameter::int(':id', $agentConfiguration['id']),

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -283,9 +283,9 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
                 UPDATE agent_configuration
                 SET configuration = :configuration
                 WHERE id = :id
-                SQL,
+            SQL,
             QueryParameters::create([
-                QueryParameter::string(':configuration', json_encode($configuration)),
+                QueryParameter::string(':configuration', json_encode($configuration, JSON_THROW_ON_ERROR)),
                 QueryParameter::int(':id', $agentConfiguration['id']),
             ])
         );

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -175,10 +175,27 @@ $generateToken = function () use ($pearDB): array {
             SQL
     );
 
+    // Reuse an existing cma-default token if available for this creator
+    $existing = $pearDB->fetchAssociative(
+        <<<'SQL'
+            SELECT token_name, creator_id
+            FROM jwt_tokens
+            WHERE token_name = :token_name AND creator_id = :creator_id
+            LIMIT 1
+        SQL,
+        QueryParameters::create([
+            QueryParameter::string(':token_name', 'cma-default'),
+            QueryParameter::int(':creator_id', (int) $admin['contact_id']),
+        ])
+    );
+    if (!empty($existing)) {
+        return ['name' => 'cma-default', 'creator_id' => (int) $admin['contact_id']];
+    }
+
     $token = new NewJwtToken(
         name: new TrimmedString('cma-default'),
-        creatorId: $admin['contact_id'],
-        creatorName: new TrimmedString($admin['contact_name']),
+        creatorId: (int) $admin['contact_id'],
+        creatorName: new TrimmedString((string) $admin['contact_name']),
         expirationDate: null
     );
 
@@ -186,19 +203,20 @@ $generateToken = function () use ($pearDB): array {
         <<<'SQL'
             INSERT INTO `jwt_tokens` (token_string,token_name,creator_id,creator_name,encoding_key,is_revoked,creation_date,expiration_date)
             VALUES (:token_string,:token_name,:creator_id,:creator_name,:encoding_key,:is_revoked,:creation_date,:expiration_date)
-            SQL,
+        SQL,
         QueryParameters::create([
-            QueryParameter::string(':token_string', $token->getToken()),
-            QueryParameter::string(':token_name', $token->getName()),
-            QueryParameter::int(':creator_id', $token->getCreatorId()),
-            QueryParameter::string(':creator_name', $token->getCreatorName()),
-            QueryParameter::string(':encoding_key', $token->getEncodingKey()),
+            QueryParameter::string(':token_string', (string) $token->getToken()),
+            QueryParameter::string(':token_name', (string) $token->getName()),
+            QueryParameter::int(':creator_id', (int) $token->getCreatorId()),
+            QueryParameter::string(':creator_name', (string) $token->getCreatorName()),
+            QueryParameter::string(':encoding_key', (string) $token->getEncodingKey()),
             QueryParameter::bool(':is_revoked', false),
             QueryParameter::int(':creation_date', $token->getCreationDate()->getTimestamp()),
             QueryParameter::null(':expiration_date'),
         ])
     );
 
+    return ['name' => 'cma-default', 'creator_id' => (int) $admin['contact_id']];
     return ['name' => 'cma-default', 'creator_id' => $admin['contact_id']];
 };
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -19,6 +19,13 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Common\Domain\TrimmedString;
+use Core\Security\Token\Domain\Model\NewJwtToken;
+use Core\Security\Token\Domain\Model\TokenFactory;
+use Core\Security\Token\Domain\Model\TokenTypeEnum;
+
 require_once __DIR__ . '/../../../bootstrap.php';
 
 /**
@@ -155,6 +162,122 @@ $alterContactPagerSize = function () use ($pearDB, &$errorMessage): void {
     }
 };
 
+/**
+ * Generate a token based on the first found admin contact to update old agent_configurations
+ *
+ * @return array{token_name: string, creator_id: int}
+ */
+$generateToken = function () use ($pearDB): array {
+    $admin = $pearDB->fetchAssociative(
+        <<<'SQL'
+            SELECT contact_id, contact_name
+            FROM contact
+            WHERE contact_admin = '1'
+            LIMIT 1
+            SQL
+    );
+
+    $token = new NewJwtToken(
+        name: new TrimmedString('cma-hotfix'),
+        creatorId: $admin['contact_id'],
+        creatorName: $admin['contact_name'],
+        expirationDate: null
+    );
+
+    $pearDB->executeStatement(
+        <<<'SQL'
+            INSERT INTO `jwt_tokens` (token_string,token_name,creator_id,creator_name,encoding_key,is_revoked,creation_date,expiration_date)
+            VALUES (:token_string,:token_name,:creator_id,:creator_name,:encoding_key,:is_revoked,:creation_date,:expiration_date)
+            SQL,
+        QueryParameters::create([
+            QueryParameter::string(':token_string', $token->getToken()),
+            QueryParameter::string(':token_name', $token->getName()),
+            QueryParameter::int(':creator_id', $token->getCreatorId()),
+            QueryParameter::string(':creator_name', $token->getCreatorName()),
+            QueryParameter::string(':encoding_key', $token->getEncodingKey()),
+            QueryParameter::bool(':is_revoked', false),
+            QueryParameter::int(':creation_date', $token->getCreationDate()->getTimestamp()),
+            QueryParameter::null(':expiration_date')
+        ])
+    );
+
+    return ['token_name' => 'cma-hotfix', 'creator_id' => $admin['contact_id']];
+};
+
+/**
+ * Align inconsistent Agent Configuration with the new schema:
+ *      - Add a `tokens` key for each configuration in non reverse
+ *      - Add a `token` key for each configuration in reverse
+ *      - Add a `id` key for each hosts in each in reverse configuration
+ *          - host id is based on the first ID found for this address.
+ *          - As many hosts could have the same address, users should validate that the picken host is the good one.
+ */
+$alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMessage, $generateToken): void {
+    $errorMessage = 'Unable to align agent configuration with new schema';
+    $agentConfigurations = $pearDB->fetchAllAssociative(
+        <<<'SQL'
+            SELECT * FROM `agent_configuration`
+            WHERE `type` = 'centreon-agent'
+            SQL
+    );
+    if (empty($agentConfigurations)) {
+        return;
+    }
+    $tokenInformation = $generateToken();
+    foreach ($agentConfigurations as $agentConfiguration) {
+        $configuration = json_decode(
+            json: $agentConfiguration['configuration'],
+            associative: true,
+            flags: JSON_THROW_ON_ERROR
+        );
+        if ($configuration['is_reverse']) {
+            // `tokens` should be an empty array for reverse connection
+            if (! array_key_exists('tokens', $configuration)) {
+                $configuration['tokens'] = [];
+            }
+            foreach ($configuration['hosts'] as &$host) {
+                if (! array_key_exists('token', $host)) {
+                    $host['token'] = $tokenInformation;
+                }
+                if (! array_key_exists('id', $host)) {
+                    $hostId = $pearDB->fetchOne(
+                        <<<SQL
+                            SELECT host_id
+                            FROM host
+                            WHERE host_address = :hostAddress
+                            LIMIT 1
+                            SQL,
+                        QueryParameters::create([QueryParameter::string(':hostAddress', $host['address'])])
+                    );
+                    $host['id'] = $hostId;
+                }
+            }
+        } else {
+            // `hosts` should be an empty array for reverse connection
+            if (! array_key_exists('hosts', $configuration)) {
+                $configuration['hosts'] = [];
+            }
+            if (! array_key_exists('tokens', $configuration)) {
+                $configuration['tokens'] = [$tokenInformation];
+            }
+        }
+
+        $configuration = json_encode($configuration);
+        $pearDB->update(
+            <<<SQL
+                UPDATE agent_configuration
+                SET configuration = :configuration
+                WHERE id = :id
+                SQL,
+            QueryParameters::create([
+                QueryParameter::string(':configuration', json_encode($configuration)),
+                QueryParameter::int(':id', $agentConfiguration['id'])
+            ])
+        );
+    }
+};
+
+
 try {
     // DDL statements for real time database
     // TODO add your function calls to update the real time database structure here
@@ -173,6 +296,7 @@ try {
     $bbdoCfgUpdate();
     $addResourceStatusSearchModeOption();
     $flagContactsAsServiceAccount();
+    $alignCMAAgentConfigurationWithNewSchema();
 
     $pearDB->commit();
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -262,7 +262,6 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
             }
         }
 
-        $configuration = json_encode($configuration);
         $pearDB->update(
             <<<SQL
                 UPDATE agent_configuration


### PR DESCRIPTION
## Description

This PR intends to correctly reset the agent configurations following the new mandatories fields in configuration that have not taken into account in previous upgrade, resulting in export and listing failure

**Fixes** # MON-180962

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
