### PR TITLE
ci(secu): ignore security internal actions sha

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -44,6 +44,9 @@ jobs:
 
       - name: Ensure SHA pinned actions
         uses: centreon/github-actions-ensure-sha-pinned-actions@47d553c67ceb08ad660deaeb3b994e47a3dd8fc3 # v3.0.23.3
+        with:
+          allowlist: |
+            centreon/security-tools
 
   yaml-lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -46,7 +46,7 @@ jobs:
         uses: centreon/github-actions-ensure-sha-pinned-actions@47d553c67ceb08ad660deaeb3b994e47a3dd8fc3 # v3.0.23.3
         with:
           allowlist: |
-            centreon/security-tools  # internal security team's actions
+            centreon/security-tools
 
   yaml-lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -46,7 +46,7 @@ jobs:
         uses: centreon/github-actions-ensure-sha-pinned-actions@47d553c67ceb08ad660deaeb3b994e47a3dd8fc3 # v3.0.23.3
         with:
           allowlist: |
-            centreon/security-tools
+            centreon/security-tools  # internal security team's actions
 
   yaml-lint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Allows to ignore gha sha from actions maintained internally by the security team
Will help maintain all security pipelines from a single entrypoint

Usage exemple : https://github.com/centreon/cs-files/pull/2/files#diff-55703367e57244349c2dfe5db5f7b36beb97bd836a2a9155b0ed3a8998d02240R13