### PR TITLE
fix(services): in cloud a command should be required for services

### DIFF
--- a/centreon/www/include/configuration/configObject/service/formService.php
+++ b/centreon/www/include/configuration/configObject/service/formService.php
@@ -1025,16 +1025,14 @@ if ($o !== SERVICE_MASSIVE_CHANGE) {
     $form->addRule('service_description', _('Compulsory Name'), 'required');
     // If we are using a Template, no need to check the value, we hope there are in the Template
     if (! $form->getSubmitValue('service_template_model_stm_id')) {
-        if (! $isCloudPlatform) {
-            $form->addRule('command_command_id', _('Compulsory Command'), 'required');
-        }
+        $form->addRule('command_command_id', _('Compulsory Command'), 'required');
         if (! $form->getSubmitValue('service_hPars') && $serviceHgParsFieldIsAdded) {
             $form->addRule('service_hgPars', _('HostGroup or Host Required'), 'required');
         }
         if (! $form->getSubmitValue('service_hgPars') && $serviceHParsFieldIsAdded) {
             $form->addRule('service_hPars', _('HostGroup or Host Required'), 'required');
         }
-    } elseif (! $isCloudPlatform) {
+    } else {
         $form->addFormRule('checkServiceTemplateHasCommand');
     }
     if (! $form->getSubmitValue('service_hPars') && $serviceHgParsFieldIsAdded) {


### PR DESCRIPTION
## Description

In cloud when a service is created without a command (added or inherited), it can not be exported, this PR intends to add the rule for mandatory command while creating services.

**Fixes** # ([MON-174657](https://centreon.atlassian.net/browse/MON-174657))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

On a cloud platform, create a service if the command is not added and the service template (if exists) does not have one a error should be displayed in th form and the service should not be saved.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-174657]: https://centreon.atlassian.net/browse/MON-174657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ