### PR TITLE
fix(configuration): fix error msg in export

### DIFF
--- a/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
+++ b/centreon/www/include/configuration/configGenerate/xml/moveFiles.php
@@ -338,7 +338,7 @@ try {
                             Could not write to VMWare's configuration file '%s' for monitoring server '%s'.
                             Please add writing permissions for the webserver's user.
                             MSG,
-                        basename($fileCfg),
+                        basename($listVmWareFile[0] ?? ''),
                         $host['name']
                     ));
                 }


### PR DESCRIPTION
## Description

This Pr intends to fix filename in export error message. wrong file is mentionned when it should be centreon_vmware.json.

**Fixes** # ([MON-159458](https://centreon.atlassian.net/browse/MON-159458))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- Break rights on /etc/centreon/centreon_vmware.json.
- export configuration on Central : error message should include the correct filename (centreon_vmware.json).

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-159458]: https://centreon.atlassian.net/browse/MON-159458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ