### PR TITLE
fix(ldap): contacts with special chars shouldn't be imported more than once

### DIFF
--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -45,16 +45,24 @@ function testContactExistence($name = null)
         $id = $form->getSubmitValue('contact_id');
     }
 
-    $query = "SELECT contact_name, contact_id FROM contact WHERE contact_name = '"
-        . htmlentities($centreon->checkIllegalChar($name), ENT_QUOTES, 'UTF-8') . "'";
-    $dbResult = $pearDB->query($query);
-    $contact = $dbResult->fetch();
+    $contactName = htmlspecialchars($centreon->checkIllegalChar($name), ENT_QUOTES, 'UTF-8');
 
-    if ($dbResult->rowCount() >= 1 && $contact['contact_id'] == $id) {
+    $query = <<<'SQL'
+        SELECT contact_name, contact_id FROM contact WHERE contact_name = :contact_name
+        SQL;
+
+    $contact = $pearDB->fetchAssociative(
+        $query,
+        QueryParameters::create([
+            QueryParameter::string(':contact_name', $contactName),
+        ])
+    );
+
+    if ($contact && $contact['contact_id'] === $id) {
         return true;
     }
 
-    return ! ($dbResult->rowCount() >= 1 && $contact['contact_id'] != $id);
+    return ! ($contact && $contact['contact_id'] !== $id);
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -58,11 +58,11 @@ function testContactExistence($name = null)
         ])
     );
 
-    if ($contact && $contact['contact_id'] === $id) {
+    if ($contact && $contact['contact_id'] === (int) $id) {
         return true;
     }
 
-    return ! ($contact && $contact['contact_id'] !== $id);
+    return ! ($contact && $contact['contact_id'] !== (int) $id);
 }
 
 /**

--- a/centreon/www/include/configuration/configObject/contact/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/contact/DB-Func.php
@@ -45,7 +45,7 @@ function testContactExistence($name = null)
         $id = $form->getSubmitValue('contact_id');
     }
 
-    $contactName = htmlspecialchars($centreon->checkIllegalChar($name), ENT_QUOTES, 'UTF-8');
+    $contactName = $centreon->checkIllegalChar($name);
 
     $query = <<<'SQL'
         SELECT contact_name, contact_id FROM contact WHERE contact_name = :contact_name
@@ -54,7 +54,7 @@ function testContactExistence($name = null)
     $contact = $pearDB->fetchAssociative(
         $query,
         QueryParameters::create([
-            QueryParameter::string(':contact_name', $contactName),
+            QueryParameter::string('contact_name', $contactName),
         ])
     );
 

--- a/centreon/www/include/configuration/configObject/contact/ldapsearch.php
+++ b/centreon/www/include/configuration/configObject/contact/ldapsearch.php
@@ -136,7 +136,7 @@ foreach ($ids as $arId) {
                         $isvalid = '1';
                     }
                     $in_database = '0';
-                    if (in_array(htmlspecialchars($searchResult[$i]['alias'], ENT_QUOTES, 'UTF-8'), $listLdapUsers)) {
+                    if (in_array($searchResult[$i]['alias'], $listLdapUsers)) {
                         $in_database = '1';
                     }
 
@@ -153,7 +153,7 @@ foreach ($ids as $arId) {
                     $searchResult[$i]['name'] = str_replace("\'", "\\\'", $searchResult[$i]['name']);
 
                     $buffer->startElement('user');
-                    $query = 'SELECT `ar_id`, `ar_name` 
+                    $query = 'SELECT `ar_id`, `ar_name`
                               FROM auth_ressource
                               WHERE ar_id = ' . $pearDB->escape($arId);
                     $resServer = $pearDB->query($query);

--- a/centreon/www/include/configuration/configObject/contact/ldapsearch.php
+++ b/centreon/www/include/configuration/configObject/contact/ldapsearch.php
@@ -136,7 +136,7 @@ foreach ($ids as $arId) {
                         $isvalid = '1';
                     }
                     $in_database = '0';
-                    if (in_array(htmlentities($searchResult[$i]['alias'], ENT_QUOTES, 'UTF-8'), $listLdapUsers)) {
+                    if (in_array(htmlspecialchars($searchResult[$i]['alias'], ENT_QUOTES, 'UTF-8'), $listLdapUsers)) {
                         $in_database = '1';
                     }
 


### PR DESCRIPTION
## Description

This PR intends to fix this behaviour so that contacts with special chars (e.g. centréon-test) gets imported, via ldap imports, only once and the checkbox in the ldap search list gets disabled when the contact is already imported.

**Fixes** # ([MON-160513](https://centreon.atlassian.net/browse/MON-160513))

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- import a contact with a special character in the name via ldap imports : the contact should be imported, it can no more be imported and the checkbox in the ldap search list should be disabled.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-160513]: https://centreon.atlassian.net/browse/MON-160513?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ