### PR TITLE
fix(logs): show special chars in logs details

### DIFF
--- a/centreon/www/class/centreonLogAction.class.php
+++ b/centreon/www/class/centreonLogAction.class.php
@@ -407,7 +407,7 @@ class CentreonLogAction
                     $list_modifications[$i]['action_log_id'] = $field['action_log_id'];
                     $list_modifications[$i]['field_name'] = $field['field_name'];
                     $list_modifications[$i]['field_value_before'] = '';
-                    $list_modifications[$i]['field_value_after'] = HtmlSanitizer::createFromString($field['field_value'])->sanitize()->getString();
+                    $list_modifications[$i]['field_value_after'] = $field['field_value'];
                     foreach ($macroPasswordRef as $macroPasswordId) {
                         // handle the display modification for the fields macroOldValue_n while nothing was set before
                         if (str_contains($field['field_name'], 'macroOldValue_' . $macroPasswordId)) {
@@ -417,8 +417,8 @@ class CentreonLogAction
                 } elseif (isset($ref[$field['field_name']]) && $ref[$field['field_name']] != $field['field_value']) {
                     $list_modifications[$i]['action_log_id'] = $field['action_log_id'];
                     $list_modifications[$i]['field_name'] = $field['field_name'];
-                    $list_modifications[$i]['field_value_before'] = HtmlSanitizer::createFromString($ref[$field['field_name']])->sanitize()->getString();
-                    $list_modifications[$i]['field_value_after'] = HtmlSanitizer::createFromString($field['field_value'])->sanitize()->getString();
+                    $list_modifications[$i]['field_value_before'] = $ref[$field['field_name']];
+                    $list_modifications[$i]['field_value_after'] = $field['field_value'];
                     foreach ($macroPasswordRef as $macroPasswordId) {
                         // handle the display modification for the fields macroOldValue_n for "Before" and "After" value
                         if (str_contains($field['field_name'], 'macroOldValue_' . $macroPasswordId)) {
@@ -427,7 +427,7 @@ class CentreonLogAction
                         }
                     }
                 }
-                $ref[$field['field_name']] = HtmlSanitizer::createFromString($field['field_value'])->sanitize()->getString();
+                $ref[$field['field_name']] = $field['field_value'];
                 $i++;
             }
         }

--- a/centreon/www/include/Administration/configChangelog/viewLogsDetails.ihtml
+++ b/centreon/www/include/Administration/configChangelog/viewLogsDetails.ihtml
@@ -56,8 +56,8 @@
                                 <td colspan="3">{$noModifLabel}</td>
                             </tr>
                         {/if}
-                </table>                
-            {/if}       
+                </table>
+            {/if}
             </td>
         </tr>
     {/foreach}


### PR DESCRIPTION
## Description

This PR intends to render special characters correctly in administration->logs details.

**Jira ticket** # ([MON-177458](https://centreon.atlassian.net/browse/MON-177458))

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

- edit a host
- add special chars to notes
- visualise logs details of the change : characters should be preserved as they are

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-177458]: https://centreon.atlassian.net/browse/MON-177458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ