### PR TITLE
fix(hostgroup):correctly escape hg name characters

### DIFF
--- a/centreon/www/include/configuration/configObject/hostgroup/listHostGroup.ihtml
+++ b/centreon/www/include/configuration/configObject/hostgroup/listHostGroup.ihtml
@@ -56,7 +56,7 @@
                     {else}
                         <img src='{$elemArr[elem].RowMenu_icone}' class='ico-16 margin_right' />
                     {/if}
-                    {$elemArr[elem].RowMenu_name}</a>
+                    {$elemArr[elem].RowMenu_name|escape:"html"}</a>
             </td>
             <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_hostAct}</td>
@@ -64,7 +64,7 @@
             <td class="ListColCenter"><span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span></td>
             <td class="ListColRight" align="right">{if $mode_access == 'w' }{$elemArr[elem].RowMenu_options}{else}&nbsp;{/if}</td>
         </tr>
-        {/section}  
+        {/section}
     </table>
     <table class="ToolbarTable ToolbarTR table">
         <tr>
@@ -80,7 +80,7 @@
         </tr>
     </table>
     <input type='hidden' name='o' id='o' value='42'>
-    <input type='hidden' id='limit' name='limit' value='{$limit}'>  
+    <input type='hidden' id='limit' name='limit' value='{$limit}'>
 {$form.hidden}
 </form>
 {literal}


### PR DESCRIPTION
## Description

This PR intends to correctly escape hg name characters

**Fixes** # MON-178093

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 22.10.x
- [ ] 23.04.x
- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
