### PR TITLE
fix(ci): update references to bitnami mariadb 10.11 in dockerfiles and workflows

### DIFF
--- a/.github/docker/docker-compose.yml
+++ b/.github/docker/docker-compose.yml
@@ -26,7 +26,7 @@ services:
     platform: linux/amd64
     env_file:
       - .env
-    image: "${MYSQL_IMAGE:-bitnami/mariadb:10.11}"
+    image: "${MYSQL_IMAGE:-bitnamilegacy/mariadb:10.11}"
     ports: ["3306"]
     deploy:
       resources:

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -519,7 +519,7 @@ jobs:
       name: e2e
       module_name: centreon-open-tickets
       image_name: centreon-open-tickets
-      database_image: bitnami/${{ matrix.database }}
+      database_image: bitnamilegacy/${{ matrix.database }}
       os: ${{ matrix.operating_system }}
       features_path: tests/e2e/features
       major_version: ${{ needs.get-environment.outputs.major_version }}

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -949,7 +949,7 @@ jobs:
       container_name: my_centreon_container
       centreon_url: http://localhost
       centreon_image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-slim-${{ matrix.operating_system }}:${{ github.head_ref || github.ref_name }}
-      database_image: bitnami/${{ matrix.database }}
+      database_image: bitnamilegacy/${{ matrix.database }}
       dependencies_lock_file: centreon/pnpm-lock.yaml
       major_version: ${{ needs.get-environment.outputs.major_version }}
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
@@ -977,7 +977,7 @@ jobs:
     with:
       name: legacy-e2e
       module_name: centreon
-      database_image: bitnami/${{ matrix.database }}
+      database_image: bitnamilegacy/${{ matrix.database }}
       image_name: centreon-web
       os: ${{ matrix.operating_system }}
       features_path: features
@@ -1018,7 +1018,7 @@ jobs:
       name: e2e
       module_name: centreon
       image_name: centreon-web
-      database_image: bitnami/${{ matrix.database }}
+      database_image: bitnamilegacy/${{ matrix.database }}
       os: ${{ matrix.operating_system }}
       features_path: tests/e2e/features
       major_version: ${{ needs.get-environment.outputs.major_version }}
@@ -1068,7 +1068,7 @@ jobs:
           path: "centreon/lighthouse"
           image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-slim-alma9
           image_version: ${{ github.head_ref || github.ref_name }}
-          database_image: bitnami/mariadb:10.11
+          database_image: bitnamilegacy/mariadb:10.11
           image_lighthouse_version: ${{ needs.get-environment.outputs.major_version }}
           module: centreon
           dependencies_lock_file: centreon/pnpm-lock.yaml


### PR DESCRIPTION
## Description

* due to https://hub.docker.com/r/bitnami/mariadb#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog, all references to mariadb 10.11 must be updated with the proper registry name

**Fixes** #MON-182586

