### PR TITLE
fix(ci): update references to bitnami mariadb 10.11 in dockerfiles and workflows

### DIFF
--- a/.github/docker/.env
+++ b/.github/docker/.env
@@ -1,4 +1,4 @@
-MYSQL_IMAGE=bitnami/mariadb:10.11
+MYSQL_IMAGE=bitnamilegacy/mariadb:10.11
 OPENID_IMAGE=docker.centreon.com/centreon/keycloak:24.04
 SAML_IMAGE=docker.centreon.com/centreon/keycloak:24.04
 

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -771,7 +771,7 @@ jobs:
       container_name: my_centreon_container
       centreon_url: http://localhost
       centreon_image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-slim-${{ matrix.operating_system }}:${{ github.head_ref || github.ref_name }}
-      database_image: bitnami/mariadb:10.11
+      database_image: bitnamilegacy/mariadb:10.11
       dependencies_lock_file: centreon/pnpm-lock.yaml
       major_version: ${{ needs.get-environment.outputs.major_version }}
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
@@ -799,7 +799,7 @@ jobs:
     with:
       name: api
       module_name: centreon
-      database_image: bitnami/mariadb:10.11
+      database_image: bitnamilegacy/mariadb:10.11
       image_name: centreon-web
       os: ${{ matrix.operating_system }}
       features_path: tests/api/features
@@ -825,7 +825,7 @@ jobs:
     with:
       name: legacy-e2e
       module_name: centreon
-      database_image: bitnami/mariadb:10.11
+      database_image: bitnamilegacy/mariadb:10.11
       image_name: centreon-web
       os: ${{ matrix.operating_system }}
       features_path: features
@@ -876,7 +876,7 @@ jobs:
       name: e2e
       module_name: centreon
       image_name: centreon-web
-      database_image: bitnami/mariadb:10.11
+      database_image: bitnamilegacy/mariadb:10.11
       os: ${{ matrix.operating_system }}
       features_path: tests/e2e/features
       major_version: ${{ needs.get-environment.outputs.major_version }}
@@ -917,7 +917,7 @@ jobs:
           path: "centreon/lighthouse"
           image: ${{ vars.DOCKER_INTERNAL_REGISTRY_URL }}/centreon-web-slim-alma9
           image_version: ${{ github.head_ref || github.ref_name }}
-          database_image: bitnami/mariadb:10.11
+          database_image: bitnamilegacy/mariadb:10.11
           image_lighthouse_version: ${{ needs.get-environment.outputs.major_version }}
           module: centreon
           dependencies_lock_file: centreon/pnpm-lock.yaml


### PR DESCRIPTION
## Description

https://github.com/centreon/centreon/pull/8150

* due to https://hub.docker.com/r/bitnami/mariadb#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog, all references to mariadb 10.11 must be updated with the proper registry name

Fixes #MON-182586
