### PR TITLE
fix(clapi): Do not override engine-context.json rights during cfgMove

### DIFF
--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -495,6 +495,9 @@ class CentreonConfigPoller
             // Change files owner
             if ($apacheUser != '') {
                 foreach (glob($Nagioscfg['cfg_dir'] . '/*.{json,cfg}', GLOB_BRACE) as $file) {
+                    if($file === $Nagioscfg['cfg_dir'] . '/engine-context.json') {
+                        continue;
+                    }
                     // handle path traversal vulnerability
                     if (str_contains($file, '..')) {
                         throw new Exception('Path traversal found');

--- a/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
+++ b/centreon/www/class/centreon-clapi/centreon.Config.Poller.class.php
@@ -495,7 +495,7 @@ class CentreonConfigPoller
             // Change files owner
             if ($apacheUser != '') {
                 foreach (glob($Nagioscfg['cfg_dir'] . '/*.{json,cfg}', GLOB_BRACE) as $file) {
-                    if($file === $Nagioscfg['cfg_dir'] . '/engine-context.json') {
+                    if ($file === $Nagioscfg['cfg_dir'] . '/engine-context.json') {
                         continue;
                     }
                     // handle path traversal vulnerability


### PR DESCRIPTION
## Description

This PR Intends to not Override the file of engine-context.json during an move configuration files through CLAPI.
If CLAPI is executed as root the rights on the differents exported files are set to apache user (apache / www-data).


The file engine-context.json don't need to be updated.
**Fixes** # MON-182985

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master


## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
