### PR TITLE
enh(ci): fetch upload-artifacts label form api instead of github context

### DIFF
--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -46,6 +46,10 @@ inputs:
   is_nightly:
     description: "nightly status"
     required: false
+  upload_artifacts:
+    description: "Upload packages as artifacts"
+    required: false
+    default: "false"
 
 runs:
   using: composite

--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -133,9 +133,7 @@ runs:
         key: ${{ inputs.cache_key }}
 
     # Add 'upload-artifacts' label to pull request to get packages as artifacts
-    - if: |
-        contains(github.event.pull_request.labels.*.name, 'upload-artifacts') ||
-        inputs.is_nightly == 'true'
+    - if: inputs.upload_artifacts == 'true'
       name: Upload package artifacts
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -7,12 +7,12 @@ concurrency:
 on:
   workflow_dispatch:
   pull_request:
-    # paths:
-    #   - ".version"
-    #   - ".version.centreon-awie"
-    #   - "centreon-awie/**"
-    #   - "!centreon-awie/features/**"
-    #   - "!centreon-awie/behat.yml"
+    paths:
+      - ".version"
+      - ".version.centreon-awie"
+      - "centreon-awie/**"
+      - "!centreon-awie/features/**"
+      - "!centreon-awie/behat.yml"
   push:
     branches:
       - develop
@@ -415,11 +415,11 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-  # set-skip-label:
-  #   needs: [get-environment, deliver-rpm, deliver-deb, promote]
-  #   if: |
-  #     needs.get-environment.outputs.skip_workflow == 'false' &&
-  #     ! cancelled() &&
-  #     ! contains(needs.*.result, 'failure') &&
-  #     ! contains(needs.*.result, 'cancelled')
-  #   uses: ./.github/workflows/set-pull-request-skip-label.yml
+  set-skip-label:
+    needs: [get-environment, deliver-rpm, deliver-deb, promote]
+    if: |
+      needs.get-environment.outputs.skip_workflow == 'false' &&
+      ! cancelled() &&
+      ! contains(needs.*.result, 'failure') &&
+      ! contains(needs.*.result, 'cancelled')
+    uses: ./.github/workflows/set-pull-request-skip-label.yml

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -7,12 +7,12 @@ concurrency:
 on:
   workflow_dispatch:
   pull_request:
-    paths:
-      - ".version"
-      - ".version.centreon-awie"
-      - "centreon-awie/**"
-      - "!centreon-awie/features/**"
-      - "!centreon-awie/behat.yml"
+    # paths:
+    #   - ".version"
+    #   - ".version.centreon-awie"
+    #   - "centreon-awie/**"
+    #   - "!centreon-awie/features/**"
+    #   - "!centreon-awie/behat.yml"
   push:
     branches:
       - develop
@@ -289,6 +289,7 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
+          upload-artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'update-artifacts') && 'true' || 'false' }}
 
   deliver-sources:
     runs-on: centreon-common

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -289,7 +289,7 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
-          upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'update-artifacts') && 'true' || 'false' }}
+          upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
   deliver-sources:
     runs-on: centreon-common

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -289,7 +289,7 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
-          upload-artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'update-artifacts') && 'true' || 'false' }}
+          upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'update-artifacts') && 'true' || 'false' }}
 
   deliver-sources:
     runs-on: centreon-common
@@ -415,11 +415,11 @@ jobs:
           release_type: ${{ needs.get-environment.outputs.release_type }}
           is_cloud: ${{ needs.get-environment.outputs.is_cloud }}
 
-  set-skip-label:
-    needs: [get-environment, deliver-rpm, deliver-deb, promote]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      ! cancelled() &&
-      ! contains(needs.*.result, 'failure') &&
-      ! contains(needs.*.result, 'cancelled')
-    uses: ./.github/workflows/set-pull-request-skip-label.yml
+  # set-skip-label:
+  #   needs: [get-environment, deliver-rpm, deliver-deb, promote]
+  #   if: |
+  #     needs.get-environment.outputs.skip_workflow == 'false' &&
+  #     ! cancelled() &&
+  #     ! contains(needs.*.result, 'failure') &&
+  #     ! contains(needs.*.result, 'cancelled')
+  #   uses: ./.github/workflows/set-pull-request-skip-label.yml

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -265,6 +265,7 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
+          upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
   deliver-sources:
     runs-on: centreon-common

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -342,6 +342,7 @@ jobs:
           rpm_gpg_signing_key_id: ${{ secrets.RPM_GPG_SIGNING_KEY_ID }}
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
+          upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
   dockerize:
     runs-on: ubuntu-24.04

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -770,6 +770,7 @@ jobs:
           rpm_gpg_signing_passphrase: ${{ secrets.RPM_GPG_SIGNING_PASSPHRASE }}
           stability: ${{ needs.get-environment.outputs.stability }}
           is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
+          upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
 
   dockerize:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Description

enh(ci): fetch upload-artifacts label form api instead of github context

**Fixes** Mon-182395