### PR TITLE
enh(ci): fetch upload-artifacts label form api instead of github context

### DIFF
--- a/.github/actions/package-nfpm/action.yml
+++ b/.github/actions/package-nfpm/action.yml
@@ -43,6 +43,10 @@ inputs:
   is_nightly:
     description: "nightly status"
     required: false
+  upload_artifacts:
+    description: "Upload packages as artifacts"
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -91,9 +95,7 @@ runs:
         key: ${{ inputs.cache_key }}
 
     # Add 'upload-artifacts' label to pull request to get packages as artifacts
-    - if: |
-        contains(github.event.pull_request.labels.*.name, 'upload-artifacts') ||
-        inputs.is_nightly == 'true'
+    - if: inputs.upload_artifacts == 'true'
       name: Upload package artifacts
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:

--- a/.github/actions/package/action.yml
+++ b/.github/actions/package/action.yml
@@ -65,6 +65,10 @@ inputs:
   jira_api_token:
     description: jira api token
     required: false
+  upload_artifacts:
+    description: "Upload packages as artifacts"
+    required: false
+    default: "false"
 
 runs:
   using: composite
@@ -203,10 +207,8 @@ runs:
         path: ./*.${{ inputs.package_extension }}
         key: ${{ inputs.cache_key }}
 
-    # Update if condition to true to get packages as artifacts
-    - if: |
-        contains(github.event.pull_request.labels.*.name, 'upload-artifacts') ||
-        inputs.is_nightly == 'true'
+    # Add 'upload-artifacts' label to pull request to get packages as artifacts
+    - if: inputs.upload_artifacts == 'true'
       name: Upload package artifacts
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
       with:

--- a/.github/workflows/awie.yml
+++ b/.github/workflows/awie.yml
@@ -133,6 +133,7 @@ jobs:
       release: ${{ needs.get-environment.outputs.release }}
       commit_hash: ${{ github.sha }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
     secrets:
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}

--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -126,6 +126,7 @@ jobs:
       release: ${{ needs.get-environment.outputs.release }}
       commit_hash: ${{ github.sha }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
     secrets:
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}

--- a/.github/workflows/open-tickets.yml
+++ b/.github/workflows/open-tickets.yml
@@ -110,6 +110,7 @@ jobs:
       release: ${{ needs.get-environment.outputs.release }}
       commit_hash: ${{ github.sha }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
+      upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
     secrets:
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -82,6 +82,10 @@ on:
         type: string
         description: Nightly context or not
         required: false
+      upload_artifacts:
+        type: string
+        required: false
+        default: "false"
 
     secrets:
       registry_username:
@@ -139,6 +143,7 @@ jobs:
           jira_base_url: ${{ secrets.jira_base_url }}
           jira_user_email: ${{ secrets.jira_user_email }}
           jira_api_token: ${{ secrets.jira_api_token }}
+          upload_artifacts: ${{ inputs.upload_artifacts }}
 
       - if: ${{ inputs.package_extension == 'deb' }}
         uses: actions/cache/save@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -463,6 +463,7 @@ jobs:
       commit_hash: ${{ github.sha }}
       cache_key: ${{ github.sha }}-${{ github.run_id }}-${{ matrix.package_extension }}-${{ matrix.distrib }}
       is_nightly: ${{ needs.get-environment.outputs.is_nightly }}
+      upload_artifacts: ${{ needs.get-environment.outputs.is_nightly == 'true' || contains(needs.get-environment.outputs.labels, 'upload-artifacts') && 'true' || 'false' }}
     secrets:
       registry_username: ${{ secrets.HARBOR_CENTREON_PULL_USERNAME }}
       registry_password: ${{ secrets.HARBOR_CENTREON_PULL_TOKEN }}


### PR DESCRIPTION
## Description

enh(ci): fetch upload-artifacts label form api instead of github context (#8186)

**Fixes** MON-182395