### PR TITLE
fix(install): install remi repo on alma8 for php 8.1

### DIFF
--- a/centreon/unattended.sh
+++ b/centreon/unattended.sh
@@ -455,6 +455,7 @@ function set_required_prerequisite() {
 		8*)
 			log "INFO" "Setting specific part for v8 ($detected_os_version)"
 			RELEASE_REPO_FILE="https://packages.centreon.com/artifactory/rpm-standard/$version/el8/centreon-$version.repo"
+			REMI_RELEASE_RPM_URL="https://rpms.remirepo.net/enterprise/remi-release-8.rpm"
 			PHP_SERVICE_UNIT="php-fpm"
 			HTTP_SERVICE_UNIT="httpd"
 			PKG_MGR="dnf"
@@ -487,10 +488,11 @@ function set_required_prerequisite() {
 			if [ "$topology" == "central" ]; then
 				case "$version" in
 					"23.10" | "24.04")
+					    install_remi_repo
 						log "INFO" "Installing PHP 8.1 and enable it"
 						$PKG_MGR module reset php -y -q
-						$PKG_MGR module install php:8.1 -y -q
-						$PKG_MGR module enable php:8.1 -y -q
+						$PKG_MGR module install php:remi-8.1 -y -q
+						$PKG_MGR module enable php:remi-8.1 -y -q
 						;;
 					"24.10")
 						log "INFO" "Installing PHP 8.2 and enable it"


### PR DESCRIPTION
## Description

dnf module for php 8.1 does not existe on almalinux 8:
```
# dnf module list php
AlmaLinux 8 - AppStream
Name                              Stream                               Profiles                                                Summary                                            
php                               7.2 [d]                              common [d], devel, minimal                              PHP scripting language                             
php                               7.3                                  common [d], devel, minimal                              PHP scripting language                             
php                               7.4                                  common [d], devel, minimal                              PHP scripting language                             
php                               8.0                                  common [d], devel, minimal                              PHP scripting language                             
php                               8.2                                  common [d], devel, minimal                              PHP scripting language
```