### PR TITLE
fix(hostgroup): correctly check illegal characters when editing hostgroup name

### DIFF
--- a/centreon/www/include/configuration/configObject/hostgroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/DB-Func.php
@@ -857,7 +857,6 @@ function updateHostGroupInDBForCloud(int $hostGroupId, array $submittedValues, b
     }
 
     if (isset($submittedValues['hg_name'])) {
-
         $submittedValues['hg_name'] = $centreon->checkIllegalChar($submittedValues['hg_name']);
         $request .= ', hg_name = :name';
         $bindValues[':name'] = [

--- a/centreon/www/include/configuration/configObject/hostgroup/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/hostgroup/DB-Func.php
@@ -857,6 +857,8 @@ function updateHostGroupInDBForCloud(int $hostGroupId, array $submittedValues, b
     }
 
     if (isset($submittedValues['hg_name'])) {
+
+        $submittedValues['hg_name'] = $centreon->checkIllegalChar($submittedValues['hg_name']);
         $request .= ', hg_name = :name';
         $bindValues[':name'] = [
             \PDO::PARAM_STR,
@@ -919,6 +921,7 @@ function updateHostGroupInDBForOnPrem(int $hostGroupId, array $submittedValues, 
     $submittedValues = $submittedValues ?: $form->getSubmitValues();
 
     if (isset($submittedValues['hg_name'])) {
+        $submittedValues['hg_name'] = $centreon->checkIllegalChar($submittedValues['hg_name']);
         $request .= ' hg_name = :name';
         $bindValues[':name'] = [
             \PDO::PARAM_STR,


### PR DESCRIPTION
## Description

This PR intends to correctly check illegal characters when editing hostgroup name.
Illegal characters are defined in Engine configuration

<img width="640" height="372" alt="image" src="https://github.com/user-attachments/assets/a3c855a4-41fb-4279-873e-8b9c40d6d1a0" />


**Fixes** # MON-183640

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
