### PR TITLE
fix(poller) poller not properly re-enabled when using poller config form (#8178)

### DIFF
--- a/centreon/www/include/configuration/configServers/DB-Func.php
+++ b/centreon/www/include/configuration/configServers/DB-Func.php
@@ -1000,7 +1000,7 @@ function updateServer(int $id, array $data): void
     $stmt->execute();
 
     // if the poller is activated, always keep cfg file activated
-    if (isset($data['ns_activate']['ns_activate']) && $data['ns_activate']['ns_activate'] === 1) {
+    if (isset($data['ns_activate']['ns_activate']) && $data['ns_activate']['ns_activate'] === '1') {
         enableServerInDB($id);
     }
 


### PR DESCRIPTION
## Description

BACKPORT #8178

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
