### PR TITLE
fix(acl): avoid infinite loop while calculating ACL on Medias

### DIFF
--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -2402,7 +2402,10 @@ class CentreonACL
     private function hasAccessToAllImageFolders(): bool
     {
         $accessGroups = $this->getAccessGroups();
-        if ($accessGroups === []) {
+        $aclResources = $this->getResourceGroups();
+
+        // Users not linked to an ACL group or ACL resource will not be able to see images.
+        if ($accessGroups === [] || $aclResources === []) {
             return false;
         }
 

--- a/centreon/www/class/centreonACL.class.php
+++ b/centreon/www/class/centreonACL.class.php
@@ -2429,7 +2429,7 @@ class CentreonACL
 
             $db = CentreonDBInstance::getDbCentreonInstance();
 
-            while (false !== ($hasAccessToAll = $db->fetchOne($query, QueryParameters::create($bindQueryParameters)))) {
+            while (false !== ($hasAccessToAll = $db->fetchFirstColumn($query, QueryParameters::create($bindQueryParameters)))) {
                 if (true === (bool) $hasAccessToAll) {
                     return true;
                 }


### PR DESCRIPTION
## Description

This PR intends to avoid an infinite loop when calculating if the user has access to all medias

**Fixes** # MON-183719

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
