### PR TITLE
fix(docker): skip mariadb maxscale repo (#8222)

### DIFF
--- a/.github/docker/centreon-web/alma8/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma8/Dockerfile.dependencies
@@ -111,7 +111,7 @@ dnf install -y \
 #################################
 
 curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup \
-  | bash -s -- --os-type=rhel --skip-check-installed --os-version=8 --mariadb-server-version="mariadb-10.11"
+  | bash -s -- --os-type=rhel --skip-check-installed --os-version=8 --mariadb-server-version="mariadb-10.11" --skip-maxscale
 dnf install -y mariadb-server mariadb
 
 echo "[server]

--- a/.github/docker/centreon-web/alma9/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma9/Dockerfile.dependencies
@@ -108,7 +108,7 @@ dnf install -y \
 #################################
 
 curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup \
-  | bash -s -- --os-type=rhel --skip-check-installed --os-version=9 --mariadb-server-version="mariadb-10.11"
+  | bash -s -- --os-type=rhel --skip-check-installed --os-version=9 --mariadb-server-version="mariadb-10.11" --skip-maxscale
 dnf install -y mariadb-server mariadb
 
 echo "[server]

--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -99,7 +99,7 @@ apt-get install -y \
 #################################
 
 curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup \
-  | sudo bash -s -- --os-type=debian --os-version=12 --mariadb-server-version="mariadb-10.11"
+  | sudo bash -s -- --os-type=debian --os-version=12 --mariadb-server-version="mariadb-10.11" --skip-maxscale
 
 apt-get update
 

--- a/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bullseye/Dockerfile.dependencies
@@ -99,7 +99,7 @@ apt-get install -y \
 #################################
 
 curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup \
-  | sudo bash -s -- --os-type=debian --os-version=11 --mariadb-server-version="mariadb-10.11"
+  | sudo bash -s -- --os-type=debian --os-version=11 --mariadb-server-version="mariadb-10.11" --skip-maxscale
 
 apt-get update
 

--- a/.github/docker/centreon-web/jammy/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/jammy/Dockerfile.dependencies
@@ -97,7 +97,7 @@ apt-get install -y \
 #################################
 
 curl -LsS https://r.mariadb.com/downloads/mariadb_repo_setup \
-  | sudo bash -s -- --os-type=ubuntu --os-version=jammy --mariadb-server-version="mariadb-10.11"
+  | sudo bash -s -- --os-type=ubuntu --os-version=jammy --mariadb-server-version="mariadb-10.11" --skip-maxscale
 
 apt-get update
 


### PR DESCRIPTION
## Description

fix(docker): skip mariadb maxscale repo (#8222)