### PR TITLE
fix(web): Escape the command passed to shell_exec

### DIFF
--- a/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
+++ b/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
@@ -192,7 +192,9 @@ class PollerInteractionService
 
         foreach ($tabServers as $poller) {
             if (isset($poller['localhost']) && $poller['localhost'] == 1) {
-                shell_exec(escapeshellcmd("sudo {$poller['engine_restart_command']}"));
+                if ($poller['engine_restart_command'] != '') {
+                    shell_exec(escapeshellcmd("sudo -n -- {$poller['engine_restart_command']}"));
+                }
             } elseif ($fh = @fopen($centCorePipe, 'a+')) {
                 fwrite($fh, 'RESTART:' . $poller['id'] . "\n");
                 fclose($fh);

--- a/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
+++ b/centreon/src/CentreonRemote/Infrastructure/Service/PollerInteractionService.php
@@ -192,7 +192,7 @@ class PollerInteractionService
 
         foreach ($tabServers as $poller) {
             if (isset($poller['localhost']) && $poller['localhost'] == 1) {
-                shell_exec("sudo {$poller['engine_restart_command']}");
+                shell_exec(escapeshellcmd("sudo {$poller['engine_restart_command']}"));
             } elseif ($fh = @fopen($centCorePipe, 'a+')) {
                 fwrite($fh, 'RESTART:' . $poller['id'] . "\n");
                 fclose($fh);

--- a/centreon/www/class/centreonBroker.class.php
+++ b/centreon/www/class/centreonBroker.class.php
@@ -48,7 +48,7 @@ class CentreonBroker
     public function reload(): void
     {
         if ($command = $this->getReloadCommand()) {
-            shell_exec("sudo {$command}");
+            shell_exec(escapeshellcmd("sudo {$command}"));
         }
     }
 

--- a/centreon/www/class/centreonBroker.class.php
+++ b/centreon/www/class/centreonBroker.class.php
@@ -48,7 +48,7 @@ class CentreonBroker
     public function reload(): void
     {
         if ($command = $this->getReloadCommand()) {
-            shell_exec(escapeshellcmd("sudo {$command}"));
+            shell_exec(escapeshellcmd("sudo -n -- {$command}"));
         }
     }
 


### PR DESCRIPTION
## Description

**Fixes** #[MON-175157](https://centreon.atlassian.net/browse/MON-175157)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

[MON-175157]: https://centreon.atlassian.net/browse/MON-175157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ