### PR TITLE
fix(docker): add authentication access to apt-internal repositories on debian docker containers

### DIFF
--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -42,11 +42,10 @@ wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/tr
 
 if [[ "${IS_CLOUD}" == "true" ]]; then
   echo "deb https://$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME):$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)@packages.centreon.com/apt-standard-internal/ \$VERSION_CODENAME-${VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
-
   APT_AUTH_CONF_FILE="/etc/apt/auth.conf.d/centreon-${VERSION}-internal-${STABILITY}.conf"
   echo "machine packages.centreon.com" > $APT_AUTH_CONF_FILE
-  echo "login $ARTIFACTORY_INTERNAL_REPO_USERNAME" >> $APT_AUTH_CONF_FILE
-  echo "password $ARTIFACTORY_INTERNAL_REPO_PASSWORD" >> $APT_AUTH_CONF_FILE
+  echo "login $(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME)" >> $APT_AUTH_CONF_FILE
+  echo "password $(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)" >> $APT_AUTH_CONF_FILE
   chmod 600 $APT_AUTH_CONF_FILE
 else
   echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${VERSION}-stable main" | tee -a /etc/apt/sources.list.d/centreon-stable.list

--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -42,6 +42,12 @@ wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/tr
 
 if [[ "${IS_CLOUD}" == "true" ]]; then
   echo "deb https://$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME):$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)@packages.centreon.com/apt-standard-internal/ \$VERSION_CODENAME-${VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+
+  APT_AUTH_CONF_FILE="/etc/apt/auth.conf.d/centreon-${VERSION}-internal-${STABILITY}.conf"
+  echo "machine packages.centreon.com" > $APT_AUTH_CONF_FILE
+  echo "login $ARTIFACTORY_INTERNAL_REPO_USERNAME" >> $APT_AUTH_CONF_FILE
+  echo "password $ARTIFACTORY_INTERNAL_REPO_PASSWORD" >> $APT_AUTH_CONF_FILE
+  chmod 600 $APT_AUTH_CONF_FILE
 else
   echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${VERSION}-stable main" | tee -a /etc/apt/sources.list.d/centreon-stable.list
   echo "deb https://packages.centreon.com/apt-standard/ \$VERSION_CODENAME-${VERSION}-testing main" | tee -a /etc/apt/sources.list.d/centreon-testing.list

--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -5,6 +5,7 @@ FROM debian:bookworm AS web_dependencies
 ARG VERSION
 ARG STABILITY
 ARG IS_CLOUD
+ARG APT_AUTH_CONF_FILE="/etc/apt/auth.conf.d/centreon-${VERSION}-internal-${STABILITY}.conf"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -42,7 +43,6 @@ wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/tr
 
 if [[ "${IS_CLOUD}" == "true" ]]; then
   echo "deb https://$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME):$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)@packages.centreon.com/apt-standard-internal/ \$VERSION_CODENAME-${VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
-  APT_AUTH_CONF_FILE="/etc/apt/auth.conf.d/centreon-${VERSION}-internal-${STABILITY}.conf"
   echo "machine packages.centreon.com" > $APT_AUTH_CONF_FILE
   echo "login $(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME)" >> $APT_AUTH_CONF_FILE
   echo "password $(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)" >> $APT_AUTH_CONF_FILE

--- a/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/bookworm/Dockerfile.dependencies
@@ -42,7 +42,7 @@ echo "deb https://packages.sury.org/php/ \$VERSION_CODENAME main" | tee /etc/apt
 wget -O- https://packages.sury.org/php/apt.gpg | gpg --dearmor | tee /etc/apt/trusted.gpg.d/php.gpg  > /dev/null 2>&1
 
 if [[ "${IS_CLOUD}" == "true" ]]; then
-  echo "deb https://$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME):$(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)@packages.centreon.com/apt-standard-internal/ \$VERSION_CODENAME-${VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
+  echo "deb https://packages.centreon.com/apt-standard-internal/ \$VERSION_CODENAME-${VERSION}-unstable main" | tee -a /etc/apt/sources.list.d/centreon-unstable.list
   echo "machine packages.centreon.com" > $APT_AUTH_CONF_FILE
   echo "login $(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_USERNAME)" >> $APT_AUTH_CONF_FILE
   echo "password $(cat /run/secrets/ARTIFACTORY_INTERNAL_REPO_PASSWORD)" >> $APT_AUTH_CONF_FILE


### PR DESCRIPTION
## Description

factorizing this portion on the centreon-oss repository prevents us from having to include it in every single module debian dockerfile  

**Fixes** # MON-167935

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
