### PR TITLE
fix(packaging): remove deprecated map4jmx plugin from dependencies

### DIFF
--- a/centreon/packaging/centreon-poller.yaml
+++ b/centreon/packaging/centreon-poller.yaml
@@ -91,7 +91,6 @@ overrides:
       - centreon-plugin-Applications-Databases-Mysql
       - centreon-plugin-Applications-Monitoring-Centreon-Central
       - centreon-plugin-Applications-Monitoring-Centreon-Database
-      - centreon-plugin-Applications-Monitoring-Centreon-Map4-Jmx
       - centreon-plugin-Applications-Monitoring-Centreon-Poller
       - centreon-plugin-Applications-Protocol-Dns
       - centreon-plugin-Applications-Protocol-Ftp
@@ -130,7 +129,6 @@ overrides:
       - centreon-plugin-applications-databases-mysql
       - centreon-plugin-applications-monitoring-centreon-central
       - centreon-plugin-applications-monitoring-centreon-database
-      - centreon-plugin-applications-monitoring-centreon-map4-jmx
       - centreon-plugin-applications-monitoring-centreon-poller
       - centreon-plugin-applications-protocol-dns
       - centreon-plugin-applications-protocol-ftp


### PR DESCRIPTION
## Description

fix(packaging): remove deprecated map4jmx plugin from dependencies (#8233)

**Fixes** MON-177739