### PR TITLE
fix(conf) FindHostCategories when using search parameters part 2

### DIFF
--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadHostCategoryRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadHostCategoryRepository.php
@@ -130,7 +130,7 @@ class DbReadHostCategoryRepository extends AbstractRepositoryRDB implements Read
         // Update the SQL string builder with the RequestParameters through SqlRequestParametersTranslator
         $searchRequest = $sqlTranslator?->translateSearchParameterToSql();
 
-        if ($searchRequest !== null) {
+        if ($searchRequest !== null && str_contains($searchRequest, 'hg.')) {
             $request .= <<<'SQL'
 
                     INNER JOIN `:db`.hostcategories_relation hcr


### PR DESCRIPTION
## Description

Part 2 of #8103 
Apply same fix for FindAll() method

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
