### PR TITLE
fix(reccurentdowntime): Remove unneeded stripping of dangerous tags in listing

### DIFF
--- a/centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+++ b/centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
@@ -92,7 +92,7 @@ foreach ($listDowntime as $dt) {
         . ' event.returnValue = false; if(event.which > 31 && (event.which < 45 || event.which > 57))'
         . " return false;\" maxlength=\"3\" size=\"3\" value='1' style=\"margin-bottom:0px;\" "
         . "name='dupNbr[" . $dt['dt_id'] . "]'></input>";
-    $elemArr[] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => CentreonUtils::escapeSecure($dt['dt_name']), 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&dt_id=' . $dt['dt_id'], 'RowMenu_desc' => CentreonUtils::escapeSecure($dt['dt_description']), 'RowMenu_status' => $dt['dt_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_options' => $moptions];
+    $elemArr[] = ['MenuClass' => 'list_' . $style, 'RowMenu_select' => $selectedElements->toHtml(), 'RowMenu_name' => $dt['dt_name'], 'RowMenu_link' => 'main.php?p=' . $p . '&o=c&dt_id=' . $dt['dt_id'], 'RowMenu_desc' => $dt['dt_description'], 'RowMenu_status' => $dt['dt_activate'] ? _('Enabled') : _('Disabled'), 'RowMenu_options' => $moptions];
     $style = $style != 'two' ? 'two' : 'one';
 }
 $tpl->assign('elemArr', $elemArr);


### PR DESCRIPTION
## Description

We correctly escape the text thanks to https://github.com/centreon/centreon/pull/7978 now.

**Fixes** #[MON-150551](https://centreon.atlassian.net/browse/MON-150551) (and improves fix for [MON-178590](https://centreon.atlassian.net/browse/MON-178590)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

[MON-150551]: https://centreon.atlassian.net/browse/MON-150551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MON-178590]: https://centreon.atlassian.net/browse/MON-178590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ