### PR TITLE
chore(test): ensure collection normalization is correct

### DIFF
--- a/centreon/phpunit.new.xml
+++ b/centreon/phpunit.new.xml
@@ -18,6 +18,9 @@
         <testsuite name="shared">
             <directory>tests/php/App/Shared</directory>
         </testsuite>
+        <testsuite name="shared">
+            <directory>tests/php/App/Shared</directory>
+        </testsuite>
     </testsuites>
 
     <php>

--- a/centreon/tests/php/App/Shared/Infrastructure/ApiPlatform/CollectionNormalizationTest.php
+++ b/centreon/tests/php/App/Shared/Infrastructure/ApiPlatform/CollectionNormalizationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\App\Shared\Infrastructure\ApiPlatform;
+
+use App\Shared\Domain\Collection;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+/**
+ * Ensures that collections normalized properly by API Platform.
+ */
+final class CollectionNormalizationTest extends KernelTestCase
+{
+    public function testNormalizeCollection(): void
+    {
+        /** @var NormalizerInterface $normalizer */
+        $normalizer = self::getContainer()->get(NormalizerInterface::class);
+
+        $items = [(object) ['foo' => 'bar'], (object) ['bar' => 'baz']];
+        $collection = new Collection($items, \stdClass::class);
+        $lazyCollection = new Collection(fn (): array => $items, \stdClass::class);
+
+        $normalizedItems = $normalizer->normalize($items, 'jsonld');
+        $normalizedCollection = $normalizer->normalize($collection, 'jsonld');
+        $lazyNormalizedCollection = $normalizer->normalize($lazyCollection, 'jsonld');
+
+        self::assertSame($normalizedItems, $normalizedCollection);
+        self::assertSame($normalizedItems, $lazyNormalizedCollection);
+    }
+}


### PR DESCRIPTION
## Description

Ensure that `Collection` and `array` are normalized the same way by API Platform

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
