### PR TITLE
enh(kernel): add ad compilerpass for bam indicators registration

### DIFF
--- a/centreon/src/App/Kernel.php
+++ b/centreon/src/App/Kernel.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
@@ -115,7 +116,9 @@ class Kernel extends BaseKernel
         $class = 'CentreonAnomalyDetection\DependencyInjection\TagIndicatorPass';
 
         if (class_exists($class)) {
-            $container->addCompilerPass(new $class());
+            /** @var CompilerPassInterface $compilerPass */
+            $compilerPass = new $class();
+            $container->addCompilerPass($compilerPass);
         }
     }
 }

--- a/centreon/src/App/Kernel.php
+++ b/centreon/src/App/Kernel.php
@@ -112,7 +112,6 @@ class Kernel extends BaseKernel
 
     protected function build(ContainerBuilder $container): void
     {
-        /** @var class-string $class */
         $class = 'CentreonAnomalyDetection\DependencyInjection\TagIndicatorPass';
 
         if (class_exists($class)) {

--- a/centreon/src/App/Kernel.php
+++ b/centreon/src/App/Kernel.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
@@ -107,5 +108,15 @@ class Kernel extends BaseKernel
     public function getLogDir(): string
     {
         return $this->logDir;
+    }
+
+    public function build(ContainerBuilder $container): void
+    {
+        /** @var class-string $class */
+        $class = 'CentreonAnomalyDetection\DependencyInjection\TagIndicatorPass';
+
+        if (class_exists($class)) {
+            $container->addCompilerPass(new $class());
+        }
     }
 }

--- a/centreon/src/App/Kernel.php
+++ b/centreon/src/App/Kernel.php
@@ -110,7 +110,7 @@ class Kernel extends BaseKernel
         return $this->logDir;
     }
 
-    public function build(ContainerBuilder $container): void
+    protected function build(ContainerBuilder $container): void
     {
         /** @var class-string $class */
         $class = 'CentreonAnomalyDetection\DependencyInjection\TagIndicatorPass';


### PR DESCRIPTION
ℹ️ centreon-web part for this patch https://github.com/centreon/centreon-modules/pull/6507
This has been done until we get bundles for modules