### PR TITLE
fix(custom views): remove deprecation message

### DIFF
--- a/centreon/www/include/home/customViews/index.php
+++ b/centreon/www/include/home/customViews/index.php
@@ -342,7 +342,6 @@ if (isset($_SESSION['customview_edit_mode'])) {
     $modeEdit = ($_SESSION['customview_edit_mode'] === 'true') ? 'true' : 'false';
 }
 
-$deprecationMessage = _('[Page deprecated] This page will be removed in the next major version. Please use the new page: ');
 $resourcesStatusLabel = _('Dashboards');
 $basePath = (Request::createFromGlobals())->getBasePath();
 $redirectionUrl = $basePath . '/home/dashboards/library';
@@ -359,18 +358,6 @@ $redirectionUrl = $basePath . '/home/dashboards/library';
     var setDefaultMessage = "<?php echo _('Set this view as your default view?'); ?>";
     var wrenchSpan = '<span class="ui-icon ui-icon-wrench"></span>';
     var trashSpan = '<span class="ui-icon ui-icon-trash"></span>';
-
-    function display_deprecated_banner() {
-        const url = "<?php echo $redirectionUrl; ?>";
-        const message = "<?php echo $deprecationMessage; ?>";
-        const label = "<?php echo $resourcesStatusLabel; ?>";
-        jQuery('.pathway').append(
-            '<span style="color:#FF4500;padding-left:10px;font-weight:bold">' + message +
-            '<a style="position:relative" href="' + url + '" isreact="isreact">' + label + '</a></span>'
-        );
-    }
-
-    display_deprecated_banner();
 
     /**
      * Resize widget iframe

--- a/centreon/www/include/home/customViews/index.php
+++ b/centreon/www/include/home/customViews/index.php
@@ -18,7 +18,6 @@
  *
  */
 
-use Symfony\Component\HttpFoundation\Request;
 require_once _CENTREON_PATH_ . 'www/class/centreonCustomView.class.php';
 require_once _CENTREON_PATH_ . 'www/class/centreonWidget.class.php';
 require_once _CENTREON_PATH_ . 'www/class/centreonContactgroup.class.php';

--- a/centreon/www/include/home/customViews/index.php
+++ b/centreon/www/include/home/customViews/index.php
@@ -19,7 +19,6 @@
  */
 
 use Symfony\Component\HttpFoundation\Request;
-
 require_once _CENTREON_PATH_ . 'www/class/centreonCustomView.class.php';
 require_once _CENTREON_PATH_ . 'www/class/centreonWidget.class.php';
 require_once _CENTREON_PATH_ . 'www/class/centreonContactgroup.class.php';

--- a/centreon/www/include/home/customViews/index.php
+++ b/centreon/www/include/home/customViews/index.php
@@ -342,9 +342,6 @@ if (isset($_SESSION['customview_edit_mode'])) {
     $modeEdit = ($_SESSION['customview_edit_mode'] === 'true') ? 'true' : 'false';
 }
 
-$resourcesStatusLabel = _('Dashboards');
-$basePath = (Request::createFromGlobals())->getBasePath();
-$redirectionUrl = $basePath . '/home/dashboards/library';
 ?>
 
 


### PR DESCRIPTION
## Description

This PR intends to remove deprecation message from custom views page

**Fixes** # (MON-184159)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] release-2.09.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Check the custom views page, it should't have a deprecation message in the breadcramb

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
