### PR TITLE
enh(kernel): add ad compilerpass for bam indicators registration (#8261)

### DIFF
--- a/centreon/src/App/Kernel.php
+++ b/centreon/src/App/Kernel.php
@@ -24,6 +24,8 @@ declare(strict_types=1);
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
@@ -107,5 +109,16 @@ class Kernel extends BaseKernel
     public function getLogDir(): string
     {
         return $this->logDir;
+    }
+
+    protected function build(ContainerBuilder $container): void
+    {
+        $class = 'CentreonAnomalyDetection\DependencyInjection\TagIndicatorPass';
+
+        if (class_exists($class)) {
+            /** @var CompilerPassInterface $compilerPass */
+            $compilerPass = new $class();
+            $container->addCompilerPass($compilerPass);
+        }
     }
 }


### PR DESCRIPTION
ℹ️ release-25.09-next backport of #8261 