### PR TITLE
Remove not empty string assertion from TinyHost

### DIFF
--- a/centreon/src/Core/Host/Domain/Model/TinyHost.php
+++ b/centreon/src/Core/Host/Domain/Model/TinyHost.php
@@ -49,7 +49,6 @@ class TinyHost implements Comparable, Identifiable
         Assertion::notEmptyString($this->name, 'Host::name');
         if ($this->alias !== null) {
             $this->alias = trim($this->alias);
-            Assertion::notEmptyString($this->alias, 'Host::alias');
         }
         Assertion::positiveInt($this->id, 'Host::monitoringServerId');
     }


### PR DESCRIPTION
## Description

The export is no longer working when a CMA Agent is configured initiated by poller with a host having no alias.
The host alias being an optional data, this PR intend to remove the hard validation made in `TinyHost` class model ensuring the string is not empty.

Backport 24.10: https://github.com/centreon/centreon/pull/8297

MON-185663