### PR TITLE
fix(global macros): Correctly Validate Global Macro Name in legacy form

### DIFF
--- a/centreon/www/include/configuration/configResources/DB-Func.php
+++ b/centreon/www/include/configuration/configResources/DB-Func.php
@@ -571,5 +571,5 @@ function deleteFromVault(array $data): void
 function validateName(string $name): bool
 {
 
-    return preg_match(GlobalMacroName::NAMING_VALIDATION_REGEX, $name);
+    return (bool) preg_match(GlobalMacroName::NAMING_VALIDATION_REGEX, $name);
 }

--- a/centreon/www/include/configuration/configResources/DB-Func.php
+++ b/centreon/www/include/configuration/configResources/DB-Func.php
@@ -28,6 +28,8 @@ if (! isset($centreon)) {
 require_once _CENTREON_PATH_ . 'www/include/common/vault-functions.php';
 
 use App\Kernel;
+use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacro;
+use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroName;
 use Centreon\Domain\Log\Logger;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;
 use Core\Common\Application\Repository\WriteVaultRepositoryInterface;
@@ -564,4 +566,10 @@ function deleteFromVault(array $data): void
             }
         }
     }
+}
+
+function validateName(string $name): bool
+{
+
+    return preg_match(GlobalMacroName::NAMING_VALIDATION_REGEX, $name);
 }

--- a/centreon/www/include/configuration/configResources/DB-Func.php
+++ b/centreon/www/include/configuration/configResources/DB-Func.php
@@ -570,6 +570,5 @@ function deleteFromVault(array $data): void
 
 function validateName(string $name): bool
 {
-
     return (bool) preg_match(GlobalMacroName::NAMING_VALIDATION_REGEX, $name);
 }

--- a/centreon/www/include/configuration/configResources/DB-Func.php
+++ b/centreon/www/include/configuration/configResources/DB-Func.php
@@ -28,7 +28,6 @@ if (! isset($centreon)) {
 require_once _CENTREON_PATH_ . 'www/include/common/vault-functions.php';
 
 use App\Kernel;
-use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacro;
 use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacroName;
 use Centreon\Domain\Log\Logger;
 use Core\Common\Application\Repository\ReadVaultRepositoryInterface;

--- a/centreon/www/include/configuration/configResources/formResources.php
+++ b/centreon/www/include/configuration/configResources/formResources.php
@@ -140,6 +140,8 @@ function myReplace()
 
 $form->applyFilter('__ALL__', 'myTrim');
 $form->applyFilter('resource_name', 'myReplace');
+$form->registerRule('validateName', 'callback', 'validateName');
+$form->addRule('resource_name', _("Name must start and end with a '$'"), 'validateName');
 $form->addRule('resource_name', _('Compulsory Name'), 'required');
 $form->addRule('resource_line', _('Compulsory Alias'), 'required');
 $form->addRule('instance_id', _('Compulsory Instance'), 'required');

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -391,6 +391,37 @@ $updateOnPremiseACLs = function () use ($pearDB, &$errorMessage): void {
     );
 };
 
+$cleanGlobalMacrosName = function () use ($pearDB, &$errorMessage): void {
+    $errorMessage = 'Failed to update cfg_resource table';
+    $invalidMacros = $pearDB->fetchAllAssociative(
+        <<<'SQL'
+            SELECT resource_id, resource_name FROM cfg_resource
+            WHERE resource_name NOT LIKE '\$%' OR resource_name NOT LIKE '%\$'
+            SQL
+    );
+
+    foreach ($invalidMacros as $macro) {
+        $newName = $macro['resource_name'];
+        if (str_starts_with($newName, '$') === false) {
+            $newName = '$' . $newName;
+        }
+        if (str_ends_with($newName, '$') === false) {
+            $newName .= '$';
+        }
+        $pearDB->update(
+            <<<'SQL'
+                UPDATE cfg_resource
+                SET resource_name = :resource_name
+                WHERE id = :id
+                SQL,
+            QueryParameters::create([
+                QueryParameter::string(':resource_name', $newName),
+                QueryParameter::int(':id', (int) $macro['resource_id']),
+            ])
+        );
+    }
+};
+
 try {
 
     $addIsEncryptionReadyColumn();

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -457,6 +457,8 @@ try {
     $addResourceStatusSearchModeOption();
     $flagContactsAsServiceAccount();
     $updateOnPremiseACLs();
+    $cleanGlobalMacrosName();
+    $fixTypoInStandardMacroName();
 
     $pearDB->commit();
     $pearDBO->commit();


### PR DESCRIPTION
## Description

This PR Intends to Correctly Validate Global Macro Name in legacy form.
Currently the legacy form does not validate that the macro name starts and end with a `$`.
Creating a macro not following this standard will break the configuration export.


**Fixes** # MON-183155

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
