### PR TITLE
fix(cma): change default value in otel_server.json generation from null to empty string (#8276)

### DIFF
--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -163,13 +163,11 @@ class AgentConfiguration extends AbstractObjectJSON
                         ConnectionModeEnum::NO_TLS => 'no',
                         default => 'full',
                     },
-                    'ca_certificate' => $host['poller_ca_certificate'] !== null
-                        ? $host['poller_ca_certificate']
-                        : '',
-                    'ca_name' => $host['poller_ca_name'],
+                    'ca_certificate' => $host['poller_ca_certificate'] ?? '',
+                    'ca_name' => $host['poller_ca_name'] ?? '',
                     'token' => isset($tokens[$host['token']['name']])
                         ? $tokens[$host['token']['name']]->getToken()
-                        : null,
+                        : '',
                 ],
                 array_filter(
                     $data['hosts'],


### PR DESCRIPTION
## Description

BACKPORT #8276 

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] master
