### PR TITLE
enh(widget): reduce SQL calls for ACL in widgets

### DIFF
--- a/centreon/www/api/class/centreon_metric.class.php
+++ b/centreon/www/api/class/centreon_metric.class.php
@@ -19,11 +19,16 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+
 require_once _CENTREON_PATH_ . '/www/class/centreonDB.class.php';
 require_once _CENTREON_PATH_ . '/www/class/centreonGraphNg.class.php';
 require_once _CENTREON_PATH_ . '/www/class/centreonGraphService.class.php';
 require_once _CENTREON_PATH_ . '/www/class/centreonGraphPoller.class.php';
 require_once _CENTREON_PATH_ . '/www/class/centreonGraphStatus.class.php';
+require_once _CENTREON_PATH_ . '/www/include/common/sqlCommonFunction.php';
 require_once __DIR__ . '/webService.class.php';
 
 /**
@@ -698,18 +703,12 @@ class CentreonMetric extends CentreonWebService
      * @throws RestNotFoundException
      * @return array
      */
-    protected function serviceDatasNg($id, $metric = null)
+    protected function serviceDatasNg(string $id, ?int $metric = null)
     {
         global $centreon;
 
         $userId = $centreon->user->user_id;
         $isAdmin = $centreon->user->admin;
-
-        // Get ACL if user is not admin
-        if (! $isAdmin) {
-            $acl = new CentreonACL($userId, $isAdmin);
-            $aclGroups = $acl->getAccessGroupsString();
-        }
 
         if (
             ! isset($this->arguments['start']) || ! is_numeric($this->arguments['start'])
@@ -721,7 +720,12 @@ class CentreonMetric extends CentreonWebService
         $start = $this->arguments['start'];
         $end = $this->arguments['end'];
 
-        [$hostId, $serviceId] = explode('_', $id);
+        if (! preg_match('/^(\d+)_(\d+)$/', $id, $matches)) {
+            throw new RestBadRequestException('Bad parameters');
+        }
+
+        [, $hostId, $serviceId] = $matches;
+
         if (
             ! is_numeric($hostId)
             || ! is_numeric($serviceId)
@@ -729,23 +733,58 @@ class CentreonMetric extends CentreonWebService
             throw new RestBadRequestException('Bad parameters');
         }
 
-        // Check ACL is not admin
         if (! $isAdmin) {
-            $query = 'SELECT service_id '
-                . 'FROM centreon_acl '
-                . 'WHERE host_id = :hostId '
-                . 'AND service_id = :serviceId '
-                . 'AND group_id IN (' . $aclGroups . ')';
+            try {
+                $acl = new CentreonAclLazy($userId);
+                $accessGroups = $acl->getAccessGroups();
 
-            $stmt = $this->pearDBMonitoring->prepare($query);
-            $stmt->bindParam(':hostId', $hostId, PDO::PARAM_INT);
-            $stmt->bindParam(':serviceId', $serviceId, PDO::PARAM_INT);
-            $dbResult = $stmt->execute();
-            if (! $dbResult) {
-                throw new Exception('An error occured');
-            }
-            if ($stmt->rowCount() === 0) {
-                throw new RestForbiddenException('Access denied');
+                if ($accessGroups->isEmpty()) {
+                    throw new RestForbiddenException('Access denied');
+                }
+
+                $queryParameters = [
+                    QueryParameter::int('serviceId', (int) $serviceId),
+                    QueryParameter::int('hostId', (int) $hostId),
+                ];
+
+                ['parameters' => $aclParameters, 'placeholderList' => $bindQuery] = createMultipleBindParameters(
+                    $accessGroups->getIds(),
+                    'access_group_id',
+                    QueryParameterTypeEnum::INTEGER,
+                );
+
+                $request = <<<SQL
+                        SELECT
+                            1 AS REALTIME,
+                            host_id
+                        FROM
+                            centreon_acl
+                        WHERE
+                            host_id = :hostId
+                            AND service_id = :serviceId
+                            AND group_id IN ({$bindQuery})
+                    SQL;
+
+                $result = $this->pearDBMonitoring->fetchAllAssociative(
+                    $request,
+                    QueryParameters::create([...$queryParameters, ...$aclParameters]),
+                );
+
+                if ($result === []) {
+                    throw new RestForbiddenException(sprintf('You are not allowed to see graphs for service identified by ID %d', $serviceId));
+                }
+            } catch (Exception $exception) {
+                CentreonLog::create()->error(
+                    logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+                    message: 'Error fetching metrics data for service: ' . $exception->getMessage(),
+                    customContext: [
+                        'hostId' => $hostId,
+                        'serviceId' => $serviceId,
+                    ],
+                    exception: $exception
+                );
+
+                throw $exception;
             }
         }
 
@@ -757,7 +796,13 @@ class CentreonMetric extends CentreonWebService
             } else {
                 $graph->addMetric($metric);
             }
-        } catch (Exception $e) {
+        } catch (Exception $exception) {
+            CentreonLog::create()->error(
+                logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+                message: sprintf('Graph not found for metric %s: %s', $metric ?? '', $exception->getMessage()),
+                exception: $exception
+            );
+
             throw new RestNotFoundException('Graph not found');
         }
 
@@ -766,12 +811,14 @@ class CentreonMetric extends CentreonWebService
         // Get extra information (downtime/acknowledgment)
         $result['acknowledge'] = [];
         $result['downtime'] = [];
-        $query = 'SELECT `value` FROM `options` WHERE `key` = "display_downtime_chart"';
 
-        $res = $this->pearDB->query($query);
+        $request = <<<'SQL'
+                SELECT `value` FROM `options` WHERE `key` = "display_downtime_chart"
+            SQL;
 
-        $row = $res->fetch();
-        if ($row && $row['value'] === '1') {
+        $record = $this->pearDB->fetchOne($request);
+
+        if ((int) $record === 1) {
             $result['acknowledge'] = $this->getAcknowlegePeriods($hostId, $serviceId, $start, $end);
             $result['downtime'] = $this->getDowntimePeriods($hostId, $serviceId, $start, $end);
         }

--- a/centreon/www/class/centreonAclLazy.class.php
+++ b/centreon/www/class/centreonAclLazy.class.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+use Assert\AssertionFailedException;
+use Core\Common\Domain\Exception\CollectionException;
+use Core\Common\Domain\Exception\RepositoryException;
+use Core\Common\Infrastructure\Repository\SqlMultipleBindTrait;
+use Core\Security\AccessGroup\Domain\Collection\AccessGroupCollection;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+
+class CentreonAclLazy
+{
+    use SqlMultipleBindTrait;
+
+    private AccessGroupCollection $accessGroups;
+
+    private CentreonDB $database;
+
+    /**
+     * This class is specificaly dedicated to non admin users
+     *
+     * @param int $userId
+     * @param CentreonDB $database
+     */
+    public function __construct(private readonly int $userId)
+    {
+        $this->database = new CentreonDB();
+        $this->accessGroups = $this->findAccessGroups();
+    }
+
+    /**
+     * @return AccessGroupCollection
+     */
+    public function getAccessGroups(): AccessGroupCollection
+    {
+        return $this->accessGroups;
+    }
+
+    /**
+     * Find all access groups according to a contact.
+     *
+     * @param int $userId
+     *
+     * @throws RepositoryException
+     * @return AccessGroupCollection
+     */
+    private function findAccessGroups(): AccessGroupCollection
+    {
+        try {
+            $accessGroups = new AccessGroupCollection();
+            /**
+             * Retrieve all access group from contact
+             * and contact groups linked to contact.
+             */
+            $query = <<<'SQL'
+                SELECT *
+                FROM acl_groups
+                WHERE acl_group_activate = '1'
+                AND (
+                    acl_group_id IN (
+                        SELECT acl_group_id
+                        FROM acl_group_contacts_relations
+                        WHERE contact_contact_id = :userId
+                    )
+                    OR acl_group_id IN (
+                        SELECT acl_group_id
+                        FROM acl_group_contactgroups_relations agcr
+                        INNER JOIN contactgroup_contact_relation cgcr
+                            ON cgcr.contactgroup_cg_id = agcr.cg_cg_id
+                        WHERE cgcr.contact_contact_id = :userId
+                    )
+                )
+                SQL;
+
+            $statement = $this->database->prepare($query);
+
+            $statement->bindValue(':userId', $this->userId, PDO::PARAM_INT);
+            if ($statement->execute()) {
+                /**
+                 * @var array{
+                 *     acl_group_id: int|string,
+                 *     acl_group_name: string,
+                 *     acl_group_alias: string,
+                 *     acl_group_activate: string,
+                 *     acl_group_changed: int,
+                 *     claim_value: string,
+                 *     priority: int,
+                 * } $result
+                 */
+                while ($result = $statement->fetch(PDO::FETCH_ASSOC)) {
+                    $accessGroup = new AccessGroup((int) $result['acl_group_id'], $result['acl_group_name'], $result['acl_group_alias']);
+                    $accessGroup->setActivate($result['acl_group_activate'] === '1');
+                    $accessGroup->setChanged($result['acl_group_changed'] === 1);
+
+                    $accessGroups->add($accessGroup->getId(), $accessGroup);
+                }
+
+                return $accessGroups;
+            }
+
+            return $accessGroups;
+        } catch (PDOException|CollectionException|AssertionFailedException $e) {
+            throw new RepositoryException(
+                'Error while getting access groups by contact id',
+                ['contact_id' => $this->userId],
+                $e
+            );
+        }
+    }
+}

--- a/centreon/www/widgets/engine-status/index.php
+++ b/centreon/www/widgets/engine-status/index.php
@@ -19,14 +19,19 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\Exception\ConnectionException;
+
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
+require_once $centreon_path . 'www/include/common/sqlCommonFunction.php';
 require_once $centreon_path . 'bootstrap.php';
 
 CentreonSession::start(1);
@@ -34,6 +39,7 @@ CentreonSession::start(1);
 if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId'])) {
     exit;
 }
+
 $centreon = $_SESSION['centreon'];
 $widgetId = filter_var($_REQUEST['widgetId'], FILTER_VALIDATE_INT);
 
@@ -42,29 +48,61 @@ try {
         throw new InvalidArgumentException('Widget ID must be an integer');
     }
 
-    $db_centreon = $dependencyInjector['configuration_db'];
-    $db = $dependencyInjector['realtime_db'];
+    /**
+     * @var CentreonDB $configurationDatabase
+     */
+    $configurationDatabase = $dependencyInjector['configuration_db'];
 
-    if ($centreon->user->admin == 0) {
-        $access = new CentreonACL($centreon->user->get_id());
-        $grouplist = $access->getAccessGroups();
-        $grouplistStr = $access->getAccessGroupsString();
-    }
+    /**
+     * @var CentreonDB $realtimeDatabase
+     */
+    $realtimeDatabase = $dependencyInjector['realtime_db'];
 
-    $widgetObj = new CentreonWidget($centreon, $db_centreon);
+    $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
+
+    /**
+     * @var array{
+     *     poller: string,
+     *     avg-l: string,
+     *     max-e: string,
+     *     avg-e: string,
+     *     autoRefresh: string
+     * } $preferences
+     */
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
 
-    $autoRefresh = filter_var($preferences['autoRefresh'], FILTER_VALIDATE_INT);
+    if (empty($preferences['poller'])) {
+        throw new InvalidArgumentException('Please select a poller');
+    }
+
+    $autoRefresh = filter_var(
+        $preferences['autoRefresh'],
+        FILTER_VALIDATE_INT,
+    );
+
     if ($autoRefresh === false || $autoRefresh < 5) {
         $autoRefresh = 30;
     }
+
     $variablesThemeCSS = match ($centreon->user->theme) {
         'light' => 'Generic-theme',
         'dark' => 'Centreon-Dark',
         default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
     };
-} catch (InvalidArgumentException $e) {
-    echo $e->getMessage() . '<br/>';
+
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error while using engine-status widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
 }
@@ -73,100 +111,154 @@ try {
 $path = $centreon_path . 'www/widgets/engine-status/src/';
 $template = SmartyBC::createSmartyTemplate($path, './');
 
-$dataLat = [];
-$dataEx = [];
-$dataSth = [];
-$dataSts = [];
-$db = new CentreonDB('centstorage');
+$latencyData = [];
+$executionTimeData = [];
+$hostStatusesData = [];
+$serviceStatusesData = [];
 
-$instances = [];
-if (isset($preferences['poller']) && $preferences['poller']) {
-    $pollerIds = explode(',', $preferences['poller']);
-    $queryPoller = '';
-    foreach ($pollerIds as $pollerId) {
-        $instances[] = (int) $pollerId;
+['parameters' => $parameters, 'placeholderList' => $pollerList] = createMultipleBindParameters(
+    explode(',', $preferences['poller']),
+    'poller_id',
+    QueryParameterTypeEnum::INTEGER,
+);
+
+$queryParameters = QueryParameters::create($parameters);
+
+$queryLatency = <<<SQL
+    SELECT
+        1 AS realtime,
+        MAX(h.latency) AS h_max,
+        AVG(h.latency) AS h_moy,
+        MAX(s.latency) AS s_max,
+        AVG(s.latency) AS s_moy
+    FROM hosts h
+    INNER JOIN services s
+        ON h.host_id = s.host_id
+    WHERE
+        h.instance_id IN ({$pollerList})
+        AND s.enabled = '1'
+        AND s.check_type = '0'
+    SQL;
+
+$queryExecutionTime = <<<SQL
+        SELECT
+            1 AS realtime,
+            MAX(h.execution_time) AS h_max,
+            AVG(h.execution_time) AS h_moy,
+            MAX(s.execution_time) AS s_max,
+            AVG(s.execution_time) AS s_moy
+        FROM hosts h
+        INNER JOIN services s
+            ON h.host_id = s.host_id
+        WHERE
+            h.instance_id IN ({$pollerList})
+            AND s.enabled = '1'
+            AND s.check_type = '0';
+    SQL;
+
+try {
+    foreach ($realtimeDatabase->iterateAssociative($queryLatency, $queryParameters) as $record) {
+        $record['h_max'] = round($record['h_max'], 3);
+        $record['h_moy'] = round($record['h_moy'], 3);
+        $record['s_max'] = round($record['s_max'], 3);
+        $record['s_moy'] = round($record['s_moy'], 3);
+        $latencyData[] = $record;
     }
+} catch (ConnectionException $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_SQL,
+        message: 'Error retrieving latency data for engine-status widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme);
+
+    exit;
 }
 
-if ($instances !== []) {
-    $queryLat = 'SELECT
+try {
+    foreach ($realtimeDatabase->iterateAssociative($queryExecutionTime, $queryParameters) as $record) {
+        $record['h_max'] = round($record['h_max'], 3);
+        $record['h_moy'] = round($record['h_moy'], 3);
+        $record['s_max'] = round($record['s_max'], 3);
+        $record['s_moy'] = round($record['s_moy'], 3);
+        $executionTimeData[] = $record;
+    }
+} catch (ConnectionException $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_SQL,
+        message: 'Error retrieving execution time data for engine-status widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme);
+
+    exit;
+}
+
+$queryHostStatuses = <<<SQL
+        SELECT
             1 AS REALTIME,
-            MAX(T1.latency) AS h_max,
-            AVG(T1.latency) AS h_moy,
-            MAX(T2.latency) AS s_max,
-            AVG(T2.latency) AS s_moy
-            FROM hosts T1, services T2
-            WHERE T1.instance_id IN (' . implode(',', $instances) . ")
-            AND T1.host_id = T2.host_id
-            AND T2.enabled = '1'
-            AND T2.check_type = '0'";
-    $queryEx = 'SELECT
+            SUM(h.state = 1) AS Dow,
+            SUM(h.state = 2) AS Un,
+            SUM(h.state = 0) AS Up,
+            SUM(h.state = 4) AS Pend
+        FROM hosts h
+        WHERE h.instance_id IN ({$pollerList})
+          AND h.enabled = 1
+          AND h.name NOT LIKE '%Module%'
+    SQL;
+
+$queryServiceStatuses = <<<SQL
+        SELECT
             1 AS REALTIME,
-            MAX(T1.execution_time) AS h_max,
-            AVG(T1.execution_time) AS h_moy,
-            MAX(T2.execution_time) AS s_max,
-            AVG(T2.execution_time) AS s_moy
-            FROM hosts T1, services T2
-            WHERE T1.instance_id IN (' . implode(',', $instances) . ") AND T1.host_id = T2.host_id
-            AND T2.enabled = '1'
-            AND T2.check_type = '0'";
+            SUM(s.state = 2) AS Cri,
+            SUM(s.state = 1) AS Wa,
+            SUM(s.state = 0) AS Ok,
+            SUM(s.state = 4) AS Pend,
+            SUM(s.state = 3) AS Unk
+        FROM services s
+        INNER JOIN hosts h
+            ON h.host_id = s.host_id
+        WHERE h.instance_id IN ({$pollerList})
+          AND s.enabled = 1
+          AND h.name NOT LIKE '%Module%'
+    SQL;
 
-    $res = $db->query($queryLat);
-    $res2 = $db->query($queryEx);
+try {
+    $hostStatusesData = $realtimeDatabase->fetchAllAssociative($queryHostStatuses, $queryParameters);
+} catch (ConnectionException $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_SQL,
+        message: 'Error retrieving host statuses data for engine-status widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme);
 
-    while ($row = $res->fetch()) {
-        $row['h_max'] = round($row['h_max'], 3);
-        $row['h_moy'] = round($row['h_moy'], 3);
-        $row['s_max'] = round($row['s_max'], 3);
-        $row['s_moy'] = round($row['s_moy'], 3);
-        $dataLat[] = $row;
-    }
+    exit;
+}
 
-    while ($row = $res2->fetch()) {
-        $row['h_max'] = round($row['h_max'], 3);
-        $row['h_moy'] = round($row['h_moy'], 3);
-        $row['s_max'] = round($row['s_max'], 3);
-        $row['s_moy'] = round($row['s_moy'], 3);
-        $dataEx[] = $row;
-    }
+try {
+    $serviceStatusesData = $realtimeDatabase->fetchAllAssociative($queryServiceStatuses, $queryParameters);
+} catch (ConnectionException $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_SQL,
+        message: 'Error retrieving service statuses data for engine-status widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme);
 
-    $querySth = "SELECT
-                1 AS REALTIME,
-                SUM(CASE WHEN h.state = 1 AND h.enabled = 1 AND h.name NOT LIKE '%Module%'
-                THEN 1 ELSE 0 END) AS Dow,
-                SUM(CASE WHEN h.state = 2 AND h.enabled = 1 AND h.name NOT LIKE '%Module%'
-                THEN 1 ELSE 0 END) AS Un,
-                SUM(CASE WHEN h.state = 0 AND h.enabled = 1 AND h.name NOT LIKE '%Module%'
-                THEN 1 ELSE 0 END) AS Up,
-                SUM(CASE WHEN h.state = 4 AND h.enabled = 1 AND h.name NOT LIKE '%Module%'
-                THEN 1 ELSE 0 END) AS Pend
-                FROM hosts h WHERE h.instance_id IN (" . implode(',', $instances) . ')';
-
-    $querySts = "SELECT
-                1 AS REALTIME,
-                SUM(CASE WHEN s.state = 2 AND s.enabled = 1 AND h.name NOT LIKE '%Module%'
-                THEN 1 ELSE 0 END) AS Cri,
-                SUM(CASE WHEN s.state = 1 AND s.enabled = 1 AND h.name NOT LIKE '%Module%'
-                THEN 1 ELSE 0 END) AS Wa,
-                SUM(CASE WHEN s.state = 0 AND s.enabled = 1 AND h.name NOT LIKE '%Module%'
-                THEN 1 ELSE 0 END) AS Ok,
-                SUM(CASE WHEN s.state = 4 AND s.enabled = 1 AND h.name NOT LIKE '%Module%'
-                THEN 1 ELSE 0 END) AS Pend,
-                SUM(CASE WHEN s.state = 3 AND s.enabled = 1 AND h.name NOT LIKE '%Module%'
-                THEN 1 ELSE 0 END) AS Unk
-                FROM services s, hosts h
-                WHERE h.host_id = s.host_id AND h.instance_id IN (" . implode(',', $instances) . ')';
-
-    $res = $db->query($querySth);
-    $res2 = $db->query($querySts);
-
-    while ($row = $res->fetch()) {
-        $dataSth[] = $row;
-    }
-
-    while ($row = $res2->fetch()) {
-        $dataSts[] = $row;
-    }
+    exit;
 }
 
 $avg_l = $preferences['avg-l'];
@@ -178,12 +270,12 @@ $template->assign('widgetId', $widgetId);
 $template->assign('autoRefresh', $autoRefresh);
 $template->assign('preferences', $preferences);
 $template->assign('max_e', $max_e);
-$template->assign('dataSth', $dataSth);
-$template->assign('dataSts', $dataSts);
-$template->assign('dataEx', $dataEx);
-$template->assign('dataLat', $dataLat);
+$template->assign('dataSth', $hostStatusesData);
+$template->assign('dataSts', $serviceStatusesData);
+$template->assign('dataEx', $executionTimeData);
+$template->assign('dataLat', $latencyData);
 $template->assign(
     'theme',
-    $variablesThemeCSS === 'Generic-theme' ? $variablesThemeCSS . '/Variables-css' : $variablesThemeCSS
+    $theme
 );
 $template->display('engine-status.ihtml');

--- a/centreon/www/widgets/engine-status/src/engine-status.ihtml
+++ b/centreon/www/widgets/engine-status/src/engine-status.ihtml
@@ -6,7 +6,6 @@
     <link href="../../Themes/{$theme}/variables.css" rel="stylesheet" type="text/css"/>
 </head>
 <body>
-    {if $preferences.poller != ''}
     <div id="engine-status">
         <table class="styleTable ListTable">
             <h4>Status</h4>
@@ -136,9 +135,6 @@
             </tr>
         </table>
     </div>
-	{else if !isset($preferences["engine-status"]) || $preferences["engine-status"] == ''}
-	<div class="update" style="text-align:center;width:350px;">Please select a poller</div>
-	{/if}
     <script>
         var widgetId = "{$widgetId}";
         var autoRefresh = "{$autoRefresh}";

--- a/centreon/www/widgets/global-health/src/global_health.php
+++ b/centreon/www/widgets/global-health/src/global_health.php
@@ -26,7 +26,6 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'www/class/centreonLang.class.php';
 require_once $centreon_path . 'www/class/centreonMedia.class.php';

--- a/centreon/www/widgets/graph-monitoring/index.php
+++ b/centreon/www/widgets/graph-monitoring/index.php
@@ -19,18 +19,25 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once $centreon_path . 'bootstrap.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonUser.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
+require_once $centreon_path . 'www/include/common/sqlCommonFunction.php';
 
-$pearDB = $dependencyInjector['configuration_db'];
+/** @var CentreonDB $configurationDatabase */
+$configurationDatabase = $dependencyInjector['configuration_db'];
 
 CentreonSession::start(1);
-if (! CentreonSession::checkSession(session_id(), $pearDB)) {
+if (! CentreonSession::checkSession(session_id(), $configurationDatabase)) {
     echo 'Bad Session';
 
     exit();
@@ -41,93 +48,114 @@ if (! isset($_REQUEST['widgetId'])) {
 }
 
 $centreon = $_SESSION['centreon'];
-$widgetId = filter_var($_REQUEST['widgetId'], FILTER_VALIDATE_INT);
+
+$widgetId = filter_var(
+    $_REQUEST['widgetId'],
+    FILTER_VALIDATE_INT,
+);
 
 try {
-    if ($widgetId === false) {
-        throw new InvalidArgumentException('Widget ID must be an integer');
-    }
-
-    global $pearDB;
-    $pearDB = $dependencyInjector['configuration_db'];
-    $dbAcl = $dependencyInjector['configuration_db'];
-    $db = $dependencyInjector['configuration_db'];
-    $db2 = $dependencyInjector['realtime_db'];
-
-    $widgetObj = new CentreonWidget($centreon, $db);
-    $preferences = $widgetObj->getWidgetPreferences($widgetId);
-
-    $autoRefresh = filter_var($preferences['refresh_interval'], FILTER_VALIDATE_INT);
-
-    if ($autoRefresh === false || $autoRefresh < 5) {
-        $autoRefresh = 30;
-    }
     $variablesThemeCSS = match ($centreon->user->theme) {
         'light' => 'Generic-theme',
         'dark' => 'Centreon-Dark',
         default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
     };
-} catch (Exception $e) {
-    echo $e->getMessage() . '<br/>';
+
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+
+    if ($widgetId === false) {
+        throw new InvalidArgumentException('Widget ID must be an integer');
+    }
+
+    /** @var CentreonDB $realTimeDatabase */
+    $realTimeDatabase = $dependencyInjector['realtime_db'];
+
+    $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
+
+    /**
+     * @var array{
+     *     service: string,
+     *     graph_period: string,
+     *     refresh_interval: string,
+     * } $preferences
+     */
+    $preferences = $widgetObj->getWidgetPreferences($widgetId);
+
+    if (! preg_match('/^(\d+)-(\d+)$/', $preferences['service'], $matches)) {
+        throw new InvalidArgumentException(_('Please select a resource first'));
+    }
+
+    [, $hostId, $serviceId] = $matches;
+
+    if (empty($preferences['graph_period'])) {
+        throw new InvalidArgumentException(_('Please select a graph period'));
+    }
+
+    $autoRefresh = filter_var(
+        $preferences['refresh_interval'],
+        FILTER_VALIDATE_INT,
+    );
+
+    if ($autoRefresh === false || $autoRefresh < 5) {
+        $autoRefresh = 30;
+    }
+
+    if (! $centreon->user->admin) {
+        $acls = new CentreonAclLazy($centreon->user->user_id);
+        $accessGroups = $acls->getAccessGroups();
+
+        if ($accessGroups->isEmpty()) {
+            throw new Exception(sprintf('You are not allowed to see graphs for service identified by ID %d', $serviceId));
+        }
+
+        $queryParameters = [
+            QueryParameter::int('serviceId', (int) $serviceId),
+            QueryParameter::int('hostId', (int) $hostId),
+        ];
+
+        ['parameters' => $aclParameters, 'placeholderList' => $bindQuery] = createMultipleBindParameters(
+            $accessGroups->getIds(),
+            'access_group_id',
+            QueryParameterTypeEnum::INTEGER,
+        );
+
+        $request = <<<SQL
+                SELECT
+                    1 AS REALTIME,
+                    host_id
+                FROM
+                    centreon_acl
+                WHERE
+                    host_id = :hostId
+                    AND service_id = :serviceId
+                    AND group_id IN ({$bindQuery})
+            SQL;
+
+        if ($realTimeDatabase->fetchAllAssociative($request, QueryParameters::create([...$queryParameters, ...$aclParameters])) === []) {
+            throw new Exception(sprintf('You are not allowed to see graphs for service identified by ID %d', $serviceId));
+        }
+    }
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error fetching data for graph-monitoring widget: ' . $exception->getMessage(),
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
-}
-
-if ($centreon->user->admin == 0) {
-    $access = new CentreonACL($centreon->user->get_id());
-    $grouplist = $access->getAccessGroups();
-    $grouplistStr = $access->getAccessGroupsString();
 }
 
 // Smarty template initialization
 $path = $centreon_path . 'www/widgets/graph-monitoring/src/';
 $template = SmartyBC::createSmartyTemplate($path, '/');
-
-// Check ACL
-
-$acl = 1;
-if (isset($tab[0], $tab[1])   && $centreon->user->admin == 0) {
-    $sql = <<<'SQL'
-        SELECT
-            1 AS REALTIME,
-            host_id
-        FROM centreon_acl
-        WHERE host_id = :hostId
-        AND service_id = :serviceId
-        AND group_id IN (:groupList)
-        SQL;
-
-    $res = $dbAcl->prepare($sql);
-    $res->bindValue(':hostId', $tab[0], PDO::PARAM_INT);
-    $res->bindValue(':serviceId', $tab[1], PDO::PARAM_INT);
-    $res->bindValue(':groupList', $grouplistStr, PDO::PARAM_STR);
-    $res->execute();
-
-    if (! $res->rowCount()) {
-        $acl = 0;
-    }
-}
-
-$servicePreferences = '';
-
-if ($acl === 0) {
-    $servicePreferences = '';
-} elseif (isset($preferences['service']) === false || trim($preferences['service']) === '') {
-    $servicePreferences = "<div class='update' style='text-align:center;margin-left: auto;margin-right: "
-        . "auto;width:350px;'>" . _('Please select a resource first') . '</div>';
-} elseif (isset($preferences['graph_period']) === false || trim($preferences['graph_period']) === '') {
-    $servicePreferences = "<div class='update' style='text-align:center;margin-left: auto;margin-right: "
-        . "auto;width:350px;'>" . _('Please select a graph period') . '</div>';
-}
-$template->assign(
-    'theme',
-    $variablesThemeCSS === 'Generic-theme' ? $variablesThemeCSS . '/Variables-css' : $variablesThemeCSS
-);
+$template->assign('theme', $theme);
 $template->assign('widgetId', $widgetId);
 $template->assign('preferences', $preferences);
 $template->assign('interval', $preferences['graph_period']);
 $template->assign('autoRefresh', $autoRefresh);
-$template->assign('graphId', str_replace('-', '_', $preferences['service']));
-$template->assign('servicePreferences', $servicePreferences);
+$template->assign('graphId', sprintf('%d_%d', (int) $hostId, (int) $serviceId));
 
 $template->display('index.ihtml');

--- a/centreon/www/widgets/graph-monitoring/src/generateGraph.php
+++ b/centreon/www/widgets/graph-monitoring/src/generateGraph.php
@@ -25,7 +25,6 @@ require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'www/class/centreonService.class.php';
 require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';

--- a/centreon/www/widgets/graph-monitoring/src/index.ihtml
+++ b/centreon/www/widgets/graph-monitoring/src/index.ihtml
@@ -8,7 +8,6 @@
         <link href="../../include/common/javascript/charts/c3.min.css" rel="stylesheet">
     </head>
     <body>
-        {$servicePreferences}
         <!--<div id='graphMonitoringTable'></div>-->
         <div class="chart" data-graph-id="{$graphId}" data-graph-type="service"></div>
 

--- a/centreon/www/widgets/grid-map/index.php
+++ b/centreon/www/widgets/grid-map/index.php
@@ -20,6 +20,7 @@
  */
 
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once '../../../config/centreon.config.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
@@ -40,11 +41,18 @@ try {
     if ($widgetId === false) {
         throw new InvalidArgumentException('Widget ID must be an integer');
     }
-    $db_centreon = $dependencyInjector['configuration_db'];
-    $db = $dependencyInjector['realtime_db'];
 
-    $widgetObj = new CentreonWidget($centreon, $db_centreon);
+    $widgetObj = new CentreonWidget($centreon, $dependencyInjector['configuration_db']);
+
+    /**
+     * @var array{
+     *     host_group: string,
+     *     service: string,
+     *     refresh_interval: string
+     * } $preferences
+     */
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
+
     $autoRefresh = filter_var($preferences['refresh_interval'], FILTER_VALIDATE_INT);
     if ($autoRefresh === false || $autoRefresh < 5) {
         $autoRefresh = 30;
@@ -54,8 +62,20 @@ try {
         'dark' => 'Centreon-Dark',
         default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
     };
-} catch (Exception $e) {
-    echo $e->getMessage() . '<br/>';
+
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error while using grid-map widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
 }
@@ -65,11 +85,5 @@ $template = SmartyBC::createSmartyTemplate(getcwd() . '/', './');
 
 $template->assign('autoRefresh', $autoRefresh);
 $template->assign('widgetId', $widgetId);
-$template->assign(
-    'theme',
-    $variablesThemeCSS === 'Generic-theme'
-        ? $variablesThemeCSS . '/Variables-css'
-        : $variablesThemeCSS
-);
-// Display
+$template->assign('theme', $theme);
 $template->display('index.ihtml');

--- a/centreon/www/widgets/grid-map/src/table.php
+++ b/centreon/www/widgets/grid-map/src/table.php
@@ -26,10 +26,10 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'bootstrap.php';
 require_once $centreon_path . 'www/include/common/sqlCommonFunction.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
 
 CentreonSession::start(1);
 
@@ -56,16 +56,15 @@ try {
         throw new InvalidArgumentException('Widget ID must be an integer');
     }
 
-    $db_centreon = $dependencyInjector['configuration_db'];
-    $db = $dependencyInjector['realtime_db'];
+    $configurationDatabase = $dependencyInjector['configuration_db'];
+    $realTimeDatabase = $dependencyInjector['realtime_db'];
 
     if ($centreon->user->admin == 0) {
-        $access = new CentreonACL($centreon->user->get_id());
+        $access = new CentreonAclLazy($centreon->user->user_id);
         $accessGroups = $access->getAccessGroups();
-        $arrayKeysAccessGroups = array_keys($accessGroups);
     }
 
-    $widgetObj = new CentreonWidget($centreon, $db_centreon);
+    $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
     $autoRefresh = filter_var($preferences['refresh_interval'], FILTER_VALIDATE_INT);
     if ($autoRefresh === false || $autoRefresh < 5) {
@@ -107,7 +106,7 @@ if (! empty($preferences['host_group'])) {
     if ($accessGroups !== []) {
         $aclJoin = $centreon->user->admin == 0 ? ' INNER JOIN centreon_acl acl ON T1.host_id = acl.host_id' : '';
         [$bindValuesAcl, $bindQueryAcl] = createMultipleBindQuery(
-            list: $arrayKeysAccessGroups,
+            list: $accessGroups->getIds(),
             prefix: ':access_group_id_host_',
             bindType: PDO::PARAM_INT
         );
@@ -128,9 +127,9 @@ if (! empty($preferences['host_group'])) {
     $bindParams1 = array_merge($bindParams1, $bindValuesAcl);
 
     try {
-        $stmt1 = $db->prepareQuery($query1);
-        $db->executePreparedQuery($stmt1, $bindParams1, true);
-        while ($row = $db->fetch($stmt1)) {
+        $stmt1 = $realTimeDatabase->prepareQuery($query1);
+        $realTimeDatabase->executePreparedQuery($stmt1, $bindParams1, true);
+        while ($row = $realTimeDatabase->fetch($stmt1)) {
             $row['details_uri'] = $useDeprecatedPages
                 ? '../../main.php?p=20202&o=hd&host_name=' . $row['name']
                 : $resourceController->buildHostDetailsUri($row['host_id']);
@@ -187,9 +186,9 @@ if (! empty($preferences['host_group'])) {
     $bindParams2 = array_merge($bindValues, $bindValuesAcl);
 
     try {
-        $stmt2 = $db->prepareQuery($query2);
-        $db->executePreparedQuery($stmt2, $bindParams2, true);
-        while ($row = $db->fetch($stmt2)) {
+        $stmt2 = $realTimeDatabase->prepareQuery($query2);
+        $realTimeDatabase->executePreparedQuery($stmt2, $bindParams2, true);
+        while ($row = $realTimeDatabase->fetch($stmt2)) {
             $data_service[$row['description']] = [
                 'description' => $row['description'],
                 'hosts' => [],
@@ -233,9 +232,9 @@ if (! empty($preferences['host_group'])) {
     $bindParams3 = $bindParams2;
 
     try {
-        $stmt3 = $db->prepareQuery($query3);
-        $db->executePreparedQuery($stmt3, $bindParams3, true);
-        while ($row = $db->fetch($stmt3)) {
+        $stmt3 = $realTimeDatabase->prepareQuery($query3);
+        $realTimeDatabase->executePreparedQuery($stmt3, $bindParams3, true);
+        while ($row = $realTimeDatabase->fetch($stmt3)) {
             if (isset($data_service[$row['description']])) {
                 $data_service[$row['description']]['hosts'][] = $row['host_id'];
                 $data_service[$row['description']]['hostsStatus'][$row['host_id']] = $colors[$row['state']];

--- a/centreon/www/widgets/host-monitoring/index.php
+++ b/centreon/www/widgets/host-monitoring/index.php
@@ -20,12 +20,14 @@
  */
 
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once $centreon_path . 'bootstrap.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 
 CentreonSession::start(1);
+
 if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId'])) {
     exit;
 }
@@ -40,13 +42,26 @@ try {
     if ($autoRefresh === false || $autoRefresh < 5) {
         $autoRefresh = 30;
     }
+
     $variablesThemeCSS = match ($centreon->user->theme) {
         'light' => 'Generic-theme',
         'dark' => 'Centreon-Dark',
         default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
     };
-} catch (Exception $e) {
-    echo $e->getMessage() . '<br/>';
+
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error while using host-monitoring widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
 }

--- a/centreon/www/widgets/host-monitoring/src/action.php
+++ b/centreon/www/widgets/host-monitoring/src/action.php
@@ -25,7 +25,6 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonDB.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';
 

--- a/centreon/www/widgets/host-monitoring/src/export.php
+++ b/centreon/www/widgets/host-monitoring/src/export.php
@@ -19,6 +19,10 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+
 require_once '../../require.php';
 require_once './DB-Func.php';
 require_once $centreon_path . 'bootstrap.php';
@@ -27,7 +31,7 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'www/class/centreonMedia.class.php';
 require_once $centreon_path . 'www/class/centreonCriticality.class.php';
@@ -39,18 +43,34 @@ if (! isset($_SESSION['centreon'], $_GET['widgetId'], $_GET['list'])) {
     exit;
 }
 
-$db = $dependencyInjector['configuration_db'];
-if (CentreonSession::checkSession(session_id(), $db) == 0) {
+/**
+ * @var CentreonDB $configurationDatabase
+ */
+$configurationDatabase = $dependencyInjector['configuration_db'];
+if (CentreonSession::checkSession(session_id(), $configurationDatabase) == 0) {
     exit;
 }
-$dbb = $dependencyInjector['realtime_db'];
+
+/**
+ * @var CentreonDB $realtimeDatabase
+ */
+$realtimeDatabase = $dependencyInjector['realtime_db'];
 
 // Init Objects
-$criticality = new CentreonCriticality($db);
-$aStateType = ['1' => 'H', '0' => 'S'];
+$criticality = new CentreonCriticality($configurationDatabase);
+$aStateType = [
+    '1' => 'H',
+    '0' => 'S',
+];
 
 $centreon = $_SESSION['centreon'];
-$widgetId = filter_input(INPUT_GET, 'widgetId', FILTER_VALIDATE_INT, ['options' => ['default' => 0]]);
+
+$widgetId = filter_input(
+    INPUT_GET,
+    'widgetId',
+    FILTER_VALIDATE_INT,
+    ['options' => ['default' => 0]],
+);
 
 /**
  * Sanitize and concatenate selected resources for the query
@@ -72,15 +92,21 @@ $filteredHostList = array_filter($exportList, static function ($hostId) {
     return (int) $hostId > 0; // Keep only valid positive integers
 });
 
-[$hostBindValues, $hostQuery] = createMultipleBindQuery(
-    $filteredHostList,
-    ':host_',
-    PDO::PARAM_INT
-);
 $mainQueryParameters = [];
 
-$widgetObj = new CentreonWidget($centreon, $db);
-$preferences = $widgetObj->getWidgetPreferences($widgetId);
+try {
+    $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
+    $preferences = $widgetObj->getWidgetPreferences($widgetId);
+} catch (Exception $e) {
+    CentreonLog::create()->error(
+        CentreonLog::TYPE_SQL,
+        'Error while getting widget preferences for the host monitoring custom view',
+        ['widget_id' => $widgetId],
+        $e
+    );
+
+    throw $e;
+}
 
 // Get status labels
 $stateLabels = getLabels();
@@ -116,18 +142,47 @@ $columns = <<<'SQL'
             cv2.value AS criticality_id,
             cv.name IS NULL as isnull
     SQL;
+
 $baseQuery = <<<'SQL'
         FROM hosts h
         LEFT JOIN `customvariables` cv
             ON (cv.host_id = h.host_id AND cv.service_id IS NULL AND cv.name = 'CRITICALITY_LEVEL')
         LEFT JOIN `customvariables` cv2
             ON (cv2.host_id = h.host_id AND cv2.service_id IS NULL AND cv2.name = 'CRITICALITY_ID')
-        WHERE enabled = 1
-        AND h.name NOT LIKE '_Module_%'
     SQL;
 
+if (! $centreon->user->admin) {
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups = $acls->getAccessGroups()->getIds();
+
+    ['parameters' => $accessGroupParameters, 'placeholderList' => $accessGroupList] = createMultipleBindParameters(
+        $accessGroups,
+        'access_group',
+        QueryParameterTypeEnum::INTEGER
+    );
+
+    $baseQuery .= <<<SQL
+            INNER JOIN centreon_acl acl
+                ON h.host_id = acl.host_id
+                AND acl.service_id IS NULL
+                AND acl.group_id IN ({$accessGroupList})
+        SQL;
+
+    $mainQueryParameters = [...$accessGroupParameters, ...$mainQueryParameters];
+}
+
+$baseQuery .= " WHERE enabled = 1 AND h.name NOT LIKE '_Module_%'";
+
+['parameters' => $hostQueryParameters, 'placeholderList' => $hostQuery] = createMultipleBindParameters(
+    $filteredHostList,
+    'host_',
+    QueryParameterTypeEnum::INTEGER,
+);
+
+$mainQueryParameters = [...$hostQueryParameters, ...$mainQueryParameters];
+
 if (! empty($hostQuery)) {
-    $baseQuery .= 'AND h.host_id IN (' . $hostQuery . ') ';
+    $baseQuery .= ' AND h.host_id IN (' . $hostQuery . ') ';
 }
 
 if (isset($preferences['host_name_search']) && $preferences['host_name_search'] != '') {
@@ -137,11 +192,7 @@ if (isset($preferences['host_name_search']) && $preferences['host_name_search'] 
         $search = $tab[1];
     }
     if ($op && isset($search) && $search != '') {
-        $mainQueryParameters[] = [
-            'parameter' => ':host_name_search',
-            'value' => $search,
-            'type' => PDO::PARAM_STR,
-        ];
+        $mainQueryParameters[] = QueryParameter::string('host_name_search', $search);
         $hostNameCondition = 'h.name ' . CentreonUtils::operandToMysqlFormat($op) . ' :host_name_search ';
         $baseQuery = CentreonUtils::conditionBuilder($baseQuery, $hostNameCondition);
     }
@@ -199,52 +250,42 @@ if (isset($preferences['state_type_filter']) && $preferences['state_type_filter'
 
 if (isset($preferences['hostgroup']) && $preferences['hostgroup']) {
     $results = explode(',', $preferences['hostgroup']);
-    $queryHg = '';
-    foreach ($results as $result) {
-        if ($queryHg != '') {
-            $queryHg .= ', ';
-        }
-        $queryHg .= ':id_' . $result;
-        $mainQueryParameters[] = [
-            'parameter' => ':id_' . $result,
-            'value' => (int) $result,
-            'type' => PDO::PARAM_INT,
-        ];
-    }
+    ['parameters' => $hostGroupIdsParameters, 'placeholderList' => $hostGroupList] = createMultipleBindParameters(
+        $results,
+        'hg_id',
+        QueryParameterTypeEnum::INTEGER,
+    );
+
     $hostgroupHgIdCondition = <<<SQL
         h.host_id IN (
               SELECT host_id
               FROM hosts_hostgroups
-              WHERE hostgroup_id IN ({$queryHg}))
+              WHERE hostgroup_id IN ({$hostGroupList}))
         SQL;
+
     $baseQuery = CentreonUtils::conditionBuilder($baseQuery, $hostgroupHgIdCondition);
+
+    $mainQueryParameters = [...$mainQueryParameters, ...$hostGroupIdsParameters];
 }
+
 if (! empty($preferences['display_severities']) && ! empty($preferences['criticality_filter'])) {
-    $tab = explode(',', $preferences['criticality_filter']);
-    $labels = '';
-    foreach ($tab as $p) {
-        if ($labels != '') {
-            $labels .= ',';
-        }
-        $labels .= ':id_' . $p;
-        $mainQueryParameters[] = [
-            'parameter' => ':id_' . $p,
-            'value' => (int) $p,
-            'type' => PDO::PARAM_INT,
-        ];
-    }
+    $severities = explode(',', $preferences['criticality_filter']);
+    ['parameters' => $severityParameters, 'placeholderList' => $severityList] = createMultipleBindParameters(
+        $severities,
+        'severity_id',
+        QueryParameterTypeEnum::INTEGER,
+    );
+
     $SeverityIdCondition
         = "h.host_id IN (
             SELECT DISTINCT host_host_id
             FROM `{$conf_centreon['db']}`.hostcategories_relation
-            WHERE hostcategories_hc_id IN ({$labels}))";
+            WHERE hostcategories_hc_id IN ({$severityList}))";
+
+    $mainQueryParameters = [...$mainQueryParameters, ...$severityParameters];
     $baseQuery = CentreonUtils::conditionBuilder($baseQuery, $SeverityIdCondition);
 }
-if (! $centreon->user->admin) {
-    $pearDB = $db;
-    $aclObj = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
-    $baseQuery .= $aclObj->queryBuilder('AND', 'h.host_id', $aclObj->getHostsString('ID', $dbb));
-}
+
 $orderBy = 'h.name ASC';
 
 $allowedOrderColumns = [
@@ -297,37 +338,17 @@ if ($orderByToAnalyse !== null) {
 $data = [];
 
 try {
-    // Query to count total rows
-    $countQuery = 'SELECT COUNT(*) ' . $baseQuery;
-
     // Main SELECT query
     $query = $columns . $baseQuery;
     $query .= " ORDER BY {$orderBy}";
 
-    $countStatement = $dbb->prepareQuery($countQuery);
-    $statement = $dbb->prepareQuery($query);
-
-    // Bind parameters
-    foreach ($mainQueryParameters as $parameter) {
-        $countStatement->bindValue($parameter['parameter'], $parameter['value'], $parameter['type']);
-        $statement->bindValue($parameter['parameter'], $parameter['value'], $parameter['type']);
-    }
-
-    $dbb->executePreparedQuery($countStatement, $hostBindValues, true);
-    $nbRows = (int) $dbb->fetchColumn($countStatement);
-
-    // Execute the query
-    $dbb->executePreparedQuery($statement, $hostBindValues, true);
-    // Unset parameters
-    unset($parameter, $mainQueryParameters);
-
     $outputLength = $preferences['output_length'] ?? 50;
     $commentLength = $preferences['comment_length'] ?? 50;
-    $hostObj = new CentreonHost($db);
+    $hostObj = new CentreonHost($configurationDatabase);
     $gmt = new CentreonGMT();
     $gmt->getMyGMTFromSession(session_id());
 
-    while ($row = $dbb->fetch($statement)) {
+    foreach ($realtimeDatabase->iterateAssociative($query, QueryParameters::create($mainQueryParameters)) as $row) {
         foreach ($row as $key => $value) {
             if ($key == 'last_check') {
                 $value = $gmt->getDate('Y-m-d H:i:s', $value);
@@ -354,9 +375,9 @@ try {
         }
 
         if (isset($preferences['display_last_comment']) && $preferences['display_last_comment']) {
-            $res2 = $dbb->prepare(
+            $res2 = $realtimeDatabase->prepare(
                 <<<'SQL'
-                    SELECT 
+                    SELECT
                         1 AS REALTIME,
                         data
                     FROM comments

--- a/centreon/www/widgets/host-monitoring/src/index.php
+++ b/centreon/www/widgets/host-monitoring/src/index.php
@@ -312,32 +312,20 @@ if ($orderByToAnalyse !== null) {
     }
 }
 
-try {
-    $stmt = $dbb->prepare($query);
-    $stmt->execute();
-    $records = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-    $hostIds = array_map(
-        fn (array $record) => $record['host_id'],
-        $records,
-    );
-
-    CentreonSession::writeSessionClose(sprintf('w_hm_%d', $widgetId), $hostIds);
-} catch (PDOException $ex) {
-    CentreonLog::create()->error(
-        logTypeId: CentreonLog::TYPE_SQL,
-        message: 'Error while getting  all hosts information for the host monitoring custom view',
-        exception: $ex,
-    );
-
-    throw $ex;
-}
-
 // concatenate order by + limit + offset  to the query
 $baseQuery .= ' ORDER BY ' . $orderBy;
 
 try {
-    $nbRows = (int) $realtimeDatabase->fetchOne('SELECT COUNT(*)' . $baseQuery, QueryParameters::create($mainQueryParameters));
+    $recordIds = $realtimeDatabase->fetchAllAssociative('SELECT h.host_id' . $baseQuery, QueryParameters::create($mainQueryParameters));
+
+    $hostIds = array_map(
+        fn (array $record) => $record['host_id'],
+        $recordIds,
+    );
+
+    $nbRows = count($hostIds);
+
+    CentreonSession::writeSessionClose(sprintf('w_hm_%d', $widgetId), $hostIds);
 } catch (PDOException $e) {
     CentreonLog::create()->error(
         CentreonLog::TYPE_SQL,

--- a/centreon/www/widgets/host-monitoring/src/index.php
+++ b/centreon/www/widgets/host-monitoring/src/index.php
@@ -19,6 +19,9 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
 use App\Kernel;
 use Centreon\Application\Controller\MonitoringResourceController;
 use Centreon\Domain\Log\Logger;
@@ -31,7 +34,7 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'www/class/centreonMedia.class.php';
 require_once $centreon_path . 'www/class/centreonCriticality.class.php';
@@ -41,19 +44,19 @@ if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId']) || ! isset(
     exit;
 }
 
-$db = $dependencyInjector['configuration_db'];
-if (CentreonSession::checkSession(session_id(), $db) == 0) {
+$configurationDatabase = $dependencyInjector['configuration_db'];
+if (CentreonSession::checkSession(session_id(), $configurationDatabase) == 0) {
     exit;
 }
 
 /**
- * @var CentreonDB $dbb
+ * @var CentreonDB $realtimeDatabase
  */
-$dbb = $dependencyInjector['realtime_db'];
+$realtimeDatabase = $dependencyInjector['realtime_db'];
 
 // Init Objects
-$criticality = new CentreonCriticality($db);
-$media = new CentreonMedia($db);
+$criticality = new CentreonCriticality($configurationDatabase);
+$media = new CentreonMedia($configurationDatabase);
 
 // Smarty template initialization
 $path = $centreon_path . 'www/widgets/host-monitoring/src/';
@@ -77,7 +80,7 @@ $page = filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT, ['options' => ['def
 $mainQueryParameters = [];
 
 try {
-    $widgetObj = new CentreonWidget($centreon, $db);
+    $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
 } catch (Exception $e) {
     CentreonLog::create()->error(
@@ -91,47 +94,76 @@ try {
 }
 
 // Default colors
-$stateColors = getColors($db);
+$stateColors = getColors($configurationDatabase);
 // Get status labels
 $stateLabels = getLabels();
 
-$aStateType = ['1' => 'H', '0' => 'S'];
+$aStateType = [
+    '1' => 'H',
+    '0' => 'S',
+];
 
-$query = 'SELECT SQL_CALC_FOUND_ROWS
-    1 AS REALTIME,
-    h.host_id,
-    h.name AS host_name,
-    h.alias,
-    h.flapping,
-    state,
-    state_type,
-    address,
-    last_hard_state,
-    output,
-    scheduled_downtime_depth,
-    acknowledged,
-    notify,
-    active_checks,
-    passive_checks,
-    last_check,
-    last_state_change,
-    last_hard_state_change,
-    check_attempt,
-    max_check_attempts,
-    action_url,
-    notes_url,
-    cv.value AS criticality,
-    h.icon_image,
-    h.icon_image_alt,
-    cv2.value AS criticality_id,
-    cv.name IS NULL as isnull
-    FROM hosts h
-    LEFT JOIN `customvariables` cv
-        ON (cv.host_id = h.host_id AND cv.service_id = 0 AND cv.name = \'CRITICALITY_LEVEL\')
-    LEFT JOIN `customvariables` cv2
-        ON (cv2.host_id = h.host_id AND cv2.service_id = 0 AND cv2.name = \'CRITICALITY_ID\')
-    WHERE enabled = 1
-    AND h.name NOT LIKE \'_Module_%\' ';
+$querySelect = <<<'SQL'
+        SELECT SQL_CALC_FOUND_ROWS
+            1 AS REALTIME,
+            h.host_id,
+            h.name AS host_name,
+            h.alias,
+            h.flapping,
+            state,
+            state_type,
+            address,
+            last_hard_state,
+            output,
+            scheduled_downtime_depth,
+            acknowledged,
+            notify,
+            active_checks,
+            passive_checks,
+            last_check,
+            last_state_change,
+            last_hard_state_change,
+            check_attempt,
+            max_check_attempts,
+            action_url,
+            notes_url,
+            cv.value AS criticality,
+            h.icon_image,
+            h.icon_image_alt,
+            cv2.value AS criticality_id,
+            cv.name IS NULL as isnull
+    SQL;
+
+$baseQuery = <<<'SQL'
+        FROM hosts h
+        LEFT JOIN `customvariables` cv
+            ON (cv.host_id = h.host_id AND cv.service_id = 0 AND cv.name = 'CRITICALITY_LEVEL')
+        LEFT JOIN `customvariables` cv2
+            ON (cv2.host_id = h.host_id AND cv2.service_id = 0 AND cv2.name = 'CRITICALITY_ID')
+    SQL;
+
+if (! $centreon->user->admin) {
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups = $acls->getAccessGroups()->getIds();
+
+    ['parameters' => $accessGroupParameters, 'placeholderList' => $accessGroupList] = createMultipleBindParameters(
+        $accessGroups,
+        'access_group',
+        QueryParameterTypeEnum::INTEGER
+    );
+
+    $baseQuery .= <<<SQL
+            INNER JOIN centreon_acl acl
+                ON h.host_id = acl.host_id
+                AND acl.service_id IS NULL
+                AND acl.group_id IN ({$accessGroupList})
+        SQL;
+
+    $mainQueryParameters = [...$accessGroupParameters, ...$mainQueryParameters];
+}
+
+$baseQuery .= " WHERE enabled = 1 AND h.name NOT LIKE '_Module_%'";
+
 $stateTab = [];
 
 if (isset($preferences['host_name_search']) && $preferences['host_name_search'] != '') {
@@ -143,17 +175,17 @@ if (isset($preferences['host_name_search']) && $preferences['host_name_search'] 
     }
 
     if ($op && isset($search) && $search != '') {
-        $mainQueryParameters[] = ['parameter' => ':host_name_search', 'value' => $search, 'type' => PDO::PARAM_STR];
+        $mainQueryParameters[] = QueryParameter::string('host_name_search', $search);
         $hostNameCondition = 'h.name ' . CentreonUtils::operandToMysqlFormat($op) . ' :host_name_search ';
-        $query = CentreonUtils::conditionBuilder($query, $hostNameCondition);
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, $hostNameCondition);
     }
 }
 
 if (isset($preferences['notification_filter']) && $preferences['notification_filter']) {
     if ($preferences['notification_filter'] == 'enabled') {
-        $query = CentreonUtils::conditionBuilder($query, ' notify = 1');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' notify = 1');
     } elseif ($preferences['notification_filter'] == 'disabled') {
-        $query = CentreonUtils::conditionBuilder($query, ' notify = 0');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' notify = 0');
     }
 }
 
@@ -167,79 +199,76 @@ if (isset($preferences['host_unreachable']) && $preferences['host_unreachable'])
     $stateTab[] = 2;
 }
 if ($stateTab !== []) {
-    $query = CentreonUtils::conditionBuilder($query, ' state IN (' . implode(',', $stateTab) . ')');
+    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' state IN (' . implode(',', $stateTab) . ')');
 }
 if (isset($preferences['acknowledgement_filter']) && $preferences['acknowledgement_filter']) {
     if ($preferences['acknowledgement_filter'] == 'ack') {
-        $query = CentreonUtils::conditionBuilder($query, ' acknowledged = 1');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' acknowledged = 1');
     } elseif ($preferences['acknowledgement_filter'] == 'nack') {
-        $query = CentreonUtils::conditionBuilder($query, ' acknowledged = 0');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' acknowledged = 0');
     }
 }
 
 if (isset($preferences['downtime_filter']) && $preferences['downtime_filter']) {
     if ($preferences['downtime_filter'] == 'downtime') {
-        $query = CentreonUtils::conditionBuilder($query, ' scheduled_downtime_depth > 0 ');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' scheduled_downtime_depth > 0 ');
     } elseif ($preferences['downtime_filter'] == 'ndowntime') {
-        $query = CentreonUtils::conditionBuilder($query, ' scheduled_downtime_depth = 0 ');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' scheduled_downtime_depth = 0 ');
     }
 }
 
 if (isset($preferences['poller_filter']) && $preferences['poller_filter']) {
-    $query = CentreonUtils::conditionBuilder($query, ' instance_id = ' . $preferences['poller_filter'] . ' ');
+    $mainQueryParameters[] = QueryParameter::int('instance_id', (int) $preferences['poller_filter']);
+    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' instance_id = :instance_id ');
 }
 
 if (isset($preferences['state_type_filter']) && $preferences['state_type_filter']) {
     if ($preferences['state_type_filter'] == 'hardonly') {
-        $query = CentreonUtils::conditionBuilder($query, ' state_type = 1 ');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' state_type = 1 ');
     } elseif ($preferences['state_type_filter'] == 'softonly') {
-        $query = CentreonUtils::conditionBuilder($query, ' state_type = 0 ');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' state_type = 0 ');
     }
 }
 
 if (isset($preferences['hostgroup']) && $preferences['hostgroup']) {
     $results = explode(',', $preferences['hostgroup']);
-    $queryHg = '';
-    foreach ($results as $result) {
-        if ($queryHg != '') {
-            $queryHg .= ', ';
-        }
-        $queryHg .= ':id_' . $result;
-        $mainQueryParameters[] = [
-            'parameter' => ':id_' . $result,
-            'value' => (int) $result,
-            'type' => PDO::PARAM_INT,
-        ];
+
+    if ($results !== []) {
+        ['parameters' => $hostGroupIdsParameters, 'placeholderList' => $hostGroupList] = createMultipleBindParameters(
+            $results,
+            'hg_id',
+            QueryParameterTypeEnum::INTEGER,
+        );
+
+        $hostgroupHgIdCondition = <<<SQL
+            h.host_id IN (
+                  SELECT host_id
+                  FROM hosts_hostgroups
+                  WHERE hostgroup_id IN ({$hostGroupList}))
+            SQL;
+
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, $hostgroupHgIdCondition);
+
+        $mainQueryParameters = [...$mainQueryParameters, ...$hostGroupIdsParameters];
     }
-    $hostgroupHgIdCondition = <<<SQL
-        h.host_id IN (
-              SELECT host_id
-              FROM hosts_hostgroups
-              WHERE hostgroup_id IN ({$queryHg}))
+}
+
+if (! empty($preferences['display_severities']) && ! empty($preferences['criticality_filter'])) {
+    $severities = explode(',', $preferences['criticality_filter']);
+
+    ['parameters' => $severityParameters, 'placeholderList' => $severityList] = createMultipleBindParameters(
+        $severities,
+        'severity_id',
+        QueryParameterTypeEnum::INTEGER,
+    );
+
+    $severityIdCondition = <<<SQL
+            cv2.value IN ({$severityList})
         SQL;
-    $query = CentreonUtils::conditionBuilder($query, $hostgroupHgIdCondition);
-}
-if (! empty($preferences['criticality_filter'])) {
-    $tab = explode(',', $preferences['criticality_filter']);
-    $labels = '';
-    foreach ($tab as $p) {
-        if ($labels != '') {
-            $labels .= ',';
-        }
-        $labels .= ':severity_id_' . $p;
-        $mainQueryParameters[] = [
-            'parameter' => ':severity_id_' . $p,
-            'value' => (int) $p,
-            'type' => PDO::PARAM_INT,
-        ];
-    }
-    $severityIdCondition = 'cv2.value IN (' . $labels . ')';
-    $query = CentreonUtils::conditionBuilder($query, $severityIdCondition);
-}
-if (! $centreon->user->admin) {
-    $pearDB = $db;
-    $aclObj = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
-    $query .= $aclObj->queryBuilder('AND', 'h.host_id', $aclObj->getHostsString('ID', $dbb));
+
+    $mainQueryParameters = [...$mainQueryParameters, ...$severityParameters];
+
+    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, $severityIdCondition);
 }
 
 // prepare order_by
@@ -305,41 +334,10 @@ try {
 }
 
 // concatenate order by + limit + offset  to the query
-$query .= 'ORDER BY ' . $orderBy . ' LIMIT :limit OFFSET :offset';
-
-$num = filter_var($preferences['entries'], FILTER_VALIDATE_INT) ?: 10;
-$mainQueryParameters[] = [
-    'parameter' => 'limit',
-    'value' => $num,
-    'type' => PDO::PARAM_INT,
-];
-$mainQueryParameters[] = [
-    'parameter' => 'offset',
-    'value' => ($page * $num),
-    'type' => PDO::PARAM_INT,
-];
+$baseQuery .= ' ORDER BY ' . $orderBy;
 
 try {
-    $res = $dbb->prepare($query);
-    foreach ($mainQueryParameters as $parameter) {
-        $res->bindValue($parameter['parameter'], $parameter['value'], $parameter['type']);
-    }
-    $res->execute();
-} catch (PDOException $e) {
-    CentreonLog::create()->error(
-        CentreonLog::TYPE_SQL,
-        'Error while getting hosts for the host monitoring custom view',
-        ['pdo_info' => $e->errorInfo, 'query_parameters' => $mainQueryParameters],
-        $e
-    );
-
-    throw $e;
-}
-
-unset($mainQueryParameters);
-
-try {
-    $nbRows = (int) $dbb->query('SELECT FOUND_ROWS() AS REALTIME')->fetchColumn();
+    $nbRows = (int) $realtimeDatabase->fetchOne('SELECT COUNT(*)' . $baseQuery, QueryParameters::create($mainQueryParameters));
 } catch (PDOException $e) {
     CentreonLog::create()->error(
         CentreonLog::TYPE_SQL,
@@ -351,12 +349,32 @@ try {
     throw $e;
 }
 
+$query = $querySelect . $baseQuery . ' LIMIT :limit OFFSET :offset';
+
+$num = filter_var($preferences['entries'], FILTER_VALIDATE_INT) ?: 10;
+
+$mainQueryParameters[] = QueryParameter::int('limit', $num);
+$mainQueryParameters[] = QueryParameter::int('offset', ($page * $num));
+
+try {
+    $records = $realtimeDatabase->fetchAllAssociative($query, QueryParameters::create($mainQueryParameters));
+} catch (PDOException $e) {
+    CentreonLog::create()->error(
+        CentreonLog::TYPE_SQL,
+        'Error while getting hosts for the host monitoring custom view',
+        ['pdo_info' => $e->errorInfo, 'query_parameters' => $mainQueryParameters],
+        $e
+    );
+
+    throw $e;
+}
+
 $data = [];
 $outputLength = $preferences['output_length'] ?: 50;
 $commentLength = $preferences['comment_length'] ?: 50;
 
 try {
-    $hostObj = new CentreonHost($db);
+    $hostObj = new CentreonHost($configurationDatabase);
 } catch (PDOException $e) {
     CentreonLog::create()->error(
         CentreonLog::TYPE_SQL,
@@ -372,9 +390,8 @@ $gmt = new CentreonGMT();
 $gmt->getMyGMTFromSession(session_id());
 $allowedActionProtocols = ['http[s]?', '//', 'ssh', 'rdp', 'ftp', 'sftp'];
 $allowedProtocolsRegex = '#(^' . implode(')|(^', $allowedActionProtocols) . ')#';
-// String starting with one of these protocols
 
-while ($row = $res->fetch()) {
+foreach ($records as $row) {
     foreach ($row as $key => $value) {
         $data[$row['host_id']][$key] = $value;
     }
@@ -384,7 +401,7 @@ while ($row = $res->fetch()) {
     $valueLastCheckTimestamp = time() - $valueLastCheck;
     if (
         $valueLastCheckTimestamp > 0
-        && $valueLastCheckTimestamp < 3600
+            && $valueLastCheckTimestamp < 3600
     ) {
         $valueLastCheck = CentreonDuration::toString($valueLastCheckTimestamp) . ' ago';
     }
@@ -425,8 +442,8 @@ while ($row = $res->fetch()) {
 
     $resourceController = $kernel->getContainer()->get(MonitoringResourceController::class);
     $data[$row['host_id']]['details_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=20202&o=hd&host_name=' . $row['host_name']
-        : $resourceController->buildHostDetailsUri($row['host_id']);
+    ? '../../main.php?p=20202&o=hd&host_name=' . $row['host_name']
+    : $resourceController->buildHostDetailsUri($row['host_id']);
 
     // action_url
     $valueActionUrl = $row['action_url'];
@@ -470,15 +487,14 @@ while ($row = $res->fetch()) {
 
     if (isset($preferences['display_last_comment']) && $preferences['display_last_comment']) {
         try {
-            $query = <<<'SQL'
-                    SELECT data FROM comments where host_id = :hostId
-                    AND service_id = 0 ORDER BY entry_time DESC LIMIT 1
+            $baseQuery = <<<'SQL'
+                SELECT data FROM comments where host_id = :hostId
+                AND service_id = 0 ORDER BY entry_time DESC LIMIT 1
                 SQL;
-            $res2 = $dbb->prepare($query);
+            $res2 = $realtimeDatabase->prepare($baseQuery);
             $res2->bindValue(':hostId', $row['host_id'], PDO::PARAM_INT);
             $res2->execute();
             $data[$row['host_id']]['comment'] = ($row2 = $res2->fetch()) ? substr($row2['data'], 0, $commentLength) : '-';
-            $res2->closeCursor();
         } catch (PDOException $e) {
             CentreonLog::create()->error(
                 CentreonLog::TYPE_SQL,
@@ -503,8 +519,6 @@ while ($row = $res->fetch()) {
     }
     $data[$row['host_id']]['class_tr'] = $class;
 }
-
-$res->closeCursor();
 
 $aColorHost = [
     0 => 'host_up',

--- a/centreon/www/widgets/host-monitoring/src/sendCmd.php
+++ b/centreon/www/widgets/host-monitoring/src/sendCmd.php
@@ -23,7 +23,6 @@ require_once '../../require.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonDB.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'www/class/centreonService.class.php';
 require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';

--- a/centreon/www/widgets/host-monitoring/src/toolbar.php
+++ b/centreon/www/widgets/host-monitoring/src/toolbar.php
@@ -26,7 +26,6 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 
 session_start();
 if (! isset($_SESSION['centreon']) || ! isset($_POST['widgetId'])) {

--- a/centreon/www/widgets/hostgroup-monitoring/index.php
+++ b/centreon/www/widgets/hostgroup-monitoring/index.php
@@ -20,6 +20,7 @@
  */
 
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonDB.class.php';
@@ -29,6 +30,7 @@ CentreonSession::start(1);
 if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId'])) {
     exit;
 }
+
 $centreon = $_SESSION['centreon'];
 $widgetId = filter_var($_REQUEST['widgetId'], FILTER_VALIDATE_INT);
 
@@ -49,8 +51,20 @@ try {
         'dark' => 'Centreon-Dark',
         default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
     };
-} catch (Exception $e) {
-    echo $e->getMessage() . '<br/>';
+
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error while using hostgroup-monitoring widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
 }

--- a/centreon/www/widgets/hostgroup-monitoring/src/class/HostgroupMonitoring.class.php
+++ b/centreon/www/widgets/hostgroup-monitoring/src/class/HostgroupMonitoring.class.php
@@ -19,6 +19,10 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Core\Security\AccessGroup\Domain\Collection\AccessGroupCollection;
+
 class HostgroupMonitoring
 {
     protected $dbb;
@@ -38,28 +42,59 @@ class HostgroupMonitoring
      * Get Host States
      *
      * @param $data | array('name' => '', 'host_state' => array(), 'service_state' => array())
-     * @param int $detailFlag
-     * @param int $admin
-     * @param CentreonACL $aclObj
-     * @param array $preferences
+     * @param bool $isUserAdmin
+     * @param AccessGroupCollection $accessGroups
+     * @param bool $detailFlag
      */
-    public function getHostStates(&$data, $admin, $aclObj, $preferences, $detailFlag = false)
-    {
-        if (! count($data)) {
+    public function getHostStates(
+        array &$data,
+        bool $isUserAdmin,
+        AccessGroupCollection $accessGroups,
+        bool $detailFlag = false,
+    ) {
+        if (
+            $data === []
+            || (! $isUserAdmin && $accessGroups->isEmpty())
+        ) {
             return [];
         }
-        $query = "SELECT 1 AS REALTIME, h.host_id, h.state, h.name, h.alias, hhg.hostgroup_id, hg.name as hgname
-            FROM hosts_hostgroups hhg, hosts h, hostgroups hg
-            WHERE h.host_id = hhg.host_id
-            AND h.enabled = 1
-            AND hhg.hostgroup_id = hg.hostgroup_id
-            AND hg.name IN ('" . implode("', '", array_keys($data)) . "') ";
-        if (! $admin) {
-            $query .= $aclObj->queryBuilder('AND', 'h.host_id', $aclObj->getHostsString('ID', $this->dbb));
+
+        ['parameters' => $queryParameters, 'placeholderList' => $hostGroupNameList] = createMultipleBindParameters(
+            array_keys($data),
+            'hg_name',
+            QueryParameterTypeEnum::STRING,
+        );
+
+        $query = <<<SQL
+                SELECT
+                    1 AS REALTIME,
+                    h.host_id,
+                    h.state,
+                    h.name,
+                    h.alias,
+                    hhg.hostgroup_id,
+                    hg.name AS hgname
+                FROM hosts h
+                INNER JOIN hosts_hostgroups hhg
+                    ON h.host_id = hhg.host_id
+                INNER JOIN hostgroups hg
+                    ON hhg.hostgroup_id = hg.hostgroup_id
+                    AND hg.name IN ({$hostGroupNameList})
+            SQL;
+
+        if (! $isUserAdmin) {
+            $accessGroupsList = implode(', ', $accessGroups->getIds());
+
+            $query .= <<<SQL
+                    INNER JOIN centreon_acl
+                        ON centreon_acl.host_id = h.host_id
+                        AND centreon_acl.group_id IN ({$accessGroupsList})
+                SQL;
         }
-        $query .= ' ORDER BY h.name ';
-        $res = $this->dbb->query($query);
-        while ($row = $res->fetch()) {
+
+        $query .= ' WHERE h.enabled = 1 ORDER BY h.name';
+
+        foreach ($this->dbb->iterateAssociative($query, QueryParameters::create($queryParameters)) as $row) {
             $k = $row['hgname'];
             if ($detailFlag === true) {
                 if (! isset($data[$k]['host_state'][$row['name']])) {
@@ -80,38 +115,72 @@ class HostgroupMonitoring
     /**
      * Get Service States
      *
-     * @param array $data | array('name' => '', 'host_state' => array(), 'service_state' => array())
-     * @param int $detailFlag
-     * @param int $admin
-     * @param CentreonACL $aclObj
-     * @param array $preferences
+     * @param array $data
+     * @param bool $isUserAdmin
+     * @param AccessGroupCollection $accessGroups
+     * @param bool $detailFlag
      */
-    public function getServiceStates(&$data, $admin, $aclObj, $preferences, $detailFlag = false)
-    {
-        if (! count($data)) {
+    public function getServiceStates(
+        array &$data,
+        bool $isUserAdmin,
+        AccessGroupCollection $accessGroups,
+        bool $detailFlag = false,
+    ) {
+        if (
+            $data === []
+            || (! $isUserAdmin && $accessGroups->isEmpty())
+        ) {
             return [];
         }
-        $query = 'SELECT DISTINCT 1 AS REALTIME,
-                h.host_id, s.state, h.name, s.service_id, s.description, hhg.hostgroup_id, hg.name as hgname,
-                (case s.state when 0 then 3 when 2 then 0 when 3 then 2  when 3 then 2 else s.state END) as tri
-            FROM hosts_hostgroups hhg, hosts h, services s, hostgroups hg ';
-        if (! $admin) {
-            $query .= ', centreon_acl acl ';
+
+        ['parameters' => $queryParameters, 'placeholderList' => $hostGroupNameList] = createMultipleBindParameters(
+            array_keys($data),
+            'hg_name',
+            QueryParameterTypeEnum::STRING,
+        );
+
+        $query = <<<SQL
+                SELECT
+                    1 AS REALTIME,
+                    h.host_id,
+                    h.name,
+                    s.service_id,
+                    s.description,
+                    s.state,
+                    hhg.hostgroup_id,
+                    hg.name as hgname,
+                    CASE s.state
+                        WHEN 0 THEN 3
+                        WHEN 2 THEN 0
+                        WHEN 3 THEN 2
+                        ELSE s.state
+                    END AS tri
+                FROM hosts h
+                INNER JOIN hosts_hostgroups hhg
+                    ON h.host_id = hhg.host_id
+                INNER JOIN services s
+                    ON s.host_id = h.host_id
+                INNER JOIN hostgroups hg
+                    ON hg.hostgroup_id = hhg.hostgroup_id
+                    AND hg.name IN ({$hostGroupNameList})
+            SQL;
+
+        if (! $isUserAdmin) {
+            $accessGroupsList = implode(', ', $accessGroups->getIds());
+
+            $query .= <<<SQL
+                    INNER JOIN centreon_acl
+                        ON centreon_acl.host_id = h.host_id
+                        AND centreon_acl.service_id = s.service_id
+                        AND centreon_acl.group_id IN ({$accessGroupsList})
+                SQL;
         }
-        $query .= "WHERE h.host_id = hhg.host_id
-            AND hhg.host_id = s.host_id
-            AND s.enabled = 1
-            AND h.enabled = 1
-            AND hhg.hostgroup_id = hg.hostgroup_id
-            AND hg.name IN ('" . implode("', '", array_keys($data)) . "') ";
-        if (! $admin) {
-            $query .= ' AND h.host_id = acl.host_id
-                AND acl.service_id = s.service_id
-                AND acl.group_id IN (' . $aclObj->getAccessGroupsString() . ')';
-        }
-        $query .= ' ORDER BY tri, description ASC';
-        $res = $this->dbb->query($query);
-        while ($row = $res->fetch()) {
+
+        $query .= <<<'SQL'
+                WHERE s.enabled = 1 AND h.enabled = 1 ORDER BY tri, s.description ASC
+            SQL;
+
+        foreach ($this->dbb->iterateAssociative($query, QueryParameters::create($queryParameters)) as $row) {
             $k = $row['hgname'];
             if ($detailFlag === true) {
                 if (! isset($data[$k]['service_state'][$row['host_id']])) {

--- a/centreon/www/widgets/hostgroup-monitoring/src/export.php
+++ b/centreon/www/widgets/hostgroup-monitoring/src/export.php
@@ -19,6 +19,10 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Security\AccessGroup\Domain\Collection\AccessGroupCollection;
+
 header('Content-type: application/csv');
 header('Content-Disposition: attachment; filename="hostgroups-monitoring.csv"');
 
@@ -29,7 +33,6 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/include/common/sqlCommonFunction.php';
 require_once $centreon_path . 'www/widgets/hostgroup-monitoring/src/class/HostgroupMonitoring.class.php';
 
@@ -37,8 +40,12 @@ session_start();
 if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId'])) {
     exit;
 }
-$db = new CentreonDB();
-if (CentreonSession::checkSession(session_id(), $db) == 0) {
+
+/**
+ * @var CentreonDB $configurationDatabase
+ */
+$configurationDatabase = new CentreonDB();
+if (CentreonSession::checkSession(session_id(), $configurationDatabase) == 0) {
     exit;
 }
 
@@ -52,24 +59,62 @@ if ($widgetId === false) {
     throw new InvalidArgumentException('Widget ID must be an integer');
 }
 
-$dbb = $dependencyInjector['realtime_db'];
-$widgetObj = new CentreonWidget($centreon, $db);
-$sgMonObj = new HostgroupMonitoring($dbb);
+/**
+ * @var CentreonDB $realtimeDatabase
+ */
+$realtimeDatabase = $dependencyInjector['realtime_db'];
+$widgetObj = new CentreonWidget($centreon, $configurationDatabase);
+$hostGroupService = new HostgroupMonitoring($realtimeDatabase);
 $preferences = $widgetObj->getWidgetPreferences($widgetId);
-$aclObj = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
 
-$hostStateLabels = [0 => 'Up', 1 => 'Down', 2 => 'Unreachable', 4 => 'Pending'];
+$hostStateLabels = [
+    0 => 'Up',
+    1 => 'Down',
+    2 => 'Unreachable',
+    4 => 'Pending',
+];
 
-$serviceStateLabels = [0 => 'Ok', 1 => 'Warning', 2 => 'Critical', 3 => 'Unknown', 4 => 'Pending'];
+$serviceStateLabels = [
+    0 => 'Ok',
+    1 => 'Warning',
+    2 => 'Critical',
+    3 => 'Unknown',
+    4 => 'Pending',
+];
 
 const ORDER_DIRECTION_ASC = 'ASC';
 const ORDER_DIRECTION_DESC = 'DESC';
+
+$accessGroups = new AccessGroupCollection();
+
+if (! $centreon->user->admin) {
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups->mergeWith($acls->getAccessGroups());
+}
 
 try {
     $columns = 'SELECT DISTINCT 1 AS REALTIME, name ';
     $baseQuery = ' FROM hostgroups';
 
-    $bindParams = [];
+    $queryParameters = [];
+
+    if (! $centreon->user->admin) {
+        $accessGroupsList = implode(',', $accessGroups->getIds());
+        $configurationDatabaseName = $configurationDatabase->getConnectionConfig()->getDatabaseNameConfiguration();
+        $baseQuery .= <<<SQL
+                INNER JOIN {$configurationDatabaseName}.acl_resources_hg_relations arhr
+                    ON hostgroups.hostgroup_id = arhr.hg_hg_id
+                INNER JOIN {$configurationDatabaseName}.acl_resources res
+                    ON arhr.acl_res_id = res.acl_res_id
+                INNER JOIN {$configurationDatabaseName}.acl_res_group_relations argr
+                    ON res.acl_res_id = argr.acl_res_id
+                INNER JOIN {$configurationDatabaseName}.acl_groups ag
+                    ON argr.acl_group_id = ag.acl_group_id
+                    AND ag.acl_group_id IN ({$accessGroupsList})
+            SQL;
+
+    }
+
     if (isset($preferences['hg_name_search']) && trim($preferences['hg_name_search']) !== '') {
         $tab = explode(' ', $preferences['hg_name_search']);
         $op = $tab[0];
@@ -81,15 +126,10 @@ try {
                 $baseQuery,
                 'name ' . CentreonUtils::operandToMysqlFormat($op) . ' :search '
             );
-            $bindParams[':search'] = [$search, PDO::PARAM_STR];
+            $queryParameters[] = QueryParameter::string('search', $search);
         }
     }
 
-    if (! $centreon->user->admin) {
-        [$bindValues, $bindQuery] = createMultipleBindQuery($aclObj->getHostGroups(), ':hostgroup_name_', PDO::PARAM_STR);
-        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, "name IN ({$bindQuery})");
-        $bindParams = array_merge($bindParams, $bindValues);
-    }
     $orderby = 'name ' . ORDER_DIRECTION_ASC;
 
     $allowedOrderColumns = ['name'];
@@ -116,31 +156,15 @@ try {
     $query = $columns . $baseQuery;
     $query .= " ORDER BY {$orderby}";
 
-    // Execute count query
-    if ($bindParams !== []) {
-        $countStatement = $dbb->prepareQuery($countQuery);
-        $dbb->executePreparedQuery($countStatement, $bindParams, true);
-    } else {
-        $countStatement = $dbb->executeQuery($countQuery);
-    }
-
-    $nbRows = (int) $dbb->fetchColumn($countStatement);
-
-    // Execute main query
-    if ($bindParams !== []) {
-        $statement = $dbb->prepareQuery($query);
-        $dbb->executePreparedQuery($statement, $bindParams, true);
-    } else {
-        $statement = $dbb->executeQuery($query);
-    }
+    $nbRows = (int) $realtimeDatabase->fetchOne($countQuery, QueryParameters::create($queryParameters));
 
     $detailMode = false;
     if (isset($preferences['enable_detailed_mode']) && $preferences['enable_detailed_mode']) {
         $detailMode = true;
     }
     $data = [];
-    while ($row = $dbb->fetch($statement)) {
-        $name = HtmlSanitizer::createFromString($row['name'])->sanitize()->getString();
+    foreach ($realtimeDatabase->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+        $name = HtmlSanitizer::createFromString($record['name'])->sanitize()->getString();
         $data[$name]['name'] = $name;
     }
 } catch (CentreonDbException $e) {
@@ -153,8 +177,18 @@ try {
     throw new Exception('Error fetching hostgroup monitoring usage data for export: ' . $e->getMessage());
 }
 
-$sgMonObj->getHostStates($data, $centreon->user->admin, $aclObj, $preferences, $detailMode);
-$sgMonObj->getServiceStates($data, $centreon->user->admin, $aclObj, $preferences, $detailMode);
+$hostGroupService->getHostStates(
+    $data,
+    $centreon->user->admin === '1',
+    $accessGroups,
+    $detailMode,
+);
+$hostGroupService->getServiceStates(
+    $data,
+    $centreon->user->admin === '1',
+    $accessGroups,
+    $detailMode,
+);
 
 $template->assign('preferences', $preferences);
 $template->assign('hostStateLabels', $hostStateLabels);

--- a/centreon/www/widgets/hostgroup-monitoring/src/index.php
+++ b/centreon/www/widgets/hostgroup-monitoring/src/index.php
@@ -19,24 +19,35 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Security\AccessGroup\Domain\Collection\AccessGroupCollection;
+
 require_once '../../require.php';
+require_once '../../widget-error-handling.php';
 require_once $centreon_path . 'bootstrap.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/widgets/hostgroup-monitoring/src/class/HostgroupMonitoring.class.php';
 require_once $centreon_path . 'www/include/common/sqlCommonFunction.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
 
 CentreonSession::start(1);
 
 if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId']) || ! isset($_REQUEST['page'])) {
     exit;
 }
-$db = $dependencyInjector['configuration_db'];
-if (CentreonSession::checkSession(session_id(), $db) == 0) {
+
+/**
+ * @var CentreonDB $configurationDatabase
+ */
+$configurationDatabase = $dependencyInjector['configuration_db'];
+
+if (CentreonSession::checkSession(session_id(), $configurationDatabase) == 0) {
     exit;
 }
 
@@ -61,37 +72,107 @@ try {
     if ($page === false) {
         throw new InvalidArgumentException('Page must be an integer');
     }
-} catch (InvalidArgumentException $e) {
-    echo $e->getMessage();
+
+    $variablesThemeCSS = match ($centreon->user->theme) {
+        'light' => 'Generic-theme',
+        'dark' => 'Centreon-Dark',
+        default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
+    };
+
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error while using hostgroup-monitoring widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
 }
 
 /**
- * @var CentreonDB $dbb
+ * @var CentreonDB $realtimeDatabase
  */
-$dbb = $dependencyInjector['realtime_db'];
-$widgetObj = new CentreonWidget($centreon, $db);
-$hgMonObj = new HostgroupMonitoring($dbb);
+$realtimeDatabase = $dependencyInjector['realtime_db'];
+
+$widgetObj = new CentreonWidget($centreon, $configurationDatabase);
+$hostGroupMonitoringService = new HostgroupMonitoring($realtimeDatabase);
 $preferences = $widgetObj->getWidgetPreferences($widgetId);
-$aclObj = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
 
-$aColorHost = [0 => 'host_up', 1 => 'host_down', 2 => 'host_unreachable', 4 => 'host_pending'];
-$aColorService = [0 => 'service_ok', 1 => 'service_warning', 2 => 'service_critical', 3 => 'service_unknown', 4 => 'pending'];
+$aColorHost = [
+    0 => 'host_up',
+    1 => 'host_down',
+    2 => 'host_unreachable',
+    4 => 'host_pending',
+];
+$aColorService = [
+    0 => 'service_ok',
+    1 => 'service_warning',
+    2 => 'service_critical',
+    3 => 'service_unknown',
+    4 => 'pending',
+];
 
-$hostStateLabels = [0 => 'Up', 1 => 'Down', 2 => 'Unreachable', 4 => 'Pending'];
+$hostStateLabels = [
+    0 => 'Up',
+    1 => 'Down',
+    2 => 'Unreachable',
+    4 => 'Pending',
+];
 
-$serviceStateLabels = [0 => 'Ok', 1 => 'Warning', 2 => 'Critical', 3 => 'Unknown', 4 => 'Pending'];
+$serviceStateLabels = [
+    0 => 'Ok',
+    1 => 'Warning',
+    2 => 'Critical',
+    3 => 'Unknown',
+    4 => 'Pending',
+];
 
 const ORDER_DIRECTION_ASC = 'ASC';
 const ORDER_DIRECTION_DESC = 'DESC';
 const DEFAULT_ENTRIES_PER_PAGE = 10;
 
+$accessGroups = new AccessGroupCollection();
+
+if (! $centreon->user->admin) {
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups->mergeWith($acls->getAccessGroups());
+}
+
 try {
     $columns = 'SELECT DISTINCT 1 AS REALTIME, name, hostgroup_id ';
     $baseQuery = ' FROM hostgroups';
 
-    $bindParams = [];
+    $queryParameters = [];
+
+    if (! $centreon->user->admin) {
+        // Shortcut the request and make it return nothing if user has no accessgroups.
+        if ($accessGroups->isEmpty()) {
+            $baseQuery .= ' WHERE 1 = 0';
+        } else {
+            $accessGroupsList = implode(',', $accessGroups->getIds());
+            $configurationDatabaseName = $configurationDatabase->getConnectionConfig()->getDatabaseNameConfiguration();
+            $baseQuery .= <<<SQL
+                    INNER JOIN {$configurationDatabaseName}.acl_resources_hg_relations arhr
+                        ON hostgroups.hostgroup_id = arhr.hg_hg_id
+                    INNER JOIN {$configurationDatabaseName}.acl_resources res
+                        ON arhr.acl_res_id = res.acl_res_id
+                    INNER JOIN {$configurationDatabaseName}.acl_res_group_relations argr
+                        ON res.acl_res_id = argr.acl_res_id
+                    INNER JOIN {$configurationDatabaseName}.acl_groups ag
+                        ON argr.acl_group_id = ag.acl_group_id
+                        AND ag.acl_group_id IN ({$accessGroupsList})
+                SQL;
+        }
+
+    }
+
     if (isset($preferences['hg_name_search']) && trim($preferences['hg_name_search']) !== '') {
         $tab = explode(' ', $preferences['hg_name_search']);
         $op = $tab[0];
@@ -103,14 +184,8 @@ try {
                 $baseQuery,
                 'name ' . CentreonUtils::operandToMysqlFormat($op) . ' :search '
             );
-            $bindParams[':search'] = [$search, PDO::PARAM_STR];
+            $queryParameters[] = QueryParameter::string('search', $search);
         }
-    }
-
-    if (! $centreon->user->admin) {
-        [$bindValues, $bindQuery] = createMultipleBindQuery($aclObj->getHostGroups(), ':hostgroup_name_', PDO::PARAM_STR);
-        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, "name IN ({$bindQuery})");
-        $bindParams = array_merge($bindParams, $bindValues);
     }
 
     $orderby = 'name ' . ORDER_DIRECTION_ASC;
@@ -140,33 +215,17 @@ try {
     $offset = max(0, $page) * $entriesPerPage;
 
     // Query to count total rows
-    $countQuery = 'SELECT COUNT(*) ' . $baseQuery;
+    $countQuery = 'SELECT COUNT(DISTINCT hostgroups.hostgroup_id) ' . $baseQuery;
+
+    $nbRows = (int) $realtimeDatabase->fetchOne($countQuery, QueryParameters::create($queryParameters));
 
     // Main SELECT query with LIMIT
     $query = $columns . $baseQuery;
     $query .= " ORDER BY {$orderby}";
     $query .= ' LIMIT :offset, :entriesPerPage';
 
-    // Execute count query
-    if ($bindParams !== []) {
-        $countStatement = $dbb->prepareQuery($countQuery);
-        $dbb->executePreparedQuery($countStatement, $bindParams, true);
-    } else {
-        $countStatement = $dbb->executeQuery($countQuery);
-    }
-
-    $nbRows = (int) $dbb->fetchColumn($countStatement);
-
-    $bindParams[':offset'] = [$offset, PDO::PARAM_INT];
-    $bindParams[':entriesPerPage'] = [$entriesPerPage, PDO::PARAM_INT];
-
-    // Execute main query
-    if ($bindParams !== []) {
-        $statement = $dbb->prepareQuery($query);
-        $dbb->executePreparedQuery($statement, $bindParams, true);
-    } else {
-        $statement = $dbb->executeQuery($query);
-    }
+    $queryParameters[] = QueryParameter::int('offset', $offset);
+    $queryParameters[] = QueryParameter::int('entriesPerPage', $entriesPerPage);
 
     $data = [];
     $detailMode = false;
@@ -234,7 +293,7 @@ try {
     $downStatus = $buildParameter('DOWN', 'Down');
     $unreachableStatus = $buildParameter('UNREACHABLE', 'Unreachable');
 
-    while ($row = $dbb->fetch($statement)) {
+    foreach ($realtimeDatabase->fetchAllAssociative($query, QueryParameters::create($queryParameters)) as $row) {
         $hostgroup = [
             'id' => (int) $row['hostgroup_id'],
             'name' => HtmlSanitizer::createFromString($row['name'])->sanitize()->getString(),
@@ -303,7 +362,7 @@ try {
             'service_state' => [],
         ];
     }
-} catch (CentreonDbException $e) {
+} catch (ConnectionException $e) {
     CentreonLog::create()->error(
         logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
         message: 'Error while fetching hostgroup monitoring data: ' . $e->getMessage(),
@@ -312,8 +371,9 @@ try {
 
     throw new Exception('Error while fetching hostgroup monitoring data: ' . $e->getMessage());
 }
-$hgMonObj->getHostStates($data, $centreon->user->admin, $aclObj, $preferences, $detailMode);
-$hgMonObj->getServiceStates($data, $centreon->user->admin, $aclObj, $preferences, $detailMode);
+
+$hostGroupMonitoringService->getHostStates($data, (int) $centreon->user->admin === 1, $accessGroups, $detailMode);
+$hostGroupMonitoringService->getServiceStates($data, (int) $centreon->user->admin === 1, $accessGroups, $detailMode);
 
 if ($detailMode === true) {
     foreach ($data as $hostgroupName => &$properties) {

--- a/centreon/www/widgets/httploader/index.php
+++ b/centreon/www/widgets/httploader/index.php
@@ -20,6 +20,7 @@
  */
 
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
@@ -63,33 +64,18 @@ try {
     if ($website === false) {
         throw new Exception(_('The URL provided for the website does not use a valid URL pattern.'));
     }
-} catch (Exception $e) {
-    showError($e->getMessage(), $theme);
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error while using httploader widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
-}
-
-function showError(string $message, string $theme)
-{
-    $escapedMessage = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
-    $escapedTheme = htmlspecialchars($theme, ENT_QUOTES, 'UTF-8');
-    echo <<<HTML
-        <!DOCTYPE html>
-        <html>
-            <head>
-                <meta charset="UTF-8">
-                <title>Error</title>
-                <link href="../../Themes/Generic-theme/style.css" rel="stylesheet" type="text/css"/>
-                <link href="../../Themes/Generic-theme/color.css" rel="stylesheet" type="text/css"/>
-                <link href="../../Themes/{$escapedTheme}/variables.css" rel="stylesheet" type="text/css"/>
-            </head>
-            <body>
-                <div class="update" style="text-align: center; width: 350px; margin: 0 auto;">
-                    {$escapedMessage}
-                </div>
-            </body>
-        </html>
-        HTML;
 }
 
 ?>

--- a/centreon/www/widgets/live-top10-cpu-usage/index.php
+++ b/centreon/www/widgets/live-top10-cpu-usage/index.php
@@ -19,14 +19,21 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Security\AccessGroup\Domain\Collection\AccessGroupCollection;
+
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
 require_once $centreon_path . 'bootstrap.php';
 
 CentreonSession::start(1);
@@ -38,7 +45,6 @@ if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId'])) {
 $centreon = $_SESSION['centreon'];
 
 $widgetId = filter_var($_REQUEST['widgetId'], FILTER_VALIDATE_INT);
-$grouplistStr = '';
 
 /**
  * true: URIs will correspond to deprecated pages
@@ -50,12 +56,18 @@ try {
     if ($widgetId === false) {
         throw new InvalidArgumentException('Widget ID must be an integer');
     }
-    $db_centreon = $dependencyInjector['configuration_db'];
-    $db = $dependencyInjector['realtime_db'];
+    $configurationDatabase = $dependencyInjector['configuration_db'];
 
-    $widgetObj = new CentreonWidget($centreon, $db_centreon);
+    /**
+     * @var CentreonDB $realtimeDatabase
+     */
+    $realtimeDatabase = $dependencyInjector['realtime_db'];
+
+    $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
+
     $autoRefresh = filter_var($preferences['refresh_interval'], FILTER_VALIDATE_INT);
+
     if ($autoRefresh === false || $autoRefresh < 5) {
         $autoRefresh = 30;
     }
@@ -64,8 +76,20 @@ try {
         'dark' => 'Centreon-Dark',
         default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
     };
-} catch (Exception $e) {
-    echo $e->getMessage() . '<br/>';
+
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error fetching data for live-top10-cpu-usage widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
 }
@@ -75,12 +99,11 @@ $resourceController = $kernel->getContainer()->get(
     Centreon\Application\Controller\MonitoringResourceController::class
 );
 
-// configure smarty
+$accessGroups = new AccessGroupCollection();
 
-if ($centreon->user->admin == 0) {
-    $access = new CentreonACL($centreon->user->get_id());
-    $grouplist = $access->getAccessGroups();
-    $grouplistStr = $access->getAccessGroupsString();
+if (! $centreon->user->admin) {
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups->mergeWith($acls->getAccessGroups());
 }
 
 // Smarty template initialization
@@ -90,82 +113,98 @@ $template = SmartyBC::createSmartyTemplate($path, './');
 $data = [];
 
 try {
-    $query = 'SELECT
-            1 AS REALTIME,
-            i.host_name,
-            i.service_description,
-            i.service_id,
-            i.host_id,
-            AVG(m.current_value) AS current_value,
-            s.state AS status
-        FROM
-            metrics m,
-            hosts h '
-        . ($preferences['host_group'] ? ', hosts_hostgroups hg ' : '')
-        . ($centreon->user->admin == 0 ? ', centreon_acl acl ' : '')
-        . ' , index_data i
-        LEFT JOIN services s ON s.service_id  = i.service_id AND s.enabled = 1
-        WHERE i.service_description LIKE :service_description
-        AND i.id = m.index_id
-        AND m.metric_name LIKE :metric_name
-        AND current_value <= 100
-        AND i.host_id = h.host_id '
-        . ($preferences['host_group']
-            ? 'AND hg.hostgroup_id = :host_group AND i.host_id = hg.host_id ' : '');
-    if ($centreon->user->admin == 0) {
-        $query .= 'AND i.host_id = acl.host_id
-            AND i.service_id = acl.service_id
-            AND acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')';
-    }
-    $query .= 'AND s.enabled = 1
-            AND h.enabled = 1
-        GROUP BY i.host_id,
-            i.service_id,
-            i.host_name,
-            i.service_description,
-            s.state
-        ORDER BY current_value DESC
-        LIMIT :nb_lin;';
+    if ($centreon->user->admin || ! $accessGroups->isEmpty()) {
+        $queryParameters = [];
+        $query = <<<'SQL'
+                SELECT
+                    1 AS REALTIME,
+                    i.host_name,
+                    i.service_description,
+                    i.service_id,
+                    i.host_id,
+                    AVG(m.current_value) AS current_value,
+                    s.state AS status
+                FROM index_data i
+                INNER JOIN metrics m
+                    ON i.id = m.index_id
+                INNER JOIN hosts h
+                    ON i.host_id = h.host_id
+                LEFT JOIN services s
+                    ON s.service_id = i.service_id
+                    AND s.enabled = 1
+            SQL;
 
-    $numLine = 1;
+        if ($preferences['host_group']) {
+            $query .= <<<'SQL'
+                    INNER JOIN hosts_hostgroups hg
+                        ON i.host_id = hg.host_id
+                        AND hg.hostgroup_id = :hostGroupId
+                SQL;
 
-    $statement = $db->prepareQuery($query);
+            $queryParameters[] = QueryParameter::int('hostGroupId', (int) $preferences['host_group']);
+        }
 
-    $bindParams = [
-        ':service_description' => ['%' . $preferences['service_description'] . '%', PDO::PARAM_STR],
-        ':metric_name' => ['%' . $preferences['metric_name'] . '%', PDO::PARAM_STR],
-        ':nb_lin' => [$preferences['nb_lin'], PDO::PARAM_INT],
-    ];
-
-    if ($preferences['host_group']) {
-        $bindParams[':host_group'] = [$preferences['host_group'], PDO::PARAM_INT];
-    }
-
-    $db->executePreparedQuery($statement, $bindParams, true);
-
-    while ($row = $db->fetch($statement)) {
-        $row['numLin'] = $numLine;
-        $row['current_value'] = ceil($row['current_value']);
-        $row['details_uri'] = $useDeprecatedPages
-            ? '../../main.php?p=20201&o=svcd&host_name='
-                . $row['host_name']
-                . '&service_description='
-                . $row['service_description']
-            : $resourceController->buildServiceDetailsUri(
-                $row['host_id'],
-                $row['service_id']
+        if (! $centreon->user->admin) {
+            ['parameters' => $accessGroupParameters, 'placeholderList' => $accessGroupList] = createMultipleBindParameters(
+                $accessGroups->getIds(),
+                'access_group',
+                QueryParameterTypeEnum::INTEGER
             );
-        $data[] = $row;
-        $numLine++;
+
+            $query .= <<<SQL
+                    INNER JOIN centreon_acl acl
+                        ON i.host_id = acl.host_id
+                        AND i.service_id = acl.service_id
+                        AND acl.group_id IN ({$accessGroupList})
+                SQL;
+
+            $queryParameters = [...$accessGroupParameters, ...$queryParameters];
+        }
+
+        $query .= <<<'SQL'
+                WHERE i.service_description LIKE :serviceDescription
+                  AND m.metric_name LIKE :metricName
+                  AND m.current_value <= 100
+                  AND h.enabled = 1
+                GROUP BY
+                    i.host_id,
+                    i.service_id,
+                    i.host_name,
+                    i.service_description,
+                    s.state
+                ORDER BY current_value DESC
+                LIMIT :numberOfLines;
+            SQL;
+
+        $queryParameters[] = QueryParameter::string('serviceDescription', '%' . $preferences['service_description'] . '%');
+        $queryParameters[] = QueryParameter::string('metricName', '%' . $preferences['metric_name'] . '%');
+        $queryParameters[] = QueryParameter::int('numberOfLines', $preferences['nb_lin']);
+
+        $numLine = 1;
+        foreach ($realtimeDatabase->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+            $record['numLin'] = $numLine;
+            $record['current_value'] = ceil($record['current_value']);
+            $record['details_uri'] = $useDeprecatedPages
+                ? '../../main.php?p=20201&o=svcd&host_name='
+                    . $record['host_name']
+                    . '&service_description='
+                    . $record['service_description']
+                : $resourceController->buildServiceDetailsUri(
+                    $record['host_id'],
+                    $record['service_id']
+                );
+            $data[] = $record;
+            $numLine++;
+        }
     }
-} catch (CentreonDbException $e) {
+} catch (ConnectionException $exception) {
     CentreonLog::create()->error(
         logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
-        message: 'Error fetching cpu usage data: ' . $e->getMessage(),
-        exception: $e
+        message: 'Error fetching cpu usage data: ' . $exception->getMessage(),
+        exception: $exception
     );
 
-    throw $e;
+    throw $exception;
 }
 
 $template->assign('preferences', $preferences);

--- a/centreon/www/widgets/live-top10-memory-usage/index.php
+++ b/centreon/www/widgets/live-top10-memory-usage/index.php
@@ -19,14 +19,21 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\Exception\ConnectionException;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Security\AccessGroup\Domain\Collection\AccessGroupCollection;
+
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
 require_once $centreon_path . 'bootstrap.php';
 require_once __DIR__ . '/src/function.php';
 
@@ -51,13 +58,23 @@ try {
     if ($widgetId === false) {
         throw new InvalidArgumentException('Widget ID must be an integer');
     }
-    $db_centreon = $dependencyInjector['configuration_db'];
-    $db = $dependencyInjector['realtime_db'];
 
-    $widgetObj = new CentreonWidget($centreon, $db_centreon);
+    /**
+     * @var CentreonDB $configurationDatabase
+     */
+    $configurationDatabase = $dependencyInjector['configuration_db'];
+
+    /**
+     * @var CentreonDB $realtimeDatabase
+     */
+    $realtimeDatabase = $dependencyInjector['realtime_db'];
+
+    $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
-    $autoRefresh = (int) $preferences['refresh_interval'];
-    if ($autoRefresh < 5) {
+
+    $autoRefresh = filter_var($preferences['refresh_interval'], FILTER_VALIDATE_INT);
+
+    if ($autoRefresh === false || $autoRefresh < 5) {
         $autoRefresh = 30;
     }
     $variablesThemeCSS = match ($centreon->user->theme) {
@@ -65,8 +82,19 @@ try {
         'dark' => 'Centreon-Dark',
         default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
     };
-} catch (Exception $e) {
-    echo $e->getMessage() . '<br/>';
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error fetching data for live-top10-memory-usage widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
 }
@@ -76,10 +104,11 @@ $resourceController = $kernel->getContainer()->get(
     Centreon\Application\Controller\MonitoringResourceController::class
 );
 
-if ($centreon->user->admin == 0) {
-    $access = new CentreonACL($centreon->user->get_id());
-    $grouplist = $access->getAccessGroups();
-    $grouplistStr = $access->getAccessGroupsString();
+$accessGroups = new AccessGroupCollection();
+
+if (! $centreon->user->admin) {
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups->mergeWith($acls->getAccessGroups());
 }
 
 // Smarty template initialization
@@ -88,91 +117,109 @@ $template = SmartyBC::createSmartyTemplate($path, './');
 
 $data = [];
 try {
-    $query = 'SELECT
-            1 AS REALTIME,
-            i.host_name,
-            i.service_description,
-            i.service_id, i.host_id,
-            m.current_value/max AS ratio,
-            max-current_value AS remaining_space,
-            s.state AS status
-        FROM
-            metrics m,
-            hosts h '
-        . ($preferences['host_group'] ? ', hosts_hostgroups hg ' : '')
-        . ($centreon->user->admin == 0 ? ', centreon_acl acl ' : '')
-        . ' , index_data i
-        LEFT JOIN services s ON s.service_id  = i.service_id AND s.enabled = 1
-        WHERE i.service_description LIKE :service_description
-            AND i.id = m.index_id
-            AND m.metric_name LIKE :metric_name
-            AND i.host_id = h.host_id '
-        . ($preferences['host_group']
-            ? 'AND hg.hostgroup_id = :host_group AND i.host_id = hg.host_id ' : '');
-    if ($centreon->user->admin == 0) {
-        $query .= 'AND i.host_id = acl.host_id
-            AND i.service_id = acl.service_id
-            AND acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')';
-    }
-    $query .= 'AND s.enabled = 1
-            AND h.enabled = 1
-        GROUP BY i.host_id,
-            i.service_id,
-            i.host_name,
-            i.service_description,
-            s.state,
-            m.current_value,
-            m.max
-        ORDER BY ratio DESC
-        LIMIT :nb_lin;';
+    if ($centreon->user->admin || ! $accessGroups->isEmpty()) {
+        $queryParameters = [];
+        $query = <<<'SQL'
+                SELECT
+                    1 AS REALTIME,
+                    i.host_name,
+                    i.service_description,
+                    i.service_id,
+                    i.host_id,
+                    m.current_value / m.max AS ratio,
+                    m.max - m.current_value AS remaining_space,
+                    s.state AS status
+                FROM index_data i
+                JOIN metrics m
+                    ON i.id = m.index_id
+                JOIN hosts h
+                    ON i.host_id = h.host_id
+                LEFT JOIN services s
+                    ON s.service_id = i.service_id
+                    AND s.enabled = 1
+            SQL;
 
-    $numLine = 1;
-    $in = 0;
+        if ($preferences['host_group']) {
+            $query .= <<<'SQL'
+                    INNER JOIN hosts_hostgroups hg
+                        ON i.host_id = hg.host_id
+                        AND hg.hostgroup_id = :hostGroupId
+                SQL;
 
-    $statement = $db->prepareQuery($query);
-
-    $bindParams = [
-        ':service_description' => ['%' . $preferences['service_description'] . '%', PDO::PARAM_STR],
-        ':metric_name' => ['%' . $preferences['metric_name'] . '%', PDO::PARAM_STR],
-        ':nb_lin' => [$preferences['nb_lin'], PDO::PARAM_INT],
-    ];
-
-    if ($preferences['host_group']) {
-        $bindParams[':host_group'] = [$preferences['host_group'], PDO::PARAM_INT];
-    }
-
-    $db->executePreparedQuery($statement, $bindParams, true);
-
-    while ($row = $db->fetch($statement)) {
-        $row['numLin'] = $numLine;
-        while ($row['remaining_space'] >= 1024) {
-            $row['remaining_space'] = $row['remaining_space'] / 1024;
-            $in = $in + 1;
+            $queryParameters[] = QueryParameter::int('hostGroupId', (int) $preferences['host_group']);
         }
-        $row['unit'] = getUnit($in);
-        $in = 0;
-        $row['remaining_space'] = round($row['remaining_space']);
-        $row['ratio'] = ceil($row['ratio'] * 100);
-        $row['details_uri'] = $useDeprecatedPages
-            ? '../../main.php?p=20201&o=svcd&host_name='
-                . $row['host_name']
-                . '&service_description='
-                . $row['service_description']
-            : $resourceController->buildServiceDetailsUri(
-                $row['host_id'],
-                $row['service_id']
+
+        if (! $centreon->user->admin) {
+            ['parameters' => $accessGroupParameters, 'placeholderList' => $accessGroupList] = createMultipleBindParameters(
+                $accessGroups->getIds(),
+                'access_group',
+                QueryParameterTypeEnum::INTEGER
             );
-        $data[] = $row;
-        $numLine++;
+
+            $query .= <<<SQL
+                    INNER JOIN centreon_acl acl
+                        ON i.host_id = acl.host_id
+                        AND i.service_id = acl.service_id
+                        AND acl.group_id IN ({$accessGroupList})
+                SQL;
+
+            $queryParameters = [...$accessGroupParameters, ...$queryParameters];
+        }
+
+        $query .= <<<'SQL'
+                WHERE i.service_description LIKE :serviceDescription
+                  AND m.metric_name LIKE :metricName
+                  AND h.enabled = 1
+                GROUP BY
+                    i.host_id,
+                    i.service_id,
+                    i.host_name,
+                    i.service_description,
+                    s.state,
+                    m.current_value,
+                    m.max
+                ORDER BY ratio DESC
+                LIMIT :numberOfLines;
+            SQL;
+
+        $queryParameters[] = QueryParameter::string('serviceDescription', '%' . $preferences['service_description'] . '%');
+        $queryParameters[] = QueryParameter::string('metricName', '%' . $preferences['metric_name'] . '%');
+        $queryParameters[] = QueryParameter::int('numberOfLines', $preferences['nb_lin']);
+
+        $numLine = 1;
+        $in = 0;
+
+        foreach ($realtimeDatabase->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+            $record['numLin'] = $numLine;
+            while ($record['remaining_space'] >= 1024) {
+                $record['remaining_space'] = $record['remaining_space'] / 1024;
+                $in = $in + 1;
+            }
+            $record['unit'] = getUnit($in);
+            $in = 0;
+            $record['remaining_space'] = round($record['remaining_space']);
+            $record['ratio'] = ceil($record['ratio'] * 100);
+            $record['details_uri'] = $useDeprecatedPages
+                ? '../../main.php?p=20201&o=svcd&host_name='
+                    . $record['host_name']
+                    . '&service_description='
+                    . $record['service_description']
+                : $resourceController->buildServiceDetailsUri(
+                    $record['host_id'],
+                    $record['service_id']
+                );
+            $data[] = $record;
+            $numLine++;
+        }
     }
-} catch (CentreonDbException $e) {
+} catch (ConnectionException $exception) {
     CentreonLog::create()->error(
         logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
-        message: 'Error fetching memory usage data: ' . $e->getMessage(),
-        exception: $e
+        message: 'Error fetching memory usage data: ' . $exception->getMessage(),
+        exception: $exception
     );
 
-    throw $e;
+    throw $exception;
 }
 
 $template->assign('preferences', $preferences);

--- a/centreon/www/widgets/service-monitoring/index.php
+++ b/centreon/www/widgets/service-monitoring/index.php
@@ -20,6 +20,7 @@
  */
 
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once $centreon_path . 'bootstrap.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
@@ -30,23 +31,47 @@ if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId'])) {
     exit();
 }
 $centreon = $_SESSION['centreon'];
-$widgetId = filter_input(INPUT_GET, 'widgetId', FILTER_VALIDATE_INT, ['options' => ['default' => 0]]);
+
+$widgetId = filter_input(
+    INPUT_GET,
+    'widgetId',
+    FILTER_VALIDATE_INT,
+    ['options' => ['default' => 0]],
+);
 
 try {
-    $db = $dependencyInjector['configuration_db'];
-    $widgetObj = new CentreonWidget($centreon, $db);
+    if ($widgetId <= 0) {
+        throw new InvalidArgumentException('Widget ID must be a positive integer');
+    }
+    $configurationDatabase = $dependencyInjector['configuration_db'];
+    $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
+
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
+
     $autoRefresh = filter_var($preferences['refresh_interval'], FILTER_VALIDATE_INT);
+
     if ($autoRefresh === false || $autoRefresh < 5) {
         $autoRefresh = 30;
     }
+
     $variablesThemeCSS = match ($centreon->user->theme) {
         'light' => 'Generic-theme',
         'dark' => 'Centreon-Dark',
         default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
     };
-} catch (Exception $e) {
-    echo $e->getMessage() . '<br/>';
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error fetching data for service-monitoring widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
 }

--- a/centreon/www/widgets/service-monitoring/src/action.php
+++ b/centreon/www/widgets/service-monitoring/src/action.php
@@ -25,7 +25,6 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonDB.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'www/class/centreonService.class.php';
 require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';

--- a/centreon/www/widgets/service-monitoring/src/export.php
+++ b/centreon/www/widgets/service-monitoring/src/export.php
@@ -19,6 +19,10 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+
 header('Content-type: application/csv');
 header('Content-Disposition: attachment; filename="services-monitoring.csv"');
 
@@ -41,17 +45,23 @@ if (! isset($_SESSION['centreon'], $_GET['widgetId'], $_GET['list'])) {
     exit();
 }
 
-$db = $dependencyInjector['configuration_db'];
-if (CentreonSession::checkSession(session_id(), $db) == 0) {
+$configurationDatabase = $dependencyInjector['configuration_db'];
+if (CentreonSession::checkSession(session_id(), $configurationDatabase) == 0) {
     exit();
 }
 
 // Init Objects
-$criticality = new CentreonCriticality($db);
-$media = new CentreonMedia($db);
+$criticality = new CentreonCriticality($configurationDatabase);
+$media = new CentreonMedia($configurationDatabase);
 
 $centreon = $_SESSION['centreon'];
-$widgetId = filter_input(INPUT_GET, 'widgetId', FILTER_VALIDATE_INT, ['options' => ['default' => 0]]);
+
+$widgetId = filter_input(
+    INPUT_GET,
+    'widgetId',
+    FILTER_VALIDATE_INT,
+    ['options' => ['default' => 0]],
+);
 
 /**
  * Sanitize and concatenate selected resources for the query
@@ -76,6 +86,9 @@ $hostQuery = '';
 $serviceQuery = '';
 // Prepare the query concatenation and the bind values
 $firstResult = true;
+
+$mainQueryParameters = [];
+
 foreach ($exportList as $key => $Id) {
     if (
         ! isset($exportList[$key][1])
@@ -90,77 +103,115 @@ foreach ($exportList as $key => $Id) {
         $serviceQuery .= ', ';
     }
     $hostQuery .= ':' . $key . 'hId' . $exportList[$key][0];
-    $mainQueryParameters[] = [
-        'parameter' => ':' . $key . 'hId' . $exportList[$key][0],
-        'value' => (int) $exportList[$key][0],
-        'type' => PDO::PARAM_INT,
-    ];
+    $mainQueryParameters[] = QueryParameter::int(
+        $key . 'hId' . $exportList[$key][0],
+        (int) $exportList[$key][0]
+    );
+
     $serviceQuery .= ':' . $key . 'sId' . $exportList[$key][1];
-    $mainQueryParameters[] = [
-        'parameter' => ':' . $key . 'sId' . $exportList[$key][1],
-        'value' => (int) $exportList[$key][1],
-        'type' => PDO::PARAM_INT,
-    ];
+
+    $mainQueryParameters[] = QueryParameter::int(
+        $key . 'sId' . $exportList[$key][1],
+        (int) $exportList[$key][1]
+    );
     $firstResult = false;
 }
 
-$dbb = $dependencyInjector['realtime_db'];
-$widgetObj = new CentreonWidget($centreon, $db);
+/**
+ * @var CentreonDB $realtimeDatabase
+ */
+$realtimeDatabase = $dependencyInjector['realtime_db'];
+$widgetObj = new CentreonWidget($centreon, $configurationDatabase);
 $preferences = $widgetObj->getWidgetPreferences($widgetId);
 
-$aStateType = ['1' => 'H', '0' => 'S'];
-$stateLabels = [0 => 'Ok', 1 => 'Warning', 2 => 'Critical', 3 => 'Unknown', 4 => 'Pending'];
+$aStateType = [
+    '1' => 'H',
+    '0' => 'S',
+];
+
+$stateLabels = [
+    0 => 'Ok',
+    1 => 'Warning',
+    2 => 'Critical',
+    3 => 'Unknown',
+    4 => 'Pending',
+];
 
 // Build Query
-$query = "SELECT SQL_CALC_FOUND_ROWS
-    1 AS REALTIME,
-    h.host_id,
-    h.name as hostname,
-    h.alias as hostalias,
-    s.latency,
-    s.execution_time,
-    h.state as h_state,
-    s.service_id,
-    s.description,
-    s.state as s_state,
-    h.state_type as state_type,
-    s.last_hard_state,
-    s.output,
-    s.scheduled_downtime_depth as s_scheduled_downtime_depth,
-    s.acknowledged as s_acknowledged,
-    s.notify as s_notify,
-    s.active_checks as s_active_checks,
-    s.passive_checks as s_passive_checks,
-    h.scheduled_downtime_depth as h_scheduled_downtime_depth,
-    h.acknowledged as h_acknowledged,
-    h.notify as h_notify,
-    h.active_checks as h_active_checks,
-    h.passive_checks as h_passive_checks,
-    s.last_check,
-    s.last_state_change,
-    s.last_hard_state_change,
-    s.check_attempt,
-    s.max_check_attempts,
-    h.action_url as h_action_url,
-    h.notes_url as h_notes_url,
-    s.action_url as s_action_url,
-    s.notes_url as s_notes_url,
-    cv2.value AS criticality_id,
-    cv.value AS criticality_level
-    FROM hosts h, services s
-    LEFT JOIN customvariables cv ON (
-        s.service_id = cv.service_id AND s.host_id = cv.host_id AND cv.name = 'CRITICALITY_LEVEL'
-    )
-    LEFT JOIN customvariables cv2 ON (
-        s.service_id = cv2.service_id AND s.host_id = cv2.host_id AND cv2.name = 'CRITICALITY_ID'
-    ) ";
+$query = <<<'SQL'
+        SELECT SQL_CALC_FOUND_ROWS
+            1 AS REALTIME,
+            h.host_id,
+            h.name AS hostname,
+            h.alias AS hostalias,
+            s.latency,
+            s.execution_time,
+            h.state AS h_state,
+            s.service_id,
+            s.description,
+            s.state AS s_state,
+            h.state_type AS state_type,
+            s.last_hard_state,
+            s.output,
+            s.scheduled_downtime_depth AS s_scheduled_downtime_depth,
+            s.acknowledged AS s_acknowledged,
+            s.notify AS s_notify,
+            s.active_checks AS s_active_checks,
+            s.passive_checks AS s_passive_checks,
+            h.scheduled_downtime_depth AS h_scheduled_downtime_depth,
+            h.acknowledged AS h_acknowledged,
+            h.notify AS h_notify,
+            h.active_checks AS h_active_checks,
+            h.passive_checks AS h_passive_checks,
+            s.last_check,
+            s.last_state_change,
+            s.last_hard_state_change,
+            s.check_attempt,
+            s.max_check_attempts,
+            h.action_url AS h_action_url,
+            h.notes_url AS h_notes_url,
+            s.action_url AS s_action_url,
+            s.notes_url AS s_notes_url,
+            cv2.value AS criticality_id,
+            cv.value AS criticality_level
+        FROM hosts h
+        INNER JOIN services s
+            ON h.host_id = s.host_id
+        LEFT JOIN customvariables cv
+            ON cv.service_id = s.service_id
+            AND cv.host_id = s.host_id
+            AND cv.name = 'CRITICALITY_LEVEL'
+        LEFT JOIN customvariables cv2
+            ON cv2.service_id = s.service_id
+            AND cv2.host_id = s.host_id
+            AND cv2.name = 'CRITICALITY_ID';
+    SQL;
+
 if (! $centreon->user->admin) {
-    $query .= ' , centreon_acl acl ';
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups = $acls->getAccessGroups()->getIds();
+
+    ['parameters' => $accessGroupParameters, 'placeholderList' => $accessGroupList] = createMultipleBindParameters(
+        $accessGroups,
+        'access_group',
+        QueryParameterTypeEnum::INTEGER
+    );
+
+    $query .= <<<SQL
+            INNER JOIN centreon_acl acl
+                ON h.host_id = acl.host_id
+                AND s.service_id = acl.service_id
+                AND acl.group_id IN ({$accessGroupList})
+        SQL;
+
+    $mainQueryParameters = [...$accessGroupParameters, ...$mainQueryParameters];
 }
-$query .= " WHERE s.host_id = h.host_id
-    AND h.name NOT LIKE '_Module_%'
-    AND s.enabled = 1
-    AND h.enabled = 1 ";
+
+$query .= <<<'SQL'
+        WHERE h.name NOT LIKE '_Module_%'
+          AND s.enabled = 1
+          AND h.enabled = 1
+    SQL;
 
 if ($firstResult === false) {
     $query .= " AND h.host_id IN ({$hostQuery}) AND s.service_id IN ({$serviceQuery}) ";
@@ -173,11 +224,7 @@ if (isset($preferences['host_name_search']) && $preferences['host_name_search'] 
         $search = $tab[1];
     }
     if ($op && isset($search) && $search != '') {
-        $mainQueryParameters[] = [
-            'parameter' => ':host_name',
-            'value' => $search,
-            'type' => PDO::PARAM_STR,
-        ];
+        $mainQueryParameters[] = QueryParameter::string('host_name', $search);
         $hostNameCondition = 'h.name ' . CentreonUtils::operandToMysqlFormat($op) . ' :host_name ';
         $query = CentreonUtils::conditionBuilder($query, $hostNameCondition);
     }
@@ -189,11 +236,7 @@ if (isset($preferences['service_description_search']) && $preferences['service_d
         $search = $tab[1];
     }
     if ($op && isset($search) && $search != '') {
-        $mainQueryParameters[] = [
-            'parameter' => ':service_description',
-            'value' => $search,
-            'type' => PDO::PARAM_STR,
-        ];
+        $mainQueryParameters[] = QueryParameter::string('service_description', $search);
         $serviceDescriptionCondition = 's.description '
             . CentreonUtils::operandToMysqlFormat($op) . ' :service_description ';
         $query = CentreonUtils::conditionBuilder($query, $serviceDescriptionCondition);
@@ -263,11 +306,7 @@ if (isset($preferences['hostgroup']) && $preferences['hostgroup']) {
             $queryHG .= ', ';
         }
         $queryHG .= ':id_' . $result;
-        $mainQueryParameters[] = [
-            'parameter' => ':id_' . $result,
-            'value' => (int) $result,
-            'type' => PDO::PARAM_INT,
-        ];
+        $mainQueryParameters[] = QueryParameter::int('id_' . $result, (int) $result);
     }
     $query = CentreonUtils::conditionBuilder(
         $query,
@@ -286,11 +325,7 @@ if (isset($preferences['servicegroup']) && $preferences['servicegroup']) {
             $querySG .= ', ';
         }
         $querySG .= ':id_' . $resultSG;
-        $mainQueryParameters[] = [
-            'parameter' => ':id_' . $resultSG,
-            'value' => (int) $resultSG,
-            'type' => PDO::PARAM_INT,
-        ];
+        $mainQueryParameters[] = QueryParameter::int('id_' . $resultSG, (int) $resultSG);
     }
     $query = CentreonUtils::conditionBuilder(
         $query,
@@ -306,11 +341,7 @@ if (! empty($preferences['criticality_filter'])) {
     $labels = [];
     foreach ($tab as $p) {
         $labels[] = ':id_' . $p;
-        $mainQueryParameters[] = [
-            'parameter' => ':id_' . $p,
-            'value' => (int) $p,
-            'type' => PDO::PARAM_INT,
-        ];
+        $mainQueryParameters[] = QueryParameter::int('id_' . $p, (int) $p);
     }
     $query = CentreonUtils::conditionBuilder(
         $query,
@@ -324,22 +355,12 @@ if (isset($preferences['output_search']) && $preferences['output_search'] != '')
         $search = $tab[1];
     }
     if ($op && isset($search) && $search != '') {
-        $mainQueryParameters[] = [
-            'parameter' => ':service_output',
-            'value' => $search,
-            'type' => PDO::PARAM_STR,
-        ];
+        $mainQueryParameters[] = QueryParameter::string('service_output', $search);
         $serviceOutputCondition = ' s.output ' . CentreonUtils::operandToMysqlFormat($op) . ' :service_output ';
         $query = CentreonUtils::conditionBuilder($query, $serviceOutputCondition);
     }
 }
-if (! $centreon->user->admin) {
-    $aclObj = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
-    $groupList = $aclObj->getAccessGroupsString();
-    $query .= ' AND h.host_id = acl.host_id
-        AND acl.service_id = s.service_id
-        AND acl.group_id IN (' . $groupList . ')';
-}
+
 $orderby = ' hostname ASC , description ASC';
 
 // Define allowed columns and directions
@@ -395,24 +416,13 @@ if (isset($preferences['order_by']) && trim($preferences['order_by']) !== '') {
 
 $query .= ' ORDER BY ' . $orderby;
 
-$res = $dbb->prepare($query);
-
-foreach ($mainQueryParameters as $parameter) {
-    $res->bindValue($parameter['parameter'], $parameter['value'], $parameter['type']);
-}
-
-unset($parameter, $mainQueryParameters);
-
-$res->execute();
-
-$nbRows = (int) $dbb->query('SELECT FOUND_ROWS() AS REALTIME')->fetchColumn();
 $data = [];
 $outputLength = $preferences['output_length'] ?? 50;
 $commentLength = $preferences['comment_length'] ?? 50;
 
-$hostObj = new CentreonHost($db);
-$svcObj = new CentreonService($db);
-while ($row = $res->fetch()) {
+$hostObj = new CentreonHost($configurationDatabase);
+$svcObj = new CentreonService($configurationDatabase);
+foreach ($realtimeDatabase->iterateAssociative($query, QueryParameters::create($mainQueryParameters)) as $row) {
     foreach ($row as $key => $value) {
         if ($key == 'last_check') {
             $gmt = new CentreonGMT();
@@ -437,8 +447,7 @@ while ($row = $res->fetch()) {
         $data[$row['host_id'] . '_' . $row['service_id']][$key] = $value;
     }
     if (isset($preferences['display_last_comment']) && $preferences['display_last_comment']) {
-        $res2 = $dbb->prepare(
-            <<<'SQL'
+        $commentQuery = <<<'SQL'
                 SELECT
                     1 AS REALTIME,
                     data
@@ -446,16 +455,17 @@ while ($row = $res->fetch()) {
                 WHERE host_id = :host_id
                     AND service_id = :service_id
                 ORDER BY entry_time DESC LIMIT 1
-                SQL
-        );
-        $res2->bindValue(':host_id', $row['host_id'], PDO::PARAM_INT);
-        $res2->bindValue(':service_id', $row['service_id'], PDO::PARAM_INT);
-        $res2->execute();
+            SQL;
+
+        $commentQueryParameters = [
+            QueryParameter::int('host_id', $row['host_id']),
+            QueryParameter::int('service_id', $row['service_id']),
+        ];
 
         $data[$row['host_id'] . '_' . $row['service_id']]['comment'] = '-';
 
-        while ($row2 = $res2->fetch()) {
-            $data[$row['host_id'] . '_' . $row['service_id']]['comment'] = substr($row2['data'], 0, $commentLength);
+        foreach ($realtimeDatabase->iterateAssociative($commentQuery, QueryParameters::create($commentQueryParameters)) as $comment) {
+            $data[$row['host_id'] . '_' . $row['service_id']]['comment'] = substr($comment['data'], 0, $commentLength);
         }
     }
     $data[$row['host_id'] . '_' . $row['service_id']]['encoded_description'] = urlencode(

--- a/centreon/www/widgets/service-monitoring/src/index.php
+++ b/centreon/www/widgets/service-monitoring/src/index.php
@@ -19,6 +19,10 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+
 require_once '../../require.php';
 require_once $centreon_path . 'bootstrap.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
@@ -26,19 +30,23 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'www/class/centreonService.class.php';
 require_once $centreon_path . 'www/class/centreonMedia.class.php';
 require_once $centreon_path . 'www/class/centreonCriticality.class.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
+require_once $centreon_path . 'www/include/common/sqlCommonFunction.php';
 
 CentreonSession::start(1);
 if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId']) || ! isset($_REQUEST['page'])) {
     exit;
 }
 
-$db = $dependencyInjector['configuration_db'];
-if (CentreonSession::checkSession(session_id(), $db) == 0) {
+/**
+ * @var CentreonDB $configurationDatabase
+ */
+$configurationDatabase = $dependencyInjector['configuration_db'];
+if (CentreonSession::checkSession(session_id(), $configurationDatabase) == 0) {
     exit();
 }
 
@@ -46,8 +54,8 @@ if (CentreonSession::checkSession(session_id(), $db) == 0) {
 $template = SmartyBC::createSmartyTemplate($centreon_path . 'www/widgets/service-monitoring/src/', './');
 
 // Init Objects
-$criticality = new CentreonCriticality($db);
-$media = new CentreonMedia($db);
+$criticality = new CentreonCriticality($configurationDatabase);
+$media = new CentreonMedia($configurationDatabase);
 
 $centreon = $_SESSION['centreon'];
 
@@ -57,15 +65,74 @@ $centreon = $_SESSION['centreon'];
  */
 $useDeprecatedPages = $centreon->user->doesShowDeprecatedPages();
 
-$widgetId = filter_input(INPUT_GET, 'widgetId', FILTER_VALIDATE_INT, ['options' => ['default' => 0]]);
-$page = filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT, ['options' => ['default' => 0]]);
+$widgetId = filter_input(
+    INPUT_GET,
+    'widgetId',
+    FILTER_VALIDATE_INT,
+    ['options' => ['default' => 0]],
+);
+
+$page = filter_input(
+    INPUT_GET,
+    'page',
+    FILTER_VALIDATE_INT,
+    ['options' => ['default' => 0]],
+);
 
 /**
- * @var CentreonDB $dbb
+ * @var CentreonDB $realtimeDatabase
  */
-$dbb = $dependencyInjector['realtime_db'];
-$widgetObj = new CentreonWidget($centreon, $db);
+$realtimeDatabase = $dependencyInjector['realtime_db'];
+$widgetObj = new CentreonWidget($centreon, $configurationDatabase);
+
+/**
+ * @var array{
+ *     host_name_search: string,
+ *     service_description_search: string,
+ *     svc_ok: string,
+ *     hide_down_host: string,
+ *     hide_unreachable_host: string,
+ *     svc_warning: string,
+ *     svc_critical: string,
+ *     svc_unknown: string,
+ *     svc_pending: string,
+ *     criticality_filter: string,
+ *     acknowledgement_filter: string,
+ *     notification_filter: string,
+ *     downtime_filter: string,
+ *     state_type_filter: string,
+ *     poller: string,
+ *     hostgroup: string,
+ *     servicegroup: string,
+ *     entries: string,
+ *     output_search: string,
+ *     display_severities: string,
+ *     display_host_name: string,
+ *     display_host_alias: string,
+ *     display_chart_icon: string,
+ *     display_svc_description: string,
+ *     display_output: string,
+ *     output_length: string,
+ *     display_status: string,
+ *     display_last_check: string,
+ *     display_duration: string,
+ *     display_hard_state_duration: string,
+ *     display_tries: string,
+ *     display_last_comment: string,
+ *     display_latency: string,
+ *     display_execution_time: string,
+ *     comment_length: string,
+ *     order_by: string,
+ *     order_by2: string,
+ *     refresh_interval: string,
+ *     more_views: string
+ * } $preferences
+ */
 $preferences = $widgetObj->getWidgetPreferences($widgetId);
+
+$autoRefresh = (isset($preferences['refresh_interval']) && (int) $preferences['refresh_interval'] > 0)
+    ? (int) $preferences['refresh_interval']
+    : 30;
 
 $stateSColors = [
     0 => '#88b917',
@@ -88,73 +155,102 @@ $stateLabels = [
     3 => 'Unknown',
     4 => 'Pending',
 ];
-$aStateType = ['1' => 'H', '0' => 'S'];
+
+$aStateType = [
+    '1' => 'H',
+    '0' => 'S',
+];
+
 $mainQueryParameters = [];
 
-// Build Query
-$query = 'SELECT SQL_CALC_FOUND_ROWS DISTINCT
-    1 AS REALTIME,
-    h.host_id,
-    h.name as hostname,
-    h.alias as hostalias,
-    s.latency,
-    s.execution_time,
-    h.state as h_state,
-    s.service_id,
-    s.description,
-    s.state as s_state,
-    s.state_type as state_type,
-    s.last_hard_state,
-    s.output,
-    s.scheduled_downtime_depth as s_scheduled_downtime_depth,
-    s.acknowledged as s_acknowledged,
-    s.notify as s_notify,
-    s.perfdata,
-    s.active_checks as s_active_checks,
-    s.passive_checks as s_passive_checks,
-    h.scheduled_downtime_depth as h_scheduled_downtime_depth,
-    h.acknowledged as h_acknowledged,
-    h.notify as h_notify,
-    h.active_checks as h_active_checks,
-    h.passive_checks as h_passive_checks,
-    s.last_check,
-    s.last_state_change,
-    s.last_hard_state_change,
-    s.check_attempt,
-    s.max_check_attempts,
-    h.action_url as h_action_url,
-    h.notes_url as h_notes_url,
-    s.action_url as s_action_url,
-    s.notes_url as s_notes_url,
-    cv2.value AS criticality_id,
-    cv.value AS criticality_level,
-    h.icon_image
-    FROM hosts h JOIN instances i ON h.instance_id=i.instance_id, services s
-    LEFT JOIN customvariables cv ON (
-        s.service_id = cv.service_id
-        AND s.host_id = cv.host_id
-        AND cv.name = \'CRITICALITY_LEVEL\'
-    )
-    LEFT JOIN customvariables cv2 ON (
-        s.service_id = cv2.service_id
-        AND s.host_id = cv2.host_id
-        AND cv2.name = \'CRITICALITY_ID\'
-    )';
+$querySelect = <<<'SQL'
+            SELECT DISTINCT
+                1 AS REALTIME,
+                h.host_id,
+                h.name AS hostname,
+                h.alias AS hostalias,
+                s.latency,
+                s.execution_time,
+                h.state AS h_state,
+                s.service_id,
+                s.description,
+                s.state AS s_state,
+                s.state_type AS state_type,
+                s.last_hard_state,
+                s.output,
+                s.scheduled_downtime_depth AS s_scheduled_downtime_depth,
+                s.acknowledged AS s_acknowledged,
+                s.notify AS s_notify,
+                s.perfdata,
+                s.active_checks AS s_active_checks,
+                s.passive_checks AS s_passive_checks,
+                h.scheduled_downtime_depth AS h_scheduled_downtime_depth,
+                h.acknowledged AS h_acknowledged,
+                h.notify AS h_notify,
+                h.active_checks AS h_active_checks,
+                h.passive_checks AS h_passive_checks,
+                s.last_check,
+                s.last_state_change,
+                s.last_hard_state_change,
+                s.check_attempt,
+                s.max_check_attempts,
+                h.action_url AS h_action_url,
+                h.notes_url AS h_notes_url,
+                s.action_url AS s_action_url,
+                s.notes_url AS s_notes_url,
+                cv2.value AS criticality_id,
+                cv.value AS criticality_level,
+                h.icon_image
+    SQL;
 
-if (isset($preferences['acknowledgement_filter']) &&  $preferences['acknowledgement_filter'] == 'ackByMe') {
-    $query .= ' JOIN acknowledgements ack ON (
-        s.service_id = ack.service_id
-    )';
+$baseQuery = <<<'SQL'
+        FROM hosts h
+        INNER JOIN instances i
+            ON h.instance_id = i.instance_id
+        INNER JOIN services s
+            ON s.host_id = h.host_id
+        LEFT JOIN customvariables cv
+            ON s.service_id = cv.service_id
+            AND s.host_id = cv.host_id
+            AND cv.name = 'CRITICALITY_LEVEL'
+        LEFT JOIN customvariables cv2
+            ON s.service_id = cv2.service_id
+            AND s.host_id = cv2.host_id
+            AND cv2.name = 'CRITICALITY_ID'
+    SQL;
+
+if (! empty($preferences['acknowledgement_filter']) &&  $preferences['acknowledgement_filter'] == 'ackByMe') {
+    $baseQuery .= <<<'SQL'
+            INNER JOIN acknowledgements ack
+                ON s.service_id = ack.service_id
+        SQL;
 }
 
 if (! $centreon->user->admin) {
-    $query .= ' , centreon_acl acl ';
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups = $acls->getAccessGroups()->getIds();
+
+    ['parameters' => $accessGroupParameters, 'placeholderList' => $accessGroupList] = createMultipleBindParameters(
+        $accessGroups,
+        'access_group',
+        QueryParameterTypeEnum::INTEGER
+    );
+
+    $baseQuery .= <<<SQL
+            INNER JOIN centreon_acl acl
+                ON h.host_id = acl.host_id
+                AND s.service_id = acl.service_id
+                AND acl.group_id IN ({$accessGroupList})
+        SQL;
+
+    $mainQueryParameters = [...$accessGroupParameters, ...$mainQueryParameters];
 }
 
-$query .= ' WHERE s.host_id = h.host_id
-    AND h.name NOT LIKE \'_Module_%\'
-    AND s.enabled = 1
-    AND h.enabled = 1 ';
+$baseQuery .= <<<'SQL'
+        WHERE h.name NOT LIKE '_Module_%'
+          AND s.enabled = 1
+          AND h.enabled = 1
+    SQL;
 
 if (isset($preferences['host_name_search']) && $preferences['host_name_search'] != '') {
     $tab = explode(' ', $preferences['host_name_search']);
@@ -163,13 +259,9 @@ if (isset($preferences['host_name_search']) && $preferences['host_name_search'] 
         $search = $tab[1];
     }
     if ($op && isset($search) && $search != '') {
-        $mainQueryParameters[] = [
-            'parameter' => ':host_name_search',
-            'value' => $search,
-            'type' => PDO::PARAM_STR,
-        ];
+        $mainQueryParameters[] = QueryParameter::string('host_name_search', $search);
         $hostNameCondition = 'h.name ' . CentreonUtils::operandToMysqlFormat($op) . ' :host_name_search ';
-        $query = CentreonUtils::conditionBuilder($query, $hostNameCondition);
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, $hostNameCondition);
     }
 }
 if (isset($preferences['service_description_search']) && $preferences['service_description_search'] != '') {
@@ -179,14 +271,11 @@ if (isset($preferences['service_description_search']) && $preferences['service_d
         $search = $tab[1];
     }
     if ($op && isset($search) && $search != '') {
-        $mainQueryParameters[] = [
-            'parameter' => ':service_description',
-            'value' => $search,
-            'type' => PDO::PARAM_STR,
-        ];
+        $mainQueryParameters[] = QueryParameter::string('service_description', $search);
+
         $serviceDescriptionCondition = 's.description '
             . CentreonUtils::operandToMysqlFormat($op) . ' :service_description ';
-        $query = CentreonUtils::conditionBuilder($query, $serviceDescriptionCondition);
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, $serviceDescriptionCondition);
     }
 }
 $stateTab = [];
@@ -207,24 +296,24 @@ if (isset($preferences['svc_pending']) && $preferences['svc_pending']) {
 }
 
 if (isset($preferences['hide_down_host']) && $preferences['hide_down_host']) {
-    $query = CentreonUtils::conditionBuilder($query, ' h.state != 1 ');
+    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' h.state != 1 ');
 }
 if (isset($preferences['hide_unreachable_host']) && $preferences['hide_unreachable_host']) {
-    $query = CentreonUtils::conditionBuilder($query, ' h.state != 2 ');
+    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' h.state != 2 ');
 }
 
 if ($stateTab !== []) {
-    $query = CentreonUtils::conditionBuilder($query, ' s.state IN (' . implode(',', $stateTab) . ')');
+    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' s.state IN (' . implode(',', $stateTab) . ')');
 }
 if (isset($preferences['acknowledgement_filter']) && $preferences['acknowledgement_filter']) {
     if ($preferences['acknowledgement_filter'] == 'ack') {
-        $query = CentreonUtils::conditionBuilder($query, ' s.acknowledged = 1');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' s.acknowledged = 1');
     } elseif ($preferences['acknowledgement_filter'] == 'ackByMe') {
-        $query = CentreonUtils::conditionBuilder($query, ' s.acknowledged = 1 AND ack.author = "'
-            . $centreon->user->alias . '"');
+        $mainQueryParameters[] = QueryParameter::string('ack_author', $centreon->user->alias);
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' s.acknowledged = 1 AND ack.author = :ack_author');
     } elseif ($preferences['acknowledgement_filter'] == 'nack') {
-        $query = CentreonUtils::conditionBuilder(
-            $query,
+        $baseQuery = CentreonUtils::conditionBuilder(
+            $baseQuery,
             ' s.acknowledged = 0 AND h.acknowledged = 0 AND h.scheduled_downtime_depth = 0 '
         );
     }
@@ -232,36 +321,32 @@ if (isset($preferences['acknowledgement_filter']) && $preferences['acknowledgeme
 
 if (isset($preferences['notification_filter']) && $preferences['notification_filter']) {
     if ($preferences['notification_filter'] == 'enabled') {
-        $query = CentreonUtils::conditionBuilder($query, ' s.notify = 1');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' s.notify = 1');
     } elseif ($preferences['notification_filter'] == 'disabled') {
-        $query = CentreonUtils::conditionBuilder($query, ' s.notify = 0');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' s.notify = 0');
     }
 }
 
 if (isset($preferences['downtime_filter']) && $preferences['downtime_filter']) {
     if ($preferences['downtime_filter'] == 'downtime') {
-        $query = CentreonUtils::conditionBuilder($query, ' s.scheduled_downtime_depth > 0 ');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' s.scheduled_downtime_depth > 0 ');
     } elseif ($preferences['downtime_filter'] == 'ndowntime') {
-        $query = CentreonUtils::conditionBuilder($query, ' s.scheduled_downtime_depth = 0 ');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' s.scheduled_downtime_depth = 0 ');
     }
 }
 
 if (isset($preferences['state_type_filter']) && $preferences['state_type_filter']) {
     if ($preferences['state_type_filter'] == 'hardonly') {
-        $query = CentreonUtils::conditionBuilder($query, ' s.state_type = 1 ');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' s.state_type = 1 ');
     } elseif ($preferences['state_type_filter'] == 'softonly') {
-        $query = CentreonUtils::conditionBuilder($query, ' s.state_type = 0 ');
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, ' s.state_type = 0 ');
     }
 }
 
 if (isset($preferences['poller']) && $preferences['poller']) {
-    $mainQueryParameters[] = [
-        'parameter' => ':instance_id',
-        'value' => $preferences['poller'],
-        'type' => PDO::PARAM_INT,
-    ];
+    $mainQueryParameters[] = QueryParameter::int('instance_id', $preferences['poller']);
     $instanceIdCondition = ' i.instance_id = :instance_id';
-    $query = CentreonUtils::conditionBuilder($query, $instanceIdCondition);
+    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, $instanceIdCondition);
 }
 
 if (isset($preferences['hostgroup']) && $preferences['hostgroup']) {
@@ -272,14 +357,10 @@ if (isset($preferences['hostgroup']) && $preferences['hostgroup']) {
             $queryHG .= ', ';
         }
         $queryHG .= ':id_' . $result;
-        $mainQueryParameters[] = [
-            'parameter' => ':id_' . $result,
-            'value' => (int) $result,
-            'type' => PDO::PARAM_INT,
-        ];
+        $mainQueryParameters[] = QueryParameter::int('id_' . $result, (int) $result);
     }
-    $query = CentreonUtils::conditionBuilder(
-        $query,
+    $baseQuery = CentreonUtils::conditionBuilder(
+        $baseQuery,
         ' s.host_id IN (
             SELECT host_host_id
             FROM `' . $conf_centreon['db'] . '`.hostgroup_relation
@@ -295,14 +376,10 @@ if (isset($preferences['servicegroup']) && $preferences['servicegroup']) {
             $querySG .= ', ';
         }
         $querySG .= ':id_' . $resultSG;
-        $mainQueryParameters[] = [
-            'parameter' => ':id_' . $resultSG,
-            'value' => (int) $resultSG,
-            'type' => PDO::PARAM_INT,
-        ];
+        $mainQueryParameters[] = QueryParameter::int('id_' . $resultSG, (int) $resultSG);
     }
-    $query = CentreonUtils::conditionBuilder(
-        $query,
+    $baseQuery = CentreonUtils::conditionBuilder(
+        $baseQuery,
         ' s.service_id IN (
             SELECT DISTINCT service_id
             FROM services_servicegroups
@@ -315,14 +392,10 @@ if (! empty($preferences['criticality_filter'])) {
     $labels = [];
     foreach ($tab as $p) {
         $labels[] = ':id_' . $p;
-        $mainQueryParameters[] = [
-            'parameter' => ':id_' . $p,
-            'value' => (int) $p,
-            'type' => PDO::PARAM_INT,
-        ];
+        $mainQueryParameters[] = QueryParameter::int('id_' . $p, (int) $p);
     }
-    $query = CentreonUtils::conditionBuilder(
-        $query,
+    $baseQuery = CentreonUtils::conditionBuilder(
+        $baseQuery,
         'cv2.value IN (' . implode(',', $labels) . ')'
     );
 }
@@ -333,22 +406,12 @@ if (isset($preferences['output_search']) && $preferences['output_search'] != '')
         $search = $tab[1];
     }
     if ($op && isset($search) && $search != '') {
-        $mainQueryParameters[] = [
-            'parameter' => ':service_output',
-            'value' => $search,
-            'type' => PDO::PARAM_STR,
-        ];
+        $mainQueryParameters[] = QueryParameter::string('service_output', $search);
         $serviceOutputCondition = 's.output ' . CentreonUtils::operandToMysqlFormat($op) . ' :service_output ';
-        $query = CentreonUtils::conditionBuilder($query, $serviceOutputCondition);
+        $baseQuery = CentreonUtils::conditionBuilder($baseQuery, $serviceOutputCondition);
     }
 }
-if (! $centreon->user->admin) {
-    $aclObj = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
-    $groupList = $aclObj->getAccessGroupsString();
-    $query .= ' AND h.host_id = acl.host_id
-        AND acl.service_id = s.service_id
-        AND acl.group_id IN (' . $groupList . ') ';
-}
+
 $orderByClause = 'hostname ASC ';
 
 // Define allowed columns and directions
@@ -391,6 +454,9 @@ $allowedOrderColumns = [
 ];
 $allowedDirections = ['ASC', 'DESC'];
 
+$countQuery = 'SELECT COUNT(*) ' . $baseQuery;
+$nbRows = (int) $realtimeDatabase->fetchOne($countQuery, QueryParameters::create($mainQueryParameters));
+
 if (isset($preferences['order_by']) && trim($preferences['order_by']) != '') {
     $aOrder = explode(' ', trim($preferences['order_by']));
     $column = $aOrder[0] ?? '';
@@ -414,28 +480,20 @@ if (isset($preferences['order_by']) && trim($preferences['order_by']) != '') {
 }
 
 if (trim($orderByClause)) {
-    $query .= 'ORDER BY ' . $orderByClause;
+    $baseQuery .= 'ORDER BY ' . $orderByClause;
 }
 
 $num = filter_var($preferences['entries'], FILTER_VALIDATE_INT) ?: 10;
-$query .= ' LIMIT ' . ($page * $num) . ',' . $num;
+$baseQuery .= ' LIMIT ' . ($page * $num) . ',' . $num;
 
-$res = $dbb->prepare($query);
+$records = $realtimeDatabase->fetchAllAssociative($querySelect . $baseQuery, QueryParameters::create($mainQueryParameters));
 
-foreach ($mainQueryParameters as $parameter) {
-    $res->bindValue($parameter['parameter'], $parameter['value'], $parameter['type']);
-}
-
-unset($parameter, $mainQueryParameters);
-$res->execute();
-
-$nbRows = (int) $dbb->query('SELECT FOUND_ROWS() AS REALTIME')->fetchColumn();
 $data = [];
 $outputLength = $preferences['output_length'] ?: 50;
 $commentLength = $preferences['comment_length'] ?: 50;
 
-$hostObj = new CentreonHost($db);
-$svcObj = new CentreonService($db);
+$hostObj = new CentreonHost($configurationDatabase);
+$svcObj = new CentreonService($configurationDatabase);
 $gmt = new CentreonGMT();
 $gmt->getMyGMTFromSession(session_id());
 $allowedActionProtocols = ['http[s]?', '//', 'ssh', 'rdp', 'ftp', 'sftp'];
@@ -444,15 +502,15 @@ $allowedProtocolsRegex = '#(^' . implode(
     $allowedActionProtocols
 ) . ')#'; // String starting with one of these protocols
 
-while ($row = $res->fetch()) {
-    foreach ($row as $key => $value) {
-        $data[$row['host_id'] . '_' . $row['service_id']][$key] = $value;
+foreach ($records as $record) {
+    foreach ($record as $key => $value) {
+        $data[$record['host_id'] . '_' . $record['service_id']][$key] = $value;
     }
 
-    $dataKey = $row['host_id'] . '_' . $row['service_id'];
+    $dataKey = $record['host_id'] . '_' . $record['service_id'];
 
     // last_check
-    $valueLastCheck = (int) $row['last_check'];
+    $valueLastCheck = (int) $record['last_check'];
     $valueLastCheckTimestamp = time() - $valueLastCheck;
     if (
         $valueLastCheckTimestamp > 0
@@ -463,7 +521,7 @@ while ($row = $res->fetch()) {
     $data[$dataKey]['last_check'] = $valueLastCheck;
 
     // last_state_change
-    $valueLastState = (int) $row['last_state_change'];
+    $valueLastState = (int) $record['last_state_change'];
     if ($valueLastState > 0) {
         $valueLastStateTimestamp = time() - $valueLastState;
         $valueLastState = CentreonDuration::toString($valueLastStateTimestamp) . ' ago';
@@ -473,7 +531,7 @@ while ($row = $res->fetch()) {
     $data[$dataKey]['last_state_change'] = $valueLastState;
 
     // last_hard_state_change
-    $valueLastHardState = (int) $row['last_hard_state_change'];
+    $valueLastHardState = (int) $record['last_hard_state_change'];
     if ($valueLastHardState > 0) {
         $valueLastHardStateTimestamp = time() - $valueLastHardState;
         $valueLastHardState = CentreonDuration::toString($valueLastHardStateTimestamp) . ' ago';
@@ -483,44 +541,44 @@ while ($row = $res->fetch()) {
     $data[$dataKey]['last_hard_state_change'] = $valueLastHardState;
 
     // check_attempt
-    $valueCheckAttempt = $row['check_attempt'] . '/'
-        . $row['max_check_attempts'] . ' (' . $aStateType[$row['state_type']] . ')';
+    $valueCheckAttempt = $record['check_attempt'] . '/'
+        . $record['max_check_attempts'] . ' (' . $aStateType[$record['state_type']] . ')';
     $data[$dataKey]['check_attempt'] = $valueCheckAttempt;
 
     // s_state
-    $data[$dataKey]['color'] = $stateSColors[$row['s_state']];
-    $data[$dataKey]['s_state'] = $stateLabels[$row['s_state']];
+    $data[$dataKey]['color'] = $stateSColors[$record['s_state']];
+    $data[$dataKey]['s_state'] = $stateLabels[$record['s_state']];
 
     // h_state
-    $value = $data[$dataKey]['hcolor'] = $stateHColors[$row['h_state']];
-    $data[$dataKey]['h_state'] = $stateLabels[$row['h_state']];
+    $value = $data[$dataKey]['hcolor'] = $stateHColors[$record['h_state']];
+    $data[$dataKey]['h_state'] = $stateLabels[$record['h_state']];
 
     // output
-    $data[$dataKey]['output'] = htmlspecialchars(substr($row['output'], 0, $outputLength));
+    $data[$dataKey]['output'] = htmlspecialchars(substr($record['output'], 0, $outputLength));
 
     $kernel = App\Kernel::createForWeb();
     $resourceController = $kernel->getContainer()->get(
         Centreon\Application\Controller\MonitoringResourceController::class
     );
     $data[$dataKey]['h_details_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=20202&o=hd&host_name=' . $row['hostname']
-        : $resourceController->buildHostDetailsUri($row['host_id']);
+        ? '../../main.php?p=20202&o=hd&host_name=' . $record['hostname']
+        : $resourceController->buildHostDetailsUri($record['host_id']);
 
     $data[$dataKey]['s_details_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=20201&o=svcd&host_name=' . $row['hostname']
-            . '&service_description=' . $row['description']
-        : $resourceController->buildServiceDetailsUri($row['host_id'], $row['service_id']);
+        ? '../../main.php?p=20201&o=svcd&host_name=' . $record['hostname']
+            . '&service_description=' . $record['description']
+        : $resourceController->buildServiceDetailsUri($record['host_id'], $record['service_id']);
 
     $data[$dataKey]['s_graph_uri'] = $useDeprecatedPages
-        ? '../../main.php?p=204&mode=0&svc_id=' . $row['hostname'] . ';' . $row['description']
+        ? '../../main.php?p=204&mode=0&svc_id=' . $record['hostname'] . ';' . $record['description']
         : $resourceController->buildServiceUri(
-            $row['host_id'],
-            $row['service_id'],
+            $record['host_id'],
+            $record['service_id'],
             $resourceController::TAB_GRAPH_NAME
         );
 
     // h_action_url
-    $valueHActionUrl = $row['h_action_url'];
+    $valueHActionUrl = $record['h_action_url'];
     if ($valueHActionUrl) {
         if (preg_match('#^\./(.+)#', $valueHActionUrl, $matches)) {
             $valueHActionUrl = '../../' . $matches[1];
@@ -530,7 +588,7 @@ while ($row = $res->fetch()) {
 
         $valueHActionUrl = CentreonUtils::escapeSecure(
             $hostObj->replaceMacroInString(
-                $row['hostname'],
+                $record['hostname'],
                 $valueHActionUrl
             )
         );
@@ -538,7 +596,7 @@ while ($row = $res->fetch()) {
     }
 
     // h_notes_url
-    $valueHNotesUrl = $row['h_notes_url'];
+    $valueHNotesUrl = $record['h_notes_url'];
     if ($valueHNotesUrl) {
         if (preg_match('#^\./(.+)#', $valueHNotesUrl, $matches)) {
             $valueHNotesUrl = '../../' . $matches[1];
@@ -548,7 +606,7 @@ while ($row = $res->fetch()) {
 
         $valueHNotesUrl = CentreonUtils::escapeSecure(
             $hostObj->replaceMacroInString(
-                $row['hostname'],
+                $record['hostname'],
                 $valueHNotesUrl
             )
         );
@@ -556,7 +614,7 @@ while ($row = $res->fetch()) {
     }
 
     // s_action_url
-    $valueSActionUrl = $row['s_action_url'];
+    $valueSActionUrl = $record['s_action_url'];
     if ($valueSActionUrl) {
         if (preg_match('#^\./(.+)#', $valueSActionUrl, $matches)) {
             $valueSActionUrl = '../../' . $matches[1];
@@ -564,18 +622,18 @@ while ($row = $res->fetch()) {
             $valueSActionUrl = '//' . $valueSActionUrl;
         }
         $valueSActionUrl = CentreonUtils::escapeSecure($hostObj->replaceMacroInString(
-            $row['hostname'],
+            $record['hostname'],
             $valueSActionUrl
         ));
         $valueSActionUrl = CentreonUtils::escapeSecure($svcObj->replaceMacroInString(
-            $row['service_id'],
+            $record['service_id'],
             $valueSActionUrl
         ));
         $data[$dataKey]['s_action_url'] = $valueSActionUrl;
     }
 
     // s_notes_url
-    $valueSNotesUrl = $row['s_notes_url'];
+    $valueSNotesUrl = $record['s_notes_url'];
     if ($valueSNotesUrl) {
         if (preg_match('#^\./(.+)#', $valueSNotesUrl, $matches)) {
             $valueSNotesUrl = '../../' . $matches[1];
@@ -583,11 +641,11 @@ while ($row = $res->fetch()) {
             $valueSNotesUrl = '//' . $valueSNotesUrl;
         }
         $valueSNotesUrl = CentreonUtils::escapeSecure($hostObj->replaceMacroInString(
-            $row['hostname'],
+            $record['hostname'],
             $valueSNotesUrl
         ));
         $valueSNotesUrl = CentreonUtils::escapeSecure($svcObj->replaceMacroInString(
-            $row['service_id'],
+            $record['service_id'],
             $valueSNotesUrl
         ));
         $data[$dataKey]['s_notes_url'] = $valueSNotesUrl;
@@ -595,7 +653,7 @@ while ($row = $res->fetch()) {
 
     // criticality_id
     if ($value != '') {
-        $critData = $criticality->getData($row['criticality_id'], 1);
+        $critData = $criticality->getData($record['criticality_id'], 1);
 
         // get criticality icon path
         $valueCriticalityId = '';
@@ -607,19 +665,21 @@ while ($row = $res->fetch()) {
         $data[$dataKey]['criticality_id'] = $valueCriticalityId;
     }
 
+    // FIXME: A SQL REQUEST IS PLAYED ON EACH LINE TO GET THE COMMENTS !!!!!!
+    // Meaning that for 100 results on which a comment has been set we get 100 SQL requests...
     if (isset($preferences['display_last_comment']) && $preferences['display_last_comment']) {
         $commentSql = 'SELECT 1 AS REALTIME, data FROM comments';
         $comment = '-';
 
-        if ((int) $row['s_acknowledged'] === 1) { // Service is acknowledged
+        if ((int) $record['s_acknowledged'] === 1) { // Service is acknowledged
             $commentSql = 'SELECT 1 AS REALTIME, comment_data AS data FROM acknowledgements';
-        } elseif ((int) $row['s_scheduled_downtime_depth'] === 1) { // Service is in downtime
+        } elseif ((int) $record['s_scheduled_downtime_depth'] === 1) { // Service is in downtime
             $commentSql = 'SELECT 1 AS REALTIME, comment_data AS data FROM downtimes';
         }
 
-        $commentSql .= ' WHERE host_id = ' . $row['host_id'] . ' AND service_id = ' . $row['service_id'];
+        $commentSql .= ' WHERE host_id = ' . $record['host_id'] . ' AND service_id = ' . $record['service_id'];
         $commentSql .= ' ORDER BY entry_time DESC LIMIT 1';
-        $commentResult = $dbb->query($commentSql);
+        $commentResult = $realtimeDatabase->query($commentSql);
 
         while ($commentRow = $commentResult->fetch()) {
             $comment = substr($commentRow['data'], 0, $commentLength);
@@ -634,9 +694,6 @@ while ($row = $res->fetch()) {
     $data[$dataKey]['encoded_hostname'] = urlencode($data[$dataKey]['hostname']);
 }
 
-$autoRefresh = (isset($preferences['refresh_interval']) && (int) $preferences['refresh_interval'] > 0)
-    ? (int) $preferences['refresh_interval']
-    : 30;
 $template->assign('widgetId', $widgetId);
 $template->assign('autoRefresh', $autoRefresh);
 $template->assign('preferences', $preferences);

--- a/centreon/www/widgets/service-monitoring/src/sendCmd.php
+++ b/centreon/www/widgets/service-monitoring/src/sendCmd.php
@@ -23,7 +23,6 @@ require_once '../../require.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonDB.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
 require_once $centreon_path . 'www/class/centreonService.class.php';
 require_once $centreon_path . 'www/class/centreonExternalCommand.class.php';

--- a/centreon/www/widgets/service-monitoring/src/toolbar.php
+++ b/centreon/www/widgets/service-monitoring/src/toolbar.php
@@ -26,7 +26,6 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 
 session_start();
 if (! isset($_SESSION['centreon']) || ! isset($_POST['widgetId'])) {

--- a/centreon/www/widgets/servicegroup-monitoring/index.php
+++ b/centreon/www/widgets/servicegroup-monitoring/index.php
@@ -20,6 +20,7 @@
  */
 
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once $centreon_path . 'bootstrap.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
@@ -31,7 +32,11 @@ if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId'])) {
     exit;
 }
 $centreon = $_SESSION['centreon'];
-$widgetId = filter_var($_REQUEST['widgetId'], FILTER_VALIDATE_INT);
+
+$widgetId = filter_var(
+    $_REQUEST['widgetId'],
+    FILTER_VALIDATE_INT,
+);
 
 try {
     if ($widgetId === false) {
@@ -40,12 +45,13 @@ try {
 
     global $pearDB;
 
-    $db_centreon = $dependencyInjector['configuration_db'];
-    $db = $dependencyInjector['realtime_db'];
-    $pearDB = $db_centreon;
-    $widgetObj = new CentreonWidget($centreon, $db_centreon);
+    $configurationDatabase = $dependencyInjector['configuration_db'];
+    $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
-    $autoRefresh = filter_var($preferences['refresh_interval'], FILTER_VALIDATE_INT);
+    $autoRefresh = filter_var(
+        $preferences['refresh_interval'],
+        FILTER_VALIDATE_INT,
+    );
     $variablesThemeCSS = match ($centreon->user->theme) {
         'light' => 'Generic-theme',
         'dark' => 'Centreon-Dark',
@@ -54,8 +60,19 @@ try {
     if ($autoRefresh === false || $autoRefresh < 5) {
         $autoRefresh = 30;
     }
-} catch (Exception $e) {
-    echo $e->getMessage() . '<br/>';
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error fetching data for servicegroup-monitoring widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
 }

--- a/centreon/www/widgets/servicegroup-monitoring/src/class/ServicegroupMonitoring.class.php
+++ b/centreon/www/widgets/servicegroup-monitoring/src/class/ServicegroupMonitoring.class.php
@@ -19,6 +19,10 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Security\AccessGroup\Domain\Collection\AccessGroupCollection;
+
 class ServicegroupMonitoring
 {
     protected $dbb;
@@ -37,40 +41,72 @@ class ServicegroupMonitoring
     /**
      * Get Host States
      *
-     * @param string $sgName
-     * @param int $detailFlag
-     * @param int $admin
-     * @param CentreonACL $aclObj
-     * @param array $preferences
+     * @param string $serviceGroupName
+     * @param bool $isUserAdmin
+     * @param AccessGroupCollection $accessGroups
+     * @param bool $detailFlag
      * @return array
      */
-    public function getHostStates($sgName, $admin, $aclObj, $preferences, $detailFlag = false)
-    {
-        $query = "SELECT DISTINCT h.host_id, h.state, h.name, h.alias, ssg.servicegroup_id
-            FROM `services_servicegroups` ssg, `hosts` h, `servicegroups` sg
-            WHERE h.host_id = ssg.host_id
-                AND h.name NOT LIKE '_Module_%'
-                AND h.enabled = 1
-                AND ssg.servicegroup_id = sg.servicegroup_id
-                AND sg.name = '" . $this->dbb->escape($sgName) . "' ";
-        if (! $admin) {
-            $query .= $aclObj->queryBuilder('AND', 'h.host_id', $aclObj->getHostsString('ID', $this->dbb));
+    public function getHostStates(
+        string $serviceGroupName,
+        bool $isUserAdmin,
+        AccessGroupCollection $accessGroups,
+        bool $detailFlag = false,
+    ): array {
+        if (
+            empty($serviceGroupName)
+            || (! $isUserAdmin && $accessGroups->isEmpty())
+        ) {
+            return [];
         }
-        $query .= ' ORDER BY h.name ';
-        $res = $this->dbb->query($query);
+
+        $queryParameters = [];
+        $queryParameters[] = QueryParameter::string('serviceGroupName', $serviceGroupName);
+
+        $query = <<<'SQL'
+                SELECT DISTINCT
+                    h.host_id,
+                    h.state,
+                    h.name,
+                    h.alias,
+                    ssg.servicegroup_id
+                FROM hosts h
+                INNER JOIN services_servicegroups ssg
+                    ON h.host_id = ssg.host_id
+                INNER JOIN servicegroups sg
+                    ON ssg.servicegroup_id = sg.servicegroup_id
+            SQL;
+
+        if (! $isUserAdmin) {
+            $accessGroupsList = implode(', ', $accessGroups->getIds());
+
+            $query .= <<<SQL
+                    INNER JOIN centreon_acl
+                        ON centreon_acl.host_id = h.host_id
+                        AND centreon_acl.group_id IN ({$accessGroupsList})
+                SQL;
+        }
+
+        $query .= <<<'SQL'
+                WHERE h.name NOT LIKE '_Module_%'
+                    AND h.enabled = 1
+                    AND sg.name = :serviceGroupName
+                ORDER BY h.name
+            SQL;
+
         $tab = [];
         $detailTab = [];
-        while ($row = $res->fetch()) {
-            if (! isset($tab[$row['state']])) {
-                $tab[$row['state']] = 0;
+        foreach ($this->dbb->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+            if (! isset($tab[$record['state']])) {
+                $tab[$record['state']] = 0;
             }
-            if (! isset($detailTab[$row['name']])) {
-                $detailTab[$row['name']] = [];
+            if (! isset($detailTab[$record['name']])) {
+                $detailTab[$record['name']] = [];
             }
-            foreach ($row as $key => $val) {
-                $detailTab[$row['name']][$key] = $val;
+            foreach ($record as $key => $val) {
+                $detailTab[$record['name']][$key] = $val;
             }
-            $tab[$row['state']]++;
+            $tab[$record['state']]++;
         }
         if ($detailFlag == true) {
             return $detailTab;
@@ -82,50 +118,77 @@ class ServicegroupMonitoring
     /**
      * Get Service States
      *
-     * @param string $sgName
-     * @param int $detailFlag
-     * @param int $admin
-     * @param CentreonACL $aclObj
-     * @param array $preferences
+     * @param string $serviceGroupName
+     * @param bool $isUserAdmin
+     * @param AccessGroupCollection $accessGroups
+     * @param bool $detailFlag
      * @return array
      */
-    public function getServiceStates($sgName, $admin, $aclObj, $preferences, $detailFlag = false): array
-    {
-        $query = 'SELECT DISTINCT h.host_id, s.state, h.name, s.service_id, s.description, ssg.servicegroup_id
-            FROM `services_servicegroups` ssg, `services` s, `hosts` h, `servicegroups` sg ';
-        if (! $admin) {
-            $query .= ', centreon_acl acl ';
+    public function getServiceStates(
+        string $serviceGroupName,
+        bool $isUserAdmin,
+        AccessGroupCollection $accessGroups,
+        bool $detailFlag = false,
+    ): array {
+        if (
+            empty($serviceGroupName)
+            || (! $isUserAdmin && $accessGroups->isEmpty())
+        ) {
+            return [];
         }
-        $query .= "WHERE h.host_id = s.host_id
-                AND h.name NOT LIKE '_Module_%'
-                AND s.enabled = 1
-                AND s.host_id = ssg.host_id
-                AND ssg.service_id = s.service_id
-                AND ssg.servicegroup_id = sg.servicegroup_id
-                AND sg.name = '" . $this->dbb->escape($sgName) . "' ";
-        if (! $admin) {
-            $query .= ' AND h.host_id = acl.host_id
-                AND acl.service_id = s.service_id
-                AND acl.group_id IN (' . $aclObj->getAccessGroupsString() . ') ';
+
+        $query = <<<'SQL'
+                SELECT DISTINCT
+                    h.host_id,
+                    s.state,
+                    h.name,
+                    s.service_id,
+                    s.description,
+                    ssg.servicegroup_id
+                FROM hosts h
+                INNER JOIN services s
+                    ON h.host_id = s.host_id
+                INNER JOIN services_servicegroups ssg
+                    ON s.host_id = ssg.host_id
+                    AND s.service_id = ssg.service_id
+                INNER JOIN servicegroups sg
+                    ON ssg.servicegroup_id = sg.servicegroup_id
+            SQL;
+
+        if (! $isUserAdmin) {
+            $accessGroupsList = implode(', ', $accessGroups->getIds());
+            $query .= <<<SQL
+                    INNER JOIN centreon_acl acl
+                        ON h.host_id = acl.host_id
+                        AND s.service_id = acl.service_id
+                        AND acl.group_id IN ({$accessGroupsList})
+                SQL;
         }
-        $query .= ' ORDER BY h.name ';
-        $res = $this->dbb->query($query);
+
+        $query .= <<<'SQL'
+                WHERE h.name NOT LIKE '_Module_%'
+                    AND s.enabled = 1
+                    AND sg.name = :serviceGroupName
+                ORDER BY h.name
+            SQL;
+
         $tab = [];
         $detailTab = [];
-        while ($row = $res->fetch()) {
-            if (! isset($tab[$row['state']])) {
-                $tab[$row['state']] = 0;
+        $queryParameters = QueryParameters::create([QueryParameter::string('serviceGroupName', $serviceGroupName)]);
+        foreach ($this->dbb->iterateAssociative($query, $queryParameters) as $record) {
+            if (! isset($tab[$record['state']])) {
+                $tab[$record['state']] = 0;
             }
-            if (! isset($detailTab[$row['host_id']])) {
-                $detailTab[$row['host_id']] = [];
+            if (! isset($detailTab[$record['host_id']])) {
+                $detailTab[$record['host_id']] = [];
             }
-            if (isset($detailTab[$row['name']]) && ! isset($detailTab[$row['name']][$row['service_id']])) {
-                $detailTab[$row['host_id']][$row['service_id']] = [];
+            if (isset($detailTab[$record['name']]) && ! isset($detailTab[$record['name']][$record['service_id']])) {
+                $detailTab[$record['host_id']][$record['service_id']] = [];
             }
-            foreach ($row as $key => $val) {
-                $detailTab[$row['host_id']][$row['service_id']][$key] = $val;
+            foreach ($record as $key => $val) {
+                $detailTab[$record['host_id']][$record['service_id']][$key] = $val;
             }
-            $tab[$row['state']]++;
+            $tab[$record['state']]++;
         }
         if ($detailFlag == true) {
             return $detailTab;

--- a/centreon/www/widgets/servicegroup-monitoring/src/export.php
+++ b/centreon/www/widgets/servicegroup-monitoring/src/export.php
@@ -19,6 +19,11 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Security\AccessGroup\Domain\Collection\AccessGroupCollection;
+
 header('Content-type: application/csv');
 header('Content-Disposition: attachment; filename="servicegroups-monitoring.csv"');
 
@@ -29,15 +34,16 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/widgets/servicegroup-monitoring/src/class/ServicegroupMonitoring.class.php';
+require_once $centreon_path . 'www/include/common/sqlCommonFunction.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
 
 session_start();
 if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId'])) {
     exit;
 }
-$db = $dependencyInjector['configuration_db'];
-if (CentreonSession::checkSession(session_id(), $db) == 0) {
+$configurationDatabase = $dependencyInjector['configuration_db'];
+if (CentreonSession::checkSession(session_id(), $configurationDatabase) == 0) {
     exit;
 }
 
@@ -47,20 +53,54 @@ $template = SmartyBC::createSmartyTemplate($path, './');
 
 $centreon = $_SESSION['centreon'];
 $widgetId = $_REQUEST['widgetId'];
-$dbb = $dependencyInjector['realtime_db'];
-$widgetObj = new CentreonWidget($centreon, $db);
-$sgMonObj = new ServicegroupMonitoring($dbb);
+$realtimeDatabase = $dependencyInjector['realtime_db'];
+$widgetObj = new CentreonWidget($centreon, $configurationDatabase);
+$serviceGroupService = new ServicegroupMonitoring($realtimeDatabase);
 $preferences = $widgetObj->getWidgetPreferences($widgetId);
-$pearDB = $db;
-$aclObj = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
 
-$hostStateLabels = [0 => 'Up', 1 => 'Down', 2 => 'Unreachable', 4 => 'Pending'];
+$hostStateLabels = [
+    0 => 'Up',
+    1 => 'Down',
+    2 => 'Unreachable',
+    4 => 'Pending',
+];
 
-$serviceStateLabels = [0 => 'Ok', 1 => 'Warning', 2 => 'Critical', 3 => 'Unknown', 4 => 'Pending'];
+$serviceStateLabels = [
+    0 => 'Ok',
+    1 => 'Warning',
+    2 => 'Critical',
+    3 => 'Unknown',
+    4 => 'Pending',
+];
 
 $baseQuery = 'FROM servicegroups ';
+$queryParameters = [];
 
-$bindParams = [];
+$accessGroups = new AccessGroupCollection();
+
+if (! $centreon->user->admin) {
+    $acl = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups = $acl->getAccessGroups();
+
+    ['parameters' => $queryParameters, 'placeholderList' => $accessGroupList] = createMultipleBindParameters(
+        $accessGroups->getIds(),
+        'access_group',
+        QueryParameterTypeEnum::INTEGER
+    );
+
+    $configurationDatabaseName = $configurationDatabase->getConnectionConfig()->getDatabaseNameConfiguration();
+    $baseQuery .= <<<SQL
+            INNER JOIN {$configurationDatabaseName}.acl_resources_sg_relations arsr
+                ON servicegroups.servicegroup_id = arsr.sg_id
+            INNER JOIN {$configurationDatabaseName}.acl_resources res
+                ON arsr.acl_res_id = res.acl_res_id
+            INNER JOIN {$configurationDatabaseName}.acl_res_group_relations argr
+                ON res.acl_res_id = argr.acl_res_id
+            INNER JOIN {$configurationDatabaseName}.acl_groups ag
+                ON argr.acl_group_id = ag.acl_group_id
+            WHERE ag.acl_group_id IN ({$accessGroupList})
+        SQL;
+}
 
 if (isset($preferences['sg_name_search']) && trim($preferences['sg_name_search']) != '') {
     $tab = explode(' ', $preferences['sg_name_search']);
@@ -73,14 +113,8 @@ if (isset($preferences['sg_name_search']) && trim($preferences['sg_name_search']
             $baseQuery,
             'name ' . CentreonUtils::operandToMysqlFormat($op) . ' :search '
         );
-        $bindParams[':search'] = [$search, PDO::PARAM_STR];
+        $queryParameters[] = QueryParameter::string('search', $search);
     }
-}
-
-if (! $centreon->user->admin) {
-    [$bindValues, $bindQuery] = createMultipleBindQuery($aclObj->getServiceGroups(), ':servicegroup_name_', PDO::PARAM_STR);
-    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, "name IN ({$bindQuery})");
-    $bindParams = array_merge($bindParams, $bindValues);
 }
 
 $orderBy = 'name ASC';
@@ -101,44 +135,32 @@ if (isset($preferences['order_by']) && trim($preferences['order_by']) !== '') {
 
 try {
     // Query to count total rows
-    $countQuery = 'SELECT COUNT(*) ' . $baseQuery;
-    if ($bindParams !== []) {
-        $countStatement = $dbb->prepareQuery($countQuery);
-        $dbb->executePreparedQuery($countStatement, $bindParams, true);
-    } else {
-        $countStatement = $dbb->executeQuery($countQuery);
-    }
-    $nbRows = (int) $dbb->fetchColumn($countStatement);
+    $countQuery = 'SELECT COUNT(DISTINCT servicegroups.servicegroup_id) ' . $baseQuery;
+    $nbRows = (int) $realtimeDatabase->fetchOne($countQuery, QueryParameters::create($queryParameters));
 
     // Main SELECT query
     $query = 'SELECT DISTINCT 1 AS REALTIME, name, servicegroup_id ' . $baseQuery;
     $query .= " ORDER BY {$orderBy}";
 
-    // Prepare the query
-    $statement = $dbb->prepareQuery($query);
-
-    // Execute the query
-    $dbb->executePreparedQuery($statement, $bindParams, true);
     $data = [];
     $detailMode = false;
     if (isset($preferences['enable_detailed_mode']) && $preferences['enable_detailed_mode']) {
         $detailMode = true;
     }
-    while ($row = $statement->fetch(PDO::FETCH_ASSOC)) {
+
+    foreach ($realtimeDatabase->iterateAssociative($query, QueryParameters::create($queryParameters)) as $row) {
         $data[$row['name']]['name'] = $row['name'];
 
-        $data[$row['name']]['host_state'] = $sgMonObj->getHostStates(
+        $data[$row['name']]['host_state'] = $serviceGroupService->getHostStates(
             $row['name'],
-            $centreon->user->admin,
-            $aclObj,
-            $preferences,
+            (int) $centreon->user->admin === 1,
+            $accessGroups,
             $detailMode
         );
-        $data[$row['name']]['service_state'] = $sgMonObj->getServiceStates(
+        $data[$row['name']]['service_state'] = $serviceGroupService->getServiceStates(
             $row['name'],
-            $centreon->user->admin,
-            $aclObj,
-            $preferences,
+            (int) $centreon->user->admin === 1,
+            $accessGroups,
             $detailMode
         );
     }

--- a/centreon/www/widgets/servicegroup-monitoring/src/index.php
+++ b/centreon/www/widgets/servicegroup-monitoring/src/index.php
@@ -19,6 +19,11 @@
  *
  */
 
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+use Adaptation\Database\Connection\ValueObject\QueryParameter;
+use Core\Security\AccessGroup\Domain\Collection\AccessGroupCollection;
+
 require_once '../../require.php';
 require_once $centreon_path . 'bootstrap.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
@@ -26,17 +31,22 @@ require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonLog.class.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
 require_once $centreon_path . 'www/widgets/servicegroup-monitoring/src/class/ServicegroupMonitoring.class.php';
+require_once $centreon_path . 'www/include/common/sqlCommonFunction.php';
 
 CentreonSession::start(1);
 
 if (! isset($_SESSION['centreon']) || ! isset($_REQUEST['widgetId']) || ! isset($_REQUEST['page'])) {
     exit();
 }
-$db = $dependencyInjector['configuration_db'];
-if (CentreonSession::checkSession(session_id(), $db) == 0) {
+
+/**
+ * @var CentreonDB $configurationDatabase
+ */
+$configurationDatabase = $dependencyInjector['configuration_db'];
+if (CentreonSession::checkSession(session_id(), $configurationDatabase) == 0) {
     exit();
 }
 
@@ -52,8 +62,15 @@ $centreon = $_SESSION['centreon'];
  */
 $useDeprecatedPages = $centreon->user->doesShowDeprecatedPages();
 
-$widgetId = filter_var($_REQUEST['widgetId'], FILTER_VALIDATE_INT);
-$page = filter_var($_REQUEST['page'], FILTER_VALIDATE_INT);
+$widgetId = filter_var(
+    $_REQUEST['widgetId'],
+    FILTER_VALIDATE_INT,
+);
+
+$page = filter_var(
+    $_REQUEST['page'],
+    FILTER_VALIDATE_INT,
+);
 
 if ($widgetId === false) {
     throw new InvalidArgumentException('Widget ID must be an integer');
@@ -63,26 +80,72 @@ if ($page === false) {
 }
 
 /**
- * @var CentreonDB $dbb
+ * @var CentreonDB $realtimeDatabase
  */
-$dbb = $dependencyInjector['realtime_db'];
-$widgetObj = new CentreonWidget($centreon, $db);
-$sgMonObj = new ServicegroupMonitoring($dbb);
+$realtimeDatabase = $dependencyInjector['realtime_db'];
+$widgetObj = new CentreonWidget($centreon, $configurationDatabase);
+$sgMonObj = new ServicegroupMonitoring($realtimeDatabase);
 $preferences = $widgetObj->getWidgetPreferences($widgetId);
-$pearDB = $db;
-$aclObj = new CentreonACL($centreon->user->user_id, $centreon->user->admin);
 
-$aColorHost = [0 => 'host_up', 1 => 'host_down', 2 => 'host_unreachable', 4 => 'host_pending'];
+$aColorHost = [
+    0 => 'host_up',
+    1 => 'host_down',
+    2 => 'host_unreachable',
+    4 => 'host_pending',
+];
 
-$aColorService = [0 => 'service_ok', 1 => 'service_warning', 2 => 'service_critical', 3 => 'service_unknown', 4 => 'pending'];
+$aColorService = [
+    0 => 'service_ok',
+    1 => 'service_warning',
+    2 => 'service_critical',
+    3 => 'service_unknown',
+    4 => 'pending',
+];
 
-$hostStateLabels = [0 => 'Up', 1 => 'Down', 2 => 'Unreachable', 4 => 'Pending'];
+$hostStateLabels = [
+    0 => 'Up',
+    1 => 'Down',
+    2 => 'Unreachable',
+    4 => 'Pending',
+];
 
-$serviceStateLabels = [0 => 'Ok', 1 => 'Warning', 2 => 'Critical', 3 => 'Unknown', 4 => 'Pending'];
+$serviceStateLabels = [
+    0 => 'Ok',
+    1 => 'Warning',
+    2 => 'Critical',
+    3 => 'Unknown',
+    4 => 'Pending',
+];
 
 // Prepare the base query
 $baseQuery = 'FROM servicegroups ';
-$bindParams = [];
+$queryParameters = [];
+
+$accessGroups = new AccessGroupCollection();
+
+if (! $centreon->user->admin) {
+    $acl = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups = $acl->getAccessGroups();
+
+    ['parameters' => $queryParameters, 'placeholderList' => $accessGroupList] = createMultipleBindParameters(
+        $accessGroups->getIds(),
+        'access_group',
+        QueryParameterTypeEnum::INTEGER
+    );
+
+    $configurationDatabaseName = $configurationDatabase->getConnectionConfig()->getDatabaseNameConfiguration();
+    $baseQuery .= <<<SQL
+            INNER JOIN {$configurationDatabaseName}.acl_resources_sg_relations arsr
+                ON servicegroups.servicegroup_id = arsr.sg_id
+            INNER JOIN {$configurationDatabaseName}.acl_resources res
+                ON arsr.acl_res_id = res.acl_res_id
+            INNER JOIN {$configurationDatabaseName}.acl_res_group_relations argr
+                ON res.acl_res_id = argr.acl_res_id
+            INNER JOIN {$configurationDatabaseName}.acl_groups ag
+                ON argr.acl_group_id = ag.acl_group_id
+            WHERE ag.acl_group_id IN ({$accessGroupList})
+        SQL;
+}
 
 if (isset($preferences['sg_name_search']) && trim($preferences['sg_name_search']) != '') {
     $tab = explode(' ', $preferences['sg_name_search']);
@@ -95,14 +158,8 @@ if (isset($preferences['sg_name_search']) && trim($preferences['sg_name_search']
             $baseQuery,
             'name ' . CentreonUtils::operandToMysqlFormat($op) . ' :search '
         );
-        $bindParams[':search'] = [$search, PDO::PARAM_STR];
+        $queryParameters[] = QueryParameter::string('search', $search);
     }
-}
-
-if (! $centreon->user->admin) {
-    [$bindValues, $bindQuery] = createMultipleBindQuery($aclObj->getServiceGroups(), ':servicegroup_name_', PDO::PARAM_STR);
-    $baseQuery = CentreonUtils::conditionBuilder($baseQuery, "name IN ({$bindQuery})");
-    $bindParams = array_merge($bindParams, $bindValues);
 }
 
 $orderby = 'name ASC';
@@ -132,13 +189,8 @@ if ($orderByToAnalyse !== null) {
 try {
     // Query to count total rows
     $countQuery = 'SELECT COUNT(*) ' . $baseQuery;
-    if ($bindParams !== []) {
-        $countStatement = $dbb->prepareQuery($countQuery);
-        $dbb->executePreparedQuery($countStatement, $bindParams, true);
-    } else {
-        $countStatement = $dbb->executeQuery($countQuery);
-    }
-    $nbRows = (int) $dbb->fetchColumn($countStatement);
+
+    $nbRows = (int) $realtimeDatabase->fetchOne($countQuery, QueryParameters::create($queryParameters));
 
     // Sanitize and validate input
     $entriesPerPage = filter_var($preferences['entries'], FILTER_VALIDATE_INT);
@@ -153,19 +205,8 @@ try {
     $query .= " ORDER BY {$orderby}";
     $query .= ' LIMIT :offset, :entriesPerPage';
 
-    $statement = $dbb->prepareQuery($query);
-
-    // Bind parameters
-    $bindParams = array_merge(
-        $bindParams,
-        [
-            ':offset' => [$offset, PDO::PARAM_INT],
-            ':entriesPerPage' => [$entriesPerPage, PDO::PARAM_INT],
-        ]
-    );
-
-    // Execute the query
-    $dbb->executePreparedQuery($statement, $bindParams, true);
+    $queryParameters[] = QueryParameter::int('offset', $offset);
+    $queryParameters[] = QueryParameter::int('entriesPerPage', $entriesPerPage);
 
     $kernel = App\Kernel::createForWeb();
     $resourceController = $kernel->getContainer()->get(
@@ -226,25 +267,23 @@ try {
     if (isset($preferences['enable_detailed_mode']) && $preferences['enable_detailed_mode']) {
         $detailMode = true;
     }
-    while ($row = $dbb->fetch($statement)) {
+    foreach ($realtimeDatabase->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
         $servicegroup = [
-            'id' => (int) $row['servicegroup_id'],
-            'name' => $row['name'],
+            'id' => (int) $record['servicegroup_id'],
+            'name' => $record['name'],
         ];
 
         $hostStates = $sgMonObj->getHostStates(
-            $row['name'],
-            $centreon->user->admin,
-            $aclObj,
-            $preferences,
+            $record['name'],
+            $centreon->user->admin === '1',
+            $accessGroups,
             $detailMode
         );
 
         $serviceStates = $sgMonObj->getServiceStates(
-            $row['name'],
-            $centreon->user->admin,
-            $aclObj,
-            $preferences,
+            $record['name'],
+            $centreon->user->admin === '1',
+            $accessGroups,
             $detailMode
         );
 
@@ -303,9 +342,9 @@ try {
             ? $serviceGroupDeprecatedUri . '&o=svc&statusFilter=unknown'
             : $buildServicegroupUri([$servicegroup], [$serviceType], [$unknownStatus]);
 
-        $data[$row['name']] = [
-            'name' => $row['name'],
-            'svc_id' => $row['servicegroup_id'],
+        $data[$record['name']] = [
+            'name' => $record['name'],
+            'svc_id' => $record['servicegroup_id'],
             'sgurl' => $serviceGroupUri,
             'host_state' => $hostStates,
             'service_state' => $serviceStates,

--- a/centreon/www/widgets/single-metric/index.php
+++ b/centreon/www/widgets/single-metric/index.php
@@ -20,14 +20,15 @@
  */
 
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once 'functions.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
 require_once $centreon_path . 'bootstrap.php';
 
 CentreonSession::start(1);
@@ -64,8 +65,20 @@ try {
         'dark' => 'Centreon-Dark',
         default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
     };
-} catch (Exception $e) {
-    echo $e->getMessage() . '<br/>';
+
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error fetching data for single-metric widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme);
 
     exit;
 }
@@ -82,8 +95,8 @@ $resourceController = $kernel->getContainer()->get(
 $isAdmin = $centreon->user->admin === '1';
 $accessGroups = [];
 if (! $isAdmin) {
-    $access = new CentreonACL($centreon->user->get_id());
-    $accessGroups = $access->getAccessGroups();
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+    $accessGroups = $acls->getAccessGroups()->getIds();
 }
 
 // Smarty template initialization
@@ -105,7 +118,7 @@ if (! isset($preferences['service']) || $preferences['service'] === '') {
 } else {
     [$hostId, $serviceId] = explode('-', $preferences['service']);
     $numLine = 0;
-    if ($isAdmin || ! empty($accessGroups)) {
+    if ($isAdmin || $accessGroups !== []) {
         $query
             = "SELECT
                 1 AS REALTIME,

--- a/centreon/www/widgets/tactical-overview/index.php
+++ b/centreon/www/widgets/tactical-overview/index.php
@@ -44,11 +44,6 @@ $widgetId = filter_input(INPUT_GET, 'widgetId', FILTER_VALIDATE_INT, ['options' 
 try {
     $configurationDatabase = $dependencyInjector['configuration_db'];
 
-    if (! $centreon->user->admin) {
-        $acls = new CentreonAclLazy($centreon->user->user_id);
-        $accessGroups = $acls->getAccessGroups()->getIds();
-    }
-
     $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
 

--- a/centreon/www/widgets/tactical-overview/index.php
+++ b/centreon/www/widgets/tactical-overview/index.php
@@ -20,14 +20,18 @@
  */
 
 require_once '../require.php';
+require_once '../widget-error-handling.php';
 require_once $centreon_path . 'www/class/centreon.class.php';
 require_once $centreon_path . 'www/class/centreonSession.class.php';
 require_once $centreon_path . 'www/class/centreonWidget.class.php';
 require_once $centreon_path . 'www/class/centreonDuration.class.php';
 require_once $centreon_path . 'www/class/centreonUtils.class.php';
-require_once $centreon_path . 'www/class/centreonACL.class.php';
 require_once $centreon_path . 'www/class/centreonHost.class.php';
+require_once $centreon_path . 'www/class/centreonAclLazy.class.php';
 require_once $centreon_path . 'bootstrap.php';
+
+const OBJECT_TYPE_HOST = 'hosts';
+const OBJECT_TYPE_SERVICE = 'services';
 
 CentreonSession::start(1);
 
@@ -38,17 +42,22 @@ $centreon = $_SESSION['centreon'];
 $widgetId = filter_input(INPUT_GET, 'widgetId', FILTER_VALIDATE_INT, ['options' => ['default' => 0]]);
 
 try {
-    $db_centreon = $dependencyInjector['configuration_db'];
-    $db = $dependencyInjector['realtime_db'];
+    $configurationDatabase = $dependencyInjector['configuration_db'];
 
-    if ($centreon->user->admin == 0) {
-        $access = new CentreonACL($centreon->user->get_id());
-        $grouplist = $access->getAccessGroups();
-        $grouplistStr = $access->getAccessGroupsString();
+    if (! $centreon->user->admin) {
+        $acls = new CentreonAclLazy($centreon->user->user_id);
+        $accessGroups = $acls->getAccessGroups()->getIds();
     }
 
-    $widgetObj = new CentreonWidget($centreon, $db_centreon);
+    $widgetObj = new CentreonWidget($centreon, $configurationDatabase);
     $preferences = $widgetObj->getWidgetPreferences($widgetId);
+
+    $objectType = ! empty($preferences['object_type']) ? $preferences['object_type'] : OBJECT_TYPE_HOST;
+
+    if (! in_array($objectType, [OBJECT_TYPE_HOST, OBJECT_TYPE_SERVICE])) {
+        throw new InvalidArgumentException('Invalid object type provided in tactical-overview. Accepted: hosts or services');
+    }
+
     $autoRefresh = (isset($preferences['refresh_interval']) && (int) $preferences['refresh_interval'] > 0)
         ? (int) $preferences['refresh_interval']
         : 30;
@@ -57,8 +66,20 @@ try {
         'dark' => 'Centreon-Dark',
         default => throw new Exception('Unknown user theme : ' . $centreon->user->theme),
     };
-} catch (Exception $e) {
-    echo $e->getMessage() . '<br/>';
+
+    $theme = $variablesThemeCSS === 'Generic-theme'
+        ? $variablesThemeCSS . '/Variables-css'
+        : $variablesThemeCSS;
+} catch (Exception $exception) {
+    CentreonLog::create()->error(
+        logTypeId: CentreonLog::TYPE_BUSINESS_LOG,
+        message: 'Error fetching data for tactical-overview widget: ' . $exception->getMessage(),
+        customContext: [
+            'widget_id' => $widgetId,
+        ],
+        exception: $exception
+    );
+    showError($exception->getMessage(), $theme ?? 'Generic-theme/Variables-css');
 
     exit;
 }
@@ -86,11 +107,4 @@ $buildParameter = function (string $id, string $name) {
     ];
 };
 
-if (
-    isset($preferences['object_type'])
-    && ($preferences['object_type'] === 'hosts' || $preferences['object_type'] == '')
-) {
-    require_once 'src/hosts_status.php';
-} elseif (isset($preferences['object_type']) && $preferences['object_type'] === 'services') {
-    require_once 'src/services_status.php';
-}
+$objectType === OBJECT_TYPE_HOST ? require_once 'src/hosts_status.php' : require_once 'src/services_status.php';

--- a/centreon/www/widgets/tactical-overview/src/hosts_status.php
+++ b/centreon/www/widgets/tactical-overview/src/hosts_status.php
@@ -19,18 +19,26 @@
  *
  */
 
-$dataDO = [];
-$dataUN = [];
-$dataUP = [];
-$dataPEND = [];
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+
+$hostsDownStatus = [];
+$hostsUnknownStatus = [];
+$hostsUpStatus = [];
+$hostsPendingStatus = [];
 $dataList = [];
-$db = new CentreonDB('centstorage');
+
+$realtimeConnection = new CentreonDB('centstorage');
 
 /**
  * true: URIs will correspond to deprecated pages
  * false: URIs will correspond to new page (Resource Status)
  */
 $useDeprecatedPages = $centreon->user->doesShowDeprecatedPages();
+
+$autoRefresh = (isset($preferences['refresh_interval']) && (int) $preferences['refresh_interval'] > 0)
+    ? (int) $preferences['refresh_interval']
+    : 30;
 
 $buildHostUri = function (array $states, array $statuses) use ($resourceController, $buildParameter) {
     return $resourceController->buildListingUri(
@@ -59,185 +67,176 @@ $inDowntimeState = $buildParameter('in_downtime', 'In downtime');
 
 $deprecatedHostListingUri = '../../main.php?p=20202&search=&o=h_';
 
-// query for DOWN status
-$res = $db->query(
-    "SELECT 1 AS REALTIME,
-        SUM(
-            CASE WHEN h.state = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) as status,
-        SUM(
-            CASE WHEN h.acknowledged = 1
-                AND h.state = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) as ack,
-        SUM(
-            CASE WHEN h.scheduled_downtime_depth = 1
-                AND h.state = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) as down
-    FROM hosts AS h " . (
-        $centreon->user->admin == 0
-        ? 'JOIN (
-            SELECT acl.host_id, acl.service_id
-            FROM centreon_acl AS acl
-            WHERE acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')
-            GROUP BY host_id
-        ) x ON x.host_id = h.host_id AND x.service_id IS NULL' : ''
-    ) . ';'
-);
-while ($row = $res->fetch()) {
-    $row['un'] = $row['status'] - ($row['ack'] + $row['down']);
+$queryParameters = [];
+$aclSubQuery = '';
+
+if (! $centreon->user->admin) {
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+
+    // Make request return nothing
+    if ($acls->getAccessGroups()->isEmpty()) {
+        $aclSubQuery = ' WHERE 1 = 0';
+    } else {
+        ['parameters' => $queryParameters, 'placeholderList' => $bindQuery] = createMultipleBindParameters(
+            $acls->getAccessGroups()->getIds(),
+            'access_group',
+            QueryParameterTypeEnum::INTEGER
+        );
+
+        $aclSubQuery = <<<SQL
+                    INNER JOIN centreon_acl acl
+                        ON acl.host_id = h.host_id
+                        AND acl.service_id IS NULL
+                    WHERE acl.group_id IN ({$bindQuery})
+            SQL;
+    }
+}
+
+$downStatusQuery = <<<SQL
+        SELECT 1 AS REALTIME,
+            SUM(
+                CASE WHEN h.state = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) as status,
+            SUM(
+                CASE WHEN h.acknowledged = 1
+                    AND h.state = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) as ack,
+            SUM(
+                CASE WHEN h.scheduled_downtime_depth = 1
+                    AND h.state = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) as down
+        FROM hosts AS h
+        {$aclSubQuery}
+    SQL;
+
+foreach ($realtimeConnection->iterateAssociative($downStatusQuery, QueryParameters::create($queryParameters)) as $record) {
+    $record['un'] = $record['status'] - ($record['ack'] + $record['down']);
 
     $deprecatedDownHostListingUri = $deprecatedHostListingUri . 'down';
 
-    $row['listing_uri'] = $useDeprecatedPages
+    $record['listing_uri'] = $useDeprecatedPages
         ? $deprecatedDownHostListingUri
         : $buildHostUri([], [$downStatus]);
 
-    $row['listing_ack_uri'] = $useDeprecatedPages
+    $record['listing_ack_uri'] = $useDeprecatedPages
         ? $deprecatedDownHostListingUri
         : $buildHostUri([$acknowledgedState], [$downStatus]);
 
-    $row['listing_downtime_uri'] = $useDeprecatedPages
+    $record['listing_downtime_uri'] = $useDeprecatedPages
         ? $deprecatedDownHostListingUri
         : $buildHostUri([$inDowntimeState], [$downStatus]);
 
-    $row['listing_unhandled_uri'] = $useDeprecatedPages
+    $record['listing_unhandled_uri'] = $useDeprecatedPages
         ? $deprecatedDownHostListingUri
         : $buildHostUri([$unhandledState], [$downStatus]);
 
-    $dataDO[] = $row;
+    $hostsDownStatus[] = $record;
 }
 
-// query for UNKNOWN status
-$res = $db->query(
-    "SELECT 1 AS REALTIME,
-        SUM(
-            CASE WHEN h.state = 2
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) as status,
-        SUM(
-            CASE WHEN h.acknowledged = 1
-                AND h.state = 2
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) as ack,
-        SUM(
-            CASE WHEN h.state = 2
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module% '
-                AND h.scheduled_downtime_depth = 1
-            THEN 1 ELSE 0 END
-        ) as down
-    FROM hosts AS h " . (
-        $centreon->user->admin == 0
-        ? 'JOIN (
-            SELECT acl.host_id, acl.service_id
-            FROM centreon_acl AS acl
-            WHERE acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')
-            GROUP BY host_id
-        ) x ON x.host_id = h.host_id AND x.service_id IS NULL' : ''
-    ) . ';'
-);
-while ($row = $res->fetch()) {
-    $row['un'] = $row['status'] - ($row['ack'] + $row['down']);
+$query = <<<SQL
+        SELECT 1 AS REALTIME,
+            SUM(
+                CASE WHEN h.state = 2
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) as status,
+            SUM(
+                CASE WHEN h.acknowledged = 1
+                    AND h.state = 2
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) as ack,
+            SUM(
+                CASE WHEN h.state = 2
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                    AND h.scheduled_downtime_depth = 1
+                THEN 1 ELSE 0 END
+            ) as down
+        FROM hosts AS h
+        {$aclSubQuery}
+    SQL;
+
+foreach ($realtimeConnection->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+    $record['un'] = $record['status'] - ($record['ack'] + $record['down']);
 
     $deprecatedUnreachableHostListingUri = $deprecatedHostListingUri . 'unreachable';
 
-    $row['listing_uri'] = $useDeprecatedPages
+    $record['listing_uri'] = $useDeprecatedPages
         ? $deprecatedUnreachableHostListingUri
         : $buildHostUri([], [$unreachableStatus]);
 
-    $row['listing_ack_uri'] = $useDeprecatedPages
+    $record['listing_ack_uri'] = $useDeprecatedPages
         ? $deprecatedUnreachableHostListingUri
         : $buildHostUri([$acknowledgedState], [$unreachableStatus]);
 
-    $row['listing_downtime_uri'] = $useDeprecatedPages
+    $record['listing_downtime_uri'] = $useDeprecatedPages
         ? $deprecatedUnreachableHostListingUri
         : $buildHostUri([$inDowntimeState], [$unreachableStatus]);
 
-    $row['listing_unhandled_uri'] = $useDeprecatedPages
+    $record['listing_unhandled_uri'] = $useDeprecatedPages
         ? $deprecatedUnreachableHostListingUri
         : $buildHostUri([$unhandledState], [$unreachableStatus]);
 
-    $dataUN[] = $row;
+    $hostsUnknownStatus[] = $record;
 }
 
-// query for UP status
-$res = $db->query(
-    "SELECT 1 AS REALTIME,
-        SUM(
-            CASE WHEN h.state = 0
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) as status
-    FROM hosts AS h " . (
-        $centreon->user->admin == 0
-        ? 'JOIN (
-            SELECT acl.host_id, acl.service_id
-            FROM centreon_acl AS acl
-            WHERE acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')
-            GROUP BY host_id
-        ) x ON x.host_id = h.host_id AND x.service_id IS NULL' : ''
-    ) . ';'
-);
-while ($row = $res->fetch()) {
-    $row['listing_uri'] = $useDeprecatedPages
+$query = <<<SQL
+        SELECT 1 AS REALTIME,
+            SUM(
+                CASE WHEN h.state = 0
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) as status
+        FROM hosts AS h
+        {$aclSubQuery}
+    SQL;
+
+foreach ($realtimeConnection->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+    $record['listing_uri'] = $useDeprecatedPages
         ? $deprecatedHostListingUri . 'up'
         : $buildHostUri([], [$upStatus]);
 
-    $dataUP[] = $row;
+    $hostsUpStatus[] = $record;
 }
 
-// query for PENDING status
-$res = $db->query(
-    "SELECT 1 AS REALTIME,
-        SUM(
-            CASE WHEN h.state = 4
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) as status
-    FROM hosts AS h " . (
-        $centreon->user->admin == 0
-        ? 'JOIN (
-            SELECT acl.host_id, acl.service_id
-            FROM centreon_acl AS acl
-            WHERE acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')
-            GROUP BY host_id
-        ) x ON x.host_id = h.host_id AND x.service_id IS NULL' : ''
-    ) . ';'
-);
-while ($row = $res->fetch()) {
-    $row['listing_uri'] = $useDeprecatedPages
+$query = <<<SQL
+        SELECT 1 AS REALTIME,
+            SUM(
+                CASE WHEN h.state = 4
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) as status
+        FROM hosts AS h
+        {$aclSubQuery}
+    SQL;
+
+foreach ($realtimeConnection->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+    $record['listing_uri'] = $useDeprecatedPages
         ? $deprecatedHostListingUri . 'pending'
         : $buildHostUri([], [$pendingStatus]);
 
-    $dataPEND[] = $row;
+    $hostsPendingStatus[] = $record;
 }
-
-$numLine = 1;
-
-$autoRefresh = (isset($preferences['refresh_interval']) && (int) $preferences['refresh_interval'] > 0)
-    ? (int) $preferences['refresh_interval']
-    : 30;
 
 $template->assign('preferences', $preferences);
 $template->assign('widgetId', $widgetId);
 $template->assign('autoRefresh', $autoRefresh);
-$template->assign('dataPEND', $dataPEND);
-$template->assign('dataUP', $dataUP);
-$template->assign('dataUN', $dataUN);
-$template->assign('dataDO', $dataDO);
+$template->assign('dataPEND', $hostsPendingStatus);
+$template->assign('dataUP', $hostsUpStatus);
+$template->assign('dataUN', $hostsUnknownStatus);
+$template->assign('dataDO', $hostsDownStatus);
 $template->display('hosts_status.ihtml');

--- a/centreon/www/widgets/tactical-overview/src/services_status.php
+++ b/centreon/www/widgets/tactical-overview/src/services_status.php
@@ -19,11 +19,17 @@
  *
  */
 
-$dataCRI = [];
-$dataWA = [];
-$dataOK = [];
-$dataUNK = [];
-$dataPEND = [];
+use Adaptation\Database\Connection\Collection\QueryParameters;
+use Adaptation\Database\Connection\Enum\QueryParameterTypeEnum;
+
+require_once $centreon_path . 'www/include/common/sqlCommonFunction.php';
+
+$serviceCriticalStatus = [];
+$serviceWarningStatus = [];
+$serviceOkStatus = [];
+$serviceUnknownStatus = [];
+$servicePendingStatus = [];
+
 $db = new CentreonDB('centstorage');
 
 /**
@@ -31,6 +37,10 @@ $db = new CentreonDB('centstorage');
  * false: URIs will correspond to new page (Resource Status)
  */
 $useDeprecatedPages = $centreon->user->doesShowDeprecatedPages();
+
+$autoRefresh = (isset($preferences['refresh_interval']) && (int) $preferences['refresh_interval'] > 0)
+    ? (int) $preferences['refresh_interval']
+    : 30;
 
 $buildServiceUri = function (array $states, array $statuses) use ($resourceController, $buildParameter) {
     return $resourceController->buildListingUri(
@@ -60,305 +70,283 @@ $inDowntimeState = $buildParameter('in_downtime', 'In downtime');
 
 $deprecatedServiceListingUri = '../../main.php?p=20201&search=';
 
-// query for CRITICAL state
-$res = $db->query(
-    "SELECT 1 AS REALTIME,
-        SUM(
-            CASE WHEN s.state = 2
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS status,
-        SUM(
-            CASE WHEN s.acknowledged = 1
-                AND s.state = 2
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS ack,
-        SUM(
-            CASE WHEN s.scheduled_downtime_depth = 1
-                AND s.state = 2
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS down,
-        SUM(
-            CASE WHEN s.state = 2
-                AND (h.state = 1 OR h.state = 4 OR h.state = 2)
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS pb,
-        SUM(
-            CASE WHEN s.state = 2
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-                AND s.acknowledged = 0
-                AND s.scheduled_downtime_depth = 0
-                AND h.state = 0
-            THEN 1 ELSE 0 END
-        ) AS un
-    FROM services AS s
-    LEFT JOIN hosts AS h ON h.host_id = s.host_id " . (
-        $centreon->user->admin == 0
-        ? 'JOIN (
-            SELECT acl.host_id, acl.service_id
-            FROM centreon_acl AS acl
-            WHERE acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')
-            GROUP BY host_id,service_id
-            ) x ON x.host_id = h.host_id AND x.service_id = s.service_id'
-        : ''
-    ) . ';'
-);
-while ($row = $res->fetch()) {
-    $row['listing_uri'] = $useDeprecatedPages
+$queryParameters = [];
+
+$aclSubQuery = '';
+if (! $centreon->user->admin) {
+    $acls = new CentreonAclLazy($centreon->user->user_id);
+    ['parameters' => $queryParameters, 'placeholderList' => $bindQuery] = createMultipleBindParameters(
+        $acls->getAccessGroups()->getIds(),
+        'access_group',
+        QueryParameterTypeEnum::INTEGER
+    );
+
+    $aclSubQuery = <<<SQL
+            INNER JOIN centreon_acl acl
+                ON acl.host_id = h.host_id
+                AND acl.service_id = s.service_id
+            WHERE acl.group_id IN ({$bindQuery})
+        SQL;
+}
+
+$query = <<<SQL
+        SELECT 1 AS REALTIME,
+            SUM(
+                CASE WHEN s.state = 2
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS status,
+            SUM(
+                CASE WHEN s.acknowledged = 1
+                    AND s.state = 2
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS ack,
+            SUM(
+                CASE WHEN s.scheduled_downtime_depth = 1
+                    AND s.state = 2
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS down,
+            SUM(
+                CASE WHEN s.state = 2
+                    AND (h.state = 1 OR h.state = 4 OR h.state = 2)
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS pb,
+            SUM(
+                CASE WHEN s.state = 2
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                    AND s.acknowledged = 0
+                    AND s.scheduled_downtime_depth = 0
+                    AND h.state = 0
+                THEN 1 ELSE 0 END
+            ) AS un
+        FROM services AS s
+        LEFT JOIN hosts AS h
+            ON h.host_id = s.host_id
+        {$aclSubQuery}
+    SQL;
+
+foreach ($db->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+    $record['listing_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=critical&o=svc'
         : $buildServiceUri([], [$criticalStatus]);
 
-    $row['listing_ack_uri'] = $useDeprecatedPages
+    $record['listing_ack_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=critical&statusService=svcpb'
         : $buildServiceUri([$acknowledgedState], [$criticalStatus]);
 
-    $row['listing_downtime_uri'] = $useDeprecatedPages
+    $record['listing_downtime_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=critical&statusService=svcpb'
         : $buildServiceUri([$inDowntimeState], [$criticalStatus]);
 
-    $row['listing_unhandled_uri'] = $useDeprecatedPages
+    $record['listing_unhandled_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=critical&statusService=svc_unhandled'
         : $buildServiceUri([$unhandledState], [$criticalStatus]);
 
-    $dataCRI[] = $row;
+    $serviceCriticalStatus[] = $record;
 }
 
-// query for WARNING state
-$res = $db->query(
-    "SELECT 1 AS REALTIME,
-        SUM(
-            CASE WHEN s.state = 1
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS status,
-        SUM(
-            CASE WHEN s.acknowledged = 1
-                AND s.state = 1
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS ack,
-        SUM(
-            CASE WHEN s.scheduled_downtime_depth > 0
-                AND s.state = 1
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS down,
-        SUM(
-            CASE WHEN s.state = 1
-                AND (h.state = 1 OR h.state = 4 OR h.state = 2)
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS pb,
-        SUM(
-            CASE WHEN s.state = 1
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-                AND s.acknowledged = 0
-                AND s.scheduled_downtime_depth = 0
-                AND h.state = 0
-            THEN 1 ELSE 0 END
-        ) AS un
-    FROM services AS s
-    LEFT JOIN hosts AS h ON h.host_id = s.host_id " . (
-        $centreon->user->admin == 0
-        ? 'JOIN (
-            SELECT acl.host_id, acl.service_id
-            FROM centreon_acl AS acl
-            WHERE acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')
-            GROUP BY host_id,service_id
-            ) x ON x.host_id = h.host_id AND x.service_id = s.service_id'
-        : ''
-    ) . ';'
-);
-while ($row = $res->fetch()) {
-    $row['listing_uri'] = $useDeprecatedPages
+$query = <<<SQL
+        SELECT 1 AS REALTIME,
+            SUM(
+                CASE WHEN s.state = 1
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS status,
+            SUM(
+                CASE WHEN s.acknowledged = 1
+                    AND s.state = 1
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS ack,
+            SUM(
+                CASE WHEN s.scheduled_downtime_depth > 0
+                    AND s.state = 1
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS down,
+            SUM(
+                CASE WHEN s.state = 1
+                    AND (h.state = 1 OR h.state = 4 OR h.state = 2)
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS pb,
+            SUM(
+                CASE WHEN s.state = 1
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                    AND s.acknowledged = 0
+                    AND s.scheduled_downtime_depth = 0
+                    AND h.state = 0
+                THEN 1 ELSE 0 END
+            ) AS un
+        FROM services AS s
+        LEFT JOIN hosts AS h
+            ON h.host_id = s.host_id
+        {$aclSubQuery}
+    SQL;
+
+foreach ($db->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+    $record['listing_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=warning&o=svc'
         : $buildServiceUri([], [$warningStatus]);
 
-    $row['listing_ack_uri'] = $useDeprecatedPages
+    $record['listing_ack_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=warning&statusService=svcpb'
         : $buildServiceUri([$acknowledgedState], [$warningStatus]);
 
-    $row['listing_downtime_uri'] = $useDeprecatedPages
+    $record['listing_downtime_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=warning&statusService=svcpb'
         : $buildServiceUri([$inDowntimeState], [$warningStatus]);
 
-    $row['listing_unhandled_uri'] = $useDeprecatedPages
+    $record['listing_unhandled_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=critical&statusService=svc_unhandled'
         : $buildServiceUri([$unhandledState], [$warningStatus]);
 
-    $dataWA[] = $row;
+    $serviceWarningStatus[] = $record;
 }
 
-// query for OK state
-$res = $db->query(
-    "SELECT 1 AS REALTIME,
-        SUM(
-            CASE WHEN s.state = 0
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS status
-    FROM services AS s
-    LEFT JOIN hosts AS h ON h.host_id = s.host_id " . (
-        $centreon->user->admin == 0
-        ? 'JOIN (
-            SELECT acl.host_id, acl.service_id
-            FROM centreon_acl AS acl
-            WHERE acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')
-            GROUP BY host_id,service_id
-            ) x ON x.host_id = h.host_id AND x.service_id = s.service_id'
-        : ''
-    ) . ';'
-);
-while ($row = $res->fetch()) {
-    $row['listing_uri'] = $useDeprecatedPages
+$query = <<<SQL
+        SELECT 1 AS REALTIME,
+            SUM(
+                CASE WHEN s.state = 0
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS status
+        FROM services AS s
+        LEFT JOIN hosts AS h
+            ON h.host_id = s.host_id
+        {$aclSubQuery}
+    SQL;
+
+foreach ($db->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+    $record['listing_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=ok&o=svc'
         : $buildServiceUri([], [$okStatus]);
 
-    $dataOK[] = $row;
+    $serviceOkStatus[] = $record;
 }
 
-// query for PENDING state
-$res = $db->query(
-    "SELECT 1 AS REALTIME,
-        SUM(
-            CASE WHEN s.state = 4
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS status
-    FROM services AS s
-    LEFT JOIN hosts AS h ON h.host_id = s.host_id " . (
-        $centreon->user->admin == 0
-        ? 'JOIN (
-            SELECT acl.host_id, acl.service_id
-            FROM centreon_acl AS acl
-            WHERE acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')
-            GROUP BY host_id,service_id
-            ) x ON x.host_id = h.host_id AND x.service_id = s.service_id'
-        : ''
-    ) . ';'
-);
-while ($row = $res->fetch()) {
-    $row['listing_uri'] = $useDeprecatedPages
+$query = <<<SQL
+        SELECT 1 AS REALTIME,
+            SUM(
+                CASE WHEN s.state = 4
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS status
+        FROM services AS s
+        LEFT JOIN hosts AS h
+            ON h.host_id = s.host_id
+        {$aclSubQuery}
+    SQL;
+
+foreach ($db->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+    $record['listing_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=pending&o=svc'
         : $buildServiceUri([], [$pendingStatus]);
 
-    $dataPEND[] = $row;
+    $servicePendingStatus[] = $record;
 }
 
-// query for UNKNOWN state
-$res = $db->query(
-    "SELECT 1 AS REALTIME,
-        SUM(
-            CASE WHEN s.state = 3
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS status,
-        SUM(
-            CASE WHEN s.acknowledged = 1
-                AND s.state = 3
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS ack,
-        SUM(
-            CASE WHEN s.scheduled_downtime_depth > 0
-                AND s.state = 3
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS down,
-        SUM(
-            CASE WHEN s.state = 3
-                AND (h.state = 1 OR h.state = 4 OR h.state = 2)
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-            THEN 1 ELSE 0 END
-        ) AS pb,
-        SUM(
-            CASE WHEN s.state = 3
-                AND s.enabled = 1
-                AND h.enabled = 1
-                AND h.name NOT LIKE '%Module%'
-                AND s.acknowledged = 0
-                AND s.scheduled_downtime_depth = 0
-                AND h.state = 0
-            THEN 1 ELSE 0 END
-        ) AS un
+$query = <<<SQL
+        SELECT 1 AS REALTIME,
+            SUM(
+                CASE WHEN s.state = 3
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS status,
+            SUM(
+                CASE WHEN s.acknowledged = 1
+                    AND s.state = 3
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS ack,
+            SUM(
+                CASE WHEN s.scheduled_downtime_depth > 0
+                    AND s.state = 3
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS down,
+            SUM(
+                CASE WHEN s.state = 3
+                    AND (h.state = 1 OR h.state = 4 OR h.state = 2)
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                THEN 1 ELSE 0 END
+            ) AS pb,
+            SUM(
+                CASE WHEN s.state = 3
+                    AND s.enabled = 1
+                    AND h.enabled = 1
+                    AND h.name NOT LIKE '%Module%'
+                    AND s.acknowledged = 0
+                    AND s.scheduled_downtime_depth = 0
+                    AND h.state = 0
+                THEN 1 ELSE 0 END
+            ) AS un
         FROM services AS s
-        LEFT JOIN hosts AS h ON h.host_id = s.host_id " . (
-        $centreon->user->admin == 0
-            ? 'JOIN (
-                SELECT acl.host_id, acl.service_id
-                FROM centreon_acl AS acl
-                WHERE acl.group_id IN (' . ($grouplistStr != '' ? $grouplistStr : 0) . ')
-                GROUP BY host_id,service_id
-                ) x ON x.host_id = h.host_id AND x.service_id = s.service_id'
-            : ''
-    ) . ';'
-);
-while ($row = $res->fetch()) {
-    $row['listing_uri'] = $useDeprecatedPages
+        LEFT JOIN hosts AS h
+            ON h.host_id = s.host_id
+        {$aclSubQuery}
+    SQL;
+
+foreach ($db->iterateAssociative($query, QueryParameters::create($queryParameters)) as $record) {
+    $record['listing_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=unknown&o=svc'
         : $buildServiceUri([], [$unknownStatus]);
 
-    $row['listing_ack_uri'] = $useDeprecatedPages
+    $record['listing_ack_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=unknown&statusService=svcpb'
         : $buildServiceUri([$acknowledgedState], [$unknownStatus]);
 
-    $row['listing_downtime_uri'] = $useDeprecatedPages
+    $record['listing_downtime_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=unknown&statusService=svcpb'
         : $buildServiceUri([$inDowntimeState], [$unknownStatus]);
 
-    $row['listing_unhandled_uri'] = $useDeprecatedPages
+    $record['listing_unhandled_uri'] = $useDeprecatedPages
         ? $deprecatedServiceListingUri . '&statusFilter=unknown&statusService=svc_unhandled'
         : $buildServiceUri([$unhandledState], [$unknownStatus]);
 
-    $dataUNK[] = $row;
+    $serviceUnknownStatus[] = $record;
 }
-
-$numLine = 1;
-
-$autoRefresh = (isset($preferences['refresh_interval']) && (int) $preferences['refresh_interval'] > 0)
-    ? (int) $preferences['refresh_interval']
-    : 30;
 
 $template->assign('widgetId', $widgetId);
 $template->assign('autoRefresh', $autoRefresh);
-$template->assign('dataPEND', $dataPEND);
-$template->assign('dataOK', $dataOK);
-$template->assign('dataWA', $dataWA);
-$template->assign('dataCRI', $dataCRI);
-$template->assign('dataUNK', $dataUNK);
+$template->assign('dataPEND', $servicePendingStatus);
+$template->assign('dataOK', $serviceOkStatus);
+$template->assign('dataWA', $serviceWarningStatus);
+$template->assign('dataCRI', $serviceCriticalStatus);
+$template->assign('dataUNK', $serviceUnknownStatus);
 $template->display('services_status.ihtml');

--- a/centreon/www/widgets/widget-error-handling.php
+++ b/centreon/www/widgets/widget-error-handling.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+/**
+ * @param string $message
+ * @param string $theme
+ */
+function showError(string $message, string $theme)
+{
+    $escapedMessage = htmlspecialchars($message, ENT_QUOTES, 'UTF-8');
+    $escapedTheme = htmlspecialchars($theme, ENT_QUOTES, 'UTF-8');
+    echo <<<HTML
+        <!DOCTYPE html>
+        <html>
+            <head>
+                <meta charset="UTF-8">
+                <title>Error</title>
+                <link href="../../Themes/Generic-theme/style.css" rel="stylesheet" type="text/css"/>
+                <link href="../../Themes/Generic-theme/color.css" rel="stylesheet" type="text/css"/>
+                <link href="../../Themes/{$escapedTheme}/variables.css" rel="stylesheet" type="text/css"/>
+            </head>
+            <body>
+                <div class="update" style="text-align: center; width: 350px; margin: 0 auto;">
+                    {$escapedMessage}
+                </div>
+            </body>
+        </html>
+        HTML;
+}


### PR DESCRIPTION
> [!NOTE]
> This PR intends to reduce the amount of SQL requests that are sent to the database server for ACL considerations

- New 'legacy' class created that will only handle the AccessGroups of a user
- Replacing the `new CentreonACL` calls by the new created class
- Change the SQL requests so that it uses the access groups of the user
- Code refactoring in order to use the new classes from src/Adaptation and fixing some identified bugs...
- Add error handling on the widgets with logging

> [!IMPORTANT]
> This has been done on widgets that were related to CentreonACL calls. Not all widgets were changed. There is also a lot of code that could be changed (duplicated and useless code) but not in the scope of the initial ticket which has already been exceeded.

### Test environnement
- Container running the latest develop branch
- 1 custom view created by admin, share as public and holding the following widgets 
- DEBUG_LEVEL has been set for PHP logging.

```
host-monitoring
service-monitoring
engine-status
grid-map
servicegroup-monitoring (detailed view enabled)
hostgroup-monitoring (detailed view enabled)
graph-monitoring
tactical-overview (hosts option)
tactical-overview (services option)
live-top10-cpu-usage
live-top10-memory-usage
```

- 1 user created, with ACL configured.

### Specific code

Some code has been added to `centreonACL.class.php` to log everytime a SQL request is made through the centreonACL class (mainly from __construct)

Code added for each SQL call

```PHP
CentreonLog::create()->debug(
    CentreonLog::TYPE_BUSINESS_LOG,
    'SQL request played for ACLs'
);
```

Same code has been added to the new class for the same purpose.

### Test procedure

- Connect with the user.
- Go to Home -> Custom views
- Load the view created by the admin
- Refresh the page

### Results

**Before applying the code of this PR, on a single page reload of Home -> Custom Views (F5)**

<img width="1407" height="490" alt="image" src="https://github.com/user-attachments/assets/32327914-0ca2-48f3-99d4-897a90810722" />

<img width="381" height="95" alt="image" src="https://github.com/user-attachments/assets/56e76843-06a1-411b-a65d-50bee3b29108" />

On a single page reload for 1 connected user on 1 custom view holding 11 widgets **337 SQL requests** were sent ONLY for ACLs.

After applying the code the SQL number of requests drops to **15**

So if we do extend this...

Let's say this custom view is shared to 10 users, and that those 10 users opens the same custom view at the same time, the SQL server will receive (again only for ACLs) 3370 SQL requests.

Lets now imagine that those 10 users keep their screen turned on the custom view page on this custom view for 10 minutes. The custom view is refreshed every 30 secs (lets say that widgets are configured to a refresh time of 30 secs too), there will be:

**10 (users) x 337 (sql requests) x 20 (custom view getting refreshed within the 10minutes) = 67400 SQL requests** 

With the patch

**10 (users) x 15 (sql requests) x 20 (custom view getting refreshed within the 10minutes) = 3000 SQL requests**

That's still huge, but it is far less that the actual performances.
