### PR TITLE
fix(host-categories): error in listing with non admin user

### DIFF
--- a/centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
+++ b/centreon/www/include/configuration/configObject/host_categories/listHostCategories.php
@@ -173,7 +173,7 @@ try {
                 $countsQuerybuilder->expr()->equal('acl.host_id', 'h.host_id')
             )
             ->andWhere(
-                $countsQuerybuilder->expr()->in('acl.group_id', "({$acl->getAccessGroupsString()})")
+                $countsQuerybuilder->expr()->in('acl.group_id', "{$acl->getAccessGroupsString()}")
             );
         $countsQuerybuilder->andWhere(
             "EXISTS( {$subQuerybuilder->getQuery()} )"


### PR DESCRIPTION
ℹ️ This PR intends to patch a SQL request issue with non admin user for host categories listing. Access Groups in the SQL request were encapsulated in a double parenthesis "IN ((1,2))".

Fixes: https://centreon.atlassian.net/browse/MON-187211