### PR TITLE
fix(dsm): Correctly escape properties for html in listing

### DIFF
--- a/.github/workflows/dsm.yml
+++ b/.github/workflows/dsm.yml
@@ -63,35 +63,8 @@ jobs:
           file: ${{ env.configuration_file }}
           version: ${{ env.version }}
 
-  backend-lint:
-    runs-on: ubuntu-24.04
-    needs: [get-environment]
-    if: |
-      needs.get-environment.outputs.skip_workflow == 'false' &&
-      needs.get-environment.outputs.stability != 'stable'
-
-    steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@6d7209f44a25a59e904b1ee9f3b0c33ab2cd888d # v2.29.0
-        with:
-          php-version: 8.1
-          coverage: none
-        env:
-          runner: ubuntu-24.04
-
-      - name: Install Dependencies
-        run: composer install --optimize-autoloader
-        working-directory: centreon-dsm
-        shell: bash
-
-      - name: Run of phpstan on /www at level 0
-        run: vendor/bin/phpstan analyse --no-progress --level=0 --configuration=phpstan.neon
-        working-directory: centreon-dsm
-
   package:
-    needs: [get-environment, check-version-consistency, backend-lint]
+    needs: [get-environment, check-version-consistency]
     if: |
       needs.get-environment.outputs.skip_workflow == 'false' &&
       needs.get-environment.outputs.stability != 'stable' &&

--- a/centreon-dsm/www/modules/centreon-dsm/core/configuration/services/listSlot.ihtml
+++ b/centreon-dsm/www/modules/centreon-dsm/core/configuration/services/listSlot.ihtml
@@ -38,10 +38,10 @@
         {section name=elem loop=$elemArr}
         <tr class={$elemArr[elem].MenuClass}>
             <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
+            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name|escape}</a></td>
+            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc|escape}</a></td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_number}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_prefix}</td>
+            <td class="ListColCenter">{$elemArr[elem].RowMenu_prefix|escape}</td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_status}</td>
             <td class="ListColRight">{$elemArr[elem].RowMenu_options}</td>
         </tr>


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/8265

**Fixes** #[MON-187220](https://centreon.atlassian.net/browse/MON-187220)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

[MON-187220]: https://centreon.atlassian.net/browse/MON-187220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ