### PR TITLE
fix(recurrentdowntime): Remove unneeded stripping of dangerous tags in listing

### DIFF
--- a/centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
+++ b/centreon/www/include/monitoring/recurrentDowntime/listDowntime.php
@@ -123,9 +123,9 @@ foreach ($listDowntime as $dt) {
     $elemArr[] = array(
         "MenuClass" => "list_" . $style,
         "RowMenu_select" => $selectedElements->toHtml(),
-        "RowMenu_name" => CentreonUtils::escapeSecure($dt["dt_name"]),
+        "RowMenu_name" => $dt["dt_name"],
         "RowMenu_link" => "main.php?p=" . $p . "&o=c&dt_id=" . $dt['dt_id'],
-        "RowMenu_desc" => CentreonUtils::escapeSecure($dt["dt_description"]),
+        "RowMenu_desc" => $dt["dt_description"],
         "RowMenu_status" => $dt["dt_activate"] ? _("Enabled") : _("Disabled"),
         "RowMenu_options" => $moptions
     );


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/8255

**Fixes** #[MON-187228](https://centreon.atlassian.net/browse/MON-187228)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

[MON-187228]: https://centreon.atlassian.net/browse/MON-187228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ