### PR TITLE
fix(router): handle reverse proxy

### DIFF
--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -96,9 +96,15 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
 
         // Manage URL Generation for HTTPS and Legacy nested route generation calls
         $context = $this->router->getContext();
-        if ($_SERVER['REQUEST_SCHEME'] === 'https') {
+        $forwardedProtoHeader = $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? null;
+        if ($forwardedProtoHeader) {
+            $scheme = strtolower($forwardedProtoHeader) === 'https' ? 'https' : 'http';
+            $context = $this->router->getContext();
+            $context->setScheme($scheme);
+        } elseif ($_SERVER['REQUEST_SCHEME'] === 'https') {
             $context->setScheme($_SERVER['REQUEST_SCHEME']);
         }
+
         if ($_SERVER['SERVER_NAME'] !== 'localhost') {
             $context->setHost($_SERVER['SERVER_NAME']);
         }

--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -98,7 +98,7 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
         $context = $this->router->getContext();
         $forwardedProtoHeader = $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? null;
         if ($forwardedProtoHeader) {
-            $scheme = strtolower($forwardedProtoHeader) === 'https' ? 'https' : 'http';
+            $scheme = mb_strtolower($forwardedProtoHeader) === 'https' ? 'https' : 'http';
             $context = $this->router->getContext();
             $context->setScheme($scheme);
         } elseif ($_SERVER['REQUEST_SCHEME'] === 'https') {

--- a/centreon/src/Core/Infrastructure/Common/Api/Router.php
+++ b/centreon/src/Core/Infrastructure/Common/Api/Router.php
@@ -98,7 +98,9 @@ class Router implements RouterInterface, RequestMatcherInterface, WarmableInterf
         $context = $this->router->getContext();
         $forwardedProtoHeader = $_SERVER['HTTP_X_FORWARDED_PROTO'] ?? null;
         if ($forwardedProtoHeader) {
-            $scheme = mb_strtolower($forwardedProtoHeader) === 'https' ? 'https' : 'http';
+            // It could be possible that HTTP_X_FORWARDED_PROTO contains multiple comma-separated values e.g "https,http"
+            $proto = mb_strtolower(trim(explode(',', $forwardedProtoHeader)[0]));
+            $scheme = $proto === 'https' ? 'https' : 'http';
             $context = $this->router->getContext();
             $context->setScheme($scheme);
         } elseif ($_SERVER['REQUEST_SCHEME'] === 'https') {


### PR DESCRIPTION
## Description

This PR intends to handle reverse proxy.
Currently if your platform is on HTTP but your reverse proxy is configured in HTTPS and do not permit unsecure request, the router will generate HTTP routes instead of HTTPS. This PR intends to manage the HTTP Scheme based on the X-Forwarded-Proto Header if present.

**Fixes** # MON-162852

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
