### PR TITLE
fix(brokercfg) fix typo causing duplicate to fail

### DIFF
--- a/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/InputBroker.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/InputBroker.php
@@ -114,7 +114,7 @@ class InputBroker
                 'grp_level' => '0',
             ],
             [
-                'config_key' => 'negociation',
+                'config_key' => 'negotiation',
                 'config_value' => 'yes',
                 'config_group' => 'input',
                 'config_group_id' => '0',

--- a/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/InputRrd.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/InputRrd.php
@@ -114,7 +114,7 @@ class InputRrd
                 'grp_level' => '0',
             ],
             [
-                'config_key' => 'negociation',
+                'config_key' => 'negotiation',
                 'config_value' => 'yes',
                 'config_group' => 'input',
                 'config_group_id' => '0',

--- a/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputCentral.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputCentral.php
@@ -114,7 +114,7 @@ class OutputCentral
                 'grp_level' => '0',
             ],
             [
-                'config_key' => 'negociation',
+                'config_key' => 'negotiation',
                 'config_value' => 'yes',
                 'config_group' => 'output',
                 'config_group_id' => '0',

--- a/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputForwardMaster.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputForwardMaster.php
@@ -114,7 +114,7 @@ class OutputForwardMaster
                 'grp_level' => '0',
             ],
             [
-                'config_key' => 'negociation',
+                'config_key' => 'negotiation',
                 'config_value' => 'yes',
                 'config_group' => 'output',
                 'config_group_id' => '3',

--- a/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputModuleMaster.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputModuleMaster.php
@@ -114,7 +114,7 @@ class OutputModuleMaster
                 'grp_level' => '0',
             ],
             [
-                'config_key' => 'negociation',
+                'config_key' => 'negotiation',
                 'config_value' => 'yes',
                 'config_group' => 'output',
                 'config_group_id' => '0',

--- a/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputRrdMaster.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/BrokerInfo/OutputRrdMaster.php
@@ -114,7 +114,7 @@ class OutputRrdMaster
                 'grp_level' => '0',
             ],
             [
-                'config_key' => 'negociation',
+                'config_key' => 'negotiation',
                 'config_value' => 'yes',
                 'config_group' => 'output',
                 'config_group_id' => '1',

--- a/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/InputFlowOnePeerRetention.php
+++ b/centreon/src/CentreonRemote/Domain/Resources/RemoteConfig/InputFlowOnePeerRetention.php
@@ -52,7 +52,7 @@ class InputFlowOnePeerRetention
             new CfgCentreonBrokerInfo('private_key', ''),
             new CfgCentreonBrokerInfo('public_cert', ''),
             new CfgCentreonBrokerInfo('ca_certificate', ''),
-            new CfgCentreonBrokerInfo('negociation', 'yes'),
+            new CfgCentreonBrokerInfo('negotiation', 'yes'),
             new CfgCentreonBrokerInfo('one_peer_retention_mode', 'no'),
             new CfgCentreonBrokerInfo('compression', 'no'),
             new CfgCentreonBrokerInfo('compression_level', ''),

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -121,6 +121,16 @@ $fixTypoInStandardMacroName = function () use ($pearDB, &$errorMessage): void {
     );
 };
 
+/** -------------------------------------- Broker configuration -------------------------------------- */
+$fixBrokerConfigTypo = function () use ($pearDB, &$errorMessage): void {
+    $errorMessage = 'Failed to fix typo in broker configuration';
+    $pearDB->executeStatement(
+        <<<'SQL'
+            UPDATE cfg_centreonbroker_info SET config_key = 'negotiation' WHERE config_key = 'negociation'
+            SQL
+    );
+};
+
 try {
     // DDL statements for real time database
     // TODO add your function calls to update the real time database structure here
@@ -137,6 +147,7 @@ try {
     $alignCMAAgentConfigurationWithNewSchema();
     $cleanGlobalMacrosName();
     $fixTypoInStandardMacroName();
+    $fixBrokerConfigTypo();
 
     $pearDB->commit();
 


### PR DESCRIPTION
## Description

Poller configuration was created with  "negociation" parameter instead of "negotiation", which later cause duplication to fail

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

