### PR TITLE
fix(host): Do not escape the <a> tag(s) for the host template

### DIFF
--- a/centreon/www/include/configuration/configObject/host/listHost.ihtml
+++ b/centreon/www/include/configuration/configObject/host/listHost.ihtml
@@ -79,7 +79,7 @@
             </td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_address|escape}</td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_poller|escape}</td>
-            <td class="ListColCenter resizeTitle">{$elemArr[elem].RowMenu_parent|escape}</td>
+            <td class="ListColCenter resizeTitle">{$elemArr[elem].RowMenu_parent}</td>
             <td class="ListColCenter">
                 <span class="badge {$elemArr[elem].RowMenu_badge}">{$elemArr[elem].RowMenu_status}</span>
             </td>


### PR DESCRIPTION
Note that the text value of the link is already properly escaped in the code, and we can safely display the string that is being passed.

## Description

Bug introduced in https://github.com/centreon/centreon/pull/8256

**Fixes** #[MON-187463](https://centreon.atlassian.net/browse/MON-187463)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

[MON-187463]: https://centreon.atlassian.net/browse/MON-187463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ