### PR TITLE
fix(apiv2 docs): fix cloud doc lint

### DIFF
--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostRequest.yaml
@@ -4,7 +4,7 @@ properties:
   monitoring_server_id:
     type: integer
     description: "ID of the host's monitoring server"
-    exmaple: 1
+    example: 1
   name:
     type: string
     description: "Host name"
@@ -24,7 +24,7 @@ properties:
   snmp_version:
     type: string
     nullable: true
-    enum: [1, 2c, 3]
+    enum: ['1', '2c', '3']
     description: |
       Version of the SNMP agent.
 

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/AddHostResponse.yaml
@@ -28,7 +28,7 @@ properties:
   snmp_version:
     type: string
     nullable: true
-    enum: [1, 2c, 3]
+    enum: ['1', '2c', '3']
     description: |
       Version of the SNMP agent.
 

--- a/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Host/Schema/PartialUpdateHostRequest.yaml
@@ -3,7 +3,7 @@ properties:
   monitoring_server_id:
     type: integer
     description: "ID of the host's monitoring server"
-    exmaple: 1
+    example: 1
   name:
     type: string
     description: "Host name"
@@ -23,7 +23,7 @@ properties:
   snmp_version:
     type: string
     nullable: true
-    enum: [1, 2c, 3]
+    enum: ['1', '2c', '3']
     description: |
       Version of the SNMP agent.
 

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/AddAndFindHostGroups.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/AddAndFindHostGroups.yaml
@@ -47,6 +47,7 @@ post:
 
     * name
     * resource_access_rules
+    * hosts (can be an empty array)
   requestBody:
     required: true
     content:

--- a/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/AddHostGroupResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostGroup/Schema/AddHostGroupResponse.yaml
@@ -32,15 +32,15 @@ properties:
     items:
       type: object
       properties:
-      id:
-        type: integer
-        description: "IHost ID"
-        example: 1
-      name:
-        type: string
-        maxLength: 200
-        description: "Host name"
-        example: "HostName-01"
+        id:
+          type: integer
+          description: "Host ID"
+          example: 1
+        name:
+          type: string
+          maxLength: 200
+          description: "Host name"
+          example: "HostName-01"
   resource_access_rules:
     type: array
     items:

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateRequest.yaml
@@ -16,7 +16,7 @@ properties:
   snmp_version:
     type: string
     nullable: true
-    enum: [1, 2c, 3]
+    enum: ['1', '2c', '3']
     description: |
       Version of the SNMP agent.
 

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/AddHostTemplateResponse.yaml
@@ -19,7 +19,7 @@ properties:
   snmp_version:
     type: string
     nullable: true
-    enum: [1, 2c, 3]
+    enum: ['1', '2c', '3']
     description: |
       Version of the SNMP agent.
 

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/HostTemplate.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/HostTemplate.yaml
@@ -19,7 +19,7 @@ properties:
   snmp_version:
     type: string
     nullable: true
-    enum: [1, 2c, 3]
+    enum: ['1', '2c', '3']
     description: |
       Version of the SNMP agent.
 

--- a/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/HostTemplate/Schema/PartialUpdateHostTemplateRequest.yaml
@@ -65,7 +65,7 @@ properties:
   snmp_version:
     type: string
     nullable: true
-    enum: [1, 2c, 3]
+    enum: ['1', '2c', '3']
     description: |
       Version of the SNMP agent.
 

--- a/centreon/doc/API/latest/Cloud/Configuration/Notification/FindNotifiableContactGroups.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Notification/FindNotifiableContactGroups.yaml
@@ -15,8 +15,8 @@ get:
                 type: array
                 items:
                   $ref: 'Schema/NotifiableContactGroups.Listing.yaml'
-                meta:
-                  $ref: '../../../Common/Schema/Meta.yaml'
+              meta:
+                $ref: '../../../Common/Schema/Meta.yaml'
     '403':
       $ref: '../../../Common/Response/Forbidden.yaml'
     '404':

--- a/centreon/doc/API/latest/Cloud/Configuration/Notification/FindNotifiableRule.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Notification/FindNotifiableRule.yaml
@@ -4,6 +4,8 @@ get:
   summary: "List methods and contacts by notification id"
   description: |
     Return a list of notification methods/channels and contacts by notification id.
+  parameters:
+    - $ref: "./QueryParameter/NotificationId.yaml"
   responses:
     '200':
       description: "OK"

--- a/centreon/doc/API/latest/Cloud/Configuration/Notification/Notification.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Notification/Notification.yaml
@@ -10,7 +10,11 @@ get:
     - $ref: 'QueryParameter/NotificationId.yaml'
   responses:
     '200':
-      $ref: 'Schema/Notification.Details.yaml'
+      description: "OK"
+      content:
+        application/json:
+          schema:
+            $ref: 'Schema/Notification.Details.yaml'
     '403':
       $ref: '../../../Common/Response/Forbidden.yaml'
     '404':

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/DeployServices.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/DeployServices.yaml
@@ -4,6 +4,8 @@ post:
   summary: "Add services to a host based on associated host template"
   description: |
     Add services to a host based on associated host templates
+  parameters:
+    - $ref: '../Host/QueryParameter/HostId.yaml'
   responses:
     '201':
       description: "Objects created"

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/AddServiceRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/AddServiceRequest.yaml
@@ -85,14 +85,14 @@ properties:
     nullable: true
   service_categories:
     type: array
-    descriptions: "IDs of service categories linked to this service."
+    description: "IDs of service categories linked to this service."
     items:
       type: integer
       description: "Service category ID"
     example: [ 1, 2 ]
   service_groups:
     type: array
-    descriptions: "IDs of service groups linked to this service."
+    description: "IDs of service groups linked to this service."
     items:
       type: integer
       description: "Service group ID"

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/FindServicesResponse.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/FindServicesResponse.yaml
@@ -15,21 +15,25 @@ allOf:
           - $ref: 'simpleEntity.yaml'
       service_template:
         description: "Service template linked to this service."
+        type: object
         nullable: true
         allOf:
           - $ref: 'simpleEntity.yaml'
       check_timeperiod:
         description: "Time period of the check command."
+        type: object
         nullable: true
         allOf:
           - $ref: 'simpleEntity.yaml'
       notification_timeperiod:
         description: "Time period of the notification command."
+        type: object
         nullable: true
         allOf:
           - $ref: 'simpleEntity.yaml'
       severity:
         description: "Severity linked to this service."
+        type: object
         nullable: true
         allOf:
           - $ref: 'simpleEntity.yaml'

--- a/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/PartialUpdateServiceRequest.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/Service/Schema/PartialUpdateServiceRequest.yaml
@@ -90,14 +90,14 @@ properties:
     example: true
   service_categories:
     type: array
-    descriptions: "IDs of service categories linked to this service."
+    description: "IDs of service categories linked to this service."
     items:
       type: integer
       description: "Service category ID"
     example: [ 1, 2 ]
   service_groups:
     type: array
-    descriptions: "IDs of service groups linked to this service."
+    description: "IDs of service groups linked to this service."
     items:
       type: integer
       description: "Service group ID"

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/AddAndFindServiceTemplates.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/AddAndFindServiceTemplates.yaml
@@ -50,9 +50,9 @@ post:
     '201':
       description: "Created"
       content:
-          application/json:
-            schema:
-              $ref: 'Schema/AddServiceTemplateResponse.yaml'
+        application/json:
+          schema:
+            $ref: 'Schema/AddServiceTemplateResponse.yaml'
     '400':
       $ref: '../../../Common/Response/BadRequest.yaml'
     '403':

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/AddAndFindServiceTemplates.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/AddAndFindServiceTemplates.yaml
@@ -45,16 +45,14 @@ post:
       application/json:
         schema:
           allOf:
-            - required: ["name", "alias"]
             - $ref: 'Schema/NewServiceTemplate.yaml'
   responses:
     '201':
-      allOf:
-        - $ref: '../../../Common/Response/Created.yaml'
-        - content:
-            application/json:
-              schema:
-                $ref: 'Schema/AddServiceTemplateResponse.yaml'
+      description: "Created"
+      content:
+          application/json:
+            schema:
+              $ref: 'Schema/AddServiceTemplateResponse.yaml'
     '400':
       $ref: '../../../Common/Response/BadRequest.yaml'
     '403':

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/NewServiceTemplate.yaml
@@ -1,4 +1,7 @@
 type: object
+required:
+  - name
+  - alias
 properties:
   name:
     type: string
@@ -96,21 +99,21 @@ properties:
     nullable: true
   host_templates:
     type: array
-    descriptions: "IDs of host templates linked to this service template."
+    description: "IDs of host templates linked to this service template."
     items:
       type: integer
       description: "Host template ID"
     example: [ 1, 2 ]
   service_categories:
     type: array
-    descriptions: "IDs of service categories linked to this service template."
+    description: "IDs of service categories linked to this service template."
     items:
       type: integer
       description: "Service category ID"
     example: [ 1, 2 ]
   service_groups:
     type: array
-    descriptions: "Service group / host template associations to be linked to this service template."
+    description: "Service group / host template associations to be linked to this service template."
     items:
       type: object
       properties:

--- a/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
+++ b/centreon/doc/API/latest/Cloud/Configuration/ServiceTemplate/Schema/PartialUpdateServiceTemplate.yaml
@@ -77,14 +77,14 @@ properties:
     nullable: true
   host_templates:
     type: array
-    descriptions: "IDs of host templates linked to this service template."
+    description: "IDs of host templates linked to this service template."
     items:
       type: integer
       description: "Host template ID"
     example: [ 1, 2 ]
   service_categories:
     type: array
-    descriptions: "IDs of service categories linked to this service template."
+    description: "IDs of service categories linked to this service template."
     items:
       type: integer
       description: "Service category ID"
@@ -99,7 +99,7 @@ properties:
       $ref: 'macro.yaml'
   service_groups:
     type: array
-    descriptions: "Service group / host template associations to be linked to this service template."
+    description: "Service group / host template associations to be linked to this service template."
     items:
       type: object
       properties:

--- a/centreon/doc/API/latest/onPremise/Configuration/Media/FindImageFolders.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/Media/FindImageFolders.yaml
@@ -27,7 +27,7 @@ get:
               result:
                 type: array
                 items:
-                  $ref: 'Schema/FindImageFolders.yaml'
+                  $ref: 'Schema/FindImageFoldersResponse.yaml'
               meta:
                 $ref: '../../Common/Schema/Meta.yaml'
     '403':


### PR DESCRIPTION
## Description

apiv2 docs is incomplete for hostgroup add
this PR intends to correct docs error in order for the docs to be rendered correctly
<img width="1873" height="842" alt="image" src="https://github.com/user-attachments/assets/af282e50-9a80-4475-8a44-d8ed8b8251a7" />

MON-178911

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

run this command to build the docs html file : 
`pnpm --package=@redocly/cli dlx openapi build-docs centreon/doc/API/centreon-cloud-api.yaml -o docs.html`

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
