### PR TITLE
fix(ldap): make method public to be able to be called from outside of context

### DIFF
--- a/centreon/www/class/centreonLDAP.class.php
+++ b/centreon/www/class/centreonLDAP.class.php
@@ -1041,7 +1041,7 @@ class CentreonLDAP
      * @param int $errline The error line
      * @return bool
      */
-    private function errorLdapHandler($errno, $errstr, $errfile, $errline): bool
+    public function errorLdapHandler($errno, $errstr, $errfile, $errline): bool
     {
         if ($errno === 2 && ldap_errno($this->ds) === 4) {
             /*

--- a/centreon/www/class/centreonLDAP.class.php
+++ b/centreon/www/class/centreonLDAP.class.php
@@ -869,6 +869,37 @@ class CentreonLDAP
     }
 
     /**
+     * Override the custom errorHandler to avoid false errors in the log,
+     *
+     * @param int $errno The error num
+     * @param string $errstr The error message
+     * @param string $errfile The error file
+     * @param int $errline The error line
+     * @return bool
+     */
+    public function errorLdapHandler($errno, $errstr, $errfile, $errline): bool
+    {
+        if ($errno === 2 && ldap_errno($this->ds) === 4) {
+            /*
+            Silencing : 'size limit exceeded' warnings in the logs
+            As the $searchLimit value needs to be consistent with the ldap server's configuration and
+            as the size limit error thrown is not related with the results.
+                ldap_errno : 4 = LDAP_SIZELIMIT_EXCEEDED
+                $errno     : 2 = PHP_WARNING
+            */
+            $this->debug('LDAP Error : Size limit exceeded error. This error was not added to php log. '
+                . "Kindly, check your LDAP server's configuration and your Centreon's LDAP parameters.");
+
+            return true;
+        }
+
+        // throwing all errors
+        $this->debug('LDAP Error : ' . ldap_error($this->ds));
+
+        return false;
+    }
+
+    /**
      * Load the search information
      *
      * @param null $ldapHostId
@@ -1030,37 +1061,6 @@ class CentreonLDAP
         if ($this->debugImport) {
             error_log('[' . date('d/m/Y H:i') . '] ' . $msg . "\n", 3, $this->debugPath . 'ldapsearch.log');
         }
-    }
-
-    /**
-     * Override the custom errorHandler to avoid false errors in the log,
-     *
-     * @param int $errno The error num
-     * @param string $errstr The error message
-     * @param string $errfile The error file
-     * @param int $errline The error line
-     * @return bool
-     */
-    public function errorLdapHandler($errno, $errstr, $errfile, $errline): bool
-    {
-        if ($errno === 2 && ldap_errno($this->ds) === 4) {
-            /*
-            Silencing : 'size limit exceeded' warnings in the logs
-            As the $searchLimit value needs to be consistent with the ldap server's configuration and
-            as the size limit error thrown is not related with the results.
-                ldap_errno : 4 = LDAP_SIZELIMIT_EXCEEDED
-                $errno     : 2 = PHP_WARNING
-            */
-            $this->debug('LDAP Error : Size limit exceeded error. This error was not added to php log. '
-                . "Kindly, check your LDAP server's configuration and your Centreon's LDAP parameters.");
-
-            return true;
-        }
-
-        // throwing all errors
-        $this->debug('LDAP Error : ' . ldap_error($this->ds));
-
-        return false;
     }
 
     /**


### PR DESCRIPTION
## Description

This PR intends to fix an issue where LDAP Connection could fail due to a private method called outside of its context

```
PHP Fatal error: Uncaught TypeError: set_error_handler(): 
Argument #1 ($callback) must be a valid callback, 
cannot access private method CentreonLDAP::errorLdapHandler() 
in /usr/share/centreon/www/class/centreonLDAP.class.php:871
```

**Fixes** # MON-184134

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
