### PR TITLE
fix(realtime services): Prevent GROUPBY clause to be called without associated field in SELECT

### DIFF
--- a/centreon/www/api/class/centreon_realtime_services.class.php
+++ b/centreon/www/api/class/centreon_realtime_services.class.php
@@ -564,6 +564,35 @@ class CentreonRealtimeServices extends CentreonRealtimeBase
             }
         }
 
+        $sortColumns = [
+            'criticality_id' => ['criticality', 'h.name', 's.description'],
+            'service_id' => ['s.service_id'],
+            'host_name' => ['h.name', 's.description'],
+            'service_description' => ['s.description', 'h.name'],
+            'current_state' => ['s.state', 'h.name', 's.description'],
+            'last_state_change' => ['s.last_state_change', 'h.name', 's.description'],
+            'last_hard_state_change' => ['s.last_hard_state_change', 'h.name', 's.description'],
+            'last_check' => ['s.last_check', 'h.name', 's.description'],
+            'current_attempt' => ['s.check_attempt', 'h.name', 's.description'],
+            'output' => ['s.output', 'h.name', 's.description'],
+            'default' => ['s.description', 'h.name'],
+        ];
+        $sortType = $this->sortType ?? 'default';
+        $columnsToAdd = $sortColumns[$sortType] ?? $sortColumns['default'];
+        foreach ($columnsToAdd as $col) {
+            // If column isn't already in the SELECT, add it
+            $alreadyPresent = false;
+            foreach ($fields as $key => $alias) {
+                if (str_contains($key, $col)) {
+                    $alreadyPresent = true;
+                    break;
+                }
+            }
+            if (! $alreadyPresent) {
+                $fields[$col] = $col;
+            }
+        }
+
         // Build Field List
         $this->fieldList = '';
         foreach ($fields as $key => $value) {


### PR DESCRIPTION
## Description

This ticket addresses a bug where an API command fails when using MySQL 8 with Centreon.
The error is due to SQL syntax issues related to the only_full_group_by mode in MySQL 8.

## Fix

The fix consists in preventing the SQL GROUP BY clause to use fields that are not present in the SELECT CLAUSE.

Please bear with me, the fix is not my proudest piece of code but ... you know legacy 😅 

Compare the diff with that portion of untouched - and thus not visible - code in the same file

https://github.com/centreon/centreon/blob/6599878b1178cf53cba17e22a277f04286dd8070/centreon/www/api/class/centreon_realtime_services.class.php#L192-L203