### PR TITLE
fix(host categories): allow acl user to add host templates to hc

### DIFF
--- a/centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
+++ b/centreon/www/include/configuration/configObject/host_categories/formHostCategories.php
@@ -140,10 +140,6 @@ $form->addElement('select2', 'hc_hosts', _('Linked Hosts'), [], array_merge($att
 $defTpls = './include/common/webServices/rest/internal.php?object=centreon_configuration_hosttemplate'
          . "&action=defaultValues&target=hostcategories&field=hc_hostsTemplate&id={$hc_id}";
 $ams1 = $form->addElement('select2', 'hc_hostsTemplate', _('Linked Host Template'), [], array_merge($attrHosttemplates, ['defaultDatasetRoute' => $defTpls]));
-if (! $oreon->user->admin) {
-    $ams1->setPersistantFreeze(true);
-    $ams1->freeze();
-}
 
 // Further informations
 $form->addElement('header', 'furtherInfos', _('Additional Information'));


### PR DESCRIPTION
## Description

This PR intends to allow user under ACLs to add host templates to a host category.

MON-159400

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>
- log into centreon web with simple user with necessary acls (not admin)
- add a host category
- user should be able to add host templates to the hc
<img width="1371" height="726" alt="image" src="https://github.com/user-attachments/assets/fe65075e-66f4-4b85-b78f-6e7196a231e4" />

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
