### PR TITLE
enh(export): Remove credentials_encryption from engine config file

### DIFF
--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -197,7 +197,6 @@ class Engine extends AbstractObject
         'log_level_process',
         'log_level_runtime',
         'broker_module_cfg_file',
-        'credentials_encryption',
     ];
 
     /** @var string[] */
@@ -425,13 +424,6 @@ class Engine extends AbstractObject
                 : '0';
     }
 
-    private function setEncryptionReady(int $pollerId): void
-    {
-        $readMonitoringServerRepository = $this->kernel->getContainer()->get(ReadMonitoringServerRepositoryInterface::class);
-        $this->engine['credentials_encryption'] = $readMonitoringServerRepository->isEncryptionReady($pollerId);
-
-    }
-
     /**
      * @param $poller_id
      *
@@ -467,7 +459,6 @@ class Engine extends AbstractObject
         $this->setLoggerCfg();
         $this->getBrokerModules();
         $this->getIntervalLength();
-        $this->setEncryptionReady((int) $poller_id);
         $object = $this->engine;
 
         $timezoneInstance = Timezone::getInstance($this->dependencyInjector);

--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -19,7 +19,6 @@
  *
  */
 
-use Core\MonitoringServer\Application\Repository\ReadMonitoringServerRepositoryInterface;
 use Symfony\Component\DependencyInjection\Exception\ServiceCircularReferenceException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException;
 


### PR DESCRIPTION
## Description

this PR intends to remove the credentials_encryption key from engine.cfg config file

**Fixes** # MON-187820

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
