### PR TITLE
fix(dsm): Correctly escape properties for html in listing (#8265)

### DIFF
--- a/centreon-dsm/www/modules/centreon-dsm/core/configuration/services/listSlot.ihtml
+++ b/centreon-dsm/www/modules/centreon-dsm/core/configuration/services/listSlot.ihtml
@@ -36,10 +36,10 @@
         {section name=elem loop=$elemArr}
         <tr class={$elemArr[elem].MenuClass}>
             <td class="ListColPicker">{$elemArr[elem].RowMenu_select}</td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name}</a></td>
-            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc}</a></td>
+            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_name|escape}</a></td>
+            <td class="ListColLeft"><a href="{$elemArr[elem].RowMenu_link}">{$elemArr[elem].RowMenu_desc|escape}</a></td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_number}</td>
-            <td class="ListColCenter">{$elemArr[elem].RowMenu_prefix}</td>
+            <td class="ListColCenter">{$elemArr[elem].RowMenu_prefix|escape}</td>
             <td class="ListColCenter">{$elemArr[elem].RowMenu_status}</td>
             <td class="ListColRight">{$elemArr[elem].RowMenu_options}</td>
         </tr>


### PR DESCRIPTION
## Description

Backport of https://github.com/centreon/centreon/pull/8265

**Fixes** #[MON-187218](https://centreon.atlassian.net/browse/MON-187218)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

[MON-187218]: https://centreon.atlassian.net/browse/MON-187218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ