### PR TITLE
fix(api): Fix host category filtering on realtime service categories endpoint

### DIFF
--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbReadRealTimeServiceCategoryRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbReadRealTimeServiceCategoryRepository.php
@@ -102,7 +102,7 @@ class DbReadRealTimeServiceCategoryRepository extends AbstractRepositoryRDB impl
                         ON rtags_host_groups.tag_id = host_groups.tag_id
                         AND host_groups.`type` = 1
                     LEFT JOIN `:dbstg`.resources_tags rtags_host_categories
-                        ON rtags_host_categories.resource_id = resources.resource_id
+                        ON rtags_host_categories.resource_id = parent_resource.resource_id
                     LEFT JOIN `:dbstg`.tags AS host_categories
                         ON rtags_host_categories.tag_id = host_categories.tag_id
                         AND host_categories.`type` = 3


### PR DESCRIPTION
## Description

The following endpoint `GET /monitoring/services/categories` returns no result when filtering on host category name.
That's because the SQL JOIN between the host category & the associated resource (host) is made on the wrong resource (service).

The PR just change the JOIN to target the host instead of the service.