### PR TITLE
fix(api): Fix error 500 occuring on generate & reload configuration

### DIFF
--- a/centreon/src/Centreon/Application/Controller/Configuration/MonitoringServerController.php
+++ b/centreon/src/Centreon/Application/Controller/Configuration/MonitoringServerController.php
@@ -258,8 +258,8 @@ class MonitoringServerController extends AbstractController
             $this->error($ex->getMessage());
 
             throw new MonitoringServerException(
-                'There was an consistency error in the exported files  - please use the legacy export menu to '
-                . 'troubleshoot'
+                'There was an consistency error in the exported files - please use the legacy export menu to troubleshoot',
+                previous: $ex,
             );
         }
     }

--- a/centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php
@@ -57,10 +57,12 @@ class ConfigurationMonitoringServerException extends \Exception
      * @param string $errorMessage
      * @return self
      */
-    public static function errorOnGeneration(int $monitoringServerId, string $errorMessage): self
+    public static function errorOnGeneration(int $monitoringServerId, string $errorMessage, int $code = 0, ?\Throwable $previous = null): self
     {
         return new self(
-            sprintf(_('Generation error on monitoring server #%d: %s'), $monitoringServerId, $errorMessage)
+            sprintf(_('Generation error on monitoring server #%d: %s'), $monitoringServerId, $errorMessage),
+            $code,
+            $previous,
         );
     }
 

--- a/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateConfiguration.php
+++ b/centreon/src/Centreon/Domain/MonitoringServer/UseCase/GenerateConfiguration.php
@@ -106,7 +106,9 @@ class GenerateConfiguration
         } catch (\Exception $ex) {
             throw ConfigurationMonitoringServerException::errorOnGeneration(
                 $monitoringServerId,
-                $ex->getMessage()
+                $ex->getMessage(),
+                $ex->getCode(),
+                $ex,
             );
         }
     }

--- a/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryApi.php
+++ b/centreon/src/Centreon/Infrastructure/MonitoringServer/Repository/MonitoringServerConfigurationRepositoryApi.php
@@ -147,8 +147,8 @@ class MonitoringServerConfigurationRepositoryApi implements MonitoringServerConf
             }
             $providerToken = $authenticationTokens->getProviderToken();
             if (
-                $providerToken->getExpirationDate() === null
-                || $providerToken->getExpirationDate()->getTimestamp() < (new DateTime())->getTimestamp()
+                $providerToken->getExpirationDate() !== null
+                && $providerToken->getExpirationDate()->getTimestamp() < (new DateTime())->getTimestamp()
             ) {
                 throw AuthenticationException::authenticationTokenExpired();
             }


### PR DESCRIPTION
## Description

Fix a wrong check on token expiration date that lead to error 500 on generate & reload configuration when the token did not expire.

## Extra

Also improve exception tracing so the root cause can be found in error logs.

### Before

```
{
    "exception": {
        "exceptions": [
            {
                "type": "Centreon\\Domain\\MonitoringServer\\Exception\\MonitoringServerException",
                "message": "There was an consistency error in the exported files  - please use the legacy export menu to troubleshoot",
                "file": "/usr/share/centreon/src/Centreon/Application/Controller/Configuration/MonitoringServerController.php",
                "line": 260,
                "code": 0,
                "class": "Centreon\\Application\\Controller\\Configuration\\MonitoringServerController",
                "method": "execute"
            }
        ],
    },
}
```

### After 

```
{
    "exception": {
        "exceptions": [
            {
                "type": "Centreon\\Domain\\MonitoringServer\\Exception\\MonitoringServerException",
                "message": "There was an consistency error in the exported files  - please use the legacy export menu to troubleshoot",
                "file": "/usr/share/centreon/src/Centreon/Application/Controller/Configuration/MonitoringServerController.php",
                "line": 260,
                "code": 0,
                "class": "Centreon\\Application\\Controller\\Configuration\\MonitoringServerController",
                "method": "execute"
            },
            {
                "type": "Centreon\\Domain\\MonitoringServer\\Exception\\ConfigurationMonitoringServerException",
                "message": "Generation error on monitoring server #1: Authentication token expired",
                "file": "/usr/share/centreon/src/Centreon/Domain/MonitoringServer/Exception/ConfigurationMonitoringServerException.php",
                "line": 62,
                "code": 0,
                "class": "Centreon\\Domain\\MonitoringServer\\Exception\\ConfigurationMonitoringServerException",
                "method": "errorOnGeneration"
            },
            {
                "type": "Centreon\\Domain\\Authentication\\Exception\\AuthenticationException",
                "message": "Authentication token expired",
                "file": "/usr/share/centreon/src/Centreon/Domain/Authentication/Exception/AuthenticationException.php",
                "line": 150,
                "code": 0,
                "class": "Centreon\\Domain\\Authentication\\Exception\\AuthenticationException",
                "method": "authenticationTokenExpired"
            }
        ],
    },
}
```