### PR TITLE
fix(Resources Status): Services attached to a deleted host still appear in the menu filter (#8394) [dev-24.10.x]

### DIFF
--- a/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbReadRealTimeServiceRepository.php
@@ -344,6 +344,7 @@ class DbReadRealTimeServiceRepository extends AbstractRepositoryRDB implements R
             {$search}
             {$typeSearch}
             {$aclSearch}
+                AND services.enabled = 1
             GROUP BY services.name
             {$sort}
             {$limit}


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/8394 t to dev-24.10.x.

**Fixes** # MON-188625

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
