### PR TITLE
fix(E2E): ensure proper cleanup of web container after tests

### DIFF
--- a/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
@@ -166,5 +166,6 @@ Given(
 
 afterEach(() => {
   cy.visitEmptyPage()
+    .copyWebContainerLogs({ name: 'web' })
     .stopContainer({ name: 'web' });
 });

--- a/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts
@@ -165,5 +165,6 @@ Given(
 );
 
 afterEach(() => {
-  cy.stopContainers();
+  cy.visitEmptyPage()
+    .stopContainer({ name: 'web' });
 });

--- a/centreon/tests/e2e/support/commands.ts
+++ b/centreon/tests/e2e/support/commands.ts
@@ -1,7 +1,7 @@
 
 
 import 'cypress-wait-until';
-import '@centreon/js-config/cypress/e2e/commands';
+import '../../../packages/js-config/cypress/e2e/commands';
 import { refreshButton } from '../features/Resources-status/common';
 import '../features/ACLs/commands';
 import '../features/Api-Token/commands';


### PR DESCRIPTION
## Description

This pull request makes updates to the Cypress end-to-end test setup for the Centreon platform, focusing on improving container management and updating import paths for custom commands.

**Test container management improvements:**

* In the `afterEach` hook of `centreon/tests/e2e/features/Platform-upgrade-update/01-platform-update/index.ts`, the container stop logic was enhanced to first visit an empty page, copy web container logs, and then stop the web container, instead of just stopping all containers at once.

**Test support and command imports:**

* In `centreon/tests/e2e/support/commands.ts`, the import path for custom Cypress commands was updated to use a relative path to `../../../packages/js-config/cypress/e2e/commands` instead of the previous package alias.

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
