### PR TITLE
fix(extentions manager): remove release note url from modules info

### DIFF
--- a/centreon-awie/www/modules/centreon-awie/conf.php
+++ b/centreon-awie/www/modules/centreon-awie/conf.php
@@ -36,8 +36,6 @@ $module_conf['centreon-awie']['is_removeable'] = '1';
 $module_conf['centreon-awie']['author'] = 'Centreon';
 $module_conf['centreon-awie']['stability'] = 'stable';
 $module_conf['centreon-awie']['last_update'] = '2025-09-08';
-$module_conf['centreon-awie']['release_note']
-    = 'https://docs.centreon.com/23.10/en/releases/centreon-os-extensions.html';
 $module_conf['centreon-awie']['images'] = [
     'images/image1.png',
 ];

--- a/centreon-dsm/www/modules/centreon-dsm/conf.php
+++ b/centreon-dsm/www/modules/centreon-dsm/conf.php
@@ -38,8 +38,6 @@ $module_conf['centreon-dsm']['is_removeable'] = '1';
 $module_conf['centreon-dsm']['author'] = 'Centreon';
 $module_conf['centreon-dsm']['stability'] = 'stable';
 $module_conf['centreon-dsm']['last_update'] = '2025-09-08';
-$module_conf['centreon-dsm']['release_note']
-    = 'https://docs.centreon.com/23.10/en/releases/centreon-os-extensions.html';
 $module_conf['centreon-dsm']['images'] = [
     'images/dsm_snmp_events_tray.png',
 ];

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
@@ -37,8 +37,6 @@ $module_conf['centreon-open-tickets']['is_removeable'] = '1';
 $module_conf['centreon-open-tickets']['author'] = 'Centreon';
 $module_conf['centreon-open-tickets']['stability'] = 'stable';
 $module_conf['centreon-open-tickets']['last_update'] = '2025-09-08';
-$module_conf['centreon-open-tickets']['release_note']
-    = 'https://docs.centreon.com/23.10/en/releases/centreon-os-extensions.html';
 $module_conf['centreon-open-tickets']['images'] = [
     'images/image1.png',
     'images/image2.png',


### PR DESCRIPTION
## Description

This PR intends to remove the release note link from modules informations [open-tickets, dsl et awie].
<img width="300" height="500" alt="image" src="https://github.com/user-attachments/assets/e585f8cd-82e1-46c0-b404-5c7ea57b7817" />

MON-151456

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

In the extensions manager, centreon-awie, centreon-open-tickets and centreon-dsm should not have the release note mentioned in the information modal.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
