### PR TITLE
fix(cfg) force bbdo version to 3.0.1

### DIFF
--- a/centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
+++ b/centreon/www/include/configuration/configCentreonBroker/formCentreonBroker.php
@@ -183,7 +183,17 @@ foreach ($tags as $tagId => $tag) {
  */
 if (isset($_GET['o']) && $_GET['o'] == ADD_BROKER_CONFIGURATION) {
     $result = array_merge(
-        ['name' => '', 'cache_directory' => '/var/lib/centreon-broker/', 'log_directory' => '/var/log/centreon-broker/', 'write_timestamp' => '1', 'write_thread_id' => '1', 'stats_activate' => '1', 'activate' => '1', 'activate_watchdog' => '1', 'bbdo_version' => '3.1.0'],
+        [
+            'name' => '',
+            'cache_directory' => '/var/lib/centreon-broker/',
+            'log_directory' => '/var/log/centreon-broker/',
+            'write_timestamp' => '1',
+            'write_thread_id' => '1',
+            'stats_activate' => '1',
+            'activate' => '1',
+            'activate_watchdog' => '1',
+            'bbdo_version' => '3.0.1',
+        ],
         $defaultLog
     );
     $form->setDefaults($result);

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -475,7 +475,7 @@ CREATE TABLE `cfg_centreonbroker` (
   `stats_activate` enum('0','1') DEFAULT '1',
   `daemon` TINYINT(1),
   `pool_size` int(11) DEFAULT NULL,
-  `bbdo_version` varchar(50) DEFAULT '3.1.0',
+  `bbdo_version` varchar(50) DEFAULT '3.0.1',
   PRIMARY KEY (`config_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -139,7 +139,7 @@ $fixBrokerConfigTypo = function () use ($pearDB, &$errorMessage): void {
 $addOpentelemetryLogLevelColumn = function () use ($pearDB, &$errorMessage): void {
     $errorMessage = 'Failed to add log_level_otl column to cfg_nagios_logger table';
     if (! $pearDB->isColumnExist('cfg_nagios_logger', 'log_level_otl')) {
-        $pearDB->query(
+        $pearDB->executeQuery(
             <<<'SQL'
                 ALTER TABLE `cfg_nagios_logger`
                 ADD COLUMN `log_level_otl` enum('trace', 'debug', 'info', 'warning', 'err', 'critical', 'off') DEFAULT 'err'
@@ -148,11 +148,25 @@ $addOpentelemetryLogLevelColumn = function () use ($pearDB, &$errorMessage): voi
     }
 };
 
+/** -------------------------------------------- BBDO cfg update -------------------------------------------- */
+$bbdoDefaultUpdate = function () use ($pearDB, &$errorMessage): void {
+    if ($pearDB->isColumnExist('cfg_centreonbroker', 'bbdo_version')) {
+        $errorMessage = "Unable to update 'bbdo_version' column to 'cfg_centreonbroker' table";
+        $pearDB->executeQuery('ALTER TABLE `cfg_centreonbroker` MODIFY `bbdo_version` VARCHAR(50) DEFAULT "3.0.1"');
+    }
+};
+
+$bbdoCfgUpdate = function () use ($pearDB, &$errorMessage): void {
+    $errorMessage = "Unable to update 'bbdo_version' version in 'cfg_centreonbroker' table";
+    $pearDB->update('UPDATE `cfg_centreonbroker` SET `bbdo_version` = "3.0.1"');
+};
+
 try {
     // DDL statements for real time database
     // TODO add your function calls to update the real time database structure here
 
     // DDL statements for configuration database
+    $bbdoDefaultUpdate();
     $addOpentelemetryLogLevelColumn();
 
     // Transactional queries for configuration database
@@ -165,6 +179,7 @@ try {
     $cleanGlobalMacrosName();
     $fixTypoInStandardMacroName();
     $fixBrokerConfigTypo();
+    $bbdoCfgUpdate();
 
     $pearDB->commitTransaction();
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -158,7 +158,7 @@ $bbdoDefaultUpdate = function () use ($pearDB, &$errorMessage): void {
 
 $bbdoCfgUpdate = function () use ($pearDB, &$errorMessage): void {
     $errorMessage = "Unable to update 'bbdo_version' version in 'cfg_centreonbroker' table";
-    $pearDB->update('UPDATE `cfg_centreonbroker` SET `bbdo_version` = "3.0.1"');
+    $pearDB->executeStatement('UPDATE `cfg_centreonbroker` SET `bbdo_version` = "3.0.1"');
 };
 
 try {


### PR DESCRIPTION
## Description

Force engine (fresh install and upgrade) to have bbdo_version=3.0.1

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master
