### PR TITLE
fix(open-tickets): hide token in EasyVistaRestProvider provider form

### DIFF
--- a/centreon-open-tickets/www/modules/centreon-open-tickets/providers/EasyVistaRest/EasyVistaRestProvider.class.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/providers/EasyVistaRest/EasyVistaRestProvider.class.php
@@ -303,7 +303,7 @@ class EasyVistaRestProvider extends AbstractProvider
             . $this->getFormValue('protocol') . '" />';
         $account_html = '<input size="50" name="account" type="text" value="'
             . $this->getFormValue('account') . '" autocomplete="off" />';
-        $token_html = '<input size="50" name="token" type="token" value="'
+        $token_html = '<input size="50" name="token" type="password" value="'
             . $this->getFormValue('token') . '" autocomplete="off" />';
         $timeout_html = '<input size="50" name="timeout" type="text" value="'
             . $this->getFormValue('timeout') . '" :>';


### PR DESCRIPTION
ℹ️ https://centreon.atlassian.net/browse/MON-123354
📃 This PR intends to make the "token" input field of the EasyVistaRestProvider form of type password so that the token appears with "*" instead of a clear string