### PR TITLE
fix(API): Wrong SQL indentation in Read Real Time Host Category Repository (#8541) [dev-25.10.x]

### DIFF
--- a/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadRealTimeHostCategoryRepository.php
+++ b/centreon/src/Core/HostCategory/Infrastructure/Repository/DbReadRealTimeHostCategoryRepository.php
@@ -88,11 +88,11 @@ class DbReadRealTimeHostCategoryRepository extends AbstractRepositoryRDB impleme
 
         if ($searchRequest !== null) {
             $request .= <<<'SQL'
-                LEFT JOIN `:dbstg`.resources_tags rtags_host_groups
-                    ON rtags_host_groups.resource_id = resources.resource_id
-                LEFT JOIN `:dbstg`.tags AS host_groups
-                    ON rtags_host_groups.tag_id = host_groups.tag_id
-                    AND host_groups.`type` = 1
+                    LEFT JOIN `:dbstg`.resources_tags rtags_host_groups
+                        ON rtags_host_groups.resource_id = resources.resource_id
+                    LEFT JOIN `:dbstg`.tags AS host_groups
+                        ON rtags_host_groups.tag_id = host_groups.tag_id
+                        AND host_groups.`type` = 1
                 SQL;
 
             $request .= $searchRequest;


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/8541 to dev-25.10.x

**Fixes** # MON-189574

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
