### PR TITLE
fix(conf) avoid api error when changing HT order in host form

### DIFF
--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3025,7 +3025,7 @@ function getPayloadForHostTemplate(bool $isCloudPlatform, array $formData, Kerne
         'retry_check_interval' => $formData['host_retry_check_interval'] !== ''
             ? (int) $formData['host_retry_check_interval']
             : null,
-        'templates' => array_map(static fn (string $id): int => (int) $id, $formData['tpSelect'] ?? []),
+        'templates' => array_map(static fn (string $id): int => (int) $id, array_values($formData['tpSelect'] ?? [])),
         'categories' => array_map(static fn (string $id): int => (int) $id, $formData['host_hcs'] ?? []),
         'macros' => array_map(
             static function (int|string $key, string $name, string $value) use ($formData, $kernel): array {
@@ -3166,7 +3166,7 @@ function getPayloadForHost(bool $isCloudPlatform, array $formData, Kernel $kerne
             ? (int) $formData['host_retry_check_interval']
             : null,
         'is_activated' => (bool) ($formData['host_activate']['host_activate'] ?: false),
-        'templates' => array_map(static fn (string $id): int => (int) $id, $formData['tpSelect'] ?? []),
+        'templates' => array_map(static fn (string $id): int => (int) $id, array_values($formData['tpSelect'] ?? [])),
         'categories' => array_map(static fn (string $id): int => (int) $id, $formData['host_hcs'] ?? []),
         'groups' => array_map(static fn (string $id): int => (int) $id, $formData['host_hgs'] ?? []),
         'macros' => array_map(


### PR DESCRIPTION
## Description

Changing order of the HT in host form lead to an API error as the array keys where mixed up

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] master
