### PR TITLE
fix(vault): adjust log level for 404 case

### DIFF
--- a/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfiguration.php
+++ b/centreon/src/Core/Security/Vault/Application/UseCase/FindVaultConfiguration/FindVaultConfiguration.php
@@ -61,7 +61,7 @@ final class FindVaultConfiguration
             }
 
             if (! $this->readVaultConfigurationRepository->exists()) {
-                $this->error('Vault configuration not found');
+                $this->info('Vault configuration not found');
                 $presenter->presentResponse(
                     new NotFoundResponse('Vault configuration')
                 );


### PR DESCRIPTION
## Description

This PR intends to adjust log level from error() to info() for find vault configuration not found scenario, as 404 is a valid business state, not an error.

MON-182269

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
