### PR TITLE
fix(license manager): remove deprecated creation of dynamic property

### DIFF
--- a/centreon/src/Centreon/Infrastructure/FileManager/File.php
+++ b/centreon/src/Centreon/Infrastructure/FileManager/File.php
@@ -37,13 +37,12 @@ class File
 
     public function __construct(array $data)
     {
-        foreach ($data as $prop => $value) {
-            $this->{$prop} = $value;
-        }
-
-        if ($this->name) {
-            $this->extension = pathinfo($this->name, PATHINFO_EXTENSION);
-        }
+        $this->name = $data['name'] ?? '';
+        $this->type = $data['type'] ?? '';
+        $this->tmp_name = $data['tmp_name'] ?? '';
+        $this->error = $data['error'] ?? 0;
+        $this->size = $data['size'] ?? 0;
+        $this->extension = $this->name ? pathinfo($this->name, PATHINFO_EXTENSION) : '';
     }
 
     public function getName(): string
@@ -66,12 +65,12 @@ class File
         return $this->tmp_name;
     }
 
-    public function getError(): string
+    public function getError(): int
     {
         return $this->error;
     }
 
-    public function getSize(): string
+    public function getSize(): int
     {
         return $this->size;
     }


### PR DESCRIPTION
## Description

This PR intends to remove deprecation after migration to php8.2
```
PHP Deprecated:  Creation of dynamic property Centreon\Infrastructure\FileManager\File::$full_path is deprecated in /usr/share/centreon/src/Centreon/Infrastructure/FileManager/File.php
```

MON-155955

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
