### PR TITLE
enh(resource access): return alias instead of name in RA rule detail

### DIFF
--- a/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml
+++ b/centreon/doc/API/latest/Cloud/Administration/ResourceAccessManagement/FindUpdatesAndDeleteRule.yaml
@@ -38,7 +38,7 @@ get:
                           type: integer
                           description: "ID of the contact linked to the rule"
                           example: 1
-                        name:
+                        alias:
                           type: string
                           description: "Name of the contact linked to the rule"
                   all:

--- a/centreon/src/Core/Contact/Application/Repository/ReadContactRepositoryInterface.php
+++ b/centreon/src/Core/Contact/Application/Repository/ReadContactRepositoryInterface.php
@@ -44,6 +44,17 @@ interface ReadContactRepositoryInterface
     public function findNamesByIds(int ...$ids): array;
 
     /**
+     * Find contact alias by IDs.
+     *
+     * @param int ...$ids
+     *
+     * @throws RepositoryException
+     *
+     * @return array<int, array{id: int, alias: string}>
+     */
+    public function findAliasesByIds(int ...$ids): array;
+
+    /**
      * Check user existence by its id.
      *
      * @param int $userId

--- a/centreon/src/Core/Contact/Infrastructure/Repository/DbReadContactRepository.php
+++ b/centreon/src/Core/Contact/Infrastructure/Repository/DbReadContactRepository.php
@@ -115,6 +115,58 @@ class DbReadContactRepository extends AbstractRepositoryRDB implements ReadConta
     /**
      * @inheritDoc
      */
+    public function findAliasesByIds(int ...$ids): array
+    {
+        try {
+            if ($ids === []) {
+                return [];
+            }
+
+            $ids = array_unique($ids);
+
+            $fields = '';
+            foreach ($ids as $index => $id) {
+                $fields .= ($fields === '' ? '' : ', ') . ':id_' . $index;
+            }
+
+            $select = <<<SQL
+                SELECT
+                    `contact_id` as `id`,
+                    `contact_alias` as `alias`
+                FROM
+                    `:db`.`contact`
+                WHERE
+                    `contact_id` IN ({$fields})
+                SQL;
+
+            $statement = $this->db->prepare($this->translateDbName($select));
+            foreach ($ids as $index => $id) {
+                $statement->bindValue(':id_' . $index, $id, \PDO::PARAM_INT);
+            }
+            $statement->setFetchMode(\PDO::FETCH_ASSOC);
+            $statement->execute();
+
+            // Retrieve data
+            $names = [];
+            foreach ($statement as $result) {
+                /** @var array{ id: int, alias: string } $result */
+                $names[$result['id']] = $result;
+            }
+
+            return $names;
+        } catch (\PDOException $e) {
+            throw new RepositoryException(
+                message: 'An error occurred while retrieving contact names by IDs.',
+                context: ['ids' => $ids],
+                previous: $e
+            );
+        }
+
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function exists(int $userId): bool
     {
         $request = $this->translateDbName(

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRule.php
@@ -132,7 +132,7 @@ final readonly class FindRule
 
         // retrieve names of linked contact IDs
         $response->contacts = array_values(
-            $this->contactRepository->findNamesByIds(...$rule->getLinkedContactIds())
+            $this->contactRepository->findAliasesByIds(...$rule->getLinkedContactIds())
         );
 
         // retrieve names of linked contact group IDs

--- a/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleResponse.php
+++ b/centreon/src/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleResponse.php
@@ -37,7 +37,7 @@ final class FindRuleResponse
 
     public bool $applyToAllContactGroups = false;
 
-    /** @var array<int, array{id: int, name: string}> */
+    /** @var array<int, array{id: int, alias: string}> */
     public array $contacts = [];
 
     /** @var array<int, array{id: int, name: string}> */

--- a/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
+++ b/centreon/tests/php/Core/ResourceAccess/Application/UseCase/FindRule/FindRuleTest.php
@@ -199,9 +199,9 @@ it('should present a FindRuleResponse when no error occurs', function (): void {
 
     $this->contactRepository
         ->expects($this->any())
-        ->method('findNamesByIds')
+        ->method('findAliasesByIds')
         ->with(...$this->rule->getLinkedContactIds())
-        ->willReturn(['1' => ['id' => 1, 'name' => 'contact1']]);
+        ->willReturn(['1' => ['id' => 1, 'alias' => 'contact1']]);
 
     $this->contactGroupRepository
         ->expects($this->any())


### PR DESCRIPTION
## Description

This  PR intends to return user alias instead of name in Resource Access Rule Detail

**Fixes** # MON-190121

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
