### PR TITLE
feat(tests): Adding log to display versions used for Upgrade test

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/configuration.ts
+++ b/centreon/packages/js-config/cypress/e2e/configuration.ts
@@ -54,6 +54,12 @@ export default ({
           commandTrimLength: 5000,
           defaultTrimLength: 5000,
         });
+        on("task", {
+          logVersion(message) {
+            console.log(`[LOG]: ${message}`);
+            return null;
+          },
+        });
         await esbuildPreprocessor(on, config);
         tasks(on);
 

--- a/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade/index.ts
@@ -103,12 +103,18 @@ Given(
     cy.log(`Testing ${Cypress.env('IS_CLOUD') ? 'cloud' : 'onprem'} upgrade`);
 
     return cy.getWebVersion().then(({ major_version, minor_version }) => {
+      cy.task("logVersion", `Current Major version value is ${major_version}`);
       let majorVersionFrom = '0';
       switch (majorVersionFromExpression) {
         case 'n - 1': {
           const previousVersion =
             getCentreonPreviousMajorVersion(major_version);
           cy.log(`Getting Centreon previous major version: ${previousVersion}`);
+          cy.task(
+            "logVersion",
+            `Previous Major version value is ${previousVersion}`,
+          );
+          // Cloud versioning is different from on-prem
           if (Cypress.env('IS_CLOUD')) {
             const versionDir = './././../../www/install/php';
             const versionFilePath = `${versionDir}/Update-${previousVersion}.${minor_version}.php`;
@@ -117,6 +123,10 @@ Given(
                 cy.log(`The file with version: ${previousVersion} exist`);
                 cy.wrap(previousVersion).as('majorVersionFrom');
                 majorVersionFrom = previousVersion;
+                cy.task(
+                  "logVersion",
+                  `Found version value is ${previousVersion}`,
+                );
               } else {
                 cy.log(
                   `The file with version: ${previousVersion} does not exist`
@@ -127,13 +137,21 @@ Given(
                     const newVersion = versionFilePath;
                     majorVersionFrom = versionFilePath;
                     cy.wrap(newVersion).as('majorVersionFrom');
+                    cy.task(
+                      "logVersion",
+                      `Closest version found value is ${newVersion}`,
+                    );
                   }
                 );
               }
             });
           } else {
             majorVersionFrom = previousVersion;
-            cy.wrap(majorVersionFrom).as('majorVersionFrom');
+            cy.wrap(previousVersion).as("majorVersionFrom");
+            cy.task(
+              "logVersion",
+              `Found version value is ${previousVersion}`,
+            );
           }
           break;
         }
@@ -210,7 +228,10 @@ Given(
                   const installedVersion = `${majorVersionFrom}.${stableMinorVersions[minorVersionIndex]}`;
                   Cypress.env('installed_version', installedVersion);
                   cy.log('installed_version', installedVersion);
-
+                  cy.task(
+                    "logVersion",
+                    `Installed version value is ${installedVersion}`,
+                  );
                   return installCentreon(installedVersion)
                     .then(() => {
                       if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {


### PR DESCRIPTION

## Description

Currently, E2E update and upgrade tests display the versions found, starting and ending, in the logs.

To enable analysis whenever desired, it is necessary to always display the versions used during these tests.

**Fixes** # MON-189710

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
