### PR TITLE
feat(tests): Adding log to display versions used for Upgrade test (#8583)

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/configuration.ts
+++ b/centreon/packages/js-config/cypress/e2e/configuration.ts
@@ -49,13 +49,16 @@ export default ({
       },
       setupNodeEvents: async (cypressOn, config) => {
         const on = require('cypress-on-fix')(cypressOn)
-        installLogsPrinter(
-          on,
-          {
-            commandTrimLength: 5000,
-            defaultTrimLength: 5000,
-          }
-      );
+        installLogsPrinter(on, {
+          commandTrimLength: 5000,
+          defaultTrimLength: 5000,
+        });
+        on("task", {
+          logVersion(message) {
+            console.log(`[LOG]: ${message}`);
+            return null;
+          },
+        });
         await esbuildPreprocessor(on, config);
         tasks(on);
 

--- a/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade/index.ts
+++ b/centreon/tests/e2e/features/Platform-upgrade-update/02-platform-upgrade/index.ts
@@ -72,14 +72,23 @@ Given(
   'a running platform in major {string} with {string} version',
   (major_version_from_expression: string, version_from_expression: string) => {
     return cy.getWebVersion().then(({ major_version }) => {
+      cy.task('logVersion', `Current Major version value is ${major_version}`);
       let major_version_from = '0';
       switch (major_version_from_expression) {
         case 'n - 1':
           major_version_from = getCentreonPreviousMajorVersion(major_version);
+          cy.task(
+            'logVersion',
+            `Previous Major version value is ${major_version_from}`,
+          );
           break;
         case 'n - 2':
           major_version_from = getCentreonPreviousMajorVersion(
             getCentreonPreviousMajorVersion(major_version)
+          );
+          cy.task(
+            'logVersion',
+            `Previous Major version value is ${major_version_from}`
           );
           break;
         default:
@@ -140,7 +149,10 @@ Given(
                 const installed_version = `${major_version_from}.${stable_minor_versions[minor_version_index]}`;
                 Cypress.env('installed_version', installed_version);
                 cy.log('installed_version', installed_version);
-
+                cy.task(
+                  "logVersion",
+                  `Installed version value is ${installed_version}`
+                );
                 return installCentreon(installed_version)
                   .then(() => {
                     if (Cypress.env('WEB_IMAGE_OS').includes('alma')) {


### PR DESCRIPTION

## Description

Currently, E2E update and upgrade tests display the versions found, starting and ending, in the logs.

To enable analysis whenever desired, it is necessary to always display the versions used during these tests.

**Fixes** # MON-189710

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [x] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
