### PR TITLE
fix(export) update is_encryption_ready column type

### DIFF
--- a/centreon/src/Core/Macro/Infrastructure/Repository/DbReadHostMacroRepository.php
+++ b/centreon/src/Core/Macro/Infrastructure/Repository/DbReadHostMacroRepository.php
@@ -170,7 +170,7 @@ class DbReadHostMacroRepository extends DatabaseRepository implements ReadHostMa
      *    is_password:int|null,
      *    description:string|null,
      *    macro_order:int,
-     *    is_encryption_ready?:string
+     *    is_encryption_ready?:int
      * } $data
      *
      * @throws AssertionFailedException

--- a/centreon/src/Core/Macro/Infrastructure/Repository/DbReadServiceMacroRepository.php
+++ b/centreon/src/Core/Macro/Infrastructure/Repository/DbReadServiceMacroRepository.php
@@ -39,7 +39,7 @@ use Core\Macro\Domain\Model\Macro;
  *    is_password:int|null,
  *    description:string|null,
  *    macro_order:int,
- *    is_encryption_ready?:string
+ *    is_encryption_ready?:int
  * }
  */
 class DbReadServiceMacroRepository extends DatabaseRepository implements ReadServiceMacroRepositoryInterface
@@ -155,7 +155,7 @@ class DbReadServiceMacroRepository extends DatabaseRepository implements ReadSer
              *    is_password:int|null,
              *    description:string|null,
              *    macro_order:int,
-             *    is_encryption_ready:string
+             *    is_encryption_ready:int
              * } $result */
             $macros[] = $this->createMacro($result);
         }
@@ -203,7 +203,7 @@ class DbReadServiceMacroRepository extends DatabaseRepository implements ReadSer
              *    is_password:int|null,
              *    description:string|null,
              *    macro_order:int,
-             *    is_encryption_ready:string
+             *    is_encryption_ready:int
              * } $result */
             $macros[] = $this->createMacro($result);
         }

--- a/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
+++ b/centreon/src/Core/MonitoringServer/Infrastructure/Repository/DbReadMonitoringServerRepository.php
@@ -387,7 +387,7 @@ class DbReadMonitoringServerRepository extends AbstractRepositoryRDB implements 
                 SELECT 1
                 FROM `:dbstg`.`instances`
                 WHERE instance_id = :monitoringServerId
-                    AND is_encryption_ready = '1'
+                    AND is_encryption_ready = 1
                 SQL
         ));
         $statement->bindValue(':monitoringServerId', $monitoringServerId, \PDO::PARAM_INT);
@@ -401,7 +401,7 @@ class DbReadMonitoringServerRepository extends AbstractRepositoryRDB implements 
                 SELECT 1
                 FROM `:db`.`nagios_server`
                 WHERE id = :monitoringServerId
-                    AND is_encryption_ready = '1'
+                    AND is_encryption_ready = 1
                 SQL
         ));
         $statement->bindValue(':monitoringServerId', $monitoringServerId, \PDO::PARAM_INT);

--- a/centreon/www/class/config-generate/abstract/host.class.php
+++ b/centreon/www/class/config-generate/abstract/host.class.php
@@ -325,7 +325,7 @@ abstract class AbstractHost extends AbstractObject
                     INNER JOIN ns_host_relation nsr
                     ON ns.id = nsr.nagios_server_id
                     WHERE nsr.host_host_id = :hostId
-                    AND ns.is_encryption_ready = '1'
+                    AND ns.is_encryption_ready = 1
                     SQL,
                 QueryParameters::create([QueryParameter::int('hostId', $host['host_id'])])
             );

--- a/centreon/www/install/createTables.sql
+++ b/centreon/www/install/createTables.sql
@@ -1662,7 +1662,7 @@ CREATE TABLE `nagios_server` (
   `remote_id` int(11) NULL,
   `remote_server_use_as_proxy` enum('0','1') NOT NULL DEFAULT '1',
   `updated` enum('1','0') NOT NULL DEFAULT '0',
-  `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '1',
+  `is_encryption_ready` BOOLEAN NOT NULL DEFAULT 1,
   PRIMARY KEY (`id`),
   CONSTRAINT `nagios_server_remote_id_id` FOREIGN KEY (`remote_id`) REFERENCES `nagios_server` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/centreon/www/install/installBroker.sql
+++ b/centreon/www/install/installBroker.sql
@@ -408,7 +408,7 @@ CREATE TABLE `instances` (
   `version` varchar(16) DEFAULT NULL,
   `deleted` boolean NOT NULL default false,
   `outdated` boolean NOT NULL default false,
-  `is_encryption_ready` enum('0', '1') NOT NULL DEFAULT '0',
+  `is_encryption_ready` BOOLEAN NOT NULL DEFAULT 0,
   PRIMARY KEY (`instance_id`),
   KEY `instances_name_idx` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
@@ -705,4 +705,3 @@ UNLOCK TABLES;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
-

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -139,7 +139,7 @@ $fixBrokerConfigTypo = function () use ($pearDB, &$errorMessage): void {
 $addOpentelemetryLogLevelColumn = function () use ($pearDB, &$errorMessage): void {
     $errorMessage = 'Failed to add log_level_otl column to cfg_nagios_logger table';
     if (! $pearDB->isColumnExist('cfg_nagios_logger', 'log_level_otl')) {
-        $pearDB->executeQuery(
+        $pearDB->executeStatement(
             <<<'SQL'
                 ALTER TABLE `cfg_nagios_logger`
                 ADD COLUMN `log_level_otl` enum('trace', 'debug', 'info', 'warning', 'err', 'critical', 'off') DEFAULT 'err'
@@ -152,13 +152,92 @@ $addOpentelemetryLogLevelColumn = function () use ($pearDB, &$errorMessage): voi
 $bbdoDefaultUpdate = function () use ($pearDB, &$errorMessage): void {
     if ($pearDB->isColumnExist('cfg_centreonbroker', 'bbdo_version')) {
         $errorMessage = "Unable to update 'bbdo_version' column to 'cfg_centreonbroker' table";
-        $pearDB->executeQuery('ALTER TABLE `cfg_centreonbroker` MODIFY `bbdo_version` VARCHAR(50) DEFAULT "3.0.1"');
+        $pearDB->executeStatement('ALTER TABLE `cfg_centreonbroker` MODIFY `bbdo_version` VARCHAR(50) DEFAULT "3.0.1"');
     }
 };
 
 $bbdoCfgUpdate = function () use ($pearDB, &$errorMessage): void {
     $errorMessage = "Unable to update 'bbdo_version' version in 'cfg_centreonbroker' table";
     $pearDB->executeStatement('UPDATE `cfg_centreonbroker` SET `bbdo_version` = "3.0.1"');
+};
+
+/** -------------------------------------------- Password encryption -------------------------------------------- */
+$addIsEncryptionReadyAsBooleanColumn = function () use ($pearDB, $pearDBO, &$errorMessage, $version): void {
+    $errorMessage = "Unable to update 'is_encryption_ready' column to boolean type";
+    if (
+        $pearDB->isColumnExist('nagios_server', 'is_encryption_ready')
+        && $pearDB->isColumnExist('nagios_server', 'is_encryption_ready_old') !== 1
+    ) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Renaming column 'is_encryption_ready' on 'nagios_server' table",
+        );
+        $pearDB->executeStatement('ALTER TABLE `nagios_server` RENAME COLUMN `is_encryption_ready` TO `is_encryption_ready_old`');
+    }
+    if ($pearDB->isColumnExist('nagios_server', 'is_encryption_ready') !== 1) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Adding column 'is_encryption_ready' of type boolean on 'nagios_server' table",
+        );
+        $pearDB->executeStatement('ALTER TABLE `nagios_server` ADD COLUMN `is_encryption_ready` BOOLEAN NOT NULL DEFAULT 1');
+    }
+    if ($pearDB->isColumnExist('nagios_server', 'is_encryption_ready_old')) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Moving 'is_encryption_ready' value of existing pollers on 'nagios_server' table",
+        );
+
+        $pearDB->executeStatement(
+            <<<'SQL'
+                UPDATE nagios_server ns
+                SET ns.is_encryption_ready = 0
+                WHERE ns.is_encryption_ready_old = '0'
+                SQL
+        );
+
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Dropping column 'is_encryption_ready_old' on 'nagios_server' table",
+        );
+        $pearDB->executeStatement('ALTER TABLE `nagios_server` DROP COLUMN `is_encryption_ready_old`');
+    }
+
+    if (
+        $pearDBO->isColumnExist('instances', 'is_encryption_ready')
+        && $pearDBO->isColumnExist('instances', 'is_encryption_ready_old') !== 1
+    ) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Moving 'is_encryption_ready' value of existing pollers on 'instances' table",
+        );
+        $pearDBO->executeStatement('ALTER TABLE `instances` RENAME COLUMN `is_encryption_ready` TO `is_encryption_ready_old`');
+    }
+    if ($pearDBO->isColumnExist('instances', 'is_encryption_ready') !== 1) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Adding column 'is_encryption_ready' of type boolean on 'instances' table",
+        );
+        $pearDBO->executeStatement('ALTER TABLE `instances` ADD COLUMN `is_encryption_ready` BOOLEAN NOT NULL DEFAULT 0');
+    }
+    if ($pearDBO->isColumnExist('instances', 'is_encryption_ready_old')) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Moving 'is_encryption_ready' value of existing pollers on 'instances' table",
+        );
+        $pearDBO->executeStatement(
+            <<<'SQL'
+                UPDATE instances ins
+                SET ins.is_encryption_ready = 1
+                WHERE ins.is_encryption_ready_old = '1'
+                SQL
+        );
+
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: Dropping column 'is_encryption_ready_old' on 'instances' table",
+        );
+        $pearDBO->executeStatement('ALTER TABLE `instances` DROP COLUMN `is_encryption_ready_old`');
+    }
 };
 
 try {
@@ -168,6 +247,7 @@ try {
     // DDL statements for configuration database
     $bbdoDefaultUpdate();
     $addOpentelemetryLogLevelColumn();
+    $addIsEncryptionReadyAsBooleanColumn();
 
     // Transactional queries for configuration database
     if (! $pearDB->isTransactionActive()) {


### PR DESCRIPTION
## Description

Change is_encryption_ready type from enum to boolean for centreon.nagios_server and centreon_storage.instances tables

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master
