### PR TITLE
enh(packaging): increase centreon php memory_limit to 256M

### DIFF
--- a/centreon/packaging/src/php.ini
+++ b/centreon/packaging/src/php.ini
@@ -3,3 +3,4 @@ session.use_strict_mode = 1
 session.gc_maxlifetime = 7200
 expose_php = Off
 allow_url_fopen = Off
+memory_limit = 256M


### PR DESCRIPTION
## Description

* increase php memory_limit to 256M

**Fixes** #MON-190510

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
