### PR TITLE
fix(Authentication-Token): Prevent manual token type to change expiration date

### DIFF
--- a/centreon/www/api/class/webService.class.php
+++ b/centreon/www/api/class/webService.class.php
@@ -331,6 +331,7 @@ class CentreonWebService
 
     /**
      * Update the ttl for a token if the authentication is by token
+     * Does not update the manual tokens
      *
      * @return void
      */
@@ -341,13 +342,15 @@ class CentreonWebService
         if (isset($_SERVER['HTTP_CENTREON_AUTH_TOKEN'])) {
             try {
                 $stmt = $pearDB->prepare(
-                    'UPDATE security_token
-                    SET expiration_date = (
+                    'UPDATE security_token st
+                    INNER JOIN security_authentication_tokens sat
+                        ON st.id = sat.provider_token_id AND sat.token_type = \'auto\'
+                    SET st.expiration_date = (
                         SELECT UNIX_TIMESTAMP(NOW() + INTERVAL (`value` * 60) SECOND)
                         FROM `options`
                         wHERE `key` = \'session_expire\'
                     )
-                    WHERE token = :token'
+                    WHERE st.token = :token'
                 );
                 $stmt->bindValue(':token', $_SERVER['HTTP_CENTREON_AUTH_TOKEN'], PDO::PARAM_STR);
                 $stmt->execute();


### PR DESCRIPTION
## Description

When Using APIv1, API Token created from UI with "Never Expires" should keep their expiration null even after being used.
This PR ensures that it doesn't change by updating the expiration date only if it is already set.

It also applies to manual token having an expiration date defined: these dates should not be updated when used.