### PR TITLE
fix(cfg): poller version check in broker export

### DIFF
--- a/centreon/www/class/config-generate/engine.class.php
+++ b/centreon/www/class/config-generate/engine.class.php
@@ -358,7 +358,11 @@ class Engine extends AbstractObject
         $pollerStmt->execute();
         $pollerVersion = $pollerStmt->fetchColumn();
 
-        if ($pollerVersion === false || version_compare($pollerVersion, '25.05.0', '<')) {
+        if ($pollerVersion === false) {
+            // Unknown version, both broker_module and broker_module_cfg_file configurations are needed
+            $this->engine['broker_module'][] = '/usr/lib64/nagios/cbmod.so ' . $this->engine['broker_module_cfg_file'];
+        } elseif (version_compare($pollerVersion, '25.05.0', '<')) {
+            // Version is less than 25.05.0, add the legacy broker module and remove the cfg file reference
             $this->engine['broker_module'][] = '/usr/lib64/nagios/cbmod.so ' . $this->engine['broker_module_cfg_file'];
             unset($this->engine['broker_module_cfg_file']);
         }


### PR DESCRIPTION
## Description

Do not send cbmod.so command in broker conf export, when poller version is unknown

Fixes: [MON-190585](https://centreon.atlassian.net/browse/MON-190585)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master


[MON-190585]: https://centreon.atlassian.net/browse/MON-190585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ