### PR TITLE
fix(extentions manager): remove release note url from modules info (#8534)

### DIFF
--- a/centreon-awie/www/modules/centreon-awie/conf.php
+++ b/centreon-awie/www/modules/centreon-awie/conf.php
@@ -33,8 +33,6 @@ $module_conf['centreon-awie']['is_removeable'] = '1';
 $module_conf['centreon-awie']['author'] = 'Centreon';
 $module_conf['centreon-awie']['stability'] = 'stable';
 $module_conf['centreon-awie']['last_update'] = '2025-02-13';
-$module_conf['centreon-awie']['release_note']
-    = 'https://docs.centreon.com/23.10/en/releases/centreon-os-extensions.html';
 $module_conf['centreon-awie']['images'] = [
     'images/image1.png',
 ];

--- a/centreon-dsm/www/modules/centreon-dsm/conf.php
+++ b/centreon-dsm/www/modules/centreon-dsm/conf.php
@@ -53,8 +53,6 @@ $module_conf['centreon-dsm']['is_removeable'] = '1';
 $module_conf['centreon-dsm']['author'] = 'Centreon';
 $module_conf['centreon-dsm']['stability'] = 'stable';
 $module_conf['centreon-dsm']['last_update'] = '2025-08-29';
-$module_conf['centreon-dsm']['release_note']
-    = 'https://docs.centreon.com/23.10/en/releases/centreon-os-extensions.html';
 $module_conf['centreon-dsm']['images'] = [
     'images/dsm_snmp_events_tray.png',
 ];

--- a/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
+++ b/centreon-open-tickets/www/modules/centreon-open-tickets/conf.php
@@ -38,8 +38,6 @@ $module_conf['centreon-open-tickets']["is_removeable"] = "1";
 $module_conf['centreon-open-tickets']["author"] = "Centreon";
 $module_conf['centreon-open-tickets']["stability"] = "stable";
 $module_conf['centreon-open-tickets']["last_update"] = "2025-02-13";
-$module_conf['centreon-open-tickets']["release_note"] =
-    "https://docs.centreon.com/23.10/en/releases/centreon-os-extensions.html";
 $module_conf['centreon-open-tickets']["images"] = [
     'images/image1.png',
     'images/image2.png',


### PR DESCRIPTION
## Description

Backport of #8534

[MON-190219](https://centreon.atlassian.net/browse/MON-190219)

[MON-190219]: https://centreon.atlassian.net/browse/MON-190219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ