### PR TITLE
enh(Status Grid): Added filter for resources state (#8602) [dev-25.10.x]

### DIFF
--- a/centreon/tests/e2e/features/Dashboards/12-status-grid-widget-configuration/index.ts
+++ b/centreon/tests/e2e/features/Dashboards/12-status-grid-widget-configuration/index.ts
@@ -336,18 +336,19 @@ When(
     cy.getByLabel({ label: 'RichTextEditor' })
       .eq(0)
       .type(genericTextWidgets.default.description);
+    cy.contains("Select all").eq(0).click();
+    cy.get('input[name="unhandled_problems"]').click();
     cy.getByTestId({ testId: 'Resource type' }).realClick();
     cy.getByLabel({ label: 'Host Group' }).click();
     cy.getByTestId({ testId: 'Select resource' }).click();
     cy.contains('Linux-Servers').realClick();
-    cy.get('input[name="success"]').click();
   }
 );
 
 Then(
   'a grid representing the statuses of this list of resources are displayed in the widget preview',
   () => {
-    cy.get('[class*="heatMapTile"]').should('exist');
+    cy.get('[class*="heatMapTile"]').its('length').should('be.gte', 1);
   }
 );
 
@@ -356,7 +357,7 @@ When('the user saves the Status Grid widget', () => {
 });
 
 Then("the Status Grid widget is added in the dashboard's layout", () => {
-  cy.get('[class*="heatMapTile"]').should('exist');
+  cy.get('[class*="heatMapTile"]').its('length').should('be.gte', 1);
 });
 
 Given('a dashboard with a configured Status Grid widget', () => {

--- a/centreon/tests/e2e/features/Dashboards/13-dashboard-all-widgets/index.ts
+++ b/centreon/tests/e2e/features/Dashboards/13-dashboard-all-widgets/index.ts
@@ -274,11 +274,12 @@ When(
     cy.getByTestId({ testId: 'Widget type' }).click();
     cy.contains('Status grid').click();
     cy.getByLabel({ label: 'Title' }).type(genericTextWidgets.default.title);
+    cy.contains("Select all").eq(0).click();
+    cy.get('input[name="unhandled_problems"]').click();
     cy.getByTestId({ testId: 'Resource type' }).realClick();
     cy.getByLabel({ label: 'Host Group' }).click();
     cy.getByTestId({ testId: 'Select resource' }).click();
     cy.contains('Linux-Servers').realClick();
-    cy.get('input[name="success"]').click();
     cy.getByTestId({ testId: 'confirm' }).click();
     cy.getByTestId({ testId: 'save_dashboard' }).click();
   }
@@ -423,10 +424,8 @@ Then(
       case 'status grid': {
         cy.url().should('include', '/centreon/monitoring/resources?filter=');
         const statusGridStatuses = [
-          'Critical',
-          'Unknown',
-          'Unknown',
-          'Ok',
+          'Up',
+          'Up',
           'Up'
         ];
         cy.get('[class$="chip-statusColumnChip"]')

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/properties.json
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/properties.json
@@ -67,6 +67,35 @@
       ],
       "defaultValue": ["warning", "problem"]
     },
+    "states": {
+      "type": "checkbox",
+      "label": "Display resources with this state",
+      "options": [
+        {
+          "id": "unhandled_problems",
+          "name": "Unhandled"
+        },
+        {
+          "id": "acknowledged",
+          "name": "Acknowledged"
+        },
+        {
+          "id": "in_downtime",
+          "name": "In downtime"
+        },
+        {
+          "id": "in_flapping",
+          "name": "Flapping"
+        }
+      ],
+      "defaultValue": ["unhandled_problems"],
+      "hiddenCondition": {
+        "target": "options",
+        "when": "options.viewMode",
+        "method": "equals",
+        "matches": "condensed"
+      }
+    },
     "sortBy": {
       "type": "radio",
       "label": "Sort by",

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/StatusGrid.tsx
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/StatusGridStandard/StatusGrid.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { ReactElement, useMemo } from 'react';
 
 import { useAtomValue } from 'jotai';
 import { equals, gt, isNil, last, pipe, pluck, reject } from 'ramda';
@@ -51,7 +51,7 @@ const StatusGrid = ({
   dashboardId,
   playlistHash,
   widgetPrefixQuery
-}: Omit<StatusGridProps, 'store' | 'queryClient'>): JSX.Element => {
+}: Omit<StatusGridProps, 'store' | 'queryClient'>): ReactElement => {
   const theme = useTheme();
   const { t } = useTranslation();
 
@@ -59,6 +59,7 @@ const StatusGrid = ({
     refreshInterval,
     resourceType,
     sortBy,
+    states,
     statuses,
     tiles,
     refreshIntervalCustom
@@ -125,7 +126,7 @@ const StatusGrid = ({
                 limit: tiles,
                 resources,
                 sortBy,
-                states: [],
+                states,
                 statuses: statusesToUse,
                 type: resourceType
               }),
@@ -138,6 +139,7 @@ const StatusGrid = ({
       'statusgrid',
       resourceType,
       JSON.stringify(statuses),
+      JSON.stringify(states),
       sortBy,
       tiles,
       JSON.stringify(resources),

--- a/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/api/endpoints.ts
+++ b/centreon/www/front_src/src/Dashboards/SingleInstancePage/Dashboard/Widgets/centreon-widget-statusgrid/src/api/endpoints.ts
@@ -27,10 +27,10 @@ export const hostsEndpoint = '/monitoring/resources/hosts';
 export const baIndicatorsEndpoint =
   '/bam/monitoring/business-activities/indicators';
 export const businessActivitiesEndpoint = '/bam/monitoring/business-activities';
-export const getBAEndpoint = (id): string =>
+export const getBAEndpoint = (id: number): string =>
   `/bam/monitoring/business-activities/${id}`;
 
-export const getBooleanRuleEndpoint = (id): string =>
+export const getBooleanRuleEndpoint = (id: number): string =>
   `/bam/monitoring/indicators/boolean-rules/${id}`;
 
 interface BuildResourcesEndpointProps {


### PR DESCRIPTION
## Description

This is a backport of https://github.com/centreon/centreon/pull/8602 to dev-25.10.x

**Fixes** # MON-190927

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
