### PR TITLE
enh(connection): add columnExists method in connection interface

### DIFF
--- a/centreon/src/Adaptation/Database/Connection/ConnectionInterface.php
+++ b/centreon/src/Adaptation/Database/Connection/ConnectionInterface.php
@@ -469,5 +469,5 @@ interface ConnectionInterface
      *
      * @throws ConnectionException
      */
-    public function columnExists(string $tableName, string $columnName): bool;
+    public function columnExists(string $dbName, string $tableName, string $columnName): bool;
 }

--- a/centreon/src/Adaptation/Database/Connection/ConnectionInterface.php
+++ b/centreon/src/Adaptation/Database/Connection/ConnectionInterface.php
@@ -435,6 +435,7 @@ interface ConnectionInterface
     public function rollBackTransaction(): bool;
 
     // ------------------------------------- UNBUFFERED QUERIES -----------------------------------------
+
     /**
      * Checks that the connection instance allows the use of unbuffered queries.
      *
@@ -460,4 +461,13 @@ interface ConnectionInterface
      * @throws ConnectionException
      */
     public function stopUnbufferedQuery(): void;
+
+    // --------------------------------------- DDL TOOLS -----------------------------------------------
+
+    /**
+     * Check if a column exists in a table.
+     *
+     * @throws ConnectionException
+     */
+    public function columnExists(string $tableName, string $columnName): bool;
 }

--- a/centreon/src/Adaptation/Database/Connection/Exception/ConnectionException.php
+++ b/centreon/src/Adaptation/Database/Connection/Exception/ConnectionException.php
@@ -578,4 +578,23 @@ class ConnectionException extends DatabaseException
             previous: $previous
         );
     }
+
+    // --------------------------------------- DDL TOOLS -----------------------------------------------
+
+    public static function columnExistsFailed(
+        string $message,
+        string $tableName,
+        string $columnName,
+        ?\Exception $previous = null,
+    ): self {
+        return new self(
+            message: "Error while checking if column '{$columnName}' exists in table '{$tableName}' : {$message}",
+            code: self::ERROR_CODE_DATABASE,
+            context: [
+                'table_name' => $tableName,
+                'column_name' => $columnName,
+            ],
+            previous: $previous
+        );
+    }
 }

--- a/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
+++ b/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
@@ -34,6 +34,8 @@ use Adaptation\Database\ExpressionBuilder\ExpressionBuilderInterface;
 use Adaptation\Database\QueryBuilder\Adapter\Dbal\DbalQueryBuilderAdapter;
 use Adaptation\Database\QueryBuilder\Exception\QueryBuilderException;
 use Adaptation\Database\QueryBuilder\QueryBuilderInterface;
+use Core\Common\Domain\Exception\CollectionException;
+use Core\Common\Domain\Exception\ValueObjectException;
 
 /**
  * Trait.
@@ -442,7 +444,52 @@ trait ConnectionTrait
         }
     }
 
+    // --------------------------------------- DDL TOOLS -----------------------------------------------
+
+    /**
+     * Check if a column exists in a table.
+     *
+     * @throws ConnectionException
+     */
+    public function columnExists(string $tableName, string $columnName): bool
+    {
+        if (empty($tableName)) {
+            throw ConnectionException::columnExistsFailed('Table name must not be empty', $tableName, $columnName);
+        }
+
+        if (empty($columnName)) {
+            throw ConnectionException::columnExistsFailed('Column name must not be empty', $tableName, $columnName);
+        }
+
+        $query = <<<'SQL'
+                SELECT COUNT(*) FROM information_schema.COLUMNS
+                WHERE TABLE_NAME = :tableName 
+                  AND COLUMN_NAME = :columnName
+                  AND TABLE_SCHEMA = :dbName
+                SQL;
+
+        try {
+            $queryParameters = QueryParameters::create([
+                QueryParameter::string('tableName', $tableName),
+                QueryParameter::string('columnName', $columnName),
+                QueryParameter::string('dbName', $this->getConnectionConfig()->getDatabaseNameConfiguration()),
+            ]);
+
+            $entry = $this->fetchOne($query, $queryParameters);
+
+            return $entry !== false && (int) $entry > 0;
+        } catch (ValueObjectException|CollectionException|ConnectionException $exception) {
+            throw ConnectionException::columnExistsFailed(
+                message: 'Failed to query column existence',
+                tableName: $tableName,
+                columnName: $columnName,
+                previous: $exception
+            );
+        }
+    }
+
     // ----------------------------------------- PROTECTED METHODS -----------------------------------------
+
     abstract protected function writeDbLog(
         string $message,
         array $customContext = [],
@@ -451,6 +498,7 @@ trait ConnectionTrait
     ): void;
 
     // ----------------------------------------- PRIVATE METHODS -----------------------------------------
+
     /**
      * @throws ConnectionException
      */

--- a/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
+++ b/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
@@ -462,11 +462,11 @@ trait ConnectionTrait
         }
 
         $query = <<<'SQL'
-                SELECT COUNT(*) FROM information_schema.COLUMNS
-                WHERE TABLE_NAME = :tableName 
-                  AND COLUMN_NAME = :columnName
-                  AND TABLE_SCHEMA = :dbName
-                SQL;
+            SELECT COUNT(*) FROM information_schema.COLUMNS
+            WHERE TABLE_NAME = :tableName
+              AND COLUMN_NAME = :columnName
+              AND TABLE_SCHEMA = :dbName
+            SQL;
 
         try {
             $queryParameters = QueryParameters::create([
@@ -477,7 +477,7 @@ trait ConnectionTrait
 
             $entry = $this->fetchOne($query, $queryParameters);
 
-            return $entry !== false && (int) $entry > 0;
+            return is_numeric($entry) && (int) $entry > 0;
         } catch (ValueObjectException|CollectionException|ConnectionException $exception) {
             throw ConnectionException::columnExistsFailed(
                 message: 'Failed to query column existence',

--- a/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
+++ b/centreon/src/Adaptation/Database/Connection/Trait/ConnectionTrait.php
@@ -451,8 +451,12 @@ trait ConnectionTrait
      *
      * @throws ConnectionException
      */
-    public function columnExists(string $tableName, string $columnName): bool
+    public function columnExists(string $dbName, string $tableName, string $columnName): bool
     {
+        if (empty($dbName)) {
+            throw ConnectionException::columnExistsFailed('Database name must not be empty', $tableName, $columnName);
+        }
+
         if (empty($tableName)) {
             throw ConnectionException::columnExistsFailed('Table name must not be empty', $tableName, $columnName);
         }
@@ -472,7 +476,7 @@ trait ConnectionTrait
             $queryParameters = QueryParameters::create([
                 QueryParameter::string('tableName', $tableName),
                 QueryParameter::string('columnName', $columnName),
-                QueryParameter::string('dbName', $this->getConnectionConfig()->getDatabaseNameConfiguration()),
+                QueryParameter::string('dbName', $dbName),
             ]);
 
             $entry = $this->fetchOne($query, $queryParameters);

--- a/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
+++ b/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
@@ -1595,8 +1595,8 @@ if ($dbConfigCentreon instanceof ConnectionConfig && hasConnectionDb($dbConfigCe
 
     it('check if a column exists with errors must to throw an exception', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
-        expect(fn() => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
-            ->and(fn() => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
+        expect(fn (): bool => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
+            ->and(fn (): bool => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
     });
 
     // ----------------------------------- QUERY ON SEVERAL DATABASES -------------------------------------

--- a/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
+++ b/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
@@ -1573,6 +1573,32 @@ if ($dbConfigCentreon instanceof ConnectionConfig && hasConnectionDb($dbConfigCe
         }
     )->throws(ConnectionException::class);
 
+    // --------------------------------------- DDL TOOLS -----------------------------------------------
+
+    it('check if a column exists with success', function () use ($dbConfigCentreon): void {
+        $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
+        $exists = $db->columnExists(
+            tableName: 'contact',
+            columnName: 'contact_id'
+        );
+        expect($exists)->toBeTrue();
+    });
+
+    it('check if a non-existent column with success', function () use ($dbConfigCentreon): void {
+        $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
+        $exists = $db->columnExists(
+            tableName: 'contact',
+            columnName: 'dummy_column'
+        );
+        expect($exists)->toBeFalse();
+    });
+
+    it('check if a column exists with errors must to throw an exception', function () use ($dbConfigCentreon): void {
+        $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
+        expect(fn() => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
+            ->and(fn() => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
+    });
+
     // ----------------------------------- QUERY ON SEVERAL DATABASES -------------------------------------
 
     it(

--- a/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
+++ b/centreon/tests/php/Adaptation/Database/Connection/Adapter/Dbal/DbalConnectionAdapterTest.php
@@ -1578,6 +1578,7 @@ if ($dbConfigCentreon instanceof ConnectionConfig && hasConnectionDb($dbConfigCe
     it('check if a column exists with success', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $exists = $db->columnExists(
+            dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
             tableName: 'contact',
             columnName: 'contact_id'
         );
@@ -1587,6 +1588,7 @@ if ($dbConfigCentreon instanceof ConnectionConfig && hasConnectionDb($dbConfigCe
     it('check if a non-existent column with success', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
         $exists = $db->columnExists(
+            dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
             tableName: 'contact',
             columnName: 'dummy_column'
         );
@@ -1595,8 +1597,21 @@ if ($dbConfigCentreon instanceof ConnectionConfig && hasConnectionDb($dbConfigCe
 
     it('check if a column exists with errors must to throw an exception', function () use ($dbConfigCentreon): void {
         $db = DbalConnectionAdapter::createFromConfig(connectionConfig: $dbConfigCentreon);
-        expect(fn (): bool => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
-            ->and(fn (): bool => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
+        expect(fn (): bool => $db->columnExists(
+            dbName: '',
+            tableName: 'contact',
+            columnName: 'contact_id'
+        ))->toThrow(ConnectionException::class)
+            ->and(fn (): bool => $db->columnExists(
+                dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
+                tableName: 'contact',
+                columnName: ''
+            ))->toThrow(ConnectionException::class)
+            ->and(fn (): bool => $db->columnExists(
+                dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
+                tableName: '',
+                columnName: 'contact_id'
+            ))->toThrow(ConnectionException::class);
     });
 
     // ----------------------------------- QUERY ON SEVERAL DATABASES -------------------------------------

--- a/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
+++ b/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
@@ -1557,8 +1557,18 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     it('check if a column exists with success', function () use ($dbConfigCentreon): void {
         $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
         $exists = $db->columnExists(
+            dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
             tableName: 'contact',
             columnName: 'contact_id'
+        );
+        expect($exists)->toBeTrue();
+
+        $db->switchToDb($dbConfigCentreon->getDatabaseNameRealTime());
+
+        $exists = $db->columnExists(
+            dbName: $dbConfigCentreon->getDatabaseNameRealTime(),
+            tableName: 'notifications',
+            columnName: 'notification_id'
         );
         expect($exists)->toBeTrue();
     });
@@ -1566,6 +1576,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     it('check if a non-existent column with success', function () use ($dbConfigCentreon): void {
         $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
         $exists = $db->columnExists(
+            dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
             tableName: 'contact',
             columnName: 'dummy_column'
         );
@@ -1574,8 +1585,21 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
 
     it('check if a column exists with errors must to throw an exception', function () use ($dbConfigCentreon): void {
         $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
-        expect(fn () => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
-            ->and(fn () => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
+        expect(fn (): bool => $db->columnExists(
+            dbName: '',
+            tableName: 'contact',
+            columnName: 'contact_id'
+        ))->toThrow(ConnectionException::class)
+            ->and(fn (): bool => $db->columnExists(
+                dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
+                tableName: 'contact',
+                columnName: ''
+            ))->toThrow(ConnectionException::class)
+            ->and(fn (): bool => $db->columnExists(
+                dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
+                tableName: '',
+                columnName: 'contact_id'
+            ))->toThrow(ConnectionException::class);
     });
 
     // ---------------------------------------- BASE METHOD ----------------------------------------------

--- a/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
+++ b/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
@@ -1574,8 +1574,8 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
 
     it('check if a column exists with errors must to throw an exception', function () use ($dbConfigCentreon): void {
         $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
-        expect(fn() => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
-            ->and(fn() => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
+        expect(fn () => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
+            ->and(fn () => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
     });
 
     // ---------------------------------------- BASE METHOD ----------------------------------------------

--- a/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
+++ b/centreon/tests/php/Centreon/Infrastructure/DatabaseConnectionTest.php
@@ -1552,6 +1552,32 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     )->throws(ConnectionException::class);
 
+    // --------------------------------------- DDL TOOLS -----------------------------------------------
+
+    it('check if a column exists with success', function () use ($dbConfigCentreon): void {
+        $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
+        $exists = $db->columnExists(
+            tableName: 'contact',
+            columnName: 'contact_id'
+        );
+        expect($exists)->toBeTrue();
+    });
+
+    it('check if a non-existent column with success', function () use ($dbConfigCentreon): void {
+        $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
+        $exists = $db->columnExists(
+            tableName: 'contact',
+            columnName: 'dummy_column'
+        );
+        expect($exists)->toBeFalse();
+    });
+
+    it('check if a column exists with errors must to throw an exception', function () use ($dbConfigCentreon): void {
+        $db = DatabaseConnection::createFromConfig(connectionConfig: $dbConfigCentreon);
+        expect(fn() => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
+            ->and(fn() => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
+    });
+
     // ---------------------------------------- BASE METHOD ----------------------------------------------
 
     // -- closeQuery

--- a/centreon/tests/php/www/class/CentreonDBTest.php
+++ b/centreon/tests/php/www/class/CentreonDBTest.php
@@ -1678,8 +1678,8 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
 
     it('check if a column exists with errors must to throw an exception', function () use ($dbConfigCentreon): void {
         $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
-        expect(fn() => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
-            ->and(fn() => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
+        expect(fn () => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
+            ->and(fn () => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
     });
 
     // ---------------------------------------- BASE METHOD ----------------------------------------------

--- a/centreon/tests/php/www/class/CentreonDBTest.php
+++ b/centreon/tests/php/www/class/CentreonDBTest.php
@@ -1661,6 +1661,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     it('check if a column exists with success', function () use ($dbConfigCentreon): void {
         $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
         $exists = $db->columnExists(
+            dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
             tableName: 'contact',
             columnName: 'contact_id'
         );
@@ -1670,6 +1671,7 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
     it('check if a non-existent column with success', function () use ($dbConfigCentreon): void {
         $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
         $exists = $db->columnExists(
+            dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
             tableName: 'contact',
             columnName: 'dummy_column'
         );
@@ -1678,8 +1680,21 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
 
     it('check if a column exists with errors must to throw an exception', function () use ($dbConfigCentreon): void {
         $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
-        expect(fn () => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
-            ->and(fn () => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
+        expect(fn (): bool => $db->columnExists(
+            dbName: '',
+            tableName: 'contact',
+            columnName: 'contact_id'
+        ))->toThrow(ConnectionException::class)
+            ->and(fn (): bool => $db->columnExists(
+                dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
+                tableName: 'contact',
+                columnName: ''
+            ))->toThrow(ConnectionException::class)
+            ->and(fn (): bool => $db->columnExists(
+                dbName: $dbConfigCentreon->getDatabaseNameConfiguration(),
+                tableName: '',
+                columnName: 'contact_id'
+            ))->toThrow(ConnectionException::class);
     });
 
     // ---------------------------------------- BASE METHOD ----------------------------------------------

--- a/centreon/tests/php/www/class/CentreonDBTest.php
+++ b/centreon/tests/php/www/class/CentreonDBTest.php
@@ -1656,6 +1656,32 @@ if (! is_null($dbConfigCentreon) && hasConnectionDb($dbConfigCentreon)) {
         }
     )->throws(ConnectionException::class);
 
+    // --------------------------------------- DDL TOOLS -----------------------------------------------
+
+    it('check if a column exists with success', function () use ($dbConfigCentreon): void {
+        $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
+        $exists = $db->columnExists(
+            tableName: 'contact',
+            columnName: 'contact_id'
+        );
+        expect($exists)->toBeTrue();
+    });
+
+    it('check if a non-existent column with success', function () use ($dbConfigCentreon): void {
+        $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
+        $exists = $db->columnExists(
+            tableName: 'contact',
+            columnName: 'dummy_column'
+        );
+        expect($exists)->toBeFalse();
+    });
+
+    it('check if a column exists with errors must to throw an exception', function () use ($dbConfigCentreon): void {
+        $db = CentreonDB::connectToCentreonDb($dbConfigCentreon);
+        expect(fn() => $db->columnExists(tableName: '', columnName: 'contact_id'))->toThrow(ConnectionException::class)
+            ->and(fn() => $db->columnExists(tableName: 'contact', columnName: ''))->toThrow(ConnectionException::class);
+    });
+
     // ---------------------------------------- BASE METHOD ----------------------------------------------
 
     // -- closeQuery

--- a/centreon/www/class/centreonDB.class.php
+++ b/centreon/www/class/centreonDB.class.php
@@ -963,6 +963,8 @@ class CentreonDB extends PDO implements ConnectionInterface
      * @param string|null $column - the column name to be checked
      *
      * @return int
+     *
+     * @deprecated use {@see ConnectionInterface::columnExists()} instead
      */
     public function isColumnExist(?string $table = null, ?string $column = null): int
     {

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -43,8 +43,19 @@ $errorMessage = '';
  *      - Add is_agent_initiated bool
  *      - Remove is_reverse bool
  */
-$alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMessage): void {
+$alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = 'Unable to align agent configuration with new schema';
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: aligning agent configuration with new schema"
+    );
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: retrieving agent configurations from database..."
+    );
+
     $agentConfigurations = $pearDB->fetchAllAssociative(
         <<<'SQL'
             SELECT * FROM `agent_configuration`
@@ -52,8 +63,19 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
             SQL
     );
     if ($agentConfigurations === []) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: no agent configurations found, skipping"
+        );
+
         return;
     }
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: found " . count($agentConfigurations) . ' agent configurations, updating...'
+    );
+
     foreach ($agentConfigurations as $agentConfiguration) {
         $configuration = json_decode(
             json: $agentConfiguration['configuration'],
@@ -83,15 +105,45 @@ $alignCMAAgentConfigurationWithNewSchema = function () use ($pearDB, &$errorMess
             ])
         );
     }
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: agent configurations aligned successfully"
+    );
 };
 
-$cleanGlobalMacrosName = function () use ($pearDB, &$errorMessage): void {
-    $errorMessage = 'Failed to update cfg_resource table';
+$cleanGlobalMacrosName = function () use ($pearDB, &$errorMessage, $version): void {
+    $errorMessage = 'Failed to clean global macros name';
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: cleaning global macros name"
+    );
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: retrieving invalid macros from database..."
+    );
+
     $invalidMacros = $pearDB->fetchAllAssociative(
         <<<'SQL'
             SELECT resource_id, resource_name FROM cfg_resource
             WHERE resource_name NOT LIKE '\$%' OR resource_name NOT LIKE '%\$'
             SQL
+    );
+
+    if ($invalidMacros === []) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: no invalid macros found, skipping"
+        );
+
+        return;
+    }
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: found " . count($invalidMacros) . ' invalid macros, updating...'
     );
 
     foreach ($invalidMacros as $macro) {
@@ -114,77 +166,190 @@ $cleanGlobalMacrosName = function () use ($pearDB, &$errorMessage): void {
             ])
         );
     }
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: global macros name cleaned successfully"
+    );
 };
 
-$fixTypoInStandardMacroName = function () use ($pearDB, &$errorMessage): void {
+$fixTypoInStandardMacroName = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = 'Failed to fix typo in standard macro name';
-    $pearDB->update(
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: fixing typo in standard macro name..."
+    );
+
+    $nbUpdate = $pearDB->update(
         <<<'SQL'
                 UPDATE nagios_macro SET macro_name = '$TOTALHOSTSUNREACHABLEUNHANDLED$' WHERE macro_id = 65
             SQL
     );
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: {$nbUpdate} typo in standard macro name fixed successfully"
+    );
 };
 
 /** -------------------------------------- Broker configuration -------------------------------------- */
-$fixBrokerConfigTypo = function () use ($pearDB, &$errorMessage): void {
+$fixBrokerConfigTypo = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = 'Failed to fix typo in broker configuration';
-    $pearDB->executeStatement(
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: fixing typo in broker configuration..."
+    );
+
+    $nbUpdate = $pearDB->executeStatement(
         <<<'SQL'
             UPDATE cfg_centreonbroker_info SET config_key = 'negotiation' WHERE config_key = 'negociation'
             SQL
     );
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: {$nbUpdate} typo in broker configuration fixed successfully"
+    );
 };
 
 /** -------------------------------------- Engine Configuration updates -------------------------------------- */
-$addOpentelemetryLogLevelColumn = function () use ($pearDB, &$errorMessage): void {
+$addOpentelemetryLogLevelColumn = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = 'Failed to add log_level_otl column to cfg_nagios_logger table';
-    if (! $pearDB->isColumnExist('cfg_nagios_logger', 'log_level_otl')) {
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: adding log_level_otl column to cfg_nagios_logger table..."
+    );
+
+    if (! $pearDB->columnExists('cfg_nagios_logger', 'log_level_otl')) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: log_level_otl column does not exist, adding it..."
+        );
+
         $pearDB->executeStatement(
             <<<'SQL'
                 ALTER TABLE `cfg_nagios_logger`
                 ADD COLUMN `log_level_otl` enum('trace', 'debug', 'info', 'warning', 'err', 'critical', 'off') DEFAULT 'err'
                 SQL
         );
+
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: log_level_otl column added successfully"
+        );
     }
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: log_level_otl column already exists, skipping"
+    );
 };
 
 /** -------------------------------------------- BBDO cfg update -------------------------------------------- */
-$bbdoDefaultUpdate = function () use ($pearDB, &$errorMessage): void {
-    if ($pearDB->isColumnExist('cfg_centreonbroker', 'bbdo_version')) {
-        $errorMessage = "Unable to update 'bbdo_version' column to 'cfg_centreonbroker' table";
+$bbdoDefaultUpdate = function () use ($pearDB, &$errorMessage, $version): void {
+    $errorMessage = "Unable to update 'bbdo_version' column to 'cfg_centreonbroker' table";
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: updating 'bbdo_version' column to 'cfg_centreonbroker' table"
+    );
+
+    if ($pearDB->columnExists('cfg_centreonbroker', 'bbdo_version')) {
+
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: 'bbdo_version' column exists, modifying it..."
+        );
+
         $pearDB->executeStatement('ALTER TABLE `cfg_centreonbroker` MODIFY `bbdo_version` VARCHAR(50) DEFAULT "3.0.1"');
+
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: 'bbdo_version' column modified successfully"
+        );
+
+    } else {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: 'bbdo_version' column does not exist, skipping"
+        );
     }
 };
 
-$bbdoCfgUpdate = function () use ($pearDB, &$errorMessage): void {
+$bbdoCfgUpdate = function () use ($pearDB, &$errorMessage, $version): void {
     $errorMessage = "Unable to update 'bbdo_version' version in 'cfg_centreonbroker' table";
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: updating 'bbdo_version' version in 'cfg_centreonbroker' table"
+    );
+
     $pearDB->executeStatement('UPDATE `cfg_centreonbroker` SET `bbdo_version` = "3.0.1"');
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: 'bbdo_version' version updated successfully"
+    );
 };
 
-/** -------------------------------------------- Password encryption -------------------------------------------- */
+// -------------------------------------------- Password encryption --------------------------------------------
+
 $addIsEncryptionReadyAsBooleanColumn = function () use ($pearDB, $pearDBO, &$errorMessage, $version): void {
     $errorMessage = "Unable to update 'is_encryption_ready' column to boolean type";
+
+    CentreonLog::create()->info(
+        logTypeId: CentreonLog::TYPE_UPGRADE,
+        message: "UPGRADE - {$version}: updating 'is_encryption_ready' column to boolean type"
+    );
+
     if (
-        $pearDB->isColumnExist('nagios_server', 'is_encryption_ready')
-        && $pearDB->isColumnExist('nagios_server', 'is_encryption_ready_old') !== 1
+        $pearDB->columnExists('nagios_server', 'is_encryption_ready')
+        && ! $pearDB->columnExists('nagios_server', 'is_encryption_ready_old')
     ) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Renaming column 'is_encryption_ready' on 'nagios_server' table",
+            message: "UPGRADE - {$version}: [DB Configuration] Renaming column 'is_encryption_ready' on 'nagios_server' table",
         );
+
         $pearDB->executeStatement('ALTER TABLE `nagios_server` RENAME COLUMN `is_encryption_ready` TO `is_encryption_ready_old`');
-    }
-    if ($pearDB->isColumnExist('nagios_server', 'is_encryption_ready') !== 1) {
+
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Adding column 'is_encryption_ready' of type boolean on 'nagios_server' table",
+            message: "UPGRADE - {$version}: [DB Configuration] Column 'is_encryption_ready' renamed successfully on 'nagios_server' table",
         );
-        $pearDB->executeStatement('ALTER TABLE `nagios_server` ADD COLUMN `is_encryption_ready` BOOLEAN NOT NULL DEFAULT 1');
-    }
-    if ($pearDB->isColumnExist('nagios_server', 'is_encryption_ready_old')) {
+    } else {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Moving 'is_encryption_ready' value of existing pollers on 'nagios_server' table",
+            message: "UPGRADE - {$version}: [DB Configuration] Column 'is_encryption_ready' already renamed on 'nagios_server' table, skipping",
+        );
+    }
+
+    if (! $pearDB->columnExists('nagios_server', 'is_encryption_ready')) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Configuration] Adding column 'is_encryption_ready' of type boolean on 'nagios_server' table",
+        );
+
+        $pearDB->executeStatement('ALTER TABLE `nagios_server` ADD COLUMN `is_encryption_ready` BOOLEAN NOT NULL DEFAULT 1');
+
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Configuration] Column 'is_encryption_ready' added successfully on 'nagios_server' table",
+        );
+    } else {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Configuration] Column 'is_encryption_ready' already exists on 'nagios_server' table, skipping",
+        );
+    }
+
+    if ($pearDB->columnExists('nagios_server', 'is_encryption_ready_old')) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Configuration] Moving 'is_encryption_ready' value of existing pollers on 'nagios_server' table",
         );
 
         $pearDB->executeStatement(
@@ -197,33 +362,74 @@ $addIsEncryptionReadyAsBooleanColumn = function () use ($pearDB, $pearDBO, &$err
 
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Dropping column 'is_encryption_ready_old' on 'nagios_server' table",
+            message: "UPGRADE - {$version}: [DB Configuration] 'is_encryption_ready' values moved successfully on 'nagios_server' table",
         );
+
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Configuration] Dropping column 'is_encryption_ready_old' on 'nagios_server' table",
+        );
+
         $pearDB->executeStatement('ALTER TABLE `nagios_server` DROP COLUMN `is_encryption_ready_old`');
+
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Configuration] Column 'is_encryption_ready_old' dropped successfully on 'nagios_server' table",
+        );
+    } else {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Configuration] Column 'is_encryption_ready_old' does not exist on 'nagios_server' table, skipping",
+        );
     }
 
     if (
-        $pearDBO->isColumnExist('instances', 'is_encryption_ready')
-        && $pearDBO->isColumnExist('instances', 'is_encryption_ready_old') !== 1
+        $pearDBO->columnExists('instances', 'is_encryption_ready')
+        && ! $pearDBO->columnExists('instances', 'is_encryption_ready_old')
     ) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Moving 'is_encryption_ready' value of existing pollers on 'instances' table",
+            message: "UPGRADE - {$version}: [DB Realtime] Moving 'is_encryption_ready' value of existing pollers on 'instances' table",
         );
+
         $pearDBO->executeStatement('ALTER TABLE `instances` RENAME COLUMN `is_encryption_ready` TO `is_encryption_ready_old`');
-    }
-    if ($pearDBO->isColumnExist('instances', 'is_encryption_ready') !== 1) {
+
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Adding column 'is_encryption_ready' of type boolean on 'instances' table",
+            message: "UPGRADE - {$version}: [DB Realtime] Column 'is_encryption_ready' renamed successfully on 'instances' table",
         );
+    } else {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Realtime] Column 'is_encryption_ready' already renamed on 'instances' table, skipping",
+        );
+    }
+
+    if (! $pearDBO->columnExists('instances', 'is_encryption_ready')) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Realtime] Adding column 'is_encryption_ready' of type boolean on 'instances' table",
+        );
+
         $pearDBO->executeStatement('ALTER TABLE `instances` ADD COLUMN `is_encryption_ready` BOOLEAN NOT NULL DEFAULT 0');
-    }
-    if ($pearDBO->isColumnExist('instances', 'is_encryption_ready_old')) {
+
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Moving 'is_encryption_ready' value of existing pollers on 'instances' table",
+            message: "UPGRADE - {$version}: [DB Realtime] Column 'is_encryption_ready' added successfully on 'instances' table",
         );
+    } else {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Realtime] Column 'is_encryption_ready' already exists on 'instances' table, skipping",
+        );
+    }
+
+    if ($pearDBO->columnExists('instances', 'is_encryption_ready_old')) {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Realtime] Moving 'is_encryption_ready' value of existing pollers on 'instances' table",
+        );
+
         $pearDBO->executeStatement(
             <<<'SQL'
                 UPDATE instances ins
@@ -234,9 +440,25 @@ $addIsEncryptionReadyAsBooleanColumn = function () use ($pearDB, $pearDBO, &$err
 
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
-            message: "UPGRADE - {$version}: Dropping column 'is_encryption_ready_old' on 'instances' table",
+            message: "UPGRADE - {$version}: [DB Realtime] 'is_encryption_ready' values moved successfully on 'instances' table",
         );
+
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Realtime] Dropping column 'is_encryption_ready_old' on 'instances' table",
+        );
+
         $pearDBO->executeStatement('ALTER TABLE `instances` DROP COLUMN `is_encryption_ready_old`');
+
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Realtime] Column 'is_encryption_ready_old' dropped successfully on 'instances' table",
+        );
+    } else {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: [DB Realtime] Column 'is_encryption_ready_old' does not exist on 'instances' table, skipping",
+        );
     }
 };
 

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -223,7 +223,11 @@ $addOpentelemetryLogLevelColumn = function () use ($pearDB, &$errorMessage, $ver
         message: "UPGRADE - {$version}: adding log_level_otl column to cfg_nagios_logger table..."
     );
 
-    if (! $pearDB->columnExists('cfg_nagios_logger', 'log_level_otl')) {
+    if (! $pearDB->columnExists(
+        $pearDB->getConnectionConfig()->getDatabaseNameConfiguration(),
+        'cfg_nagios_logger',
+        'log_level_otl'
+    )) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
             message: "UPGRADE - {$version}: log_level_otl column does not exist, adding it..."
@@ -257,7 +261,11 @@ $bbdoDefaultUpdate = function () use ($pearDB, &$errorMessage, $version): void {
         message: "UPGRADE - {$version}: updating 'bbdo_version' column to 'cfg_centreonbroker' table"
     );
 
-    if ($pearDB->columnExists('cfg_centreonbroker', 'bbdo_version')) {
+    if ($pearDB->columnExists(
+        $pearDB->getConnectionConfig()->getDatabaseNameConfiguration(),
+        'cfg_centreonbroker',
+        'bbdo_version'
+    )) {
 
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
@@ -306,8 +314,16 @@ $addIsEncryptionReadyAsBooleanColumn = function () use ($pearDB, $pearDBO, &$err
     );
 
     if (
-        $pearDB->columnExists('nagios_server', 'is_encryption_ready')
-        && ! $pearDB->columnExists('nagios_server', 'is_encryption_ready_old')
+        $pearDB->columnExists(
+            $pearDB->getConnectionConfig()->getDatabaseNameConfiguration(),
+            'nagios_server',
+            'is_encryption_ready'
+        )
+        && ! $pearDB->columnExists(
+            $pearDB->getConnectionConfig()->getDatabaseNameConfiguration(),
+            'nagios_server',
+            'is_encryption_ready_old'
+        )
     ) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
@@ -327,7 +343,11 @@ $addIsEncryptionReadyAsBooleanColumn = function () use ($pearDB, $pearDBO, &$err
         );
     }
 
-    if (! $pearDB->columnExists('nagios_server', 'is_encryption_ready')) {
+    if (! $pearDB->columnExists(
+        $pearDB->getConnectionConfig()->getDatabaseNameConfiguration(),
+        'nagios_server',
+        'is_encryption_ready'
+    )) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
             message: "UPGRADE - {$version}: [DB Configuration] Adding column 'is_encryption_ready' of type boolean on 'nagios_server' table",
@@ -346,7 +366,11 @@ $addIsEncryptionReadyAsBooleanColumn = function () use ($pearDB, $pearDBO, &$err
         );
     }
 
-    if ($pearDB->columnExists('nagios_server', 'is_encryption_ready_old')) {
+    if ($pearDB->columnExists(
+        $pearDB->getConnectionConfig()->getDatabaseNameConfiguration(),
+        'nagios_server',
+        'is_encryption_ready_old'
+    )) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
             message: "UPGRADE - {$version}: [DB Configuration] Moving 'is_encryption_ready' value of existing pollers on 'nagios_server' table",
@@ -384,8 +408,16 @@ $addIsEncryptionReadyAsBooleanColumn = function () use ($pearDB, $pearDBO, &$err
     }
 
     if (
-        $pearDBO->columnExists('instances', 'is_encryption_ready')
-        && ! $pearDBO->columnExists('instances', 'is_encryption_ready_old')
+        $pearDBO->columnExists(
+            $pearDBO->getConnectionConfig()->getDatabaseNameRealTime(),
+            'instances',
+            'is_encryption_ready'
+        )
+        && ! $pearDBO->columnExists(
+            $pearDBO->getConnectionConfig()->getDatabaseNameRealTime(),
+            'instances',
+            'is_encryption_ready_old'
+        )
     ) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
@@ -405,7 +437,11 @@ $addIsEncryptionReadyAsBooleanColumn = function () use ($pearDB, $pearDBO, &$err
         );
     }
 
-    if (! $pearDBO->columnExists('instances', 'is_encryption_ready')) {
+    if (! $pearDBO->columnExists(
+        $pearDBO->getConnectionConfig()->getDatabaseNameRealTime(),
+        'instances',
+        'is_encryption_ready'
+    )) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
             message: "UPGRADE - {$version}: [DB Realtime] Adding column 'is_encryption_ready' of type boolean on 'instances' table",
@@ -424,7 +460,11 @@ $addIsEncryptionReadyAsBooleanColumn = function () use ($pearDB, $pearDBO, &$err
         );
     }
 
-    if ($pearDBO->columnExists('instances', 'is_encryption_ready_old')) {
+    if ($pearDBO->columnExists(
+        $pearDBO->getConnectionConfig()->getDatabaseNameRealTime(),
+        'instances',
+        'is_encryption_ready_old'
+    )) {
         CentreonLog::create()->info(
             logTypeId: CentreonLog::TYPE_UPGRADE,
             message: "UPGRADE - {$version}: [DB Realtime] Moving 'is_encryption_ready' value of existing pollers on 'instances' table",

--- a/centreon/www/install/php/Update-next.php
+++ b/centreon/www/install/php/Update-next.php
@@ -240,12 +240,12 @@ $addOpentelemetryLogLevelColumn = function () use ($pearDB, &$errorMessage, $ver
             logTypeId: CentreonLog::TYPE_UPGRADE,
             message: "UPGRADE - {$version}: log_level_otl column added successfully"
         );
+    } else {
+        CentreonLog::create()->info(
+            logTypeId: CentreonLog::TYPE_UPGRADE,
+            message: "UPGRADE - {$version}: log_level_otl column already exists, skipping"
+        );
     }
-
-    CentreonLog::create()->info(
-        logTypeId: CentreonLog::TYPE_UPGRADE,
-        message: "UPGRADE - {$version}: log_level_otl column already exists, skipping"
-    );
 };
 
 /** -------------------------------------------- BBDO cfg update -------------------------------------------- */


### PR DESCRIPTION
## Description

### Changed

* add columnExists method in connection interface
* replace isColumnExist by columnExists
* unit tests added to check columnExists

### Fixed

* logging in the next php upgrade script fixed

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] develop

<h2> How this pull request can be tested ? </h2>

By CI tests.
You can test this new method running unit tests on a container.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
