### PR TITLE
fix(hosts): fix acl_group value in case of form error

### DIFF
--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -144,6 +144,7 @@ $attributes = [
         'availableDatasetRoute' => $datasetRoutes['acl_groups'],
         'defaultDatasetRoute' => $datasetRoutes['default_acl_groups'],
         'multiple' => true,
+        'linkedObject' => 'centreonAclGroup',
     ],
 ];
 


### PR DESCRIPTION
## Description

In case of a host form error for a user under acl, the value of acl groups is list and replaced by a 0, this PR intends to cerrect that.

[MON-190494](https://github.com/centreon/centreon/pull/new/MON-190494)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master


[MON-190494]: https://centreon.atlassian.net/browse/MON-190494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ