### PR TITLE
enh(symfony): add assets install new command for APIP doc

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -402,7 +402,7 @@ jobs:
 
       - name: Ensure Symfony cache directories exist and are writable (legacy and new)
         run: |
-          echo "Ensure Symfony cache directories exist" && set -e
+          echo "Ensure Symfony cache directories exist"
           sudo mkdir -p /var/cache/centreon/symfony.new
           sudo mkdir -p /var/cache/centreon/symfony
           echo "Set permissions on Symfony cache directories with user: '$USER'" && set -e

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -405,8 +405,7 @@ jobs:
           echo "Ensure Symfony cache directories exist"
           sudo mkdir -p /var/cache/centreon/symfony{,.new}
           echo "Set permissions on Symfony cache directories with user: '$USER'"
-          sudo chown -R $USER:$USER /var/cache/centreon/symfony.new
-          sudo chown -R $USER:$USER /var/cache/centreon/symfony
+          sudo chown -R $USER:$USER /var/cache/centreon/symfony{,.new}
 
       - name: Install dependencies
         uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3.1.1

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -403,8 +403,7 @@ jobs:
       - name: Ensure Symfony cache directories exist and are writable (legacy and new)
         run: |
           echo "Ensure Symfony cache directories exist"
-          sudo mkdir -p /var/cache/centreon/symfony.new
-          sudo mkdir -p /var/cache/centreon/symfony
+          sudo mkdir -p /var/cache/centreon/symfony{,.new}
           echo "Set permissions on Symfony cache directories with user: '$USER'"
           sudo chown -R $USER:$USER /var/cache/centreon/symfony.new
           sudo chown -R $USER:$USER /var/cache/centreon/symfony

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -400,6 +400,15 @@ jobs:
         run: cp config/centreon.config.php.template config/centreon.config.php
         working-directory: centreon
 
+      - name: Ensure Symfony cache directories exist and are writable (legacy and new)
+        run: |
+          echo "Ensure Symfony cache directories exist" && set -e
+          sudo mkdir -p /var/cache/centreon/symfony.new
+          sudo mkdir -p /var/cache/centreon/symfony
+          echo "Set permissions on Symfony cache directories with user: '$USER'" && set -e
+          sudo chown -R $USER:$USER /var/cache/centreon/symfony.new
+          sudo chown -R $USER:$USER /var/cache/centreon/symfony
+
       - name: Install dependencies
         uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # v3.1.1
         with:

--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -405,7 +405,7 @@ jobs:
           echo "Ensure Symfony cache directories exist"
           sudo mkdir -p /var/cache/centreon/symfony.new
           sudo mkdir -p /var/cache/centreon/symfony
-          echo "Set permissions on Symfony cache directories with user: '$USER'" && set -e
+          echo "Set permissions on Symfony cache directories with user: '$USER'"
           sudo chown -R $USER:$USER /var/cache/centreon/symfony.new
           sudo chown -R $USER:$USER /var/cache/centreon/symfony
 

--- a/centreon/composer.json
+++ b/centreon/composer.json
@@ -162,11 +162,15 @@
       "assets:install %PUBLIC_DIR%": "symfony-cmd"
     },
     "post-install-cmd": [
-      "@auto-scripts"
+      "@auto-scripts",
+      "@symfony:assets:install:new"
     ],
     "post-update-cmd": [
-      "@auto-scripts"
+      "@auto-scripts",
+      "@symfony:assets:install:new"
     ],
+    "symfony:assets:install": "bin/console assets:install www",
+    "symfony:assets:install:new": "bin/console.new assets:install www",
     "symfony:update": "composer update symfony/* --with-all-dependencies --no-scripts",
     "symfony:update:test": "composer update symfony/* --with-all-dependencies --no-scripts --dry-run",
     "require:check": "../php-tools/vendor/bin/composer-require-checker check composer.json",


### PR DESCRIPTION
## Description

Jira ticket : [MON-190560](https://centreon.atlassian.net/browse/MON-190560)

### Changed

* add a new command to install assets for APIP when we install or update by composer by autoscripts of symfony/flex

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] develop

[MON-190560]: https://centreon.atlassian.net/browse/MON-190560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ