### PR TITLE
fix(packaging): fix packaging dependencies to require web 24.10.13 (#…

### DIFF
--- a/centreon-open-tickets/packaging/centreon-open-tickets.yaml
+++ b/centreon-open-tickets/packaging/centreon-open-tickets.yaml
@@ -45,7 +45,7 @@ scripts:
 overrides:
   rpm:
     depends:
-      - centreon-web >= ${MAJOR_VERSION}
+      - centreon-web >= 24.10.13
       - centreon-web < ${NEXT_MAJOR_VERSION}
     conflicts:
       - centreon-open-tickets-module
@@ -58,7 +58,7 @@ overrides:
       - centreon-open-tickets-widget
   deb:
     depends:
-      - "centreon-web (>= ${MAJOR_VERSION}~)"
+      - "centreon-web (>= 24.10.13~)"
       - "centreon-web (<< ${NEXT_MAJOR_VERSION}~)"
 
 rpm:


### PR DESCRIPTION
…8713)

## Description

* to make sure any module here has the code from web 24.10.13, adding the exact dependency to web-24.10.13

Fixes #MON-191090
Backports https://github.com/centreon/centreon/pull/8713

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
