### PR TITLE
fix(macro): handle case of NULL macro order in database

### DIFF
--- a/centreon/src/Core/Macro/Infrastructure/Repository/DbReadHostMacroRepository.php
+++ b/centreon/src/Core/Macro/Infrastructure/Repository/DbReadHostMacroRepository.php
@@ -169,7 +169,7 @@ class DbReadHostMacroRepository extends DatabaseRepository implements ReadHostMa
      *    host_macro_value:string,
      *    is_password:int|null,
      *    description:string|null,
-     *    macro_order:int,
+     *    macro_order:int|null,
      *    is_encryption_ready?:int
      * } $data
      *
@@ -192,7 +192,7 @@ class DbReadHostMacroRepository extends DatabaseRepository implements ReadHostMa
             && (bool) $data['is_encryption_ready'];
         $macro->setIsPassword((bool) $data['is_password']);
         $macro->setDescription($data['description'] ?? '');
-        $macro->setOrder($data['macro_order']);
+        $macro->setOrder($data['macro_order'] ?? 0);
         $macro->setShouldBeEncrypted($shouldBeEncrypted);
 
         return $macro;


### PR DESCRIPTION
🔗 https://centreon.atlassian.net/browse/MON-191168
This PR intends to handle properly (re-apply old patch) NULL values for macro order in the database