### PR TITLE
fix: anchor points and highlights in tooltip for stacked line chart

### DIFF
--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/StackedAnchorPoint.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/AnchorPoint/StackedAnchorPoint.tsx
@@ -46,7 +46,7 @@ export const getYAnchorPoint = ({
     return null;
   }
 
-  return yScale(timeValue[1] as number);
+  return yScale(timeValue[0] as number);
 };
 
 const StackedAnchorPoint = ({

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/index.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/index.tsx
@@ -12,6 +12,7 @@ import {
   keys,
   map,
   negate,
+  omit,
   pick,
   pipe,
   pluck,
@@ -54,6 +55,7 @@ import {
   eventMouseUpAtom,
   graphTooltipDataAtom
 } from './interactionWithGraphAtoms';
+import { number } from 'yup';
 
 const useStyles = makeStyles()(() => ({
   overlay: {
@@ -211,6 +213,38 @@ const InteractionWithGraph = ({
           unit: (lineData as Line).unit,
           yScalesPerUnit
         });
+
+        if (!isNil(lineData?.stackOrder)) {
+          const test = Object.entries(omit(['timeTick'], timeValue)).reduce(
+            (acc, [key, value]) => {
+              const line = getLineForMetric({
+                lines,
+                metric_id: Number(key)
+              });
+
+              if (
+                !isNil(line?.stackOrder) &&
+                (line?.stackOrder as number) >= (lineData.stackOrder as number)
+              ) {
+                return acc + value[1];
+              }
+
+              return acc;
+            },
+            0
+          );
+
+          const y0 = yScale(test);
+
+          const diffBetweenY0AndPointPosition = Math.abs(
+            y0 - margin.top - (graphHeight - pointPosition[1])
+          );
+
+          return {
+            ...acc,
+            [metricId]: diffBetweenY0AndPointPosition
+          };
+        }
 
         const y0 = yScale(value);
 

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/index.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/index.tsx
@@ -9,6 +9,7 @@ import {
   find,
   isEmpty,
   isNil,
+  isNotNil,
   keys,
   map,
   negate,
@@ -213,7 +214,7 @@ const InteractionWithGraph = ({
           yScalesPerUnit
         });
 
-        if (!isNil(lineData?.stackOrder)) {
+        if (isNotNil(lineData?.stackOrder)) {
           const test = Object.entries(omit(['timeTick'], timeValue)).reduce(
             (acc, [key, value]) => {
               const line = getLineForMetric({
@@ -221,10 +222,11 @@ const InteractionWithGraph = ({
                 metric_id: Number(key)
               });
 
-              if (
-                !isNil(line?.stackOrder) &&
-                (line?.stackOrder as number) >= (lineData.stackOrder as number)
-              ) {
+              const isBelowStackOrder =
+                isNotNil(line?.stackOrder) &&
+                (line?.stackOrder as number) >= (lineData.stackOrder as number);
+
+              if (isBelowStackOrder) {
                 return acc + value;
               }
 

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/index.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/index.tsx
@@ -225,7 +225,7 @@ const InteractionWithGraph = ({
                 !isNil(line?.stackOrder) &&
                 (line?.stackOrder as number) >= (lineData.stackOrder as number)
               ) {
-                return acc + value[1];
+                return acc + value;
               }
 
               return acc;

--- a/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/index.tsx
+++ b/centreon/packages/ui/src/Graph/Chart/InteractiveComponents/index.tsx
@@ -55,7 +55,6 @@ import {
   eventMouseUpAtom,
   graphTooltipDataAtom
 } from './interactionWithGraphAtoms';
-import { number } from 'yup';
 
 const useStyles = makeStyles()(() => ({
   overlay: {

--- a/centreon/packages/ui/src/TimePeriods/CustomTimePeriod/PopoverCustomTimePeriod/PickersStartEndDate.tsx
+++ b/centreon/packages/ui/src/TimePeriods/CustomTimePeriod/PopoverCustomTimePeriod/PickersStartEndDate.tsx
@@ -107,14 +107,16 @@ const PickersStartEndDate = ({
   const maxEnd = rangeEndDate?.max;
   const minEnd = rangeEndDate?.min || startDate;
 
-  const isColumn = equals(direction, PickersStartEndDateDirection.column)
+  const isColumn = equals(direction, PickersStartEndDateDirection.column);
 
   return (
     <LocalizationProvider
       adapterLocale={locale.substring(0, 2)}
       dateAdapter={AdapterDayjs}
     >
-      <div className={`flex ${isColumn ? 'flex-col justify-center' : 'flex-row items-center py-2 px-4'} gap-2 ${className}`}>
+      <div
+        className={`flex ${isColumn ? 'flex-col justify-center' : 'flex-row items-center py-2 px-4'} gap-2 ${className}`}
+      >
         <PickerDateWithLabel
           changeDate={changeDate}
           date={startDate}


### PR DESCRIPTION
## Description

This fix anchor point and highlights in tooltip that does not display correctly in stacked line chart

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
