### PR TITLE
enh(ac) tokens mandatory in NO-TLS mode

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Application/Factory/AgentConfigurationFactory.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Factory/AgentConfigurationFactory.php
@@ -55,7 +55,7 @@ class AgentConfigurationFactory
             connectionMode: $connectionMode,
             configuration: match ($type) {
                 Type::TELEGRAF => new TelegrafConfigurationParameters($parameters),
-                Type::CMA => new CmaConfigurationParameters($parameters, $connectionMode),
+                Type::CMA => new CmaConfigurationParameters($parameters),
             }
         );
     }
@@ -85,7 +85,7 @@ class AgentConfigurationFactory
             connectionMode: $connectionMode,
             configuration: match ($type) {
                 Type::TELEGRAF => new TelegrafConfigurationParameters($parameters),
-                Type::CMA => new CmaConfigurationParameters($parameters, $connectionMode),
+                Type::CMA => new CmaConfigurationParameters($parameters),
             }
         );
     }

--- a/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
@@ -96,10 +96,10 @@ class CmaValidator implements TypeValidatorInterface
                 $configuration['otel_private_key'],
                 false
             );
+        }
 
-            if ($configuration['tokens'] === []) {
-                throw AgentConfigurationException::tokensAreMandatory();
-            }
+        if ($configuration['tokens'] === []) {
+            throw AgentConfigurationException::tokensAreMandatory();
         }
         $this->validateTokens($configuration['tokens']);
     }
@@ -121,13 +121,10 @@ class CmaValidator implements TypeValidatorInterface
                 throw AgentConfigurationException::invalidHostId($host['id']);
             }
 
-            if ($connectionMode !== ConnectionModeEnum::NO_TLS && $host['token'] === null) {
+            if ($host['token'] === null) {
                 throw AgentConfigurationException::tokensAreMandatory();
             }
-
-            if ($host['token'] !== null) {
-                $this->validateTokens([$host['token']]);
-            }
+            $this->validateTokens([$host['token']]);
         }
     }
 

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -60,11 +60,10 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
 
     /**
      * @param array<string,mixed> $parameters
-     * @param ConnectionModeEnum $connectionMode
      *
      * @throws AssertionFailedException
      */
-    public function __construct(array $parameters, ConnectionModeEnum $connectionMode)
+    public function __construct(array $parameters)
     {
         /** @var _CmaParameters $parameters */
         $parameters = $this->normalizeCertificatePaths($parameters);
@@ -87,11 +86,9 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
                 $parameters['otel_ca_certificate'],
                 'configuration.otel_ca_certificate'
             );
-            if ($connectionMode !== ConnectionModeEnum::NO_TLS) {
-                Assertion::notEmpty($parameters['tokens'], 'configuration.tokens');
-                foreach ($parameters['tokens'] as $token) {
-                    Assertion::notEmptyString($token['name']);
-                }
+            Assertion::notEmpty($parameters['tokens'], 'configuration.tokens');
+            foreach ($parameters['tokens'] as $token) {
+                Assertion::notEmptyString($token['name']);
             }
         }
 
@@ -111,11 +108,9 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
                     'configuration.hosts[].poller_ca_name'
                 );
 
-                if ($connectionMode !== ConnectionModeEnum::NO_TLS) {
-                    Assertion::notNull($host['token'], 'configuration.hosts[].token');
-                    Assertion::notEmptyString($host['token']['name'] ?? '');
-                    Assertion::positiveInt($host['token']['creator_id'] ?? 0);
-                }
+                Assertion::notNull($host['token'], 'configuration.hosts[].token');
+                Assertion::notEmptyString($host['token']['name'] ?? '');
+                Assertion::positiveInt($host['token']['creator_id'] ?? 0);
             }
         }
 

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -26,7 +26,6 @@ namespace Core\AgentConfiguration\Domain\Model\ConfigurationParameters;
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParametersInterface;
-use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 
 /**
  * @phpstan-type _CmaParameters array{

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbReadAgentConfigurationRepository.php
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/Repository/DbReadAgentConfigurationRepository.php
@@ -417,7 +417,7 @@ class DbReadAgentConfigurationRepository extends AbstractRepositoryRDB implement
             connectionMode: $connectionMode,
             configuration: match ($type->value) {
                 Type::TELEGRAF->value => new TelegrafConfigurationParameters($configuration),
-                Type::CMA->value => new CmaConfigurationParameters($configuration, $connectionMode),
+                Type::CMA->value => new CmaConfigurationParameters($configuration),
             }
         );
     }

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
@@ -65,7 +65,7 @@ foreach (
         "should throw an exception when the hosts[].{$field} is not valid",
         function () use ($field): void {
             $this->parameters['hosts'][0][$field] = 9999999999;
-            new CmaConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
+            new CmaConfigurationParameters($this->parameters);
         }
     )->throws(
         AssertionException::range(
@@ -90,7 +90,7 @@ foreach (
         function () use ($field, $tooLong): void {
             $this->parameters[$field] = $tooLong;
 
-            new CmaConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
+            new CmaConfigurationParameters($this->parameters);
         }
     )->throws(
         AssertionException::maxLength(
@@ -115,7 +115,7 @@ foreach (
         function () use ($field): void {
             $field === 'poller_ca_certificate' ? $this->parameters['hosts'][0][$field] = 'test.crt' : $this->parameters[$field] = 'test.crt';
 
-            $cmaConfig = new CmaConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
+            $cmaConfig = new CmaConfigurationParameters($this->parameters);
             $result = $cmaConfig->getData();
             $field === 'poller_ca_certificate'
                 ? $this->assertEquals($result['hosts'][0][$field], CmaConfigurationParameters::CERTIFICATE_BASE_PATH . 'test.crt')
@@ -137,7 +137,7 @@ foreach (
         function () use ($field): void {
             $field === 'poller_ca_certificate' ? $this->parameters['hosts'][0][$field] = '/etc/pki/test.crt' : $this->parameters[$field] = '/etc/pki/test.crt';
 
-            $cmaConfig = new CmaConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
+            $cmaConfig = new CmaConfigurationParameters($this->parameters);
             $result = $cmaConfig->getData();
             $field === 'poller_ca_certificate'
                 ? $this->assertEquals($result['hosts'][0][$field], CmaConfigurationParameters::CERTIFICATE_BASE_PATH . 'test.crt')
@@ -148,7 +148,7 @@ foreach (
 
 it('should empty the related properties when agent_initiated is false', function (): void {
     $this->parameters['agent_initiated'] = false;
-    $cmaConfig = new CmaConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
+    $cmaConfig = new CmaConfigurationParameters($this->parameters);
     $result = $cmaConfig->getData();
     $this->assertEquals($result['otel_public_certificate'], null);
     $this->assertEquals($result['otel_private_key'], null);
@@ -158,7 +158,7 @@ it('should empty the related properties when agent_initiated is false', function
 
 it('should empty the related properties when poller_initiated is false', function (): void {
     $this->parameters['poller_initiated'] = false;
-    $cmaConfig = new CmaConfigurationParameters($this->parameters, ConnectionModeEnum::SECURE);
+    $cmaConfig = new CmaConfigurationParameters($this->parameters);
     $result = $cmaConfig->getData();
     $this->assertEquals($result['hosts'], []);
 });

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
@@ -25,7 +25,6 @@ namespace Core\AdditionalConnectorConfiguration\Application\Validation;
 
 use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
-use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 
 beforeEach(function (): void {
     $this->parameters = [


### PR DESCRIPTION
## Description

Update AddAgentConfiguration and UpdateAgentConfiguration endpoints to have tokens mandatory even when connection type  is "NO-TLS"

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master
