### PR TITLE
fix(open-tickets) Custom views - fix the subquery filtering on host categories

### DIFF
--- a/centreon-open-tickets/widgets/open-tickets/src/index.php
+++ b/centreon-open-tickets/widgets/open-tickets/src/index.php
@@ -380,7 +380,7 @@ if (! empty($preferences['hostcategories'])) {
         $queryHC .= ':id_' . $resultHC;
         $mainQueryParameters[] = [
             'parameter' => ':id_' . $resultHC,
-            'value' => (int) $resultsHC,
+            'value' => (int) $resultHC,
             'type' => PDO::PARAM_INT,
         ];
     }


### PR DESCRIPTION
## Description

The hostcategory subquery contained an issue and it always filtered on host category with ID 1 (if a filter was used).

**Fixes** # MON-191150

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
