### PR TITLE
fix(hosts): avoid circular references between parents / children relations (#8660)

### DIFF
--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -24578,3 +24578,7 @@ msgstr "alerte"
 #: unknown
 msgid "will display resources with host name starting by'"
 msgstr "affichera les ressources avec un nom d'hôte commençant par"
+
+#: unknown
+msgid "Circular reference detected with host children : %s"
+msgstr "Référence circulaire détectée avec les hôtes enfants : %s"

--- a/centreon/tests/rest_api/collections/monitoring/Resources_By_Parent_Monitoring.postman_collection.json
+++ b/centreon/tests/rest_api/collections/monitoring/Resources_By_Parent_Monitoring.postman_collection.json
@@ -3142,7 +3142,7 @@
 							"raw": ""
 						},
 						"url": {
-							"raw": "{{baseUrl}}/monitoring/resources/hosts?hostgroup_names=[\"{{HostGroup1Name}}\"]",
+							"raw": "{{baseUrl}}/monitoring/resources/hosts?types=[\"host\"]",
 							"host": [
 								"{{baseUrl}}"
 							],
@@ -3153,8 +3153,8 @@
 							],
 							"query": [
 								{
-									"key": "hostgroup_names",
-									"value": "[\"{{HostGroup1Name}}\"]"
+									"key": "types",
+									"value": "[\"host\"]"
 								}
 							]
 						}

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3254,3 +3254,107 @@ function getPayloadForHost(bool $isCloudPlatform, array $formData): array
 
     return $payload;
 }
+
+/**
+ * Validates that there are no circular references between host parents and children.
+ *
+ * Checks if any host is both a parent and a child, or if adding the specified parent-child
+ * relationships would create a circular reference in the host hierarchy.
+ *
+ * @param array<string, mixed> $fields associative array with 'host_parents' and 'host_childs' as arrays of host IDs
+ *
+ * @return array|true returns an array on the form [form_field => error_message] if a circular reference is detected,
+ *                    or true if validation passes
+ */
+function validateParentChildAreNotCircular(array $fields): array|true
+{
+    global $pearDB;
+
+    $parents = $fields['host_parents'] ?? [];
+    $children = $fields['host_childs'] ?? [];
+    $common = array_intersect($parents, $children);
+
+    if ($common) {
+        $hostIds = [];
+        foreach ($common as $hostId) {
+            $hostIds[':host' . $hostId] = $hostId;
+        }
+        $hostIdsAsString = implode(',', array_keys($hostIds));
+        $statement = $pearDB->prepare("SELECT host_name FROM host WHERE host_id IN ({$hostIdsAsString})");
+        foreach ($hostIds as $param => $id) {
+            $statement->bindValue($param, $id, PDO::PARAM_INT);
+        }
+
+        $statement->execute();
+        $hostNames = $statement->fetchAll(PDO::FETCH_COLUMN);
+
+        return [
+            'host_parents' => 'Circular reference detected with host children: ' . implode(', ', $hostNames),
+        ];
+    }
+
+    $circular = [];
+    foreach ($parents as $parentId) {
+        foreach ($children as $childId) {
+            if (($foundId = hasCircularReference($parentId, $childId)) !== null) {
+                $circular[] = $foundId;
+            }
+        }
+    }
+
+    if ($circular) {
+        $hostIds = [];
+        foreach (array_unique($circular) as $hostId) {
+            $hostIds[':host' . $hostId] = $hostId;
+        }
+        $hostIdsAsString = implode(',', array_keys($hostIds));
+        $statement = $pearDB->prepare(
+            "SELECT host_name FROM host WHERE host_id IN ({$hostIdsAsString})"
+        );
+        foreach ($hostIds as $param => $id) {
+            $statement->bindValue($param, $id, PDO::PARAM_INT);
+        }
+        $statement->execute();
+        $hostNames = $statement->fetchAll(PDO::FETCH_COLUMN);
+
+        return [
+            'host_parents' => 'Circular reference detected with host children: ' . implode(', ', $hostNames),
+        ];
+    }
+
+    return true;
+}
+
+/**
+ * Checks if adding a parent-child relationship would create a circular reference.
+ *
+ * Traverses the parent hierarchy to determine if the child is already an ancestor of the parent.
+ *
+ * @param int $parentId the ID of the proposed parent host
+ * @param int $childId the ID of the proposed child host
+ * @return int|null returns the ID of the host causing the circular reference, or null if none is found
+ */
+function hasCircularReference($parentId, $childId): ?int
+{
+    global $pearDB;
+
+    $toCheck = [$parentId];
+    $checked = [];
+    while ($toCheck) {
+        $current = array_pop($toCheck);
+        if ($current == $childId) {
+            return $current;
+        }
+        $checked[] = $current;
+        $stmt = $pearDB->prepare('SELECT host_parent_hp_id FROM host_hostparent_relation WHERE host_host_id = :hostId');
+        $stmt->bindValue(':hostId', $current, PDO::PARAM_INT);
+        $stmt->execute();
+        foreach ($stmt->fetchAll(PDO::FETCH_COLUMN) as $parent) {
+            if (! in_array($parent, $checked)) {
+                $toCheck[] = $parent;
+            }
+        }
+    }
+
+    return null;
+}

--- a/centreon/www/include/configuration/configObject/host/formHost.php
+++ b/centreon/www/include/configuration/configObject/host/formHost.php
@@ -1082,6 +1082,10 @@ if ($o === HOST_WATCH) {
     $res = $form->addElement('reset', 'reset', _('Reset'), ['class' => 'btc bt_default']);
 }
 
+if ($o === HOST_ADD || $o === HOST_MODIFY || $o === HOST_MASSIVE_CHANGE) {
+    $form->addFormRule('validateParentChildAreNotCircular');
+}
+
 if (! $isCloudPlatform) {
     $tpl->assign(
         'msg',


### PR DESCRIPTION
## Description

backport of #8660

**Fixes** # MON-191586

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [ ] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
