### PR TITLE
enh(Agent Configuration): Add Port to CMA Agent Initiated Configuration

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Exception/AgentConfigurationException.php
@@ -172,4 +172,9 @@ class AgentConfigurationException extends \Exception
     {
         return new self('At least one connection mode (agent initiated or poller initiated) must be set to true', self::CODE_CONFLICT);
     }
+
+    public static function portIsMandatoryForAgentInitiated(): self
+    {
+        return new self('Port is mandatory when connection mode is set to agent initiated', self::CODE_CONFLICT);
+    }
 }

--- a/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
@@ -79,6 +79,9 @@ class CmaValidator implements TypeValidatorInterface
         if ($configuration['agent_initiated'] === false) {
             return;
         }
+        if ($configuration['port'] === null) {
+            throw AgentConfigurationException::portIsMandatoryForAgentInitiated();
+        }
 
         if ($connectionMode !== ConnectionModeEnum::NO_TLS) {
             $this->validateFilename(

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -35,6 +35,7 @@ use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
  *		otel_private_key: ?string,
  *		otel_ca_certificate: ?string,
  *      tokens: array<array{name:string,creator_id:int}>,
+ *      port: ?int,
  *      poller_initiated: bool,
  *		hosts: array<array{
  *			id: int,

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -25,6 +25,7 @@ namespace Core\AgentConfiguration\Domain\Model\ConfigurationParameters;
 
 use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
+use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParametersInterface;
 use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 
@@ -93,6 +94,9 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
                 foreach ($parameters['tokens'] as $token) {
                     Assertion::notEmptyString($token['name']);
                 }
+            }
+            if (! isset($parameters['port'])) {
+                $parameters['port'] = AgentConfiguration::DEFAULT_PORT;
             }
         }
 

--- a/centreon/src/Core/AgentConfiguration/Infrastructure/API/Schema/CmaConfigurationSchema.json
+++ b/centreon/src/Core/AgentConfiguration/Infrastructure/API/Schema/CmaConfigurationSchema.json
@@ -16,6 +16,7 @@
                 "otel_public_certificate",
                 "otel_ca_certificate",
                 "otel_private_key",
+                "port",
                 "hosts",
                 "tokens"
             ],
@@ -42,6 +43,12 @@
                     "type": [
                         "null",
                         "string"
+                    ]
+                },
+                "port": {
+                    "type": [
+                        "null",
+                        "integer"
                     ]
                 },
                 "tokens": {

--- a/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
@@ -60,6 +60,7 @@ beforeEach(function (): void {
         'otel_public_certificate' => '/etc/pki/test.crt',
         'otel_private_key' => '/etc/pki/test.key',
         'otel_ca_certificate' => '/etc/pki/test.cer',
+        'port' => 4444,
         'tokens' => [
             [
                 'name' => $this->token->getName(),
@@ -187,6 +188,13 @@ it('should throw an exception when a token is provided but invalid and connectio
         ->expects($this->once())
         ->method('findByNameAndUserId')
         ->willReturn(null);
+    $this->expectException(AgentConfigurationException::class);
+    $this->cmaValidator->validateParametersOrFail($this->request);
+});
+
+it('should throw an exception when port is not provided (agent_initiated)', function (): void {
+    $this->request->configuration['agent_initiated'] = true;
+    $this->request->configuration['port'] = null;
     $this->expectException(AgentConfigurationException::class);
     $this->cmaValidator->validateParametersOrFail($this->request);
 });

--- a/centreon/tests/rest_api/collections/configuration/Agent_Configuration.postman_collection.json
+++ b/centreon/tests/rest_api/collections/configuration/Agent_Configuration.postman_collection.json
@@ -1,10 +1,9 @@
 {
 	"info": {
-		"_postman_id": "f40c9c17-d91f-4a0b-a88a-03217badd3ee",
+		"_postman_id": "21fb393d-fafa-4b7a-a984-786684b50508",
 		"name": "Agent_Configuration",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "16182525",
-		"_collection_link": "https://centreon-api-testing.postman.co/workspace/develop-OSS~7c78046c-a719-4dae-bbf9-70e6e2c5b9bd/collection/16182525-9536ebf6-3b65-4b2e-9647-82afa65dda83?action=share&source=collection_link&creator=16182525"
+		"_exporter_id": "29556865"
 	},
 	"item": [
 		{
@@ -1089,7 +1088,8 @@
 									""
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						},
 						{
@@ -1114,6 +1114,7 @@
 									"            \"otel_public_certificate\": \"/etc/pki/my-otel-certificate-name-ac2.crt\",\r",
 									"            \"otel_ca_certificate\": null,\r",
 									"            \"otel_private_key\": \"/etc/pki/my-otel-private-key-name-ac2.key\",\r",
+									"            \"port\": 4317,\r",
 									"            \"tokens\": [{\"name\": pm.collectionVariables.get(\"Token-1-name\"), \"creator_id\": pm.collectionVariables.get(\"Token-1-creator-id\")}],\r",
 									"            \"hosts\": [\r",
 									"                {\r",
@@ -1198,7 +1199,8 @@
 									"});"
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -1213,7 +1215,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC2Name}}\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [{\"name\": \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\": \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC2Name}}\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [{\"name\": \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }],\r\n        \"port\": 4317,\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\": \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -2011,7 +2018,8 @@
 									""
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -2026,7 +2034,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": null\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"bad-ac\",\r\n    \"poller_ids\": [ {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [],\r\n        \"port\": 4317,\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": null\r\n        }]\r\n    }\r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -2052,7 +2065,8 @@
 									""
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						},
 						{
@@ -2077,6 +2091,7 @@
 									"            \"otel_ca_certificate\": null,\r",
 									"            \"otel_private_key\": \"/etc/pki/my-otél_private-key-name-ac2.key\",\r",
 									"            \"tokens\": [{\"name\": pm.collectionVariables.get(\"Token-1-name\"), \"creator_id\": pm.collectionVariables.get(\"Token-1-creator-id\")}],\r",
+									"            \"port\": 4317,\r",
 									"            \"hosts\": [\r",
 									"                {\r",
 									"                    \"address\": \"127.0.0.1\",\r",
@@ -2132,6 +2147,7 @@
 									"                            \"creator_id\": { \"type\": \"string\" }\r",
 									"                        }\r",
 									"                    },\r",
+									"                    \"port\": { \"type\": \"integer\" },\r",
 									"                    \"hosts\": {\r",
 									"                        \"type\": \"array\",\r",
 									"                        \"items\": {\r",
@@ -2170,7 +2186,8 @@
 									"});"
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -2185,7 +2202,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC3Name}}\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otél-certificate-name-ac2!.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otél_private-key-name-ac2.key\",\r\n        \"tokens\": [{\"name\": \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"ca-filé.crt\",\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\":  \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }\r\n        },\r\n        {\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\":  \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC3Name}}\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otél-certificate-name-ac2!.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otél_private-key-name-ac2.key\",\r\n        \"tokens\": [{\"name\": \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }],\r\n        \"port\": 4317,\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"ca-filé.crt\",\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\":  \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }\r\n        },\r\n        {\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\":  \"{{Token-1-name}}\", \"creator_id\": {{Token-1-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -4171,7 +4193,8 @@
 									""
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						},
 						{
@@ -4195,6 +4218,7 @@
 									"            \"otel_public_certificate\": \"/etc/pki/my-otel-certificate-name-ac4.crt\",\r",
 									"            \"otel_ca_certificate\": \"/etc/pki/hello.crt\",\r",
 									"            \"otel_private_key\": \"/etc/pki/my-otel-private-key-name-ac4.key\",\r",
+									"            \"port\": 443,\r",
 									"            \"tokens\": [{\"name\": pm.collectionVariables.get(\"Token-2-name\"), \"creator_id\": pm.collectionVariables.get(\"Token-2-creator-id\")}],\r",
 									"            \"hosts\": [{\r",
 									"                \"address\": \"localhost\",\r",
@@ -4243,6 +4267,7 @@
 									"                            \"creator_id\": { \"type\": \"string\" }\r",
 									"                        }\r",
 									"                    },\r",
+									"                    \"port\": { \"type\": \"integer\" },\r",
 									"                    \"hosts\": {\r",
 									"                        \"type\": \"array\",\r",
 									"                        \"items\": {\r",
@@ -4282,7 +4307,8 @@
 									"});"
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -4297,7 +4323,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4.crt\",\r\n        \"otel_ca_certificate\": \"hello.crt\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4.key\",\r\n        \"tokens\": [{\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }],\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"hi.crt\",\r\n            \"poller_ca_name\": \"halo\",\r\n            \"token\": {\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4.crt\",\r\n        \"otel_ca_certificate\": \"hello.crt\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4.key\",\r\n        \"port\": 443,\r\n        \"tokens\": [{\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }],\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"hi.crt\",\r\n            \"poller_ca_name\": \"halo\",\r\n            \"token\": {\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations",
@@ -4674,7 +4705,8 @@
 									""
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						},
 						{
@@ -4686,7 +4718,8 @@
 									"});"
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -4701,7 +4734,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4.crt\",\r\n        \"otel_ca_certificate\": \"hello.crt\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4.key\",\r\n        \"tokens\": [{\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }],\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"hi.crt\",\r\n            \"poller_ca_name\": \"halo\",\r\n            \"token\": {\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"{{AC4Name}}\",\r\n    \"poller_ids\": [ {{Central_Id}}, {{poller1_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac4.crt\",\r\n        \"otel_ca_certificate\": \"hello.crt\",\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac4.key\",\r\n        \"tokens\": [{\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }],\r\n        \"port\": 443,\r\n        \"hosts\": [{\r\n            \"address\": \"localhost\",\r\n            \"port\": 443,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": \"hi.crt\",\r\n            \"poller_ca_name\": \"halo\",\r\n            \"token\": {\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations/{{AC4Id}}",
@@ -4784,7 +4822,8 @@
 									""
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						},
 						{
@@ -4878,7 +4917,8 @@
 									""
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -5613,7 +5653,8 @@
 									""
 								],
 								"type": "text/javascript",
-								"packages": {}
+								"packages": {},
+								"requests": {}
 							}
 						}
 					],
@@ -5628,7 +5669,12 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"name\": \"nop\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"tokens\": [{\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n"
+							"raw": "{\r\n    \"name\": \"nop\",\r\n    \"poller_ids\": [ {{poller2_Id}} ],\r\n    \"type\": \"centreon-agent\",\r\n    \"connection_mode\": \"secure\",\r\n    \"configuration\": {\r\n        \"agent_initiated\": true,\r\n        \"poller_initiated\": true,\r\n        \"otel_public_certificate\": \"my-otel-certificate-name-ac2.crt\",\r\n        \"otel_ca_certificate\": null,\r\n        \"otel_private_key\": \"my-otel-private-key-name-ac2.key\",\r\n        \"port\": 4317,\r\n        \"tokens\": [{\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }],\r\n        \"hosts\": [{\r\n            \"address\": \"127.0.0.1\",\r\n            \"port\": 4317,\r\n            \"id\": {{Host1Id}},\r\n            \"poller_ca_certificate\": null,\r\n            \"poller_ca_name\": null,\r\n            \"token\": {\"name\":  \"{{Token-2-name}}\", \"creator_id\": {{Token-2-creator-id}} }\r\n        }]\r\n    }\r\n}\r\n",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
 						},
 						"url": {
 							"raw": "{{baseUrl}}/configuration/agent-configurations/{{AC4Id}}",
@@ -6409,6 +6455,22 @@
 		},
 		{
 			"key": "AC4Id",
+			"value": ""
+		},
+		{
+			"key": "Host1Name",
+			"value": ""
+		},
+		{
+			"key": "Host1Id",
+			"value": ""
+		},
+		{
+			"key": "Token-2-name",
+			"value": ""
+		},
+		{
+			"key": "Token-2-creator-id",
 			"value": ""
 		}
 	]

--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration as ModelAgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
-use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\TelegrafConfigurationParameters;
 use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 use Core\AgentConfiguration\Domain\Model\Type;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;
@@ -88,7 +87,6 @@ class AgentConfiguration extends AbstractObjectJSON
      */
     private function formatOtelConfiguration(array $data, array $tokens, ConnectionModeEnum $connectionMode): array
     {
-        error_log(json_encode($data));
         return [
             'host' => ModelAgentConfiguration::DEFAULT_HOST,
             'port' => $data['port'] ?? ModelAgentConfiguration::DEFAULT_PORT,

--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -88,6 +88,7 @@ class AgentConfiguration extends AbstractObjectJSON
      */
     private function formatOtelConfiguration(array $data, array $tokens, ConnectionModeEnum $connectionMode): array
     {
+        error_log(json_encode($data));
         return [
             'host' => ModelAgentConfiguration::DEFAULT_HOST,
             'port' => $data['port'] ?? ModelAgentConfiguration::DEFAULT_PORT,

--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 use Core\AgentConfiguration\Application\Repository\ReadAgentConfigurationRepositoryInterface;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration as ModelAgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\CmaConfigurationParameters;
+use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\TelegrafConfigurationParameters;
 use Core\AgentConfiguration\Domain\Model\ConnectionModeEnum;
 use Core\AgentConfiguration\Domain\Model\Type;
 use Core\Host\Application\Repository\ReadHostRepositoryInterface;

--- a/centreon/www/class/config-generate/AgentConfiguration.php
+++ b/centreon/www/class/config-generate/AgentConfiguration.php
@@ -90,7 +90,7 @@ class AgentConfiguration extends AbstractObjectJSON
     {
         return [
             'host' => ModelAgentConfiguration::DEFAULT_HOST,
-            'port' => ModelAgentConfiguration::DEFAULT_PORT,
+            'port' => $data['port'] ?? ModelAgentConfiguration::DEFAULT_PORT,
             'encryption' => match ($connectionMode) {
                 ConnectionModeEnum::SECURE => 'full',
                 ConnectionModeEnum::INSECURE => 'insecure',


### PR DESCRIPTION
## Description

This PR intends to add `port` property when adding / updating a CMA Agent Initiated Configuration. To ensure backward compatibility a default value of 4317 will still be export.

**Fixes** # MON-191597

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
