### PR TITLE
enh(ldap): use ldap_escape instead of str replace

### DIFF
--- a/centreon/www/class/centreonLDAP.class.php
+++ b/centreon/www/class/centreonLDAP.class.php
@@ -309,9 +309,7 @@ class CentreonLDAP
      */
     public function replaceFilter($name): string
     {
-        $name = str_replace('(', '\\(', $name);
-
-        return str_replace(')', '\\)', $name);
+        return ldap_escape(value: $name, flags: LDAP_ESCAPE_FILTER);
     }
 
     /**
@@ -400,7 +398,8 @@ class CentreonLDAP
             return [];
         }
         $this->setErrorHandler();
-        $filter = preg_replace('/%s/', $pattern, $this->groupSearchInfo['filter']);
+        $escapedPattern = ldap_escape($pattern, '*', LDAP_ESCAPE_FILTER);
+        $filter = preg_replace('/%s/', $escapedPattern, $this->groupSearchInfo['filter']);
         $result = @ldap_search($this->ds, $this->groupSearchInfo['base_search'], $filter);
         if ($result === false) {
             restore_error_handler();
@@ -505,9 +504,8 @@ class CentreonLDAP
 
             return [];
         }
-        $userdn = str_replace('\\', '\\\\', $userdn);
         $filter = '(&' . preg_replace('/%s/', '*', $this->groupSearchInfo['filter'])
-            . '(' . $this->groupSearchInfo['member'] . '=' . $this->replaceFilter($userdn) . '))';
+            . '(' . $this->groupSearchInfo['member'] . '=' . ldap_escape($userdn, '', LDAP_ESCAPE_FILTER) . '))';
         $result = @ldap_search($this->ds, $this->groupSearchInfo['base_search'], $filter);
         if ($result === false) {
             restore_error_handler();

--- a/centreon/www/class/centreonLDAP.class.php
+++ b/centreon/www/class/centreonLDAP.class.php
@@ -302,17 +302,6 @@ class CentreonLDAP
     }
 
     /**
-     * Transform user, group name for filter
-     *
-     * @param string $name the atrribute
-     * @return string The string changed
-     */
-    public function replaceFilter($name): string
-    {
-        return ldap_escape(value: $name, flags: LDAP_ESCAPE_FILTER);
-    }
-
-    /**
      * Escape special characters in LDAP filter value for username and group
      * @see https://datatracker.ietf.org/doc/html/rfc4515#section-3
      *
@@ -348,7 +337,8 @@ class CentreonLDAP
             return false;
         }
         $this->setErrorHandler();
-        $filter = $this->replaceFilter($username);
+        $filter = preg_replace('/%s/', $this->escapeLdapFilterSpecialChars($username), $this->userSearchInfo['filter']);
+        error_log($filter);
         $result = ldap_search($this->ds, $this->userSearchInfo['base_search'], $filter);
         // no results were returned using this base_search
         if ($result === false) {
@@ -375,7 +365,7 @@ class CentreonLDAP
             return false;
         }
         $this->setErrorHandler();
-        $filter = $this->replaceFilter($group);
+        $filter = ldap_escape($group);
         $result = ldap_search($this->ds, $this->groupSearchInfo['base_search'], $filter);
         $entries = ldap_get_entries($this->ds, $result);
         restore_error_handler();
@@ -544,7 +534,7 @@ class CentreonLDAP
              * we have specific parameter for user to denote groups he belongs to
              */
             $filter = '(&' . preg_replace('/%s/', '*', $this->userSearchInfo['filter'])
-                . '(' . $this->userSearchInfo['group'] . '=' . $this->replaceFilter($groupdn) . '))';
+                . '(' . $this->userSearchInfo['group'] . '=' . ldap_escape($groupdn) . '))';
             $result = @ldap_search($this->ds, $this->userSearchInfo['base_search'], $filter);
 
             if ($result === false) {

--- a/centreon/www/class/centreonLDAP.class.php
+++ b/centreon/www/class/centreonLDAP.class.php
@@ -348,7 +348,7 @@ class CentreonLDAP
             return false;
         }
         $this->setErrorHandler();
-        $filter = preg_replace('/%s/', $this->escapeLdapFilterSpecialChars($username), $this->userSearchInfo['filter']);
+        $filter = $this->replaceFilter($username);
         $result = ldap_search($this->ds, $this->userSearchInfo['base_search'], $filter);
         // no results were returned using this base_search
         if ($result === false) {
@@ -375,7 +375,7 @@ class CentreonLDAP
             return false;
         }
         $this->setErrorHandler();
-        $filter = preg_replace('/%s/', $this->escapeLdapFilterSpecialChars($group), $this->groupSearchInfo['filter']);
+        $filter = $this->replaceFilter($group);
         $result = ldap_search($this->ds, $this->groupSearchInfo['base_search'], $filter);
         $entries = ldap_get_entries($this->ds, $result);
         restore_error_handler();
@@ -434,7 +434,8 @@ class CentreonLDAP
             return [];
         }
         $this->setErrorHandler();
-        $filter = preg_replace('/%s/', $pattern, $this->userSearchInfo['filter']);
+        $escapedPattern = ldap_escape($pattern, '*', LDAP_ESCAPE_FILTER);
+        $filter = preg_replace('/%s/', $escapedPattern, $this->userSearchInfo['filter']);
         $result = ldap_search($this->ds, $this->userSearchInfo['base_search'], $filter);
         $entries = ldap_get_entries($this->ds, $result);
         $nbEntries = $entries['count'];
@@ -537,7 +538,6 @@ class CentreonLDAP
 
             return [];
         }
-        $groupdn = str_replace('\\', '\\\\', $groupdn);
         $list = [];
         if (! empty($this->userSearchInfo['group'])) {
             /**

--- a/centreon/www/class/centreonLDAP.class.php
+++ b/centreon/www/class/centreonLDAP.class.php
@@ -338,7 +338,6 @@ class CentreonLDAP
         }
         $this->setErrorHandler();
         $filter = preg_replace('/%s/', $this->escapeLdapFilterSpecialChars($username), $this->userSearchInfo['filter']);
-        error_log($filter);
         $result = ldap_search($this->ds, $this->userSearchInfo['base_search'], $filter);
         // no results were returned using this base_search
         if ($result === false) {


### PR DESCRIPTION
## Description

This PR intends to replace str_replace for ldap_escape that is more convenient and  modern.

**Fixes** # MON-37981

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
