### PR TITLE
enh(graphs): handle correctly graphs when too many metrics on service

### DIFF
--- a/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/de_DE.UTF-8/LC_MESSAGES/messages.po
@@ -4793,8 +4793,12 @@ msgid "Display Autologin shortcut"
 msgstr "Autologin-Shortcut einblenden"
 
 #: centreon/www/install/smarty_translate.php
-msgid "Display Chart"
-msgstr "Diagramm anzeigen"
+msgid "Display anyway"
+msgstr ""
+
+#: centreon/www/include/views/graphs/javascript/centreon-graph.js
+msgid "Too many metrics (X). More than 20 may cause performance issues."
+msgstr ""
 
 #: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "Display Finished Downtimes"

--- a/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/es_ES.UTF-8/LC_MESSAGES/messages.po
@@ -5054,8 +5054,12 @@ msgid "Display Autologin shortcut"
 msgstr "Mostrar el atajo de conexión automática"
 
 #: centreon/www/install/smarty_translate.php
-msgid "Display Chart"
-msgstr "Ver gráfico"
+msgid "Display anyway"
+msgstr ""
+
+#: centreon/www/include/views/graphs/javascript/centreon-graph.js
+msgid "Too many metrics (X). More than 20 may cause performance issues."
+msgstr ""
 
 #: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "Display Finished Downtimes"

--- a/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/fr_FR.UTF-8/LC_MESSAGES/messages.po
@@ -4868,8 +4868,8 @@ msgid "Display Autologin shortcut"
 msgstr "Afficher le raccourci de connexion automatique"
 
 #: centreon/www/install/smarty_translate.php
-msgid "Display Chart"
-msgstr "Afficher le graphique"
+msgid "Display anyway"
+msgstr "Afficher quand même"
 
 #: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "Display Finished Downtimes"
@@ -17422,6 +17422,10 @@ msgstr "Les jetons sont obligatoires"
 #: centreon/www/install/front_translate.php
 msgid "Too many elements to be displayed (>{{graphsCapNumber}})"
 msgstr ""
+
+#: centreon/www/include/views/graphs/javascript/centreon-graph.js
+msgid "Too many metrics (X). More than 20 may cause performance issues."
+msgstr "Trop de métriques (X). Plus de 20 peuvent provoquer des problèmes de performance."
 
 #: centreon/www/include/monitoring/objectDetails/serviceDetails.php
 msgid "Tools"

--- a/centreon/lang/messages.pot
+++ b/centreon/lang/messages.pot
@@ -5076,6 +5076,10 @@ msgstr ""
 msgid "Display Chart"
 msgstr ""
 
+#: centreon/www/include/views/graphs/javascript/centreon-graph.js
+msgid "Too many metrics (X). More than 20 may cause performance issues."
+msgstr ""
+
 #: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "Display Finished Downtimes"
 msgstr ""

--- a/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_BR.UTF-8/LC_MESSAGES/messages.po
@@ -5037,8 +5037,12 @@ msgid "Display Autologin shortcut"
 msgstr "Mostrar atalho para Auto-Login"
 
 #: centreon/www/install/smarty_translate.php
-msgid "Display Chart"
-msgstr "Mostrar Gráficos"
+msgid "Display anyway"
+msgstr ""
+
+#: centreon/www/include/views/graphs/javascript/centreon-graph.js
+msgid "Too many metrics (X). More than 20 may cause performance issues."
+msgstr ""
 
 #: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "Display Finished Downtimes"

--- a/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
+++ b/centreon/lang/pt_PT.UTF-8/LC_MESSAGES/messages.po
@@ -5026,8 +5026,12 @@ msgid "Display Autologin shortcut"
 msgstr "Mostrar atalho para Auto-Login"
 
 #: centreon/www/install/smarty_translate.php
-msgid "Display Chart"
-msgstr "Mostrar Gráficos"
+msgid "Display anyway"
+msgstr ""
+
+#: centreon/www/include/views/graphs/javascript/centreon-graph.js
+msgid "Too many metrics (X). More than 20 may cause performance issues."
+msgstr ""
 
 #: centreon/www/include/monitoring/downtime/listDowntime.php
 msgid "Display Finished Downtimes"

--- a/centreon/tests/e2e/features/Services-configuration/14-limit-metric-in-chart/index.ts
+++ b/centreon/tests/e2e/features/Services-configuration/14-limit-metric-in-chart/index.ts
@@ -96,11 +96,11 @@ Then('a message says that the chart will not be displayed is visible', () => {
   cy.waitForElementInIframe('#main-content', 'a:contains("Split chart ")');
   // Check that the message is displayed inside the graph
   cy.getIframeBody()
-    .contains('text', "Too many metrics, the chart can't be displayed")
+    .contains('text', 'More than 20 may cause performance issues.')
     .should('be.visible');
 });
 
 Then('a button is available to display the chart', () => {
   // Check that the button is displayed inside the graph
-  cy.getIframeBody().contains('button', 'Display Chart').should('be.visible');
+  cy.getIframeBody().contains('button', 'Display anyway').should('be.visible');
 });

--- a/centreon/www/include/views/graphs/graphs.html
+++ b/centreon/www/include/views/graphs/graphs.html
@@ -90,6 +90,7 @@
 var defaultCharts = {$defaultCharts};
 var nbDisplayedCharts = {$nbDisplayedCharts};
 var tooManyChartMsg = "{t}You cannot add more charts. The maximum charts is {/t}" + nbDisplayedCharts;
+var tooManyMetricsMessage = "{$metricExceededWarningMessage|escape:'javascript'}";
 
 {literal}
 
@@ -135,7 +136,7 @@ const templateGraph = ({ graphId, graphType, graphTitle, hostId, serviceId }) =>
                     data-graph-type="${graphType}"
                     class="btc bt_info performance_button"
                 >
-                    Display Chart
+                    {/literal}{t}Display anyway{/t}{literal}
                 </button>
                 <div class="action left">
                     <button class="bt_action">&lt;&lt;</button>
@@ -223,6 +224,9 @@ function addChart(id, name, times, hostId, serviceId) {
     if (autoRefresh) {
         times.refresh = 300;
     }
+
+    times.tooManyMetricsMessage = tooManyMetricsMessage;
+
     /* Add zoom */
     times.zoom = {
         enabled: true,
@@ -260,6 +264,7 @@ function addChart(id, name, times, hostId, serviceId) {
             serviceId: serviceId,
         })
     );
+
     jQuery('#graph-' + id).centreonGraph(times);
     jQuery('#graph-status-' + id).centreonGraph(times);
 }

--- a/centreon/www/include/views/graphs/graphs.php
+++ b/centreon/www/include/views/graphs/graphs.php
@@ -248,6 +248,10 @@ $tpl->assign('nbDisplayedCharts', $graphsPerPage);
 $tpl->assign('from', _('From'));
 $tpl->assign('to', _('to'));
 $tpl->assign('displayStatus', _('Display Status'));
+$tpl->assign(
+    'metricExceededWarningMessage',
+    _('Too many metrics (X). More than 20 may cause performance issues.'),
+);
 $tpl->assign('Apply', _('Apply'));
 $tpl->assign('defaultCharts', json_encode($defaultGraphs));
 $tpl->assign('admin', $centreon->user->admin);

--- a/centreon/www/include/views/graphs/javascript/centreon-graph.js
+++ b/centreon/www/include/views/graphs/javascript/centreon-graph.js
@@ -182,7 +182,7 @@
         };
       }
 
-      if (data.metrics.length > 15) {
+      if (data.metrics.length > 20) {
           datasToAppend = {
             x: parsedData.data.x,
             columns: [],
@@ -191,8 +191,9 @@
             colors: {},
             regions: {},
             order: null,
-            empty: { label: { text: "Too many metrics, the chart can't be displayed" } }
+            empty: { label: { text: this.settings.tooManyMetricsMessage.replace("(X)", "(" + data.metrics.length + ")") } }
           }
+          this.legendDiv.hide();
       } else {
           datasToAppend = parsedData.data;
       }
@@ -232,16 +233,18 @@
         }
       });
 
-      if (data.metrics.length > 15) {
+      if (data.metrics.length > 20) {
           jQuery("#display-graph-" + self.id).css('display', 'block');
           jQuery("#display-graph-" + self.id).on('click', function (e){
               self.chart.load(parsedData.data)
               self.chart.regions(self.buildRegions(data));
+              self.buildLegend(data.metrics);
+              self.legendDiv.show();
               jQuery(this).css('display', 'none');
           });
+      } else {
+         this.buildLegend(data.metrics);
       }
-
-      this.buildLegend(data.metrics);
     },
     /**
      * Load data from rest api in ajax


### PR DESCRIPTION
🔗 https://centreon.atlassian.net/browse/MON-188969
ℹ️ This PR intends to correctly manage the case of a service that has a lot of metrics (>20) in the performance graph page.
If the service has more than 20 metrics (15 before patch) then a clear message indicates why the graph and legend are not displayed and a button "Display anyway" gives the user the possibility to display the graph if he wants to (with the consequences)


https://github.com/user-attachments/assets/ddf3ae44-b9e2-4dc3-a27e-31d47ff15be2

