### PR TITLE
enh(API): Add Sort for listing commands

### DIFF
--- a/centreon/src/App/ActivityLogging/Domain/Event/LogActivityEventHandler.php
+++ b/centreon/src/App/ActivityLogging/Domain/Event/LogActivityEventHandler.php
@@ -29,6 +29,7 @@ use App\ActivityLogging\Domain\Aggregate\ActorId;
 use App\ActivityLogging\Domain\Factory\ActivityLogFactoryInterface;
 use App\ActivityLogging\Domain\Repository\ActivityLogRepository;
 use App\Shared\Domain\Aggregate\AggregateRoot;
+use App\Shared\Domain\Aggregate\AggregateRootId;
 use App\Shared\Domain\Event\AggregateCreated;
 use App\Shared\Domain\Event\AggregateUpdated;
 use App\Shared\Domain\Event\AsEventHandler;
@@ -51,7 +52,7 @@ final readonly class LogActivityEventHandler
             throw new \LogicException(\sprintf('There is no "%s" for "%s", did you add a service with "activity_logging.activity_log_factory" tag?', ActivityLogFactoryInterface::class, $event->aggregate::class));
         }
 
-        /** @var ActivityLogFactoryInterface<AggregateRoot> $factory */
+        /** @var ActivityLogFactoryInterface<AggregateRoot<AggregateRootId>> $factory */
         $factory = $this->activityLogFactories->get($event->aggregate::class);
 
         $action = match (true) {

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Command/Command.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Command/Command.php
@@ -29,6 +29,9 @@ use App\Shared\Domain\Aggregate\AggregateRoot;
 
 final class Command extends AggregateRoot
 {
+    /**
+     * @param Connector|(\Closure(): ?Connector)|null $connector
+     */
     public function __construct(
         ?CommandId $id,
         public CommandName $name,
@@ -37,7 +40,7 @@ final class Command extends AggregateRoot
         public bool $isShellEnabled,
         public bool $isActivated,
         public bool $isFromMonitoringConnector,
-        public ?Connector $connector,
+        private Connector|\Closure|null $connector,
         public ?CommandComment $comment,
     ) {
         parent::__construct($id);
@@ -83,7 +86,19 @@ final class Command extends AggregateRoot
         $this->isActivated = false;
     }
 
-    public function addConnector(Connector $connector): void
+    public function connector(): ?Connector
+    {
+        if ($this->connector instanceof \Closure) {
+            $this->connector = ($this->connector)();
+        }
+
+        return $this->connector;
+    }
+
+    /**
+     * @param (\Closure(): ?Connector)|Connector $connector
+     */
+    public function addConnector(\Closure|Connector $connector): void
     {
         $this->connector = $connector;
     }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Command/Command.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Command/Command.php
@@ -27,6 +27,9 @@ use App\MonitoringConfiguration\Domain\Aggregate\Connector\Connector;
 use App\MonitoringConfiguration\Domain\Security\CommandPermissionEnum;
 use App\Shared\Domain\Aggregate\AggregateRoot;
 
+/**
+ * @extends AggregateRoot<CommandId>
+ */
 final class Command extends AggregateRoot
 {
     /**

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Connector/Connector.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Connector/Connector.php
@@ -25,6 +25,9 @@ namespace App\MonitoringConfiguration\Domain\Aggregate\Connector;
 
 use App\Shared\Domain\Aggregate\AggregateRoot;
 
+/**
+ * @extends AggregateRoot<ConnectorId>
+ */
 final class Connector extends AggregateRoot
 {
     public function __construct(

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/GlobalMacro/GlobalMacro.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/GlobalMacro/GlobalMacro.php
@@ -27,6 +27,9 @@ use App\MonitoringConfiguration\Domain\Aggregate\Poller\Poller;
 use App\Shared\Domain\Aggregate\AggregateRoot;
 use App\Shared\Domain\Collection;
 
+/**
+ * @extends AggregateRoot<GlobalMacroId>
+ */
 final class GlobalMacro extends AggregateRoot
 {
     /**

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Option/Option.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Option/Option.php
@@ -23,15 +23,13 @@ declare(strict_types=1);
 
 namespace App\MonitoringConfiguration\Domain\Aggregate\Option;
 
-use App\Shared\Domain\Aggregate\AggregateRoot;
-
-final class Option extends AggregateRoot
+final readonly class Option
 {
     public const PLUGIN_PATH_OPTION_NAME = 'nagios_path_plugins';
 
     public function __construct(
-        public readonly OptionName $name,
-        public readonly OptionValue $value,
+        public OptionName $name,
+        public OptionValue $value,
     ) {
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Plugin/Plugin.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Plugin/Plugin.php
@@ -23,12 +23,10 @@ declare(strict_types=1);
 
 namespace App\MonitoringConfiguration\Domain\Aggregate\Plugin;
 
-use App\Shared\Domain\Aggregate\AggregateRoot;
-
-final class Plugin extends AggregateRoot
+final readonly class Plugin
 {
     public function __construct(
-        public readonly PluginName $name,
+        public PluginName $name,
     ) {
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/Poller.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/Poller/Poller.php
@@ -27,6 +27,9 @@ use App\MonitoringConfiguration\Domain\Aggregate\GlobalMacro\GlobalMacro;
 use App\Shared\Domain\Aggregate\AggregateRoot;
 use App\Shared\Domain\Collection;
 
+/**
+ * @extends AggregateRoot<PollerId>
+ */
 final class Poller extends AggregateRoot
 {
     /**

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/ServiceCategory/ServiceCategory.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/ServiceCategory/ServiceCategory.php
@@ -25,6 +25,9 @@ namespace App\MonitoringConfiguration\Domain\Aggregate\ServiceCategory;
 
 use App\Shared\Domain\Aggregate\AggregateRoot;
 
+/**
+ * @extends AggregateRoot<ServiceCategoryId>
+ */
 final class ServiceCategory extends AggregateRoot
 {
     public function __construct(

--- a/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/StandardMacro/StandardMacro.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Aggregate/StandardMacro/StandardMacro.php
@@ -25,6 +25,9 @@ namespace App\MonitoringConfiguration\Domain\Aggregate\StandardMacro;
 
 use App\Shared\Domain\Aggregate\AggregateRoot;
 
+/**
+ * @extends AggregateRoot<StandardMacroId>
+ */
 final class StandardMacro extends AggregateRoot
 {
     public function __construct(

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/CommandRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/CommandRepository.php
@@ -48,9 +48,9 @@ interface CommandRepository
     public function findAll(?CommandCriteria $criteria): \IteratorAggregate&\Countable;
 
     /**
-     * @param list<CommandId> $commandId
+     * @param array<CommandId> $commandIds
      *
-     * @return array<int, CommandResourceCount
+     * @return array<int, CommandResourceCount>
      */
     public function countLinkedResources(array $commandIds): array;
 }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/CommandRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/CommandRepository.php
@@ -47,5 +47,10 @@ interface CommandRepository
      */
     public function findAll(?CommandCriteria $criteria): \IteratorAggregate&\Countable;
 
-    public function countLinkedResources(CommandId $commandId): CommandResourceCount;
+    /**
+     * @param list<CommandId> $commandId
+     *
+     * @return array<int, CommandResourceCount
+     */
+    public function countLinkedResources(array $commandIds): array;
 }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/CommandCriteria.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/CommandCriteria.php
@@ -31,7 +31,6 @@ use Webmozart\Assert\Assert;
 final class CommandCriteria implements SortableCriteria
 {
     use SortableCriteriaTrait;
-
     public const OPERATOR_EQUAL = 'eq';
     public const OPERATOR_LIKE = 'lk';
     public const ALLOWED_OPERATORS = [self::OPERATOR_EQUAL, self::OPERATOR_LIKE];
@@ -136,6 +135,7 @@ final class CommandCriteria implements SortableCriteria
     {
         return [
             'name' => 'command_name',
+            'type' => 'command_type',
         ];
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/CommandCriteria.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/CommandCriteria.php
@@ -24,10 +24,14 @@ declare(strict_types=1);
 namespace App\MonitoringConfiguration\Domain\Repository\Criteria;
 
 use App\MonitoringConfiguration\Domain\Aggregate\Command\CommandTypeEnum;
+use App\Shared\Domain\Repository\SortableCriteria;
+use App\Shared\Domain\Repository\SortableCriteriaTrait;
 use Webmozart\Assert\Assert;
 
-final class CommandCriteria
+final class CommandCriteria implements SortableCriteria
 {
+    use SortableCriteriaTrait;
+
     public const OPERATOR_EQUAL = 'eq';
     public const OPERATOR_LIKE = 'lk';
     public const ALLOWED_OPERATORS = [self::OPERATOR_EQUAL, self::OPERATOR_LIKE];
@@ -126,5 +130,12 @@ final class CommandCriteria
     public function getStatus(): ?bool
     {
         return $this->status;
+    }
+
+    public function getFieldMapping(): array
+    {
+        return [
+            'name' => 'command_name',
+        ];
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
@@ -77,7 +77,7 @@ final readonly class ListCommandsProvider implements ProviderInterface
                 $allowedTypes[] = $commandType->name;
             }
         }
-        /** @var array{type?: string|array<string>, name?: array<string>|null, is_activated?: string}|null $filters */
+        /** @var array{type?: string|array<string>, name?: array<string>|null, is_activated?: string} $filters */
         $filters = $context['filters'] ?? [];
 
         // Filter allowed types by requested types
@@ -101,17 +101,22 @@ final readonly class ListCommandsProvider implements ProviderInterface
         $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
         $criteria = $this->handleStatusFilter($filters['is_activated'] ?? null, $criteria);
         $criteria = $this->handleSort($filters, $criteria);
+
         $commands = $this->commandRepository->findAll($criteria);
         $commandResources = [];
-        $counts = $this->commandRepository->countLinkedResources(array_map(
-            fn (Command $command) => $command->id(),
-            is_array($commands) ? $commands : iterator_to_array($commands)
-        ));
+        if (count($commands) > 0) {
+            $counts = $this->commandRepository->countLinkedResources(array_map(
+                fn (Command $command): CommandId => $command->id(),
+                iterator_to_array($commands)
+            ));
+        }
         foreach ($commands as $command) {
             /** @var CommandId $id */
             $id = $command->id();
             $commandResource = $this->transformer->transform($command);
-            $commandResource->hydrateLinkedResourceCount($counts[$id->value]);
+            if ($counts !== []) {
+                $commandResource->hydrateLinkedResourceCount($counts[$id->value]);
+            }
             $commandResources[] = $commandResource;
         }
 

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
@@ -114,7 +114,7 @@ final readonly class ListCommandsProvider implements ProviderInterface
             /** @var CommandId $id */
             $id = $command->id();
             $commandResource = $this->transformer->transform($command);
-            if ($counts !== []) {
+            if (isset($counts) && $counts !== []) {
                 $commandResource->hydrateLinkedResourceCount($counts[$id->value]);
             }
             $commandResources[] = $commandResource;

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
@@ -36,6 +36,7 @@ use App\MonitoringConfiguration\Domain\Repository\Criteria\CommandCriteria;
 use App\MonitoringConfiguration\Domain\Security\CommandActionEnum;
 use App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Command\ListCommandResource;
 use App\Shared\Domain\Repository\Paginator;
+use App\Shared\Infrastructure\ApiPlatform\State\SortAwareProviderTrait;
 use App\Shared\Infrastructure\TransformerInterface;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -45,6 +46,8 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  */
 final readonly class ListCommandsProvider implements ProviderInterface
 {
+    use SortAwareProviderTrait;
+
     /**
      * @param TransformerInterface<Command,ListCommandResource> $transformer
      */
@@ -97,7 +100,7 @@ final readonly class ListCommandsProvider implements ProviderInterface
         $criteria = $this->handleTypeFilter($allowedTypes, $criteria);
         $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
         $criteria = $this->handleStatusFilter($filters['is_activated'] ?? null, $criteria);
-
+        $criteria = $this->handleSort($filters, $criteria);
         $commands = $this->commandRepository->findAll($criteria);
         $commandResources = [];
         foreach ($commands as $command) {

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
@@ -103,12 +103,15 @@ final readonly class ListCommandsProvider implements ProviderInterface
         $criteria = $this->handleSort($filters, $criteria);
         $commands = $this->commandRepository->findAll($criteria);
         $commandResources = [];
+        $counts = $this->commandRepository->countLinkedResources(array_map(
+            fn (Command $command) => $command->id(),
+            is_array($commands) ? $commands : iterator_to_array($commands)
+        ));
         foreach ($commands as $command) {
             /** @var CommandId $id */
             $id = $command->id();
-            $count = $this->commandRepository->countLinkedResources($id);
             $commandResource = $this->transformer->transform($command);
-            $commandResource->hydrateLinkedResourceCount($count);
+            $commandResource->hydrateLinkedResourceCount($counts[$id->value]);
             $commandResources[] = $commandResource;
         }
 

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ResourceCommandTransformer.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ResourceCommandTransformer.php
@@ -54,8 +54,8 @@ final readonly class ResourceCommandTransformer implements TransformerInterface
             isShellEnabled: $from->isShellEnabled,
             isActivated: $from->isActivated ?? false,
             isFromMonitoringConnector: $from->isFromMonitoringConnector ?? false,
-            connector: $from->connector !== null
-                ? $this->connectorTransformer->transform($from->connector)
+            connector: $from->connector() !== null
+                ? $this->connectorTransformer->transform($from->connector())
                 : null,
             comment: $from->comment?->value,
         );

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
@@ -129,6 +129,7 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
         if ($criteria instanceof CommandCriteria) {
             $this->filterByCriteria($qb, $criteria);
         }
+
         // if no pagination
         if ($criteria?->getPage() === null || $criteria->getItemsPerPage() === null) {
             /** @var array<RowTypeAlias> $rows */
@@ -296,6 +297,9 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
             $qb->andWhere('cm.command_activate = :command_activate');
             $qb->setParameter('command_activate', $criteria->getStatus() ? '1' : '0');
         }
+
+        $this->sort($qb, 'cm', $criteria);
+
     }
 
     /**

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
@@ -37,6 +37,7 @@ use App\Shared\Infrastructure\Dbal\DbalRepository;
 use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
 use App\Shared\Infrastructure\TransformerInterface;
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Webmozart\Assert\Assert;
@@ -175,7 +176,7 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
             ->setParameter('command_activate', $command->isActivated ? '1' : '0')
             ->setParameter('command_locked', $command->isFromMonitoringConnector ? '1' : '0')
             ->setParameter('command_comment', $command->comment?->value)
-            ->setParameter('connector_id', $command->connector?->id()->value)
+            ->setParameter('connector_id', $command->connector()?->id()->value)
             ->executeStatement();
 
         $id = (int) $this->connection->lastInsertId();
@@ -187,39 +188,39 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
         $this->setId($command, new CommandId($id));
     }
 
-    public function countLinkedResources(CommandId $id): CommandResourceCount
+    public function countLinkedResources(array $commandIds): array
     {
         $qb = $this->connection->createQueryBuilder();
-
         $qb->select(
+            'cm.command_id',
             "(SELECT COUNT(host_id) FROM host WHERE (command_command_id = cm.command_id OR command_command_id2 = cm.command_id) AND host_register = '1') AS cm_used_hosts_count",
             "(SELECT COUNT(host_id) FROM host WHERE (command_command_id = cm.command_id OR command_command_id2 = cm.command_id) AND host_register = '0') AS cm_used_host_templates_count",
             "(SELECT COUNT(service_id) FROM service WHERE (command_command_id = cm.command_id OR command_command_id2 = cm.command_id) AND service_register = '1') AS cm_used_services_count",
             "(SELECT COUNT(service_id) FROM service WHERE (command_command_id = cm.command_id OR command_command_id2 = cm.command_id) AND service_register = '0') AS cm_used_service_templates_count"
         )
             ->from(self::TABLE_NAME, 'cm')
-            ->where('cm.command_id = :id')
-            ->setParameter('id', $id->value)
-            ->setMaxResults(1);
+            ->where($qb->expr()->in('cm.command_id', array_column($commandIds, 'value')));
 
-        /** @var array{
+        /** @var array<array{
+         *   command_id: string,
          *   cm_used_hosts_count: string,
          *   cm_used_host_templates_count: string,
          *   cm_used_services_count: string,
          *   cm_used_service_templates_count: string
-         *   }|false $row */
-        $row = $qb->executeQuery()->fetchAssociative();
+         *   }> $rows */
+        $rows = $qb->executeQuery()->fetchAllAssociative();
 
-        if (! $row) {
-            throw new \RuntimeException(sprintf('Unable to retrieve resource counts for command #%d.', $id->value));
+        $results = [];
+        foreach ($rows as $row) {
+            $results[(int) $row['command_id']] = new CommandResourceCount(
+                usedHosts: (int) $row['cm_used_hosts_count'],
+                usedHostTemplates: (int) $row['cm_used_host_templates_count'],
+                usedServices: (int) $row['cm_used_services_count'],
+                usedServiceTemplates: (int) $row['cm_used_service_templates_count'],
+            );
         }
 
-        return new CommandResourceCount(
-            usedHosts: (int) $row['cm_used_hosts_count'],
-            usedHostTemplates: (int) $row['cm_used_host_templates_count'],
-            usedServices: (int) $row['cm_used_services_count'],
-            usedServiceTemplates: (int) $row['cm_used_service_templates_count'],
-        );
+        return $results;
     }
 
     /**
@@ -262,7 +263,7 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
             ->setParameter('enable_shell', $command->isShellEnabled ? 1 : 0)
             ->setParameter('activate', $command->isActivated ? 1 : 0)
             ->setParameter('comment', $command->comment->value ?? null)
-            ->setParameter('connector_id', $command->connector instanceof Connector ? $command->connector->id()->value : null);
+            ->setParameter('connector_id', $command->connector() instanceof Connector ? $command->connector()->id()->value : null);
 
         $qb->executeStatement();
     }
@@ -308,11 +309,7 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
     private function createCommand(array $row): Command
     {
         $command = $this->transformer->transform($row);
-        if (($connector = $this->connectorRepository->findByCommand($command)) instanceof Connector) {
-            $command->addConnector($connector);
-
-            return $command;
-        }
+        $command->addConnector(fn (): ?Connector => $this->connectorRepository->findByCommand($command));
 
         return $command;
     }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
@@ -37,7 +37,6 @@ use App\Shared\Infrastructure\Dbal\DbalRepository;
 use App\Shared\Infrastructure\InMemory\InMemoryPaginator;
 use App\Shared\Infrastructure\TransformerInterface;
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Webmozart\Assert\Assert;
@@ -199,7 +198,7 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
             "(SELECT COUNT(service_id) FROM service WHERE (command_command_id = cm.command_id OR command_command_id2 = cm.command_id) AND service_register = '0') AS cm_used_service_templates_count"
         )
             ->from(self::TABLE_NAME, 'cm')
-            ->where($qb->expr()->in('cm.command_id', array_column($commandIds, 'value')));
+            ->where($qb->expr()->in('cm.command_id', array_map(strval(...), array_column($commandIds, 'value'))));
 
         /** @var array<array{
          *   command_id: string,

--- a/centreon/src/App/Shared/Domain/Aggregate/AggregateRoot.php
+++ b/centreon/src/App/Shared/Domain/Aggregate/AggregateRoot.php
@@ -25,13 +25,22 @@ namespace App\Shared\Domain\Aggregate;
 
 use App\Shared\Domain\Exception\MissingIdException;
 
+/**
+ * @template-covariant TIdTypeAlias of AggregateRootId
+ */
 abstract class AggregateRoot
 {
+    /**
+     * @param TIdTypeAlias|null $id
+     */
     public function __construct(
         private ?AggregateRootId $id,
     ) {
     }
 
+    /**
+     * @return TIdTypeAlias
+     */
     public function id(): AggregateRootId
     {
         if (! $this->id instanceof AggregateRootId) {

--- a/centreon/src/App/Shared/Domain/Event/AggregateCreated.php
+++ b/centreon/src/App/Shared/Domain/Event/AggregateCreated.php
@@ -24,9 +24,13 @@ declare(strict_types=1);
 namespace App\Shared\Domain\Event;
 
 use App\Shared\Domain\Aggregate\AggregateRoot;
+use App\Shared\Domain\Aggregate\AggregateRootId;
 
 abstract readonly class AggregateCreated implements EventInterface
 {
+    /**
+     * @param AggregateRoot<AggregateRootId> $aggregate
+     */
     public function __construct(
         public AggregateRoot $aggregate,
         public int $creatorId,

--- a/centreon/src/App/Shared/Domain/Event/AggregateUpdated.php
+++ b/centreon/src/App/Shared/Domain/Event/AggregateUpdated.php
@@ -24,9 +24,13 @@ declare(strict_types=1);
 namespace App\Shared\Domain\Event;
 
 use App\Shared\Domain\Aggregate\AggregateRoot;
+use App\Shared\Domain\Aggregate\AggregateRootId;
 
 abstract readonly class AggregateUpdated implements EventInterface
 {
+    /**
+     * @param AggregateRoot<AggregateRootId> $aggregate
+     */
     public function __construct(
         public AggregateRoot $aggregate,
         public int $creatorId,

--- a/centreon/src/App/Shared/Domain/Repository/SortDirectionEnum.php
+++ b/centreon/src/App/Shared/Domain/Repository/SortDirectionEnum.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Repository;
+
+enum SortDirectionEnum: string
+{
+    case ASC = 'ASC';
+    case DESC = 'DESC';
+}

--- a/centreon/src/App/Shared/Domain/Repository/SortableCriteria.php
+++ b/centreon/src/App/Shared/Domain/Repository/SortableCriteria.php
@@ -37,4 +37,3 @@ interface SortableCriteria
      */
     public function getFieldMapping(): array;
 }
-

--- a/centreon/src/App/Shared/Domain/Repository/SortableCriteria.php
+++ b/centreon/src/App/Shared/Domain/Repository/SortableCriteria.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Repository;
+
+interface SortableCriteria
+{
+    public function withSort(string $field, string|SortDirectionEnum $direction): static;
+
+    /**
+     * @return array<string, SortDirectionEnum>
+     */
+    public function getSort(): array;
+
+    /**
+     * @return array<string, string>
+     */
+    public function getFieldMapping(): array;
+}
+

--- a/centreon/src/App/Shared/Domain/Repository/SortableCriteriaTrait.php
+++ b/centreon/src/App/Shared/Domain/Repository/SortableCriteriaTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Domain\Repository;
+
+trait SortableCriteriaTrait
+{
+    /**
+     * @var array<string, SortDirectionEnum>
+     */
+    private array $sort = [];
+
+    public function withSort(string $field, string|SortDirectionEnum $direction): static
+    {
+        $clone = clone $this;
+        $direction = is_string($direction) ? SortDirectionEnum::from($direction) : $direction;
+        $clone->sort[$field] = $direction;
+
+        return $clone;
+    }
+
+    /**
+     * @return array<string, SortDirectionEnum>
+     */
+    public function getSort(): array
+    {
+        return $this->sort;
+    }
+}

--- a/centreon/src/App/Shared/Domain/Repository/SortableCriteriaTrait.php
+++ b/centreon/src/App/Shared/Domain/Repository/SortableCriteriaTrait.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace App\Shared\Domain\Repository;
 
+use Webmozart\Assert\Assert;
+
 trait SortableCriteriaTrait
 {
     /** @var array<string, SortDirectionEnum> */
@@ -31,7 +33,18 @@ trait SortableCriteriaTrait
     public function withSort(string $field, string|SortDirectionEnum $direction): static
     {
         $clone = clone $this;
-        $direction = is_string($direction) ? SortDirectionEnum::from($direction) : $direction;
+        if (is_string($direction)) {
+            Assert::oneOf(
+                $direction,
+                [SortDirectionEnum::ASC->value, SortDirectionEnum::DESC->value],
+                sprintf(
+                    'Sort direction must be one of: %s.',
+                    implode(', ', [SortDirectionEnum::ASC->value, SortDirectionEnum::DESC->value])
+                )
+            );
+
+            $direction = SortDirectionEnum::from($direction);
+        }
         $clone->sort[$field] = $direction;
 
         return $clone;

--- a/centreon/src/App/Shared/Domain/Repository/SortableCriteriaTrait.php
+++ b/centreon/src/App/Shared/Domain/Repository/SortableCriteriaTrait.php
@@ -25,9 +25,7 @@ namespace App\Shared\Domain\Repository;
 
 trait SortableCriteriaTrait
 {
-    /**
-     * @var array<string, SortDirectionEnum>
-     */
+    /** @var array<string, SortDirectionEnum> */
     private array $sort = [];
 
     public function withSort(string $field, string|SortDirectionEnum $direction): static

--- a/centreon/src/App/Shared/Infrastructure/ApiPlatform/State/SortAwareProviderTrait.php
+++ b/centreon/src/App/Shared/Infrastructure/ApiPlatform/State/SortAwareProviderTrait.php
@@ -30,6 +30,7 @@ trait SortAwareProviderTrait
     /**
      * @template T of SortableCriteria
      *
+     * @param array{sort?: array<string,string>} $filters
      * @param T $criteria
      *
      * @return T
@@ -38,7 +39,7 @@ trait SortAwareProviderTrait
     {
         $sort = $filters['sort'] ?? [];
         foreach ($sort as $field => $direction) {
-            $criteria = $criteria->withSort($field, strtoupper($direction));
+            $criteria = $criteria->withSort($field, mb_strtoupper((string) $direction));
         }
 
         return $criteria;

--- a/centreon/src/App/Shared/Infrastructure/ApiPlatform/State/SortAwareProviderTrait.php
+++ b/centreon/src/App/Shared/Infrastructure/ApiPlatform/State/SortAwareProviderTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace App\Shared\Infrastructure\ApiPlatform\State;
+
+use App\Shared\Domain\Repository\SortableCriteria;
+
+trait SortAwareProviderTrait
+{
+    /**
+     * @template T of SortableCriteria
+     *
+     * @param T $criteria
+     *
+     * @return T
+     */
+    public function handleSort(array $filters, SortableCriteria $criteria): SortableCriteria
+    {
+        $sort = $filters['sort'] ?? [];
+        foreach ($sort as $field => $direction) {
+            $criteria = $criteria->withSort($field, strtoupper($direction));
+        }
+
+        return $criteria;
+    }
+}

--- a/centreon/src/App/Shared/Infrastructure/Dbal/DbalRepository.php
+++ b/centreon/src/App/Shared/Infrastructure/Dbal/DbalRepository.php
@@ -23,6 +23,9 @@ declare(strict_types=1);
 
 namespace App\Shared\Infrastructure\Dbal;
 
+use App\Shared\Domain\Repository\SortableCriteria;
+use Doctrine\DBAL\Query\QueryBuilder;
+
 abstract readonly class DbalRepository
 {
     final protected function setId(object $object, mixed $id): void
@@ -79,6 +82,15 @@ abstract readonly class DbalRepository
 
             $relatedEntities[$relatedId] ??= $relatedFactoryCallback($row);
             $relationCallback($primaryEntity, $relatedEntities[$relatedId]);
+        }
+    }
+
+    final protected function sort(QueryBuilder $qb, string $alias, SortableCriteria $criteria): void
+    {
+        if ($criteria->getSort() !== []) {
+            foreach ($criteria->getSort() as $field => $direction) {
+                $qb->addOrderBy("{$alias}." . $criteria->getFieldMapping()[$field] ?? $field, $direction->value);
+            }
         }
     }
 }

--- a/centreon/src/App/Shared/Infrastructure/Dbal/DbalRepository.php
+++ b/centreon/src/App/Shared/Infrastructure/Dbal/DbalRepository.php
@@ -87,10 +87,8 @@ abstract readonly class DbalRepository
 
     final protected function sort(QueryBuilder $qb, string $alias, SortableCriteria $criteria): void
     {
-        if ($criteria->getSort() !== []) {
-            foreach ($criteria->getSort() as $field => $direction) {
-                $qb->addOrderBy("{$alias}." . $criteria->getFieldMapping()[$field] ?? $field, $direction->value);
-            }
+        foreach ($criteria->getSort() as $field => $direction) {
+            $qb->addOrderBy("{$alias}." . ($criteria->getFieldMapping()[$field] ?? $field), $direction->value);
         }
     }
 }

--- a/centreon/tests/php/App/ActivityLogging/Infrastructure/Double/FakeActivityLogFactory.php
+++ b/centreon/tests/php/App/ActivityLogging/Infrastructure/Double/FakeActivityLogFactory.php
@@ -32,9 +32,10 @@ use App\ActivityLogging\Domain\Aggregate\TargetName;
 use App\ActivityLogging\Domain\Aggregate\TargetTypeEnum;
 use App\ActivityLogging\Domain\Factory\ActivityLogFactoryInterface;
 use App\Shared\Domain\Aggregate\AggregateRoot;
+use App\Shared\Domain\Aggregate\AggregateRootId;
 
 /**
- * @implements ActivityLogFactoryInterface<AggregateRoot>
+ * @implements ActivityLogFactoryInterface<AggregateRoot<AggregateRootId>>
  */
 final class FakeActivityLogFactory implements ActivityLogFactoryInterface
 {

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProviderTest.php
@@ -199,8 +199,10 @@ final class ListCommandsProviderTest extends ApiTestCase
             ['query' => ['sort' => ['name' => 'asc']]]
         );
         self::assertResponseIsSuccessful();
-        $this->assertCount(30, (array) $response->toArray()['member']);
-        $this->assertEquals('check_centreon_cpu', (array) $response->toArray()['member'][0]['name']);
+        /** @var array<int, array{name: string}> $members */
+        $members = (array) $response->toArray()['member'];
+        $this->assertCount(30, $members);
+        $this->assertEquals('check_centreon_cpu', $members[0]['name']);
     }
 
     public function testItFindAllCommandsWithNameSortedDescending(): void
@@ -213,8 +215,10 @@ final class ListCommandsProviderTest extends ApiTestCase
             ['query' => ['sort' => ['name' => 'desc']]]
         );
         self::assertResponseIsSuccessful();
-        $this->assertCount(30, (array) $response->toArray()['member']);
-        $this->assertEquals('submit-service-check-result', (array) $response->toArray()['member'][0]['name']);
+        /** @var array<int, array{name: string}> $members */
+        $members = (array) $response->toArray()['member'];
+        $this->assertCount(30, $members);
+        $this->assertEquals('submit-service-check-result', $members[0]['name']);
     }
 
     public function testItShouldIgnoreUnknownOperator(): void

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProviderTest.php
@@ -189,6 +189,34 @@ final class ListCommandsProviderTest extends ApiTestCase
         $this->assertEquals(3, $response->toArray()['totalItems']);
     }
 
+    public function testItFindAllCommandsWithNameSortedAscending(): void
+    {
+        $this->login();
+
+        $response = $this->request(
+            'GET',
+            self::BASE_ENDPOINT,
+            ['query' => ['sort' => ['name' => 'asc']]]
+        );
+        self::assertResponseIsSuccessful();
+        $this->assertCount(30, (array) $response->toArray()['member']);
+        $this->assertEquals('check_centreon_cpu', (array) $response->toArray()['member'][0]['name']);
+    }
+
+    public function testItFindAllCommandsWithNameSortedDescending(): void
+    {
+        $this->login();
+
+        $response = $this->request(
+            'GET',
+            self::BASE_ENDPOINT,
+            ['query' => ['sort' => ['name' => 'desc']]]
+        );
+        self::assertResponseIsSuccessful();
+        $this->assertCount(30, (array) $response->toArray()['member']);
+        $this->assertEquals('submit-service-check-result', (array) $response->toArray()['member'][0]['name']);
+    }
+
     public function testItShouldIgnoreUnknownOperator(): void
     {
         $this->login();

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/UpdateCommandProcessorTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/UpdateCommandProcessorTest.php
@@ -112,7 +112,6 @@ final class UpdateCommandProcessorTest extends ApiTestCase
                 'connector' => null,
             ],
         ]);
-
         self::assertResponseIsSuccessful();
         self::assertMatchesResourceItemJsonSchema(CommandResource::class);
         self::assertArrayNotHasKey('connector', $response->toArray());

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepositoryTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepositoryTest.php
@@ -80,7 +80,7 @@ final class DbalCommandRepositoryTest extends KernelTestCase
         );
 
         $this->repository->add($command);
-        self::assertEquals($command, $this->repository->findOneByName(new CommandName('NAME')));
+        self::assertEquals($command->name->value, ($this->repository->findOneByName(new CommandName('NAME'))?->name->value));
     }
 
     public function testUpdate(): void
@@ -89,7 +89,7 @@ final class DbalCommandRepositoryTest extends KernelTestCase
         $command->updateName(new CommandName('UPDATED_NAME'));
 
         $this->repository->update($command);
-        self::assertEquals($command, $this->repository->getById(new CommandId(2)));
+        self::assertEquals('UPDATED_NAME', ($this->repository->getById(new CommandId(2))->name->value));
     }
 
     public function testFindAll(): void

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Double/FakeCommandRepository.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/Double/FakeCommandRepository.php
@@ -80,13 +80,18 @@ final class FakeCommandRepository implements CommandRepository
         throw new \RuntimeException('Not yet implemented');
     }
 
-    public function countLinkedResources(CommandId $commandId): CommandResourceCount
+    public function countLinkedResources(array $commandIds): array
     {
-        return new CommandResourceCount(
-            usedHosts: mt_rand(0, 10),
-            usedServices: mt_rand(0, 10),
-            usedHostTemplates: mt_rand(0, 10),
-            usedServiceTemplates: mt_rand(0, 10)
-        );
+        $results = [];
+        foreach ($commandIds as $commandId) {
+            $results[$commandId->value] = new CommandResourceCount(
+                usedHosts: mt_rand(0, 10),
+                usedServices: mt_rand(0, 10),
+                usedHostTemplates: mt_rand(0, 10),
+                usedServiceTemplates: mt_rand(0, 10)
+            );
+        }
+
+        return $results;
     }
 }


### PR DESCRIPTION
## Description

This PR intends to add a sort filter on Command Listing

**/configuration/commands?sort[name]=asc&itemsPerPage=1**
```json
{
  "@context": "/centreon/api/latest/contexts/ListCommandResource",
  "@id": "/centreon/api/latest/configuration/commands",
  "@type": "Collection",
  "totalItems": 52,
  "member": [
    {
      "@id": "/centreon/api/latest/list_command_resources/96",
      "@type": "ListCommandResource",
      "used_hosts_count": 0,
      "used_host_templates_count": 0,
      "used_services_count": 0,
      "used_service_templates_count": 2,
      "id": 96,
      "name": "check_centreon_cpu",
      "type": "Check",
      "command_line": "$CENTREONPLUGINS$/centreon_linux_snmp.pl --mode=cpu --hostname=$HOSTADDRESS$ --warning-average=$ARG1$ --critical-average=$ARG2$",
      "is_activated": true
    }
  ],
  "view": {
    "@id": "/centreon/api/latest/configuration/commands?itemsPerPage=1&sort%5Bname%5D=asc&page=1",
    "@type": "PartialCollectionView",
    "first": "/centreon/api/latest/configuration/commands?itemsPerPage=1&sort%5Bname%5D=asc&page=1",
    "last": "/centreon/api/latest/configuration/commands?itemsPerPage=1&sort%5Bname%5D=asc&page=52",
    "next": "/centreon/api/latest/configuration/commands?itemsPerPage=1&sort%5Bname%5D=asc&page=2"
  }
}
```

**Fixes** # MON-191831

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
