### PR TITLE
fix(configuration H/HT): fix empty template error

### DIFF
--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3025,7 +3025,7 @@ function getPayloadForHostTemplate(bool $isCloudPlatform, array $formData): arra
             : null,
         'templates' => array_map(
             static fn (string $id): int => (int) $id,
-            array_filter(array_values($formData['tpSelect'] ?? []), static fn ($id) => ! empty($id))
+            array_values(array_filter(array_values($formData['tpSelect'] ?? []), static fn ($id) => ! empty($id)))
         ),
         'categories' => array_map(static fn (string $id): int => (int) $id, $formData['host_hcs'] ?? []),
         'macros' => array_map(
@@ -3165,7 +3165,7 @@ function getPayloadForHost(bool $isCloudPlatform, array $formData): array
         'is_activated' => (bool) ($formData['host_activate']['host_activate'] ?: false),
         'templates' => array_map(
             static fn (string $id): int => (int) $id,
-            array_filter(array_values($formData['tpSelect'] ?? []), static fn ($id) => ! empty($id))
+            array_values(array_filter(array_values($formData['tpSelect'] ?? []), static fn ($id) => ! empty($id)))
         ),
         'categories' => array_map(static fn (string $id): int => (int) $id, $formData['host_hcs'] ?? []),
         'groups' => array_map(static fn (string $id): int => (int) $id, $formData['host_hgs'] ?? []),

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3023,7 +3023,10 @@ function getPayloadForHostTemplate(bool $isCloudPlatform, array $formData): arra
         'retry_check_interval' => $formData['host_retry_check_interval'] !== ''
             ? (int) $formData['host_retry_check_interval']
             : null,
-        'templates' => array_map(static fn (string $id): int => (int) $id, array_values($formData['tpSelect'] ?? [])),
+        'templates' => array_map(
+            static fn (string $id): int => (int) $id,
+            array_filter(array_values($formData['tpSelect'] ?? []), static fn ($id) => ! empty($id))
+        ),
         'categories' => array_map(static fn (string $id): int => (int) $id, $formData['host_hcs'] ?? []),
         'macros' => array_map(
             static function (int|string $key, string $name, string $value) use ($formData): array {
@@ -3160,7 +3163,10 @@ function getPayloadForHost(bool $isCloudPlatform, array $formData): array
             ? (int) $formData['host_retry_check_interval']
             : null,
         'is_activated' => (bool) ($formData['host_activate']['host_activate'] ?: false),
-        'templates' => array_map(static fn (string $id): int => (int) $id, array_values($formData['tpSelect'] ?? [])),
+        'templates' => array_map(
+            static fn (string $id): int => (int) $id,
+            array_filter(array_values($formData['tpSelect'] ?? []), static fn ($id) => ! empty($id))
+        ),
         'categories' => array_map(static fn (string $id): int => (int) $id, $formData['host_hcs'] ?? []),
         'groups' => array_map(static fn (string $id): int => (int) $id, $formData['host_hgs'] ?? []),
         'macros' => array_map(

--- a/centreon/www/include/configuration/configObject/host/DB-Func.php
+++ b/centreon/www/include/configuration/configObject/host/DB-Func.php
@@ -3025,7 +3025,7 @@ function getPayloadForHostTemplate(bool $isCloudPlatform, array $formData): arra
             : null,
         'templates' => array_map(
             static fn (string $id): int => (int) $id,
-            array_values(array_filter(array_values($formData['tpSelect'] ?? []), static fn ($id) => ! empty($id)))
+            array_values(array_filter($formData['tpSelect'] ?? [], static fn ($id) => ! empty($id)))
         ),
         'categories' => array_map(static fn (string $id): int => (int) $id, $formData['host_hcs'] ?? []),
         'macros' => array_map(
@@ -3165,7 +3165,7 @@ function getPayloadForHost(bool $isCloudPlatform, array $formData): array
         'is_activated' => (bool) ($formData['host_activate']['host_activate'] ?: false),
         'templates' => array_map(
             static fn (string $id): int => (int) $id,
-            array_values(array_filter(array_values($formData['tpSelect'] ?? []), static fn ($id) => ! empty($id)))
+            array_values(array_filter($formData['tpSelect'] ?? [], static fn ($id) => ! empty($id)))
         ),
         'categories' => array_map(static fn (string $id): int => (int) $id, $formData['host_hcs'] ?? []),
         'groups' => array_map(static fn (string $id): int => (int) $id, $formData['host_hgs'] ?? []),


### PR DESCRIPTION
## Description

This PR intends to filter empty templates out in configuration host and host templates from

[MON-191245](https://centreon.atlassian.net/browse/MON-191245)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-191245]: https://centreon.atlassian.net/browse/MON-191245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ