### PR TITLE
Fix(e2e): Align macro tests after the Credentials Encryption merge on 25.10

### DIFF
--- a/centreon/tests/e2e/features/Macros/commands.ts
+++ b/centreon/tests/e2e/features/Macros/commands.ts
@@ -88,11 +88,11 @@ Cypress.Commands.add(
       expect(result.exitCode).to.eq(0);
       const output = result.output;
       const regexNormal = new RegExp(
-        `${normalMacro.name}\\s+${normalMacro.value}`
+        `${normalMacro.name}\\s+raw::${normalMacro.value}`
       );
       expect(output).to.match(regexNormal);
       const regexPassword = new RegExp(
-        `${passMacro.name}\\s+${passMacro.value}`
+        `${passMacro.name}\\s+encrypt::[A-Za-z0-9+/=]+`
       );
       if (!isInherited) {
         expect(output).to.match(regexPassword);


### PR DESCRIPTION
## Description
Linked to https://centreon.atlassian.net/browse/MON-191876