### PR TITLE
fix(poller): Correctly check insecure flag for engine secret script

### DIFF
--- a/centreon/bin/writeEngineSecrets.sh
+++ b/centreon/bin/writeEngineSecrets.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-if [ "$#" -ne 3 ]; then
-  echo "Usage: $0 <api_base_url> <username> <password>"
-  exit 1
-fi
-
 # Ensure positional parameters are handled correctly
 INSECURE_FLAG=""
 POSITIONAL=()
@@ -20,6 +15,12 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [ "${#POSITIONAL[@]}" -ne 3 ]; then
+  echo "Usage: $0 <api_base_url> <username> <password> [--insecure]"
+  exit 1
+fi
+
 set -- "${POSITIONAL[@]}"
 
 API_URL="$1"


### PR DESCRIPTION
## Description

This PR intends to fix an issue where --insecure flag was not correctly handle by writeEngineSecrets.sh 

**Fixes** # MON-191850

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
