### PR TITLE
Top counter wrongfully displays password expiration message for non-local users

### DIFF
--- a/centreon/www/api/class/centreon_topcounter.class.php
+++ b/centreon/www/api/class/centreon_topcounter.class.php
@@ -755,7 +755,7 @@ class CentreonTopCounter extends CentreonWebService
      */
     private function getPasswordRemainingTime(): ?int
     {
-        if ($this->centreon->user->authType === CentreonAuth::AUTH_TYPE_LDAP) {
+        if ($this->centreon->user->authType !== CentreonAuth::AUTH_TYPE_LOCAL) {
             return null;
         }
         $passwordRemainingTime = null;


### PR DESCRIPTION
## Description

fix an issue where the top counter can display some password expiration message for non-local users when they are logged in using some sso/openid/saml connection
## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
