### PR TITLE
fix(resource): return also services on host_severity filter

### DIFF
--- a/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
+++ b/centreon/src/Core/Resources/Infrastructure/Repository/DbReadResourceRepository.php
@@ -1148,7 +1148,7 @@ class DbReadResourceRepository extends DatabaseRepository implements ReadResourc
         ) {
             $subRequest = ' AND EXISTS (
                 SELECT 1 FROM `:dbstg`.severities
-                WHERE severities.severity_id = resources.severity_id
+                WHERE (severities.severity_id = resources.severity_id OR severities.severity_id = parent_resource.severity_id)
                     AND severities.type IN (' . implode(', ', $filteredTypes) . ')';
 
             $subRequest .= $filteredNames !== []


### PR DESCRIPTION
🔗 https://centreon.atlassian.net/browse/MON-191120
🏷️ This PR intends to handle properly filter on the host_severity within the Resource Status API. It should behave like the host_group and host_category filter and therefore the listing should return both service and host resource types