### PR TITLE
fix(clapi): dont reload acl for each templates while apply templates

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonHost.class.php
+++ b/centreon/www/class/centreon-clapi/centreonHost.class.php
@@ -1091,7 +1091,7 @@ class CentreonHost extends CentreonObject
         $this->deployServices($hostId);
 
         $aclObj = new CentreonACL($this->dependencyInjector);
-        $aclObj->reload(false);
+        $aclObj->reload(true);
     }
 
     /**

--- a/centreon/www/class/centreon-clapi/centreonHost.class.php
+++ b/centreon/www/class/centreon-clapi/centreonHost.class.php
@@ -1089,6 +1089,9 @@ class CentreonHost extends CentreonObject
             throw new CentreonClapiException(self::OBJECT_NOT_FOUND . ':' . $hostName);
         }
         $this->deployServices($hostId);
+
+        $aclObj = new CentreonACL($this->dependencyInjector);
+        $aclObj->reload(false);
     }
 
     /**
@@ -1724,9 +1727,6 @@ class CentreonHost extends CentreonObject
             }
             $this->deployServices($hostId, $templateId);
         }
-
-        $aclObj = new CentreonACL($this->dependencyInjector);
-        $aclObj->reload(false);
     }
 
     /**


### PR DESCRIPTION
## Description

This PR Intends to avoid an issue where the ACL Cron was executed for each host templates attached to the host of APPLYTPL command. The Reload ACL is now executed at the end of the process

**Fixes** # MON-191906

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
