### PR TITLE
feat(commands): add filter is_from_monitoring_connector

### DIFF
--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/CommandCriteria.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/CommandCriteria.php
@@ -47,6 +47,8 @@ final class CommandCriteria implements SortableCriteria
 
     private ?bool $status = null;
 
+    private ?bool $fromMonitoringConnector = null;
+
     public function withPagination(int $page, int $itemsPerPage): self
     {
         Assert::positiveInteger($page);
@@ -100,6 +102,13 @@ final class CommandCriteria implements SortableCriteria
         return clone $this;
     }
 
+    public function withFromMonitoringConnector(bool $fromMonitoringConnector): self
+    {
+        $this->fromMonitoringConnector = $fromMonitoringConnector;
+
+        return clone $this;
+    }
+
     public function getPage(): ?int
     {
         return $this->page;
@@ -129,6 +138,11 @@ final class CommandCriteria implements SortableCriteria
     public function getStatus(): ?bool
     {
         return $this->status;
+    }
+
+    public function getFromMonitoringConnector(): ?bool
+    {
+        return $this->fromMonitoringConnector;
     }
 
     public function getFieldMapping(): array

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/CommandCriteria.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/CommandCriteria.php
@@ -45,9 +45,9 @@ final class CommandCriteria implements SortableCriteria
     /** @var list<CommandTypeEnum> */
     private array $types = [];
 
-    private ?bool $status = null;
+    private ?bool $isActivated = null;
 
-    private ?bool $locked = null;
+    private ?bool $isFromMonitoringConnector = null;
 
     public function withPagination(int $page, int $itemsPerPage): self
     {
@@ -95,16 +95,16 @@ final class CommandCriteria implements SortableCriteria
         return $new;
     }
 
-    public function withStatus(bool $status): self
+    public function withIsActivated(bool $isActivated): self
     {
-        $this->status = $status;
+        $this->isActivated = $isActivated;
 
         return clone $this;
     }
 
-    public function withLocked(bool $locked): self
+    public function withIsFromMonitoringConnector(bool $isFromMonitoringConnector): self
     {
-        $this->locked = $locked;
+        $this->isFromMonitoringConnector = $isFromMonitoringConnector;
 
         return clone $this;
     }
@@ -135,14 +135,14 @@ final class CommandCriteria implements SortableCriteria
         return $this->types;
     }
 
-    public function getStatus(): ?bool
+    public function getIsActivated(): ?bool
     {
-        return $this->status;
+        return $this->isActivated;
     }
 
-    public function getLocked(): ?bool
+    public function getIsFromMonitoringConnector(): ?bool
     {
-        return $this->locked;
+        return $this->isFromMonitoringConnector;
     }
 
     public function getFieldMapping(): array

--- a/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/CommandCriteria.php
+++ b/centreon/src/App/MonitoringConfiguration/Domain/Repository/Criteria/CommandCriteria.php
@@ -47,7 +47,7 @@ final class CommandCriteria implements SortableCriteria
 
     private ?bool $status = null;
 
-    private ?bool $fromMonitoringConnector = null;
+    private ?bool $locked = null;
 
     public function withPagination(int $page, int $itemsPerPage): self
     {
@@ -102,9 +102,9 @@ final class CommandCriteria implements SortableCriteria
         return clone $this;
     }
 
-    public function withFromMonitoringConnector(bool $fromMonitoringConnector): self
+    public function withLocked(bool $locked): self
     {
-        $this->fromMonitoringConnector = $fromMonitoringConnector;
+        $this->locked = $locked;
 
         return clone $this;
     }
@@ -140,9 +140,9 @@ final class CommandCriteria implements SortableCriteria
         return $this->status;
     }
 
-    public function getFromMonitoringConnector(): ?bool
+    public function getLocked(): ?bool
     {
-        return $this->fromMonitoringConnector;
+        return $this->locked;
     }
 
     public function getFieldMapping(): array

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Command/ListCommandResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Command/ListCommandResource.php
@@ -25,6 +25,7 @@ namespace App\MonitoringConfiguration\Infrastructure\ApiPlatform\Resource\Comman
 
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\GetCollection;
+use ApiPlatform\Metadata\QueryParameter;
 use ApiPlatform\OpenApi\Model;
 use App\MonitoringConfiguration\Domain\Aggregate\Command\CommandTypeEnum;
 use App\MonitoringConfiguration\Domain\Repository\CommandResourceCount;
@@ -39,30 +40,16 @@ use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Command\ListCom
             403 => new Model\Response('You are not allowed to access commands'),
         ],
         parameters: [
-            new Model\Parameter(
-                name: 'name[lk]',
-                in: 'query',
-                description: 'Filter by name using "like" operator',
+            'name' => new QueryParameter(
+                description: 'Filter commands by name (partial or exact match)',
                 required: false,
                 schema: [
                     'type' => 'array',
                     'items' => ['type' => 'string'],
                 ],
             ),
-            new Model\Parameter(
-                name: 'name[eq]',
-                in: 'query',
-                description: 'Filter by name using "equals" operator',
-                required: false,
-                schema: [
-                    'type' => 'array',
-                    'items' => ['type' => 'string'],
-                ],
-            ),
-            new Model\Parameter(
-                name: 'type[]',
-                in: 'query',
-                description: 'Filter by command type',
+            'type' => new QueryParameter(
+                description: 'Filter commands by type',
                 required: false,
                 schema: [
                     'type' => 'array',
@@ -75,25 +62,17 @@ use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Command\ListCom
                             CommandTypeEnum::Discovery->name,
                         ],
                     ],
-                ],
+                ]
             ),
-            new Model\Parameter(
-                name: 'is_activated',
-                in: 'query',
-                description: 'Filter by activation status',
+            'is_activated' => new QueryParameter(
+                description: 'Filter commands by activation status',
                 required: false,
-                schema: [
-                    'type' => 'boolean',
-                ],
+                schema: ['type' => 'boolean'],
             ),
-            new Model\Parameter(
-                name: 'is_from_monitoring_connector',
-                in: 'query',
-                description: 'If set to true, includes commands coming from monitoring connectors to the results',
+            'is_from_monitoring_connector' => new QueryParameter(
+                description: 'Filter commands by whether they are from a monitoring connector',
                 required: false,
-                schema: [
-                    'type' => 'boolean',
-                ],
+                schema: ['type' => 'boolean'],
             ),
         ],
     ),

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Command/ListCommandResource.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/Resource/Command/ListCommandResource.php
@@ -78,9 +78,18 @@ use App\MonitoringConfiguration\Infrastructure\ApiPlatform\State\Command\ListCom
                 ],
             ),
             new Model\Parameter(
-                name: 'status',
+                name: 'is_activated',
                 in: 'query',
                 description: 'Filter by activation status',
+                required: false,
+                schema: [
+                    'type' => 'boolean',
+                ],
+            ),
+            new Model\Parameter(
+                name: 'is_from_monitoring_connector',
+                in: 'query',
+                description: 'If set to true, includes commands coming from monitoring connectors to the results',
                 required: false,
                 schema: [
                     'type' => 'boolean',

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
@@ -100,6 +100,7 @@ final readonly class ListCommandsProvider implements ProviderInterface
         $criteria = $this->handleTypeFilter($allowedTypes, $criteria);
         $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
         $criteria = $this->handleStatusFilter($filters['is_activated'] ?? null, $criteria);
+        $criteria = $this->handleFromMonitoringConnectorFilter($filters['is_from_monitoring_connector'] ?? null, $criteria);
         $criteria = $this->handleSort($filters, $criteria);
 
         $commands = $this->commandRepository->findAll($criteria);
@@ -182,5 +183,18 @@ final readonly class ListCommandsProvider implements ProviderInterface
         $statusFilter = filter_var($statusFilter, FILTER_VALIDATE_BOOLEAN);
 
         return $criteria->withStatus($statusFilter);
+    }
+
+    private function handleFromMonitoringConnectorFilter(?string $fromMonitoringConnectorFilter, CommandCriteria $criteria): CommandCriteria
+    {
+        if ($fromMonitoringConnectorFilter === null) {
+            return $criteria;
+        }
+
+        $fromMonitoringConnectorFilter = filter_var($fromMonitoringConnectorFilter, FILTER_VALIDATE_BOOLEAN);
+
+        return $fromMonitoringConnectorFilter
+            ? $criteria->withFromMonitoringConnector(true)
+            : $criteria;
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
@@ -99,8 +99,8 @@ final readonly class ListCommandsProvider implements ProviderInterface
 
         $criteria = $this->handleTypeFilter($allowedTypes, $criteria);
         $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
-        $criteria = $this->handleStatusFilter($filters['is_activated'] ?? null, $criteria);
-        $criteria = $this->handleLockedFilter($filters['is_from_monitoring_connector'] ?? null, $criteria);
+        $criteria = $this->handleIsActivatedFilter($filters['is_activated'] ?? null, $criteria);
+        $criteria = $this->handleIsFromMonitoringConnectorFilter($filters['is_from_monitoring_connector'] ?? null, $criteria);
         $criteria = $this->handleSort($filters, $criteria);
 
         $commands = $this->commandRepository->findAll($criteria);
@@ -174,27 +174,27 @@ final readonly class ListCommandsProvider implements ProviderInterface
         return $criteria;
     }
 
-    private function handleStatusFilter(?string $statusFilter, CommandCriteria $criteria): CommandCriteria
+    private function handleIsActivatedFilter(?string $isActivatedFilter, CommandCriteria $criteria): CommandCriteria
     {
-        if ($statusFilter === null) {
+        if ($isActivatedFilter === null) {
             return $criteria;
         }
 
-        $statusFilter = filter_var($statusFilter, FILTER_VALIDATE_BOOLEAN);
+        $isActivatedFilter = filter_var($isActivatedFilter, FILTER_VALIDATE_BOOLEAN);
 
-        return $criteria->withStatus($statusFilter);
+        return $criteria->withIsActivated($isActivatedFilter);
     }
 
-    private function handleLockedFilter(?string $lockedFilter, CommandCriteria $criteria): CommandCriteria
+    private function handleIsFromMonitoringConnectorFilter(?string $isFromMonitoringConnectorFilter, CommandCriteria $criteria): CommandCriteria
     {
-        if ($lockedFilter === null) {
+        if ($isFromMonitoringConnectorFilter === null) {
             return $criteria;
         }
 
-        $lockedFilter = filter_var($lockedFilter, FILTER_VALIDATE_BOOLEAN);
+        $isFromMonitoringConnectorFilter = filter_var($isFromMonitoringConnectorFilter, FILTER_VALIDATE_BOOLEAN);
 
-        return $lockedFilter
-            ? $criteria->withLocked(true)
+        return $isFromMonitoringConnectorFilter
+            ? $criteria->withIsFromMonitoringConnector(true)
             : $criteria;
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProvider.php
@@ -100,7 +100,7 @@ final readonly class ListCommandsProvider implements ProviderInterface
         $criteria = $this->handleTypeFilter($allowedTypes, $criteria);
         $criteria = $this->handleNameFilter($filters['name'] ?? null, $criteria);
         $criteria = $this->handleStatusFilter($filters['is_activated'] ?? null, $criteria);
-        $criteria = $this->handleFromMonitoringConnectorFilter($filters['is_from_monitoring_connector'] ?? null, $criteria);
+        $criteria = $this->handleLockedFilter($filters['is_from_monitoring_connector'] ?? null, $criteria);
         $criteria = $this->handleSort($filters, $criteria);
 
         $commands = $this->commandRepository->findAll($criteria);
@@ -185,16 +185,16 @@ final readonly class ListCommandsProvider implements ProviderInterface
         return $criteria->withStatus($statusFilter);
     }
 
-    private function handleFromMonitoringConnectorFilter(?string $fromMonitoringConnectorFilter, CommandCriteria $criteria): CommandCriteria
+    private function handleLockedFilter(?string $lockedFilter, CommandCriteria $criteria): CommandCriteria
     {
-        if ($fromMonitoringConnectorFilter === null) {
+        if ($lockedFilter === null) {
             return $criteria;
         }
 
-        $fromMonitoringConnectorFilter = filter_var($fromMonitoringConnectorFilter, FILTER_VALIDATE_BOOLEAN);
+        $lockedFilter = filter_var($lockedFilter, FILTER_VALIDATE_BOOLEAN);
 
-        return $fromMonitoringConnectorFilter
-            ? $criteria->withFromMonitoringConnector(true)
+        return $lockedFilter
+            ? $criteria->withLocked(true)
             : $criteria;
     }
 }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
@@ -125,6 +125,12 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
         $qb->select(...self::getSelectColumns())
             ->from(self::TABLE_NAME, 'cm');
 
+        // only fetch unlocked commands unless getFromMonitoringConnector is true
+        if ($criteria?->getFromMonitoringConnector() !== true) {
+            $qb->where('command_locked = :command_locked')
+                ->setParameter('command_locked', '0');
+        }
+
         // if we have a criteria, filter the query
         if ($criteria instanceof CommandCriteria) {
             $this->filterByCriteria($qb, $criteria);
@@ -313,7 +319,6 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
         }
 
         $this->sort($qb, 'cm', $criteria);
-
     }
 
     /**

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
@@ -125,7 +125,7 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
         $qb->select(...self::getSelectColumns())
             ->from(self::TABLE_NAME, 'cm');
 
-        // only fetch unlocked commands unless getLocked is true
+        // only fetch unlocked commands unless getIsFromMonitoringConnector is true
         if ($criteria?->getIsFromMonitoringConnector() !== true) {
             $qb->where('command_locked = :command_locked')
                 ->setParameter('command_locked', '0');

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
@@ -125,8 +125,8 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
         $qb->select(...self::getSelectColumns())
             ->from(self::TABLE_NAME, 'cm');
 
-        // only fetch unlocked commands unless getFromMonitoringConnector is true
-        if ($criteria?->getFromMonitoringConnector() !== true) {
+        // only fetch unlocked commands unless getLocked is true
+        if ($criteria?->getLocked() !== true) {
             $qb->where('command_locked = :command_locked')
                 ->setParameter('command_locked', '0');
         }

--- a/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
+++ b/centreon/src/App/MonitoringConfiguration/Infrastructure/Dbal/DbalCommandRepository.php
@@ -126,7 +126,7 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
             ->from(self::TABLE_NAME, 'cm');
 
         // only fetch unlocked commands unless getLocked is true
-        if ($criteria?->getLocked() !== true) {
+        if ($criteria?->getIsFromMonitoringConnector() !== true) {
             $qb->where('command_locked = :command_locked')
                 ->setParameter('command_locked', '0');
         }
@@ -313,9 +313,9 @@ final readonly class DbalCommandRepository extends DbalRepository implements Com
             ));
         }
 
-        if ($criteria->getStatus() !== null) {
+        if ($criteria->getIsActivated() !== null) {
             $qb->andWhere('cm.command_activate = :command_activate');
-            $qb->setParameter('command_activate', $criteria->getStatus() ? '1' : '0');
+            $qb->setParameter('command_activate', $criteria->getIsActivated() ? '1' : '0');
         }
 
         $this->sort($qb, 'cm', $criteria);

--- a/centreon/src/App/Shared/Domain/Event/AggregateDeleted.php
+++ b/centreon/src/App/Shared/Domain/Event/AggregateDeleted.php
@@ -24,9 +24,13 @@ declare(strict_types=1);
 namespace App\Shared\Domain\Event;
 
 use App\Shared\Domain\Aggregate\AggregateRoot;
+use App\Shared\Domain\Aggregate\AggregateRootId;
 
 abstract readonly class AggregateDeleted implements EventInterface
 {
+    /**
+     * @param AggregateRoot<AggregateRootId> $aggregate
+     */
     public function __construct(
         public AggregateRoot $aggregate,
         public int $creatorId,

--- a/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProviderTest.php
+++ b/centreon/tests/php/App/MonitoringConfiguration/Infrastructure/ApiPlatform/State/Command/ListCommandsProviderTest.php
@@ -257,6 +257,32 @@ final class ListCommandsProviderTest extends ApiTestCase
         );
     }
 
+    /**
+     * TODO : before running this test, ensure there are locked commands in the database.
+     */
+    public function testItFindCommandsFilteredByIsLockedTrue(): void
+    {
+        $this->login();
+
+        // Get baseline count without filter
+        $responseWithoutFilter = $this->request('GET', self::BASE_ENDPOINT, ['query' => ['type[]' => 'Notification']]);
+        $baselineCount = count((array) $responseWithoutFilter->toArray()['member']); // by default we have 6 Notification commands
+
+        // Get count with filter enabled
+        $responseWithFilter = $this->request(
+            'GET',
+            self::BASE_ENDPOINT,
+            ['query' => ['is_from_monitoring_connector' => 'true', 'type[]' => 'Notification']]
+        );
+        self::assertResponseIsSuccessful();
+        self::assertMatchesResourceCollectionJsonSchema(ListCommandResource::class);
+
+        // We added the Or Equal in the assertion in case there are no locked commands, the count will be the same
+        $data = $responseWithFilter->toArray();
+        $membersWithLocked = is_array($data['member']) ? $data['member'] : [];
+        $this->assertGreaterThanOrEqual($baselineCount, count($membersWithLocked));
+    }
+
     public function testItShouldDenyAccessWhenUserHasNoCommandPermissions(): void
     {
         $this->login('user_without_command_permissions');


### PR DESCRIPTION
## Description

Add filter is_from_monitoring_connector,
This filter works in a unique way, by default, only commands that don't come from monitoring connectors are listed, and if the filter is set to true, the commands coming from monitoring connectors are added to the list of commands

Request example :

`GET /centreon/api/latest/configuration/commands?type[]=Notification&is_from_monitoring_connector=true
`

[MON-192033](https://centreon.atlassian.net/browse/MON-192033)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-192033]: https://centreon.atlassian.net/browse/MON-192033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ