### PR TITLE
fix(clapi): Dont print return code when there is no return code

### DIFF
--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -742,7 +742,7 @@ class CentreonAPI
                 }
             }
             $obj = new $objName($this->dependencyInjector);
-            var_dump($this->return_code);
+
             if (method_exists($obj, $action) || method_exists($obj, '__call')) {
                 $this->return_code = $obj->{$action}($this->variables);
             } else {

--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -758,7 +758,7 @@ class CentreonAPI
         }
 
         if ($exit) {
-            if ( $this->return_code !== null) {
+            if ($this->return_code !== null) {
                 echo 'Return code end : ' . $this->return_code . "\n";
             }
 

--- a/centreon/www/class/centreon-clapi/centreonAPI.class.php
+++ b/centreon/www/class/centreon-clapi/centreonAPI.class.php
@@ -742,6 +742,7 @@ class CentreonAPI
                 }
             }
             $obj = new $objName($this->dependencyInjector);
+            var_dump($this->return_code);
             if (method_exists($obj, $action) || method_exists($obj, '__call')) {
                 $this->return_code = $obj->{$action}($this->variables);
             } else {
@@ -757,7 +758,9 @@ class CentreonAPI
         }
 
         if ($exit) {
-            echo 'Return code end : ' . $this->return_code . "\n";
+            if ( $this->return_code !== null) {
+                echo 'Return code end : ' . $this->return_code . "\n";
+            }
 
             exit($this->return_code);
         }


### PR DESCRIPTION
## Description

this PR intends to fix an issue Where CLAPI was printing a message when there is no return code provided

Pre Patch
```
root@5089a73ac156 /]# centreon -u admin -p xxxxxxxxx -o host -a show -d
Array
(
    [u] => admin
    [p] => xxxxxxxxx
    [o] => host
    [a] => show
    [d] =>
)
id;name;alias;address;activate
14;Centreon-Server;Monitoring Server;127.0.0.1;1
Return code end :
```

Post Patch
```
root@5089a73ac156 /]# centreon -u admin -p xxxxxxxxx -o host -a show -d
Array
(
    [u] => admin
    [p] => xxxxxxxxx
    [o] => host
    [a] => show
    [d] =>
)
id;name;alias;address;activate
14;Centreon-Server;Monitoring Server;127.0.0.1;1
```

**Fixes** # MON-184535

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
