### PR TITLE
test(E2E): set video recording to always enabled (#8116)

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/configuration.ts
+++ b/centreon/packages/js-config/cypress/e2e/configuration.ts
@@ -86,8 +86,11 @@ export default ({
       runMode: 2
     },
     screenshotsFolder: `${resultsFolder}/screenshots`,
-    video: isDevelopment,
-    videoCompression: 0,
+    // Ensure previous run assets are removed to avoid accumulation
+    trashAssetsBeforeRuns: true,
+    video: true,
+    // Keep files small in CI, but fast locally
+    videoCompression: process.env.CI ? 32 : 0,
     videosFolder: `${resultsFolder}/videos`,
     viewportHeight: 1080,
     viewportWidth: 1920


### PR DESCRIPTION
## Description

This pull request updates the Cypress configuration to improve test asset management and video recording behavior. The main changes focus on cleaning up old test artifacts and optimizing video compression settings for different environments.

Test asset management:

Enabled trashAssetsBeforeRuns to automatically remove previous run assets before each test execution, preventing accumulation of old screenshots and videos.
Video recording and compression:

Set video to true to ensure video recording is always enabled during tests.
Adjusted videoCompression to use higher compression in CI environments (32) for smaller file sizes, while keeping it fast and uncompressed (0) locally.

**Fixes** # MON-181996

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [x] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
