### PR TITLE
fix(cfg) fix severities conf export

### DIFF
--- a/centreon/www/class/config-generate/abstract/host.class.php
+++ b/centreon/www/class/config-generate/abstract/host.class.php
@@ -269,6 +269,7 @@ abstract class AbstractHost extends AbstractObject
 
     /**
      * Format Macros for export.
+     * Warning: is to be run BEFORE running getSeverity to not override severity export.
      *
      * @param array<string, mixed> $host
      * @param MacroDomain[] $hostMacros

--- a/centreon/www/class/config-generate/host.class.php
+++ b/centreon/www/class/config-generate/host.class.php
@@ -121,7 +121,6 @@ class Host extends AbstractHost
         $host['category_tags'] = $hostCategory->getIdsByHostId($host['host_id']);
 
         $this->getParents($host);
-        $this->getSeverity($host['host_id']);
 
         $this->manageNotificationInheritance($host, $generateConfigurationFile);
 
@@ -141,6 +140,7 @@ class Host extends AbstractHost
     {
         $this->processingFromHost($host, hostTemplateMacros: $hostTemplateMacros);
         $this->formatMacros($host, $hostMacros);
+        $this->getSeverity($host['host_id']);
         $this->getServices($host, $serviceMacros, $serviceTemplateMacros);
         $this->getServicesByHg($host);
         $this->generateObjectInFile($host, $host['host_id']);
@@ -276,6 +276,8 @@ class Host extends AbstractHost
     }
 
     /**
+     * Warning: is to be run AFTER running formatMacros to not override severity export.
+     *
      * @param $host_id_arg
      *
      * @throws PDOException

--- a/centreon/www/class/config-generate/hosttemplate.class.php
+++ b/centreon/www/class/config-generate/hosttemplate.class.php
@@ -168,8 +168,8 @@ class HostTemplate extends AbstractHost
 
         $this->getContactGroups($this->hosts[$host_id]);
         $this->getContacts($this->hosts[$host_id]);
-        $this->getSeverity($host_id);
         $this->formatMacros($this->hosts[$host_id], $hostTemplateMacros);
+        $this->getSeverity($host_id);
         $this->generateObjectInFile($this->hosts[$host_id], $host_id);
 
         return $this->hosts[$host_id]['name'];
@@ -202,6 +202,8 @@ class HostTemplate extends AbstractHost
     }
 
     /**
+     * Warning: is to be run AFTER running formatMacros to not override severity export.
+     *
      * @param $host_id
      *
      * @throws PDOException


### PR DESCRIPTION
## Description

Severites where missing from export conf files (host/host templates)
Before fix
```
define host {
    host_name                      Central
    alias                          Central
    address                        10.25.8.122
    register                       1
    use                            App-Monitoring-Centreon-Central-custom
    _HOST_ID                       31
```
After fix
```
define host {
    host_name                      Central
    alias                          Central
    address                        10.25.8.122
    register                       1
    use                            App-Monitoring-Centreon-Central-custom
    _HOST_ID                       31
    _CRITICALITY_LEVEL             1
    _CRITICALITY_ID                1
    severity                       1
}
```

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 23.10.x
- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master
