### PR TITLE
fix(E2E):  update password input selector to use type attribute for better accuracy

### DIFF
--- a/centreon/packages/js-config/cypress/e2e/commands.ts
+++ b/centreon/packages/js-config/cypress/e2e/commands.ts
@@ -259,7 +259,7 @@ Cypress.Commands.add(
         cy.getByLabel({ label: 'Alias', tag: 'input' }).type(
           `{selectAll}{backspace}${credential.login}`
         );
-        cy.getByLabel({ label: 'Password', tag: 'input' }).type(
+        cy.get('input[type="password"]').type(
           `{selectAll}{backspace}${credential.password}`
         );
       })

--- a/centreon/packages/js-config/cypress/e2e/configuration.ts
+++ b/centreon/packages/js-config/cypress/e2e/configuration.ts
@@ -50,38 +50,16 @@ export default ({
       },
       setupNodeEvents: async (cypressOn, config) => {
         const on = require('cypress-on-fix')(cypressOn)
-
         installLogsPrinter(on, {
           commandTrimLength: 5000,
           defaultTrimLength: 5000,
         });
-
         on("task", {
           logVersion(message) {
             console.log(`[LOG]: ${message}`);
             return null;
           },
         });
-
-        // ------------------------------------------------------------------
-        //  FORCING BROWSER LANGUAGE TO ENGLISH (CHROME / EDGE / FIREFOX)
-        // ------------------------------------------------------------------
-        on('before:browser:launch', (browser: Cypress.Browser, launchOptions) => {
-          // For Chromium browsers (Chrome, Edge, Electron)
-          if (browser.family === 'chromium') {
-            launchOptions.args.push('--lang=en');
-            launchOptions.args.push('--accept-lang=en,en-US');
-          }
-
-          // For Firefox
-          if (browser.family === 'firefox') {
-            launchOptions.preferences['intl.accept_languages'] = 'en-US,en';
-          }
-
-          return launchOptions;
-        });
-        // ------------------------------------------------------------------
-
         await esbuildPreprocessor(on, config);
         tasks(on);
 
@@ -108,8 +86,10 @@ export default ({
       runMode: 2
     },
     screenshotsFolder: `${resultsFolder}/screenshots`,
+    // Ensure previous run assets are removed to avoid accumulation
     trashAssetsBeforeRuns: true,
     video: true,
+    // Keep files small in CI, but fast locally
     videoCompression: process.env.CI ? 32 : 0,
     videosFolder: `${resultsFolder}/videos`,
     viewportHeight: 1080,

--- a/centreon/packages/js-config/cypress/e2e/configuration.ts
+++ b/centreon/packages/js-config/cypress/e2e/configuration.ts
@@ -50,16 +50,38 @@ export default ({
       },
       setupNodeEvents: async (cypressOn, config) => {
         const on = require('cypress-on-fix')(cypressOn)
+
         installLogsPrinter(on, {
           commandTrimLength: 5000,
           defaultTrimLength: 5000,
         });
+
         on("task", {
           logVersion(message) {
             console.log(`[LOG]: ${message}`);
             return null;
           },
         });
+
+        // ------------------------------------------------------------------
+        //  FORCING BROWSER LANGUAGE TO ENGLISH (CHROME / EDGE / FIREFOX)
+        // ------------------------------------------------------------------
+        on('before:browser:launch', (browser: Cypress.Browser, launchOptions) => {
+          // For Chromium browsers (Chrome, Edge, Electron)
+          if (browser.family === 'chromium') {
+            launchOptions.args.push('--lang=en');
+            launchOptions.args.push('--accept-lang=en,en-US');
+          }
+
+          // For Firefox
+          if (browser.family === 'firefox') {
+            launchOptions.preferences['intl.accept_languages'] = 'en-US,en';
+          }
+
+          return launchOptions;
+        });
+        // ------------------------------------------------------------------
+
         await esbuildPreprocessor(on, config);
         tasks(on);
 
@@ -86,10 +108,8 @@ export default ({
       runMode: 2
     },
     screenshotsFolder: `${resultsFolder}/screenshots`,
-    // Ensure previous run assets are removed to avoid accumulation
     trashAssetsBeforeRuns: true,
     video: true,
-    // Keep files small in CI, but fast locally
     videoCompression: process.env.CI ? 32 : 0,
     videosFolder: `${resultsFolder}/videos`,
     viewportHeight: 1080,


### PR DESCRIPTION
This pull request makes a targeted update to the Cypress custom command for handling password input fields. The change improves the selector used for password fields, making it more robust and less dependent on label text.

* Test automation improvement:
  * In `centreon/packages/js-config/cypress/e2e/commands.ts`, updated the selector for password inputs from using `getByLabel` with the label "Password" to directly querying `input[type="password"]`, ensuring the command works even if the label changes or is absent.

## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
