### PR TITLE
fix(cfg) unsure all inputs are disabled in read-only mode in service form

### DIFF
--- a/centreon/www/include/configuration/configObject/service/formServiceOnPrem.ihtml
+++ b/centreon/www/include/configuration/configObject/service/formServiceOnPrem.ihtml
@@ -613,12 +613,16 @@ jQuery(function() {
             jQuery("#service_cs").select2("val", "");
             jQuery("#service_cgs").attr('disabled', 'disabled');
             jQuery("#service_cgs").select2("val", "");
-        } else {
-            jQuery("input[name='contact_additive_inheritance']").removeAttr('disabled');
-            jQuery("input[name='cg_additive_inheritance']").removeAttr('disabled');
-            jQuery("#service_cs").removeAttr('disabled');
-            jQuery("#service_cgs").removeAttr('disabled');
+
+            return;
         }
+
+        {/literal}{if $form.frozen == false}{literal}
+        jQuery("input[name='contact_additive_inheritance']").removeAttr('disabled');
+        jQuery("input[name='cg_additive_inheritance']").removeAttr('disabled');
+        jQuery("#service_cs").removeAttr('disabled');
+        jQuery("#service_cgs").removeAttr('disabled');
+        {/literal}{/if}{literal}
     }
 
     bindInhertance();


### PR DESCRIPTION
## Description

Some inputs where still editable in read-only mode

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] 24.04.x
- [x] 24.10.x
- [x] 25.10.x
- [x] master
