### PR TITLE
Fix(Hosts): remove service only if it is exclusive to deleted host

### DIFF
--- a/centreon/src/Core/Host/Application/UseCase/DeleteHost/DeleteHost.php
+++ b/centreon/src/Core/Host/Application/UseCase/DeleteHost/DeleteHost.php
@@ -114,9 +114,10 @@ final class DeleteHost
         $this->storageEngine->startTransaction();
         $isVaultActive = $this->writeVaultRepository->isVaultConfigured();
         try {
-            $serviceIds = $this->readServiceRepository->findServiceIdsLinkedToHostId($host->getId());
+            // Only delete services that are exclusively linked to this host
+            $serviceIds = $this->readServiceRepository->findServiceIdsExclusivelyLinkedToHostId($host->getId());
             if ($serviceIds !== []) {
-                $this->info('Services to delete', ['user_id' => $this->contact->getId(), 'services' => $serviceIds]);
+                $this->info('Services to delete (exclusively linked to this host)', ['user_id' => $this->contact->getId(), 'services' => $serviceIds]);
                 if ($isVaultActive) {
                     $serviceUuids = $this->retrieveServiceUuidsFromVault($serviceIds);
                     $this->writeVaultRepository->setCustomPath(AbstractVaultRepository::SERVICE_VAULT_PATH);

--- a/centreon/src/Core/Service/Application/Repository/ReadServiceRepositoryInterface.php
+++ b/centreon/src/Core/Service/Application/Repository/ReadServiceRepositoryInterface.php
@@ -91,6 +91,19 @@ interface ReadServiceRepositoryInterface
     public function findServiceIdsLinkedToHostId(int $hostId): array;
 
     /**
+     * Find service IDs that are exclusively linked to the host.
+     * These are services that should be deleted when the host is deleted
+     * because they are not used by any other host.
+     *
+     * @param int $hostId Host ID for which to find exclusively linked services
+     *
+     * @throws \Throwable
+     *
+     * @return list<int>
+     */
+    public function findServiceIdsExclusivelyLinkedToHostId(int $hostId): array;
+
+    /**
      * Indicates whether the service name already exists.
      *
      * @param int $hostId

--- a/centreon/src/Core/Service/Infrastructure/Repository/ApiReadServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/ApiReadServiceRepository.php
@@ -83,6 +83,14 @@ class ApiReadServiceRepository implements ReadServiceRepositoryInterface
     /**
      * @inheritDoc
      */
+    public function findServiceIdsExclusivelyLinkedToHostId(int $hostId): array
+    {
+        throw RepositoryException::notYetImplemented();
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function findServiceNamesByHost(int $hostId): ?ServiceNamesByHost
     {
         throw RepositoryException::notYetImplemented();

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
@@ -285,13 +285,15 @@ class DbReadServiceRepository extends AbstractRepositoryRDB implements ReadServi
                 FROM `:db`.host_service_relation hsr
                 INNER JOIN `:db`.host h
                     ON h.host_id = hsr.host_host_id
+                INNER JOIN (
+                    SELECT service_service_id
+                    FROM `:db`.host_service_relation
+                    GROUP BY service_service_id
+                    HAVING COUNT(*) = 1
+                ) uniq
+                    ON uniq.service_service_id = hsr.service_service_id
                 WHERE hsr.host_host_id = :host_id
                     AND h.host_register = '1'
-                    AND (
-                        SELECT COUNT(*)
-                        FROM `:db`.host_service_relation hsr2
-                        WHERE hsr2.service_service_id = hsr.service_service_id
-                    ) = 1
                 SQL
         );
 

--- a/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
+++ b/centreon/src/Core/Service/Infrastructure/Repository/DbReadServiceRepository.php
@@ -277,6 +277,39 @@ class DbReadServiceRepository extends AbstractRepositoryRDB implements ReadServi
     /**
      * @inheritDoc
      */
+    public function findServiceIdsExclusivelyLinkedToHostId(int $hostId): array
+    {
+        $request = $this->translateDbName(
+            <<<'SQL'
+                SELECT hsr.service_service_id
+                FROM `:db`.host_service_relation hsr
+                INNER JOIN `:db`.host h
+                    ON h.host_id = hsr.host_host_id
+                WHERE hsr.host_host_id = :host_id
+                    AND h.host_register = '1'
+                    AND (
+                        SELECT COUNT(*)
+                        FROM `:db`.host_service_relation hsr2
+                        WHERE hsr2.service_service_id = hsr.service_service_id
+                    ) = 1
+                SQL
+        );
+
+        $statement = $this->db->prepare($request);
+        $statement->bindValue(':host_id', $hostId, \PDO::PARAM_INT);
+        $statement->execute();
+
+        $serviceIds = [];
+        while (($serviceId = $statement->fetchColumn()) !== false) {
+            $serviceIds[] = (int) $serviceId;
+        }
+
+        return $serviceIds;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function findServiceNamesByHost(int $hostId): ?ServiceNamesByHost
     {
         $request = $this->translateDbName(

--- a/centreon/tests/php/Core/Host/Application/UseCase/DeleteHost/DeleteHostTest.php
+++ b/centreon/tests/php/Core/Host/Application/UseCase/DeleteHost/DeleteHostTest.php
@@ -140,7 +140,7 @@ it('should present an ErrorResponse when an exception is thrown', function (): v
 
     $this->readServiceRepository
         ->expects($this->once())
-        ->method('findServiceIdsLinkedToHostId')
+        ->method('findServiceIdsExclusivelyLinkedToHostId')
         ->with($hostId)
         ->willThrowException(new Exception());
 
@@ -187,7 +187,7 @@ it('should present a NoContentResponse when the service template has been delete
 
     $this->readServiceRepository
         ->expects($this->once())
-        ->method('findServiceIdsLinkedToHostId')
+        ->method('findServiceIdsExclusivelyLinkedToHostId')
         ->with($hostId)
         ->willReturn($serviceIdsFound);
 


### PR DESCRIPTION
## Description

After the switch legacy to API for host deletion, if a host is deleted, all related services are deleted even if they are still used by other hosts.
This PR intends to fix this issue by deleting services that are exclusivly related to a host while deleting it (the host).

[MON-192654](https://centreon.atlassian.net/browse/MON-192654)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-192654]: https://centreon.atlassian.net/browse/MON-192654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ