### PR TITLE
feat(agent configuration): handle any certificate path

### DIFF
--- a/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Application\Validation;
 
+use Centreon\Domain\Common\Assertion\AssertionException;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\AgentConfiguration\Application\Exception\AgentConfigurationException;
 use Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration\AddAgentConfigurationRequest;
@@ -137,7 +138,7 @@ class CmaValidator implements TypeValidatorInterface
      * @param ?string $value
      * @param bool $isCertificate (default true)
      *
-     * @throws AgentConfigurationException
+     * @throws AssertionException
      */
     private function validateFilename(string $name, ?string $value, bool $isCertificate = true): void
     {
@@ -146,7 +147,9 @@ class CmaValidator implements TypeValidatorInterface
             : '/^(?!.*\.key$).+$/';
 
         if ($value !== null && preg_match($pattern, $value)) {
-            throw AgentConfigurationException::invalidFilename($name, (string) $value);
+            throw new AssertionException(
+                sprintf("File path or format '%s' (%s) is invalid", $value, $name)
+            );
         }
     }
 

--- a/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/CmaValidator.php
@@ -131,6 +131,8 @@ class CmaValidator implements TypeValidatorInterface
     }
 
     /**
+     * Validates filename extension.
+     *
      * @param string $name
      * @param ?string $value
      * @param bool $isCertificate (default true)
@@ -140,8 +142,8 @@ class CmaValidator implements TypeValidatorInterface
     private function validateFilename(string $name, ?string $value, bool $isCertificate = true): void
     {
         $pattern = $isCertificate
-            ? '/\.\/|\.\.\/|\/\/|^(?!.*\.(cer|crt)$).+$/'
-            : '/\.\/|\.\.\/|\/\/|^(?!.*\.key$).+$/';
+            ? '/^(?!.*\.(cer|crt)$).+$/'
+            : '/^(?!.*\.key$).+$/';
 
         if ($value !== null && preg_match($pattern, $value)) {
             throw AgentConfigurationException::invalidFilename($name, (string) $value);

--- a/centreon/src/Core/AgentConfiguration/Application/Validation/TelegrafValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/TelegrafValidator.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Application\Validation;
 
-use Core\AgentConfiguration\Application\Exception\AgentConfigurationException;
+use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration\AddAgentConfigurationRequest;
 use Core\AgentConfiguration\Application\UseCase\UpdateAgentConfiguration\UpdateAgentConfigurationRequest;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParameters\TelegrafConfigurationParameters;
@@ -53,11 +53,15 @@ class TelegrafValidator implements TypeValidatorInterface
             // validate file extension
             if (str_ends_with($key, '_certificate') && (is_string($value) || is_null($value))) {
                 if (preg_match('/^(?!.*\.(cer|crt)$).+$/', (string) $value) === 1) {
-                    throw AgentConfigurationException::invalidFilename("configuration.{$key}", (string) $value);
+                    throw new AssertionException(
+                        sprintf("File path or format '%s' (%s) is invalid", (string) $value, "configuration.{$key}")
+                    );
                 }
             } elseif (str_ends_with($key, '_key') && (is_string($value) || is_null($value))) {
                 if (preg_match('/^(?!.*\.key$).+$/', (string) $value) === 1) {
-                    throw AgentConfigurationException::invalidFilename("configuration.{$key}", (string) $value);
+                    throw new AssertionException(
+                        sprintf("File path or format '%s' (%s) is invalid", (string) $value, "configuration.{$key}")
+                    );
                 }
             }
         }

--- a/centreon/src/Core/AgentConfiguration/Application/Validation/TelegrafValidator.php
+++ b/centreon/src/Core/AgentConfiguration/Application/Validation/TelegrafValidator.php
@@ -50,12 +50,13 @@ class TelegrafValidator implements TypeValidatorInterface
         /** @var _TelegrafParameters $configuration */
         $configuration = $request->configuration;
         foreach ($configuration as $key => $value) {
+            // validate file extension
             if (str_ends_with($key, '_certificate') && (is_string($value) || is_null($value))) {
-                if (preg_match('/\.\/|\.\.\/|\/\/|^(?!.*\.(cer|crt)$).+$/', (string) $value) === 1) {
+                if (preg_match('/^(?!.*\.(cer|crt)$).+$/', (string) $value) === 1) {
                     throw AgentConfigurationException::invalidFilename("configuration.{$key}", (string) $value);
                 }
             } elseif (str_ends_with($key, '_key') && (is_string($value) || is_null($value))) {
-                if (preg_match('/\.\/|\.\.\/|\/\/|^(?!.*\.key$).+$/', (string) $value) === 1) {
+                if (preg_match('/^(?!.*\.key$).+$/', (string) $value) === 1) {
                     throw AgentConfigurationException::invalidFilename("configuration.{$key}", (string) $value);
                 }
             }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -56,20 +56,10 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
     public const DEFAULT_EXPORT_PERIOD = 60;
     public const CERTIFICATE_BASE_PATH = '/etc/pki/';
 
-    /** @var array<string> Forbidden base directories for certificates */
+    /** @var array<string> */
     private const FORBIDDEN_DIRECTORIES = [
-        '/tmp',
-        '/root',
-        '/proc',
-        '/mnt',
-        '/run',
-        '/snap',
-        '/sys',
-        '/boot',
+        '/tmp', '/root', '/proc', '/mnt', '/run', '/snap', '/sys', '/boot',
     ];
-
-    /** @var _CmaParameters */
-    private array $parameters;
 
     /**
      * @param array<string,mixed> $parameters
@@ -77,70 +67,60 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
      *
      * @throws AssertionException
      */
-    public function __construct(array $parameters, bool $fromReadRepository = false)
+    public function __construct(private array $parameters, private readonly bool $fromReadRepository = false)
     {
-        /** @var _CmaParameters $parameters */
-        $parameters = $this->normalizeCertificatePaths($parameters);
-
-        if ($parameters['agent_initiated'] === false) {
-            $parameters['otel_public_certificate'] = null;
-            $parameters['otel_private_key'] = null;
-            $parameters['otel_ca_certificate'] = null;
-            $parameters['tokens'] = [];
+        if ($this->parameters['agent_initiated'] === false) {
+            $this->parameters['otel_public_certificate'] = null;
+            $this->parameters['otel_private_key'] = null;
+            $this->parameters['otel_ca_certificate'] = null;
+            $this->parameters['tokens'] = [];
         } else {
-            $this->validateOptionalCertificate(
-                $parameters['otel_public_certificate'],
+            $this->parameters['otel_public_certificate'] = $this->validateCertificatePath(
+                $this->parameters['otel_public_certificate'],
                 'configuration.otel_public_certificate'
             );
-            $this->validateOptionalCertificate(
-                $parameters['otel_private_key'],
+            $this->parameters['otel_private_key'] = $this->validateCertificatePath(
+                $this->parameters['otel_private_key'],
                 'configuration.otel_private_key'
             );
-            $this->validateOptionalCertificate(
-                $parameters['otel_ca_certificate'],
+            $this->parameters['otel_ca_certificate'] = $this->validateCertificatePath(
+                $this->parameters['otel_ca_certificate'],
                 'configuration.otel_ca_certificate'
             );
 
             // $fromReadRepository allow configurations created before tokens was mandatoryto be read even without tokens
-            if (! $fromReadRepository) {
-                Assertion::notEmpty($parameters['tokens'], 'configuration.tokens');
-                foreach ($parameters['tokens'] as $token) {
+            if (! $this->fromReadRepository) {
+                Assertion::notEmpty($this->parameters['tokens'], 'configuration.tokens');
+                foreach ($this->parameters['tokens'] as $token) {
                     Assertion::notEmptyString($token['name']);
                 }
             }
-            if (! isset($parameters['port'])) {
-                $parameters['port'] = AgentConfiguration::DEFAULT_PORT;
+            if (! isset($this->parameters['port'])) {
+                $this->parameters['port'] = AgentConfiguration::DEFAULT_PORT;
             }
-            Assertion::range($parameters['port'] ?? AgentConfiguration::DEFAULT_PORT, 0, 65535, 'configuration.port');
+            Assertion::range($this->parameters['port'] ?? AgentConfiguration::DEFAULT_PORT, 0, 65535, 'configuration.port');
         }
 
-        if ($parameters['poller_initiated'] === false) {
-            $parameters['hosts'] = [];
+        if ($this->parameters['poller_initiated'] === false) {
+            $this->parameters['hosts'] = [];
         } else {
-            foreach ($parameters['hosts'] as $host) {
+            foreach ($this->parameters['hosts'] as $key => $host) {
                 Assertion::positiveInt($host['id'], 'configuration.hosts[].id');
                 Assertion::ipOrDomain($host['address'], 'configuration.hosts[].address');
                 Assertion::range($host['port'], 0, 65535, 'configuration.hosts[].port');
-                $this->validateOptionalCertificate(
+                $this->parameters['hosts'][$key]['poller_ca_certificate'] = $this->validateCertificatePath(
                     $host['poller_ca_certificate'],
                     'configuration.hosts[].poller_ca_certificate'
                 );
-                $this->validateOptionalCertificate(
-                    $host['poller_ca_name'],
-                    'configuration.hosts[].poller_ca_name'
-                );
 
                 // $fromReadRepository allow configurations created before tokens was mandatoryto be read even without tokens
-                if (! $fromReadRepository) {
+                if (! $this->fromReadRepository) {
                     Assertion::notNull($host['token'], 'configuration.hosts[].token');
                     Assertion::notEmptyString($host['token']['name'] ?? '');
                     Assertion::positiveInt($host['token']['creator_id'] ?? 0);
                 }
             }
         }
-
-        /** @var _CmaParameters $parameters */
-        $this->parameters = $parameters;
     }
 
     /**
@@ -150,6 +130,7 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
      */
     public function getData(): array
     {
+        /** @var _CmaParameters */
         return $this->parameters;
     }
 
@@ -161,73 +142,33 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
         return self::BROKER_MODULE_DIRECTIVE;
     }
 
-    /**
-     * Normalizes the certificate paths in the given parameters array.
-     *
-     * @param array<string,mixed> $parameters
-     *
-     * @return array<string, mixed>
-     */
-    private function normalizeCertificatePaths(array $parameters): array
+    private function validateCertificatePath(?string $path, string $field): ?string
     {
-        foreach ($parameters as $key => $value) {
-            if (
-                (
-                    str_ends_with($key, '_certificate')
-                    || str_ends_with($key, '_key')
-                )
-                && (is_string($value) || is_null($value))
-            ) {
-                $parameters[$key] = $this->prependPrefix($value);
-            }
-
-            if ($key === 'hosts' && is_array($value)) {
-                foreach ($value as $hostIndex => $host) {
-                    if (isset($host['poller_ca_certificate']) && is_string($host['poller_ca_certificate'])) {
-                        $parameters[$key][$hostIndex]['poller_ca_certificate'] = $this->prependPrefix(
-                            $host['poller_ca_certificate']
-                        );
-                    }
-                }
-            }
+        if ($path === null || $path === '') {
+            return null;
         }
 
-        return $parameters;
+        $this->assertPathSecurity($path, $field);
+        $normalizedPath = $this->prependPrefix($path);
+        Assertion::maxLength($normalizedPath, self::MAX_LENGTH, $field);
+
+        return $normalizedPath;
     }
 
     /**
      * Prepends a prefix to a certificate path if it's a relative path.
      *
-     * @param ?string $path
+     * @param string $path
      *
-     * @return ?string
+     * @return string
      */
-    private function prependPrefix(?string $path): ?string
+    private function prependPrefix(string $path): string
     {
-        if ($path === null || $path === '') {
+        if (str_starts_with($path, '/')) {
             return $path;
         }
 
-        // Prepend the default certificate base path
-        return str_starts_with($path, '/')
-            ? $path
-            : self::CERTIFICATE_BASE_PATH . ltrim($path, '/');
-    }
-
-    /**
-     * Validates an optional certificate.
-     *
-     * @param ?string $certificate
-     * @param string $field Used for error reporting
-     *
-     * @throws AssertionException
-     */
-    private function validateOptionalCertificate(?string $certificate, string $field): void
-    {
-        if ($certificate !== null && $certificate !== '') {
-            Assertion::maxLength($certificate, self::MAX_LENGTH, $field);
-            $this->validateCertificatePath($certificate, $field);
-        }
+        return self::CERTIFICATE_BASE_PATH . ltrim($path, '/');
     }
 
     /**
@@ -238,7 +179,7 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
      *
      * @throws AssertionException
      */
-    private function validateCertificatePath(string $path, string $field): void
+    private function assertPathSecurity(string $path, string $field): void
     {
         // Reject relative paths
         if (

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/CmaConfigurationParameters.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Domain\Model\ConfigurationParameters;
 
-use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
+use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Domain\Model\AgentConfiguration;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParametersInterface;
 
@@ -56,6 +56,18 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
     public const DEFAULT_EXPORT_PERIOD = 60;
     public const CERTIFICATE_BASE_PATH = '/etc/pki/';
 
+    /** @var array<string> Forbidden base directories for certificates */
+    private const FORBIDDEN_DIRECTORIES = [
+        '/tmp',
+        '/root',
+        '/proc',
+        '/mnt',
+        '/run',
+        '/snap',
+        '/sys',
+        '/boot',
+    ];
+
     /** @var _CmaParameters */
     private array $parameters;
 
@@ -63,7 +75,7 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
      * @param array<string,mixed> $parameters
      * @param bool $fromReadRepository
      *
-     * @throws AssertionFailedException
+     * @throws AssertionException
      */
     public function __construct(array $parameters, bool $fromReadRepository = false)
     {
@@ -184,7 +196,7 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
     }
 
     /**
-     * Prepends a prefix to a certificate path.
+     * Prepends a prefix to a certificate path if it's a relative path.
      *
      * @param ?string $path
      *
@@ -196,7 +208,8 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
             return $path;
         }
 
-        return str_starts_with($path, self::CERTIFICATE_BASE_PATH)
+        // Prepend the default certificate base path
+        return str_starts_with($path, '/')
             ? $path
             : self::CERTIFICATE_BASE_PATH . ltrim($path, '/');
     }
@@ -207,12 +220,62 @@ class CmaConfigurationParameters implements ConfigurationParametersInterface
      * @param ?string $certificate
      * @param string $field Used for error reporting
      *
-     * @throws AssertionFailedException
+     * @throws AssertionException
      */
     private function validateOptionalCertificate(?string $certificate, string $field): void
     {
         if ($certificate !== null && $certificate !== '') {
             Assertion::maxLength($certificate, self::MAX_LENGTH, $field);
+            $this->validateCertificatePath($certificate, $field);
+        }
+    }
+
+    /**
+     * Validates that a certificate path is safe and not in a forbidden directory.
+     *
+     * @param string $path
+     * @param string $field Used for error reporting
+     *
+     * @throws AssertionException
+     */
+    private function validateCertificatePath(string $path, string $field): void
+    {
+        // Reject relative paths
+        if (
+            str_contains($path, '../')
+            || str_contains($path, '//')
+            || str_contains($path, './')
+            || $path === '.'
+            || $path === '..'
+        ) {
+            throw new AssertionException(
+                sprintf('[%s] The path "%s" contains invalid relative path patterns', $field, $path),
+            );
+        }
+
+        // Reject hidden directories
+        if (preg_match('#/\\.#', $path) || (str_starts_with($path, '.') && ! str_starts_with($path, './'))) {
+            throw new AssertionException(
+                sprintf('[%s] The path "%s" cannot be in a hidden directory', $field, $path),
+            );
+        }
+
+        // Reject forbidden directories
+        foreach (self::FORBIDDEN_DIRECTORIES as $forbiddenDirectory) {
+            if (str_starts_with($path, $forbiddenDirectory . '/') || $path === $forbiddenDirectory) {
+                throw new AssertionException(
+                    sprintf('[%s] The path "%s" cannot be in directory %s', $field, $path, $forbiddenDirectory),
+                );
+            }
+        }
+
+        // Reject forbidden directories : /etc but not /etc/pki
+        if (str_starts_with($path, '/etc/')) {
+            if (! str_starts_with($path, '/etc/pki/') && $path !== '/etc/pki') {
+                throw new AssertionException(
+                    sprintf('[%s] The path "%s" can only be in /etc/pki/ directory', $field, $path),
+                );
+            }
         }
     }
 }

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
@@ -44,44 +44,40 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
     public const MAX_LENGTH = 255;
     public const CERTIFICATE_BASE_PATH = '/etc/pki/';
 
-    /** @var array<string> Forbidden base directories for certificates */
+    /** @var array<string> */
     private const FORBIDDEN_DIRECTORIES = [
-        '/tmp',
-        '/root',
-        '/proc',
-        '/mnt',
-        '/run',
-        '/snap',
-        '/sys',
-        '/boot',
+        '/tmp', '/root', '/proc', '/mnt', '/run', '/snap', '/sys', '/boot',
     ];
-
-    /** @var _TelegrafParameters */
-    private array $parameters;
 
     /**
      * @param array<string,mixed> $parameters
      *
      * @throws AssertionException
      */
-    public function __construct(array $parameters)
+    public function __construct(private array $parameters)
     {
-        /** @var _TelegrafParameters $parameters */
-        $parameters = $this->normalizeCertificatePaths($parameters);
+        Assertion::range($this->parameters['conf_server_port'], 0, 65535, 'configuration.conf_server_port');
 
-        Assertion::range($parameters['conf_server_port'], 0, 65535, 'configuration.conf_server_port');
-
-        $this->validateOptionalCertificate(
-            $parameters['otel_public_certificate'],
+        $this->parameters['otel_public_certificate'] = $this->validateCertificatePath(
+            $this->parameters['otel_public_certificate'],
             'configuration.otel_public_certificate'
         );
-        $this->validateOptionalCertificate($parameters['otel_private_key'], 'configuration.otel_private_key');
-        $this->validateOptionalCertificate($parameters['conf_certificate'], 'configuration.conf_certificate');
-        $this->validateOptionalCertificate($parameters['conf_private_key'], 'configuration.conf_private_key');
-        $this->validateOptionalCertificate($parameters['otel_ca_certificate'], 'configuration.otel_ca_certificate');
-
-        /** @var _TelegrafParameters $parameters */
-        $this->parameters = $parameters;
+        $this->parameters['otel_private_key'] = $this->validateCertificatePath(
+            $this->parameters['otel_private_key'],
+            'configuration.otel_private_key'
+        );
+        $this->parameters['conf_certificate'] = $this->validateCertificatePath(
+            $this->parameters['conf_certificate'],
+            'configuration.conf_certificate'
+        );
+        $this->parameters['conf_private_key'] = $this->validateCertificatePath(
+            $this->parameters['conf_private_key'],
+            'configuration.conf_private_key'
+        );
+        $this->parameters['otel_ca_certificate'] = $this->validateCertificatePath(
+            $this->parameters['otel_ca_certificate'],
+            'configuration.otel_ca_certificate'
+        );
     }
 
     /**
@@ -91,6 +87,7 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
      */
     public function getData(): array
     {
+        /** @var _TelegrafParameters */
         return $this->parameters;
     }
 
@@ -100,64 +97,32 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
     }
 
     /**
-     * Normalizes the certificate paths in the given parameters array.
-     *
-     * @param array<string,mixed> $parameters
-     *
-     * @return array<string, mixed>
-     */
-    private function normalizeCertificatePaths(array $parameters): array
-    {
-        foreach ($parameters as $key => $value) {
-            if (
-                (
-                    str_ends_with($key, '_certificate')
-                    || str_ends_with($key, '_key')
-                )
-                && (is_string($value) || is_null($value))
-            ) {
-                $parameters[$key] = $this->prependPrefix($value);
-            }
-        }
-
-        return $parameters;
-    }
-
-    /**
      * Prepends a prefix to a certificate path if it's a relative path.
-     * Absolute paths are kept as-is to allow custom directories.
      *
-     * @param ?string $path
+     * @param string $path
      *
-     * @return ?string
+     * @return string
      */
-    private function prependPrefix(?string $path): ?string
+    private function prependPrefix(string $path): string
     {
-        if ($path === null || $path === '') {
+        if (str_starts_with($path, '/')) {
             return $path;
         }
 
-        // If path starts with '/', it's an absolute path - keep it as-is
-        // Otherwise, prepend the default certificate base path
-        return str_starts_with($path, '/')
-            ? $path
-            : self::CERTIFICATE_BASE_PATH . ltrim($path, '/');
+        return self::CERTIFICATE_BASE_PATH . ltrim($path, '/');
     }
 
-    /**
-     * Validates an optional certificate.
-     *
-     * @param ?string $certificate
-     * @param string $field
-     *
-     * @throws AssertionException
-     */
-    private function validateOptionalCertificate(?string $certificate, string $field): void
+    private function validateCertificatePath(?string $path, string $field): ?string
     {
-        if ($certificate !== null && $certificate !== '') {
-            Assertion::maxLength($certificate, self::MAX_LENGTH, $field);
-            $this->validateCertificatePath($certificate, $field);
+        if ($path === null || $path === '') {
+            return null;
         }
+
+        $this->assertPathSecurity($path, $field);
+        $normalizedPath = $this->prependPrefix($path);
+        Assertion::maxLength($normalizedPath, self::MAX_LENGTH, $field);
+
+        return $normalizedPath;
     }
 
     /**
@@ -168,7 +133,7 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
      *
      * @throws AssertionException
      */
-    private function validateCertificatePath(string $path, string $field): void
+    private function assertPathSecurity(string $path, string $field): void
     {
         // Reject relative path patterns
         if (
@@ -183,23 +148,23 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
             );
         }
 
-        // Reject ALL hidden directories (no exceptions - user must use /etc/pki not /etc/.pki)
+        // Reject hidden directories
         if (preg_match('#/\\.#', $path) || (str_starts_with($path, '.') && ! str_starts_with($path, './'))) {
             throw new AssertionException(
                 sprintf('[%s] The path "%s" cannot be in a hidden directory', $field, $path),
             );
         }
 
-        // Check forbidden directories
-        foreach (self::FORBIDDEN_DIRECTORIES as $forbiddenDir) {
-            if (str_starts_with($path, $forbiddenDir . '/') || $path === $forbiddenDir) {
+        // Reject forbidden directories
+        foreach (self::FORBIDDEN_DIRECTORIES as $forbiddenDirectory) {
+            if (str_starts_with($path, $forbiddenDirectory . '/') || $path === $forbiddenDirectory) {
                 throw new AssertionException(
-                    sprintf('[%s] The path "%s" cannot be in directory %s', $field, $path, $forbiddenDir),
+                    sprintf('[%s] The path "%s" cannot be in directory %s', $field, $path, $forbiddenDirectory),
                 );
             }
         }
 
-        // Special handling for /etc: only /etc/pki/** is allowed
+        // Reject forbidden directories : /etc but not /etc/pki
         if (str_starts_with($path, '/etc/')) {
             if (! str_starts_with($path, '/etc/pki/') && $path !== '/etc/pki') {
                 throw new AssertionException(

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
@@ -166,7 +166,7 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
 
         // Reject forbidden directories : /etc but not /etc/pki
         if (str_starts_with($path, '/etc/')) {
-            if (! str_starts_with($path, '/etc/pki/') && $path !== '/etc/pki') {
+            if (! str_starts_with($path, self::CERTIFICATE_BASE_PATH) && $path !== '/etc/pki') {
                 throw new AssertionException(
                     sprintf('[%s] The path "%s" can only be in /etc/pki/ directory', $field, $path),
                 );

--- a/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
+++ b/centreon/src/Core/AgentConfiguration/Domain/Model/ConfigurationParameters/TelegrafConfigurationParameters.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 namespace Core\AgentConfiguration\Domain\Model\ConfigurationParameters;
 
-use Assert\AssertionFailedException;
 use Centreon\Domain\Common\Assertion\Assertion;
+use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Domain\Model\ConfigurationParametersInterface;
 
 /**
@@ -44,13 +44,25 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
     public const MAX_LENGTH = 255;
     public const CERTIFICATE_BASE_PATH = '/etc/pki/';
 
+    /** @var array<string> Forbidden base directories for certificates */
+    private const FORBIDDEN_DIRECTORIES = [
+        '/tmp',
+        '/root',
+        '/proc',
+        '/mnt',
+        '/run',
+        '/snap',
+        '/sys',
+        '/boot',
+    ];
+
     /** @var _TelegrafParameters */
     private array $parameters;
 
     /**
      * @param array<string,mixed> $parameters
      *
-     * @throws AssertionFailedException
+     * @throws AssertionException
      */
     public function __construct(array $parameters)
     {
@@ -112,7 +124,8 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
     }
 
     /**
-     * Prepends a prefix to a certificate path.
+     * Prepends a prefix to a certificate path if it's a relative path.
+     * Absolute paths are kept as-is to allow custom directories.
      *
      * @param ?string $path
      *
@@ -124,7 +137,9 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
             return $path;
         }
 
-        return str_starts_with($path, self::CERTIFICATE_BASE_PATH)
+        // If path starts with '/', it's an absolute path - keep it as-is
+        // Otherwise, prepend the default certificate base path
+        return str_starts_with($path, '/')
             ? $path
             : self::CERTIFICATE_BASE_PATH . ltrim($path, '/');
     }
@@ -135,12 +150,62 @@ class TelegrafConfigurationParameters implements ConfigurationParametersInterfac
      * @param ?string $certificate
      * @param string $field
      *
-     * @throws AssertionFailedException
+     * @throws AssertionException
      */
     private function validateOptionalCertificate(?string $certificate, string $field): void
     {
         if ($certificate !== null && $certificate !== '') {
             Assertion::maxLength($certificate, self::MAX_LENGTH, $field);
+            $this->validateCertificatePath($certificate, $field);
+        }
+    }
+
+    /**
+     * Validates that a certificate path is safe and not in a forbidden directory.
+     *
+     * @param string $path
+     * @param string $field Used for error reporting
+     *
+     * @throws AssertionException
+     */
+    private function validateCertificatePath(string $path, string $field): void
+    {
+        // Reject relative path patterns
+        if (
+            str_contains($path, '../')
+            || str_contains($path, '//')
+            || str_contains($path, './')
+            || $path === '.'
+            || $path === '..'
+        ) {
+            throw new AssertionException(
+                sprintf('[%s] The path "%s" contains invalid relative path patterns', $field, $path),
+            );
+        }
+
+        // Reject ALL hidden directories (no exceptions - user must use /etc/pki not /etc/.pki)
+        if (preg_match('#/\\.#', $path) || (str_starts_with($path, '.') && ! str_starts_with($path, './'))) {
+            throw new AssertionException(
+                sprintf('[%s] The path "%s" cannot be in a hidden directory', $field, $path),
+            );
+        }
+
+        // Check forbidden directories
+        foreach (self::FORBIDDEN_DIRECTORIES as $forbiddenDir) {
+            if (str_starts_with($path, $forbiddenDir . '/') || $path === $forbiddenDir) {
+                throw new AssertionException(
+                    sprintf('[%s] The path "%s" cannot be in directory %s', $field, $path, $forbiddenDir),
+                );
+            }
+        }
+
+        // Special handling for /etc: only /etc/pki/** is allowed
+        if (str_starts_with($path, '/etc/')) {
+            if (! str_starts_with($path, '/etc/pki/') && $path !== '/etc/pki') {
+                throw new AssertionException(
+                    sprintf('[%s] The path "%s" can only be in /etc/pki/ directory', $field, $path),
+                );
+            }
         }
     }
 }

--- a/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
@@ -100,9 +100,6 @@ it('should correctly identify that it does not handle other types', function ():
 foreach (
     [
         'invalidfilename',
-        './fileName.crt',
-        '../fileName.cer',
-        '//fileName.crt',
         '/etc/pki/test.txt',
         '/etc/pki/test.doc',
     ] as $index => $filename
@@ -138,9 +135,6 @@ foreach (
 foreach (
     [
         'invalidfilename',
-        './fileName.key',
-        '../fileName.key',
-        '//fileName.key',
         '/etc/pki/test.txt',
         '/etc/pki/test.doc',
     ] as $index => $filename

--- a/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/CmaValidatorTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace Tests\Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration;
 
+use Centreon\Domain\Common\Assertion\AssertionException;
 use Centreon\Domain\Contact\Interfaces\ContactInterface;
 use Core\AgentConfiguration\Application\Exception\AgentConfigurationException;
 use Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration\AddAgentConfigurationRequest;
@@ -108,7 +109,7 @@ foreach (
     it("Invalid certificate filename #{$index}: should throw an exception because of the filename for certificate {$cleanFilename} invalidity", function () use ($filename): void {
         $this->request->configuration['agent_initiated'] = true;
         $this->request->configuration['otel_ca_certificate'] = $filename;
-        $this->expectException(AgentConfigurationException::class);
+        $this->expectException(AssertionException::class);
         $this->cmaValidator->validateParametersOrFail($this->request);
     });
 }
@@ -143,7 +144,7 @@ foreach (
     it("Invalid key filename #{$index}: should throw an exception because of the filename for key {$cleanFilename} invalidity", function () use ($filename): void {
         $this->request->configuration['agent_initiated'] = true;
         $this->request->configuration['otel_private_key'] = $filename;
-        $this->expectException(AgentConfigurationException::class);
+        $this->expectException(AssertionException::class);
         $this->cmaValidator->validateParametersOrFail($this->request);
     });
 }

--- a/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/TelegrafValidatorTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/TelegrafValidatorTest.php
@@ -54,9 +54,6 @@ it('should correctly identify that it does not handle other types', function ():
 foreach (
     [
         'invalidfilename',
-        './fileName.crt',
-        '../fileName.cer',
-        '//fileName.crt',
         '/etc/pki/test.txt',
         '/etc/pki/test.doc',
     ] as $index => $filename
@@ -87,9 +84,6 @@ foreach (
 foreach (
     [
         'invalidfilename',
-        './fileName.key',
-        '../fileName.key',
-        '//fileName.key',
         '/etc/pki/test.txt',
         '/etc/pki/test.doc',
     ] as $index => $filename

--- a/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/TelegrafValidatorTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Application/UseCase/AddAgentConfiguration/TelegrafValidatorTest.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace Tests\Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration;
 
-use Core\AgentConfiguration\Application\Exception\AgentConfigurationException;
+use Centreon\Domain\Common\Assertion\AssertionException;
 use Core\AgentConfiguration\Application\UseCase\AddAgentConfiguration\AddAgentConfigurationRequest;
 use Core\AgentConfiguration\Application\Validation\TelegrafValidator;
 use Core\AgentConfiguration\Domain\Model\Poller;
@@ -61,7 +61,7 @@ foreach (
     $cleanFilename = str_replace(['/', '.', '..'], '-', $filename);
     it("Invalid certificate {$cleanFilename} #{$index}: should throw an exception because of the filename for certificate {$cleanFilename} invalidity", function () use ($filename): void {
         $this->request->configuration['conf_certificate'] = $filename;
-        $this->expectException(AgentConfigurationException::class);
+        $this->expectException(AssertionException::class);
         $this->TelegrafValidator->validateParametersOrFail($this->request);
     });
 }
@@ -91,7 +91,7 @@ foreach (
     $cleanFilename = str_replace(['/', '.', '..'], '-', $filename);
     it("Invalid key {$cleanFilename} #{$index}: should throw an exception because of the filename for key {$cleanFilename} invalidity", function () use ($filename): void {
         $this->request->configuration['conf_private_key'] = $filename;
-        $this->expectException(AgentConfigurationException::class);
+        $this->expectException(AssertionException::class);
         $this->TelegrafValidator->validateParametersOrFail($this->request);
     });
 }

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/CmaConfigurationParametersTest.php
@@ -163,3 +163,40 @@ it('should empty the related properties when poller_initiated is false', functio
     $result = $cmaConfig->getData();
     $this->assertEquals($result['hosts'], []);
 });
+
+// Path security validation tests
+foreach (
+    [
+        '../cert.crt' => 'relative path with ../',
+        './cert.crt' => 'relative path with ./',
+        'path//cert.crt' => 'double slashes',
+        '.hidden/cert.crt' => 'hidden directory',
+        '/.ssh/cert.crt' => 'hidden directory in root',
+        '/tmp/cert.crt' => 'forbidden directory /tmp',
+        '/root/cert.crt' => 'forbidden directory /root',
+        '/proc/cert.crt' => 'forbidden directory /proc',
+        '/etc/ssl/cert.crt' => '/etc subdirectory other than /etc/pki',
+    ] as $path => $reason
+) {
+    it("should throw an exception for {$reason}: {$path}", function () use ($path): void {
+        $this->parameters['otel_public_certificate'] = $path;
+        new CmaConfigurationParameters($this->parameters);
+    })->throws(AssertionException::class);
+}
+
+// Valid custom paths
+foreach (
+    [
+        '/usr/local/certs/cert.crt',
+        '/opt/ssl/cert.crt',
+        '/etc/pki/cert.crt',
+        '/etc/pki/subdir/cert.crt',
+    ] as $path
+) {
+    it("should accept valid custom path: {$path}", function () use ($path): void {
+        $this->parameters['otel_public_certificate'] = $path;
+        $cmaConfig = new CmaConfigurationParameters($this->parameters);
+        $result = $cmaConfig->getData();
+        $this->assertEquals($result['otel_public_certificate'], $path);
+    });
+}

--- a/centreon/tests/php/Core/AgentConfiguration/Domain/Model/TelegrafConfigurationParametersTest.php
+++ b/centreon/tests/php/Core/AgentConfiguration/Domain/Model/TelegrafConfigurationParametersTest.php
@@ -130,3 +130,40 @@ foreach (
         }
     );
 }
+
+// Path security validation tests
+foreach (
+    [
+        '../cert.crt' => 'relative path with ../',
+        './cert.crt' => 'relative path with ./',
+        'path//cert.crt' => 'double slashes',
+        '.hidden/cert.crt' => 'hidden directory',
+        '/.ssh/cert.crt' => 'hidden directory in root',
+        '/tmp/cert.crt' => 'forbidden directory /tmp',
+        '/root/cert.crt' => 'forbidden directory /root',
+        '/proc/cert.crt' => 'forbidden directory /proc',
+        '/etc/ssl/cert.crt' => '/etc subdirectory other than /etc/pki',
+    ] as $path => $reason
+) {
+    it("should throw an exception for {$reason}: {$path}", function () use ($path): void {
+        $this->parameters['otel_public_certificate'] = $path;
+        new TelegrafConfigurationParameters($this->parameters);
+    })->throws(AssertionException::class);
+}
+
+// Valid custom paths
+foreach (
+    [
+        '/usr/local/certs/cert.crt',
+        '/opt/ssl/cert.crt',
+        '/etc/pki/cert.crt',
+        '/etc/pki/subdir/cert.crt',
+    ] as $path
+) {
+    it("should accept valid custom path: {$path}", function () use ($path): void {
+        $this->parameters['otel_public_certificate'] = $path;
+        $telegrafConfig = new TelegrafConfigurationParameters($this->parameters);
+        $result = $telegrafConfig->getData();
+        $this->assertEquals($result['otel_public_certificate'], $path);
+    });
+}


### PR DESCRIPTION
## Description

This PR intentds to allow custom certificate paths for agent configuration with enhanced validation, it is now possible to specify custom certificate locations while relative paths still default to /etc/pki/.

[MON-186021](https://centreon.atlassian.net/browse/MON-186021)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

call `POST` or `PUT` update agent configuratoin endpoints with different certificate paths.
`configuration/agent-configurations`

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-186021]: https://centreon.atlassian.net/browse/MON-186021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ