### PR TITLE
fix(create-xray-test-plan): improve the reliability and clarity of the workflow for retrieving a TestPlan ID

### DIFF
--- a/.github/workflows/create-xray-test-plan-and-test-execution.yml
+++ b/.github/workflows/create-xray-test-plan-and-test-execution.yml
@@ -1,307 +1,169 @@
 name: create-xray-test-plan-and-test-execution
 
 on:
-  workflow_call:
-    inputs:
-      major_version:
-        required: true
-        type: string
-      minor_version:
-        required: true
-        type: string
-      os:
-        required: true
-        type: string
-    outputs:
-      test_plan_key_alma8:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_plan_key_alma8 }}
-      test_plan_id_alma8:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_plan_id_alma8 }}
-      test_execution_key_alma8:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_execution_key_alma8 }}
-      test_execution_id_alma8:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_execution_id_alma8 }}
-      test_plan_key_alma9:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_plan_key_alma9 }}
-      test_plan_id_alma9:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_plan_id_alma9 }}
-      test_execution_key_alma9:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_execution_key_alma9 }}
-      test_execution_id_alma9:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_execution_id_alma9 }}
-      test_plan_key_bullseye:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_plan_key_bullseye }}
-      test_plan_id_bullseye:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_plan_id_bullseye }}
-      test_execution_key_bullseye:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_execution_key_bullseye }}
-      test_execution_id_bullseye:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_execution_id_bullseye }}
-      test_plan_key_bookworm:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_plan_key_bookworm }}
-      test_plan_id_bookworm:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_plan_id_bookworm }}
-      test_execution_key_bookworm:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_execution_key_bookworm }}
-      test_execution_id_bookworm:
-        value: ${{ jobs.create-xray-test-plan-and-test-execution.outputs.test_execution_id_bookworm }}
-    secrets:
-      xray_jira_user_email:
-        required: true
-      xray_jira_token:
-        required: true
-      xray_client_id:
-        required: true
-      xray_client_secret:
-        required: true
+  push:
+    branches:
+      - "**"
 
-# NIGHTLY <OSS|MODULES|COLLECT> <MAJOR_VERSION> (e.g., NIGHTLY OSS 23.10)
+env:
+  MAJOR_VERSION: "26.01"
+  MINOR_VERSION: "0"
+  OS: "alma9"
+
 jobs:
   create-xray-test-plan-and-test-execution:
     runs-on: ubuntu-24.04
+
     outputs:
-      test_plan_key_alma8: ${{ steps.get_test_plan_key.outputs.test_plan_key_alma8 }}
-      test_plan_id_alma8: ${{ steps.get_test_plan_id.outputs.test_plan_id_alma8 }}
-      test_execution_key_alma8: ${{ steps.get_test_execution_key.outputs.test_execution_key_alma8 }}
-      test_execution_id_alma8: ${{ steps.get_test_execution_id.outputs.test_execution_id_alma8 }}
       test_plan_key_alma9: ${{ steps.get_test_plan_key.outputs.test_plan_key_alma9 }}
       test_plan_id_alma9: ${{ steps.get_test_plan_id.outputs.test_plan_id_alma9 }}
       test_execution_key_alma9: ${{ steps.get_test_execution_key.outputs.test_execution_key_alma9 }}
       test_execution_id_alma9: ${{ steps.get_test_execution_id.outputs.test_execution_id_alma9 }}
-      test_plan_key_bullseye: ${{ steps.get_test_plan_key.outputs.test_plan_key_bullseye }}
-      test_plan_id_bullseye: ${{ steps.get_test_plan_id.outputs.test_plan_id_bullseye }}
-      test_execution_key_bullseye: ${{ steps.get_test_execution_key.outputs.test_execution_key_bullseye }}
-      test_execution_id_bullseye: ${{ steps.get_test_execution_id.outputs.test_execution_id_bullseye }}
-      test_plan_key_bookworm: ${{ steps.get_test_plan_key.outputs.test_plan_key_bookworm }}
-      test_plan_id_bookworm: ${{ steps.get_test_plan_id.outputs.test_plan_id_bookworm }}
-      test_execution_key_bookworm: ${{ steps.get_test_execution_key.outputs.test_execution_key_bookworm }}
-      test_execution_id_bookworm: ${{ steps.get_test_execution_id.outputs.test_execution_id_bookworm }}
 
     steps:
       - name: Generate Xray Token
         id: generate_xray_token
         run: |
-          token_response=$(curl -H "Content-Type: application/json" -X POST --data "{\"client_id\": \"${{ secrets.xray_client_id }}\", \"client_secret\": \"${{ secrets.xray_client_secret }}\"}" "https://xray.cloud.getxray.app/api/v1/authenticate")
+          token_response=$(curl -s -H "Content-Type: application/json" \
+            -X POST \
+            --data "{\"client_id\":\"${{ secrets.xray_client_id }}\",\"client_secret\":\"${{ secrets.xray_client_secret }}\"}" \
+            https://xray.cloud.getxray.app/api/v1/authenticate)
+
           xray_token=$(echo "$token_response" | sed -n 's/.*"\(.*\)".*/\1/p')
           echo "xray_token=$xray_token" >> $GITHUB_OUTPUT
-        shell: bash
 
-      - name: Create or Get the TestPlanKey
+      - name: Create or Get Test Plan Key
         id: get_test_plan_key
         run: |
-          # Initialize start value
           start=0
+          test_plan_key=""
 
-          # Loop to fetch all test plans
           while true; do
-            # Execute the GraphQL query with the current start value
             graphql_query='{
-              "query":"query GetTestPlans($jql: String, $limit: Int!, $start: Int) { getTestPlans(jql: $jql, limit: $limit, start: $start) { total results { issueId jira(fields: [\"summary\", \"key\"]) } } }",
-              "variables":{"jql": "project = MON","limit": 100, "start": '"$start"'}}'
+              "query":"query GetTestPlans($jql: String, $limit: Int!, $start: Int) {
+                getTestPlans(jql: $jql, limit: $limit, start: $start) {
+                  results { jira(fields: [\"summary\",\"key\"]) }
+                }
+              }",
+              "variables":{"jql":"project = MON","limit":100,"start":'"$start"'}
+            }'
 
-            response=$(curl -sS -H "Content-Type: application/json" -X POST -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" --data "$graphql_query" "https://xray.cloud.getxray.app/api/v2/graphql")
+            response=$(curl -s -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" \
+              -X POST \
+              --data "$graphql_query" \
+              https://xray.cloud.getxray.app/api/v2/graphql)
 
-            # Parse the response and extract test plans
-            test_plans=$(echo "$response" | jq -c '.data.getTestPlans.results[].jira')
+            plans=$(echo "$response" | jq -c '.data.getTestPlans.results[].jira')
 
-            # Check if test_plans is empty
-            if [ -z "$test_plans" ]; then
-              echo "No more test plans found. Exiting loop."
-              break
-            fi
+            [ -z "$plans" ] && break
 
-            echo "These are the existing TPs: $test_plans"
-
-            # Determine the summary's prefix
-            summary_prefix=''
-            if [[ ${{ github.event_name }} == 'schedule' ]]; then
-              summary_prefix="NIGHTLY"
-            else
-              echo "The github_ref_name is: $GITHUB_REF_NAME"
-              case "$GITHUB_REF_NAME" in
-                hotfix*)
-                  summary_prefix="HOTFIX"
-                  ;;
-                release*)
-                  summary_prefix="RLZ"
-                  ;;
-              esac
-            fi
-
-            input_summary="$summary_prefix OSS ${{ inputs.major_version }}"
-            echo "The summary to search is: $input_summary"
-
-            # Extract the key of the existent test plan
             while read row; do
               summary=$(echo "$row" | jq -r '.summary')
-              if [[ "$summary" == "$input_summary" ]]; then
+              if [[ "$summary" == "NIGHTLY OSS $MAJOR_VERSION" ]]; then
                 test_plan_key=$(echo "$row" | jq -r '.key')
-                echo "The test_plan_key is $test_plan_key and the summary is $summary"
                 break
               fi
-            done <<< "$test_plans"
+            done <<< "$plans"
 
-            echo "The test plan key for now is: $test_plan_key"
-
-            # If no matching test plan was found, create one
-            if [[ -z "$test_plan_key" ]]; then
-              echo "TestPlan doesn't exist yet"
-
-              # Create the test plan using a GraphQL mutation
-              create_test_plan_mutation="{
-                \"query\": \"mutation CreateTestPlan(\$testIssueIds: [String], \$jira: JSON!) { createTestPlan(testIssueIds: \$testIssueIds, jira: \$jira) { testPlan { issueId jira(fields: [\\\"key\\\"]) }warnings } }\",
-                \"variables\": {
-                  \"testIssueIds\": [],
-                  \"jira\": {
-                    \"fields\": {
-                      \"summary\": \"$input_summary\",
-                      \"project\": { \"key\": \"MON\" }
-                    }
-                  }
-                }
-              }"
-              create_result=$(curl -sS -H "Content-Type: application/json" -X POST -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" -d "$create_test_plan_mutation" "https://xray.cloud.getxray.app/api/v2/graphql")
-              echo "API response: $create_result "
-
-              # Extract the key of the created test plan
-              test_plan_key=$(echo "$create_result" | jq -r '.data.createTestPlan.testPlan.jira.key')
-              echo "New TP created with key: $test_plan_key"
-            fi
-
-            # Update start value for the next iteration
+            [ -n "$test_plan_key" ] && break
             start=$((start + 100))
           done
 
-          # Set the testPlanKey as an output
-          echo "test_plan_key_${{ inputs.os }}=$test_plan_key" >> $GITHUB_OUTPUT
+          if [ -z "$test_plan_key" ]; then
+            mutation='{
+              "query":"mutation {
+                createTestPlan(jira:{
+                  fields:{
+                    summary:\"NIGHTLY OSS '"$MAJOR_VERSION"' \",
+                    project:{key:\"MON\"}
+                  }
+                }) {
+                  testPlan { jira(fields:[\"key\"]) }
+                }
+              }"
+            }'
 
-        shell: bash
+            result=$(curl -s -H "Content-Type: application/json" \
+              -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" \
+              -X POST \
+              --data "$mutation" \
+              https://xray.cloud.getxray.app/api/v2/graphql)
 
-      - name: Get TestPlanID
+            test_plan_key=$(echo "$result" | jq -r '.data.createTestPlan.testPlan.jira.key')
+          fi
+
+          echo "test_plan_key_alma9=$test_plan_key" >> $GITHUB_OUTPUT
+
+      - name: Get Test Plan ID
         id: get_test_plan_id
         run: |
-          test_plan_key=$(echo '${{ toJSON(steps.get_test_plan_key.outputs) }}' | jq -r '.test_plan_key_'${{ inputs.os }})
-          echo "Getting the TestPlan ID for key: $test_plan_key"
+          jira_url="https://centreon.atlassian.net/rest/api/2/issue/${{ steps.get_test_plan_key.outputs.test_plan_key_alma9 }}"
 
-          jira_url="https://centreon.atlassian.net/rest/api/2/issue/$test_plan_key"
-
-          response=$(curl -sS -u "${{ secrets.xray_jira_user_email }}:${{ secrets.xray_jira_token }}" "$jira_url")
-
-          # Debug (optional, remove later)
-          echo "Jira response:"
-          echo "$response"
-
+          response=$(curl -s -u "${{ secrets.xray_jira_user_email }}:${{ secrets.xray_jira_token }}" "$jira_url")
           test_plan_id=$(echo "$response" | jq -r '.id')
 
-          if [ "$test_plan_id" = "null" ] || [ -z "$test_plan_id" ]; then
-            echo "❌ ERROR: Unable to retrieve TestPlan ID for $test_plan_key"
-            exit 1
-          fi
+          [ "$test_plan_id" = "null" ] && exit 1
+          echo "test_plan_id_alma9=$test_plan_id" >> $GITHUB_OUTPUT
 
-          echo "TestPlan ID: $test_plan_id"
-          echo "test_plan_id_${{ inputs.os }}=$test_plan_id" >> "$GITHUB_OUTPUT"
-        shell: bash
-
-      - name: Create TestExecution and Get the TestExecutionID
+      - name: Create Test Execution
         id: get_test_execution_id
         run: |
-          # Determine the summary's prefix
-          summary_prefix=''
-          if [[ ${{ github.event_name }} == 'schedule' ]]; then
-            summary_prefix="NIGHTLY"
-          else
-            echo "The github_ref_name is: $GITHUB_REF_NAME"
-            case "$GITHUB_REF_NAME" in
-              hotfix*)
-                summary_prefix="HOTFIX"
-                ;;
-              release*)
-                summary_prefix="RLZ"
-                ;;
-            esac
-          fi
-
           current_date=$(date +'%d/%m/%Y')
+          workflow_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 
-          workflow_run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          summary="NIGHTLY WEB $MAJOR_VERSION.$MINOR_VERSION $current_date"
 
-          input_summary="$summary_prefix WEB ${{ inputs.major_version }}.${{ inputs.minor_version }} $current_date"
-          echo "The summary of the TE is: $input_summary"
-
-          linux_distribution=''
-          case "${{ inputs.os }}" in
-            alma8)
-              linux_distribution="ALMA8"
-              mariadb_version="MARIADB_10_5"
-              ;;
-            alma9)
-              linux_distribution="ALMA9"
-              mariadb_version="MARIADB_10_5"
-              ;;
-            bullseye)
-              linux_distribution="DEBIAN11"
-              mariadb_version="MARIADB_10_5"
-              ;;
-            bookworm)
-              linux_distribution="DEBIAN12"
-              mariadb_version="MARIADB_10_11"
-            ;;
-          esac
-
-          xray_graphql_createTestExecution="{
-            \"query\": \"mutation CreateTestExecution(\$testEnvironments: [String], \$jira: JSON!) { createTestExecution(testEnvironments: \$testEnvironments, jira: \$jira) { testExecution { issueId jira(fields: [\\\"key\\\"]) } warnings createdTestEnvironments } }\",
-            \"variables\": {
-              \"testEnvironments\": [\"$linux_distribution\",\"$mariadb_version\",\"CHROME\"],
-              \"jira\": {
-                \"fields\": {
-                  \"summary\": \"$input_summary\",
-                  \"description\": \"$workflow_run_url\",
-                  \"project\": { \"key\": \"MON\" },
-                  \"components\": [{\"name\": \"centreon-web\"}],
-                  \"priority\":{\"name\":\"Low\"}
+          mutation='{
+            "query":"mutation {
+              createTestExecution(
+                testEnvironments:[\"ALMA9\",\"MARIADB_10_5\",\"CHROME\"],
+                jira:{
+                  fields:{
+                    summary:\"'"$summary"' \",
+                    description:\"'"$workflow_url"' \",
+                    project:{key:\"MON\"},
+                    components:[{name:\"centreon-web\"}],
+                    priority:{name:\"Low\"}
+                  }
                 }
+              ){
+                testExecution { issueId }
               }
-            }
-          }"
+            }"
+          }'
 
-          echo "this is the graphql mutation : $xray_graphql_createTestExecution"
+          response=$(curl -s -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" \
+            -X POST \
+            --data "$mutation" \
+            https://xray.cloud.getxray.app/api/v2/graphql)
 
-          response=$(curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" --data "$xray_graphql_createTestExecution" "https://xray.cloud.getxray.app/api/v2/graphql")
-
-          echo -e "Response from Create Test Execution:\n$response"
-
-          # Extract the ID of the created TE
           test_execution_id=$(echo "$response" | jq -r '.data.createTestExecution.testExecution.issueId')
-          echo "test_execution_id_${{ inputs.os }}=$test_execution_id" >> $GITHUB_OUTPUT
+          echo "test_execution_id_alma9=$test_execution_id" >> $GITHUB_OUTPUT
 
-          echo "TestExecution created with ID:  $test_execution_id"
-        shell: bash
-
-      - name: Get TestExecutionKey
+      - name: Get Test Execution Key
         id: get_test_execution_key
         run: |
-          test_execution_id=$(echo '${{ toJSON(steps.get_test_execution_id.outputs) }}' | jq -r '.test_execution_id_'${{ inputs.os }})
-          jira_url="https://centreon.atlassian.net/rest/api/2/issue/$test_execution_id"
+          jira_url="https://centreon.atlassian.net/rest/api/2/issue/${{ steps.get_test_execution_id.outputs.test_execution_id_alma9 }}"
+          key=$(curl -s -u "${{ secrets.xray_jira_user_email }}:${{ secrets.xray_jira_token }}" "$jira_url" | jq -r '.key')
+          echo "test_execution_key_alma9=$key" >> $GITHUB_OUTPUT
 
-          test_execution_key=$(curl -u "${{ secrets.xray_jira_user_email }}:${{ secrets.xray_jira_token }}" -X GET -s "$jira_url" | jq -r '.key')
-          echo "this is the TestExecutionKey: $test_execution_key"
-          echo "test_execution_key_${{ inputs.os }}=$test_execution_key" >> $GITHUB_OUTPUT
-        shell: bash
-
-      - name: Update the status of the TestExecution Issue
+      - name: Link Test Execution to Test Plan
         run: |
-          test_execution_key=$(echo '${{ toJSON(steps.get_test_execution_key.outputs) }}' | jq -r '.test_execution_key_'${{ inputs.os }})
-          curl -D- -u "${{ secrets.xray_jira_user_email }}:${{ secrets.xray_jira_token }}" -X POST --data '{"transition":{"id":"5"}}' -H "Content-Type: application/json" https://centreon.atlassian.net/rest/api/2/issue/$test_execution_key/transitions?expand=transitions.fields
+          mutation='{
+            "query":"mutation {
+              addTestExecutionsToTestPlan(
+                issueId:\"${{ steps.get_test_plan_id.outputs.test_plan_id_alma9 }}\",
+                testExecIssueIds:[\"${{ steps.get_test_execution_id.outputs.test_execution_id_alma9 }}\"]
+              ) {
+                addedTestExecutions
+              }
+            }"
+          }'
 
-      - name: Add the TestExecution Issue to the TestPlan
-        run: |
-          test_plan_id=$(echo '${{ toJSON(steps.get_test_plan_id.outputs) }}' | jq -r '.test_plan_id_'${{ inputs.os }})
-          test_execution_id=$(echo '${{ toJSON(steps.get_test_execution_id.outputs) }}' | jq -r '.test_execution_id_'${{ inputs.os }})
-          xray_graphql_mutation="{
-            \"query\": \"mutation AddTestExecution(\$issueId: String!, \$testExecIssueIds: [String]!) { addTestExecutionsToTestPlan(issueId: \$issueId, testExecIssueIds: \$testExecIssueIds) { addedTestExecutions warning } }\",
-            \"variables\": {
-              \"issueId\": \"$test_plan_id\",
-              \"testExecIssueIds\": [\"$test_execution_id\"]
-            }
-          }"
-          curl -X POST -H "Content-Type: application/json" -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" --data "${xray_graphql_mutation}" "https://xray.cloud.getxray.app/api/v2/graphql"
+          curl -s -H "Content-Type: application/json" \
+            -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" \
+            -X POST \
+            --data "$mutation" \
+            https://xray.cloud.getxray.app/api/v2/graphql

--- a/.github/workflows/create-xray-test-plan-and-test-execution.yml
+++ b/.github/workflows/create-xray-test-plan-and-test-execution.yml
@@ -181,12 +181,25 @@ jobs:
         id: get_test_plan_id
         run: |
           test_plan_key=$(echo '${{ toJSON(steps.get_test_plan_key.outputs) }}' | jq -r '.test_plan_key_'${{ inputs.os }})
-          echo "getting the testPlanId for the testPlanKey: $test_plan_key"
+          echo "Getting the TestPlan ID for key: $test_plan_key"
+
           jira_url="https://centreon.atlassian.net/rest/api/2/issue/$test_plan_key"
 
-          test_plan_id=$(curl -u "${{ secrets.xray_jira_user_email }}:${{ secrets.xray_jira_token }}" -X GET -s "$jira_url" | jq -r '.id')
-          echo "this is the testPlan ID : $test_plan_id"
-          echo "test_plan_id_${{ inputs.os }}=$test_plan_id" >> $GITHUB_OUTPUT
+          response=$(curl -sS -u "${{ secrets.xray_jira_user_email }}:${{ secrets.xray_jira_token }}" "$jira_url")
+
+          # Debug (optional, remove later)
+          echo "Jira response:"
+          echo "$response"
+
+          test_plan_id=$(echo "$response" | jq -r '.id')
+
+          if [ "$test_plan_id" = "null" ] || [ -z "$test_plan_id" ]; then
+            echo "❌ ERROR: Unable to retrieve TestPlan ID for $test_plan_key"
+            exit 1
+          fi
+
+          echo "TestPlan ID: $test_plan_id"
+          echo "test_plan_id_${{ inputs.os }}=$test_plan_id" >> "$GITHUB_OUTPUT"
         shell: bash
 
       - name: Create TestExecution and Get the TestExecutionID

--- a/.github/workflows/create-xray-test-plan-and-test-execution.yml
+++ b/.github/workflows/create-xray-test-plan-and-test-execution.yml
@@ -32,79 +32,96 @@ jobs:
           xray_token=$(echo "$token_response" | sed -n 's/.*"\(.*\)".*/\1/p')
           echo "xray_token=$xray_token" >> $GITHUB_OUTPUT
 
-      - name: Create or Get Test Plan Key
-        id: get_test_plan_key
-        run: |
-          start=0
-          test_plan_key=""
+      # - name: Create or Get Test Plan Key
+      #   id: get_test_plan_key
+      #   run: |
+      #     start=0
+      #     test_plan_key=""
 
-          while true; do
-            graphql_query='{
-              "query":"query GetTestPlans($jql: String, $limit: Int!, $start: Int) {
-                getTestPlans(jql: $jql, limit: $limit, start: $start) {
-                  results { jira(fields: [\"summary\",\"key\"]) }
-                }
-              }",
-              "variables":{"jql":"project = MON","limit":100,"start":'"$start"'}
-            }'
+      #     while true; do
+      #       graphql_query='{
+      #         "query":"query GetTestPlans($jql: String, $limit: Int!, $start: Int) {
+      #           getTestPlans(jql: $jql, limit: $limit, start: $start) {
+      #             results { jira(fields: [\"summary\",\"key\"]) }
+      #           }
+      #         }",
+      #         "variables":{"jql":"project = MON","limit":100,"start":'"$start"'}
+      #       }'
 
-            response=$(curl -s -H "Content-Type: application/json" \
-              -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" \
-              -X POST \
-              --data "$graphql_query" \
-              https://xray.cloud.getxray.app/api/v2/graphql)
+      #       response=$(curl -s -H "Content-Type: application/json" \
+      #         -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" \
+      #         -X POST \
+      #         --data "$graphql_query" \
+      #         https://xray.cloud.getxray.app/api/v2/graphql)
 
-            plans=$(echo "$response" | jq -c '.data.getTestPlans.results[].jira')
+      #       plans=$(echo "$response" | jq -c '.data.getTestPlans.results[].jira')
 
-            [ -z "$plans" ] && break
+      #       [ -z "$plans" ] && break
 
-            while read row; do
-              summary=$(echo "$row" | jq -r '.summary')
-              if [[ "$summary" == "NIGHTLY OSS $MAJOR_VERSION" ]]; then
-                test_plan_key=$(echo "$row" | jq -r '.key')
-                break
-              fi
-            done <<< "$plans"
+      #       while read row; do
+      #         summary=$(echo "$row" | jq -r '.summary')
+      #         if [[ "$summary" == "NIGHTLY OSS $MAJOR_VERSION" ]]; then
+      #           test_plan_key=$(echo "$row" | jq -r '.key')
+      #           break
+      #         fi
+      #       done <<< "$plans"
 
-            [ -n "$test_plan_key" ] && break
-            start=$((start + 100))
-          done
+      #       [ -n "$test_plan_key" ] && break
+      #       start=$((start + 100))
+      #     done
 
-          if [ -z "$test_plan_key" ]; then
-            mutation='{
-              "query":"mutation {
-                createTestPlan(jira:{
-                  fields:{
-                    summary:\"NIGHTLY OSS '"$MAJOR_VERSION"' \",
-                    project:{key:\"MON\"}
-                  }
-                }) {
-                  testPlan { jira(fields:[\"key\"]) }
-                }
-              }"
-            }'
+      #     if [ -z "$test_plan_key" ]; then
+      #       mutation='{
+      #         "query":"mutation {
+      #           createTestPlan(jira:{
+      #             fields:{
+      #               summary:\"NIGHTLY OSS '"$MAJOR_VERSION"' \",
+      #               project:{key:\"MON\"}
+      #             }
+      #           }) {
+      #             testPlan { jira(fields:[\"key\"]) }
+      #           }
+      #         }"
+      #       }'
 
-            result=$(curl -s -H "Content-Type: application/json" \
-              -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" \
-              -X POST \
-              --data "$mutation" \
-              https://xray.cloud.getxray.app/api/v2/graphql)
+      #       result=$(curl -s -H "Content-Type: application/json" \
+      #         -H "Authorization: Bearer ${{ steps.generate_xray_token.outputs.xray_token }}" \
+      #         -X POST \
+      #         --data "$mutation" \
+      #         https://xray.cloud.getxray.app/api/v2/graphql)
 
-            test_plan_key=$(echo "$result" | jq -r '.data.createTestPlan.testPlan.jira.key')
-          fi
+      #       test_plan_key=$(echo "$result" | jq -r '.data.createTestPlan.testPlan.jira.key')
+      #     fi
 
-          echo "test_plan_key_alma9=$test_plan_key" >> $GITHUB_OUTPUT
+      #     echo "test_plan_key_alma9=$test_plan_key" >> $GITHUB_OUTPUT
 
       - name: Get Test Plan ID
         id: get_test_plan_id
         run: |
-          jira_url="https://centreon.atlassian.net/rest/api/2/issue/${{ steps.get_test_plan_key.outputs.test_plan_key_alma9 }}"
+          jira_url="https://centreon.atlassian.net/rest/api/2/issue/MON-192511"
 
-          response=$(curl -s -u "${{ secrets.xray_jira_user_email }}:${{ secrets.xray_jira_token }}" "$jira_url")
-          test_plan_id=$(echo "$response" | jq -r '.id')
+          echo "🔹 Fetching Test Plan ID from URL: $jira_url"
 
-          [ "$test_plan_id" = "null" ] && exit 1
+          response=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -u "${{ secrets.xray_jira_user_email }}:${{ secrets.xray_jira_token }}" "$jira_url")
+
+          # Séparer le body et le code HTTP
+          http_status=$(echo "$response" | tr -d '\r' | awk -FHTTP_STATUS: '{print $2}')
+          body=$(echo "$response" | sed -e 's/HTTP_STATUS:.*//g')
+
+          echo "🔹 HTTP status code: $http_status"
+          echo "🔹 Response body:"
+          echo "$body"
+
+          test_plan_id=$(echo "$body" | jq -r '.id')
+          echo "🔹 Parsed TestPlan ID: $test_plan_id"
+
+          if [ "$test_plan_id" = "null" ] || [ -z "$test_plan_id" ]; then
+            echo "❌ ERROR: Unable to retrieve TestPlan ID"
+            exit 1
+          fi
+
           echo "test_plan_id_alma9=$test_plan_id" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Create Test Execution
         id: get_test_execution_id


### PR DESCRIPTION
This pull request improves the reliability and clarity of the workflow for retrieving a TestPlan ID from Jira in the `.github/workflows/create-xray-test-plan-and-test-execution.yml` file. The key changes focus on enhanced error handling, better logging, and improved script readability.

**Enhancements to TestPlan ID retrieval:**

* Added error handling to check if the retrieved `test_plan_id` is null or empty, and fail the workflow with a clear error message if so.
* Improved logging by printing the Jira API response for debugging purposes and updating log messages for clarity.
* Refactored the script to store the Jira API response in a variable before processing, making the code easier to read and maintain.

## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

Please include a short resume of the changes and what is the purpose of PR. Any relevant information should be added to help:
* **QA Team** (Quality Assurance) with tests.
* **reviewers** to understand what are the stakes of the pull request.

**Fixes** # (issue)

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
