### PR TITLE
fix(ldap): fix ignored auto import

### DIFF
--- a/centreon/www/class/centreonAuth.class.php
+++ b/centreon/www/class/centreonAuth.class.php
@@ -409,7 +409,7 @@ class CentreonAuth
      *
      * @throws PDOException
      */
-    private function checkLdapPassword($password, $autoImport): void
+    private function checkLdapPassword(string $password, bool $autoImport): void
     {
         $res = $this->pearDB->query("SELECT ar_id FROM auth_ressource WHERE ar_enable = '1'");
         $authResources = [];
@@ -423,7 +423,7 @@ class CentreonAuth
 
         foreach ($authResources as $arId) {
             if ($autoImport && ! isset($this->ldap_auto_import[$arId])) {
-                break;
+                continue;
             }
             if ($this->passwdOk == self::PASSWORD_VALID) {
                 break;


### PR DESCRIPTION
## Description

In case of multiple LDAP configurations, if the oldest one does not allow auto user imports, there is a `break` that block auto import for all other configurations.
This PR replaces the `break` with a `continue` to fix the logic.

[MON-178083](https://centreon.atlassian.net/browse/MON-178083)

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

See Jira ticket.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).


[MON-178083]: https://centreon.atlassian.net/browse/MON-178083?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ