### PR TITLE
test(e2e): clean relicat of ESLint

### DIFF
--- a/centreon/tests/e2e/.eslintrc.js
+++ b/centreon/tests/e2e/.eslintrc.js
@@ -1,6 +1,0 @@
-module.exports = {
-  extends: [
-    '../../packages/js-config/eslint/react/typescript.eslintrc.js',
-    'plugin:cypress/recommended'
-  ]
-};

--- a/centreon/tests/e2e/features/Cloud-notifications/05-notification-listing/index.ts
+++ b/centreon/tests/e2e/features/Cloud-notifications/05-notification-listing/index.ts
@@ -83,8 +83,6 @@ When('no Notification Rules are configured', () => {
     method: 'GET',
     url: 'centreon/api/latest/configuration/notifications'
   }).then((response) => {
-    // https://github.com/cypress-io/eslint-plugin-cypress?tab=readme-ov-file#chai-and-no-unused-expressions
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     expect(response.body.result).to.be.an('array').that.is.empty;
   });
 });


### PR DESCRIPTION
To clean up the E2E test code a little, as we no longer use ESLint but BiomeJS, which is already deployed.
Refs: MON-192948

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [x] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [x] master

<h2> How this pull request can be tested ? </h2>

Please describe the **procedure** to verify that the goal of the PR is matched. Provide clear instructions so that it can be **correctly tested**.

Any **relevant details** of the configuration to perform the test should be added.

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
