### PR TITLE
Fix api validation error message formating to display fields having violations

### DIFF
--- a/centreon/config.new/packages/api_platform.yaml
+++ b/centreon/config.new/packages/api_platform.yaml
@@ -5,6 +5,8 @@ api_platform:
 
     name_converter: 'serializer.name_converter.camel_case_to_snake_case'
 
+    handle_symfony_errors: true
+
     exception_to_status:
         ApiPlatform\Validator\Exception\ValidationException: 400 # To be compatible with the legacy
         App\Shared\Domain\Exception\AggregateAlreadyExistsException: 409

--- a/centreon/src/App/Shared/Infrastructure/Legacy/LegacyHttpExceptionListener.php
+++ b/centreon/src/App/Shared/Infrastructure/Legacy/LegacyHttpExceptionListener.php
@@ -31,7 +31,9 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\HttpKernel\Exception\UnprocessableEntityHttpException;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\Validator\Exception\ValidationFailedException;
 
 #[AsEventListener]
 final readonly class LegacyHttpExceptionListener
@@ -60,6 +62,14 @@ final readonly class LegacyHttpExceptionListener
 
         // this case is handled by LegacyValidationExceptionNormalizer
         if ($exception instanceof ValidationException) {
+            return;
+        }
+
+        // handle Symfony ValidationFailedException to be compatible with LegacyValidationExceptionNormalizer
+        $previous = $exception->getPrevious();
+        if ($exception instanceof UnprocessableEntityHttpException && $previous instanceof ValidationFailedException) {
+            $event->setThrowable(new ValidationException($previous->getViolations()));
+
             return;
         }
 

--- a/centreon/src/App/Shared/Infrastructure/Legacy/LegacyValidationExceptionNormalizer.php
+++ b/centreon/src/App/Shared/Infrastructure/Legacy/LegacyValidationExceptionNormalizer.php
@@ -51,7 +51,7 @@ final class LegacyValidationExceptionNormalizer implements NormalizerInterface, 
         $messages = array_map($this->convertViolationToLegacy(...), $normalized['violations']);
 
         return [
-            'code' => 400,
+            'code' => 422,
             'message' => implode("\n", $messages) . "\n",
         ];
     }


### PR DESCRIPTION
## Description

Recent changes on the way we handle exceptions have changed the way API errors were rendered (for API using MapRequestInput & Symfony validation - very few cases).

Fields with error were no longer described in the error response message.

https://github.com/user-attachments/assets/22b92959-b8e1-4d73-80f5-0e055f8b68fe

