### PR TITLE
Support multiple RDBMS for perl scripts in Centreon

### DIFF
--- a/.github/docker/centreon-web/alma9/Dockerfile.dependencies
+++ b/.github/docker/centreon-web/alma9/Dockerfile.dependencies
@@ -68,7 +68,7 @@ dnf install -y \
 
 dnf install -y \
   perl-interpreter \
-  perl-DBD-MySQL \
+  perl-DBD-MariaDB \
   perl-DBD-SQLite \
   perl-DBI \
   perl-HTML-Parser \

--- a/centreon/bin/changeRrdDsName.pl
+++ b/centreon/bin/changeRrdDsName.pl
@@ -61,19 +61,18 @@ sub get_ds_name {
 }
 
 # Prepare DB URI depending on configured RDBMS
-my $rdbms_kind = $centreon_config->{rdbms_kind};
-my $dbh_prefix = "";
-if (!defined($rdbms_kind)) {
-  die "Error : RDBMS kind not defined. Please set rdbms_kind in @CENTREON_ETC@/conf.pm\n";
-}
-if ($rdbms_kind eq "mysql") {
-  $dbh_prefix = "DBI:mysql";
-}
-elsif ($rdbms_kind eq "mariadb") {
-  $dbh_prefix = "DBI:MariaDB";
-}
-else {
-  die "Error : RDBMS kind not supported. Please check configuration in @CENTREON_ETC@/conf.pm\n";
+my $dbh_prefix = "DBI:mysql";
+my $rdbms_kind = $centreon_config->{rdbms_kind} // "";
+if($centreon_config->{rdbms_kind}) {
+  if ($rdbms_kind eq "mysql") {
+    $dbh_prefix = "DBI:mysql";
+  }
+  elsif ($rdbms_kind eq "mariadb") {
+    $dbh_prefix = "DBI:MariaDB";
+  }
+  else {
+    print "Warn : RDBMS kind not supported or undefined. Using default Mysql prefix\n";
+  }
 }
 
 my $dbh = DBI->connect(

--- a/centreon/bin/changeRrdDsName.pl
+++ b/centreon/bin/changeRrdDsName.pl
@@ -60,11 +60,27 @@ sub get_ds_name {
     return $ds_name;
 }
 
+# Prepare DB URI depending on configured RDBMS
+my $rdbms_kind = $centreon_config->{rdbms_kind};
+my $dbh_prefix = "";
+if (!defined($rdbms_kind)) {
+  die "Error : RDBMS kind not defined. Please set rdbms_kind in @CENTREON_ETC@/conf.pm\n";
+}
+if ($rdbms_kind eq "mysql") {
+  $dbh_prefix = "DBI:mysql";
+}
+elsif ($rdbms_kind eq "mariadb") {
+  $dbh_prefix = "DBI:MariaDB";
+}
+else {
+  die "Error : RDBMS kind not supported. Please check configuration in @CENTREON_ETC@/conf.pm\n";
+}
+
 my $dbh = DBI->connect(
-    "DBI:mysql:database=" . $centreon_config->{centstorage_db} . ";host=" . $centreon_config->{db_host},
+    $dbh_prefix . ":database=" . $centreon_config->{centstorage_db} . ";host=" . $centreon_config->{db_host},
     $centreon_config->{db_user},
     $centreon_config->{db_passwd},
-    { 'RaiseError' => 0, 'PrintError' => 0, 'AutoCommit' => 1}
+    { 'RaiseError' => 1, 'PrintError' => 1, 'AutoCommit' => 1}
     );
 
 # Get path to metrics file

--- a/centreon/cron/centreon-backup.pl
+++ b/centreon/cron/centreon-backup.pl
@@ -111,11 +111,27 @@ my $PROGNAME = $0;
 my $VERSION = "1.0";
 my $CENTREONDIR = "@INSTALL_DIR_CENTREON@";
 
+# Prepare DB URI depending on configured RDBMS
+my $rdbms_kind = $centreon_config->{rdbms_kind};
+my $dbh_prefix = "";
+if (!defined($rdbms_kind)) {
+  die "Error : RDBMS kind not defined. Please set rdbms_kind in @CENTREON_ETC@/conf.pm\n";
+}
+if ($rdbms_kind eq "mysql") {
+  $dbh_prefix = "DBI:mysql";
+}
+elsif ($rdbms_kind eq "mariadb") {
+  $dbh_prefix = "DBI:MariaDB";
+}
+else {
+  die "Error : RDBMS kind not supported. Please check configuration in @CENTREON_ETC@/conf.pm\n";
+}
+
 ##########################################
 # Get backup configuration from database #
 ##########################################
 
-my $dbh = DBI->connect("DBI:mysql:database=" . $mysql_database_oreon . ";host=" . $mysql_host . ";port=" . $mysql_port, $mysql_user, $mysql_passwd, { 'RaiseError' => 0, 'PrintError' => 0 });
+my $dbh = DBI->connect($dbh_prefix . ":database=" . $mysql_database_oreon . ";host=" . $mysql_host . ";port=" . $mysql_port, $mysql_user, $mysql_passwd, { 'RaiseError' => 1, 'PrintError' => 1 });
 if (!$dbh) {
     print STDERR "Couldn't connect: " . $DBI::errstr . "\n";
     exit 1;
@@ -476,7 +492,7 @@ sub databasesBackup() {
         }
     } elsif (grep $_ == $dayOfWeek, @fullBackupDays) {
         my $mysql_database_ndo;
-        my $dbh = DBI->connect("DBI:mysql:database=" . $mysql_database_oreon . ";host=" . $mysql_host . ";port=" . $mysql_port, $mysql_user, $mysql_passwd, { 'RaiseError' => 0, 'PrintError' => 0 });
+        my $dbh = DBI->connect($dbh_prefix . ":database=" . $mysql_database_oreon . ";host=" . $mysql_host . ";port=" . $mysql_port, $mysql_user, $mysql_passwd, { 'RaiseError' => 0, 'PrintError' => 0 });
         if (!$dbh) {
             print STDERR sprintf("Couldn't connect: %s", $DBI::errstr) . "\n";
         }
@@ -645,7 +661,7 @@ sub centralBackup() {
 
     # Try to Centreon logs directory
     my $centreon_log_path = "";
-    my $dbh = DBI->connect("DBI:mysql:database=" . $mysql_database_oreon . ";host=" . $mysql_host . ";port=" . $mysql_port, $mysql_user, $mysql_passwd, { 'RaiseError' => 0, 'PrintError' => 0 });
+    my $dbh = DBI->connect($dbh_prefix . ":database=" . $mysql_database_oreon . ";host=" . $mysql_host . ";port=" . $mysql_port, $mysql_user, $mysql_passwd, { 'RaiseError' => 0, 'PrintError' => 0 });
     if (!$dbh) {
         print STDERR sprintf("Couldn't connect: %s", $DBI::errstr) . "\n";
     }

--- a/centreon/cron/centreon-backup.pl
+++ b/centreon/cron/centreon-backup.pl
@@ -112,19 +112,18 @@ my $VERSION = "1.0";
 my $CENTREONDIR = "@INSTALL_DIR_CENTREON@";
 
 # Prepare DB URI depending on configured RDBMS
-my $rdbms_kind = $centreon_config->{rdbms_kind};
-my $dbh_prefix = "";
-if (!defined($rdbms_kind)) {
-  die "Error : RDBMS kind not defined. Please set rdbms_kind in @CENTREON_ETC@/conf.pm\n";
-}
-if ($rdbms_kind eq "mysql") {
-  $dbh_prefix = "DBI:mysql";
-}
-elsif ($rdbms_kind eq "mariadb") {
-  $dbh_prefix = "DBI:MariaDB";
-}
-else {
-  die "Error : RDBMS kind not supported. Please check configuration in @CENTREON_ETC@/conf.pm\n";
+my $dbh_prefix = "DBI:mysql";
+my $rdbms_kind = $centreon_config->{rdbms_kind} // "";
+if($centreon_config->{rdbms_kind}) {
+  if ($rdbms_kind eq "mysql") {
+    $dbh_prefix = "DBI:mysql";
+  }
+  elsif ($rdbms_kind eq "mariadb") {
+    $dbh_prefix = "DBI:MariaDB";
+  }
+  else {
+    print "Warn : RDBMS kind not supported or undefined. Using default Mysql prefix\n";
+  }
 }
 
 ##########################################

--- a/centreon/packaging/centreon-poller.yaml
+++ b/centreon/packaging/centreon-poller.yaml
@@ -90,7 +90,7 @@ overrides:
       - centreon-connector < ${NEXT_MAJOR_VERSION}
       - centreon-gorgone-centreon-config >= ${MAJOR_VERSION}
       - centreon-gorgone-centreon-config < ${NEXT_MAJOR_VERSION}
-      - perl-DBD-MySQL
+      - (perl-DBD-MySQL or perl-DBD-MariaDB)
       - perl-DBD-SQLite
       - nagios-plugins-dhcp >= 2.0.0
       - nagios-plugins-icmp >= 2.0.0

--- a/centreon/packaging/centreon-poller.yaml
+++ b/centreon/packaging/centreon-poller.yaml
@@ -129,7 +129,7 @@ overrides:
       - "centreon-connector (<< ${NEXT_MAJOR_VERSION}~)"
       - "centreon-gorgone-centreon-config (>= ${MAJOR_VERSION}~)"
       - "centreon-gorgone-centreon-config (<< ${NEXT_MAJOR_VERSION}~)"
-      - libdbd-mysql-perl
+      - (libdbd-mysql-perl | libdbd-mariadb-perl)
       - libdbd-sqlite3-perl
       - monitoring-plugins-basic
     recommends:

--- a/centreon/packaging/centreon-web.yaml
+++ b/centreon/packaging/centreon-web.yaml
@@ -452,7 +452,7 @@ overrides:
       - php-json
       - php-process
       - openssl
-      - perl-DBD-MySQL
+      - (perl-DBD-MySQL or perl-DBD-MariaDB)
       - perl-DBI
       - perl-HTML-Parser
       - perl(File::Which)

--- a/centreon/packaging/centreon-web.yaml
+++ b/centreon/packaging/centreon-web.yaml
@@ -524,6 +524,7 @@ overrides:
       - libfile-which-perl
       - lsb-release
       - "mariadb-client | mysql-client"
+      - (libdbd-mysql-perl | libdbd-mariadb-perl)
       - cron
       - apache2
       - rrdtool

--- a/centreon/www/install/tools/migration/logsMigration.pl
+++ b/centreon/www/install/tools/migration/logsMigration.pl
@@ -236,18 +236,34 @@ sub syncDay ($$) {
 #############################################################################################################
 
 sub main {
+	# Prepare DB URI depending on configured RDBMS
+	my $rdbms_kind = $centreon_config->{rdbms_kind};
+	my $dbh_prefix = "";
+	if (!defined($rdbms_kind)) {
+	  die "Error : RDBMS kind not defined. Please set rdbms_kind in \@CENTREON_ETC@/conf.pm\n";
+	}
+	if ($rdbms_kind eq "mysql") {
+		$dbh_prefix = "DBI:mysql";
+	}
+	elsif ($rdbms_kind eq "mariadb") {
+		$dbh_prefix = "DBI:MariaDB";
+	}
+	else {
+		die "Error : RDBMS kind not defined. Please set rdbms_kind in @CENTREON_ETC@/conf.pm\n";
+	}
+
 	# Initializing MySQL DB connection
 	$dbh = DBI->connect(
-		"DBI:mysql:database=" . $centreon_config->{centstorage_db} . ";host=" . $centreon_config->{db_host},
+		$dbh_prefix . ":database=" . $centreon_config->{centstorage_db} . ";host=" . $centreon_config->{db_host},
 		$centreon_config->{db_user},
 		$centreon_config->{db_passwd},
-		{ 'RaiseError' => 0, 'PrintError' => 0, 'AutoCommit' => 1 }
+		{ 'RaiseError' => 1, 'PrintError' => 1, 'AutoCommit' => 1 }
 	);
 	$dbhoreon = DBI->connect(
-		"DBI:mysql:database=" . $centreon_config->{centreon_db} . ";host=" . $centreon_config->{db_host},
+		$dbh_prefix . ":database=" . $centreon_config->{centreon_db} . ";host=" . $centreon_config->{db_host},
 		$centreon_config->{db_user},
 		$centreon_config->{db_passwd},
-		{ 'RaiseError' => 0, 'PrintError' => 0, 'AutoCommit' => 1 }
+		{ 'RaiseError' => 1, 'PrintError' => 1, 'AutoCommit' => 1 }
 	);
 	
 	initEnv();

--- a/centreon/www/install/tools/migration/logsMigration.pl
+++ b/centreon/www/install/tools/migration/logsMigration.pl
@@ -237,19 +237,18 @@ sub syncDay ($$) {
 
 sub main {
 	# Prepare DB URI depending on configured RDBMS
-	my $rdbms_kind = $centreon_config->{rdbms_kind};
-	my $dbh_prefix = "";
-	if (!defined($rdbms_kind)) {
-	  die "Error : RDBMS kind not defined. Please set rdbms_kind in \@CENTREON_ETC@/conf.pm\n";
-	}
-	if ($rdbms_kind eq "mysql") {
-		$dbh_prefix = "DBI:mysql";
-	}
-	elsif ($rdbms_kind eq "mariadb") {
-		$dbh_prefix = "DBI:MariaDB";
-	}
-	else {
-		die "Error : RDBMS kind not defined. Please set rdbms_kind in @CENTREON_ETC@/conf.pm\n";
+	my $dbh_prefix = "DBI:mysql";
+	my $rdbms_kind = $centreon_config->{rdbms_kind} // "";
+	if($centreon_config->{rdbms_kind}) {
+		if ($rdbms_kind eq "mysql") {
+			$dbh_prefix = "DBI:mysql";
+		}
+		elsif ($rdbms_kind eq "mariadb") {
+			$dbh_prefix = "DBI:MariaDB";
+		}
+		else {
+			print "Warn : RDBMS kind not supported or undefined. Using default Mysql prefix\n";
+		}
 	}
 
 	# Initializing MySQL DB connection


### PR DESCRIPTION
Support multiple RDBMS for perl scripts in Centreon

## Description

This PR intends to help fixing compatibility issues with the package perl-DBD-MySQL for RHEL9 especially.

### Package changes

centreon-web (rpm)
- UPDATE: requires perl-DBD-MySQL **or** perl-DBD-MariaDB

centreon-web (deb)
- ADD: requires libdbd-mysql-perl **or** libdbd-mariadb-perl (wasn't present before, applied to align with rpm behavior)

centreon-poller (rpm)
- UPDATE: requires perl-DBD-MySQL **or** perl-DBD-MariaDB

centreon-poller (deb)
- UPDATE: requires libdbd-mysql-perl **or** libdbd-mariadb-perl

### Build changes
As per the documents i could find on the tests in the repository, the tests are done on a mariadb database, then i updated accordingly the Dockerfiles associated to install the proper packages.

Files changed:
- .github/docker/centreon-web/alma9/Dockerfile.dependencies

### Script changes
This will update the perl scripts using the Mysql Perl library to make use of another DBI library like **perl-DBD-MariaDB** for rpm depending on configuration.


Also modified to **allow raising exceptions for the connexion call** from 0 to 1. The main reason is that if left like this the scripts will silently fail regarding potential issues with the URI. For example with a default host configuration value of "localhost:3306", Perl Mysql will be ok but Perl MariaDB won't allow the port value, we then need to either use "127.0.0.1:3306" or more simply "localhost"

Files changes: 
- centreon/www/install/tools/migration/logsMigration.pl
- centreon/cron/centreon-backup.pl
- centreon/bin/changeRrdDsName.pl

### Configuration changes
For now this PR adds a **breaking change** as there is no reliable way to know if a centreon instance is configured using mariadb or mysql. So i added a new **rdbms_kind** property in the conf.pm
This behavior is mitigated by applying the default behavior with mysql like behavior. I'm unsure how we could guide the user to configure this value when necessary, i'm opened to suggestions for that.

Impacted file: 
- @CENTREON_ETC@/conf.pm

### Context

This modification is for now based on develop but may be needed for **all currently supported** versions of Centreon.

**Fixes** #9134 

## Type of change

- [x] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [x] To determine
- [ ] 24.04.x
- [ ] 24.10.x
- [ ] 25.10.x
- [ ] master

<h2> How this pull request can be tested ? </h2>

This PR can be tested by building the perl scripts (as they have macros for distribution specific variables)

## Checklist
- [x] Update perl scripts to work with the **perl-DBD-MariaDB** library
- [x] Validate the configuration change and if a **breaking change** is acceptable or not
- [ ] Update **build files** to avoid having perl-DBD-Mysql as a **mandatory** dependency and move to a "choose between perl-DBD-MySQL & perl-DBD-MariaDB" model

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).

<!-- AIKIDO_SECURITY_PR_SUMMARY_START -->
## Summary by Aikido
|  Security Issues: 0 |  Quality Issues: 0 |  Resolved Issues: 0 |
| :--- | :--- | :--- |


**⚡ Enhancements**
* Allowed choice between Perl DBD MySQL and MariaDB packages
* Updated Alma9 Dockerfile to install perl-DBD-MariaDB for tests
* Modified Perl scripts to select DBI prefix based on rdbms_kind
* Introduced rdbms_kind configuration property in conf.pm as breaking change

**🔧 Refactors**
* Changed DBI connect to enable RaiseError and PrintError behavior


<sup>[More info](https://app.aikido.dev/featurebranch/scan/106063909?groupId=59752)</sup>
<!-- AIKIDO_SECURITY_PR_SUMMARY_END -->