### PR TITLE
fix(macro): handle case of NULL macro order in database (#8740)

### DIFF
--- a/centreon/src/Core/Macro/Infrastructure/Repository/DbReadHostMacroRepository.php
+++ b/centreon/src/Core/Macro/Infrastructure/Repository/DbReadHostMacroRepository.php
@@ -179,7 +179,7 @@ class DbReadHostMacroRepository extends AbstractRepositoryRDB implements ReadHos
      *    host_macro_value:string,
      *    is_password:int|null,
      *    description:string|null,
-     *    macro_order:int
+     *    macro_order:int|null,
      * } $data
      *
      * @throws AssertionFailedException
@@ -199,7 +199,7 @@ class DbReadHostMacroRepository extends AbstractRepositoryRDB implements ReadHos
         );
         $macro->setIsPassword((bool) $data['is_password']);
         $macro->setDescription($data['description'] ?? '');
-        $macro->setOrder($data['macro_order']);
+        $macro->setOrder($data['macro_order'] ?? 0);
 
         return $macro;
     }


### PR DESCRIPTION
## Description

Backport of #8740

[MON-193417](https://centreon.atlassian.net/browse/MON-193417)

[MON-193417]: https://centreon.atlassian.net/browse/MON-193417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ