### PR TITLE
fix(encryption): use app_secret from engine-context instead of .env

### DIFF
--- a/centreon/www/class/config-generate/abstract/object.class.php
+++ b/centreon/www/class/config-generate/abstract/object.class.php
@@ -113,6 +113,7 @@ abstract class AbstractObject
                 throw new RuntimeException('/etc/centreon/engine-context.json does not exists or is empty');
             }
             $engineContext = json_decode($engineContext, true, flags: JSON_THROW_ON_ERROR);
+            $this->engineContextEncryption->setFirstKey($engineContext['app_secret']);
             $this->engineContextEncryption->setSecondKey($engineContext['salt']);
         } catch (JsonException|RuntimeException $ex) {
             CentreonLog::create()->error(


### PR DESCRIPTION
## Description

This PR intends to fix an issue where crypted credentials could not be decrypted by centreon-engine

**Fixes** # MON-192371

## Type of change

- [x] Patch fixing an issue (non-breaking change)
- [ ] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [x] 25.10.x
- [x] master

## Checklist

#### Community contributors & Centreon team

- [x] I have followed the **coding style guidelines** provided by Centreon
- [x] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [x] I have commented my code, especially **hard-to-understand areas** of the PR.
- [x] I have **rebased** my development branch on the base branch (master, maintenance).
