### PR TITLE
feat: add GetServiceCategory and UpdateServiceCategory API endpoints

### DIFF
--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/GetServiceCategory.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/GetServiceCategory.yaml
@@ -1,0 +1,22 @@
+get:
+  tags:
+    - Service category
+  summary: "Get a service category"
+  description: |
+    Get an existing service category.
+
+  parameters:
+    - $ref: 'QueryParameter/ServiceCategoryId.yaml'
+  responses:
+    '200':
+      description: "OK"
+      content:
+        application/json:
+          schema:
+            $ref: 'Schema/ServiceCategoryResponse.yaml'
+    '403':
+      $ref: '../../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../../Common/Response/NotFound.yaml'
+    '500':
+      $ref: '../../../Common/Response/InternalServerError.yaml'

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/QueryParameter/ServiceCategoryId.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/QueryParameter/ServiceCategoryId.yaml
@@ -1,0 +1,8 @@
+in: path
+name: service_category_id
+required: true
+description: "Service category ID"
+schema:
+  type: integer
+  minimum: 1
+  example: 1

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/Schema/ServiceCategoryRequest.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/Schema/ServiceCategoryRequest.yaml
@@ -1,0 +1,14 @@
+type: object
+required: ["name", "alias"]
+properties:
+  name:
+    type: string
+    description: "Service category name"
+    example: "service-category"
+  alias:
+    type: string
+    description: "Service category alias"
+    example: "service-category"
+  is_activated:
+    type: boolean
+    description: "Indicates whether this service category is enabled or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/Schema/ServiceCategoryResponse.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/Schema/ServiceCategoryResponse.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  id:
+    type: integer
+    description: "Service category ID"
+    example: 1
+  name:
+    type: string
+    description: "Service category name"
+    example: "service-category"
+  alias:
+    type: string
+    description: "Service category alias"
+    example: "service-category"
+  is_activated:
+    type: boolean
+    description: "Indicates whether this service category is enabled or not"

--- a/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/UpdateServiceCategory.yaml
+++ b/centreon/doc/API/latest/onPremise/Configuration/ServiceCategory/UpdateServiceCategory.yaml
@@ -1,0 +1,27 @@
+put:
+  tags:
+    - Service category
+  summary: "Update a service category"
+  description: |
+    Update a service category configuration
+  parameters:
+    - $ref: 'QueryParameter/ServiceCategoryId.yaml'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: 'Schema/ServiceCategoryRequest.yaml'
+  responses:
+    '204':
+      description: "OK"
+    '400':
+      $ref: '../../Common/Response/BadRequest.yaml'
+    '403':
+      $ref: '../../Common/Response/Forbidden.yaml'
+    '404':
+      $ref: '../../Common/Response/NotFound.yaml'
+    '409':
+      $ref: '../../Common/Response/Conflict.yaml'
+    '500':
+      $ref: '../../Common/Response/InternalServerError.yaml'

--- a/centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
+++ b/centreon/src/Core/ServiceCategory/Application/Exception/ServiceCategoryException.php
@@ -25,6 +25,9 @@ namespace Core\ServiceCategory\Application\Exception;
 
 class ServiceCategoryException extends \Exception
 {
+
+    public const CODE_CONFLICT = 1;
+
     /**
      * @return self
      */
@@ -103,5 +106,39 @@ class ServiceCategoryException extends \Exception
     public static function errorWhileRetrievingRealTimeServiceCategories(\Throwable $exception): self
     {
         return new self(_('Error while searching service categories in real time context'), 0, $exception);
+    }
+
+    /**
+     * @return self
+     */
+    public static function errorWhileRetrieving(): self
+    {
+        return new self(_('Error while retrieving service category'));
+    }
+
+     /**
+     * @return self
+     */
+    public static function editNotAllowed(): self
+    {
+        return new self(_('You are not allowed to update service categories'));
+    }
+
+    /**
+     * @return self
+     */
+    public static function errorWhileUpdating(): self
+    {
+        return new self(_('Error while updating service category'));
+    }
+
+      /**
+     * @param string $serviceCategoryName
+     *
+     * @return self
+     */
+    public static function nameAlreadyExists(string $serviceCategoryName): self
+    {
+        return new self(sprintf(_("The service category name '%s' already exists"), $serviceCategoryName), self::CODE_CONFLICT);
     }
 }

--- a/centreon/src/Core/ServiceCategory/Application/Repository/WriteServiceCategoryRepositoryInterface.php
+++ b/centreon/src/Core/ServiceCategory/Application/Repository/WriteServiceCategoryRepositoryInterface.php
@@ -69,11 +69,11 @@ interface WriteServiceCategoryRepositoryInterface
     public function unlinkFromService(int $serviceId, array $serviceCategoriesIds): void;
 
     /**
-     * @param ServiceCategory $ServiceCategory
+     * @param ServiceCategory $serviceCategory
      *
      * @throws \Throwable
      *
      * @return void
      */
-    public function update(ServiceCategory $ServiceCategory): void;
+    public function update(ServiceCategory $serviceCategory): void;
 }

--- a/centreon/src/Core/ServiceCategory/Application/Repository/WriteServiceCategoryRepositoryInterface.php
+++ b/centreon/src/Core/ServiceCategory/Application/Repository/WriteServiceCategoryRepositoryInterface.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace Core\ServiceCategory\Application\Repository;
 
 use Core\ServiceCategory\Domain\Model\NewServiceCategory;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
 
 interface WriteServiceCategoryRepositoryInterface
 {
@@ -66,4 +67,13 @@ interface WriteServiceCategoryRepositoryInterface
      * @throws \Throwable
      */
     public function unlinkFromService(int $serviceId, array $serviceCategoriesIds): void;
+
+    /**
+     * @param ServiceCategory $ServiceCategory
+     *
+     * @throws \Throwable
+     *
+     * @return void
+     */
+    public function update(ServiceCategory $ServiceCategory): void;
 }

--- a/centreon/src/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategory.php
+++ b/centreon/src/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategory.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Application\UseCase\GetServiceCategory;
+
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Centreon\Infrastructure\RequestParameters\RequestParametersTranslatorException;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\ServiceCategory\Application\Exception\ServiceCategoryException;
+use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Security\AccessGroup\Domain\Model\AccessGroup;
+use Core\Application\Common\UseCase\PresenterInterface;
+use Core\ServiceCategory\Infrastructure\API\GetServiceCategory\GetServiceCategoryPresenter;
+
+final class GetServiceCategory
+{
+    use LoggerTrait;
+
+     /** @var AccessGroup[] */
+    private array $accessGroups;
+
+    public function __construct(
+        private readonly ReadServiceCategoryRepositoryInterface $readServiceCategoryRepository,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepository,
+        private readonly ContactInterface $user,
+    ) {
+    }
+
+    /**
+     * @param GetServiceCategoryPresenter $presenter
+     * @param int $serviceCategoryId
+     */
+    public function __invoke(PresenterInterface $presenter, int $serviceCategoryId): void
+    {
+        try {
+            if (
+                ! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_CATEGORIES_READ)
+                && ! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_CATEGORIES_READ_WRITE)
+            ) {
+                $this->error(
+                    "User doesn't have sufficient rights to see services categories",
+                    ['user_id' => $this->user->getId()]
+                );
+                $presenter->setResponseStatus(
+                    new ForbiddenResponse(ServiceCategoryException::accessNotAllowed())
+                );
+
+                return;
+            }
+
+            $serviceCategory = null;
+            if ($this->user->isAdmin()) {
+                $serviceCategory = $this->readServiceCategoryRepository->findById($serviceCategoryId);
+
+            } else {
+                
+                $this->accessGroups = $this->readAccessGroupRepository->findByContact($this->user);
+                if($this->readServiceCategoryRepository->existsByAccessGroups(
+                    $serviceCategoryId,
+                    $this->accessGroups
+                )) {
+                    $serviceCategory = $this->readServiceCategoryRepository->findById($serviceCategoryId);
+                }
+            }
+
+            if (! $serviceCategory) {
+                 $this->error(
+                    'ServiceCategory not found',
+                    ['service_category_id' => $serviceCategoryId]
+                );
+                $presenter->setResponseStatus(new NotFoundResponse('ServiceCategory'));
+
+                return;
+            }
+        
+            $presenter->present($this->createResponse($serviceCategory));
+        } catch (RequestParametersTranslatorException $ex) {
+            $presenter->setResponseStatus(new ErrorResponse($ex->getMessage()));
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        } catch (\Throwable $ex) {
+            $presenter->setResponseStatus(
+                new ErrorResponse(ServiceCategoryException::errorWhileRetrieving())
+            );
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        }
+    }
+
+    /**
+     * @param ServiceCategory $serviceCategory
+     *
+     * @throws \Throwable
+     *
+     *
+     * @return GetServiceCategoryResponse
+     */
+    private function createResponse(ServiceCategory $serviceCategory): GetServiceCategoryResponse
+    {
+        
+
+        $response = new GetServiceCategoryResponse();
+        $response->id = $serviceCategory->getId();
+        $response->name = $serviceCategory->getName();
+        $response->alias = $serviceCategory->getAlias();
+        $response->isActivated = $serviceCategory->isActivated();
+       
+
+        return $response;
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategory.php
+++ b/centreon/src/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategory.php
@@ -36,7 +36,6 @@ use Core\ServiceCategory\Domain\Model\ServiceCategory;
 use Core\Application\Common\UseCase\NotFoundResponse;
 use Core\Security\AccessGroup\Domain\Model\AccessGroup;
 use Core\Application\Common\UseCase\PresenterInterface;
-use Core\ServiceCategory\Infrastructure\API\GetServiceCategory\GetServiceCategoryPresenter;
 
 final class GetServiceCategory
 {
@@ -53,7 +52,7 @@ final class GetServiceCategory
     }
 
     /**
-     * @param GetServiceCategoryPresenter $presenter
+     * @param PresenterInterface $presenter
      * @param int $serviceCategoryId
      */
     public function __invoke(PresenterInterface $presenter, int $serviceCategoryId): void

--- a/centreon/src/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryResponse.php
+++ b/centreon/src/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryResponse.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Application\UseCase\GetServiceCategory;
+
+
+final class GetServiceCategoryResponse
+{
+     public int $id = 0;
+
+    public string $name = '';
+
+    public string $alias = '';
+
+    public bool $isActivated = true;
+}

--- a/centreon/src/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategory.php
+++ b/centreon/src/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategory.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Application\UseCase\UpdateServiceCategory;
+
+use Assert\AssertionFailedException;
+use Centreon\Domain\Contact\Contact;
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\ConflictResponse;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Application\Common\UseCase\NotFoundResponse;
+use Core\Application\Common\UseCase\PresenterInterface;
+use Core\Common\Domain\TrimmedString;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\ServiceCategory\Application\Exception\ServiceCategoryException;
+use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
+use Core\Domain\Common\GeoCoords;
+
+final class UpdateServiceCategory
+{
+    use LoggerTrait;
+
+    public function __construct(
+        private readonly WriteServiceCategoryRepositoryInterface $writeServiceCategoryRepository,
+        private readonly ReadServiceCategoryRepositoryInterface $readServiceCategoryRepository,
+        private readonly ReadAccessGroupRepositoryInterface $readAccessGroupRepositoryInterface,
+        private readonly ContactInterface $user,
+    ) {
+    }
+
+    /**
+     * @param UpdateServiceCategoryRequest $dto
+     * @param DefaultPresenter $presenter
+     * @param int $serviceCategoryId
+     */
+    public function __invoke(
+        UpdateServiceCategoryRequest $dto,
+        PresenterInterface $presenter,
+        int $serviceCategoryId,
+    ): void {
+        try {
+            if (! $this->user->hasTopologyRole(Contact::ROLE_CONFIGURATION_SERVICES_CATEGORIES_READ_WRITE)) {
+                $this->error(
+                    "User doesn't have sufficient rights to edit service categories",
+                    ['user_id' => $this->user->getId()]
+                );
+                $presenter->setResponseStatus(
+                    new ForbiddenResponse(ServiceCategoryException::editNotAllowed()->getMessage())
+                );
+
+                return;
+            }
+
+            $serviceCategory = null;
+
+            if ($this->user->isAdmin()){
+                $serviceCategory = $this->readServiceCategoryRepository->findById($serviceCategoryId);
+            } else if($this->readServiceCategoryRepository->existsByAccessGroups(
+                    $serviceCategoryId,
+                    $this->readAccessGroupRepositoryInterface->findByContact($this->user)
+                )){
+                    $serviceCategory = $this->readServiceCategoryRepository->findById($serviceCategoryId);
+                
+            }
+
+            if (! $serviceCategory) {
+                $this->error(
+                    'Service category not found',
+                    ['service_category_id' => $serviceCategoryId]
+                );
+                $presenter->setResponseStatus(new NotFoundResponse('Service category'));
+
+                return;
+            }
+
+            $this->validateNameOrFail($dto->name, $serviceCategory);
+
+            $serviceCategory = new ServiceCategory(
+                $serviceCategory->getId(),
+                $dto->name,
+                $dto->alias,
+            );
+            $serviceCategory->setActivated($dto->isActivated);
+            
+
+            $this->writeServiceCategoryRepository->update($serviceCategory);
+
+            $presenter->setResponseStatus(new NoContentResponse());
+        } catch (ServiceCategoryException $ex) {
+            $presenter->setResponseStatus(
+                match ($ex->getCode()) {
+                    ServiceCategoryException::CODE_CONFLICT => new ConflictResponse($ex),
+                    default => new ErrorResponse($ex),
+                }
+            );
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        } catch (AssertionFailedException $ex) {
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+        } catch (\Throwable $ex) {
+            $presenter->setResponseStatus(
+                new ErrorResponse(ServiceCategoryException::errorWhileUpdating())
+            );
+            $this->error((string) $ex);
+        }
+    }
+
+    /**
+     * @param string $name
+     * @param ServiceCategory $serviceCategory
+     *
+     * @throws ServiceCategoryException
+     */
+    private function validateNameOrFail(string $name, ServiceCategory $serviceCategory): void
+    {
+        if (
+            $name !== $serviceCategory->getName()
+            && $this->readServiceCategoryRepository->existsByName((new TrimmedString($name)))
+        ) {
+            $this->error(
+                'Service category name already exists',
+                ['service_category_name' => $name]
+            );
+
+            throw ServiceCategoryException::nameAlreadyExists($name);
+        }
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategoryRequest.php
+++ b/centreon/src/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategoryRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Application\UseCase\UpdateServiceCategory;
+
+final class UpdateServiceCategoryRequest
+{
+    public string $name = '';
+
+    public string $alias = '';
+
+    public bool $isActivated = true;
+
+}

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryController.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryController.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Infrastructure\API\GetServiceCategory;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\ServiceCategory\Application\UseCase\GetServiceCategory\GetServiceCategory;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+
+final class GetServiceCategoryController extends AbstractController
+{
+    use LoggerTrait;
+
+    /**
+     * @param GetServiceCategory $useCase
+     * @param GetServiceCategoryPresenter $presenter
+     * @param int $serviceCategoryId
+     *
+     * @throws AccessDeniedException
+     *
+     * @return Response
+     */
+    public function __invoke(
+        GetServiceCategory $useCase,
+        GetServiceCategoryPresenter $presenter,
+         int $serviceCategoryId,
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        $useCase($presenter, $serviceCategoryId);
+
+        return $presenter->show();
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryPresenter.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryPresenter.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Infrastructure\API\GetServiceCategory;
+
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\AbstractPresenter;
+use Core\ServiceCategory\Application\UseCase\GetServiceCategory\GetServiceCategoryResponse;
+use Symfony\Component\Serializer\NameConverter\CamelCaseToSnakeCaseNameConverter;
+use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+use Symfony\Component\Serializer\Serializer;
+
+class GetServiceCategoryPresenter extends AbstractPresenter
+{
+    use LoggerTrait;
+
+    /**
+     * @inheritDoc
+     */
+    public function present(mixed $data): void
+    {
+        if ($data instanceof GetServiceCategoryResponse) {
+            $normalizer = new ObjectNormalizer(null, new CamelCaseToSnakeCaseNameConverter());
+            $serializer = new Serializer([$normalizer]);
+            $data = $serializer->normalize($data);
+
+            // NOT setting location as required route does not currently exist
+        }
+        parent::present($data);
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryRoute.yaml
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/GetServiceCategory/GetServiceCategoryRoute.yaml
@@ -1,0 +1,7 @@
+GetServiceCategory:
+  methods: GET
+  path: /configuration/services/categories/{serviceCategoryId}
+  requirements:
+    serviceCategoryId: '\d+'
+  controller: 'Core\ServiceCategory\Infrastructure\API\GetServiceCategory\GetServiceCategoryController'
+  condition: "request.attributes.get('version') >= '25.10'"

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategoryController.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategoryController.php
@@ -77,7 +77,7 @@ final class UpdateServiceCategoryController extends AbstractController
     }
 
     /**
-     * @var array{
+     * @param array{
      *     name: string,
      *     alias: string,
      *     is_activated?: bool

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategoryController.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategoryController.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Core\ServiceCategory\Infrastructure\API\UpdateServiceCategory;
+
+use Centreon\Application\Controller\AbstractController;
+use Centreon\Domain\Log\LoggerTrait;
+use Core\Application\Common\UseCase\InvalidArgumentResponse;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\ServiceCategory\Application\UseCase\UpdateServiceCategory\UpdateServiceCategory;
+use Core\ServiceCategory\Application\UseCase\UpdateServiceCategory\UpdateServiceCategoryRequest;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+
+final class UpdateServiceCategoryController extends AbstractController
+{
+    use LoggerTrait;
+
+    /**
+     * @param Request $request
+     * @param UpdateServiceCategory $useCase
+     * @param DefaultPresenter $presenter
+     * @param int $serviceCategoryId
+     *
+     * @throws AccessDeniedException
+     *
+     * @return Response
+     */
+    public function __invoke(
+        Request $request,
+        UpdateServiceCategory $useCase,
+        DefaultPresenter $presenter,
+        int $serviceCategoryId,
+    ): Response {
+        $this->denyAccessUnlessGrantedForApiConfiguration();
+
+        try {
+            /** @var array{
+             *     name: string,
+             *     alias: string,
+             *     is_activated?: bool
+             * } $data
+             */
+            $data = $this->validateAndRetrieveDataSent($request, __DIR__ . '/UpdateServiceCategorySchema.json');
+        } catch (\InvalidArgumentException $ex) {
+            $this->error($ex->getMessage(), ['trace' => $ex->getTraceAsString()]);
+            $presenter->setResponseStatus(new InvalidArgumentResponse($ex));
+
+            return $presenter->show();
+        }
+
+        $serviceCategoryRequest = $this->createRequestDto($data);
+        $useCase($serviceCategoryRequest, $presenter, $serviceCategoryId);
+
+        return $presenter->show();
+    }
+
+    /**
+     * @var array{
+     *     name: string,
+     *     alias: string,
+     *     is_activated?: bool
+     * } $data
+     *
+     *
+     * @return UpdateServiceCategoryRequest
+     */
+    private function createRequestDto(array $data): UpdateServiceCategoryRequest
+    {
+        $serviceCategoryRequest = new UpdateServiceCategoryRequest();
+        $serviceCategoryRequest->name = $data['name'];
+        $serviceCategoryRequest->alias = $data['alias'];
+        $serviceCategoryRequest->isActivated = $data['is_activated'] ?? true;
+        
+        return $serviceCategoryRequest;
+    }
+}

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategoryRoute.yaml
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategoryRoute.yaml
@@ -1,0 +1,7 @@
+UpdateServiceCategory:
+  methods: PUT
+  path: /configuration/services/categories/{serviceCategoryId}
+  requirements:
+    serviceCategoryId: '\d+'
+  controller: 'Core\ServiceCategory\Infrastructure\API\UpdateServiceCategory\UpdateServiceCategoryController'
+  condition: "request.attributes.get('version') >= '25.10'"

--- a/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategorySchema.json
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/API/UpdateServiceCategory/UpdateServiceCategorySchema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Update a service category",
+  "type": "object",
+  "required": [
+    "name",
+    "alias"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "alias": {
+      "type": "string"
+    },
+    "is_activated": {
+      "type": "boolean"
+    }
+  }
+}

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
@@ -33,6 +33,7 @@ use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
 use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\NewServiceCategory;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
 
 class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB implements WriteServiceCategoryRepositoryInterface
 {
@@ -139,7 +140,7 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
      * @return array<string, string>
      */
     private function getServiceCategoryAsArray(
-        NewServiceCategory $serviceCategory,
+        NewServiceCategory|ServiceCategory $serviceCategory,
     ): array {
         $reflection = new \ReflectionClass($serviceCategory);
         $properties = $reflection->getProperties();
@@ -150,6 +151,9 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
             if ($property->getName() === 'isActivated') {
                 $serviceCategoryAsArray[self::SERVICE_CATEGORY_PROPERTIES_MAP[$property->getName()]]
                     = $property->getValue($serviceCategory) ? '1' : '0';
+            } elseif($property->getName() === 'id') {
+                $serviceCategoryAsArray[self::SERVICE_CATEGORY_PROPERTIES_MAP[$property->getName()]]
+                    = strval($property->getValue($serviceCategory));
             } else {
                 $serviceCategoryAsArray[self::SERVICE_CATEGORY_PROPERTIES_MAP[$property->getName()]]
                     = is_string($property->getValue($serviceCategory))
@@ -159,5 +163,37 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
         }
 
         return $serviceCategoryAsArray;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function update(ServiceCategory $serviceCategory): void
+    {
+        try {
+            $this->writeServiceCategoryRepository->update($serviceCategory);
+            
+            $actionLog = new ActionLog(
+                objectType: ActionLog::OBJECT_TYPE_SERVICECATEGORIES,
+                objectId: $serviceCategory->getId(),
+                objectName: $serviceCategory->getName(),
+                actionType: ActionLog::ACTION_TYPE_CHANGE,
+                contactId: $this->user->getId()
+            );
+            $actionLogId = $this->writeActionLogRepository->addAction($actionLog);
+            $actionLog->setId($actionLogId);
+            $details = $this->getServiceCategoryAsArray($serviceCategory);
+            //$details = [];
+            $this->writeActionLogRepository->addActionDetails($actionLog, $details);
+
+            return ;
+        } catch (\Throwable $ex) {
+            $this->error(
+                'Error while updating a service category',
+                ['serviceCategory' => $serviceCategory, 'trace' => (string) $ex]
+            );
+
+            throw $ex;
+        }
     }
 }

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryActionLogRepository.php
@@ -39,6 +39,7 @@ class DbWriteServiceCategoryActionLogRepository extends AbstractRepositoryRDB im
 {
     use LoggerTrait;
     public const SERVICE_CATEGORY_PROPERTIES_MAP = [
+        'id' => 'sc_id',
         'name' => 'sc_name',
         'alias' => 'sc_alias',
         'isActivated' => 'sc_activate',

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryRepository.php
@@ -29,6 +29,7 @@ use Core\Common\Infrastructure\Repository\AbstractRepositoryRDB;
 use Core\Common\Infrastructure\RequestParameters\Normalizer\BoolToEnumNormalizer;
 use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
 use Core\ServiceCategory\Domain\Model\NewServiceCategory;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
 
 class DbWriteServiceCategoryRepository extends AbstractRepositoryRDB implements WriteServiceCategoryRepositoryInterface
 {
@@ -172,5 +173,34 @@ class DbWriteServiceCategoryRepository extends AbstractRepositoryRDB implements 
 
             throw $ex;
         }
+    }
+
+    /**
+     * @param ServiceCategory $ServiceCategory
+     *
+     * @throws \Throwable
+     *
+     * @return void
+     */
+    public function update(ServiceCategory $serviceCategory): void {
+        $request = $this->translateDbName(
+            <<<'SQL'
+                UPDATE `:db`.service_categories
+                SET
+                    `sc_name` = :name,
+                    `sc_description` = :alias,
+                    `sc_activate` = :isActivated
+                WHERE sc_id = :id
+                SQL
+        );
+        $statement = $this->db->prepare($request);
+
+        $statement->bindValue(':name', $serviceCategory->getName(), \PDO::PARAM_STR);
+        $statement->bindValue(':alias', $serviceCategory->getAlias(), \PDO::PARAM_STR);
+        $statement->bindValue(':isActivated', (new BoolToEnumNormalizer())->normalize($serviceCategory->isActivated()), \PDO::PARAM_STR);
+        $statement->bindValue(':id', $serviceCategory->getId(), \PDO::PARAM_INT);
+
+        $statement->execute();
+
     }
 }

--- a/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryRepository.php
+++ b/centreon/src/Core/ServiceCategory/Infrastructure/Repository/DbWriteServiceCategoryRepository.php
@@ -176,7 +176,7 @@ class DbWriteServiceCategoryRepository extends AbstractRepositoryRDB implements 
     }
 
     /**
-     * @param ServiceCategory $ServiceCategory
+     * @param ServiceCategory $serviceCategory
      *
      * @throws \Throwable
      *

--- a/centreon/tests/php/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryTest.php
+++ b/centreon/tests/php/Core/ServiceCategory/Application/UseCase/GetServiceCategory/GetServiceCategoryTest.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ServiceCategory\Application\UseCase\GetServiceCategory;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\ServiceCategory\Application\Exception\ServiceCategoryException;
+use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Application\UseCase\GetServiceCategory\GetServiceCategory;
+use Core\ServiceCategory\Application\UseCase\GetServiceCategory\GetServiceCategoryResponse;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\Domain\Common\GeoCoords;
+
+beforeEach(function (): void {
+    $this->readServiceCategoryRepository = $this->createMock(ReadServiceCategoryRepositoryInterface::class);
+    $this->readAccessGroupRepository = $this->createMock(ReadAccessGroupRepositoryInterface::class);
+    $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class);
+    $this->user = $this->createMock(ContactInterface::class);
+    $this->presenter = new DefaultPresenter($this->presenterFormatter);
+    $this->useCase = new GetServiceCategory(
+        $this->readServiceCategoryRepository,
+        $this->readAccessGroupRepository,
+        $this->user
+    );
+    $this->serviceCategory = new ServiceCategory(
+        1,
+        'sg-name',
+        'sg-alias',
+    );
+});
+
+it('should present an ErrorResponse when a generic exception is thrown', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->user
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willThrowException(new \Exception());
+
+    ($this->useCase)($this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and(value: $this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceCategoryException::errorWhileRetrieving()->getMessage());
+});
+
+it('should present a ForbiddenResponse when a user has insufficient rights', function (): void {
+    $this->user
+        ->expects($this->exactly(2))
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)($this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceCategoryException::accessNotAllowed()->getMessage());
+});
+
+
+it('should present a GetServiceCategoryResponse with non-admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->user
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+    $this->readAccessGroupRepository
+        ->expects($this->once())
+        ->method('findByContact')
+        ->willReturn([]);
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->willReturn(true);
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceCategory);
+
+    ($this->useCase)($this->presenter, $this->serviceCategory->getId());
+
+    $dto = $this->presenter->getPresentedData();
+    expect($dto)
+        ->toBeInstanceOf(GetServiceCategoryResponse::class)
+        ->and($dto->name)
+        ->toBe($this->serviceCategory->getName())
+        ->and($dto->alias)
+        ->toBe($this->serviceCategory->getAlias())
+        ->and($dto->isActivated)
+        ->toBe($this->serviceCategory->isActivated());
+});
+
+
+it('should present a GetServiceCategoryResponse with admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+    $this->user
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceCategory);
+
+    ($this->useCase)($this->presenter, $this->serviceCategory->getId());
+
+    $dto = $this->presenter->getPresentedData();
+    expect($dto)
+        ->toBeInstanceOf(GetServiceCategoryResponse::class)
+        ->and($dto->name)
+        ->toBe($this->serviceCategory->getName())
+        ->and($dto->alias)
+        ->toBe($this->serviceCategory->getAlias())
+        ->and($dto->isActivated)
+        ->toBe($this->serviceCategory->isActivated());
+});

--- a/centreon/tests/php/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategoryTest.php
+++ b/centreon/tests/php/Core/ServiceCategory/Application/UseCase/UpdateServiceCategory/UpdateServiceCategoryTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/*
+ * Copyright 2005 - 2025 Centreon (https://www.centreon.com/)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For more information : contact@centreon.com
+ *
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Core\ServiceCategory\Application\UseCase\UpdateServiceCategory;
+
+use Centreon\Domain\Contact\Interfaces\ContactInterface;
+use Core\Application\Common\UseCase\ConflictResponse;
+use Core\Application\Common\UseCase\ErrorResponse;
+use Core\Application\Common\UseCase\ForbiddenResponse;
+use Core\Application\Common\UseCase\NoContentResponse;
+use Core\Infrastructure\Common\Api\DefaultPresenter;
+use Core\Infrastructure\Common\Presenter\PresenterFormatterInterface;
+use Core\Security\AccessGroup\Application\Repository\ReadAccessGroupRepositoryInterface;
+use Core\ServiceCategory\Application\Exception\ServiceCategoryException;
+use Core\ServiceCategory\Application\Repository\ReadServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Application\Repository\WriteServiceCategoryRepositoryInterface;
+use Core\ServiceCategory\Application\UseCase\UpdateServiceCategory\UpdateServiceCategory;
+use Core\ServiceCategory\Application\UseCase\UpdateServiceCategory\UpdateServiceCategoryRequest;
+use Core\ServiceCategory\Domain\Model\ServiceCategory;
+use Core\Domain\Common\GeoCoords;
+
+beforeEach(function (): void {
+    $this->presenter = new DefaultPresenter(
+        $this->presenterFormatter = $this->createMock(PresenterFormatterInterface::class)
+    );
+    $this->useCase = new UpdateServiceCategory(
+        $this->writeServiceCategoryRepository = $this->createMock(WriteServiceCategoryRepositoryInterface::class),
+        $this->readServiceCategoryRepository = $this->createMock(ReadServiceCategoryRepositoryInterface::class),
+        $this->readAccessGroupRepositoryInterface = $this->createMock(ReadAccessGroupRepositoryInterface::class),
+        $this->user = $this->createMock(ContactInterface::class)
+    );
+
+    $this->serviceCategory = new ServiceCategory(
+        1,
+        'sc-name',
+        'sc-alias',
+    );
+
+    $this->request = new UpdateServiceCategoryRequest();
+    $this->request->name = $this->serviceCategory->getName() . '-edited';
+    $this->request->alias = $this->serviceCategory->getAlias() . '-edited';
+});
+
+it('should present an ErrorResponse when a generic exception is thrown', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->user
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willThrowException(new \Exception());
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ErrorResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceCategoryException::errorWhileUpdating()->getMessage());
+});
+
+it('should present a ForbiddenResponse when a user has insufficient rights', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(false);
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ForbiddenResponse::class)
+        ->and($this->presenter->getResponseStatus()->getMessage())
+        ->toBe(ServiceCategoryException::editNotAllowed()->getMessage());
+});
+
+it('should present a ConflictResponse when name is already used', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->user
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceCategory);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('existsByName')
+        ->willReturn(true);
+        
+
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())
+        ->toBeInstanceOf(ConflictResponse::class)
+        ->and($this->presenter->getResponseStatus()?->getMessage())
+        ->toBe(ServiceCategoryException::nameAlreadyExists($this->request->name)->getMessage());
+});
+
+
+
+it('should return void on success when admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->user
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(true);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceCategory);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('existsByName')
+        ->willReturn(false);
+
+    $this->writeServiceCategoryRepository
+        ->expects($this->once())
+        ->method('update');
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});
+
+it('should return void on success when no-admin user', function (): void {
+    $this->user
+        ->expects($this->once())
+        ->method('hasTopologyRole')
+        ->willReturn(true);
+
+    $this->user
+        ->expects($this->once())
+        ->method('isAdmin')
+        ->willReturn(false);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('existsByAccessGroups')
+        ->willReturn(true);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('findById')
+        ->willReturn($this->serviceCategory);
+
+    $this->readServiceCategoryRepository
+        ->expects($this->once())
+        ->method('existsByName')
+        ->willReturn(false);
+
+
+    $this->writeServiceCategoryRepository
+        ->expects($this->once())
+        ->method('update');
+
+    ($this->useCase)($this->request, $this->presenter, $this->serviceCategory->getId());
+
+    expect($this->presenter->getResponseStatus())->toBeInstanceOf(NoContentResponse::class);
+});


### PR DESCRIPTION
## Description

**PLEASE MAKE SURE THAT THE BRANCH PR INCLUDES JIRA TICKET ID** (_for centreon-internal_)

It implement get service category by ID from configuration endpoint.
It implement update service category by ID from configuration endpoint.

```
GET /configuration/services/categories/:serviceCategoryId
PUT /configuration/services/categories/:serviceCategoryId
```

**Fixes** # (issue)

fix issue #9471 

## Type of change

- [ ] Patch fixing an issue (non-breaking change)
- [X] New functionality (non-breaking change)
- [ ] Breaking change (patch or feature) that might cause side effects breaking part of the Software

## Target serie

- [ ] 24.04.x
- [ ] 24.10.x
- [X] 25.10.x
- [X] master

<h2> How this pull request can be tested ? </h2>

We implement unit test.
You can call APi endpoints:

```
GET /configuration/services/categories/:serviceCategoryId

PUT /configuration/services/categories/:serviceCategoryId
{
  "name": "service-category2",
  "alias": "service-category2",
  "is_activated": true
}
```

## Checklist

#### Community contributors & Centreon team

- [ ] I have followed the **coding style guidelines** provided by Centreon
- [ ] I have commented my code, especially new **classes**, **functions** or any **legacy code** modified. (***docblock***)
- [ ] I have commented my code, especially **hard-to-understand areas** of the PR.
- [ ] I have **rebased** my development branch on the base branch (master, maintenance).
